### PR TITLE
[std] Mark all concepts with \libconcept or \exposconcept

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -639,11 +639,11 @@ namespace std {
                 ForwardIterator first, ForwardIterator last, Predicate pred);
 
   namespace ranges {
-    template<input_iterator I, sentinel_for<I> S, class Proj = identity,
-             indirect_unary_predicate<projected<I, Proj>> Pred>
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
       constexpr bool all_of(I first, S last, Pred pred, Proj proj = {});
-    template<input_range R, class Proj = identity,
-             indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+    template<@\libconcept{input_range}@ R, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
       constexpr bool all_of(R&& r, Pred pred, Proj proj = {});
   }
 
@@ -655,11 +655,11 @@ namespace std {
                 ForwardIterator first, ForwardIterator last, Predicate pred);
 
   namespace ranges {
-    template<input_iterator I, sentinel_for<I> S, class Proj = identity,
-             indirect_unary_predicate<projected<I, Proj>> Pred>
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
       constexpr bool any_of(I first, S last, Pred pred, Proj proj = {});
-    template<input_range R, class Proj = identity,
-             indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+    template<@\libconcept{input_range}@ R, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
       constexpr bool any_of(R&& r, Pred pred, Proj proj = {});
   }
 
@@ -671,11 +671,11 @@ namespace std {
                  ForwardIterator first, ForwardIterator last, Predicate pred);
 
   namespace ranges {
-    template<input_iterator I, sentinel_for<I> S, class Proj = identity,
-             indirect_unary_predicate<projected<I, Proj>> Pred>
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
       constexpr bool none_of(I first, S last, Pred pred, Proj proj = {});
-    template<input_range R, class Proj = identity,
-             indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+    template<@\libconcept{input_range}@ R, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
       constexpr bool none_of(R&& r, Pred pred, Proj proj = {});
   }
 
@@ -690,12 +690,12 @@ namespace std {
     template<class I, class F>
       using for_each_result = in_fun_result<I, F>;
 
-    template<input_iterator I, sentinel_for<I> S, class Proj = identity,
-             indirectly_unary_invocable<projected<I, Proj>> Fun>
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+             @\libconcept{indirectly_unary_invocable}@<projected<I, Proj>> Fun>
       constexpr for_each_result<I, Fun>
         for_each(I first, S last, Fun f, Proj proj = {});
-    template<input_range R, class Proj = identity,
-             indirectly_unary_invocable<projected<iterator_t<R>, Proj>> Fun>
+    template<@\libconcept{input_range}@ R, class Proj = identity,
+             @\libconcept{indirectly_unary_invocable}@<projected<iterator_t<R>, Proj>> Fun>
       constexpr for_each_result<borrowed_iterator_t<R>, Fun>
         for_each(R&& r, Fun f, Proj proj = {});
   }
@@ -711,7 +711,7 @@ namespace std {
       using for_each_n_result = in_fun_result<I, F>;
 
     template<input_iterator I, class Proj = identity,
-             indirectly_unary_invocable<projected<I, Proj>> Fun>
+             @\libconcept{indirectly_unary_invocable}@<projected<I, Proj>> Fun>
       constexpr for_each_n_result<I, Fun>
         for_each_n(I first, iter_difference_t<I> n, Fun f, Proj proj = {});
   }
@@ -740,26 +740,26 @@ namespace std {
                                 Predicate pred);
 
   namespace ranges {
-    template<input_iterator I, sentinel_for<I> S, class T, class Proj = identity>
-      requires indirect_binary_predicate<ranges::equal_to, projected<I, Proj>, const T*>
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T, class Proj = identity>
+      requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T*>
       constexpr I find(I first, S last, const T& value, Proj proj = {});
-    template<input_range R, class T, class Proj = identity>
-      requires indirect_binary_predicate<ranges::equal_to,
+    template<@\libconcept{input_range}@ R, class T, class Proj = identity>
+      requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to,
                                          projected<iterator_t<R>, Proj>, const T*>
       constexpr borrowed_iterator_t<R>
         find(R&& r, const T& value, Proj proj = {});
-    template<input_iterator I, sentinel_for<I> S, class Proj = identity,
-             indirect_unary_predicate<projected<I, Proj>> Pred>
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
       constexpr I find_if(I first, S last, Pred pred, Proj proj = {});
-    template<input_range R, class Proj = identity,
-             indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+    template<@\libconcept{input_range}@ R, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
       constexpr borrowed_iterator_t<R>
         find_if(R&& r, Pred pred, Proj proj = {});
-    template<input_iterator I, sentinel_for<I> S, class Proj = identity,
-             indirect_unary_predicate<projected<I, Proj>> Pred>
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
       constexpr I find_if_not(I first, S last, Pred pred, Proj proj = {});
-    template<input_range R, class Proj = identity,
-             indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+    template<@\libconcept{input_range}@ R, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
       constexpr borrowed_iterator_t<R>
         find_if_not(R&& r, Pred pred, Proj proj = {});
   }
@@ -788,13 +788,13 @@ namespace std {
                BinaryPredicate pred);
 
   namespace ranges {
-    template<forward_iterator I1, sentinel_for<I1> S1, forward_iterator I2, sentinel_for<I2> S2,
+    template<@\libconcept{forward_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{forward_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
              class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
-      requires indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
+      requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
       constexpr subrange<I1>
         find_end(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = {},
                  Proj1 proj1 = {}, Proj2 proj2 = {});
-    template<forward_range R1, forward_range R2,
+    template<@\libconcept{forward_range}@ R1, @\libconcept{forward_range}@ R2,
              class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
       requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
       constexpr borrowed_subrange_t<R1>
@@ -826,15 +826,15 @@ namespace std {
                     BinaryPredicate pred);
 
   namespace ranges {
-    template<input_iterator I1, sentinel_for<I1> S1, forward_iterator I2, sentinel_for<I2> S2,
+    template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{forward_iterator}@ I2, sentinel_for<I2> S2,
              class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
-      requires indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
+      requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
       constexpr I1 find_first_of(I1 first1, S1 last1, I2 first2, S2 last2,
                                  Pred pred = {},
                                  Proj1 proj1 = {}, Proj2 proj2 = {});
-    template<input_range R1, forward_range R2,
+    template<@\libconcept{input_range}@ R1, @\libconcept{forward_range}@ R2,
              class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
-      requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+      requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
       constexpr borrowed_iterator_t<R1>
         find_first_of(R1&& r1, R2&& r2,
                       Pred pred = {},
@@ -860,13 +860,13 @@ namespace std {
                     BinaryPredicate pred);
 
   namespace ranges {
-    template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
-             indirect_binary_predicate<projected<I, Proj>,
+    template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+             @\libconcept{indirect_binary_predicate}@<projected<I, Proj>,
                                        projected<I, Proj>> Pred = ranges::equal_to>
       constexpr I adjacent_find(I first, S last, Pred pred = {},
                                 Proj proj = {});
-    template<forward_range R, class Proj = identity,
-             indirect_binary_predicate<projected<iterator_t<R>, Proj>,
+    template<@\libconcept{forward_range}@ R, class Proj = identity,
+             @\libconcept{indirect_binary_predicate}@<projected<iterator_t<R>, Proj>,
                                        projected<iterator_t<R>, Proj>> Pred = ranges::equal_to>
       constexpr borrowed_iterator_t<R>
         adjacent_find(R&& r, Pred pred = {}, Proj proj = {});
@@ -889,21 +889,21 @@ namespace std {
                ForwardIterator first, ForwardIterator last, Predicate pred);
 
   namespace ranges {
-    template<input_iterator I, sentinel_for<I> S, class T, class Proj = identity>
-      requires indirect_binary_predicate<ranges::equal_to, projected<I, Proj>, const T*>
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T, class Proj = identity>
+      requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T*>
       constexpr iter_difference_t<I>
         count(I first, S last, const T& value, Proj proj = {});
-    template<input_range R, class T, class Proj = identity>
-      requires indirect_binary_predicate<ranges::equal_to,
+    template<@\libconcept{input_range}@ R, class T, class Proj = identity>
+      requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to,
                                          projected<iterator_t<R>, Proj>, const T*>
       constexpr range_difference_t<R>
         count(R&& r, const T& value, Proj proj = {});
-    template<input_iterator I, sentinel_for<I> S, class Proj = identity,
-             indirect_unary_predicate<projected<I, Proj>> Pred>
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
       constexpr iter_difference_t<I>
         count_if(I first, S last, Pred pred, Proj proj = {});
-    template<input_range R, class Proj = identity,
-             indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+    template<@\libconcept{input_range}@ R, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
       constexpr range_difference_t<R>
         count_if(R&& r, Pred pred, Proj proj = {});
   }
@@ -954,15 +954,15 @@ namespace std {
     template<class I1, class I2>
       using mismatch_result = in_in_result<I1, I2>;
 
-    template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
+    template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
              class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
-      requires indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
+      requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
       constexpr mismatch_result<I1, I2>
         mismatch(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = {},
                  Proj1 proj1 = {}, Proj2 proj2 = {});
-    template<input_range R1, input_range R2,
+    template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2,
              class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
-      requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+      requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
       constexpr mismatch_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
         mismatch(R1&& r1, R2&& r2, Pred pred = {},
                  Proj1 proj1 = {}, Proj2 proj2 = {});
@@ -1003,15 +1003,15 @@ namespace std {
                BinaryPredicate pred);
 
   namespace ranges {
-    template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
+    template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
              class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
-      requires indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
+      requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
       constexpr bool equal(I1 first1, S1 last1, I2 first2, S2 last2,
                            Pred pred = {},
                            Proj1 proj1 = {}, Proj2 proj2 = {});
-    template<input_range R1, input_range R2, class Pred = ranges::equal_to,
+    template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, class Pred = ranges::equal_to,
              class Proj1 = identity, class Proj2 = identity>
-      requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+      requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
       constexpr bool equal(R1&& r1, R2&& r2, Pred pred = {},
                            Proj1 proj1 = {}, Proj2 proj2 = {});
   }
@@ -1032,16 +1032,16 @@ namespace std {
                                   BinaryPredicate pred);
 
   namespace ranges {
-    template<forward_iterator I1, sentinel_for<I1> S1, forward_iterator I2,
-             sentinel_for<I2> S2, class Proj1 = identity, class Proj2 = identity,
-             indirect_equivalence_relation<projected<I1, Proj1>,
+    template<@\libconcept{forward_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{forward_iterator}@ I2,
+             @\libconcept{sentinel_for}@<I2> S2, class Proj1 = identity, class Proj2 = identity,
+             @\libconcept{indirect_equivalence_relation}@<projected<I1, Proj1>,
                                            projected<I2, Proj2>> Pred = ranges::equal_to>
       constexpr bool is_permutation(I1 first1, S1 last1, I2 first2, S2 last2,
                                     Pred pred = {},
                                     Proj1 proj1 = {}, Proj2 proj2 = {});
-    template<forward_range R1, forward_range R2,
+    template<@\libconcept{forward_range}@ R1, @\libconcept{forward_range}@ R2,
              class Proj1 = identity, class Proj2 = identity,
-             indirect_equivalence_relation<projected<iterator_t<R1>, Proj1>,
+             @\libconcept{indirect_equivalence_relation}@<projected<iterator_t<R1>, Proj1>,
                                            projected<iterator_t<R2>, Proj2>>
                Pred = ranges::equal_to>
       constexpr bool is_permutation(R1&& r1, R2&& r2, Pred pred = {},
@@ -1072,16 +1072,16 @@ namespace std {
              BinaryPredicate pred);
 
   namespace ranges {
-    template<forward_iterator I1, sentinel_for<I1> S1, forward_iterator I2,
-             sentinel_for<I2> S2, class Pred = ranges::equal_to,
+    template<@\libconcept{forward_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{forward_iterator}@ I2,
+             @\libconcept{sentinel_for}@<I2> S2, class Pred = ranges::equal_to,
              class Proj1 = identity, class Proj2 = identity>
-      requires indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
+      requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
       constexpr subrange<I1>
         search(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = {},
                Proj1 proj1 = {}, Proj2 proj2 = {});
-    template<forward_range R1, forward_range R2, class Pred = ranges::equal_to,
+    template<@\libconcept{forward_range}@ R1, @\libconcept{forward_range}@ R2, class Pred = ranges::equal_to,
              class Proj1 = identity, class Proj2 = identity>
-      requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+      requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
       constexpr borrowed_subrange_t<R1>
         search(R1&& r1, R2&& r2, Pred pred = {},
                Proj1 proj1 = {}, Proj2 proj2 = {});
@@ -1110,15 +1110,15 @@ namespace std {
                BinaryPredicate pred);
 
   namespace ranges {
-    template<forward_iterator I, sentinel_for<I> S, class T,
+    template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T,
              class Pred = ranges::equal_to, class Proj = identity>
-      requires indirectly_comparable<I, const T*, Pred, Proj>
+      requires @\libconcept{indirectly_comparable}@<I, const T*, Pred, Proj>
       constexpr subrange<I>
         search_n(I first, S last, iter_difference_t<I> count,
                  const T& value, Pred pred = {}, Proj proj = {});
-    template<forward_range R, class T, class Pred = ranges::equal_to,
+    template<@\libconcept{forward_range}@ R, class T, class Pred = ranges::equal_to,
              class Proj = identity>
-      requires indirectly_comparable<iterator_t<R>, const T*, Pred, Proj>
+      requires @\libconcept{indirectly_comparable}@<iterator_t<R>, const T*, Pred, Proj>
       constexpr borrowed_subrange_t<R>
         search_n(R&& r, range_difference_t<R> count,
                  const T& value, Pred pred = {}, Proj proj = {});
@@ -1142,12 +1142,12 @@ namespace std {
     template<class I, class O>
       using copy_result = in_out_result<I, O>;
 
-    template<input_iterator I, sentinel_for<I> S, weakly_incrementable O>
-      requires indirectly_copyable<I, O>
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O>
+      requires @\libconcept{indirectly_copyable}@<I, O>
       constexpr copy_result<I, O>
         copy(I first, S last, O result);
-    template<input_range R, weakly_incrementable O>
-      requires indirectly_copyable<iterator_t<R>, O>
+    template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O>
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O>
       constexpr copy_result<borrowed_iterator_t<R>, O>
         copy(R&& r, O result);
   }
@@ -1165,8 +1165,8 @@ namespace std {
     template<class I, class O>
       using copy_n_result = in_out_result<I, O>;
 
-    template<input_iterator I, weakly_incrementable O>
-      requires indirectly_copyable<I, O>
+    template<@\libconcept{input_iterator}@ I, @\libconcept{weakly_incrementable}@ O>
+      requires @\libconcept{indirectly_copyable}@<I, O>
       constexpr copy_n_result<I, O>
         copy_n(I first, iter_difference_t<I> n, O result);
   }
@@ -1184,14 +1184,14 @@ namespace std {
     template<class I, class O>
       using copy_if_result = in_out_result<I, O>;
 
-    template<input_iterator I, sentinel_for<I> S, weakly_incrementable O, class Proj = identity,
-             indirect_unary_predicate<projected<I, Proj>> Pred>
-      requires indirectly_copyable<I, O>
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      requires @\libconcept{indirectly_copyable}@<I, O>
       constexpr copy_if_result<I, O>
         copy_if(I first, S last, O result, Pred pred, Proj proj = {});
-    template<input_range R, weakly_incrementable O, class Proj = identity,
-             indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
-      requires indirectly_copyable<iterator_t<R>, O>
+    template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O>
       constexpr copy_if_result<borrowed_iterator_t<R>, O>
         copy_if(R&& r, O result, Pred pred, Proj proj = {});
   }
@@ -1205,12 +1205,12 @@ namespace std {
     template<class I1, class I2>
       using copy_backward_result = in_out_result<I1, I2>;
 
-    template<bidirectional_iterator I1, sentinel_for<I1> S1, bidirectional_iterator I2>
-      requires indirectly_copyable<I1, I2>
+    template<@\libconcept{bidirectional_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{bidirectional_iterator}@ I2>
+      requires @\libconcept{indirectly_copyable}@<I1, I2>
       constexpr copy_backward_result<I1, I2>
         copy_backward(I1 first, S1 last, I2 result);
-    template<bidirectional_range R, bidirectional_iterator I>
-      requires indirectly_copyable<iterator_t<R>, I>
+    template<@\libconcept{bidirectional_range}@ R, @\libconcept{bidirectional_iterator}@ I>
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R>, I>
       constexpr copy_backward_result<borrowed_iterator_t<R>, I>
         copy_backward(R&& r, I result);
   }
@@ -1229,12 +1229,12 @@ namespace std {
     template<class I, class O>
       using move_result = in_out_result<I, O>;
 
-    template<input_iterator I, sentinel_for<I> S, weakly_incrementable O>
-      requires indirectly_movable<I, O>
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O>
+      requires @\libconcept{indirectly_movable}@<I, O>
       constexpr move_result<I, O>
         move(I first, S last, O result);
-    template<input_range R, weakly_incrementable O>
-      requires indirectly_movable<iterator_t<R>, O>
+    template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O>
+      requires @\libconcept{indirectly_movable}@<iterator_t<R>, O>
       constexpr move_result<borrowed_iterator_t<R>, O>
         move(R&& r, O result);
   }
@@ -1248,12 +1248,12 @@ namespace std {
     template<class I1, class I2>
       using move_backward_result = in_out_result<I1, I2>;
 
-    template<bidirectional_iterator I1, sentinel_for<I1> S1, bidirectional_iterator I2>
-      requires indirectly_movable<I1, I2>
+    template<@\libconcept{bidirectional_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{bidirectional_iterator}@ I2>
+      requires @\libconcept{indirectly_movable}@<I1, I2>
       constexpr move_backward_result<I1, I2>
         move_backward(I1 first, S1 last, I2 result);
-    template<bidirectional_range R, bidirectional_iterator I>
-      requires indirectly_movable<iterator_t<R>, I>
+    template<@\libconcept{bidirectional_range}@ R, @\libconcept{bidirectional_iterator}@ I>
+      requires @\libconcept{indirectly_movable}@<iterator_t<R>, I>
       constexpr move_backward_result<borrowed_iterator_t<R>, I>
         move_backward(R&& r, I result);
   }
@@ -1271,12 +1271,12 @@ namespace std {
     template<class I1, class I2>
       using swap_ranges_result = in_in_result<I1, I2>;
 
-    template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2>
-      requires indirectly_swappable<I1, I2>
+    template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2>
+      requires @\libconcept{indirectly_swappable}@<I1, I2>
       constexpr swap_ranges_result<I1, I2>
         swap_ranges(I1 first1, S1 last1, I2 first2, S2 last2);
-    template<input_range R1, input_range R2>
-      requires indirectly_swappable<iterator_t<R1>, iterator_t<R2>>
+    template<@\libconcept{input_range}@ R1, input_range R2>
+      requires @\libconcept{indirectly_swappable}@<iterator_t<R1>, iterator_t<R2>>
       constexpr swap_ranges_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
         swap_ranges(R1&& r1, R2&& r2);
   }
@@ -1313,31 +1313,31 @@ namespace std {
     template<class I, class O>
       using unary_transform_result = in_out_result<I, O>;
 
-    template<input_iterator I, sentinel_for<I> S, weakly_incrementable O,
-             copy_constructible F, class Proj = identity>
-      requires writable<O, indirect_result_t<F&, projected<I, Proj>>>
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O,
+             @\libconcept{copy_constructible}@ F, class Proj = identity>
+      requires @\libconcept{writable}@<O, indirect_result_t<F&, projected<I, Proj>>>
       constexpr unary_transform_result<I, O>
         transform(I first1, S last1, O result, F op, Proj proj = {});
-    template<input_range R, weakly_incrementable O, copy_constructible F,
+    template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O, @\libconcept{copy_constructible}@ F,
              class Proj = identity>
-      requires writable<O, indirect_result_t<F&, projected<iterator_t<R>, Proj>>>
+      requires @\libconcept{writable}@<O, indirect_result_t<F&, projected<iterator_t<R>, Proj>>>
       constexpr unary_transform_result<borrowed_iterator_t<R>, O>
         transform(R&& r, O result, F op, Proj proj = {});
 
     template<class I1, class I2, class O>
       using binary_transform_result = in_in_out_result<I1, I2, O>;
 
-    template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
-             weakly_incrementable O, copy_constructible F, class Proj1 = identity,
+    template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
+             @\libconcept{weakly_incrementable}@ O, @\libconcept{copy_constructible}@ F, class Proj1 = identity,
              class Proj2 = identity>
-      requires writable<O, indirect_result_t<F&, projected<I1, Proj1>,
+      requires @\libconcept{writable}@<O, indirect_result_t<F&, projected<I1, Proj1>,
                                              projected<I2, Proj2>>>
       constexpr binary_transform_result<I1, I2, O>
         transform(I1 first1, S1 last1, I2 first2, S2 last2, O result,
                   F binary_op, Proj1 proj1 = {}, Proj2 proj2 = {});
-    template<input_range R1, input_range R2, weakly_incrementable O,
-             copy_constructible F, class Proj1 = identity, class Proj2 = identity>
-      requires writable<O, indirect_result_t<F&, projected<iterator_t<R1>, Proj1>,
+    template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, @\libconcept{weakly_incrementable}@ O,
+             @\libconcept{copy_constructible}@ F, class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{writable}@<O, indirect_result_t<F&, projected<iterator_t<R1>, Proj1>,
                                              projected<iterator_t<R2>, Proj2>>>
       constexpr binary_transform_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
         transform(R1&& r1, R2&& r2, O result,
@@ -1361,24 +1361,24 @@ namespace std {
                     Predicate pred, const T& new_value);
 
   namespace ranges {
-    template<input_iterator I, sentinel_for<I> S, class T1, class T2, class Proj = identity>
-      requires writable<I, const T2&> &&
-               indirect_binary_predicate<ranges::equal_to, projected<I, Proj>, const T1*>
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T1, class T2, class Proj = identity>
+      requires @\libconcept{writable}@<I, const T2&> &&
+               @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T1*>
       constexpr I
         replace(I first, S last, const T1& old_value, const T2& new_value, Proj proj = {});
-    template<input_range R, class T1, class T2, class Proj = identity>
-      requires writable<iterator_t<R>, const T2&> &&
-               indirect_binary_predicate<ranges::equal_to,
+    template<@\libconcept{input_range}@ R, class T1, class T2, class Proj = identity>
+      requires @\libconcept{writable}@<iterator_t<R>, const T2&> &&
+               @\libconcept{indirect_binary_predicate}@<ranges::equal_to,
                                          projected<iterator_t<R>, Proj>, const T1*>
       constexpr borrowed_iterator_t<R>
         replace(R&& r, const T1& old_value, const T2& new_value, Proj proj = {});
-    template<input_iterator I, sentinel_for<I> S, class T, class Proj = identity,
-             indirect_unary_predicate<projected<I, Proj>> Pred>
-      requires writable<I, const T&>
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      requires @\libconcept{writable}@<I, const T&>
       constexpr I replace_if(I first, S last, Pred pred, const T& new_value, Proj proj = {});
-    template<input_range R, class T, class Proj = identity,
-             indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
-      requires writable<iterator_t<R>, const T&>
+    template<@\libconcept{input_range}@ R, class T, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      requires @\libconcept{writable}@<iterator_t<R>, const T&>
       constexpr borrowed_iterator_t<R>
         replace_if(R&& r, Pred pred, const T& new_value, Proj proj = {});
   }
@@ -1407,17 +1407,17 @@ namespace std {
     template<class I, class O>
       using replace_copy_result = in_out_result<I, O>;
 
-    template<input_iterator I, sentinel_for<I> S, class T1, class T2,
-             output_iterator<const T2&> O, class Proj = identity>
-      requires indirectly_copyable<I, O> &&
-               indirect_binary_predicate<ranges::equal_to, projected<I, Proj>, const T1*>
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T1, class T2,
+             @\libconcept{output_iterator}@<const T2&> O, class Proj = identity>
+      requires @\libconcept{indirectly_copyable}@<I, O> &&
+               @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T1*>
       constexpr replace_copy_result<I, O>
         replace_copy(I first, S last, O result, const T1& old_value, const T2& new_value,
                      Proj proj = {});
-    template<input_range R, class T1, class T2, output_iterator<const T2&> O,
+    template<@\libconcept{input_range}@ R, class T1, class T2, @\libconcept{output_iterator}@<const T2&> O,
              class Proj = identity>
-      requires indirectly_copyable<iterator_t<R>, O> &&
-               indirect_binary_predicate<ranges::equal_to,
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O> &&
+               @\libconcept{indirect_binary_predicate}@<ranges::equal_to,
                                          projected<iterator_t<R>, Proj>, const T1*>
       constexpr replace_copy_result<borrowed_iterator_t<R>, O>
         replace_copy(R&& r, O result, const T1& old_value, const T2& new_value,
@@ -1426,15 +1426,15 @@ namespace std {
     template<class I, class O>
       using replace_copy_if_result = in_out_result<I, O>;
 
-    template<input_iterator I, sentinel_for<I> S, class T, output_iterator<const T&> O,
-             class Proj = identity, indirect_unary_predicate<projected<I, Proj>> Pred>
-      requires indirectly_copyable<I, O>
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T, @\libconcept{output_iterator}@<const T&> O,
+             class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      requires @\libconcept{indirectly_copyable}@<I, O>
       constexpr replace_copy_if_result<I, O>
         replace_copy_if(I first, S last, O result, Pred pred, const T& new_value,
                         Proj proj = {});
-    template<input_range R, class T, output_iterator<const T&> O, class Proj = identity,
-             indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
-      requires indirectly_copyable<iterator_t<R>, O>
+    template<@\libconcept{input_range}@ R, class T, output_iterator<const T&> O, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O>
       constexpr replace_copy_if_result<borrowed_iterator_t<R>, O>
         replace_copy_if(R&& r, O result, Pred pred, const T& new_value,
                         Proj proj = {});
@@ -1454,11 +1454,11 @@ namespace std {
                            ForwardIterator first, Size n, const T& value);
 
   namespace ranges {
-    template<class T, output_iterator<const T&> O, sentinel_for<O> S>
+    template<class T, @\libconcept{output_iterator}@<const T&> O, @\libconcept{sentinel_for}@<O> S>
       constexpr O fill(O first, S last, const T& value);
-    template<class T, output_range<const T&> R>
+    template<class T, @\libconcept{output_range}@<const T&> R>
       constexpr borrowed_iterator_t<R> fill(R&& r, const T& value);
-    template<class T, output_iterator<const T&> O>
+    template<class T, @\libconcept{output_iterator}@<const T&> O>
       constexpr O fill_n(O first, iter_difference_t<O> n, const T& value);
   }
 
@@ -1477,14 +1477,14 @@ namespace std {
                                ForwardIterator first, Size n, Generator gen);
 
   namespace ranges {
-    template<input_or_output_iterator O, sentinel_for<O> S, copy_constructible F>
-      requires invocable<F&> && writable<O, invoke_result_t<F&>>
+    template<@\libconcept{input_or_output_iterator}@ O, @\libconcept{sentinel_for}@<O> S, @\libconcept{copy_constructible}@ F>
+      requires @\libconcept{invocable}@<F&> && @\libconcept{writable}@<O, invoke_result_t<F&>>
       constexpr O generate(O first, S last, F gen);
-    template<class R, copy_constructible F>
-      requires invocable<F&> && output_range<R, invoke_result_t<F&>>
+    template<class R, @\libconcept{copy_constructible}@ F>
+      requires @\libconcept{invocable}@<F&> && @\libconcept{output_range}@<R, invoke_result_t<F&>>
       constexpr borrowed_iterator_t<R> generate(R&& r, F gen);
-    template<input_or_output_iterator O, copy_constructible F>
-      requires invocable<F&> && writable<O, invoke_result_t<F&>>
+    template<@\libconcept{input_or_output_iterator}@ O, @\libconcept{copy_constructible}@ F>
+      requires @\libconcept{invocable}@<F&> && @\libconcept{writable}@<O, invoke_result_t<F&>>
       constexpr O generate_n(O first, iter_difference_t<O> n, F gen);
   }
 
@@ -1505,21 +1505,21 @@ namespace std {
                               Predicate pred);
 
   namespace ranges {
-    template<permutable I, sentinel_for<I> S, class T, class Proj = identity>
-      requires indirect_binary_predicate<ranges::equal_to, projected<I, Proj>, const T*>
+    template<@\libconcept{permutable}@ I, @\libconcept{sentinel_for}@<I> S, class T, class Proj = identity>
+      requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T*>
       constexpr subrange<I> remove(I first, S last, const T& value, Proj proj = {});
     template<forward_range R, class T, class Proj = identity>
-      requires permutable<iterator_t<R>> &&
-               indirect_binary_predicate<ranges::equal_to,
+      requires @\libconcept{permutable}@<iterator_t<R>> &&
+               @\libconcept{indirect_binary_predicate}@<ranges::equal_to,
                                          projected<iterator_t<R>, Proj>, const T*>
       constexpr borrowed_subrange_t<R>
         remove(R&& r, const T& value, Proj proj = {});
-    template<permutable I, sentinel_for<I> S, class Proj = identity,
-             indirect_unary_predicate<projected<I, Proj>> Pred>
+    template<@\libconcept{permutable}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
       constexpr subrange<I> remove_if(I first, S last, Pred pred, Proj proj = {});
-    template<forward_range R, class Proj = identity,
-             indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
-      requires permutable<iterator_t<R>>
+    template<@\libconcept{forward_range}@ R, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      requires @\libconcept{permutable}@<iterator_t<R>>
       constexpr borrowed_subrange_t<R>
         remove_if(R&& r, Pred pred, Proj proj = {});
   }
@@ -1549,15 +1549,15 @@ namespace std {
     template<class I, class O>
       using remove_copy_result = in_out_result<I, O>;
 
-    template<input_iterator I, sentinel_for<I> S, weakly_incrementable O, class T,
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O, class T,
              class Proj = identity>
-      requires indirectly_copyable<I, O> &&
-               indirect_binary_predicate<ranges::equal_to, projected<I, Proj>, const T*>
+      requires @\libconcept{indirectly_copyable}@<I, O> &&
+               @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T*>
       constexpr remove_copy_result<I, O>
         remove_copy(I first, S last, O result, const T& value, Proj proj = {});
-    template<input_range R, weakly_incrementable O, class T, class Proj = identity>
-      requires indirectly_copyable<iterator_t<R>, O> &&
-               indirect_binary_predicate<ranges::equal_to,
+    template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O, class T, class Proj = identity>
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O> &&
+               @\libconcept{indirect_binary_predicate}@<ranges::equal_to,
                                          projected<iterator_t<R>, Proj>, const T*>
       constexpr remove_copy_result<borrowed_iterator_t<R>, O>
         remove_copy(R&& r, O result, const T& value, Proj proj = {});
@@ -1565,14 +1565,14 @@ namespace std {
     template<class I, class O>
       using remove_copy_if_result = in_out_result<I, O>;
 
-    template<input_iterator I, sentinel_for<I> S, weakly_incrementable O,
-             class Proj = identity, indirect_unary_predicate<projected<I, Proj>> Pred>
-      requires indirectly_copyable<I, O>
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O,
+             class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      requires @\libconcept{indirectly_copyable}@<I, O>
       constexpr remove_copy_if_result<I, O>
         remove_copy_if(I first, S last, O result, Pred pred, Proj proj = {});
-    template<input_range R, weakly_incrementable O, class Proj = identity,
-             indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
-      requires indirectly_copyable<iterator_t<R>, O>
+    template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O>
       constexpr remove_copy_if_result<borrowed_iterator_t<R>, O>
         remove_copy_if(R&& r, O result, Pred pred, Proj proj = {});
   }
@@ -1592,12 +1592,12 @@ namespace std {
                            BinaryPredicate pred);
 
   namespace ranges {
-    template<permutable I, sentinel_for<I> S, class Proj = identity,
-             indirect_equivalence_relation<projected<I, Proj>> C = ranges::equal_to>
+    template<@\libconcept{permutable}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+             @\libconcept{indirect_equivalence_relation}@<projected<I, Proj>> C = ranges::equal_to>
       constexpr subrange<I> unique(I first, S last, C comp = {}, Proj proj = {});
-    template<forward_range R, class Proj = identity,
-             indirect_equivalence_relation<projected<iterator_t<R>, Proj>> C = ranges::equal_to>
-      requires permutable<iterator_t<R>>
+    template<@\libconcept{forward_range}@ R, class Proj = identity,
+             @\libconcept{indirect_equivalence_relation}@<projected<iterator_t<R>, Proj>> C = ranges::equal_to>
+      requires @\libconcept{permutable}@<iterator_t<R>>
       constexpr borrowed_subrange_t<R>
         unique(R&& r, C comp = {}, Proj proj = {});
   }
@@ -1626,20 +1626,20 @@ namespace std {
     template<class I, class O>
       using unique_copy_result = in_out_result<I, O>;
 
-    template<input_iterator I, sentinel_for<I> S, weakly_incrementable O, class Proj = identity,
-             indirect_equivalence_relation<projected<I, Proj>> C = ranges::equal_to>
-      requires indirectly_copyable<I, O> &&
-               (forward_iterator<I> ||
-                (input_iterator<O> && same_as<iter_value_t<I>, iter_value_t<O>>) ||
-                indirectly_copyable_storable<I, O>)
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O, class Proj = identity,
+             @\libconcept{indirect_equivalence_relation}@<projected<I, Proj>> C = ranges::equal_to>
+      requires @\libconcept{indirectly_copyable}@<I, O> &&
+               (@\libconcept{forward_iterator}@<I> ||
+                (@\libconcept{input_iterator}@<O> && @\libconcept{same_as}@<iter_value_t<I>, iter_value_t<O>>) ||
+                @\libconcept{indirectly_copyable_storable}@<I, O>)
       constexpr unique_copy_result<I, O>
         unique_copy(I first, S last, O result, C comp = {}, Proj proj = {});
-    template<input_range R, weakly_incrementable O, class Proj = identity,
-             indirect_equivalence_relation<projected<iterator_t<R>, Proj>> C = ranges::equal_to>
-      requires indirectly_copyable<iterator_t<R>, O> &&
-               (forward_iterator<iterator_t<R>> ||
-                (input_iterator<O> && same_as<range_value_t<R>, iter_value_t<O>>) ||
-                indirectly_copyable_storable<iterator_t<R>, O>)
+    template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O, class Proj = identity,
+             @\libconcept{indirect_equivalence_relation}@<projected<iterator_t<R>, Proj>> C = ranges::equal_to>
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O> &&
+               (@\libconcept{forward_iterator}@<iterator_t<R>> ||
+                (@\libconcept{input_iterator}@<O> && @\libconcept{same_as}@<range_value_t<R>, iter_value_t<O>>) ||
+                @\libconcept{indirectly_copyable_storable}@<iterator_t<R>, O>)
       constexpr unique_copy_result<borrowed_iterator_t<R>, O>
         unique_copy(R&& r, O result, C comp = {}, Proj proj = {});
   }
@@ -1652,11 +1652,11 @@ namespace std {
                  BidirectionalIterator first, BidirectionalIterator last);
 
   namespace ranges {
-    template<bidirectional_iterator I, sentinel_for<I> S>
-      requires permutable<I>
+    template<@\libconcept{bidirectional_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
+      requires @\libconcept{permutable}@<I>
       constexpr I reverse(I first, S last);
-    template<bidirectional_range R>
-      requires permutable<iterator_t<R>>
+    template<@\libconcept{bidirectional_range}@ R>
+      requires @\libconcept{permutable}@<iterator_t<R>>
       constexpr borrowed_iterator_t<R> reverse(R&& r);
   }
 
@@ -1674,12 +1674,12 @@ namespace std {
     template<class I, class O>
       using reverse_copy_result = in_out_result<I, O>;
 
-    template<bidirectional_iterator I, sentinel_for<I> S, weakly_incrementable O>
-      requires indirectly_copyable<I, O>
+    template<@\libconcept{bidirectional_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O>
+      requires @\libconcept{indirectly_copyable}@<I, O>
       constexpr reverse_copy_result<I, O>
         reverse_copy(I first, S last, O result);
-    template<bidirectional_range R, weakly_incrementable O>
-      requires indirectly_copyable<iterator_t<R>, O>
+    template<@\libconcept{bidirectional_range}@ R, @\libconcept{weakly_incrementable}@ O>
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O>
       constexpr reverse_copy_result<borrowed_iterator_t<R>, O>
         reverse_copy(R&& r, O result);
   }
@@ -1696,10 +1696,10 @@ namespace std {
                            ForwardIterator last);
 
   namespace ranges {
-    template<permutable I, sentinel_for<I> S>
+    template<@\libconcept{permutable}@ I, @\libconcept{sentinel_for}@<I> S>
       constexpr subrange<I> rotate(I first, I middle, S last);
-    template<forward_range R>
-      requires permutable<iterator_t<R>>
+    template<@\libconcept{forward_range}@ R>
+      requires @\libconcept{permutable}@<iterator_t<R>>
       constexpr borrowed_subrange_t<R> rotate(R&& r, iterator_t<R> middle);
   }
 
@@ -1717,12 +1717,12 @@ namespace std {
     template<class I, class O>
       using rotate_copy_result = in_out_result<I, O>;
 
-    template<forward_iterator I, sentinel_for<I> S, weakly_incrementable O>
-      requires indirectly_copyable<I, O>
+    template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O>
+      requires @\libconcept{indirectly_copyable}@<I, O>
       constexpr rotate_copy_result<I, O>
         rotate_copy(I first, I middle, S last, O result);
-    template<forward_range R, weakly_incrementable O>
-      requires indirectly_copyable<iterator_t<R>, O>
+    template<@\libconcept{forward_range}@ R, @\libconcept{weakly_incrementable}@ O>
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O>
       constexpr rotate_copy_result<borrowed_iterator_t<R>, O>
         rotate_copy(R&& r, iterator_t<R> middle, O result);
   }
@@ -1736,14 +1736,14 @@ namespace std {
 
   namespace ranges {
     template<input_iterator I, sentinel_for<I> S,
-             weakly_incrementable O, class Gen>
+             @\libconcept{weakly_incrementable}@ O, class Gen>
       requires (forward_iterator<I> || random_access_iterator<O>) &&
-               indirectly_copyable<I, O> &&
+               @\libconcept{indirectly_copyable}@<I, O> &&
                uniform_random_bit_generator<remove_reference_t<Gen>>
       O sample(I first, S last, O out, iter_difference_t<I> n, Gen&& g);
-    template<input_range R, weakly_incrementable O, class Gen>
+    template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O, class Gen>
       requires (forward_range<R> || random_access_iterator<O>) &&
-               indirectly_copyable<iterator_t<R>, O> &&
+               @\libconcept{indirectly_copyable}@<iterator_t<R>, O> &&
                uniform_random_bit_generator<remove_reference_t<Gen>>
       O sample(R&& r, O out, range_difference_t<R> n, Gen&& g);
   }
@@ -1755,13 +1755,13 @@ namespace std {
                  UniformRandomBitGenerator&& g);
 
   namespace ranges {
-    template<random_access_iterator I, sentinel_for<I> S, class Gen>
-      requires permutable<I> &&
-               uniform_random_bit_generator<remove_reference_t<Gen>>
+    template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Gen>
+      requires @\libconcept{permutable}@<I> &&
+               @\libconcept{uniform_random_bit_generator}@<remove_reference_t<Gen>>
       I shuffle(I first, S last, Gen&& g);
     template<random_access_range R, class Gen>
-      requires permutable<iterator_t<R>> &&
-               uniform_random_bit_generator<remove_reference_t<Gen>>
+      requires @\libconcept{permutable}@<iterator_t<R>> &&
+               @\libconcept{uniform_random_bit_generator}@<remove_reference_t<Gen>>
       borrowed_iterator_t<R> shuffle(R&& r, Gen&& g);
   }
 
@@ -1801,13 +1801,13 @@ namespace std {
               Compare comp);
 
   namespace ranges {
-    template<random_access_iterator I, sentinel_for<I> S, class Comp = ranges::less,
+    template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
              class Proj = identity>
-      requires sortable<I, Comp, Proj>
+      requires @\libconcept{sortable}@<I, Comp, Proj>
       constexpr I
         sort(I first, S last, Comp comp = {}, Proj proj = {});
     template<random_access_range R, class Comp = ranges::less, class Proj = identity>
-      requires sortable<iterator_t<R>, Comp, Proj>
+      requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
       constexpr borrowed_iterator_t<R>
         sort(R&& r, Comp comp = {}, Proj proj = {});
   }
@@ -1826,12 +1826,12 @@ namespace std {
                      Compare comp);
 
   namespace ranges {
-    template<random_access_iterator I, sentinel_for<I> S, class Comp = ranges::less,
+    template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
              class Proj = identity>
-      requires sortable<I, Comp, Proj>
+      requires @\libconcept{sortable}@<I, Comp, Proj>
       I stable_sort(I first, S last, Comp comp = {}, Proj proj = {});
     template<random_access_range R, class Comp = ranges::less, class Proj = identity>
-      requires sortable<iterator_t<R>, Comp, Proj>
+      requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
       borrowed_iterator_t<R>
         stable_sort(R&& r, Comp comp = {}, Proj proj = {});
   }
@@ -1856,13 +1856,13 @@ namespace std {
                       RandomAccessIterator last, Compare comp);
 
   namespace ranges {
-    template<random_access_iterator I, sentinel_for<I> S, class Comp = ranges::less,
+    template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
              class Proj = identity>
-      requires sortable<I, Comp, Proj>
+      requires @\libconcept{sortable}@<I, Comp, Proj>
       constexpr I
         partial_sort(I first, I middle, S last, Comp comp = {}, Proj proj = {});
     template<random_access_range R, class Comp = ranges::less, class Proj = identity>
-      requires sortable<iterator_t<R>, Comp, Proj>
+      requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
       constexpr borrowed_iterator_t<R>
         partial_sort(R&& r, iterator_t<R> middle, Comp comp = {},
                      Proj proj = {});
@@ -1898,19 +1898,19 @@ namespace std {
     template<class I, class O>
       using partial_sort_copy_result = in_out_result<I, O>;
 
-    template<input_iterator I1, sentinel_for<I1> S1,
-             random_access_iterator I2, sentinel_for<I2> S2,
+    template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1,
+             @\libconcept{random_access_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
              class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
-      requires indirectly_copyable<I1, I2> && sortable<I2, Comp, Proj2> &&
-               indirect_strict_weak_order<Comp, projected<I1, Proj1>, projected<I2, Proj2>>
+      requires @\libconcept{indirectly_copyable}@<I1, I2> && @\libconcept{sortable}@<I2, Comp, Proj2> &&
+               @\libconcept{indirect_strict_weak_order}@<Comp, projected<I1, Proj1>, projected<I2, Proj2>>
       constexpr partial_sort_copy_result<I1, I2>
         partial_sort_copy(I1 first, S1 last, I2 result_first, S2 result_last,
                           Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
-    template<input_range R1, random_access_range R2, class Comp = ranges::less,
+    template<@\libconcept{input_range}@ R1, @\libconcept{random_access_range}@ R2, class Comp = ranges::less,
              class Proj1 = identity, class Proj2 = identity>
-      requires indirectly_copyable<iterator_t<R1>, iterator_t<R2>> &&
-               sortable<iterator_t<R2>, Comp, Proj2> &&
-               indirect_strict_weak_order<Comp, projected<iterator_t<R1>, Proj1>,
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R1>, iterator_t<R2>> &&
+               @\libconcept{sortable}@<iterator_t<R2>, Comp, Proj2> &&
+               @\libconcept{indirect_strict_weak_order}@<Comp, projected<iterator_t<R1>, Proj1>,
                                           projected<iterator_t<R2>, Proj2>>
       constexpr partial_sort_copy_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
         partial_sort_copy(R1&& r, R2&& result_r, Comp comp = {},
@@ -1931,11 +1931,11 @@ namespace std {
                    Compare comp);
 
   namespace ranges {
-    template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
-             indirect_strict_weak_order<projected<I, Proj>> Comp = ranges::less>
+    template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
       constexpr bool is_sorted(I first, S last, Comp comp = {}, Proj proj = {});
-    template<forward_range R, class Proj = identity,
-             indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+    template<@\libconcept{forward_range}@ R, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
       constexpr bool is_sorted(R&& r, Comp comp = {}, Proj proj = {});
   }
 
@@ -1957,11 +1957,11 @@ namespace std {
                       Compare comp);
 
   namespace ranges {
-    template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
-             indirect_strict_weak_order<projected<I, Proj>> Comp = ranges::less>
+    template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
       constexpr I is_sorted_until(I first, S last, Comp comp = {}, Proj proj = {});
-    template<forward_range R, class Proj = identity,
-             indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+    template<@\libconcept{forward_range}@ R, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
       constexpr borrowed_iterator_t<R>
         is_sorted_until(R&& r, Comp comp = {}, Proj proj = {});
   }
@@ -1983,13 +1983,13 @@ namespace std {
                      RandomAccessIterator last, Compare comp);
 
   namespace ranges {
-    template<random_access_iterator I, sentinel_for<I> S, class Comp = ranges::less,
+    template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
              class Proj = identity>
-      requires sortable<I, Comp, Proj>
+      requires @\libconcept{sortable}@<I, Comp, Proj>
       constexpr I
         nth_element(I first, I nth, S last, Comp comp = {}, Proj proj = {});
     template<random_access_range R, class Comp = ranges::less, class Proj = identity>
-      requires sortable<iterator_t<R>, Comp, Proj>
+      requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
       constexpr borrowed_iterator_t<R>
         nth_element(R&& r, iterator_t<R> nth, Comp comp = {}, Proj proj = {});
   }
@@ -2005,12 +2005,12 @@ namespace std {
                   const T& value, Compare comp);
 
   namespace ranges {
-    template<forward_iterator I, sentinel_for<I> S, class T, class Proj = identity,
-             indirect_strict_weak_order<const T*, projected<I, Proj>> Comp = ranges::less>
+    template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<const T*, projected<I, Proj>> Comp = ranges::less>
       constexpr I lower_bound(I first, S last, const T& value, Comp comp = {},
                               Proj proj = {});
-    template<forward_range R, class T, class Proj = identity,
-             indirect_strict_weak_order<const T*, projected<iterator_t<R>, Proj>> Comp =
+    template<@\libconcept{forward_range}@ R, class T, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<const T*, projected<iterator_t<R>, Proj>> Comp =
                ranges::less>
       constexpr borrowed_iterator_t<R>
         lower_bound(R&& r, const T& value, Comp comp = {}, Proj proj = {});
@@ -2026,11 +2026,11 @@ namespace std {
                   const T& value, Compare comp);
 
   namespace ranges {
-    template<forward_iterator I, sentinel_for<I> S, class T, class Proj = identity,
-             indirect_strict_weak_order<const T*, projected<I, Proj>> Comp = ranges::less>
+    template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<const T*, projected<I, Proj>> Comp = ranges::less>
       constexpr I upper_bound(I first, S last, const T& value, Comp comp = {}, Proj proj = {});
-    template<forward_range R, class T, class Proj = identity,
-             indirect_strict_weak_order<const T*, projected<iterator_t<R>, Proj>> Comp =
+    template<@\libconcept{forward_range}@ R, class T, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<const T*, projected<iterator_t<R>, Proj>> Comp =
                ranges::less>
       constexpr borrowed_iterator_t<R>
         upper_bound(R&& r, const T& value, Comp comp = {}, Proj proj = {});
@@ -2046,12 +2046,12 @@ namespace std {
                   const T& value, Compare comp);
 
   namespace ranges {
-    template<forward_iterator I, sentinel_for<I> S, class T, class Proj = identity,
-             indirect_strict_weak_order<const T*, projected<I, Proj>> Comp = ranges::less>
+    template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<const T*, projected<I, Proj>> Comp = ranges::less>
       constexpr subrange<I>
         equal_range(I first, S last, const T& value, Comp comp = {}, Proj proj = {});
-    template<forward_range R, class T, class Proj = identity,
-             indirect_strict_weak_order<const T*, projected<iterator_t<R>, Proj>> Comp =
+    template<@\libconcept{forward_range}@ R, class T, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<const T*, projected<iterator_t<R>, Proj>> Comp =
                ranges::less>
       constexpr borrowed_subrange_t<R>
         equal_range(R&& r, const T& value, Comp comp = {}, Proj proj = {});
@@ -2067,12 +2067,12 @@ namespace std {
                     const T& value, Compare comp);
 
   namespace ranges {
-    template<forward_iterator I, sentinel_for<I> S, class T, class Proj = identity,
-             indirect_strict_weak_order<const T*, projected<I, Proj>> Comp = ranges::less>
+    template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<const T*, projected<I, Proj>> Comp = ranges::less>
       constexpr bool binary_search(I first, S last, const T& value, Comp comp = {},
                                    Proj proj = {});
-    template<forward_range R, class T, class Proj = identity,
-             indirect_strict_weak_order<const T*, projected<iterator_t<R>, Proj>> Comp =
+    template<@\libconcept{forward_range}@ R, class T, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<const T*, projected<iterator_t<R>, Proj>> Comp =
                ranges::less>
       constexpr bool binary_search(R&& r, const T& value, Comp comp = {},
                                    Proj proj = {});
@@ -2086,11 +2086,11 @@ namespace std {
                         ForwardIterator first, ForwardIterator last, Predicate pred);
 
   namespace ranges {
-    template<input_iterator I, sentinel_for<I> S, class Proj = identity,
-             indirect_unary_predicate<projected<I, Proj>> Pred>
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
       constexpr bool is_partitioned(I first, S last, Pred pred, Proj proj = {});
-    template<input_range R, class Proj = identity,
-             indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+    template<@\libconcept{input_range}@ R, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
       constexpr bool is_partitioned(R&& r, Pred pred, Proj proj = {});
   }
 
@@ -2105,13 +2105,13 @@ namespace std {
                               Predicate pred);
 
   namespace ranges {
-    template<permutable I, sentinel_for<I> S, class Proj = identity,
-             indirect_unary_predicate<projected<I, Proj>> Pred>
+    template<@\libconcept{permutable}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
       constexpr subrange<I>
         partition(I first, S last, Pred pred, Proj proj = {});
-    template<forward_range R, class Proj = identity,
-             indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
-      requires permutable<iterator_t<R>>
+    template<@\libconcept{forward_range}@ R, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      requires @\libconcept{permutable}@<iterator_t<R>>
       constexpr borrowed_subrange_t<R>
         partition(R&& r, Pred pred, Proj proj = {});
   }
@@ -2127,13 +2127,13 @@ namespace std {
                                            Predicate pred);
 
   namespace ranges {
-    template<bidirectional_iterator I, sentinel_for<I> S, class Proj = identity,
-             indirect_unary_predicate<projected<I, Proj>> Pred>
-      requires permutable<I>
+    template<@\libconcept{bidirectional_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      requires @\libconcept{permutable}@<I>
       subrange<I> stable_partition(I first, S last, Pred pred, Proj proj = {});
-    template<bidirectional_range R, class Proj = identity,
-             indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
-      requires permutable<iterator_t<R>>
+    template<@\libconcept{bidirectional_range}@ R, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      requires @\libconcept{permutable}@<iterator_t<R>>
       borrowed_subrange_t<R> stable_partition(R&& r, Pred pred, Proj proj = {});
   }
 
@@ -2155,18 +2155,18 @@ namespace std {
     template<class I, class O1, class O2>
       using partition_copy_result = in_out_out_result<I, O1, O2>;
 
-    template<input_iterator I, sentinel_for<I> S,
-             weakly_incrementable O1, weakly_incrementable O2,
-             class Proj = identity, indirect_unary_predicate<projected<I, Proj>> Pred>
-      requires indirectly_copyable<I, O1> && indirectly_copyable<I, O2>
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S,
+             @\libconcept{weakly_incrementable}@ O1, @\libconcept{weakly_incrementable}@ O2,
+             class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      requires @\libconcept{indirectly_copyable}@<I, O1> && @\libconcept{indirectly_copyable}@<I, O2>
       constexpr partition_copy_result<I, O1, O2>
         partition_copy(I first, S last, O1 out_true, O2 out_false, Pred pred,
                        Proj proj = {});
-    template<input_range R, weakly_incrementable O1, weakly_incrementable O2,
+    template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O1, @\libconcept{weakly_incrementable}@ O2,
              class Proj = identity,
-             indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
-      requires indirectly_copyable<iterator_t<R>, O1> &&
-               indirectly_copyable<iterator_t<R>, O2>
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O1> &&
+               @\libconcept{indirectly_copyable}@<iterator_t<R>, O2>
       constexpr partition_copy_result<borrowed_iterator_t<R>, O1, O2>
         partition_copy(R&& r, O1 out_true, O2 out_false, Pred pred, Proj proj = {});
   }
@@ -2177,11 +2177,11 @@ namespace std {
                       Predicate pred);
 
   namespace ranges {
-    template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
-             indirect_unary_predicate<projected<I, Proj>> Pred>
+    template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
       constexpr I partition_point(I first, S last, Pred pred, Proj proj = {});
-    template<forward_range R, class Proj = identity,
-             indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+    template<@\libconcept{forward_range}@ R, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
       constexpr borrowed_iterator_t<R>
         partition_point(R&& r, Pred pred, Proj proj = {});
   }
@@ -2217,16 +2217,16 @@ namespace std {
     template<class I1, class I2, class O>
       using merge_result = in_in_out_result<I1, I2, O>;
 
-    template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
-             weakly_incrementable O, class Comp = ranges::less, class Proj1 = identity,
+    template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
+             @\libconcept{weakly_incrementable}@ O, class Comp = ranges::less, class Proj1 = identity,
              class Proj2 = identity>
-      requires mergeable<I1, I2, O, Comp, Proj1, Proj2>
+      requires @\libconcept{mergeable}@<I1, I2, O, Comp, Proj1, Proj2>
       constexpr merge_result<I1, I2, O>
         merge(I1 first1, S1 last1, I2 first2, S2 last2, O result,
               Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
-    template<input_range R1, input_range R2, weakly_incrementable O, class Comp = ranges::less,
+    template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, @\libconcept{weakly_incrementable}@ O, class Comp = ranges::less,
              class Proj1 = identity, class Proj2 = identity>
-      requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
+      requires @\libconcept{mergeable}@<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
       constexpr merge_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
         merge(R1&& r1, R2&& r2, O result,
               Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
@@ -2252,12 +2252,12 @@ namespace std {
                        BidirectionalIterator last, Compare comp);
 
   namespace ranges {
-    template<bidirectional_iterator I, sentinel_for<I> S, class Comp = ranges::less,
+    template<@\libconcept{bidirectional_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
              class Proj = identity>
-      requires sortable<I, Comp, Proj>
+      requires @\libconcept{sortable}@<I, Comp, Proj>
       I inplace_merge(I first, I middle, S last, Comp comp = {}, Proj proj = {});
-    template<bidirectional_range R, class Comp = ranges::less, class Proj = identity>
-      requires sortable<iterator_t<R>, Comp, Proj>
+    template<@\libconcept{bidirectional_range}@ R, class Comp = ranges::less, class Proj = identity>
+      requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
       borrowed_iterator_t<R>
         inplace_merge(R&& r, iterator_t<R> middle, Comp comp = {},
                       Proj proj = {});
@@ -2283,15 +2283,15 @@ namespace std {
                   Compare comp);
 
   namespace ranges {
-    template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
+    template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
              class Proj1 = identity, class Proj2 = identity,
-             indirect_strict_weak_order<projected<I1, Proj1>, projected<I2, Proj2>> Comp =
+             @\libconcept{indirect_strict_weak_order}@<projected<I1, Proj1>, projected<I2, Proj2>> Comp =
                ranges::less>
       constexpr bool includes(I1 first1, S1 last1, I2 first2, S2 last2, Comp comp = {},
                               Proj1 proj1 = {}, Proj2 proj2 = {});
-    template<input_range R1, input_range R2, class Proj1 = identity,
+    template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, class Proj1 = identity,
              class Proj2 = identity,
-             indirect_strict_weak_order<projected<iterator_t<R1>, Proj1>,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R1>, Proj1>,
                                         projected<iterator_t<R2>, Proj2>> Comp = ranges::less>
       constexpr bool includes(R1&& r1, R2&& r2, Comp comp = {},
                               Proj1 proj1 = {}, Proj2 proj2 = {});
@@ -2326,16 +2326,16 @@ namespace std {
     template<class I1, class I2, class O>
       using set_union_result = in_in_out_result<I1, I2, O>;
 
-    template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
-             weakly_incrementable O, class Comp = ranges::less,
+    template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
+             @\libconcept{weakly_incrementable}@ O, class Comp = ranges::less,
              class Proj1 = identity, class Proj2 = identity>
-      requires mergeable<I1, I2, O, Comp, Proj1, Proj2>
+      requires @\libconcept{mergeable}@<I1, I2, O, Comp, Proj1, Proj2>
       constexpr set_union_result<I1, I2, O>
         set_union(I1 first1, S1 last1, I2 first2, S2 last2, O result, Comp comp = {},
                   Proj1 proj1 = {}, Proj2 proj2 = {});
-    template<input_range R1, input_range R2, weakly_incrementable O,
+    template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, @\libconcept{weakly_incrementable}@ O,
              class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
-      requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
+      requires @\libconcept{mergeable}@<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
       constexpr set_union_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
         set_union(R1&& r1, R2&& r2, O result, Comp comp = {},
                   Proj1 proj1 = {}, Proj2 proj2 = {});
@@ -2370,16 +2370,16 @@ namespace std {
     template<class I1, class I2, class O>
       using set_intersection_result = in_in_out_result<I1, I2, O>;
 
-    template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
-             weakly_incrementable O, class Comp = ranges::less,
+    template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
+             @\libconcept{weakly_incrementable}@ O, class Comp = ranges::less,
              class Proj1 = identity, class Proj2 = identity>
-      requires mergeable<I1, I2, O, Comp, Proj1, Proj2>
+      requires @\libconcept{mergeable}@<I1, I2, O, Comp, Proj1, Proj2>
       constexpr set_intersection_result<I1, I2, O>
         set_intersection(I1 first1, S1 last1, I2 first2, S2 last2, O result,
                          Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
-    template<input_range R1, input_range R2, weakly_incrementable O,
+    template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, @\libconcept{weakly_incrementable}@ O,
              class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
-      requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
+      requires @\libconcept{mergeable}@<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
       constexpr set_intersection_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
         set_intersection(R1&& r1, R2&& r2, O result,
                          Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
@@ -2414,16 +2414,16 @@ namespace std {
     template<class I, class O>
       using set_difference_result = in_out_result<I, O>;
 
-    template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
-             weakly_incrementable O, class Comp = ranges::less,
+    template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
+             @\libconcept{weakly_incrementable}@ O, class Comp = ranges::less,
              class Proj1 = identity, class Proj2 = identity>
-      requires mergeable<I1, I2, O, Comp, Proj1, Proj2>
+      requires @\libconcept{mergeable}@<I1, I2, O, Comp, Proj1, Proj2>
       constexpr set_difference_result<I1, O>
         set_difference(I1 first1, S1 last1, I2 first2, S2 last2, O result,
                        Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
-    template<input_range R1, input_range R2, weakly_incrementable O,
+    template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, @\libconcept{weakly_incrementable}@ O,
              class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
-      requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
+      requires @\libconcept{mergeable}@<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
       constexpr set_difference_result<borrowed_iterator_t<R1>, O>
         set_difference(R1&& r1, R2&& r2, O result,
                        Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
@@ -2458,17 +2458,17 @@ namespace std {
     template<class I1, class I2, class O>
       using set_symmetric_difference_result = in_in_out_result<I1, I2, O>;
 
-    template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
-             weakly_incrementable O, class Comp = ranges::less,
+    template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
+             @\libconcept{weakly_incrementable}@ O, class Comp = ranges::less,
              class Proj1 = identity, class Proj2 = identity>
-      requires mergeable<I1, I2, O, Comp, Proj1, Proj2>
+      requires @\libconcept{mergeable}@<I1, I2, O, Comp, Proj1, Proj2>
       constexpr set_symmetric_difference_result<I1, I2, O>
         set_symmetric_difference(I1 first1, S1 last1, I2 first2, S2 last2, O result,
                                  Comp comp = {}, Proj1 proj1 = {},
                                  Proj2 proj2 = {});
-    template<input_range R1, input_range R2, weakly_incrementable O,
+    template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, @\libconcept{weakly_incrementable}@ O,
              class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
-      requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
+      requires @\libconcept{mergeable}@<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
       constexpr set_symmetric_difference_result<borrowed_iterator_t<R1>,
                                                 borrowed_iterator_t<R2>, O>
         set_symmetric_difference(R1&& r1, R2&& r2, O result, Comp comp = {},
@@ -2483,13 +2483,13 @@ namespace std {
                              Compare comp);
 
   namespace ranges {
-    template<random_access_iterator I, sentinel_for<I> S, class Comp = ranges::less,
+    template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
              class Proj = identity>
-      requires sortable<I, Comp, Proj>
+      requires @\libconcept{sortable}@<I, Comp, Proj>
       constexpr I
         push_heap(I first, S last, Comp comp = {}, Proj proj = {});
-    template<random_access_range R, class Comp = ranges::less, class Proj = identity>
-      requires sortable<iterator_t<R>, Comp, Proj>
+    template<@\libconcept{random_access_range}@ R, class Comp = ranges::less, class Proj = identity>
+      requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
       constexpr borrowed_iterator_t<R>
         push_heap(R&& r, Comp comp = {}, Proj proj = {});
   }
@@ -2501,13 +2501,13 @@ namespace std {
                             Compare comp);
 
   namespace ranges {
-    template<random_access_iterator I, sentinel_for<I> S, class Comp = ranges::less,
+    template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
              class Proj = identity>
-      requires sortable<I, Comp, Proj>
+      requires @\libconcept{sortable}@<I, Comp, Proj>
       constexpr I
         pop_heap(I first, S last, Comp comp = {}, Proj proj = {});
-    template<random_access_range R, class Comp = ranges::less, class Proj = identity>
-      requires sortable<iterator_t<R>, Comp, Proj>
+    template<@\libconcept{random_access_range}@ R, class Comp = ranges::less, class Proj = identity>
+      requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
       constexpr borrowed_iterator_t<R>
         pop_heap(R&& r, Comp comp = {}, Proj proj = {});
   }
@@ -2519,13 +2519,13 @@ namespace std {
                              Compare comp);
 
   namespace ranges {
-    template<random_access_iterator I, sentinel_for<I> S, class Comp = ranges::less,
+    template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
              class Proj = identity>
-      requires sortable<I, Comp, Proj>
+      requires @\libconcept{sortable}@<I, Comp, Proj>
       constexpr I
         make_heap(I first, S last, Comp comp = {}, Proj proj = {});
-    template<random_access_range R, class Comp = ranges::less, class Proj = identity>
-      requires sortable<iterator_t<R>, Comp, Proj>
+    template<@\libconcept{random_access_range}@ R, class Comp = ranges::less, class Proj = identity>
+      requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
       constexpr borrowed_iterator_t<R>
         make_heap(R&& r, Comp comp = {}, Proj proj = {});
   }
@@ -2537,13 +2537,13 @@ namespace std {
                              Compare comp);
 
   namespace ranges {
-    template<random_access_iterator I, sentinel_for<I> S, class Comp = ranges::less,
+    template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
              class Proj = identity>
-      requires sortable<I, Comp, Proj>
+      requires @\libconcept{sortable}@<I, Comp, Proj>
       constexpr I
         sort_heap(I first, S last, Comp comp = {}, Proj proj = {});
-    template<random_access_range R, class Comp = ranges::less, class Proj = identity>
-      requires sortable<iterator_t<R>, Comp, Proj>
+    template<@\libconcept{random_access_range}@ R, class Comp = ranges::less, class Proj = identity>
+      requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
       constexpr borrowed_iterator_t<R>
         sort_heap(R&& r, Comp comp = {}, Proj proj = {});
   }
@@ -2562,11 +2562,11 @@ namespace std {
                  Compare comp);
 
   namespace ranges {
-    template<random_access_iterator I, sentinel_for<I> S, class Proj = identity,
-             indirect_strict_weak_order<projected<I, Proj>> Comp = ranges::less>
+    template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
       constexpr bool is_heap(I first, S last, Comp comp = {}, Proj proj = {});
-    template<random_access_range R, class Proj = identity,
-             indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+    template<@\libconcept{random_access_range}@ R, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
       constexpr bool is_heap(R&& r, Comp comp = {}, Proj proj = {});
   }
 
@@ -2588,11 +2588,11 @@ namespace std {
                     Compare comp);
 
   namespace ranges {
-    template<random_access_iterator I, sentinel_for<I> S, class Proj = identity,
-             indirect_strict_weak_order<projected<I, Proj>> Comp = ranges::less>
+    template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
       constexpr I is_heap_until(I first, S last, Comp comp = {}, Proj proj = {});
-    template<random_access_range R, class Proj = identity,
-             indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+    template<@\libconcept{random_access_range}@ R, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
       constexpr borrowed_iterator_t<R>
         is_heap_until(R&& r, Comp comp = {}, Proj proj = {});
   }
@@ -2608,14 +2608,14 @@ namespace std {
 
   namespace ranges {
     template<class T, class Proj = identity,
-             indirect_strict_weak_order<projected<const T*, Proj>> Comp = ranges::less>
+             @\libconcept{indirect_strict_weak_order}@<projected<const T*, Proj>> Comp = ranges::less>
       constexpr const T& min(const T& a, const T& b, Comp comp = {}, Proj proj = {});
-    template<copyable T, class Proj = identity,
-             indirect_strict_weak_order<projected<const T*, Proj>> Comp = ranges::less>
+    template<@\libconcept{copyable}@ T, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<const T*, Proj>> Comp = ranges::less>
       constexpr T min(initializer_list<T> r, Comp comp = {}, Proj proj = {});
-    template<input_range R, class Proj = identity,
-             indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
-      requires indirectly_copyable_storable<iterator_t<R>, range_value_t<R>*>
+    template<@\libconcept{input_range}@ R, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+      requires @\libconcept{indirectly_copyable}@_storable<iterator_t<R>, range_value_t<R>*>
       constexpr range_value_t<R>
         min(R&& r, Comp comp = {}, Proj proj = {});
   }
@@ -2630,14 +2630,14 @@ namespace std {
 
   namespace ranges {
     template<class T, class Proj = identity,
-             indirect_strict_weak_order<projected<const T*, Proj>> Comp = ranges::less>
+             @\libconcept{indirect_strict_weak_order}@<projected<const T*, Proj>> Comp = ranges::less>
       constexpr const T& max(const T& a, const T& b, Comp comp = {}, Proj proj = {});
-    template<copyable T, class Proj = identity,
-             indirect_strict_weak_order<projected<const T*, Proj>> Comp = ranges::less>
+    template<@\libconcept{copyable}@ T, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<const T*, Proj>> Comp = ranges::less>
       constexpr T max(initializer_list<T> r, Comp comp = {}, Proj proj = {});
-    template<input_range R, class Proj = identity,
-             indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
-      requires indirectly_copyable_storable<iterator_t<R>, range_value_t<R>*>
+    template<@\libconcept{input_range}@ R, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+      requires @\libconcept{indirectly_copyable}@_storable<iterator_t<R>, range_value_t<R>*>
       constexpr range_value_t<R>
         max(R&& r, Comp comp = {}, Proj proj = {});
   }
@@ -2655,16 +2655,16 @@ namespace std {
       using minmax_result = min_max_result<T>;
 
     template<class T, class Proj = identity,
-             indirect_strict_weak_order<projected<const T*, Proj>> Comp = ranges::less>
+             @\libconcept{indirect_strict_weak_order}@<projected<const T*, Proj>> Comp = ranges::less>
       constexpr minmax_result<const T&>
         minmax(const T& a, const T& b, Comp comp = {}, Proj proj = {});
-    template<copyable T, class Proj = identity,
-             indirect_strict_weak_order<projected<const T*, Proj>> Comp = ranges::less>
+    template<@\libconcept{copyable}@ T, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<const T*, Proj>> Comp = ranges::less>
       constexpr minmax_result<T>
         minmax(initializer_list<T> r, Comp comp = {}, Proj proj = {});
-    template<input_range R, class Proj = identity,
-             indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
-      requires indirectly_copyable_storable<iterator_t<R>, range_value_t<R>*>
+    template<@\libconcept{input_range}@ R, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+      requires @\libconcept{indirectly_copyable}@_storable<iterator_t<R>, range_value_t<R>*>
       constexpr minmax_result<range_value_t<R>>
         minmax(R&& r, Comp comp = {}, Proj proj = {});
   }
@@ -2683,11 +2683,11 @@ namespace std {
                                 Compare comp);
 
   namespace ranges {
-    template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
-             indirect_strict_weak_order<projected<I, Proj>> Comp = ranges::less>
+    template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
       constexpr I min_element(I first, S last, Comp comp = {}, Proj proj = {});
-    template<forward_range R, class Proj = identity,
-             indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+    template<@\libconcept{forward_range}@ R, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
       constexpr borrowed_iterator_t<R>
         min_element(R&& r, Comp comp = {}, Proj proj = {});
   }
@@ -2706,11 +2706,11 @@ namespace std {
                                 Compare comp);
 
  namespace ranges {
-    template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
-             indirect_strict_weak_order<projected<I, Proj>> Comp = ranges::less>
+    template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
       constexpr I max_element(I first, S last, Comp comp = {}, Proj proj = {});
-    template<forward_range R, class Proj = identity,
-             indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+    template<@\libconcept{forward_range}@ R, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
       constexpr borrowed_iterator_t<R>
         max_element(R&& r, Comp comp = {}, Proj proj = {});
   }
@@ -2734,12 +2734,12 @@ namespace std {
     template<class I>
       using minmax_element_result = min_max_result<I>;
 
-    template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
-             indirect_strict_weak_order<projected<I, Proj>> Comp = ranges::less>
+    template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
       constexpr minmax_element_result<I>
         minmax_element(I first, S last, Comp comp = {}, Proj proj = {});
-    template<forward_range R, class Proj = identity,
-             indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+    template<@\libconcept{forward_range}@ R, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
       constexpr minmax_element_result<borrowed_iterator_t<R>>
         minmax_element(R&& r, Comp comp = {}, Proj proj = {});
   }
@@ -2752,7 +2752,7 @@ namespace std {
 
   namespace ranges {
     template<class T, class Proj = identity,
-             indirect_strict_weak_order<projected<const T*, Proj>> Comp = ranges::less>
+             @\libconcept{indirect_strict_weak_order}@<projected<const T*, Proj>> Comp = ranges::less>
       constexpr const T&
         clamp(const T& v, const T& lo, const T& hi, Comp comp = {}, Proj proj = {});
   }
@@ -2781,16 +2781,16 @@ namespace std {
                               Compare comp);
 
   namespace ranges {
-    template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
+    template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
              class Proj1 = identity, class Proj2 = identity,
-             indirect_strict_weak_order<projected<I1, Proj1>, projected<I2, Proj2>> Comp =
+             @\libconcept{indirect_strict_weak_order}@<projected<I1, Proj1>, projected<I2, Proj2>> Comp =
                ranges::less>
       constexpr bool
         lexicographical_compare(I1 first1, S1 last1, I2 first2, S2 last2,
                                 Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
-    template<input_range R1, input_range R2, class Proj1 = identity,
+    template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, class Proj1 = identity,
              class Proj2 = identity,
-             indirect_strict_weak_order<projected<iterator_t<R1>, Proj1>,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R1>, Proj1>,
                                         projected<iterator_t<R2>, Proj2>> Comp = ranges::less>
       constexpr bool
         lexicographical_compare(R1&& r1, R2&& r2, Comp comp = {},
@@ -2821,14 +2821,14 @@ namespace std {
     template<class I>
       using next_permutation_result = in_found_result<I>;
 
-    template<bidirectional_iterator I, sentinel_for<I> S, class Comp = ranges::less,
+    template<@\libconcept{bidirectional_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
              class Proj = identity>
-      requires sortable<I, Comp, Proj>
+      requires @\libconcept{sortable}@<I, Comp, Proj>
       constexpr next_permutation_result<I>
         next_permutation(I first, S last, Comp comp = {}, Proj proj = {});
-    template<bidirectional_range R, class Comp = ranges::less,
+    template<@\libconcept{bidirectional_range}@ R, class Comp = ranges::less,
              class Proj = identity>
-      requires sortable<iterator_t<R>, Comp, Proj>
+      requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
       constexpr next_permutation_result<borrowed_iterator_t<R>>
         next_permutation(R&& r, Comp comp = {}, Proj proj = {});
   }
@@ -2844,14 +2844,14 @@ namespace std {
     template<class I>
       using prev_permutation_result = in_found_result<I>;
 
-    template<bidirectional_iterator I, sentinel_for<I> S, class Comp = ranges::less,
+    template<@\libconcept{bidirectional_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
              class Proj = identity>
-      requires sortable<I, Comp, Proj>
+      requires @\libconcept{sortable}@<I, Comp, Proj>
       constexpr prev_permutation_result<I>
         prev_permutation(I first, S last, Comp comp = {}, Proj proj = {});
-    template<bidirectional_range R, class Comp = ranges::less,
+    template<@\libconcept{bidirectional_range}@ R, class Comp = ranges::less,
              class Proj = identity>
-      requires sortable<iterator_t<R>, Comp, Proj>
+      requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
       constexpr prev_permutation_result<borrowed_iterator_t<R>>
         prev_permutation(R&& r, Comp comp = {}, Proj proj = {});
   }
@@ -3016,11 +3016,11 @@ template<class ExecutionPolicy, class ForwardIterator, class Predicate>
   bool all_of(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last,
               Predicate pred);
 
-template<input_iterator I, sentinel_for<I> S, class Proj = identity,
-         indirect_unary_predicate<projected<I, Proj>> Pred>
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
   constexpr bool ranges::all_of(I first, S last, Pred pred, Proj proj = {});
-template<input_range R, class Proj = identity,
-         indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+template<@\libconcept{input_range}@ R, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
   constexpr bool ranges::all_of(R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
@@ -3056,11 +3056,11 @@ template<class ExecutionPolicy, class ForwardIterator, class Predicate>
   bool any_of(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last,
               Predicate pred);
 
-template<input_iterator I, sentinel_for<I> S, class Proj = identity,
-         indirect_unary_predicate<projected<I, Proj>> Pred>
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
   constexpr bool ranges::any_of(I first, S last, Pred pred, Proj proj = {});
-template<input_range R, class Proj = identity,
-         indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+template<@\libconcept{input_range}@ R, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
   constexpr bool ranges::any_of(R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
@@ -3096,11 +3096,11 @@ template<class ExecutionPolicy, class ForwardIterator, class Predicate>
   bool none_of(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last,
                Predicate pred);
 
-template<input_iterator I, sentinel_for<I> S, class Proj = identity,
-         indirect_unary_predicate<projected<I, Proj>> Pred>
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
   constexpr bool ranges::none_of(I first, S last, Pred pred, Proj proj = {});
-template<input_range R, class Proj = identity,
-         indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+template<@\libconcept{input_range}@ R, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
   constexpr bool ranges::none_of(R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
@@ -3209,12 +3209,12 @@ since parallelization may not permit efficient state accumulation.
 
 \indexlibraryglobal{for_each}%
 \begin{itemdecl}
-template<input_iterator I, sentinel_for<I> S, class Proj = identity,
-         indirectly_unary_invocable<projected<I, Proj>> Fun>
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+         @\libconcept{indirectly_unary_invocable}@<projected<I, Proj>> Fun>
   constexpr ranges::for_each_result<I, Fun>
     ranges::for_each(I first, S last, Fun f, Proj proj = {});
-template<input_range R, class Proj = identity,
-         indirectly_unary_invocable<projected<iterator_t<R>, Proj>> Fun>
+template<@\libconcept{input_range}@ R, class Proj = identity,
+         @\libconcept{indirectly_unary_invocable}@<projected<iterator_t<R>, Proj>> Fun>
   constexpr ranges::for_each_result<borrowed_iterator_t<R>, Fun>
     ranges::for_each(R&& r, Fun f, Proj proj = {});
 \end{itemdecl}
@@ -3336,7 +3336,7 @@ to make arbitrary copies of elements from the input sequence.
 \indexlibraryglobal{for_each_n}%
 \begin{itemdecl}
 template<input_iterator I, class Proj = identity,
-         indirectly_unary_invocable<projected<I, Proj>> Fun>
+         @\libconcept{indirectly_unary_invocable}@<projected<I, Proj>> Fun>
   constexpr ranges::for_each_n_result<I, Fun>
     ranges::for_each_n(I first, iter_difference_t<I> n, Fun f, Proj proj = {});
 \end{itemdecl}
@@ -3399,25 +3399,25 @@ template<class ExecutionPolicy, class ForwardIterator, class Predicate>
                               ForwardIterator first, ForwardIterator last,
                               Predicate pred);
 
-template<input_iterator I, sentinel_for<I> S, class T, class Proj = identity>
-  requires indirect_binary_predicate<ranges::equal_to, projected<I, Proj>, const T*>
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T, class Proj = identity>
+  requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T*>
   constexpr I ranges::find(I first, S last, const T& value, Proj proj = {});
-template<input_range R, class T, class Proj = identity>
-  requires indirect_binary_predicate<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
+template<@\libconcept{input_range}@ R, class T, class Proj = identity>
+  requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
   constexpr borrowed_iterator_t<R>
     ranges::find(R&& r, const T& value, Proj proj = {});
-template<input_iterator I, sentinel_for<I> S, class Proj = identity,
-         indirect_unary_predicate<projected<I, Proj>> Pred>
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
   constexpr I ranges::find_if(I first, S last, Pred pred, Proj proj = {});
-template<input_range R, class Proj = identity,
-         indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+template<@\libconcept{input_range}@ R, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
   constexpr borrowed_iterator_t<R>
     ranges::find_if(R&& r, Pred pred, Proj proj = {});
-template<input_iterator I, sentinel_for<I> S, class Proj = identity,
-         indirect_unary_predicate<projected<I, Proj>> Pred>
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
   constexpr I ranges::find_if_not(I first, S last, Pred pred, Proj proj = {});
-template<input_range R, class Proj = identity,
-         indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+template<@\libconcept{input_range}@ R, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
   constexpr borrowed_iterator_t<R>
     ranges::find_if_not(R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
@@ -3474,15 +3474,15 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
              ForwardIterator2 first2, ForwardIterator2 last2,
              BinaryPredicate pred);
 
-template<forward_iterator I1, sentinel_for<I1> S1, forward_iterator I2, sentinel_for<I2> S2,
+template<@\libconcept{forward_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{forward_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
          class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
-  requires indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
+  requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
   constexpr subrange<I1>
     ranges::find_end(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = {},
                      Proj1 proj1 = {}, Proj2 proj2 = {});
-template<forward_range R1, forward_range R2,
+template<@\libconcept{forward_range}@ R1, @\libconcept{forward_range}@ R2,
          class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
-  requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+  requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
   constexpr borrowed_subrange_t<R1>
     ranges::find_end(R1&& r1, R2&& r2, Pred pred = {},
                      Proj1 proj1 = {}, Proj2 proj2 = {});
@@ -3559,15 +3559,15 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
                   ForwardIterator2 first2, ForwardIterator2 last2,
                   BinaryPredicate pred);
 
-template<input_iterator I1, sentinel_for<I1> S1, forward_iterator I2, sentinel_for<I2> S2,
+template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{forward_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
          class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
-  requires indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
+  requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
   constexpr I1 ranges::find_first_of(I1 first1, S1 last1, I2 first2, S2 last2,
                                      Pred pred = {},
                                      Proj1 proj1 = {}, Proj2 proj2 = {});
-template<input_range R1, forward_range R2,
+template<@\libconcept{input_range}@ R1, @\libconcept{forward_range}@ R2,
          class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
-  requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+  requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
   constexpr borrowed_iterator_t<R1>
     ranges::find_first_of(R1&& r1, R2&& r2,
                           Pred pred = {},
@@ -3624,12 +3624,12 @@ template<class ExecutionPolicy, class ForwardIterator, class BinaryPredicate>
                   ForwardIterator first, ForwardIterator last,
                   BinaryPredicate pred);
 
-template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
-         indirect_binary_predicate<projected<I, Proj>,
+template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+         @\libconcept{indirect_binary_predicate}@<projected<I, Proj>,
                                    projected<I, Proj>> Pred = ranges::equal_to>
   constexpr I ranges::adjacent_find(I first, S last, Pred pred = {}, Proj proj = {});
-template<forward_range R, class Proj = identity,
-         indirect_binary_predicate<projected<iterator_t<R>, Proj>,
+template<@\libconcept{forward_range}@ R, class Proj = identity,
+         @\libconcept{indirect_binary_predicate}@<projected<iterator_t<R>, Proj>,
                                    projected<iterator_t<R>, Proj>> Pred = ranges::equal_to>
   constexpr borrowed_iterator_t<R> ranges::adjacent_find(R&& r, Pred pred = {}, Proj proj = {});
 \end{itemdecl}
@@ -3683,20 +3683,20 @@ template<class ExecutionPolicy, class ForwardIterator, class Predicate>
     count_if(ExecutionPolicy&& exec,
              ForwardIterator first, ForwardIterator last, Predicate pred);
 
-template<input_iterator I, sentinel_for<I> S, class T, class Proj = identity>
-  requires indirect_binary_predicate<ranges::equal_to, projected<I, Proj>, const T*>
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T, class Proj = identity>
+  requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T*>
   constexpr iter_difference_t<I>
     ranges::count(I first, S last, const T& value, Proj proj = {});
-template<input_range R, class T, class Proj = identity>
-  requires indirect_binary_predicate<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
+template<@\libconcept{input_range}@ R, class T, class Proj = identity>
+  requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
   constexpr range_difference_t<R>
     ranges::count(R&& r, const T& value, Proj proj = {});
-template<input_iterator I, sentinel_for<I> S, class Proj = identity,
-         indirect_unary_predicate<projected<I, Proj>> Pred>
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
   constexpr iter_difference_t<I>
     ranges::count_if(I first, S last, Pred pred, Proj proj = {});
-template<input_range R, class Proj = identity,
-         indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+template<@\libconcept{input_range}@ R, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
   constexpr range_difference_t<R>
     ranges::count_if(R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
@@ -3780,15 +3780,15 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
              ForwardIterator2 first2, ForwardIterator2 last2,
              BinaryPredicate pred);
 
-template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
+template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
          class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
-  requires indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
+  requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
   constexpr ranges::mismatch_result<I1, I2>
     ranges::mismatch(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = {},
                      Proj1 proj1 = {}, Proj2 proj2 = {});
-template<input_range R1, input_range R2,
+template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2,
          class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
-  requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+  requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
   constexpr ranges::mismatch_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
     ranges::mismatch(R1&& r1, R2&& r2, Pred pred = {},
                      Proj1 proj1 = {}, Proj2 proj2 = {});
@@ -3871,15 +3871,15 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
              ForwardIterator2 first2, ForwardIterator2 last2,
              BinaryPredicate pred);
 
-template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
+template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
          class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
-  requires indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
+  requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
   constexpr bool ranges::equal(I1 first1, S1 last1, I2 first2, S2 last2,
                                Pred pred = {},
                                Proj1 proj1 = {}, Proj2 proj2 = {});
-template<input_range R1, input_range R2, class Pred = ranges::equal_to,
+template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, class Pred = ranges::equal_to,
          class Proj1 = identity, class Proj2 = identity>
-  requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+  requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
   constexpr bool ranges::equal(R1&& r1, R2&& r2, Pred pred = {},
                                Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
@@ -4005,16 +4005,16 @@ otherwise, at worst \bigoh{N^2}, where $N$ has the value \tcode{last1 - first1}.
 
 \indexlibraryglobal{is_permutation}%
 \begin{itemdecl}
-template<forward_iterator I1, sentinel_for<I1> S1, forward_iterator I2,
-         sentinel_for<I2> S2, class Proj1 = identity, class Proj2 = identity,
-         indirect_equivalence_relation<projected<I1, Proj1>,
+template<@\libconcept{forward_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{forward_iterator}@ I2,
+         @\libconcept{sentinel_for}@<I2> S2, class Proj1 = identity, class Proj2 = identity,
+         @\libconcept{indirect_equivalence_relation}@<projected<I1, Proj1>,
                                        projected<I2, Proj2>> Pred = ranges::equal_to>
   constexpr bool ranges::is_permutation(I1 first1, S1 last1, I2 first2, S2 last2,
                                         Pred pred = {},
                                         Proj1 proj1 = {}, Proj2 proj2 = {});
-template<forward_range R1, forward_range R2,
+template<@\libconcept{forward_range}@ R1, @\libconcept{forward_range}@ R2,
          class Proj1 = identity, class Proj2 = identity,
-         indirect_equivalence_relation<projected<iterator_t<R1>, Proj1>,
+         @\libconcept{indirect_equivalence_relation}@<projected<iterator_t<R1>, Proj1>,
                                        projected<iterator_t<R2>, Proj2>> Pred = ranges::equal_to>
   constexpr bool ranges::is_permutation(R1&& r1, R2&& r2, Pred pred = {},
                                         Proj1 proj1 = {}, Proj2 proj2 = {});
@@ -4094,16 +4094,16 @@ of the corresponding predicate.
 
 \indexlibraryglobal{search}%
 \begin{itemdecl}
-template<forward_iterator I1, sentinel_for<I1> S1, forward_iterator I2,
-         sentinel_for<I2> S2, class Pred = ranges::equal_to,
+template<@\libconcept{forward_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{forward_iterator}@ I2,
+         @\libconcept{sentinel_for}@<I2> S2, class Pred = ranges::equal_to,
          class Proj1 = identity, class Proj2 = identity>
-  requires indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
+  requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
   constexpr subrange<I1>
     ranges::search(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = {},
                    Proj1 proj1 = {}, Proj2 proj2 = {});
-template<forward_range R1, forward_range R2, class Pred = ranges::equal_to,
+template<@\libconcept{forward_range}@ R1, @\libconcept{forward_range}@ R2, class Pred = ranges::equal_to,
          class Proj1 = identity, class Proj2 = identity>
-  requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+  requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
   constexpr borrowed_subrange_t<R1>
     ranges::search(R1&& r1, R2&& r2, Pred pred = {},
                    Proj1 proj1 = {}, Proj2 proj2 = {});
@@ -4183,15 +4183,15 @@ At most \tcode{last - first} applications of the corresponding predicate.
 
 \indexlibraryglobal{search_n}%
 \begin{itemdecl}
-template<forward_iterator I, sentinel_for<I> S, class T,
+template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T,
          class Pred = ranges::equal_to, class Proj = identity>
-  requires indirectly_comparable<I, const T*, Pred, Proj>
+  requires @\libconcept{indirectly_comparable}@<I, const T*, Pred, Proj>
   constexpr subrange<I>
     ranges::search_n(I first, S last, iter_difference_t<I> count,
                      const T& value, Pred pred = {}, Proj proj = {});
-template<forward_range R, class T, class Pred = ranges::equal_to,
+template<@\libconcept{forward_range}@ R, class T, class Pred = ranges::equal_to,
          class Proj = identity>
-  requires indirectly_comparable<iterator_t<R>, const T*, Pred, Proj>
+  requires @\libconcept{indirectly_comparable}@<iterator_t<R>, const T*, Pred, Proj>
   constexpr borrowed_subrange_t<R>
     ranges::search_n(R&& r, range_difference_t<R> count,
                      const T& value, Pred pred = {}, Proj proj = {});
@@ -4240,11 +4240,11 @@ template<class InputIterator, class OutputIterator>
   constexpr OutputIterator copy(InputIterator first, InputIterator last,
                                 OutputIterator result);
 
-template<input_iterator I, sentinel_for<I> S, weakly_incrementable O>
-  requires indirectly_copyable<I, O>
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O>
+  requires @\libconcept{indirectly_copyable}@<I, O>
   constexpr ranges::copy_result<I, O> ranges::copy(I first, S last, O result);
-template<input_range R, weakly_incrementable O>
-  requires indirectly_copyable<iterator_t<R>, O>
+template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O>
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O>
   constexpr ranges::copy_result<borrowed_iterator_t<R>, O> ranges::copy(R&& r, O result);
 \end{itemdecl}
 
@@ -4318,8 +4318,8 @@ template<class ExecutionPolicy, class ForwardIterator1, class Size, class Forwar
                           ForwardIterator1 first, Size n,
                           ForwardIterator2 result);
 
-template<input_iterator I, weakly_incrementable O>
-  requires indirectly_copyable<I, O>
+template<@\libconcept{input_iterator}@ I, @\libconcept{weakly_incrementable}@ O>
+  requires @\libconcept{indirectly_copyable}@<I, O>
   constexpr ranges::copy_n_result<I, O>
     ranges::copy_n(I first, iter_difference_t<I> n, O result);
 \end{itemdecl}
@@ -4365,14 +4365,14 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
                            ForwardIterator1 first, ForwardIterator1 last,
                            ForwardIterator2 result, Predicate pred);
 
-template<input_iterator I, sentinel_for<I> S, weakly_incrementable O, class Proj = identity,
-         indirect_unary_predicate<projected<I, Proj>> Pred>
-  requires indirectly_copyable<I, O>
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  requires @\libconcept{indirectly_copyable}@<I, O>
   constexpr ranges::copy_if_result<I, O>
     ranges::copy_if(I first, S last, O result, Pred pred, Proj proj = {});
-template<input_range R, weakly_incrementable O, class Proj = identity,
-         indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
-  requires indirectly_copyable<iterator_t<R>, O>
+template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O>
   constexpr ranges::copy_if_result<borrowed_iterator_t<R>, O>
     ranges::copy_if(R&& r, O result, Pred pred, Proj proj = {});
 \end{itemdecl}
@@ -4437,12 +4437,12 @@ template<class BidirectionalIterator1, class BidirectionalIterator2>
                   BidirectionalIterator1 last,
                   BidirectionalIterator2 result);
 
-template<bidirectional_iterator I1, sentinel_for<I1> S1, bidirectional_iterator I2>
-  requires indirectly_copyable<I1, I2>
+template<@\libconcept{bidirectional_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{bidirectional_iterator}@ I2>
+  requires @\libconcept{indirectly_copyable}@<I1, I2>
   constexpr ranges::copy_backward_result<I1, I2>
     ranges::copy_backward(I1 first, S1 last, I2 result);
-template<bidirectional_range R, bidirectional_iterator I>
-  requires indirectly_copyable<iterator_t<R>, I>
+template<@\libconcept{bidirectional_range}@ R, @\libconcept{bidirectional_iterator}@ I>
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R>, I>
   constexpr ranges::copy_backward_result<borrowed_iterator_t<R>, I>
     ranges::copy_backward(R&& r, I result);
 \end{itemdecl}
@@ -4489,12 +4489,12 @@ template<class InputIterator, class OutputIterator>
   constexpr OutputIterator move(InputIterator first, InputIterator last,
                                 OutputIterator result);
 
-template<input_iterator I, sentinel_for<I> S, weakly_incrementable O>
-  requires indirectly_movable<I, O>
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O>
+  requires @\libconcept{indirectly_movable}@<I, O>
   constexpr ranges::move_result<I, O>
     ranges::move(I first, S last, O result);
-template<input_range R, weakly_incrementable O>
-  requires indirectly_movable<iterator_t<R>, O>
+template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O>
+  requires @\libconcept{indirectly_movable}@<iterator_t<R>, O>
   constexpr ranges::move_result<borrowed_iterator_t<R>, O>
     ranges::move(R&& r, O result);
 \end{itemdecl}
@@ -4579,12 +4579,12 @@ template<class BidirectionalIterator1, class BidirectionalIterator2>
     move_backward(BidirectionalIterator1 first, BidirectionalIterator1 last,
                   BidirectionalIterator2 result);
 
-template<bidirectional_iterator I1, sentinel_for<I1> S1, bidirectional_iterator I2>
-  requires indirectly_movable<I1, I2>
+template<@\libconcept{bidirectional_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{bidirectional_iterator}@ I2>
+  requires @\libconcept{indirectly_movable}@<I1, I2>
   constexpr ranges::move_backward_result<I1, I2>
     ranges::move_backward(I1 first, S1 last, I2 result);
-template<bidirectional_range R, bidirectional_iterator I>
-  requires indirectly_movable<iterator_t<R>, I>
+template<@\libconcept{bidirectional_range}@ R, @\libconcept{bidirectional_iterator}@ I>
+  requires @\libconcept{indirectly_movable}@<iterator_t<R>, I>
   constexpr ranges::move_backward_result<borrowed_iterator_t<R>, I>
     ranges::move_backward(R&& r, I result);
 \end{itemdecl}
@@ -4646,12 +4646,12 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
                 ForwardIterator1 first1, ForwardIterator1 last1,
                 ForwardIterator2 first2);
 
-template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2>
-  requires indirectly_swappable<I1, I2>
+template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2>
+  requires @\libconcept{indirectly_swappable}@<I1, I2>
   constexpr ranges::swap_ranges_result<I1, I2>
     ranges::swap_ranges(I1 first1, S1 last1, I2 first2, S2 last2);
-template<input_range R1, input_range R2>
-  requires indirectly_swappable<iterator_t<R1>, iterator_t<R2>>
+template<@\libconcept{input_range}@ R1, input_range R2>
+  requires @\libconcept{indirectly_swappable}@<iterator_t<R1>, iterator_t<R2>>
   constexpr ranges::swap_ranges_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
     ranges::swap_ranges(R1&& r1, R2&& r2);
 \end{itemdecl}
@@ -4749,27 +4749,27 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
               ForwardIterator2 first2, ForwardIterator result,
               BinaryOperation binary_op);
 
-template<input_iterator I, sentinel_for<I> S, weakly_incrementable O,
-         copy_constructible F, class Proj = identity>
-  requires writable<O, indirect_result_t<F&, projected<I, Proj>>>
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O,
+         @\libconcept{copy_constructible}@ F, class Proj = identity>
+  requires @\libconcept{writable}@<O, indirect_result_t<F&, projected<I, Proj>>>
   constexpr ranges::unary_transform_result<I, O>
     ranges::transform(I first1, S last1, O result, F op, Proj proj = {});
-template<input_range R, weakly_incrementable O, copy_constructible F,
+template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O, @\libconcept{copy_constructible}@ F,
          class Proj = identity>
-  requires writable<O, indirect_result_t<F&, projected<iterator_t<R>, Proj>>>
+  requires @\libconcept{writable}@<O, indirect_result_t<F&, projected<iterator_t<R>, Proj>>>
   constexpr ranges::unary_transform_result<borrowed_iterator_t<R>, O>
     ranges::transform(R&& r, O result, F op, Proj proj = {});
-template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
-         weakly_incrementable O, copy_constructible F, class Proj1 = identity,
+template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
+         @\libconcept{weakly_incrementable}@ O, @\libconcept{copy_constructible}@ F, class Proj1 = identity,
          class Proj2 = identity>
-  requires writable<O, indirect_result_t<F&, projected<I1, Proj1>,
+  requires @\libconcept{writable}@<O, indirect_result_t<F&, projected<I1, Proj1>,
                                          projected<I2, Proj2>>>
   constexpr ranges::binary_transform_result<I1, I2, O>
     ranges::transform(I1 first1, S1 last1, I2 first2, S2 last2, O result,
                       F binary_op, Proj1 proj1 = {}, Proj2 proj2 = {});
-template<input_range R1, input_range R2, weakly_incrementable O,
-         copy_constructible F, class Proj1 = identity, class Proj2 = identity>
-  requires writable<O, indirect_result_t<F&, projected<iterator_t<R1>, Proj1>,
+template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, @\libconcept{weakly_incrementable}@ O,
+         @\libconcept{copy_constructible}@ F, class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{writable}@<O, indirect_result_t<F&, projected<iterator_t<R1>, Proj1>,
                                          projected<iterator_t<R2>, Proj2>>>
   constexpr ranges::binary_transform_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
     ranges::transform(R1&& r1, R2&& r2, O result,
@@ -4869,23 +4869,23 @@ template<class ExecutionPolicy, class ForwardIterator, class Predicate, class T>
                   ForwardIterator first, ForwardIterator last,
                   Predicate pred, const T& new_value);
 
-template<input_iterator I, sentinel_for<I> S, class T1, class T2, class Proj = identity>
-  requires writable<I, const T2&> &&
-           indirect_binary_predicate<ranges::equal_to, projected<I, Proj>, const T1*>
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T1, class T2, class Proj = identity>
+  requires @\libconcept{writable}@<I, const T2&> &&
+           @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T1*>
   constexpr I
     ranges::replace(I first, S last, const T1& old_value, const T2& new_value, Proj proj = {});
-template<input_range R, class T1, class T2, class Proj = identity>
-  requires writable<iterator_t<R>, const T2&> &&
-           indirect_binary_predicate<ranges::equal_to, projected<iterator_t<R>, Proj>, const T1*>
+template<@\libconcept{input_range}@ R, class T1, class T2, class Proj = identity>
+  requires @\libconcept{writable}@<iterator_t<R>, const T2&> &&
+           @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<iterator_t<R>, Proj>, const T1*>
   constexpr borrowed_iterator_t<R>
     ranges::replace(R&& r, const T1& old_value, const T2& new_value, Proj proj = {});
-template<input_iterator I, sentinel_for<I> S, class T, class Proj = identity,
-         indirect_unary_predicate<projected<I, Proj>> Pred>
-  requires writable<I, const T&>
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  requires @\libconcept{writable}@<I, const T&>
   constexpr I ranges::replace_if(I first, S last, Pred pred, const T& new_value, Proj proj = {});
-template<input_range R, class T, class Proj = identity,
-         indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
-  requires writable<iterator_t<R>, const T&>
+template<@\libconcept{input_range}@ R, class T, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  requires @\libconcept{writable}@<iterator_t<R>, const T&>
   constexpr borrowed_iterator_t<R>
     ranges::replace_if(R&& r, Pred pred, const T& new_value, Proj proj = {});
 \end{itemdecl}
@@ -4949,30 +4949,30 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
                     ForwardIterator2 result,
                     Predicate pred, const T& new_value);
 
-template<input_iterator I, sentinel_for<I> S, class T1, class T2, output_iterator<const T2&> O,
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T1, class T2, @\libconcept{output_iterator}@<const T2&> O,
          class Proj = identity>
-  requires indirectly_copyable<I, O> &&
-           indirect_binary_predicate<ranges::equal_to, projected<I, Proj>, const T1*>
+  requires @\libconcept{indirectly_copyable}@<I, O> &&
+           @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T1*>
   constexpr ranges::replace_copy_result<I, O>
     ranges::replace_copy(I first, S last, O result, const T1& old_value, const T2& new_value,
                          Proj proj = {});
-template<input_range R, class T1, class T2, output_iterator<const T2&> O,
+template<@\libconcept{input_range}@ R, class T1, class T2, @\libconcept{output_iterator}@<const T2&> O,
          class Proj = identity>
-  requires indirectly_copyable<iterator_t<R>, O> &&
-           indirect_binary_predicate<ranges::equal_to, projected<iterator_t<R>, Proj>, const T1*>
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O> &&
+           @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<iterator_t<R>, Proj>, const T1*>
   constexpr ranges::replace_copy_result<borrowed_iterator_t<R>, O>
     ranges::replace_copy(R&& r, O result, const T1& old_value, const T2& new_value,
                          Proj proj = {});
 
-template<input_iterator I, sentinel_for<I> S, class T, output_iterator<const T&> O,
-         class Proj = identity, indirect_unary_predicate<projected<I, Proj>> Pred>
-  requires indirectly_copyable<I, O>
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T, @\libconcept{output_iterator}@<const T&> O,
+         class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  requires @\libconcept{indirectly_copyable}@<I, O>
   constexpr ranges::replace_copy_if_result<I, O>
     ranges::replace_copy_if(I first, S last, O result, Pred pred, const T& new_value,
                             Proj proj = {});
-template<input_range R, class T, output_iterator<const T&> O, class Proj = identity,
-         indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
-  requires indirectly_copyable<iterator_t<R>, O>
+template<@\libconcept{input_range}@ R, class T, @\libconcept{output_iterator}@<const T&> O, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O>
   constexpr ranges::replace_copy_if_result<borrowed_iterator_t<R>, O>
     ranges::replace_copy_if(R&& r, O result, Pred pred, const T& new_value,
                             Proj proj = {});
@@ -5045,11 +5045,11 @@ template<class ExecutionPolicy, class ForwardIterator, class Size, class T>
                          ForwardIterator first, Size n, const T& value);
 
 
-template<class T, output_iterator<const T&> O, sentinel_for<O> S>
+template<class T, @\libconcept{output_iterator}@<const T&> O, @\libconcept{sentinel_for}@<O> S>
   constexpr O ranges::fill(O first, S last, const T& value);
-template<class T, output_range<const T&> R>
+template<class T, @\libconcept{output_range}@<const T&> R>
   constexpr borrowed_iterator_t<R> ranges::fill(R&& r, const T& value);
-template<class T, output_iterator<const T&> O>
+template<class T, @\libconcept{output_iterator}@<const T&> O>
   constexpr O ranges::fill_n(O first, iter_difference_t<O> n, const T& value);
 \end{itemdecl}
 
@@ -5098,14 +5098,14 @@ template<class ExecutionPolicy, class ForwardIterator, class Size, class Generat
   ForwardIterator generate_n(ExecutionPolicy&& exec,
                              ForwardIterator first, Size n, Generator gen);
 
-template<input_or_output_iterator O, sentinel_for<O> S, copy_constructible F>
-  requires invocable<F&> && writable<O, invoke_result_t<F&>>
+template<@\libconcept{input_or_output_iterator}@ O, @\libconcept{sentinel_for}@<O> S, @\libconcept{copy_constructible}@ F>
+  requires @\libconcept{invocable}@<F&> && @\libconcept{writable}@<O, invoke_result_t<F&>>
   constexpr O ranges::generate(O first, S last, F gen);
-template<class R, copy_constructible F>
-  requires invocable<F&> && output_range<R, invoke_result_t<F&>>
+template<class R, @\libconcept{copy_constructible}@ F>
+  requires @\libconcept{invocable}@<F&> && @\libconcept{output_range}@<R, invoke_result_t<F&>>
   constexpr borrowed_iterator_t<R> ranges::generate(R&& r, F gen);
-template<input_or_output_iterator O, copy_constructible F>
-  requires invocable<F&> && writable<O, invoke_result_t<F&>>
+template<@\libconcept{input_or_output_iterator}@ O, @\libconcept{copy_constructible}@ F>
+  requires @\libconcept{invocable}@<F&> && @\libconcept{writable}@<O, invoke_result_t<F&>>
   constexpr O ranges::generate_n(O first, iter_difference_t<O> n, F gen);
 \end{itemdecl}
 
@@ -5154,20 +5154,20 @@ template<class ExecutionPolicy, class ForwardIterator, class Predicate>
                             ForwardIterator first, ForwardIterator last,
                             Predicate pred);
 
-template<permutable I, sentinel_for<I> S, class T, class Proj = identity>
-  requires indirect_binary_predicate<ranges::equal_to, projected<I, Proj>, const T*>
+template<@\libconcept{permutable}@ I, @\libconcept{sentinel_for}@<I> S, class T, class Proj = identity>
+  requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T*>
   constexpr subrange<I> ranges::remove(I first, S last, const T& value, Proj proj = {});
-template<forward_range R, class T, class Proj = identity>
-  requires permutable<iterator_t<R>> &&
-           indirect_binary_predicate<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
+template<@\libconcept{forward_range}@ R, class T, class Proj = identity>
+  requires @\libconcept{permutable}@<iterator_t<R>> &&
+           @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
   constexpr borrowed_subrange_t<R>
     ranges::remove(R&& r, const T& value, Proj proj = {});
-template<permutable I, sentinel_for<I> S, class Proj = identity,
-         indirect_unary_predicate<projected<I, Proj>> Pred>
+template<@\libconcept{permutable}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
   constexpr subrange<I> ranges::remove_if(I first, S last, Pred pred, Proj proj = {});
-template<forward_range R, class Proj = identity,
-         indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
-  requires permutable<iterator_t<R>>
+template<@\libconcept{forward_range}@ R, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  requires @\libconcept{permutable}@<iterator_t<R>>
   constexpr borrowed_subrange_t<R>
     ranges::remove_if(R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
@@ -5245,25 +5245,25 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
                    ForwardIterator1 first, ForwardIterator1 last,
                    ForwardIterator2 result, Predicate pred);
 
-template<input_iterator I, sentinel_for<I> S, weakly_incrementable O, class T,
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O, class T,
          class Proj = identity>
-  requires indirectly_copyable<I, O> &&
-           indirect_binary_predicate<ranges::equal_to, projected<I, Proj>, const T*>
+  requires @\libconcept{indirectly_copyable}@<I, O> &&
+           @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T*>
   constexpr ranges::remove_copy_result<I, O>
     ranges::remove_copy(I first, S last, O result, const T& value, Proj proj = {});
-template<input_range R, weakly_incrementable O, class T, class Proj = identity>
-  requires indirectly_copyable<iterator_t<R>, O> &&
-           indirect_binary_predicate<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
+template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O, class T, class Proj = identity>
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O> &&
+           @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
   constexpr ranges::remove_copy_result<borrowed_iterator_t<R>, O>
     ranges::remove_copy(R&& r, O result, const T& value, Proj proj = {});
-template<input_iterator I, sentinel_for<I> S, weakly_incrementable O,
-         class Proj = identity, indirect_unary_predicate<projected<I, Proj>> Pred>
-  requires indirectly_copyable<I, O>
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O,
+         class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  requires @\libconcept{indirectly_copyable}@<I, O>
   constexpr ranges::remove_copy_if_result<I, O>
     ranges::remove_copy_if(I first, S last, O result, Pred pred, Proj proj = {});
-template<input_range R, weakly_incrementable O, class Proj = identity,
-         indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
-  requires indirectly_copyable<iterator_t<R>, O>
+template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O>
   constexpr ranges::remove_copy_if_result<borrowed_iterator_t<R>, O>
     ranges::remove_copy_if(R&& r, O result, Pred pred, Proj proj = {});
 \end{itemdecl}
@@ -5337,12 +5337,12 @@ template<class ExecutionPolicy, class ForwardIterator, class BinaryPredicate>
                          ForwardIterator first, ForwardIterator last,
                          BinaryPredicate pred);
 
-template<permutable I, sentinel_for<I> S, class Proj = identity,
-         indirect_equivalence_relation<projected<I, Proj>> C = ranges::equal_to>
+template<@\libconcept{permutable}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+         @\libconcept{indirect_equivalence_relation}@<projected<I, Proj>> C = ranges::equal_to>
   constexpr subrange<I> ranges::unique(I first, S last, C comp = {}, Proj proj = {});
-template<forward_range R, class Proj = identity,
-         indirect_equivalence_relation<projected<iterator_t<R>, Proj>> C = ranges::equal_to>
-  requires permutable<iterator_t<R>>
+template<@\libconcept{forward_range}@ R, class Proj = identity,
+         @\libconcept{indirect_equivalence_relation}@<projected<iterator_t<R>, Proj>> C = ranges::equal_to>
+  requires @\libconcept{permutable}@<iterator_t<R>>
   constexpr borrowed_subrange_t<R>
     ranges::unique(R&& r, C comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -5415,20 +5415,20 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
                 ForwardIterator1 first, ForwardIterator1 last,
                 ForwardIterator2 result, BinaryPredicate pred);
 
-template<input_iterator I, sentinel_for<I> S, weakly_incrementable O, class Proj = identity,
-         indirect_equivalence_relation<projected<I, Proj>> C = ranges::equal_to>
-  requires indirectly_copyable<I, O> &&
-           (forward_iterator<I> ||
-            (input_iterator<O> && same_as<iter_value_t<I>, iter_value_t<O>>) ||
-            indirectly_copyable_storable<I, O>)
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O, class Proj = identity,
+         @\libconcept{indirect_equivalence_relation}@<projected<I, Proj>> C = ranges::equal_to>
+  requires @\libconcept{indirectly_copyable}@<I, O> &&
+           (@\libconcept{forward_iterator}@<I> ||
+            (@\libconcept{input_iterator}@<O> && @\libconcept{same_as}@<iter_value_t<I>, iter_value_t<O>>) ||
+            @\libconcept{indirectly_copyable_storable}@<I, O>)
   constexpr ranges::unique_copy_result<I, O>
     ranges::unique_copy(I first, S last, O result, C comp = {}, Proj proj = {});
-template<input_range R, weakly_incrementable O, class Proj = identity,
-         indirect_equivalence_relation<projected<iterator_t<R>, Proj>> C = ranges::equal_to>
-  requires indirectly_copyable<iterator_t<R>, O> &&
-           (forward_iterator<iterator_t<R>> ||
-            (input_iterator<O> && same_as<range_value_t<R>, iter_value_t<O>>) ||
-            indirectly_copyable_storable<iterator_t<R>, O>)
+template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O, class Proj = identity,
+         @\libconcept{indirect_equivalence_relation}@<projected<iterator_t<R>, Proj>> C = ranges::equal_to>
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O> &&
+           (@\libconcept{forward_iterator}@<iterator_t<R>> ||
+            (@\libconcept{input_iterator}@<O> && same_as<range_value_t<R>, iter_value_t<O>>) ||
+            @\libconcept{indirectly_copyable_storable}@<iterator_t<R>, O>)
   constexpr ranges::unique_copy_result<borrowed_iterator_t<R>, O>
     ranges::unique_copy(R&& r, O result, C comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -5516,11 +5516,11 @@ template<class ExecutionPolicy, class BidirectionalIterator>
   void reverse(ExecutionPolicy&& exec,
                BidirectionalIterator first, BidirectionalIterator last);
 
-template<bidirectional_iterator I, sentinel_for<I> S>
-  requires permutable<I>
+template<@\libconcept{bidirectional_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
+  requires @\libconcept{permutable}@<I>
   constexpr I ranges::reverse(I first, S last);
-template<bidirectional_range R>
-  requires permutable<iterator_t<R>>
+template<@\libconcept{bidirectional_range}@ R>
+  requires @\libconcept{permutable}@<iterator_t<R>>
   constexpr borrowed_iterator_t<R> ranges::reverse(R&& r);
 \end{itemdecl}
 
@@ -5559,12 +5559,12 @@ template<class ExecutionPolicy, class BidirectionalIterator, class ForwardIterat
                  BidirectionalIterator first, BidirectionalIterator last,
                  ForwardIterator result);
 
-template<bidirectional_iterator I, sentinel_for<I> S, weakly_incrementable O>
-  requires indirectly_copyable<I, O>
+template<@\libconcept{bidirectional_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O>
+  requires @\libconcept{indirectly_copyable}@<I, O>
   constexpr ranges::reverse_copy_result<I, O>
     ranges::reverse_copy(I first, S last, O result);
-template<bidirectional_range R, weakly_incrementable O>
-  requires indirectly_copyable<iterator_t<R>, O>
+template<@\libconcept{bidirectional_range}@ R, @\libconcept{weakly_incrementable}@ O>
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O>
   constexpr ranges::reverse_copy_result<borrowed_iterator_t<R>, O>
     ranges::reverse_copy(R&& r, O result);
 \end{itemdecl}
@@ -5611,7 +5611,7 @@ template<class ExecutionPolicy, class ForwardIterator>
     rotate(ExecutionPolicy&& exec,
            ForwardIterator first, ForwardIterator middle, ForwardIterator last);
 
-template<permutable I, sentinel_for<I> S>
+template<@\libconcept{permutable}@ I, @\libconcept{sentinel_for}@<I> S>
   constexpr subrange<I> ranges::rotate(I first, I middle, S last);
 \end{itemdecl}
 
@@ -5652,8 +5652,8 @@ At most \tcode{last - first} swaps.
 \end{itemdescr}
 
 \begin{itemdecl}
-template<forward_range R>
-  requires permutable<iterator_t<R>>
+template<@\libconcept{forward_range}@ R>
+  requires @\libconcept{permutable}@<iterator_t<R>>
   constexpr borrowed_subrange_t<R> ranges::rotate(R&& r, iterator_t<R> middle);
 \end{itemdecl}
 
@@ -5676,8 +5676,8 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
                 ForwardIterator1 first, ForwardIterator1 middle, ForwardIterator1 last,
                 ForwardIterator2 result);
 
-  template<forward_iterator I, sentinel_for<I> S, weakly_incrementable O>
-    requires indirectly_copyable<I, O>
+  template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O>
+    requires @\libconcept{indirectly_copyable}@<I, O>
     constexpr ranges::rotate_copy_result<I, O>
       ranges::rotate_copy(I first, I middle, S last, O result);
 \end{itemdecl}
@@ -5714,8 +5714,8 @@ Exactly $N$ assignments.
 \end{itemdescr}
 
 \begin{itemdecl}
-template<forward_range R, weakly_incrementable O>
-  requires indirectly_copyable<iterator_t<R>, O>
+template<@\libconcept{forward_range}@ R, @\libconcept{weakly_incrementable}@ O>
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O>
   constexpr ranges::rotate_copy_result<borrowed_iterator_t<R>, O>
     ranges::rotate_copy(R&& r, iterator_t<R> middle, O result);
 \end{itemdecl}
@@ -5739,14 +5739,14 @@ template<class PopulationIterator, class SampleIterator,
                         SampleIterator out, Distance n,
                         UniformRandomBitGenerator&& g);
 
-template<input_iterator I, sentinel_for<I> S, weakly_incrementable O, class Gen>
+template<input_iterator I, sentinel_for<I> S, @\libconcept{weakly_incrementable}@ O, class Gen>
   requires (forward_iterator<I> || random_access_iterator<O>) &&
-           indirectly_copyable<I, O> &&
+           @\libconcept{indirectly_copyable}@<I, O> &&
            uniform_random_bit_generator<remove_reference_t<Gen>>
   O ranges::sample(I first, S last, O out, iter_difference_t<I> n, Gen&& g);
-template<input_range R, weakly_incrementable O, class Gen>
+template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O, class Gen>
   requires (forward_range<R> || random_access_iterator<O>) &&
-           indirectly_copyable<iterator_t<R>, O> &&
+           @\libconcept{indirectly_copyable}@<iterator_t<R>, O> &&
            uniform_random_bit_generator<remove_reference_t<Gen>>
   O ranges::sample(R&& r, O out, range_difference_t<R> n, Gen&& g);
 \end{itemdecl}
@@ -5822,13 +5822,13 @@ template<class RandomAccessIterator, class UniformRandomBitGenerator>
                RandomAccessIterator last,
                UniformRandomBitGenerator&& g);
 
-template<random_access_iterator I, sentinel_for<I> S, class Gen>
-  requires permutable<I> &&
-           uniform_random_bit_generator<remove_reference_t<Gen>>
+template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Gen>
+  requires @\libconcept{permutable}@<I> &&
+           @\libconcept{uniform_random_bit_generator}@<remove_reference_t<Gen>>
   I ranges::shuffle(I first, S last, Gen&& g);
-template<random_access_range R, class Gen>
-  requires permutable<iterator_t<R>> &&
-           uniform_random_bit_generator<remove_reference_t<Gen>>
+template<@\libconcept{random_access_range}@ R, class Gen>
+  requires @\libconcept{permutable}@<iterator_t<R>> &&
+           @\libconcept{uniform_random_bit_generator}@<remove_reference_t<Gen>>
   borrowed_iterator_t<R> ranges::shuffle(R&& r, Gen&& g);
 \end{itemdecl}
 
@@ -6055,13 +6055,13 @@ template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
             RandomAccessIterator first, RandomAccessIterator last,
             Compare comp);
 
-template<random_access_iterator I, sentinel_for<I> S, class Comp = ranges::less,
+template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
          class Proj = identity>
-  requires sortable<I, Comp, Proj>
+  requires @\libconcept{sortable}@<I, Comp, Proj>
   constexpr I
     ranges::sort(I first, S last, Comp comp = {}, Proj proj = {});
-template<random_access_range R, class Comp = ranges::less, class Proj = identity>
-  requires sortable<iterator_t<R>, Comp, Proj>
+template<@\libconcept{random_access_range}@ R, class Comp = ranges::less, class Proj = identity>
+  requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
   constexpr borrowed_iterator_t<R>
     ranges::sort(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -6114,12 +6114,12 @@ template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
                    RandomAccessIterator first, RandomAccessIterator last,
                    Compare comp);
 
-template<random_access_iterator I, sentinel_for<I> S, class Comp = ranges::less,
+template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
          class Proj = identity>
-  requires sortable<I, Comp, Proj>
+  requires @\libconcept{sortable}@<I, Comp, Proj>
   I ranges::stable_sort(I first, S last, Comp comp = {}, Proj proj = {});
-template<random_access_range R, class Comp = ranges::less, class Proj = identity>
-  requires sortable<iterator_t<R>, Comp, Proj>
+template<@\libconcept{random_access_range}@ R, class Comp = ranges::less, class Proj = identity>
+  requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
   borrowed_iterator_t<R>
     ranges::stable_sort(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -6186,9 +6186,9 @@ template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
                     RandomAccessIterator last,
                     Compare comp);
 
-template<random_access_iterator I, sentinel_for<I> S, class Comp = ranges::less,
+template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
          class Proj = identity>
-  requires sortable<I, Comp, Proj>
+  requires @\libconcept{sortable}@<I, Comp, Proj>
   constexpr I
     ranges::partial_sort(I first, I middle, S last, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -6230,8 +6230,8 @@ twice as many projections.
 \end{itemdescr}
 
 \begin{itemdecl}
-template<random_access_range R, class Comp = ranges::less, class Proj = identity>
-  requires sortable<iterator_t<R>, Comp, Proj>
+template<@\libconcept{random_access_range}@ R, class Comp = ranges::less, class Proj = identity>
+  requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
   constexpr borrowed_iterator_t<R>
     ranges::partial_sort(R&& r, iterator_t<R> middle, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -6277,18 +6277,18 @@ template<class ExecutionPolicy, class ForwardIterator, class RandomAccessIterato
                       RandomAccessIterator result_last,
                       Compare comp);
 
-template<input_iterator I1, sentinel_for<I1> S1, random_access_iterator I2, sentinel_for<I2> S2,
+template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{random_access_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
          class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
-  requires indirectly_copyable<I1, I2> && sortable<I2, Comp, Proj2> &&
-           indirect_strict_weak_order<Comp, projected<I1, Proj1>, projected<I2, Proj2>>
+  requires @\libconcept{indirectly_copyable}@<I1, I2> && @\libconcept{sortable}@<I2, Comp, Proj2> &&
+           @\libconcept{indirect_strict_weak_order}@<Comp, projected<I1, Proj1>, projected<I2, Proj2>>
   constexpr ranges::partial_sort_copy_result<I1, I2>
     ranges::partial_sort_copy(I1 first, S1 last, I2 result_first, S2 result_last,
                               Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
-template<input_range R1, random_access_range R2, class Comp = ranges::less,
+template<@\libconcept{input_range}@ R1, @\libconcept{random_access_range}@ R2, class Comp = ranges::less,
          class Proj1 = identity, class Proj2 = identity>
-  requires indirectly_copyable<iterator_t<R1>, iterator_t<R2>> &&
-           sortable<iterator_t<R2>, Comp, Proj2> &&
-           indirect_strict_weak_order<Comp, projected<iterator_t<R1>, Proj1>,
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R1>, iterator_t<R2>> &&
+           @\libconcept{sortable}@<iterator_t<R2>, Comp, Proj2> &&
+           @\libconcept{indirect_strict_weak_order}@<Comp, projected<iterator_t<R1>, Proj1>,
                                       projected<iterator_t<R2>, Proj2>>
   constexpr ranges::partial_sort_copy_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
     ranges::partial_sort_copy(R1&& r, R2&& result_r, Comp comp = {},
@@ -6419,11 +6419,11 @@ return is_sorted_until(std::forward<ExecutionPolicy>(exec), first, last, comp) =
 
 \indexlibraryglobal{is_sorted}%
 \begin{itemdecl}
-template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
-         indirect_strict_weak_order<projected<I, Proj>> Comp = ranges::less>
+template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
   constexpr bool ranges::is_sorted(I first, S last, Comp comp = {}, Proj proj = {});
-template<forward_range R, class Proj = identity,
-         indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+template<@\libconcept{forward_range}@ R, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
   constexpr bool ranges::is_sorted(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -6454,11 +6454,11 @@ template<class ExecutionPolicy, class ForwardIterator, class Compare>
                     ForwardIterator first, ForwardIterator last,
                     Compare comp);
 
-template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
-         indirect_strict_weak_order<projected<I, Proj>> Comp = ranges::less>
+template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
   constexpr I ranges::is_sorted_until(I first, S last, Comp comp = {}, Proj proj = {});
-template<forward_range R, class Proj = identity,
-         indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+template<@\libconcept{forward_range}@ R, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
   constexpr borrowed_iterator_t<R>
     ranges::is_sorted_until(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -6500,9 +6500,9 @@ template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
                    RandomAccessIterator first, RandomAccessIterator nth,
                    RandomAccessIterator last, Compare comp);
 
-template<random_access_iterator I, sentinel_for<I> S, class Comp = ranges::less,
+template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
          class Proj = identity>
-  requires sortable<I, Comp, Proj>
+  requires @\libconcept{sortable}@<I, Comp, Proj>
   constexpr I
     ranges::nth_element(I first, I nth, S last, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -6546,8 +6546,8 @@ the predicate, and \bigoh{N \log N} swaps, where $N = \tcode{last - first}$.
 \end{itemdescr}
 
 \begin{itemdecl}
-template<random_access_range R, class Comp = ranges::less, class Proj = identity>
-  requires sortable<iterator_t<R>, Comp, Proj>
+template<@\libconcept{random_access_range}@ R, class Comp = ranges::less, class Proj = identity>
+  requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
   constexpr borrowed_iterator_t<R>
     ranges::nth_element(R&& r, iterator_t<R> nth, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -6589,12 +6589,12 @@ template<class ForwardIterator, class T, class Compare>
     lower_bound(ForwardIterator first, ForwardIterator last,
                 const T& value, Compare comp);
 
-template<forward_iterator I, sentinel_for<I> S, class T, class Proj = identity,
-         indirect_strict_weak_order<const T*, projected<I, Proj>> Comp = ranges::less>
+template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<const T*, projected<I, Proj>> Comp = ranges::less>
   constexpr I ranges::lower_bound(I first, S last, const T& value, Comp comp = {},
                                   Proj proj = {});
-template<forward_range R, class T, class Proj = identity,
-         indirect_strict_weak_order<const T*, projected<iterator_t<R>, Proj>> Comp =
+template<@\libconcept{forward_range}@ R, class T, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<const T*, projected<iterator_t<R>, Proj>> Comp =
            ranges::less>
   constexpr borrowed_iterator_t<R>
     ranges::lower_bound(R&& r, const T& value, Comp comp = {}, Proj proj = {});
@@ -6637,11 +6637,11 @@ template<class ForwardIterator, class T, class Compare>
     upper_bound(ForwardIterator first, ForwardIterator last,
                 const T& value, Compare comp);
 
-template<forward_iterator I, sentinel_for<I> S, class T, class Proj = identity,
-         indirect_strict_weak_order<const T*, projected<I, Proj>> Comp = ranges::less>
+template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<const T*, projected<I, Proj>> Comp = ranges::less>
   constexpr I ranges::upper_bound(I first, S last, const T& value, Comp comp = {}, Proj proj = {});
-template<forward_range R, class T, class Proj = identity,
-         indirect_strict_weak_order<const T*, projected<iterator_t<R>, Proj>> Comp =
+template<@\libconcept{forward_range}@ R, class T, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<const T*, projected<iterator_t<R>, Proj>> Comp =
            ranges::less>
   constexpr borrowed_iterator_t<R>
     ranges::upper_bound(R&& r, const T& value, Comp comp = {}, Proj proj = {});
@@ -6685,12 +6685,12 @@ template<class ForwardIterator, class T, class Compare>
                 ForwardIterator last, const T& value,
                 Compare comp);
 
-template<forward_iterator I, sentinel_for<I> S, class T, class Proj = identity,
-         indirect_strict_weak_order<const T*, projected<I, Proj>> Comp = ranges::less>
+template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<const T*, projected<I, Proj>> Comp = ranges::less>
   constexpr subrange<I>
     ranges::equal_range(I first, S last, const T& value, Comp comp = {}, Proj proj = {});
-template<forward_range R, class T, class Proj = identity,
-         indirect_strict_weak_order<const T*, projected<iterator_t<R>, Proj>> Comp =
+template<@\libconcept{forward_range}@ R, class T, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<const T*, projected<iterator_t<R>, Proj>> Comp =
            ranges::less>
   constexpr borrowed_subrange_t<R>
     ranges::equal_range(R&& r, const T& value, Comp comp = {}, Proj proj = {});
@@ -6749,12 +6749,12 @@ template<class ForwardIterator, class T, class Compare>
     binary_search(ForwardIterator first, ForwardIterator last,
                   const T& value, Compare comp);
 
-template<forward_iterator I, sentinel_for<I> S, class T, class Proj = identity,
-         indirect_strict_weak_order<const T*, projected<I, Proj>> Comp = ranges::less>
+template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<const T*, projected<I, Proj>> Comp = ranges::less>
   constexpr bool ranges::binary_search(I first, S last, const T& value, Comp comp = {},
                                        Proj proj = {});
-template<forward_range R, class T, class Proj = identity,
-         indirect_strict_weak_order<const T*, projected<iterator_t<R>, Proj>> Comp =
+template<@\libconcept{forward_range}@ R, class T, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<const T*, projected<iterator_t<R>, Proj>> Comp =
            ranges::less>
   constexpr bool ranges::binary_search(R&& r, const T& value, Comp comp = {},
                                        Proj proj = {});
@@ -6799,11 +6799,11 @@ template<class ExecutionPolicy, class ForwardIterator, class Predicate>
   bool is_partitioned(ExecutionPolicy&& exec,
                       ForwardIterator first, ForwardIterator last, Predicate pred);
 
-template<input_iterator I, sentinel_for<I> S, class Proj = identity,
-         indirect_unary_predicate<projected<I, Proj>> Pred>
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
   constexpr bool ranges::is_partitioned(I first, S last, Pred pred, Proj proj = {});
-template<input_range R, class Proj = identity,
-         indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+template<@\libconcept{input_range}@ R, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
   constexpr bool ranges::is_partitioned(R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
@@ -6834,13 +6834,13 @@ template<class ExecutionPolicy, class ForwardIterator, class Predicate>
     partition(ExecutionPolicy&& exec,
               ForwardIterator first, ForwardIterator last, Predicate pred);
 
-template<permutable I, sentinel_for<I> S, class Proj = identity,
-         indirect_unary_predicate<projected<I, Proj>> Pred>
+template<@\libconcept{permutable}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
   constexpr subrange<I>
     ranges::partition(I first, S last, Pred pred, Proj proj = {});
-template<forward_range R, class Proj = identity,
-         indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
-  requires permutable<iterator_t<R>>
+template<@\libconcept{forward_range}@ R, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  requires @\libconcept{permutable}@<iterator_t<R>>
   constexpr borrowed_subrange_t<R>
     ranges::partition(R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
@@ -6904,13 +6904,13 @@ template<class ExecutionPolicy, class BidirectionalIterator, class Predicate>
     stable_partition(ExecutionPolicy&& exec,
                      BidirectionalIterator first, BidirectionalIterator last, Predicate pred);
 
-template<bidirectional_iterator I, sentinel_for<I> S, class Proj = identity,
-         indirect_unary_predicate<projected<I, Proj>> Pred>
-  requires permutable<I>
+template<@\libconcept{bidirectional_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  requires @\libconcept{permutable}@<I>
   subrange<I> ranges::stable_partition(I first, S last, Pred pred, Proj proj = {});
-template<bidirectional_range R, class Proj = identity,
-         indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
-  requires permutable<iterator_t<R>>
+template<@\libconcept{bidirectional_range}@ R, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  requires @\libconcept{permutable}@<iterator_t<R>>
   borrowed_subrange_t<R> ranges::stable_partition(R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
@@ -6977,17 +6977,17 @@ template<class ExecutionPolicy, class ForwardIterator, class ForwardIterator1,
                    ForwardIterator first, ForwardIterator last,
                    ForwardIterator1 out_true, ForwardIterator2 out_false, Predicate pred);
 
-template<input_iterator I, sentinel_for<I> S, weakly_incrementable O1, weakly_incrementable O2,
-         class Proj = identity, indirect_unary_predicate<projected<I, Proj>> Pred>
-  requires indirectly_copyable<I, O1> && indirectly_copyable<I, O2>
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O1, @\libconcept{weakly_incrementable}@ O2,
+         class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  requires @\libconcept{indirectly_copyable}@<I, O1> && @\libconcept{indirectly_copyable}@<I, O2>
   constexpr ranges::partition_copy_result<I, O1, O2>
     ranges::partition_copy(I first, S last, O1 out_true, O2 out_false, Pred pred,
                            Proj proj = {});
-template<input_range R, weakly_incrementable O1, weakly_incrementable O2,
+template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O1, @\libconcept{weakly_incrementable}@ O2,
          class Proj = identity,
-         indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
-  requires indirectly_copyable<iterator_t<R>, O1> &&
-           indirectly_copyable<iterator_t<R>, O2>
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O1> &&
+           @\libconcept{indirectly_copyable}@<iterator_t<R>, O2>
   constexpr ranges::partition_copy_result<borrowed_iterator_t<R>, O1, O2>
     ranges::partition_copy(R&& r, O1 out_true, O2 out_false, Pred pred, Proj proj = {});
 \end{itemdecl}
@@ -7043,11 +7043,11 @@ template<class ForwardIterator, class Predicate>
   constexpr ForwardIterator
     partition_point(ForwardIterator first, ForwardIterator last, Predicate pred);
 
-template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
-         indirect_unary_predicate<projected<I, Proj>> Pred>
+template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
   constexpr I ranges::partition_point(I first, S last, Pred pred, Proj proj = {});
-template<forward_range R, class Proj = identity,
-         indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
+template<@\libconcept{forward_range}@ R, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
   constexpr borrowed_iterator_t<R>
     ranges::partition_point(R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
@@ -7108,16 +7108,16 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
           ForwardIterator2 first2, ForwardIterator2 last2,
           ForwardIterator result, Compare comp);
 
-template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
-         weakly_incrementable O, class Comp = ranges::less, class Proj1 = identity,
+template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
+         @\libconcept{weakly_incrementable}@ O, class Comp = ranges::less, class Proj1 = identity,
          class Proj2 = identity>
-  requires mergeable<I1, I2, O, Comp, Proj1, Proj2>
+  requires @\libconcept{mergeable}@<I1, I2, O, Comp, Proj1, Proj2>
   constexpr ranges::merge_result<I1, I2, O>
     ranges::merge(I1 first1, S1 last1, I2 first2, S2 last2, O result,
                   Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
-template<input_range R1, input_range R2, weakly_incrementable O, class Comp = ranges::less,
+template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, @\libconcept{weakly_incrementable}@ O, class Comp = ranges::less,
          class Proj1 = identity, class Proj2 = identity>
-  requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
+  requires @\libconcept{mergeable}@<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
   constexpr ranges::merge_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
     ranges::merge(R1&& r1, R2&& r2, O result,
                   Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
@@ -7199,9 +7199,9 @@ template<class ExecutionPolicy, class BidirectionalIterator, class Compare>
                      BidirectionalIterator middle,
                      BidirectionalIterator last, Compare comp);
 
-template<bidirectional_iterator I, sentinel_for<I> S, class Comp = ranges::less,
+template<@\libconcept{bidirectional_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
          class Proj = identity>
-  requires sortable<I, Comp, Proj>
+  requires @\libconcept{sortable}@<I, Comp, Proj>
   I ranges::inplace_merge(I first, I middle, S last, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -7251,8 +7251,8 @@ Stable\iref{algorithm.stable}.
 \end{itemdescr}
 
 \begin{itemdecl}
-template<bidirectional_range R, class Comp = ranges::less, class Proj = identity>
-  requires sortable<iterator_t<R>, Comp, Proj>
+template<@\libconcept{bidirectional_range}@ R, class Comp = ranges::less, class Proj = identity>
+  requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
   borrowed_iterator_t<R>
     ranges::inplace_merge(R&& r, iterator_t<R> middle, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -7299,15 +7299,15 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, 
                 ForwardIterator2 first2, ForwardIterator2 last2,
                 Compare comp);
 
-template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
+template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
          class Proj1 = identity, class Proj2 = identity,
-         indirect_strict_weak_order<projected<I1, Proj1>,
+         @\libconcept{indirect_strict_weak_order}@<projected<I1, Proj1>,
                                     projected<I2, Proj2>> Comp = ranges::less>
   constexpr bool ranges::includes(I1 first1, S1 last1, I2 first2, S2 last2, Comp comp = {},
                                   Proj1 proj1 = {}, Proj2 proj2 = {});
-template<input_range R1, input_range R2, class Proj1 = identity,
+template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, class Proj1 = identity,
          class Proj2 = identity,
-         indirect_strict_weak_order<projected<iterator_t<R1>, Proj1>,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R1>, Proj1>,
                                     projected<iterator_t<R2>, Proj2>> Comp = ranges::less>
   constexpr bool ranges::includes(R1&& r1, R2&& r2, Comp comp = {},
                                   Proj1 proj1 = {}, Proj2 proj2 = {});
@@ -7373,16 +7373,16 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
               ForwardIterator2 first2, ForwardIterator2 last2,
               ForwardIterator result, Compare comp);
 
-template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
-         weakly_incrementable O, class Comp = ranges::less,
+template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
+         @\libconcept{weakly_incrementable}@ O, class Comp = ranges::less,
          class Proj1 = identity, class Proj2 = identity>
-  requires mergeable<I1, I2, O, Comp, Proj1, Proj2>
+  requires @\libconcept{mergeable}@<I1, I2, O, Comp, Proj1, Proj2>
   constexpr ranges::set_union_result<I1, I2, O>
     ranges::set_union(I1 first1, S1 last1, I2 first2, S2 last2, O result, Comp comp = {},
                       Proj1 proj1 = {}, Proj2 proj2 = {});
-template<input_range R1, input_range R2, weakly_incrementable O,
+template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, @\libconcept{weakly_incrementable}@ O,
          class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
-  requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
+  requires @\libconcept{mergeable}@<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
   constexpr ranges::set_union_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
     ranges::set_union(R1&& r1, R2&& r2, O result, Comp comp = {},
                       Proj1 proj1 = {}, Proj2 proj2 = {});
@@ -7468,16 +7468,16 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
                      ForwardIterator2 first2, ForwardIterator2 last2,
                      ForwardIterator result, Compare comp);
 
-template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
-         weakly_incrementable O, class Comp = ranges::less,
+template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
+         @\libconcept{weakly_incrementable}@ O, class Comp = ranges::less,
          class Proj1 = identity, class Proj2 = identity>
-  requires mergeable<I1, I2, O, Comp, Proj1, Proj2>
+  requires @\libconcept{mergeable}@<I1, I2, O, Comp, Proj1, Proj2>
   constexpr ranges::set_intersection_result<I1, I2, O>
     ranges::set_intersection(I1 first1, S1 last1, I2 first2, S2 last2, O result,
                              Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
-template<input_range R1, input_range R2, weakly_incrementable O,
+template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, @\libconcept{weakly_incrementable}@ O,
          class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
-  requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
+  requires @\libconcept{mergeable}@<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
   constexpr ranges::set_intersection_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
     ranges::set_intersection(R1&& r1, R2&& r2, O result,
                              Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
@@ -7561,16 +7561,16 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
                    ForwardIterator2 first2, ForwardIterator2 last2,
                    ForwardIterator result, Compare comp);
 
-template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
-         weakly_incrementable O, class Comp = ranges::less,
+template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
+         @\libconcept{weakly_incrementable}@ O, class Comp = ranges::less,
          class Proj1 = identity, class Proj2 = identity>
-  requires mergeable<I1, I2, O, Comp, Proj1, Proj2>
+  requires @\libconcept{mergeable}@<I1, I2, O, Comp, Proj1, Proj2>
   constexpr ranges::set_difference_result<I1, O>
     ranges::set_difference(I1 first1, S1 last1, I2 first2, S2 last2, O result,
                            Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
-template<input_range R1, input_range R2, weakly_incrementable O,
+template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, @\libconcept{weakly_incrementable}@ O,
          class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
-  requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
+  requires @\libconcept{mergeable}@<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
   constexpr ranges::set_difference_result<borrowed_iterator_t<R1>, O>
     ranges::set_difference(R1&& r1, R2&& r2, O result,
                            Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
@@ -7655,17 +7655,17 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
                              ForwardIterator2 first2, ForwardIterator2 last2,
                              ForwardIterator result, Compare comp);
 
-template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
-         weakly_incrementable O, class Comp = ranges::less,
+template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
+         @\libconcept{weakly_incrementable}@ O, class Comp = ranges::less,
          class Proj1 = identity, class Proj2 = identity>
-  requires mergeable<I1, I2, O, Comp, Proj1, Proj2>
+  requires @\libconcept{mergeable}@<I1, I2, O, Comp, Proj1, Proj2>
   constexpr ranges::set_symmetric_difference_result<I1, I2, O>
     ranges::set_symmetric_difference(I1 first1, S1 last1, I2 first2, S2 last2, O result,
                                      Comp comp = {}, Proj1 proj1 = {},
                                      Proj2 proj2 = {});
-template<input_range R1, input_range R2, weakly_incrementable O,
+template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, @\libconcept{weakly_incrementable}@ O,
          class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
-  requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
+  requires @\libconcept{mergeable}@<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
   constexpr ranges::set_symmetric_difference_result<borrowed_iterator_t<R1>,
                                                     borrowed_iterator_t<R2>, O>
     ranges::set_symmetric_difference(R1&& r1, R2&& r2, O result, Comp comp = {},
@@ -7762,13 +7762,13 @@ template<class RandomAccessIterator, class Compare>
   constexpr void push_heap(RandomAccessIterator first, RandomAccessIterator last,
                            Compare comp);
 
-template<random_access_iterator I, sentinel_for<I> S, class Comp = ranges::less,
+template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
          class Proj = identity>
-  requires sortable<I, Comp, Proj>
+  requires @\libconcept{sortable}@<I, Comp, Proj>
   constexpr I
     ranges::push_heap(I first, S last, Comp comp = {}, Proj proj = {});
-template<random_access_range R, class Comp = ranges::less, class Proj = identity>
-  requires sortable<iterator_t<R>, Comp, Proj>
+template<@\libconcept{random_access_range}@ R, class Comp = ranges::less, class Proj = identity>
+  requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
   constexpr borrowed_iterator_t<R>
     ranges::push_heap(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -7813,13 +7813,13 @@ template<class RandomAccessIterator, class Compare>
   constexpr void pop_heap(RandomAccessIterator first, RandomAccessIterator last,
                           Compare comp);
 
-template<random_access_iterator I, sentinel_for<I> S, class Comp = ranges::less,
+template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
          class Proj = identity>
-  requires sortable<I, Comp, Proj>
+  requires @\libconcept{sortable}@<I, Comp, Proj>
   constexpr I
     ranges::pop_heap(I first, S last, Comp comp = {}, Proj proj = {});
-template<random_access_range R, class Comp = ranges::less, class Proj = identity>
-  requires sortable<iterator_t<R>, Comp, Proj>
+template<@\libconcept{random_access_range}@ R, class Comp = ranges::less, class Proj = identity>
+  requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
   constexpr borrowed_iterator_t<R>
     ranges::pop_heap(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -7871,13 +7871,13 @@ template<class RandomAccessIterator, class Compare>
   constexpr void make_heap(RandomAccessIterator first, RandomAccessIterator last,
                            Compare comp);
 
-template<random_access_iterator I, sentinel_for<I> S, class Comp = ranges::less,
+template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
          class Proj = identity>
-  requires sortable<I, Comp, Proj>
+  requires @\libconcept{sortable}@<I, Comp, Proj>
   constexpr I
     ranges::make_heap(I first, S last, Comp comp = {}, Proj proj = {});
-template<random_access_range R, class Comp = ranges::less, class Proj = identity>
-  requires sortable<iterator_t<R>, Comp, Proj>
+template<@\libconcept{random_access_range}@ R, class Comp = ranges::less, class Proj = identity>
+  requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
   constexpr borrowed_iterator_t<R>
     ranges::make_heap(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -7920,13 +7920,13 @@ template<class RandomAccessIterator, class Compare>
   constexpr void sort_heap(RandomAccessIterator first, RandomAccessIterator last,
                            Compare comp);
 
-template<random_access_iterator I, sentinel_for<I> S, class Comp = ranges::less,
+template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
          class Proj = identity>
-  requires sortable<I, Comp, Proj>
+  requires @\libconcept{sortable}@<I, Comp, Proj>
   constexpr I
     ranges::sort_heap(I first, S last, Comp comp = {}, Proj proj = {});
-template<random_access_range R, class Comp = ranges::less, class Proj = identity>
-  requires sortable<iterator_t<R>, Comp, Proj>
+template<@\libconcept{random_access_range}@ R, class Comp = ranges::less, class Proj = identity>
+  requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
   constexpr borrowed_iterator_t<R>
     ranges::sort_heap(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -8025,11 +8025,11 @@ return is_heap_until(std::forward<ExecutionPolicy>(exec), first, last, comp) == 
 
 \indexlibraryglobal{is_heap}%
 \begin{itemdecl}
-template<random_access_iterator I, sentinel_for<I> S, class Proj = identity,
-         indirect_strict_weak_order<projected<I, Proj>> Comp = ranges::less>
+template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
   constexpr bool ranges::is_heap(I first, S last, Comp comp = {}, Proj proj = {});
-template<random_access_range R, class Proj = identity,
-         indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+template<@\libconcept{random_access_range}@ R, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
   constexpr bool ranges::is_heap(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -8060,11 +8060,11 @@ template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
                   RandomAccessIterator first, RandomAccessIterator last,
                   Compare comp);
 
-template<random_access_iterator I, sentinel_for<I> S, class Proj = identity,
-         indirect_strict_weak_order<projected<I, Proj>> Comp = ranges::less>
+template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
   constexpr I ranges::is_heap_until(I first, S last, Comp comp = {}, Proj proj = {});
-template<random_access_range R, class Proj = identity,
-         indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+template<@\libconcept{random_access_range}@ R, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
   constexpr borrowed_iterator_t<R>
     ranges::is_heap_until(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -8097,7 +8097,7 @@ template<class T, class Compare>
   constexpr const T& min(const T& a, const T& b, Compare comp);
 
 template<class T, class Proj = identity,
-         indirect_strict_weak_order<projected<const T*, Proj>> Comp = ranges::less>
+         @\libconcept{indirect_strict_weak_order}@<projected<const T*, Proj>> Comp = ranges::less>
   constexpr const T& ranges::min(const T& a, const T& b, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -8130,12 +8130,12 @@ template<class T>
 template<class T, class Compare>
   constexpr T min(initializer_list<T> r, Compare comp);
 
-template<copyable T, class Proj = identity,
-         indirect_strict_weak_order<projected<const T*, Proj>> Comp = ranges::less>
+template<@\libconcept{copyable}@ T, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<const T*, Proj>> Comp = ranges::less>
   constexpr T ranges::min(initializer_list<T> r, Comp comp = {}, Proj proj = {});
-template<input_range R, class Proj = identity,
-         indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
-  requires indirectly_copyable_storable<iterator_t<R>, range_value_t<R>*>
+template<@\libconcept{input_range}@ R, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+  requires @\libconcept{indirectly_copyable}@_storable<iterator_t<R>, range_value_t<R>*>
   constexpr range_value_t<R>
     ranges::min(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -8175,7 +8175,7 @@ template<class T, class Compare>
   constexpr const T& max(const T& a, const T& b, Compare comp);
 
 template<class T, class Proj = identity,
-         indirect_strict_weak_order<projected<const T*, Proj>> Comp = ranges::less>
+         @\libconcept{indirect_strict_weak_order}@<projected<const T*, Proj>> Comp = ranges::less>
   constexpr const T& ranges::max(const T& a, const T& b, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -8208,12 +8208,12 @@ template<class T>
 template<class T, class Compare>
   constexpr T max(initializer_list<T> r, Compare comp);
 
-template<copyable T, class Proj = identity,
-         indirect_strict_weak_order<projected<const T*, Proj>> Comp = ranges::less>
+template<@\libconcept{copyable}@ T, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<const T*, Proj>> Comp = ranges::less>
   constexpr T ranges::max(initializer_list<T> r, Comp comp = {}, Proj proj = {});
-template<input_range R, class Proj = identity,
-         indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
-  requires indirectly_copyable_storable<iterator_t<R>, range_value_t<R>*>
+template<@\libconcept{input_range}@ R, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+  requires @\libconcept{indirectly_copyable_storable}@<iterator_t<R>, range_value_t<R>*>
   constexpr range_value_t<R>
     ranges::max(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -8253,7 +8253,7 @@ template<class T, class Compare>
   constexpr pair<const T&, const T&> minmax(const T& a, const T& b, Compare comp);
 
 template<class T, class Proj = identity,
-         indirect_strict_weak_order<projected<const T*, Proj>> Comp = ranges::less>
+         @\libconcept{indirect_strict_weak_order}@<projected<const T*, Proj>> Comp = ranges::less>
   constexpr ranges::minmax_result<const T&>
     ranges::minmax(const T& a, const T& b, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -8288,13 +8288,13 @@ template<class T>
 template<class T, class Compare>
   constexpr pair<T, T> minmax(initializer_list<T> t, Compare comp);
 
-template<copyable T, class Proj = identity,
-         indirect_strict_weak_order<projected<const T*, Proj>> Comp = ranges::less>
+template<@\libconcept{copyable}@ T, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<const T*, Proj>> Comp = ranges::less>
   constexpr ranges::minmax_result<T>
     ranges::minmax(initializer_list<T> r, Comp comp = {}, Proj proj = {});
-template<input_range R, class Proj = identity,
-         indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
-  requires indirectly_copyable_storable<iterator_t<R>, range_value_t<R>*>
+template<@\libconcept{input_range}@ R, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+  requires @\libconcept{indirectly_copyable_storable}@<iterator_t<R>, range_value_t<R>*>
   constexpr ranges::minmax_result<range_value_t<R>>
     ranges::minmax(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -8346,11 +8346,11 @@ template<class ExecutionPolicy, class ForwardIterator, class Compare>
                               ForwardIterator first, ForwardIterator last,
                               Compare comp);
 
-template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
-         indirect_strict_weak_order<projected<I, Proj>> Comp = ranges::less>
+template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
   constexpr I ranges::min_element(I first, S last, Comp comp = {}, Proj proj = {});
-template<forward_range R, class Proj = identity,
-         indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+template<@\libconcept{forward_range}@ R, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
   constexpr borrowed_iterator_t<R>
     ranges::min_element(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -8393,11 +8393,11 @@ template<class ExecutionPolicy, class ForwardIterator, class Compare>
                               ForwardIterator first, ForwardIterator last,
                               Compare comp);
 
-template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
-         indirect_strict_weak_order<projected<I, Proj>> Comp = ranges::less>
+template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
   constexpr I ranges::max_element(I first, S last, Comp comp = {}, Proj proj = {});
-template<forward_range R, class Proj = identity,
-         indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+template<@\libconcept{forward_range}@ R, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
   constexpr borrowed_iterator_t<R>
     ranges::max_element(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -8442,12 +8442,12 @@ template<class ExecutionPolicy, class ForwardIterator, class Compare>
     minmax_element(ExecutionPolicy&& exec,
                    ForwardIterator first, ForwardIterator last, Compare comp);
 
-template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
-         indirect_strict_weak_order<projected<I, Proj>> Comp = ranges::less>
+template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
   constexpr ranges::minmax_result<I>
     ranges::minmax_element(I first, S last, Comp comp = {}, Proj proj = {});
-template<forward_range R, class Proj = identity,
-         indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+template<@\libconcept{forward_range}@ R, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
   constexpr ranges::minmax_result<borrowed_iterator_t<R>>
     ranges::minmax_element(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -8479,7 +8479,7 @@ template<class T>
 template<class T, class Compare>
   constexpr const T& clamp(const T& v, const T& lo, const T& hi, Compare comp);
 template<class T, class Proj = identity,
-         indirect_strict_weak_order<projected<const T*, Proj>> Comp = ranges::less>
+         @\libconcept{indirect_strict_weak_order}@<projected<const T*, Proj>> Comp = ranges::less>
   constexpr const T&
     ranges::clamp(const T& v, const T& lo, const T& hi, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -8535,16 +8535,16 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
                             ForwardIterator2 first2, ForwardIterator2 last2,
                             Compare comp);
 
-template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
+template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
          class Proj1 = identity, class Proj2 = identity,
-         indirect_strict_weak_order<projected<I1, Proj1>,
+         @\libconcept{indirect_strict_weak_order}@<projected<I1, Proj1>,
                                     projected<I2, Proj2>> Comp = ranges::less>
   constexpr bool
     ranges::lexicographical_compare(I1 first1, S1 last1, I2 first2, S2 last2,
                                     Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
-template<input_range R1, input_range R2, class Proj1 = identity,
+template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, class Proj1 = identity,
          class Proj2 = identity,
-         indirect_strict_weak_order<projected<iterator_t<R1>, Proj1>,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R1>, Proj1>,
                                     projected<iterator_t<R2>, Proj2>> Comp = ranges::less>
   constexpr bool
     ranges::lexicographical_compare(R1&& r1, R2&& r2, Comp comp = {},
@@ -8656,14 +8656,14 @@ template<class BidirectionalIterator, class Compare>
   constexpr bool next_permutation(BidirectionalIterator first,
                                   BidirectionalIterator last, Compare comp);
 
-template<bidirectional_iterator I, sentinel_for<I> S, class Comp = ranges::less,
+template<@\libconcept{bidirectional_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
          class Proj = identity>
-  requires sortable<I, Comp, Proj>
+  requires @\libconcept{sortable}@<I, Comp, Proj>
   constexpr ranges::next_permutation_result<I>
     ranges::next_permutation(I first, S last, Comp comp = {}, Proj proj = {});
-template<bidirectional_range R, class Comp = ranges::less,
+template<@\libconcept{bidirectional_range}@ R, class Comp = ranges::less,
          class Proj = identity>
-  requires sortable<iterator_t<R>, Comp, Proj>
+  requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
   constexpr ranges::next_permutation_result<borrowed_iterator_t<R>>
     ranges::next_permutation(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -8715,14 +8715,14 @@ template<class BidirectionalIterator, class Compare>
   constexpr bool prev_permutation(BidirectionalIterator first,
                                   BidirectionalIterator last, Compare comp);
 
-template<bidirectional_iterator I, sentinel_for<I> S, class Comp = ranges::less,
+template<@\libconcept{bidirectional_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
          class Proj = identity>
-  requires sortable<I, Comp, Proj>
+  requires @\libconcept{sortable}@<I, Comp, Proj>
   constexpr ranges::prev_permutation_result<I>
     ranges::prev_permutation(I first, S last, Comp comp = {}, Proj proj = {});
-template<bidirectional_range R, class Comp = ranges::less,
+template<@\libconcept{bidirectional_range}@ R, class Comp = ranges::less,
          class Proj = identity>
-  requires sortable<iterator_t<R>, Comp, Proj>
+  requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
   constexpr ranges::prev_permutation_result<borrowed_iterator_t<R>>
     ranges::prev_permutation(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
@@ -10392,7 +10392,7 @@ namespace ranges {
       requires constructible_from<iter_value_t<O>, iter_reference_t<I>>
     uninitialized_copy_result<I, O>
       uninitialized_copy(I ifirst, S1 ilast, O ofirst, S2 olast);
-  template<input_range IR, @\placeholdernc{no-throw-forward-range}@ OR>
+  template<@\libconcept{input_range}@ IR, @\placeholdernc{no-throw-forward-range}@ OR>
       requires constructible_from<range_value_t<OR>, range_reference_t<IR>>
     uninitialized_copy_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
       uninitialized_copy(IR&& in_range, OR&& out_range);
@@ -10501,7 +10501,7 @@ namespace ranges {
       requires constructible_from<iter_value_t<O>, iter_rvalue_reference_t<I>>
     uninitialized_move_result<I, O>
       uninitialized_move(I ifirst, S1 ilast, O ofirst, S2 olast);
-  template<input_range IR, @\placeholdernc{no-throw-forward-range}@ OR>
+  template<@\libconcept{input_range}@ IR, @\placeholdernc{no-throw-forward-range}@ OR>
       requires constructible_from<range_value_t<OR>, range_rvalue_reference_t<IR>>
     uninitialized_move_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
       uninitialized_move(IR&& in_range, OR&& out_range);

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -401,9 +401,9 @@ different type. \tcode{C} may be a reference type.
 \begin{itemdecl}
 template<class T, class U>
   concept @\deflibconcept{common_reference_with}@ =
-    same_as<common_reference_t<T, U>, common_reference_t<U, T>> &&
-    convertible_to<T, common_reference_t<T, U>> &&
-    convertible_to<U, common_reference_t<T, U>>;
+    @\libconcept{same_as}@<common_reference_t<T, U>, common_reference_t<U, T>> &&
+    @\libconcept{convertible_to}@<T, common_reference_t<T, U>> &&
+    @\libconcept{convertible_to}@<U, common_reference_t<T, U>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -444,7 +444,7 @@ different type. \tcode{C} might not be unique.
 \begin{itemdecl}
 template<class T, class U>
   concept @\deflibconcept{common_with}@ =
-    same_as<common_type_t<T, U>, common_type_t<U, T>> &&
+    @\libconcept{same_as}@<common_type_t<T, U>, common_type_t<U, T>> &&
     requires {
       static_cast<common_type_t<T, U>>(declval<T>());
       static_cast<common_type_t<T, U>>(declval<U>());
@@ -519,7 +519,7 @@ template<class LHS, class RHS>
     is_lvalue_reference_v<LHS> &&
     common_reference_with<const remove_reference_t<LHS>&, const remove_reference_t<RHS>&> &&
     requires(LHS lhs, RHS&& rhs) {
-      { lhs = std::forward<RHS>(rhs) } -> same_as<LHS>;
+      { lhs = std::forward<RHS>(rhs) } -> @\libconcept{same_as}@<LHS>;
     };
 \end{itemdecl}
 
@@ -691,7 +691,7 @@ is performed in an appropriate context under the various conditions as follows:
 
 namespace ranges = std::ranges;
 
-template<class T, std::swappable_with<T> U>
+template<class T, std::@\libconcept{swappable_with}@<T> U>
 void value_swap(T&& t, U&& u) {
   ranges::swap(std::forward<T>(t), std::forward<U>(u));
 }
@@ -786,7 +786,7 @@ Only the validity of the immediate context of the variable initialization is con
 
 \begin{itemdecl}
 template<class T>
-  concept @\deflibconcept{move_constructible}@ = constructible_from<T, T> && convertible_to<T, T>;
+  concept @\deflibconcept{move_constructible}@ = constructible_from<T, T> && @\libconcept{convertible_to}@<T, T>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -811,9 +811,9 @@ but unspecified\iref{lib.types.movedfrom}; otherwise, it is unchanged.
 template<class T>
   concept @\deflibconcept{copy_constructible}@ =
     move_constructible<T> &&
-    constructible_from<T, T&> && convertible_to<T&, T> &&
-    constructible_from<T, const T&> && convertible_to<const T&, T> &&
-    constructible_from<T, const T> && convertible_to<const T, T>;
+    constructible_from<T, T&> && @\libconcept{convertible_to}@<T&, T> &&
+    constructible_from<T, const T&> && @\libconcept{convertible_to}@<const T&, T> &&
+    constructible_from<T, const T> && @\libconcept{convertible_to}@<const T, T>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -852,7 +852,7 @@ have the conventional semantics.
 
 \begin{itemdecl}
 template<class T>
-  concept @\defexposconcept{boolean-testable-impl}@ = convertible_to<T, bool>;  // \expos
+  concept @\defexposconcept{boolean-testable-impl}@ = @\libconcept{convertible_to}@<T, bool>;  // \expos
 \end{itemdecl}
 
 \pnum
@@ -1059,7 +1059,7 @@ common_reference_t<const remove_reference_t<T>&, const remove_reference_t<U>&>
 \begin{itemdecl}
 template<class T>
   concept @\deflibconcept{totally_ordered}@ =
-    equality_comparable<T> && @\exposconcept{partially-ordered-with}@<T, T>;
+    @\libconcept{equality_comparable}@<T> && @\exposconcept{partially-ordered-with}@<T, T>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1082,9 +1082,9 @@ lvalues of type \tcode{const remove_reference_t<T>}.
 \begin{itemdecl}
 template<class T, class U>
   concept @\deflibconcept{totally_ordered_with}@ =
-    totally_ordered<T> && totally_ordered<U> &&
-    equality_comparable_with<T, U> &&
-    totally_ordered<
+    @\libconcept{totally_ordered}@<T> && @\libconcept{totally_ordered}@<U> &&
+    @\libconcept{equality_comparable_with}@<T, U> &&
+    @\libconcept{totally_ordered}@<
       common_reference_t<
         const remove_reference_t<T>&,
         const remove_reference_t<U>&>> &&
@@ -1124,10 +1124,10 @@ value-oriented programming style on which the library is based.
 \begin{itemdecl}
 template<class T>
   concept @\deflibconcept{movable}@ = is_object_v<T> && move_constructible<T> &&
-                    assignable_from<T&, T> && swappable<T>;
+                    @\libconcept{assignable_from}@<T&, T> && swappable<T>;
 template<class T>
-  concept @\deflibconcept{copyable}@ = copy_constructible<T> && movable<T> && assignable_from<T&, T&> &&
-                     assignable_from<T&, const T&> && assignable_from<T&, const T>;
+  concept @\deflibconcept{copyable}@ = @\libconcept{copy_constructible}@<T> && @\libconcept{movable}@<T> && @\libconcept{assignable_from}@<T&, T&> &&
+                     @\libconcept{assignable_from}@<T&, const T&> && @\libconcept{assignable_from}@<T&, const T>;
 template<class T>
   concept @\deflibconcept{semiregular}@ = copyable<T> && default_initializable<T>;
 template<class T>
@@ -1215,7 +1215,7 @@ is purely semantic.
 \begin{itemdecl}
 template<class F, class... Args>
   concept @\deflibconcept{predicate}@ =
-    regular_invocable<F, Args...> && @\exposconcept{boolean-testable}@<invoke_result_t<F, Args...>>;
+    @\libconcept{regular_invocable}@<F, Args...> && @\exposconcept{boolean-testable}@<invoke_result_t<F, Args...>>;
 \end{itemdecl}
 
 \rSec2[concept.relation]{Concept \cname{relation}}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9695,7 +9695,7 @@ namespace std {
     bool operator<=(const queue<T, Container>& x, const queue<T, Container>& y);
   template<class T, class Container>
     bool operator>=(const queue<T, Container>& x, const queue<T, Container>& y);
-  template<class T, three_way_comparable Container>
+  template<class T, @\libconcept{three_way_comparable}@ Container>
     compare_three_way_result_t<Container>
       operator<=>(const queue<T, Container>& x, const queue<T, Container>& y);
 
@@ -9738,7 +9738,7 @@ namespace std {
     bool operator<=(const stack<T, Container>& x, const stack<T, Container>& y);
   template<class T, class Container>
     bool operator>=(const stack<T, Container>& x, const stack<T, Container>& y);
-  template<class T, three_way_comparable Container>
+  template<class T, @\libconcept{three_way_comparable}@ Container>
     compare_three_way_result_t<Container>
       operator<=>(const stack<T, Container>& x, const stack<T, Container>& y);
 
@@ -9983,7 +9983,7 @@ template<class T, class Container>
 
 \indexlibrarymember{operator<=>}{queue}%
 \begin{itemdecl}
-template<class T, three_way_comparable Container>
+template<class T, @\libconcept{three_way_comparable}@ Container>
   compare_three_way_result_t<Container>
     operator<=>(const queue<T, Container>& x, const queue<T, Container>& y);
 \end{itemdecl}
@@ -10558,7 +10558,7 @@ template<class T, class Container>
 
 \indexlibrarymember{operator<=>}{stack}%
 \begin{itemdecl}
-template<class T, three_way_comparable Container>
+template<class T, @\libconcept{three_way_comparable}@ Container>
   compare_three_way_result_t<Container>
     operator<=>(const stack<T, Container>& x, const stack<T, Container>& y);
 \end{itemdecl}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2519,7 +2519,7 @@ requirements in concepts such as the one below:
 template<typename T>
   concept R = requires (T i) {
     typename T::type;
-    {*i} -> convertible_to<const typename T::type&>;
+    {*i} -> @\libconcept{convertible_to}@<const typename T::type&>;
   };
 \end{codeblock}
 A \grammarterm{requires-expression} can also be used in a
@@ -2731,14 +2731,14 @@ It is equivalent to the \grammarterm{simple-requirement}
 
 \begin{codeblock}
 template<typename T> concept C2 = requires(T x) {
-  {*x} -> same_as<typename T::inner>;
+  {*x} -> @\libconcept{same_as}@<typename T::inner>;
 };
 \end{codeblock}
 
 The \grammarterm{compound-requirement} in \tcode{C2}
 requires that \tcode{*x} is a valid expression,
 that \tcode{typename T::inner} is a valid type, and
-that \tcode{same_as<decltype((*x)), typename T::inner>} is satisfied.
+that \tcode{\libconcept{same_as}<decltype((*x)), typename T::inner>} is satisfied.
 
 \begin{codeblock}
 template<typename T> concept C3 =

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -37,12 +37,12 @@ as summarized in \tref{iterators.summary}.
 #include <concepts>             // see \ref{concepts.syn}
 
 namespace std {
-  template<class T> using @\placeholder{with-reference}@ = T&;  // \expos
+  template<class T> using @\exposid{with-reference}@ = T&;  // \expos
   template<class T> concept @\defexposconcept{can-reference}@       // \expos
     = requires { typename @\placeholdernc{with-reference}@<T>; };
   template<class T> concept @\defexposconcept{dereferenceable}@     // \expos
     = requires(T& t) {
-      { *t } -> @\placeholder{can-reference}@;  // not required to be equality-preserving
+      { *t } -> @\exposconcept{can-reference}@;  // not required to be equality-preserving
     };
 
   // \ref{iterator.assoc.types}, associated types
@@ -76,7 +76,7 @@ namespace std {
 
   template<@\exposconcept{dereferenceable}@ T>
     requires requires(T& t) {
-      { ranges::iter_move(t) } -> @\placeholder{can-reference}@;
+      { ranges::iter_move(t) } -> @\exposconcept{can-reference}@;
     }
   using iter_rvalue_reference_t
     = decltype(ranges::iter_move(declval<T&>()));
@@ -86,7 +86,7 @@ namespace std {
   template<class In>
     concept indirectly_readable = @\seebelow@;
 
-  template<indirectly_readable T>
+  template<@\libconcept{indirectly_readable}@ T>
     using iter_common_reference_t =
       common_reference_t<iter_reference_t<T>, iter_value_t<T>&>;
 
@@ -162,14 +162,14 @@ namespace std {
     concept indirect_strict_weak_order = @\seebelow@;
 
   template<class F, class... Is>
-    requires (indirectly_readable<Is> && ...) && invocable<F, iter_reference_t<Is>...>
+    requires (@\libconcept{indirectly_readable}@<Is> && ...) && @\libconcept{invocable}@<F, iter_reference_t<Is>...>
       using indirect_result_t = invoke_result_t<F, iter_reference_t<Is>...>;
 
   // \ref{projected}, projected
-  template<indirectly_readable I, indirectly_regular_unary_invocable<I> Proj>
+  template<@\libconcept{indirectly_readable}@ I, @\libconcept{indirectly_regular_unary_invocable}@<I> Proj>
     struct projected;
 
-  template<weakly_incrementable I, class Proj>
+  template<@\libconcept{weakly_incrementable}@ I, class Proj>
     struct incrementable_traits<projected<I, Proj>>;
 
   // \ref{alg.req}, common algorithm requirements
@@ -236,35 +236,35 @@ namespace std {
   // \ref{range.iter.ops}, range iterator operations
   namespace ranges {
     // \ref{range.iter.op.advance}, \tcode{ranges::advance}
-    template<input_or_output_iterator I>
+    template<@\libconcept{input_or_output_iterator}@ I>
       constexpr void advance(I& i, iter_difference_t<I> n);
-    template<input_or_output_iterator I, sentinel_for<I> S>
+    template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
       constexpr void advance(I& i, S bound);
-    template<input_or_output_iterator I, sentinel_for<I> S>
+    template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
       constexpr iter_difference_t<I> advance(I& i, iter_difference_t<I> n, S bound);
 
     // \ref{range.iter.op.distance}, \tcode{ranges::distance}
-    template<input_or_output_iterator I, sentinel_for<I> S>
+    template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
       constexpr iter_difference_t<I> distance(I first, S last);
-    template<range R>
+    template<@\libconcept{range}@ R>
       constexpr range_difference_t<R> distance(R&& r);
 
     // \ref{range.iter.op.next}, \tcode{ranges::next}
-    template<input_or_output_iterator I>
+    template<@\libconcept{input_or_output_iterator}@ I>
       constexpr I next(I x);
-    template<input_or_output_iterator I>
+    template<@\libconcept{input_or_output_iterator}@ I>
       constexpr I next(I x, iter_difference_t<I> n);
-    template<input_or_output_iterator I, sentinel_for<I> S>
+    template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
       constexpr I next(I x, S bound);
-    template<input_or_output_iterator I, sentinel_for<I> S>
+    template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
       constexpr I next(I x, iter_difference_t<I> n, S bound);
 
     // \ref{range.iter.op.prev}, \tcode{ranges::prev}
-    template<bidirectional_iterator I>
+    template<@\libconcept{bidirectional_iterator}@ I>
       constexpr I prev(I x);
-    template<bidirectional_iterator I>
+    template<@\libconcept{bidirectional_iterator}@ I>
       constexpr I prev(I x, iter_difference_t<I> n);
-    template<bidirectional_iterator I>
+    template<@\libconcept{bidirectional_iterator}@ I>
       constexpr I prev(I x, iter_difference_t<I> n, I bound);
   }
 
@@ -296,7 +296,7 @@ namespace std {
     constexpr bool operator>=(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
-  template<class Iterator1, three_way_comparable_with<Iterator1> Iterator2>
+  template<class Iterator1, @\libconcept{three_way_comparable_with}@<Iterator1> Iterator2>
     constexpr compare_three_way_result_t<Iterator1, Iterator2>
       operator<=>(const reverse_iterator<Iterator1>& x,
                   const reverse_iterator<Iterator2>& y);
@@ -315,7 +315,7 @@ namespace std {
     constexpr reverse_iterator<Iterator> make_reverse_iterator(Iterator i);
 
   template<class Iterator1, class Iterator2>
-      requires (!sized_sentinel_for<Iterator1, Iterator2>)
+      requires (!@\libconcept{sized_sentinel_for}@<Iterator1, Iterator2>)
     inline constexpr bool disable_sized_sentinel_for<reverse_iterator<Iterator1>,
                                                      reverse_iterator<Iterator2>> = true;
 
@@ -351,7 +351,7 @@ namespace std {
   template<class Iterator1, class Iterator2>
     constexpr bool operator>=(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
-  template<class Iterator1, three_way_comparable_with<Iterator1> Iterator2>
+  template<class Iterator1, @\libconcept{three_way_comparable_with}@<Iterator1> Iterator2>
     constexpr compare_three_way_result_t<Iterator1, Iterator2>
       operator<=>(const move_iterator<Iterator1>& x,
                   const move_iterator<Iterator2>& y);
@@ -367,17 +367,17 @@ namespace std {
   template<class Iterator>
     constexpr move_iterator<Iterator> make_move_iterator(Iterator i);
 
-  template<semiregular S> class move_sentinel;
+  template<@\libconcept{semiregular}@ S> class move_sentinel;
 
   // \ref{iterators.common}, common iterators
-  template<input_or_output_iterator I, sentinel_for<I> S>
-    requires (!same_as<I, S> && copyable<I>)
+  template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
+    requires (!@\libconcept{same_as}@<I, S> && copyable<I>)
       class common_iterator;
 
   template<class I, class S>
     struct incrementable_traits<common_iterator<I, S>>;
 
-  template<input_iterator I, class S>
+  template<@\libconcept{input_iterator}@ I, class S>
     struct iterator_traits<common_iterator<I, S>>;
 
   // \ref{default.sentinels}, default sentinels
@@ -385,12 +385,12 @@ namespace std {
   inline constexpr default_sentinel_t default_sentinel{};
 
   // \ref{iterators.counted}, counted iterators
-  template<input_or_output_iterator I> class counted_iterator;
+  template<@\libconcept{input_or_output_iterator}@ I> class counted_iterator;
 
   template<class I>
     struct incrementable_traits<counted_iterator<I>>;
 
-  template<input_iterator I>
+  template<@\libconcept{input_iterator}@ I>
     struct iterator_traits<counted_iterator<I>>;
 
   // \ref{unreachable.sentinels}, unreachable sentinels
@@ -858,16 +858,16 @@ exposition-only concepts:
 
 \begin{codeblock}
 template<class I>
-concept @\placeholder{cpp17-iterator}@ =
-  copyable<I> && requires(I i) {
-    {   *i } -> @\placeholder{can-reference}@;
-    {  ++i } -> same_as<I&>;
-    { *i++ } -> @\placeholder{can-reference}@;
+concept @\defexposconcept{cpp17-iterator}@ =
+  @\libconcept{copyable}@<I> && requires(I i) {
+    {   *i } -> @\exposconcept{can-reference}@;
+    {  ++i } -> @\libconcept{same_as}@<I&>;
+    { *i++ } -> @\exposconcept{can-reference}@;
   };
 
 template<class I>
-concept @\placeholder{cpp17-input-iterator}@ =
-  @\placeholder{cpp17-iterator}@<I> && equality_comparable<I> && requires(I i) {
+concept @\defexposconcept{cpp17-input-iterator}@ =
+  @\exposconcept{cpp17-iterator}@<I> && @\libconcept{equality_comparable}@<I> && requires(I i) {
     typename incrementable_traits<I>::difference_type;
     typename indirectly_readable_traits<I>::value_type;
     typename common_reference_t<iter_reference_t<I>&&,
@@ -878,35 +878,35 @@ concept @\placeholder{cpp17-input-iterator}@ =
   };
 
 template<class I>
-concept @\placeholder{cpp17-forward-iterator}@ =
-  @\placeholder{cpp17-input-iterator}@<I> && constructible_from<I> &&
+concept @\defexposconcept{cpp17-forward-iterator}@ =
+  @\exposconcept{cpp17-input-iterator}@<I> && @\libconcept{constructible_from}@<I> &&
   is_lvalue_reference_v<iter_reference_t<I>> &&
-  same_as<remove_cvref_t<iter_reference_t<I>>,
+  @\libconcept{same_as}@<remove_cvref_t<iter_reference_t<I>>,
           typename indirectly_readable_traits<I>::value_type> &&
   requires(I i) {
-    {  i++ } -> convertible_to<const I&>;
-    { *i++ } -> same_as<iter_reference_t<I>>;
+    {  i++ } -> @\libconcept{convertible_to}@<const I&>;
+    { *i++ } -> @\libconcept{same_as}@<iter_reference_t<I>>;
   };
 
 template<class I>
-concept @\placeholder{cpp17-bidirectional-iterator}@ =
-  @\placeholder{cpp17-forward-iterator}@<I> && requires(I i) {
-    {  --i } -> same_as<I&>;
-    {  i-- } -> convertible_to<const I&>;
-    { *i-- } -> same_as<iter_reference_t<I>>;
+concept @\defexposconcept{cpp17-bidirectional-iterator}@ =
+  @\exposconcept{cpp17-forward-iterator}@<I> && requires(I i) {
+    {  --i } -> @\libconcept{same_as}@<I&>;
+    {  i-- } -> @\libconcept{convertible_to}@<const I&>;
+    { *i-- } -> @\libconcept{same_as}@<iter_reference_t<I>>;
   };
 
 template<class I>
-concept @\placeholder{cpp17-random-access-iterator}@ =
-  @\placeholder{cpp17-bidirectional-iterator}@<I> && totally_ordered<I> &&
+concept @\defexposconcept{cpp17-random-access-iterator}@ =
+  @\exposconcept{cpp17-bidirectional-iterator}@<I> && @\libconcept{totally_ordered}@<I> &&
   requires(I i, typename incrementable_traits<I>::difference_type n) {
-    { i += n } -> same_as<I&>;
-    { i -= n } -> same_as<I&>;
-    { i +  n } -> same_as<I>;
-    { n +  i } -> same_as<I>;
-    { i -  n } -> same_as<I>;
-    { i -  i } -> same_as<decltype(n)>;
-    {  i[n]  } -> convertible_to<iter_reference_t<I>>;
+    { i += n } -> @\libconcept{same_as}@<I&>;
+    { i -= n } -> @\libconcept{same_as}@<I&>;
+    { i +  n } -> @\libconcept{same_as}@<I>;
+    { n +  i } -> @\libconcept{same_as}@<I>;
+    { i -  n } -> @\libconcept{same_as}@<I>;
+    { i -  i } -> @\libconcept{same_as}@<decltype(n)>;
+    {  i[n]  } -> @\libconcept{convertible_to}@<iter_reference_t<I>>;
   };
 \end{codeblock}
 
@@ -935,7 +935,7 @@ otherwise, it names \tcode{void}.
 
 \item
 Otherwise, if \tcode{I} satisfies the exposition-only concept
-\tcode{\placeholder{cpp17-input-iterator}},
+\exposconcept{cpp17-input-iterator},
 %then
 \tcode{iterator_traits<I>} has the following
 publicly accessible members:
@@ -964,15 +964,15 @@ Otherwise, \tcode{iterator_category} names:
 \item
 \tcode{random_access_iterator_tag}
 if
-\tcode{I} satisfies \tcode{\placeholder{cpp17-random-access-iterator}},
+\tcode{I} satisfies \exposconcept{cpp17-random-access-iterator},
 or otherwise
 \item
 \tcode{bidirectional_iterator_tag} if
-\tcode{I} satisfies \tcode{\placeholder{cpp17-bidirectional-iterator}},
+\tcode{I} satisfies \exposconcept{cpp17-bidirectional-iterator},
 or otherwise
 \item
 \tcode{forward_iterator_tag} if
-\tcode{I} satisfies \tcode{\placeholder{cpp17-forward-iterator}},
+\tcode{I} satisfies \exposconcept{cpp17-forward-iterator},
 or otherwise
 \item
 \tcode{input_iterator_tag}.
@@ -981,7 +981,7 @@ or otherwise
 
 \item
 Otherwise, if \tcode{I} satisfies the exposition-only concept
-\tcode{\placeholder{cpp17-iterator}}, then \tcode{iterator_traits<I>}
+\exposconcept{cpp17-iterator}, then \tcode{iterator_traits<I>}
 has the following publicly accessible
 members:
 \begin{codeblock}
@@ -1094,10 +1094,10 @@ that exchanges the values\iref{concept.swappable} denoted by its
 arguments.
 
 \pnum
-Let \tcode{\placeholder{iter-exchange-move}} be the exposition-only function:
+Let \exposid{iter-exchange-move} be the exposition-only function:
 \begin{itemdecl}
 template<class X, class Y>
-  constexpr iter_value_t<X> @\placeholdernc{iter-exchange-move}@(X&& x, Y&& y)
+  constexpr iter_value_t<X> @\exposid{iter-exchange-move}@(X&& x, Y&& y)
     noexcept(noexcept(iter_value_t<X>(iter_move(x))) &&
              noexcept(*x = iter_move(y)));
 \end{itemdecl}
@@ -1137,7 +1137,7 @@ then \tcode{ranges::swap(*E1, *E2)}.
 
 \item Otherwise, if the types \tcode{T1} and \tcode{T2} of \tcode{E1} and
 \tcode{E2} model \tcode{\libconcept{indirectly_movable_storable}<T1, T2>} and
-\tcode{indirectly_movable_storable<T2, T1>}, then
+\tcode{\libconcept{indirectly_movable_storable}<T2, T1>}, then
 \tcode{(void)(*E1 = \placeholdernc{iter-exchange-move}(E2, E1))},
 except that \tcode{E1} is evaluated only once.
 
@@ -1259,7 +1259,7 @@ and let \tcode{o} be a dereferenceable object of type \tcode{Out}.
 \tcode{Out} and \tcode{T} model \tcode{\libconcept{indirectly_writable}<Out, T>} only if
 \begin{itemize}
 \item If \tcode{Out} and \tcode{T} model
-  \tcode{indirectly_readable<Out> \&\& same_as<iter_value_t<Out>, decay_t<T>{>}},
+  \tcode{\libconcept{indirectly_readable}<Out> \&\& \libconcept{same_as}<iter_value_t<Out>, decay_t<T>{>}},
   then \tcode{*o} after any above assignment is equal to
   the value of \tcode{E} before the assignment.
 \end{itemize}
@@ -1303,11 +1303,11 @@ template<class T>
 
 template<class I>
   concept @\deflibconcept{weakly_incrementable}@ =
-    default_initializable<I> && movable<I> &&
+    default_initializable<I> && @\libconcept{movable}@<I> &&
     requires(I i) {
       typename iter_difference_t<I>;
       requires @\placeholdernc{is-signed-integer-like}@<iter_difference_t<I>>;
-      { ++i } -> same_as<I&>;   // not required to be equality-preserving
+      { ++i } -> @\libconcept{same_as}@<I&>;   // not required to be equality-preserving
       i++;                      // not required to be equality-preserving
     };
 \end{codeblock}
@@ -1436,7 +1436,7 @@ both pre- and post-increment, \tcode{i} is said to be \defn{incrementable}.
 
 \pnum
 \begin{note}
-For \tcode{weakly_incrementable} types, \tcode{a} equals \tcode{b} does not imply that \tcode{++a}
+For \libconcept{weakly_incrementable} types, \tcode{a} equals \tcode{b} does not imply that \tcode{++a}
 equals \tcode{++b}. (Equality does not guarantee the substitution property or referential
 transparency.) Algorithms on weakly incrementable types should never attempt to pass
 through the same incrementable value twice. They should be single-pass algorithms. These algorithms
@@ -1452,16 +1452,16 @@ and post-increment operators. The increment operations are required to be equali
 and the type is required to be \libconcept{equality_comparable}.
 \begin{note}
 This supersedes the annotations on the increment expressions
-in the definition of \tcode{weakly_incrementable}.
+in the definition of \libconcept{weakly_incrementable}.
 \end{note}
 
 \begin{codeblock}
 template<class I>
   concept @\deflibconcept{incrementable}@ =
     regular<I> &&
-    weakly_incrementable<I> &&
+    @\libconcept{weakly_incrementable}@<I> &&
     requires(I i) {
-      { i++ } -> same_as<I>;
+      { i++ } -> @\libconcept{same_as}@<I>;
     };
 \end{codeblock}
 
@@ -1500,9 +1500,9 @@ to provide a richer set of iterator movements (\ref{iterator.concept.forward},
 template<class I>
   concept @\deflibconcept{input_or_output_iterator}@ =
     requires(I i) {
-      { *i } -> @\placeholder{can-reference}@;
+      { *i } -> @\exposconcept{can-reference}@;
     } &&
-    weakly_incrementable<I>;
+    @\libconcept{weakly_incrementable}@<I>;
 \end{codeblock}
 
 \pnum
@@ -1521,9 +1521,9 @@ whose values denote a range.
 \begin{itemdecl}
 template<class S, class I>
   concept @\deflibconcept{sentinel_for}@ =
-    semiregular<S> &&
-    input_or_output_iterator<I> &&
-    @\placeholder{weakly-equality-comparable-with}@<S, I>; // See \ref{concept.equalitycomparable}
+    @\libconcept{semiregular}@<S> &&
+    @\libconcept{input_or_output_iterator}@<I> &&
+    @\exposconcept{weakly-equality-comparable-with}@<S, I>; // See \ref{concept.equalitycomparable}
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1559,11 +1559,11 @@ between them in constant time.
 \begin{itemdecl}
 template<class S, class I>
   concept @\deflibconcept{sized_sentinel_for}@ =
-    sentinel_for<S, I> &&
+    @\libconcept{sentinel_for}@<S, I> &&
     !disable_sized_sentinel_for<remove_cv_t<S>, remove_cv_t<I>> &&
     requires(const I& i, const S& s) {
-      { s - i } -> same_as<iter_difference_t<I>>;
-      { i - s } -> same_as<iter_difference_t<I>>;
+      { s - i } -> @\libconcept{same_as}@<iter_difference_t<I>>;
+      { i - s } -> @\libconcept{same_as}@<iter_difference_t<I>>;
     };
 \end{itemdecl}
 
@@ -1630,10 +1630,10 @@ equality comparison since iterators are typically compared to sentinels.
 \begin{codeblock}
 template<class I>
   concept @\deflibconcept{input_iterator}@ =
-    input_or_output_iterator<I> &&
-    indirectly_readable<I> &&
+    @\libconcept{input_or_output_iterator}@<I> &&
+    @\libconcept{indirectly_readable}@<I> &&
     requires { typename @\placeholdernc{ITER_CONCEPT}@(I); } &&
-    derived_from<@\placeholdernc{ITER_CONCEPT}@(I), input_iterator_tag>;
+    @\libconcept{derived_from}@<@\placeholdernc{ITER_CONCEPT}@(I), input_iterator_tag>;
 \end{codeblock}
 
 \rSec3[iterator.concept.output]{Concept \cname{output_iterator}}
@@ -1650,8 +1650,8 @@ Output iterators are not required to model \libconcept{equality_comparable}.
 \begin{codeblock}
 template<class I, class T>
   concept @\deflibconcept{output_iterator}@ =
-    input_or_output_iterator<I> &&
-    indirectly_writable<I, T> &&
+    @\libconcept{input_or_output_iterator}@<I> &&
+    @\libconcept{indirectly_writable}@<I, T> &&
     requires(I i, T&& t) {
       *i++ = std::forward<T>(t);        // not required to be equality-preserving
     };
@@ -1682,10 +1682,10 @@ the multi-pass guarantee, specified below.
 \begin{codeblock}
 template<class I>
   concept @\deflibconcept{forward_iterator}@ =
-    input_iterator<I> &&
-    derived_from<@\placeholdernc{ITER_CONCEPT}@(I), forward_iterator_tag> &&
-    incrementable<I> &&
-    sentinel_for<I, I>;
+    @\libconcept{input_iterator}@<I> &&
+    @\libconcept{derived_from}@<@\placeholdernc{ITER_CONCEPT}@(I), forward_iterator_tag> &&
+    @\libconcept{incrementable}@<I> &&
+    @\libconcept{sentinel_for}@<I, I>;
 \end{codeblock}
 
 \pnum
@@ -1731,11 +1731,11 @@ to move an iterator backward as well as forward.
 \begin{codeblock}
 template<class I>
   concept @\deflibconcept{bidirectional_iterator}@ =
-    forward_iterator<I> &&
-    derived_from<@\placeholdernc{ITER_CONCEPT}@(I), bidirectional_iterator_tag> &&
+    @\libconcept{forward_iterator}@<I> &&
+    @\libconcept{derived_from}@<@\placeholdernc{ITER_CONCEPT}@(I), bidirectional_iterator_tag> &&
     requires(I i) {
-      { --i } -> same_as<I&>;
-      { i-- } -> same_as<I>;
+      { --i } -> @\libconcept{same_as}@<I&>;
+      { i-- } -> @\libconcept{same_as}@<I>;
     };
 \end{codeblock}
 
@@ -1772,17 +1772,17 @@ Random access iterators also support array notation via subscripting.
 \begin{codeblock}
 template<class I>
   concept @\deflibconcept{random_access_iterator}@ =
-    bidirectional_iterator<I> &&
-    derived_from<@\placeholdernc{ITER_CONCEPT}@(I), random_access_iterator_tag> &&
-    totally_ordered<I> &&
-    sized_sentinel_for<I, I> &&
+    @\libconcept{bidirectional_iterator}@<I> &&
+    @\libconcept{derived_from}@<@\placeholdernc{ITER_CONCEPT}@(I), random_access_iterator_tag> &&
+    @\libconcept{totally_ordered}@<I> &&
+    @\libconcept{sized_sentinel_for}@<I, I> &&
     requires(I i, const I j, const iter_difference_t<I> n) {
-      { i += n } -> same_as<I&>;
-      { j +  n } -> same_as<I>;
-      { n +  j } -> same_as<I>;
-      { i -= n } -> same_as<I&>;
-      { j -  n } -> same_as<I>;
-      {  j[n]  } -> same_as<iter_reference_t<I>>;
+      { i += n } -> @\libconcept{same_as}@<I&>;
+      { j +  n } -> @\libconcept{same_as}@<I>;
+      { n +  j } -> @\libconcept{same_as}@<I>;
+      { i -= n } -> @\libconcept{same_as}@<I&>;
+      { j -  n } -> @\libconcept{same_as}@<I>;
+      {  j[n]  } -> @\libconcept{same_as}@<iter_reference_t<I>>;
     };
 \end{codeblock}
 
@@ -1822,12 +1822,12 @@ the denoted elements are stored contiguously in memory.
 \begin{codeblock}
 template<class I>
   concept @\deflibconcept{contiguous_iterator}@ =
-    random_access_iterator<I> &&
-    derived_from<@\placeholdernc{ITER_CONCEPT}@(I), contiguous_iterator_tag> &&
+    @\libconcept{random_access_iterator}@<I> &&
+    @\libconcept{derived_from}@<@\placeholdernc{ITER_CONCEPT}@(I), contiguous_iterator_tag> &&
     is_lvalue_reference_v<iter_reference_t<I>> &&
-    same_as<iter_value_t<I>, remove_cvref_t<iter_reference_t<I>>> &&
+    @\libconcept{same_as}@<iter_value_t<I>, remove_cvref_t<iter_reference_t<I>>> &&
     requires(const I& i) {
-      { to_address(i) } -> same_as<add_pointer_t<iter_reference_t<I>>>;
+      { to_address(i) } -> @\libconcept{same_as}@<add_pointer_t<iter_reference_t<I>>>;
     };
 \end{codeblock}
 
@@ -2323,63 +2323,63 @@ that accept callable objects~(\ref{func.def}) as arguments.
 namespace std {
   template<class F, class I>
     concept @\deflibconcept{indirectly_unary_invocable}@ =
-      indirectly_readable<I> &&
-      copy_constructible<F> &&
-      invocable<F&, iter_value_t<I>&> &&
-      invocable<F&, iter_reference_t<I>> &&
-      invocable<F&, iter_common_reference_t<I>> &&
+      @\libconcept{indirectly_readable}@<I> &&
+      @\libconcept{copy_constructible}@<F> &&
+      @\libconcept{invocable}@<F&, iter_value_t<I>&> &&
+      @\libconcept{invocable}@<F&, iter_reference_t<I>> &&
+      @\libconcept{invocable}@<F&, iter_common_reference_t<I>> &&
       common_reference_with<
         invoke_result_t<F&, iter_value_t<I>&>,
         invoke_result_t<F&, iter_reference_t<I>>>;
 
   template<class F, class I>
     concept @\deflibconcept{indirectly_regular_unary_invocable}@ =
-      indirectly_readable<I> &&
-      copy_constructible<F> &&
-      regular_invocable<F&, iter_value_t<I>&> &&
-      regular_invocable<F&, iter_reference_t<I>> &&
-      regular_invocable<F&, iter_common_reference_t<I>> &&
+      @\libconcept{indirectly_readable}@<I> &&
+      @\libconcept{copy_constructible}@<F> &&
+      @\libconcept{regular_invocable}@<F&, iter_value_t<I>&> &&
+      @\libconcept{regular_invocable}@<F&, iter_reference_t<I>> &&
+      @\libconcept{regular_invocable}@<F&, iter_common_reference_t<I>> &&
       common_reference_with<
         invoke_result_t<F&, iter_value_t<I>&>,
         invoke_result_t<F&, iter_reference_t<I>>>;
 
   template<class F, class I>
     concept @\deflibconcept{indirect_unary_predicate}@ =
-      indirectly_readable<I> &&
-      copy_constructible<F> &&
-      predicate<F&, iter_value_t<I>&> &&
-      predicate<F&, iter_reference_t<I>> &&
-      predicate<F&, iter_common_reference_t<I>>;
+      @\libconcept{indirectly_readable}@<I> &&
+      @\libconcept{copy_constructible}@<F> &&
+      @\libconcept{predicate}@<F&, iter_value_t<I>&> &&
+      @\libconcept{predicate}@<F&, iter_reference_t<I>> &&
+      @\libconcept{predicate}@<F&, iter_common_reference_t<I>>;
 
   template<class F, class I1, class I2>
     concept @\deflibconcept{indirect_binary_predicate}@ =
-      indirectly_readable<I1> && indirectly_readable<I2> &&
-      copy_constructible<F> &&
-      predicate<F&, iter_value_t<I1>&, iter_value_t<I2>&> &&
-      predicate<F&, iter_value_t<I1>&, iter_reference_t<I2>> &&
-      predicate<F&, iter_reference_t<I1>, iter_value_t<I2>&> &&
-      predicate<F&, iter_reference_t<I1>, iter_reference_t<I2>> &&
-      predicate<F&, iter_common_reference_t<I1>, iter_common_reference_t<I2>>;
+      @\libconcept{indirectly_readable}@<I1> && @\libconcept{indirectly_readable}@<I2> &&
+      @\libconcept{copy_constructible}@<F> &&
+      @\libconcept{predicate}@<F&, iter_value_t<I1>&, iter_value_t<I2>&> &&
+      @\libconcept{predicate}@<F&, iter_value_t<I1>&, iter_reference_t<I2>> &&
+      @\libconcept{predicate}@<F&, iter_reference_t<I1>, iter_value_t<I2>&> &&
+      @\libconcept{predicate}@<F&, iter_reference_t<I1>, iter_reference_t<I2>> &&
+      @\libconcept{predicate}@<F&, iter_common_reference_t<I1>, iter_common_reference_t<I2>>;
 
   template<class F, class I1, class I2 = I1>
     concept @\deflibconcept{indirect_equivalence_relation}@ =
-      indirectly_readable<I1> && indirectly_readable<I2> &&
-      copy_constructible<F> &&
-      equivalence_relation<F&, iter_value_t<I1>&, iter_value_t<I2>&> &&
-      equivalence_relation<F&, iter_value_t<I1>&, iter_reference_t<I2>> &&
-      equivalence_relation<F&, iter_reference_t<I1>, iter_value_t<I2>&> &&
-      equivalence_relation<F&, iter_reference_t<I1>, iter_reference_t<I2>> &&
-      equivalence_relation<F&, iter_common_reference_t<I1>, iter_common_reference_t<I2>>;
+      @\libconcept{indirectly_readable}@<I1> && @\libconcept{indirectly_readable}@<I2> &&
+      @\libconcept{copy_constructible}@<F> &&
+      @\libconcept{equivalence_relation}@<F&, iter_value_t<I1>&, iter_value_t<I2>&> &&
+      @\libconcept{equivalence_relation}@<F&, iter_value_t<I1>&, iter_reference_t<I2>> &&
+      @\libconcept{equivalence_relation}@<F&, iter_reference_t<I1>, iter_value_t<I2>&> &&
+      @\libconcept{equivalence_relation}@<F&, iter_reference_t<I1>, iter_reference_t<I2>> &&
+      @\libconcept{equivalence_relation}@<F&, iter_common_reference_t<I1>, iter_common_reference_t<I2>>;
 
   template<class F, class I1, class I2 = I1>
     concept @\deflibconcept{indirect_strict_weak_order}@ =
-      indirectly_readable<I1> && indirectly_readable<I2> &&
-      copy_constructible<F> &&
-      strict_weak_order<F&, iter_value_t<I1>&, iter_value_t<I2>&> &&
-      strict_weak_order<F&, iter_value_t<I1>&, iter_reference_t<I2>> &&
-      strict_weak_order<F&, iter_reference_t<I1>, iter_value_t<I2>&> &&
-      strict_weak_order<F&, iter_reference_t<I1>, iter_reference_t<I2>> &&
-      strict_weak_order<F&, iter_common_reference_t<I1>, iter_common_reference_t<I2>>;
+      @\libconcept{indirectly_readable}@<I1> && @\libconcept{indirectly_readable}@<I2> &&
+      @\libconcept{copy_constructible}@<F> &&
+      @\libconcept{strict_weak_order}@<F&, iter_value_t<I1>&, iter_value_t<I2>&> &&
+      @\libconcept{strict_weak_order}@<F&, iter_value_t<I1>&, iter_reference_t<I2>> &&
+      @\libconcept{strict_weak_order}@<F&, iter_reference_t<I1>, iter_value_t<I2>&> &&
+      @\libconcept{strict_weak_order}@<F&, iter_reference_t<I1>, iter_reference_t<I2>> &&
+      @\libconcept{strict_weak_order}@<F&, iter_common_reference_t<I1>, iter_common_reference_t<I2>>;
 }
 \end{codeblock}
 
@@ -2396,13 +2396,13 @@ whose \tcode{reference} type is the result of applying
 \indexlibraryglobal{projected}%
 \begin{codeblock}
 namespace std {
-  template<indirectly_readable I, indirectly_regular_unary_invocable<I> Proj>
+  template<@\libconcept{indirectly_readable}@ I, @\libconcept{indirectly_regular_unary_invocable}@<I> Proj>
   struct projected {
     using value_type = remove_cvref_t<indirect_result_t<Proj&, I>>;
     indirect_result_t<Proj&, I> operator*() const;              // \notdef
   };
 
-  template<weakly_incrementable I, class Proj>
+  template<@\libconcept{weakly_incrementable}@ I, class Proj>
   struct incrementable_traits<projected<I, Proj>> {
     using difference_type = iter_difference_t<I>;
   };
@@ -2447,8 +2447,8 @@ between which values may be moved.
 \begin{codeblock}
 template<class In, class Out>
   concept @\deflibconcept{indirectly_movable}@ =
-    indirectly_readable<In> &&
-    indirectly_writable<Out, iter_rvalue_reference_t<In>>;
+    @\libconcept{indirectly_readable}@<In> &&
+    @\libconcept{indirectly_writable}@<Out, iter_rvalue_reference_t<In>>;
 \end{codeblock}
 
 \pnum
@@ -2460,11 +2460,11 @@ the transfer to be performed through an intermediate object of the
 \begin{codeblock}
 template<class In, class Out>
   concept @\deflibconcept{indirectly_movable_storable}@ =
-    indirectly_movable<In, Out> &&
-    indirectly_writable<Out, iter_value_t<In>> &&
-    movable<iter_value_t<In>> &&
-    constructible_from<iter_value_t<In>, iter_rvalue_reference_t<In>> &&
-    assignable_from<iter_value_t<In>&, iter_rvalue_reference_t<In>>;
+    @\libconcept{indirectly_movable}@<In, Out> &&
+    @\libconcept{indirectly_writable}@<Out, iter_value_t<In>> &&
+    @\libconcept{movable}@<iter_value_t<In>> &&
+    @\libconcept{constructible_from}@<iter_value_t<In>, iter_rvalue_reference_t<In>> &&
+    @\libconcept{assignable_from}@<iter_value_t<In>&, iter_rvalue_reference_t<In>>;
 \end{codeblock}
 
 \pnum
@@ -2489,8 +2489,8 @@ between which values may be copied.
 \begin{codeblock}
 template<class In, class Out>
   concept @\deflibconcept{indirectly_copyable}@ =
-    indirectly_readable<In> &&
-    indirectly_writable<Out, iter_reference_t<In>>;
+    @\libconcept{indirectly_readable}@<In> &&
+    @\libconcept{indirectly_writable}@<Out, iter_reference_t<In>>;
 \end{codeblock}
 
 \pnum
@@ -2503,14 +2503,14 @@ to make copies of values.
 \begin{codeblock}
 template<class In, class Out>
   concept @\deflibconcept{indirectly_copyable_storable}@ =
-    indirectly_copyable<In, Out> &&
-    indirectly_writable<Out, iter_value_t<In>&> &&
-    indirectly_writable<Out, const iter_value_t<In>&> &&
-    indirectly_writable<Out, iter_value_t<In>&&> &&
-    indirectly_writable<Out, const iter_value_t<In>&&> &&
-    copyable<iter_value_t<In>> &&
-    constructible_from<iter_value_t<In>, iter_reference_t<In>> &&
-    assignable_from<iter_value_t<In>&, iter_reference_t<In>>;
+    @\libconcept{indirectly_copyable}@<In, Out> &&
+    @\libconcept{indirectly_writable}@<Out, iter_value_t<In>&> &&
+    @\libconcept{indirectly_writable}@<Out, const iter_value_t<In>&> &&
+    @\libconcept{indirectly_writable}@<Out, iter_value_t<In>&&> &&
+    @\libconcept{indirectly_writable}@<Out, const iter_value_t<In>&&> &&
+    @\libconcept{copyable}@<iter_value_t<In>> &&
+    @\libconcept{constructible_from}@<iter_value_t<In>, iter_reference_t<In>> &&
+    @\libconcept{assignable_from}@<iter_value_t<In>&, iter_reference_t<In>>;
 \end{codeblock}
 
 \pnum
@@ -2534,7 +2534,7 @@ between the values referenced by two \libconcept{indirectly_readable} types.
 \begin{codeblock}
 template<class I1, class I2 = I1>
   concept @\deflibconcept{indirectly_swappable}@ =
-    indirectly_readable<I1> && indirectly_readable<I2> &&
+    @\libconcept{indirectly_readable}@<I1> && @\libconcept{indirectly_readable}@<I2> &&
     requires(const I1 i1, const I2 i2) {
       ranges::iter_swap(i1, i1);
       ranges::iter_swap(i2, i2);
@@ -2554,7 +2554,7 @@ compare values from two different sequences.
 template<class I1, class I2, class R, class P1 = identity,
          class P2 = identity>
   concept @\deflibconcept{indirectly_comparable}@ =
-    indirect_binary_predicate<R, projected<I1, P1>, projected<I2, P2>>;
+    @\libconcept{indirect_binary_predicate}@<R, projected<I1, P1>, projected<I2, P2>>;
 \end{codeblock}
 
 \rSec3[alg.req.permutable]{Concept \cname{permutable}}
@@ -2566,9 +2566,9 @@ of algorithms that reorder elements in place by moving or swapping them.
 \begin{codeblock}
 template<class I>
   concept @\deflibconcept{permutable}@ =
-    forward_iterator<I> &&
-    indirectly_movable_storable<I, I> &&
-    indirectly_swappable<I, I>;
+    @\libconcept{forward_iterator}@<I> &&
+    @\libconcept{indirectly_movable_storable}@<I, I> &&
+    @\libconcept{indirectly_swappable}@<I, I>;
 \end{codeblock}
 
 \rSec3[alg.req.mergeable]{Concept \cname{mergeable}}
@@ -2581,12 +2581,12 @@ that merge sorted sequences into an output sequence by copying elements.
 template<class I1, class I2, class Out, class R = ranges::less,
          class P1 = identity, class P2 = identity>
   concept @\deflibconcept{mergeable}@ =
-    input_iterator<I1> &&
-    input_iterator<I2> &&
-    weakly_incrementable<Out> &&
-    indirectly_copyable<I1, Out> &&
-    indirectly_copyable<I2, Out> &&
-    indirect_strict_weak_order<R, projected<I1, P1>, projected<I2, P2>>;
+    @\libconcept{input_iterator}@<I1> &&
+    @\libconcept{input_iterator}@<I2> &&
+    @\libconcept{weakly_incrementable}@<Out> &&
+    @\libconcept{indirectly_copyable}@<I1, Out> &&
+    @\libconcept{indirectly_copyable}@<I2, Out> &&
+    @\libconcept{indirect_strict_weak_order}@<R, projected<I1, P1>, projected<I2, P2>>;
 \end{codeblock}
 
 \rSec3[alg.req.sortable]{Concept \cname{sortable}}
@@ -2598,8 +2598,8 @@ algorithms that permute sequences into ordered sequences (e.g., \tcode{sort}).
 \begin{codeblock}
 template<class I, class R = ranges::less, class P = identity>
   concept @\deflibconcept{sortable}@ =
-    permutable<I> &&
-    indirect_strict_weak_order<R, projected<I, P>>;
+    @\libconcept{permutable}@<I> &&
+    @\libconcept{indirect_strict_weak_order}@<R, projected<I, P>>;
 \end{codeblock}
 
 \rSec1[iterator.primitives]{Iterator primitives}
@@ -2845,7 +2845,7 @@ in this subclause is unspecified, except where explicitly stated otherwise.
 
 \indexlibraryglobal{advance}%
 \begin{itemdecl}
-template<input_or_output_iterator I>
+template<@\libconcept{input_or_output_iterator}@ I>
   constexpr void ranges::advance(I& i, iter_difference_t<I> n);
 \end{itemdecl}
 
@@ -2868,7 +2868,7 @@ If \tcode{I} does not model \libconcept{bidirectional_iterator},
 
 \indexlibraryglobal{advance}%
 \begin{itemdecl}
-template<input_or_output_iterator I, sentinel_for<I> S>
+template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
   constexpr void ranges::advance(I& i, S bound);
 \end{itemdecl}
 
@@ -2891,7 +2891,7 @@ template<input_or_output_iterator I, sentinel_for<I> S>
 
 \indexlibraryglobal{advance}%
 \begin{itemdecl}
-template<input_or_output_iterator I, sentinel_for<I> S>
+template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
   constexpr iter_difference_t<I> ranges::advance(I& i, iter_difference_t<I> n, S bound);
 \end{itemdecl}
 
@@ -2933,7 +2933,7 @@ the ending and starting positions of \tcode{i}.
 \rSec3[range.iter.op.distance]{\tcode{ranges::distance}}
 \indexlibraryglobal{distance}%
 \begin{itemdecl}
-template<input_or_output_iterator I, sentinel_for<I> S>
+template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
   constexpr iter_difference_t<I> ranges::distance(I first, S last);
 \end{itemdecl}
 
@@ -2943,7 +2943,7 @@ template<input_or_output_iterator I, sentinel_for<I> S>
 \range{first}{last} denotes a range, or
 \range{last}{first} denotes a range and
 \tcode{S} and \tcode{I} model
-\tcode{same_as<S, I> \&\& sized_sentinel_for<S, I>}.
+\tcode{\libconcept{same_as}<S, I> \&\& \libconcept{sized_sentinel_for}<S, I>}.
 
 \pnum
 \effects
@@ -2957,7 +2957,7 @@ to
 
 \indexlibraryglobal{distance}%
 \begin{itemdecl}
-template<range R>
+template<@\libconcept{range}@ R>
   constexpr range_difference_t<R> ranges::distance(R&& r);
 \end{itemdecl}
 
@@ -2978,7 +2978,7 @@ return ranges::distance(ranges::begin(r), ranges::end(r));      // \ref{range.ac
 
 \indexlibraryglobal{next}%
 \begin{itemdecl}
-template<input_or_output_iterator I>
+template<@\libconcept{input_or_output_iterator}@ I>
   constexpr I ranges::next(I x);
 \end{itemdecl}
 
@@ -2990,7 +2990,7 @@ Equivalent to: \tcode{++x; return x;}
 
 \indexlibraryglobal{next}%
 \begin{itemdecl}
-template<input_or_output_iterator I>
+template<@\libconcept{input_or_output_iterator}@ I>
   constexpr I ranges::next(I x, iter_difference_t<I> n);
 \end{itemdecl}
 
@@ -3002,7 +3002,7 @@ Equivalent to: \tcode{ranges::advance(x, n); return x;}
 
 \indexlibraryglobal{next}%
 \begin{itemdecl}
-template<input_or_output_iterator I, sentinel_for<I> S>
+template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
   constexpr I ranges::next(I x, S bound);
 \end{itemdecl}
 
@@ -3014,7 +3014,7 @@ Equivalent to: \tcode{ranges::advance(x, bound); return x;}
 
 \indexlibraryglobal{next}%
 \begin{itemdecl}
-template<input_or_output_iterator I, sentinel_for<I> S>
+template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
   constexpr I ranges::next(I x, iter_difference_t<I> n, S bound);
 \end{itemdecl}
 
@@ -3027,7 +3027,7 @@ Equivalent to: \tcode{ranges::advance(x, n, bound); return x;}
 \rSec3[range.iter.op.prev]{\tcode{ranges::prev}}
 \indexlibraryglobal{prev}%
 \begin{itemdecl}
-template<bidirectional_iterator I>
+template<@\libconcept{bidirectional_iterator}@ I>
   constexpr I ranges::prev(I x);
 \end{itemdecl}
 
@@ -3039,7 +3039,7 @@ Equivalent to: \tcode{-{-}x; return x;}
 
 \indexlibraryglobal{prev}%
 \begin{itemdecl}
-template<bidirectional_iterator I>
+template<@\libconcept{bidirectional_iterator}@ I>
   constexpr I ranges::prev(I x, iter_difference_t<I> n);
 \end{itemdecl}
 
@@ -3051,7 +3051,7 @@ Equivalent to: \tcode{ranges::advance(x, -n); return x;}
 
 \indexlibraryglobal{prev}%
 \begin{itemdecl}
-template<bidirectional_iterator I>
+template<@\libconcept{bidirectional_iterator}@ I>
   constexpr I ranges::prev(I x, iter_difference_t<I> n, I bound);
 \end{itemdecl}
 
@@ -3106,7 +3106,7 @@ namespace std {
 
     friend constexpr iter_rvalue_reference_t<Iterator>
       iter_move(const reverse_iterator& i) noexcept(@\seebelow@);
-    template<indirectly_swappable<Iterator> Iterator2>
+    template<@\libconcept{indirectly_swappable}@<Iterator> Iterator2>
       friend constexpr void
         iter_swap(const reverse_iterator& x,
                   const reverse_iterator<Iterator2>& y) noexcept(@\seebelow@);
@@ -3535,7 +3535,7 @@ convertible to \tcode{bool}.
 
 \indexlibrarymember{operator<=>}{reverse_iterator}%
 \begin{itemdecl}
-template<class Iterator1, three_way_comparable_with<Iterator1> Iterator2>
+template<class Iterator1, @\libconcept{three_way_comparable_with}@<Iterator1> Iterator2>
   constexpr compare_three_way_result_t<Iterator1, Iterator2>
     operator<=>(const reverse_iterator<Iterator1>& x,
                 const reverse_iterator<Iterator2>& y);
@@ -3609,7 +3609,7 @@ noexcept(ranges::iter_move(--declval<Iterator&>()))
 
 \indexlibrarymember{iter_swap}{reverse_iterator}%
 \begin{itemdecl}
-template<indirectly_swappable<Iterator> Iterator2>
+template<@\libconcept{indirectly_swappable}@<Iterator> Iterator2>
   friend constexpr void
     iter_swap(const reverse_iterator& x,
               const reverse_iterator<Iterator2>& y) noexcept(@\seebelow@);
@@ -4101,19 +4101,19 @@ namespace std {
     constexpr move_iterator& operator-=(difference_type n);
     constexpr reference operator[](difference_type n) const;
 
-    template<sentinel_for<Iterator> S>
+    template<@\libconcept{sentinel_for}@<Iterator> S>
       friend constexpr bool
         operator==(const move_iterator& x, const move_sentinel<S>& y);
-    template<sized_sentinel_for<Iterator> S>
+    template<@\libconcept{sized_sentinel_for}@<Iterator> S>
       friend constexpr iter_difference_t<Iterator>
         operator-(const move_sentinel<S>& x, const move_iterator& y);
-    template<sized_sentinel_for<Iterator> S>
+    template<@\libconcept{sized_sentinel_for}@<Iterator> S>
       friend constexpr iter_difference_t<Iterator>
         operator-(const move_iterator& x, const move_sentinel<S>& y);
     friend constexpr iter_rvalue_reference_t<Iterator>
       iter_move(const move_iterator& i)
         noexcept(noexcept(ranges::iter_move(i.current)));
-    template<indirectly_swappable<Iterator> Iterator2>
+    template<@\libconcept{indirectly_swappable}@<Iterator> Iterator2>
       friend constexpr void
         iter_swap(const move_iterator& x, const move_iterator<Iterator2>& y)
           noexcept(noexcept(ranges::iter_swap(x.current, y.current)));
@@ -4394,7 +4394,7 @@ As if by: \tcode{current -= n;}
 template<class Iterator1, class Iterator2>
   constexpr bool operator==(const move_iterator<Iterator1>& x,
                             const move_iterator<Iterator2>& y);
-template<sentinel_for<Iterator> S>
+template<@\libconcept{sentinel_for}@<Iterator> S>
   friend constexpr bool operator==(const move_iterator& x,
                                    const move_sentinel<S>& y);
 \end{itemdecl}
@@ -4480,7 +4480,7 @@ convertible to \tcode{bool}.
 
 \indexlibrarymember{operator<=>}{move_iterator}%
 \begin{itemdecl}
-template<class Iterator1, three_way_comparable_with<Iterator1> Iterator2>
+template<class Iterator1, @\libconcept{three_way_comparable_with}@<Iterator1> Iterator2>
   constexpr compare_three_way_result_t<Iterator1, Iterator2>
     operator<=>(const move_iterator<Iterator1>& x,
                 const move_iterator<Iterator2>& y);
@@ -4500,10 +4500,10 @@ template<class Iterator1, class Iterator2>
   constexpr auto operator-(const move_iterator<Iterator1>& x,
                            const move_iterator<Iterator2>& y)
     -> decltype(x.base() - y.base());
-template<sized_sentinel_for<Iterator> S>
+template<@\libconcept{sized_sentinel_for}@<Iterator> S>
   friend constexpr iter_difference_t<Iterator>
     operator-(const move_sentinel<S>& x, const move_iterator& y);
-template<sized_sentinel_for<Iterator> S>
+template<@\libconcept{sized_sentinel_for}@<Iterator> S>
   friend constexpr iter_difference_t<Iterator>
     operator-(const move_iterator& x, const move_sentinel<S>& y);
 \end{itemdecl}
@@ -4546,7 +4546,7 @@ Equivalent to: \tcode{return ranges::iter_move(i.current);}
 
 \indexlibrarymember{iter_swap}{move_iterator}%
 \begin{itemdecl}
-template<indirectly_swappable<Iterator> Iterator2>
+template<@\libconcept{indirectly_swappable}@<Iterator> Iterator2>
   friend constexpr void
     iter_swap(const move_iterator& x, const move_iterator<Iterator2>& y)
       noexcept(noexcept(ranges::iter_swap(x.current, y.current)));
@@ -4577,7 +4577,7 @@ Class template \tcode{move_sentinel} is a sentinel adaptor useful for denoting
 ranges together with \tcode{move_iterator}. When an input iterator type
 \tcode{I} and sentinel type \tcode{S} model \tcode{\libconcept{sentinel_for}<S, I>},
 \tcode{move_sentinel<S>} and \tcode{move_iterator<I>} model
-\tcode{sentinel_for<move_sentinel<S>, move_iterator<I>{>}} as well.
+\tcode{\libconcept{sentinel_for}<move_sentinel<S>, move_iterator<I>{>}} as well.
 
 \pnum
 \begin{example}
@@ -4585,9 +4585,9 @@ A \tcode{move_if} algorithm is easily implemented with
 \tcode{copy_if} using \tcode{move_iterator} and \tcode{move_sentinel}:
 
 \begin{codeblock}
-template<input_iterator I, sentinel_for<I> S, weakly_incrementable O,
-         indirect_unary_predicate<I> Pred>
-  requires indirectly_movable<I, O>
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O,
+         @\libconcept{indirect_unary_predicate}@<I> Pred>
+  requires @\libconcept{indirectly_movable}@<I, O>
 void move_if(I first, S last, O out, Pred pred) {
   std::ranges::copy_if(move_iterator<I>{first}, move_sentinel<S>{last}, out, pred);
 }
@@ -4597,16 +4597,16 @@ void move_if(I first, S last, O out, Pred pred) {
 \indexlibraryglobal{move_sentinel}%
 \begin{codeblock}
 namespace std {
-  template<semiregular S>
+  template<@\libconcept{semiregular}@ S>
   class move_sentinel {
   public:
     constexpr move_sentinel();
     constexpr explicit move_sentinel(S s);
     template<class S2>
-      requires convertible_to<const S2&, S>
+      requires @\libconcept{convertible_to}@<const S2&, S>
         constexpr move_sentinel(const move_sentinel<S2>& s);
     template<class S2>
-      requires assignable_from<S&, const S2&>
+      requires @\libconcept{assignable_from}@<S&, const S2&>
         constexpr move_sentinel& operator=(const move_sentinel<S2>& s);
 
     constexpr S base() const;
@@ -4645,7 +4645,7 @@ Initializes \tcode{last} with \tcode{std::move(s)}.
 \indexlibraryctor{move_sentinel}%
 \begin{itemdecl}
 template<class S2>
-  requires convertible_to<const S2&, S>
+  requires @\libconcept{convertible_to}@<const S2&, S>
     constexpr move_sentinel(const move_sentinel<S2>& s);
 \end{itemdecl}
 
@@ -4659,7 +4659,7 @@ Initializes \tcode{last} with \tcode{s.last}.
 \indexlibrarymember{move_sentinel}{operator=}%
 \begin{itemdecl}
 template<class S2>
-  requires assignable_from<S&, const S2&>
+  requires @\libconcept{assignable_from}@<S&, const S2&>
     constexpr move_sentinel& operator=(const move_sentinel<S2>& s);
 \end{itemdecl}
 
@@ -4714,20 +4714,20 @@ fun(CI(counted_iterator(s.begin(), 10)), CI(default_sentinel));
 \indexlibraryglobal{common_iterator}%
 \begin{codeblock}
 namespace std {
-  template<input_or_output_iterator I, sentinel_for<I> S>
-    requires (!same_as<I, S> && copyable<I>)
+  template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
+    requires (!@\libconcept{same_as}@<I, S> && @\libconcept{copyable}@<I>)
   class common_iterator {
   public:
     constexpr common_iterator() = default;
     constexpr common_iterator(I i);
     constexpr common_iterator(S s);
     template<class I2, class S2>
-      requires convertible_to<const I2&, I> && convertible_to<const S2&, S>
+      requires @\libconcept{convertible_to}@<const I2&, I> && @\libconcept{convertible_to}@<const S2&, S>
         constexpr common_iterator(const common_iterator<I2, S2>& x);
 
     template<class I2, class S2>
-      requires convertible_to<const I2&, I> && convertible_to<const S2&, S> &&
-               assignable_from<I&, const I2&> && assignable_from<S&, const S2&>
+      requires @\libconcept{convertible_to}@<const I2&, I> && @\libconcept{convertible_to}@<const S2&, S> &&
+               @\libconcept{assignable_from}@<I&, const I2&> && @\libconcept{assignable_from}@<S&, const S2&>
         common_iterator& operator=(const common_iterator<I2, S2>& x);
 
     decltype(auto) operator*();
@@ -4739,24 +4739,24 @@ namespace std {
     common_iterator& operator++();
     decltype(auto) operator++(int);
 
-    template<class I2, sentinel_for<I> S2>
-      requires sentinel_for<S, I2>
+    template<class I2, @\libconcept{sentinel_for}@<I> S2>
+      requires @\libconcept{sentinel_for}@<S, I2>
     friend bool operator==(
       const common_iterator& x, const common_iterator<I2, S2>& y);
-    template<class I2, sentinel_for<I> S2>
-      requires sentinel_for<S, I2> && equality_comparable_with<I, I2>
+    template<class I2, @\libconcept{sentinel_for}@<I> S2>
+      requires @\libconcept{sentinel_for}@<S, I2> && equality_comparable_with<I, I2>
     friend bool operator==(
       const common_iterator& x, const common_iterator<I2, S2>& y);
 
-    template<sized_sentinel_for<I> I2, sized_sentinel_for<I> S2>
-      requires sized_sentinel_for<S, I2>
+    template<@\libconcept{sized_sentinel_for}@<I> I2, @\libconcept{sized_sentinel_for}@<I> S2>
+      requires @\libconcept{sized_sentinel_for}@<S, I2>
     friend iter_difference_t<I2> operator-(
       const common_iterator& x, const common_iterator<I2, S2>& y);
 
     friend iter_rvalue_reference_t<I> iter_move(const common_iterator& i)
       noexcept(noexcept(ranges::iter_move(declval<const I&>())))
-        requires input_iterator<I>;
-    template<indirectly_swappable<I> I2, class S2>
+        requires @\libconcept{input_iterator}@<I>;
+    template<@\libconcept{indirectly_swappable}@<I> I2, class S2>
       friend void iter_swap(const common_iterator& x, const common_iterator<I2, S2>& y)
         noexcept(noexcept(ranges::iter_swap(declval<const I&>(), declval<const I2&>())));
 
@@ -4769,7 +4769,7 @@ namespace std {
     using difference_type = iter_difference_t<I>;
   };
 
-  template<input_iterator I, class S>
+  template<@\libconcept{input_iterator}@ I, class S>
   struct iterator_traits<common_iterator<I, S>> {
     using iterator_concept = @\seebelow@;
     using iterator_category = @\seebelow@;
@@ -4796,7 +4796,7 @@ otherwise it denotes \tcode{input_iterator_tag}.
 \tcode{iterator_category} denotes
 \tcode{forward_iterator_tag}
 if \tcode{iterator_traits<I>::iterator_category}
-models \tcode{derived_from<forward_iterator_tag>};
+models \tcode{\libconcept{derived_from}<forward_iterator_tag>};
 otherwise it denotes \tcode{input_iterator_tag}.
 
 \item
@@ -4834,7 +4834,7 @@ Initializes \tcode{v_} as if by
 \indexlibraryctor{common_iterator}%
 \begin{itemdecl}
 template<class I2, class S2>
-  requires convertible_to<const I2&, I> && convertible_to<const S2&, S>
+  requires @\libconcept{convertible_to}@<const I2&, I> && @\libconcept{convertible_to}@<const S2&, S>
     constexpr common_iterator(const common_iterator<I2, S2>& x);
 \end{itemdecl}
 
@@ -4853,8 +4853,8 @@ where $i$ is \tcode{x.v_.index()}.
 \indexlibrarymember{operator=}{common_iterator}%
 \begin{itemdecl}
 template<class I2, class S2>
-  requires convertible_to<const I2&, I> && convertible_to<const S2&, S> &&
-           assignable_from<I&, const I2&> && assignable_from<S&, const S2&>
+  requires @\libconcept{convertible_to}@<const I2&, I> && @\libconcept{convertible_to}@<const S2&, S> &&
+           @\libconcept{assignable_from}@<I&, const I2&> && @\libconcept{assignable_from}@<S&, const S2&>
     common_iterator& operator=(const common_iterator<I2, S2>& x);
 \end{itemdecl}
 
@@ -4908,10 +4908,10 @@ decltype(auto) operator->() const
 \pnum
 The expression in the requires clause is equivalent to:
 \begin{codeblock}
-indirectly_readable<const I> &&
+@\libconcept{indirectly_readable}@<const I> &&
 (requires(const I& i) { i.operator->(); } ||
  is_reference_v<iter_reference_t<I>> ||
- constructible_from<iter_value_t<I>, iter_reference_t<I>>)
+ @\libconcept{constructible_from}@<iter_value_t<I>, iter_reference_t<I>>)
 \end{codeblock}
 
 \pnum
@@ -4935,12 +4935,12 @@ return addressof(tmp);
 
 \item
 Otherwise, equivalent to:
-\tcode{return \placeholder{proxy}(*get<I>(v_));} where
-\tcode{\placeholder{proxy}} is the exposition-only class:
+\tcode{return \exposid{proxy}(*get<I>(v_));} where
+\exposid{proxy} is the exposition-only class:
 \begin{codeblock}
-class @\placeholder{proxy}@ {
+class @\exposid{proxy}@ {
   iter_value_t<I> keep_;
-  @\placeholder{proxy}@(iter_reference_t<I>&& x)
+  @\exposid{proxy}@(iter_reference_t<I>&& x)
     : keep_(std::move(x)) {}
 public:
   const iter_value_t<I>* operator->() const {
@@ -4997,8 +4997,8 @@ Otherwise, equivalent to: \tcode{return get<I>(v_)++;}
 
 \indexlibrarymember{operator==}{common_iterator}%
 \begin{itemdecl}
-template<class I2, sentinel_for<I> S2>
-  requires sentinel_for<S, I2>
+template<class I2, @\libconcept{sentinel_for}@<I> S2>
+  requires @\libconcept{sentinel_for}@<S, I2>
 friend bool operator==(
   const common_iterator& x, const common_iterator<I2, S2>& y);
 \end{itemdecl}
@@ -5018,8 +5018,8 @@ where $i$ is \tcode{x.v_.index()} and $j$ is \tcode{y.v_.index()}.
 
 \indexlibrarymember{operator==}{common_iterator}%
 \begin{itemdecl}
-template<class I2, sentinel_for<I> S2>
-  requires sentinel_for<S, I2> && equality_comparable_with<I, I2>
+template<class I2, @\libconcept{sentinel_for}@<I> S2>
+  requires @\libconcept{sentinel_for}@<S, I2> && equality_comparable_with<I, I2>
 friend bool operator==(
   const common_iterator& x, const common_iterator<I2, S2>& y);
 \end{itemdecl}
@@ -5039,8 +5039,8 @@ $i$ is \tcode{x.v_.index()} and $j$ is \tcode{y.v_.index()}.
 
 \indexlibrarymember{operator-}{common_iterator}%
 \begin{itemdecl}
-template<sized_sentinel_for<I> I2, sized_sentinel_for<I> S2>
-  requires sized_sentinel_for<S, I2>
+template<@\libconcept{sized_sentinel_for}@<I> I2, @\libconcept{sized_sentinel_for}@<I> S2>
+  requires @\libconcept{sized_sentinel_for}@<S, I2>
 friend iter_difference_t<I2> operator-(
   const common_iterator& x, const common_iterator<I2, S2>& y);
 \end{itemdecl}
@@ -5064,7 +5064,7 @@ $i$ is \tcode{x.v_.index()} and $j$ is \tcode{y.v_.index()}.
 \begin{itemdecl}
 friend iter_rvalue_reference_t<I> iter_move(const common_iterator& i)
   noexcept(noexcept(ranges::iter_move(declval<const I&>())))
-    requires input_iterator<I>;
+    requires @\libconcept{input_iterator}@<I>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5079,7 +5079,7 @@ Equivalent to: \tcode{return ranges::iter_move(get<I>(i.v_));}
 
 \indexlibrarymember{iter_swap}{common_iterator}%
 \begin{itemdecl}
-template<indirectly_swappable<I> I2, class S2>
+template<@\libconcept{indirectly_swappable}@<I> I2, class S2>
   friend void iter_swap(const common_iterator& x, const common_iterator<I2, S2>& y)
     noexcept(noexcept(ranges::iter_swap(declval<const I&>(), declval<const I2&>())));
 \end{itemdecl}
@@ -5147,7 +5147,7 @@ refer to the same (possibly past-the-end) element.
 \indexlibraryglobal{counted_iterator}%
 \begin{codeblock}
 namespace std {
-  template<input_or_output_iterator I>
+  template<@\libconcept{input_or_output_iterator}@ I>
   class counted_iterator {
   public:
     using iterator_type = I;
@@ -5155,11 +5155,11 @@ namespace std {
     constexpr counted_iterator() = default;
     constexpr counted_iterator(I x, iter_difference_t<I> n);
     template<class I2>
-      requires convertible_to<const I2&, I>
+      requires @\libconcept{convertible_to}@<const I2&, I>
         constexpr counted_iterator(const counted_iterator<I2>& x);
 
     template<class I2>
-      requires assignable_from<I&, const I2&>
+      requires @\libconcept{assignable_from}@<I&, const I2&>
         constexpr counted_iterator& operator=(const counted_iterator<I2>& x);
 
     constexpr I base() const & requires copy_constructible<I>;
@@ -5172,23 +5172,23 @@ namespace std {
     constexpr counted_iterator& operator++();
     decltype(auto) operator++(int);
     constexpr counted_iterator operator++(int)
-      requires forward_iterator<I>;
+      requires @\libconcept{forward_iterator}@<I>;
     constexpr counted_iterator& operator--()
-      requires bidirectional_iterator<I>;
+      requires @\libconcept{bidirectional_iterator}@<I>;
     constexpr counted_iterator operator--(int)
-      requires bidirectional_iterator<I>;
+      requires @\libconcept{bidirectional_iterator}@<I>;
 
     constexpr counted_iterator operator+(iter_difference_t<I> n) const
-      requires random_access_iterator<I>;
+      requires @\libconcept{random_access_iterator}@<I>;
     friend constexpr counted_iterator operator+(
       iter_difference_t<I> n, const counted_iterator& x)
-        requires random_access_iterator<I>;
+        requires @\libconcept{random_access_iterator}@<I>;
     constexpr counted_iterator& operator+=(iter_difference_t<I> n)
-      requires random_access_iterator<I>;
+      requires @\libconcept{random_access_iterator}@<I>;
 
     constexpr counted_iterator operator-(iter_difference_t<I> n) const
-      requires random_access_iterator<I>;
-    template<common_with<I> I2>
+      requires @\libconcept{random_access_iterator}@<I>;
+    template<@\libconcept{common_with}@<I> I2>
       friend constexpr iter_difference_t<I2> operator-(
         const counted_iterator& x, const counted_iterator<I2>& y);
     friend constexpr iter_difference_t<I> operator-(
@@ -5196,25 +5196,25 @@ namespace std {
     friend constexpr iter_difference_t<I> operator-(
       default_sentinel_t, const counted_iterator& y);
     constexpr counted_iterator& operator-=(iter_difference_t<I> n)
-      requires random_access_iterator<I>;
+      requires @\libconcept{random_access_iterator}@<I>;
 
     constexpr decltype(auto) operator[](iter_difference_t<I> n) const
-      requires random_access_iterator<I>;
+      requires @\libconcept{random_access_iterator}@<I>;
 
-    template<common_with<I> I2>
+    template<@\libconcept{common_with}@<I> I2>
       friend constexpr bool operator==(
         const counted_iterator& x, const counted_iterator<I2>& y);
     friend constexpr bool operator==(
       const counted_iterator& x, default_sentinel_t);
 
-    template<common_with<I> I2>
+    template<@\libconcept{common_with}@<I> I2>
       friend constexpr strong_ordering operator<=>(
         const counted_iterator& x, const counted_iterator<I2>& y);
 
     friend constexpr iter_rvalue_reference_t<I> iter_move(const counted_iterator& i)
       noexcept(noexcept(ranges::iter_move(i.current)))
-        requires input_iterator<I>;
-    template<indirectly_swappable<I> I2>
+        requires @\libconcept{input_iterator}@<I>;
+    template<@\libconcept{indirectly_swappable}@<I> I2>
       friend constexpr void iter_swap(const counted_iterator& x, const counted_iterator<I2>& y)
         noexcept(noexcept(ranges::iter_swap(x.current, y.current)));
 
@@ -5228,7 +5228,7 @@ namespace std {
     using difference_type = iter_difference_t<I>;
   };
 
-  template<input_iterator I>
+  template<@\libconcept{input_iterator}@ I>
   struct iterator_traits<counted_iterator<I>> : iterator_traits<I> {
     using pointer = void;
   };
@@ -5256,7 +5256,7 @@ Initializes \tcode{current} with \tcode{std::move(i)} and
 \indexlibraryctor{counted_iterator}%
 \begin{itemdecl}
 template<class I2>
-  requires convertible_to<const I2&, I>
+  requires @\libconcept{convertible_to}@<const I2&, I>
     constexpr counted_iterator(const counted_iterator<I2>& x);
 \end{itemdecl}
 
@@ -5270,7 +5270,7 @@ Initializes \tcode{current} with \tcode{x.current} and
 \indexlibrarymember{operator=}{counted_iterator}%
 \begin{itemdecl}
 template<class I2>
-  requires assignable_from<I&, const I2&>
+  requires @\libconcept{assignable_from}@<I&, const I2&>
     constexpr counted_iterator& operator=(const counted_iterator<I2>& x);
 \end{itemdecl}
 
@@ -5338,7 +5338,7 @@ Equivalent to: \tcode{return *current;}
 \indexlibrarymember{operator[]}{counted_iterator}%
 \begin{itemdecl}
 constexpr decltype(auto) operator[](iter_difference_t<I> n) const
-  requires random_access_iterator<I>;
+  requires @\libconcept{random_access_iterator}@<I>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5396,7 +5396,7 @@ catch(...) { ++length; throw; }
 \indexlibrarymember{operator++}{counted_iterator}%
 \begin{itemdecl}
 constexpr counted_iterator operator++(int)
-  requires forward_iterator<I>;
+  requires @\libconcept{forward_iterator}@<I>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5413,7 +5413,7 @@ return tmp;
 \indexlibrarymember{operator{-}-}{counted_iterator}%
 \begin{itemdecl}
   constexpr counted_iterator& operator--();
-    requires bidirectional_iterator<I>
+    requires @\libconcept{bidirectional_iterator}@<I>
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5430,7 +5430,7 @@ return *this;
 \indexlibrarymember{operator{-}-}{counted_iterator}%
 \begin{itemdecl}
   constexpr counted_iterator operator--(int)
-    requires bidirectional_iterator<I>;
+    requires @\libconcept{bidirectional_iterator}@<I>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5447,7 +5447,7 @@ return tmp;
 \indexlibrarymember{operator+}{counted_iterator}%
 \begin{itemdecl}
   constexpr counted_iterator operator+(iter_difference_t<I> n) const
-    requires random_access_iterator<I>;
+    requires @\libconcept{random_access_iterator}@<I>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5460,7 +5460,7 @@ Equivalent to: \tcode{return counted_iterator(current + n, length - n);}
 \begin{itemdecl}
 friend constexpr counted_iterator operator+(
   iter_difference_t<I> n, const counted_iterator& x)
-    requires random_access_iterator<I>;
+    requires @\libconcept{random_access_iterator}@<I>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5472,7 +5472,7 @@ Equivalent to: \tcode{return x + n;}
 \indexlibrarymember{operator+=}{counted_iterator}%
 \begin{itemdecl}
   constexpr counted_iterator& operator+=(iter_difference_t<I> n)
-    requires random_access_iterator<I>;
+    requires @\libconcept{random_access_iterator}@<I>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5493,7 +5493,7 @@ return *this;
 \indexlibrarymember{operator-}{counted_iterator}%
 \begin{itemdecl}
   constexpr counted_iterator operator-(iter_difference_t<I> n) const
-    requires random_access_iterator<I>;
+    requires @\libconcept{random_access_iterator}@<I>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5504,7 +5504,7 @@ Equivalent to: \tcode{return counted_iterator(current - n, length + n);}
 
 \indexlibrarymember{operator-}{counted_iterator}%
 \begin{itemdecl}
-template<common_with<I> I2>
+template<@\libconcept{common_with}@<I> I2>
   friend constexpr iter_difference_t<I2> operator-(
     const counted_iterator& x, const counted_iterator<I2>& y);
 \end{itemdecl}
@@ -5548,7 +5548,7 @@ Equivalent to: \tcode{return y.length;}
 \indexlibrarymember{operator-=}{counted_iterator}%
 \begin{itemdecl}
 constexpr counted_iterator& operator-=(iter_difference_t<I> n)
-  requires random_access_iterator<I>;
+  requires @\libconcept{random_access_iterator}@<I>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5570,7 +5570,7 @@ return *this;
 
 \indexlibrarymember{operator==}{counted_iterator}%
 \begin{itemdecl}
-template<common_with<I> I2>
+template<@\libconcept{common_with}@<I> I2>
   friend constexpr bool operator==(
     const counted_iterator& x, const counted_iterator<I2>& y);
 \end{itemdecl}
@@ -5600,7 +5600,7 @@ Equivalent to: \tcode{return x.length == 0;}
 
 \indexlibrarymember{operator<=>}{counted_iterator}%
 \begin{itemdecl}
-template<common_with<I> I2>
+template<@\libconcept{common_with}@<I> I2>
   friend constexpr strong_ordering operator<=>(
     const counted_iterator& x, const counted_iterator<I2>& y);
 \end{itemdecl}
@@ -5629,7 +5629,7 @@ because \tcode{length} counts down, not up.
 friend constexpr iter_rvalue_reference_t<I>
   iter_move(const counted_iterator& i)
     noexcept(noexcept(ranges::iter_move(i.current)))
-    requires input_iterator<I>;
+    requires @\libconcept{input_iterator}@<I>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5640,7 +5640,7 @@ Equivalent to: \tcode{return ranges::iter_move(i.current);}
 
 \indexlibrarymember{iter_swap}{counted_iterator}%
 \begin{itemdecl}
-template<indirectly_swappable<I> I2>
+template<@\libconcept{indirectly_swappable}@<I> I2>
   friend constexpr void
     iter_swap(const counted_iterator& x, const counted_iterator<I2>& y)
       noexcept(noexcept(ranges::iter_swap(x.current, y.current)));
@@ -5680,7 +5680,7 @@ conditional branch.
 \begin{codeblock}
 namespace std {
   struct unreachable_sentinel_t {
-    template<weakly_incrementable I>
+    template<@\libconcept{weakly_incrementable}@ I>
       friend constexpr bool operator==(unreachable_sentinel_t, const I&) noexcept
       { return false; }
   };
@@ -6239,13 +6239,13 @@ As if by \tcode{sbuf_->sbumpc()}.
 
 \indexlibrarymember{operator++}{istreambuf_iterator}%
 \begin{itemdecl}
-@\placeholder{proxy}@ operator++(int);
+@\exposid{proxy}@ operator++(int);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{\placeholder{proxy}(sbuf_->sbumpc(), sbuf_)}.
+\tcode{\exposid{proxy}(sbuf_->sbumpc(), sbuf_)}.
 \end{itemdescr}
 
 \indexlibrarymember{equal}{istreambuf_iterator}%

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -2148,11 +2148,11 @@ of being returned.
 
 \begin{codeblock}
 template<class G>
-  concept uniform_random_bit_generator =
-    invocable<G&> && unsigned_integral<invoke_result_t<G&>> &&
+  concept @\deflibconcept{uniform_random_bit_generator}@ =
+    @\libconcept{invocable}@<G&> && @\libconcept{unsigned_integral}@<invoke_result_t<G&>> &&
     requires {
-      { G::min() } -> same_as<invoke_result_t<G&>>;
-      { G::max() } -> same_as<invoke_result_t<G&>>;
+      { G::min() } -> @\libconcept{same_as}@<invoke_result_t<G&>>;
+      { G::max() } -> @\libconcept{same_as}@<invoke_result_t<G&>>;
       requires bool_constant<(G::min() < G::max())>::value;
     };
 \end{codeblock}
@@ -10716,19 +10716,19 @@ namespace std::numbers {
   template<class T> inline constexpr T egamma_v     = @\unspec@;
   template<class T> inline constexpr T phi_v        = @\unspec@;
 
-  template<floating_point T> inline constexpr T e_v<T>          = @\seebelow@;
-  template<floating_point T> inline constexpr T log2e_v<T>      = @\seebelow@;
-  template<floating_point T> inline constexpr T log10e_v<T>     = @\seebelow@;
-  template<floating_point T> inline constexpr T pi_v<T>         = @\seebelow@;
-  template<floating_point T> inline constexpr T inv_pi_v<T>     = @\seebelow@;
-  template<floating_point T> inline constexpr T inv_sqrtpi_v<T> = @\seebelow@;
-  template<floating_point T> inline constexpr T ln2_v<T>        = @\seebelow@;
-  template<floating_point T> inline constexpr T ln10_v<T>       = @\seebelow@;
-  template<floating_point T> inline constexpr T sqrt2_v<T>      = @\seebelow@;
-  template<floating_point T> inline constexpr T sqrt3_v<T>      = @\seebelow@;
-  template<floating_point T> inline constexpr T inv_sqrt3_v<T>  = @\seebelow@;
-  template<floating_point T> inline constexpr T egamma_v<T>     = @\seebelow@;
-  template<floating_point T> inline constexpr T phi_v<T>        = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> inline constexpr T e_v<T>          = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> inline constexpr T log2e_v<T>      = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> inline constexpr T log10e_v<T>     = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> inline constexpr T pi_v<T>         = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> inline constexpr T inv_pi_v<T>     = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> inline constexpr T inv_sqrtpi_v<T> = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> inline constexpr T ln2_v<T>        = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> inline constexpr T ln10_v<T>       = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> inline constexpr T sqrt2_v<T>      = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> inline constexpr T sqrt3_v<T>      = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> inline constexpr T inv_sqrt3_v<T>  = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> inline constexpr T egamma_v<T>     = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> inline constexpr T phi_v<T>        = @\seebelow@;
 
   inline constexpr double e          = e_v<double>;
   inline constexpr double log2e      = log2e_v<double>;

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1816,7 +1816,7 @@ template<class T, class U>
   C(T, U) -> C<T, std::type_identity_t<U>>;     // \#2
 
 template<class V> using A = C<V *, V *>;
-template<std::integral W> using B = A<W>;
+template<std::@\libconcept{integral}@ W> using B = A<W>;
 
 int i{};
 double d{};
@@ -1858,11 +1858,11 @@ template <class V> class BB<B<V>> { };
 template <class T> concept deduces_B = requires { sizeof(BB<T>); };
 
 // The guides for \tcode{B} derived from the above \tcode{f1'} and \tcode{f2'} for \tcode{A} are as follows:
-template<std::integral W>
+template<std::@\libconcept{integral}@ W>
   requires deduces_A<C<W *, W *>> && deduces_B<C<W *, W *>>
   auto f1_prime_for_B(W *, W *) -> C<W *, W *>;
 
-template<std::integral W, class U>
+template<std::@\libconcept{integral}@ W, class U>
   requires deduces_A<C<W *, std::type_identity_t<U>>> &&
     deduces_B<C<W *, std::type_identity_t<U>>>
   auto f2_prime_for_B(W *, U) -> C<W *, std::type_identity_t<U>>;

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -61,17 +61,17 @@ namespace std::ranges {
 
   template<class T>
     using iterator_t = decltype(ranges::begin(declval<T&>()));
-  template<range R>
+  template<@\libconcept{range}@ R>
     using sentinel_t = decltype(ranges::end(declval<R&>()));
-  template<range R>
+  template<@\libconcept{range}@ R>
     using range_difference_t = iter_difference_t<iterator_t<R>>;
-  template<sized_range R>
+  template<@\libconcept{sized_range}@ R>
     using range_size_t = decltype(ranges::size(declval<R&>()));
-  template<range R>
+  template<@\libconcept{range}@ R>
     using range_value_t = iter_value_t<iterator_t<R>>;
-  template<range R>
+  template<@\libconcept{range}@ R>
     using range_reference_t = iter_reference_t<iterator_t<R>>;
-  template<range R>
+  template<@\libconcept{range}@ R>
     using range_rvalue_reference_t = iter_rvalue_reference_t<iterator_t<R>>;
 
   // \ref{range.sized}, sized ranges
@@ -117,14 +117,14 @@ namespace std::ranges {
 
   // \ref{view.interface}, class template \tcode{view_interface}
   template<class D>
-    requires is_class_v<D> && same_as<D, remove_cv_t<D>>
+    requires is_class_v<D> && @\libconcept{same_as}@<D, remove_cv_t<D>>
   class view_interface;
 
   // \ref{range.subrange}, sub-ranges
   enum class subrange_kind : bool { unsized, sized };
 
-  template<input_or_output_iterator I, sentinel_for<I> S = I, subrange_kind K = @\seebelow@>
-    requires (K == subrange_kind::sized || !sized_sentinel_for<S, I>)
+  template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S = I, subrange_kind K = @\seebelow@>
+    requires (K == subrange_kind::sized || !@\libconcept{sized_sentinel_for}@<S, I>)
   class subrange;
 
   template<input_or_output_iterator I, sentinel_for<I> S, subrange_kind K>
@@ -133,12 +133,12 @@ namespace std::ranges {
   // \ref{range.dangling}, dangling iterator handling
   struct dangling;
 
-  template<range R>
-    using borrowed_iterator_t = conditional_t<borrowed_range<R>, iterator_t<R>, dangling>;
+  template<@\libconcept{range}@ R>
+    using borrowed_iterator_t = conditional_t<@\libconcept{borrowed_range}@<R>, iterator_t<R>, dangling>;
 
-  template<range R>
+  template<@\libconcept{range}@ R>
     using borrowed_subrange_t =
-      conditional_t<borrowed_range<R>, subrange<iterator_t<R>>, dangling>;
+      conditional_t<@\libconcept{borrowed_range}@<R>, subrange<iterator_t<R>>, dangling>;
 
   // \ref{range.empty}, empty view
   template<class T>
@@ -154,15 +154,15 @@ namespace std::ranges {
   }
 
   // \ref{range.single}, single view
-  template<copy_constructible T>
+  template<@\libconcept{copy_constructible}@ T>
     requires is_object_v<T>
   class single_view;
 
   namespace views { inline constexpr @\unspec@ single = @\unspec@; }
 
   // \ref{range.iota}, iota view
-  template<weakly_incrementable W, semiregular Bound = unreachable_sentinel_t>
-    requires @\placeholder{weakly-equality-comparable-with}@<W, Bound>
+  template<@\libconcept{weakly_incrementable}@ W, @\libconcept{semiregular}@ Bound = unreachable_sentinel_t>
+    requires @\exposconcept{weakly-equality-comparable-with}@<W, Bound>
   class iota_view;
 
   template<weakly_incrementable W, semiregular Bound>
@@ -181,11 +181,11 @@ namespace std::ranges {
   namespace views {
     inline constexpr @\unspec@ all = @\unspec@;
 
-    template<viewable_range R>
+    template<@\libconcept{viewable_range}@ R>
       using all_t = decltype(all(declval<R>()));
   }
 
-  template<range R>
+  template<@\libconcept{range}@ R>
     requires is_object_v<R>
   class ref_view;
 
@@ -193,14 +193,14 @@ namespace std::ranges {
     inline constexpr bool enable_borrowed_range<ref_view<T>> = true;
 
   // \ref{range.filter}, filter view
-  template<input_range V, indirect_unary_predicate<iterator_t<V>> Pred>
+  template<@\libconcept{input_range}@ V, @\libconcept{indirect_unary_predicate}@<iterator_t<V>> Pred>
     requires view<V> && is_object_v<Pred>
   class filter_view;
 
   namespace views { inline constexpr @\unspec@ filter = @\unspec@; }
 
   // \ref{range.transform}, transform view
-  template<input_range V, copy_constructible F>
+  template<@\libconcept{input_range}@ V, @\libconcept{copy_constructible}@ F>
     requires view<V> && is_object_v<F> &&
              regular_invocable<F&, range_reference_t<V>>
   class transform_view;
@@ -208,35 +208,35 @@ namespace std::ranges {
   namespace views { inline constexpr @\unspec@ transform = @\unspec@; }
 
   // \ref{range.take}, take view
-  template<view> class take_view;
+  template<@\libconcept{view}@> class take_view;
 
   namespace views { inline constexpr @\unspec@ take = @\unspec@; }
 
   // \ref{range.take.while}, take while view
-  template<view V, class Pred>
-    requires input_range<V> && is_object_v<Pred> &&
-      indirect_unary_predicate<const Pred, iterator_t<V>>
+  template<@\libconcept{view}@ V, class Pred>
+    requires @\libconcept{input_range}@<V> && is_object_v<Pred> &&
+      @\libconcept{indirect_unary_predicate}@<const Pred, iterator_t<V>>
     class take_while_view;
 
   namespace views { inline constexpr @\unspec@ take_while = @\unspec@; }
 
   // \ref{range.drop}, drop view
-  template<view V>
+  template<@\libconcept{view}@ V>
     class drop_view;
 
   namespace views { inline constexpr @\unspec@ drop = @\unspec@; }
 
   // \ref{range.drop.while}, drop while view
-  template<view V, class Pred>
-    requires input_range<V> && is_object_v<Pred> &&
-      indirect_unary_predicate<const Pred, iterator_t<V>>
+  template<@\libconcept{view}@ V, class Pred>
+    requires @\libconcept{input_range}@<V> && is_object_v<Pred> &&
+      @\libconcept{indirect_unary_predicate}@<const Pred, iterator_t<V>>
     class drop_while_view;
 
   namespace views { inline constexpr @\unspec@ drop_while = @\unspec@; }
 
   // \ref{range.join}, join view
-  template<input_range V>
-    requires view<V> && input_range<range_reference_t<V>> &&
+  template<@\libconcept{input_range}@ V>
+    requires view<V> && @\libconcept{input_range}@<range_reference_t<V>> &&
              (is_reference_v<range_reference_t<V>> ||
               view<range_value_t<V>>)
   class join_view;
@@ -247,10 +247,10 @@ namespace std::ranges {
   template<class R>
     concept @\exposconcept{tiny-range}@ = @\seebelow@;   // \expos
 
-  template<input_range V, forward_range Pattern>
+  template<@\libconcept{input_range}@ V, @\libconcept{forward_range}@ Pattern>
     requires view<V> && view<Pattern> &&
-             indirectly_comparable<iterator_t<V>, iterator_t<Pattern>, ranges::equal_to> &&
-             (forward_range<V> || @\placeholder{tiny-range}@<Pattern>)
+             @\libconcept{indirectly_comparable}@<iterator_t<V>, iterator_t<Pattern>, ranges::equal_to> &&
+             (@\libconcept{forward_range}@<V> || @\exposconcept{tiny-range}@<Pattern>)
   class split_view;
 
   namespace views { inline constexpr @\unspec@ split = @\unspec@; }
@@ -259,21 +259,21 @@ namespace std::ranges {
   namespace views { inline constexpr @\unspec@ counted = @\unspec@; }
 
   // \ref{range.common}, common view
-  template<view V>
+  template<@\libconcept{view}@ V>
     requires (!common_range<V> && copyable<iterator_t<V>>)
   class common_view;
 
   namespace views { inline constexpr @\unspec@ common = @\unspec@; }
 
   // \ref{range.reverse}, reverse view
-  template<view V>
-    requires bidirectional_range<V>
+  template<@\libconcept{view}@ V>
+    requires @\libconcept{bidirectional_range}@<V>
   class reverse_view;
 
   namespace views { inline constexpr @\unspec@ reverse = @\unspec@; }
 
   // \ref{range.elements}, elements view
-  template<input_range V, size_t N>
+  template<@\libconcept{input_range}@ V, size_t N>
     requires @\seebelow@;
   class elements_view;
 
@@ -1131,7 +1131,7 @@ independent of the number of elements in the \tcode{view}.
 \begin{itemdecl}
 template<class T>
   concept @\deflibconcept{view}@ =
-    range<T> && movable<T> && default_initializable<T> && enable_view<T>;
+    range<T> && @\libconcept{movable}@<T> && @\libconcept{default_initializable}@<T> && enable_view<T>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1208,23 +1208,23 @@ and \libconcept{random_access_range} are defined similarly.
 \begin{itemdecl}
 template<class R, class T>
   concept @\deflibconcept{output_range}@ =
-    range<R> && output_iterator<iterator_t<R>, T>;
+    range<R> && @\libconcept{output_iterator}@<iterator_t<R>, T>;
 
 template<class T>
   concept @\deflibconcept{input_range}@ =
-    range<T> && input_iterator<iterator_t<T>>;
+    range<T> && @\libconcept{input_iterator}@<iterator_t<T>>;
 
 template<class T>
   concept @\deflibconcept{forward_range}@ =
-    input_range<T> && forward_iterator<iterator_t<T>>;
+    @\libconcept{input_range}@<T> && @\libconcept{forward_iterator}@<iterator_t<T>>;
 
 template<class T>
   concept @\deflibconcept{bidirectional_range}@ =
-    forward_range<T> && bidirectional_iterator<iterator_t<T>>;
+    @\libconcept{forward_range}@<T> && @\libconcept{bidirectional_iterator}@<iterator_t<T>>;
 
 template<class T>
   concept @\deflibconcept{random_access_range}@ =
-    bidirectional_range<T> && random_access_iterator<iterator_t<T>>;
+    @\libconcept{bidirectional_range}@<T> && @\libconcept{random_access_iterator}@<iterator_t<T>>;
 \end{itemdecl}
 
 \pnum
@@ -1235,9 +1235,9 @@ is usable with the range.
 \begin{itemdecl}
 template<class T>
   concept @\deflibconcept{contiguous_range}@ =
-    random_access_range<T> && contiguous_iterator<iterator_t<T>> &&
+    @\libconcept{random_access_range}@<T> && contiguous_iterator<iterator_t<T>> &&
     requires(T& t) {
-      { ranges::data(t) } -> same_as<add_pointer_t<range_reference_t<T>>>;
+      { ranges::data(t) } -> @\libconcept{same_as}@<add_pointer_t<range_reference_t<T>>>;
     };
 \end{itemdecl}
 
@@ -1258,7 +1258,7 @@ The standard containers\iref{containers} model \libconcept{common_range}.
 \begin{itemdecl}
 template<class T>
   concept @\deflibconcept{common_range}@ =
-    range<T> && same_as<iterator_t<T>, sentinel_t<T>>;
+    range<T> && @\libconcept{same_as}@<iterator_t<T>, sentinel_t<T>>;
 \end{itemdecl}
 
 \pnum
@@ -1287,16 +1287,16 @@ the following exposition-only concepts:
 template<class R>
   concept @\defexposconcept{simple-view}@ =                         // \expos
     view<R> && range<const R> &&
-    same_as<iterator_t<R>, iterator_t<const R>> &&
-    same_as<sentinel_t<R>, sentinel_t<const R>>;
+    @\libconcept{same_as}@<iterator_t<R>, iterator_t<const R>> &&
+    @\libconcept{same_as}@<sentinel_t<R>, sentinel_t<const R>>;
 
 template<class I>
   concept @\defexposconcept{has-arrow}@ =                           // \expos
-    input_iterator<I> && (is_pointer_v<I> || requires(I i) { i.operator->(); });
+    @\libconcept{input_iterator<I>}@ && (is_pointer_v<I> || requires(I i) { i.operator->(); });
 
 template<class T, class U>
   concept @\defexposconcept{not-same-as}@ =                         // \expos
-    !same_as<remove_cvref_t<T>, remove_cvref_t<U>>;
+    !@\libconcept{same_as}@<remove_cvref_t<T>, remove_cvref_t<U>>;
 \end{codeblock}
 
 \rSec2[view.interface]{View interface}
@@ -1310,7 +1310,7 @@ parameterized with the type that is derived from it.
 \begin{codeblock}
 namespace std::ranges {
   template<class D>
-    requires is_class_v<D> && same_as<D, remove_cv_t<D>>
+    requires is_class_v<D> && @\libconcept{same_as}@<D, remove_cv_t<D>>
   class view_interface : public view_base {
   private:
     constexpr D& @\exposid{derived}@() noexcept {                   // \expos
@@ -1320,10 +1320,10 @@ namespace std::ranges {
       return static_cast<const D&>(*this);
     }
   public:
-    constexpr bool empty() requires forward_range<D> {
+    constexpr bool empty() requires @\libconcept{forward_range}@<D> {
       return ranges::begin(@\exposid{derived}@()) == ranges::end(@\exposid{derived}@());
     }
-    constexpr bool empty() const requires forward_range<const D> {
+    constexpr bool empty() const requires @\libconcept{forward_range}@<const D> {
       return ranges::begin(@\exposid{derived}@()) == ranges::end(@\exposid{derived}@());
     }
 
@@ -1344,27 +1344,27 @@ namespace std::ranges {
         return to_address(ranges::begin(@\exposid{derived}@()));
       }
 
-    constexpr auto size() requires forward_range<D> &&
-      sized_sentinel_for<sentinel_t<D>, iterator_t<D>> {
+    constexpr auto size() requires @\libconcept{forward_range}@<D> &&
+      @\libconcept{sized_sentinel_for}@<sentinel_t<D>, iterator_t<D>> {
         return ranges::end(@\exposid{derived}@()) - ranges::begin(@\exposid{derived}@());
       }
-    constexpr auto size() const requires forward_range<const D> &&
-      sized_sentinel_for<sentinel_t<const D>, iterator_t<const D>> {
+    constexpr auto size() const requires @\libconcept{forward_range}@<const D> &&
+      @\libconcept{sized_sentinel_for}@<sentinel_t<const D>, iterator_t<const D>> {
         return ranges::end(@\exposid{derived}@()) - ranges::begin(@\exposid{derived}@());
       }
 
-    constexpr decltype(auto) front() requires forward_range<D>;
-    constexpr decltype(auto) front() const requires forward_range<const D>;
+    constexpr decltype(auto) front() requires @\libconcept{forward_range}@<D>;
+    constexpr decltype(auto) front() const requires @\libconcept{forward_range}@<const D>;
 
-    constexpr decltype(auto) back() requires bidirectional_range<D> && common_range<D>;
+    constexpr decltype(auto) back() requires @\libconcept{bidirectional_range}@<D> && common_range<D>;
     constexpr decltype(auto) back() const
-      requires bidirectional_range<const D> && common_range<const D>;
+      requires @\libconcept{bidirectional_range}@<const D> && common_range<const D>;
 
-    template<random_access_range R = D>
+    template<@\libconcept{random_access_range}@ R = D>
       constexpr decltype(auto) operator[](range_difference_t<R> n) {
         return ranges::begin(@\exposid{derived}@())[n];
       }
-    template<random_access_range R = const D>
+    template<@\libconcept{random_access_range}@ R = const D>
       constexpr decltype(auto) operator[](range_difference_t<R> n) const {
         return ranges::begin(@\exposid{derived}@())[n];
       }
@@ -1383,8 +1383,8 @@ model both \tcode{\libconcept{derived_from}<view_interface<D>>} and \libconcept{
 
 \indexlibrarymember{front}{view_interface}%
 \begin{itemdecl}
-constexpr decltype(auto) front() requires forward_range<D>;
-constexpr decltype(auto) front() const requires forward_range<const D>;
+constexpr decltype(auto) front() requires @\libconcept{forward_range}@<D>;
+constexpr decltype(auto) front() const requires @\libconcept{forward_range}@<const D>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1399,9 +1399,9 @@ Equivalent to: \tcode{return *ranges::begin(\exposid{derived}());}
 
 \indexlibrarymember{back}{view_interface}%
 \begin{itemdecl}
-constexpr decltype(auto) back() requires bidirectional_range<D> && common_range<D>;
+constexpr decltype(auto) back() requires @\libconcept{bidirectional_range}@<D> && common_range<D>;
 constexpr decltype(auto) back() const
-  requires bidirectional_range<const D> && common_range<const D>;
+  requires @\libconcept{bidirectional_range}@<const D> && common_range<const D>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1437,32 +1437,32 @@ namespace std::ranges {
     concept @\defexposconcept{pair-like}@ =                                     // \expos
       !is_reference_v<T> && requires(T t) {
         typename tuple_size<T>::type;                       // ensures \tcode{tuple_size<T>} is complete
-        requires derived_from<tuple_size<T>, integral_constant<size_t, 2>>;
+        requires @\libconcept{derived_from}@<tuple_size<T>, integral_constant<size_t, 2>>;
         typename tuple_element_t<0, remove_const_t<T>>;
         typename tuple_element_t<1, remove_const_t<T>>;
-        { get<0>(t) } -> convertible_to<const tuple_element_t<0, T>&>;
-        { get<1>(t) } -> convertible_to<const tuple_element_t<1, T>&>;
+        { get<0>(t) } -> @\libconcept{convertible_to}@<const tuple_element_t<0, T>&>;
+        { get<1>(t) } -> @\libconcept{convertible_to}@<const tuple_element_t<1, T>&>;
       };
 
   template<class T, class U, class V>
     concept @\defexposconcept{pair-like-convertible-from}@ =                    // \expos
-      !range<T> && @\exposconcept{pair-like}@<T> &&
-      constructible_from<T, U, V> &&
+      !@\libconcept{range}@<T> && @\exposconcept{pair-like}@<T> &&
+      @\libconcept{constructible_from}@<T, U, V> &&
       @\exposconcept{convertible-to-non-slicing}@<U, tuple_element_t<0, T>> &&
-      convertible_to<V, tuple_element_t<1, T>>;
+      @\libconcept{convertible_to}@<V, tuple_element_t<1, T>>;
 
   template<class T>
     concept @\defexposconcept{iterator-sentinel-pair}@ =                        // \expos
       !range<T> && @\exposconcept{pair-like}@<T> &&
-      sentinel_for<tuple_element_t<1, T>, tuple_element_t<0, T>>;
+      @\libconcept{sentinel_for}@<tuple_element_t<1, T>, tuple_element_t<0, T>>;
 
-  template<input_or_output_iterator I, sentinel_for<I> S = I, subrange_kind K =
-      sized_sentinel_for<S, I> ? subrange_kind::sized : subrange_kind::unsized>
-    requires (K == subrange_kind::sized || !sized_sentinel_for<S, I>)
+  template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S = I, subrange_kind K =
+      @\libconcept{sized_sentinel_for}@<S, I> ? subrange_kind::sized : subrange_kind::unsized>
+    requires (K == subrange_kind::sized || !@\libconcept{sized_sentinel_for}@<S, I>)
   class subrange : public view_interface<subrange<I, S, K>> {
   private:
     static constexpr bool @\exposid{StoreSize}@ =                           // \expos
-      K == subrange_kind::sized && !sized_sentinel_for<S, I>;
+      K == subrange_kind::sized && !@\libconcept{sized_sentinel_for}@<S, I>;
     I @\exposid{begin_}@ = I();                                             // \expos
     S @\exposid{end_}@ = S();                                               // \expos
     @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>> @\exposid{size_}@ = 0;       // \expos; present only
@@ -1477,14 +1477,14 @@ namespace std::ranges {
       requires (K == subrange_kind::sized);
 
     template<@\exposconcept{not-same-as}@<subrange> R>
-      requires borrowed_range<R> &&
+      requires @\libconcept{borrowed_range}@<R> &&
                @\exposconcept{convertible-to-non-slicing}@<iterator_t<R>, I> &&
-               convertible_to<sentinel_t<R>, S>
-    constexpr subrange(R&& r) requires (!@\exposid{StoreSize}@ || sized_range<R>);
+               @\libconcept{convertible_to}@<sentinel_t<R>, S>
+    constexpr subrange(R&& r) requires (!@\exposid{StoreSize}@ || @\libconcept{sized_range}@<R>);
 
     template<borrowed_range R>
       requires @\exposconcept{convertible-to-non-slicing}@<iterator_t<R>, I> &&
-               convertible_to<sentinel_t<R>, S>
+               @\libconcept{convertible_to}@<sentinel_t<R>, S>
     constexpr subrange(R&& r, @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>> n)
       requires (K == subrange_kind::sized)
         : subrange{ranges::begin(r), ranges::end(r), n}
@@ -1506,28 +1506,28 @@ namespace std::ranges {
       requires forward_iterator<I>;
     [[nodiscard]] constexpr subrange next(iter_difference_t<I> n = 1) &&;
     [[nodiscard]] constexpr subrange prev(iter_difference_t<I> n = 1) const
-      requires bidirectional_iterator<I>;
+      requires @\libconcept{bidirectional_iterator}@<I>;
     constexpr subrange& advance(iter_difference_t<I> n);
   };
 
-  template<input_or_output_iterator I, sentinel_for<I> S>
+  template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
     subrange(I, S) -> subrange<I, S>;
 
-  template<input_or_output_iterator I, sentinel_for<I> S>
+  template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
     subrange(I, S, @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>>) ->
       subrange<I, S, subrange_kind::sized>;
 
-  template<@\placeholder{iterator-sentinel-pair}@ P>
+  template<@\exposconcept{iterator-sentinel-pair}@ P>
     subrange(P) -> subrange<tuple_element_t<0, P>, tuple_element_t<1, P>>;
 
-  template<@\placeholder{iterator-sentinel-pair}@ P>
+  template<@\exposconcept{iterator-sentinel-pair}@ P>
     subrange(P, @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<tuple_element_t<0, P>>>) ->
       subrange<tuple_element_t<0, P>, tuple_element_t<1, P>, subrange_kind::sized>;
 
   template<borrowed_range R>
     subrange(R&&) ->
       subrange<iterator_t<R>, sentinel_t<R>,
-               (sized_range<R> || sized_sentinel_for<sentinel_t<R>, iterator_t<R>>)
+               (@\libconcept{sized_range}@<R> || @\libconcept{sized_sentinel_for}@<sentinel_t<R>, iterator_t<R>>)
                  ? subrange_kind::sized : subrange_kind::unsized>;
 
   template<borrowed_range R>
@@ -1597,10 +1597,10 @@ when it stores an iterator and sentinel that do not model
 \indexlibraryctor{subrange}%
 \begin{itemdecl}
 template<@\exposconcept{not-same-as}@<subrange> R>
-  requires borrowed_range<R> &&
+  requires @\libconcept{borrowed_range}@<R> &&
            @\exposconcept{convertible-to-non-slicing}@<iterator_t<R>, I> &&
-           convertible_to<sentinel_t<R>, S>
-constexpr subrange(R&& r) requires (!@\exposid{StoreSize}@ || sized_range<R>);
+           @\libconcept{convertible_to}@<sentinel_t<R>, S>
+constexpr subrange(R&& r) requires (!@\exposid{StoreSize}@ || @\libconcept{sized_range}@<R>);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1723,7 +1723,7 @@ return std::move(*this);
 \indexlibrarymember{prev}{subrange}%
 \begin{itemdecl}
 [[nodiscard]] constexpr subrange prev(iter_difference_t<I> n = 1) const
-  requires bidirectional_iterator<I>;
+  requires @\libconcept{bidirectional_iterator}@<I>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1813,12 +1813,12 @@ namespace std::ranges {
 \begin{codeblock}
 vector<int> f();
 auto result1 = ranges::find(f(), 42);                                   // \#1
-static_assert(same_as<decltype(result1), ranges::dangling>);
+static_assert(@\libconcept{same_as}@<decltype(result1), ranges::dangling>);
 auto vec = f();
 auto result2 = ranges::find(vec, 42);                                   // \#2
-static_assert(same_as<decltype(result2), vector<int>::iterator>);
+static_assert(@\libconcept{same_as}@<decltype(result2), vector<int>::iterator>);
 auto result3 = ranges::find(subrange{vec}, 42);                         // \#3
-static_assert(same_as<decltype(result3), vector<int>::iterator>);
+static_assert(@\libconcept{same_as}@<decltype(result3), vector<int>::iterator>);
 \end{codeblock}
 The call to \tcode{ranges::find} at \#1 returns \tcode{ranges::dangling}
 since \tcode{f()} is an rvalue \tcode{vector};
@@ -1902,7 +1902,7 @@ for (int i : s)
 \indexlibraryglobal{single_view}%
 \begin{codeblock}
 namespace std::ranges {
-  template<copy_constructible T>
+  template<@\libconcept{copy_constructible}@ T>
     requires is_object_v<T>
   class single_view : public view_interface<single_view<T>> {
   private:
@@ -1912,7 +1912,7 @@ namespace std::ranges {
     constexpr explicit single_view(const T& t);
     constexpr explicit single_view(T&& t);
     template<class... Args>
-      requires constructible_from<T, Args...>
+      requires @\libconcept{constructible_from}@<T, Args...>
     constexpr single_view(in_place_t, Args&&... args);
 
     constexpr T* begin() noexcept;
@@ -2044,7 +2044,7 @@ namespace std::ranges {
     concept @\exposconcept{advanceable}@ =       // \expos
       @\seebelow@;
 
-  template<weakly_incrementable W, semiregular Bound = unreachable_sentinel_t>
+  template<@\libconcept{weakly_incrementable}@ W, @\libconcept{semiregular}@ Bound = unreachable_sentinel_t>
     requires @\exposconcept{weakly-equality-comparable-with}@<W, Bound> && semiregular<W>
   class iota_view : public view_interface<iota_view<W, Bound>> {
   private:
@@ -2063,7 +2063,7 @@ namespace std::ranges {
 
     constexpr @\exposid{iterator}@ begin() const;
     constexpr auto end() const;
-    constexpr @\exposid{iterator}@ end() const requires same_as<W, Bound>;
+    constexpr @\exposid{iterator}@ end() const requires @\libconcept{same_as}@<W, Bound>;
 
     constexpr auto size() const requires @\seebelow@;
   };
@@ -2102,9 +2102,9 @@ The exposition-only \defexposconcept{decrementable} concept is equivalent to:
 \begin{itemdecl}
 template<class I>
   concept @\defexposconcept{decrementable}@ =
-    incrementable<I> && requires(I i) {
-      { --i } -> same_as<I&>;
-      { i-- } -> same_as<I>;
+    @\libconcept{incrementable}@<I> && requires(I i) {
+      { --i } -> @\libconcept{same_as}@<I&>;
+      { i-- } -> @\libconcept{same_as}@<I>;
     };
 \end{itemdecl}
 
@@ -2135,14 +2135,14 @@ The exposition-only \defexposconcept{advanceable} concept is equivalent to:
 \begin{itemdecl}
 template<class I>
   concept @\defexposconcept{advanceable}@ =
-    @\exposconcept{decrementable}@<I> && totally_ordered<I> &&
+    @\exposconcept{decrementable}@<I> && @\libconcept{totally_ordered}@<I> &&
     requires(I i, const I j, const @\placeholdernc{IOTA-DIFF-T}@(I) n) {
-      { i += n } -> same_as<I&>;
-      { i -= n } -> same_as<I&>;
+      { i += n } -> @\libconcept{same_as}@<I&>;
+      { i -= n } -> @\libconcept{same_as}@<I&>;
       I(j + n);
       I(n + j);
       I(j - n);
-      { j - j } -> convertible_to<@\placeholdernc{IOTA-DIFF-T}@(I)>;
+      { j - j } -> @\libconcept{convertible_to}@<@\placeholdernc{IOTA-DIFF-T}@(I)>;
     };
 \end{itemdecl}
 
@@ -2228,7 +2228,7 @@ constexpr auto end() const;
 \effects
 Equivalent to:
 \begin{codeblock}
-if constexpr (same_as<Bound, unreachable_sentinel_t>)
+if constexpr (@\libconcept{same_as}@<Bound, unreachable_sentinel_t>)
   return unreachable_sentinel;
 else
   return @\exposid{sentinel}@{@\exposid{bound_}@};
@@ -2237,7 +2237,7 @@ else
 
 \indexlibrarymember{end}{iota_view}%
 \begin{itemdecl}
-constexpr @\exposid{iterator}@ end() const requires same_as<W, Bound>;
+constexpr @\exposid{iterator}@ end() const requires @\libconcept{same_as}@<W, Bound>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2270,8 +2270,8 @@ else
 \remarks
 The expression in the \grammarterm{requires-clause} is equivalent to
 \begin{codeblock}
-(same_as<W, Bound> && @\placeholder{advanceable}@<W>) || (integral<W> && integral<Bound>) ||
-  sized_sentinel_for<Bound, W>
+(@\libconcept{same_as}@<W, Bound> && @\exposconcept{advanceable}@<W>) || (integral<W> && integral<Bound>) ||
+  @\libconcept{sized_sentinel_for}@<Bound, W>
 \end{codeblock}
 \end{itemdescr}
 
@@ -2297,7 +2297,7 @@ namespace std::ranges {
 
     constexpr @\exposid{iterator}@& operator++();
     constexpr void operator++(int);
-    constexpr @\exposid{iterator}@ operator++(int) requires incrementable<W>;
+    constexpr @\exposid{iterator}@ operator++(int) requires @\libconcept{incrementable}@<W>;
 
     constexpr @\exposid{iterator}@& operator--() requires @\exposconcept{decrementable}@<W>;
     constexpr @\exposid{iterator}@ operator--(int) requires @\exposconcept{decrementable}@<W>;
@@ -2313,15 +2313,15 @@ namespace std::ranges {
       requires equality_comparable<W>;
 
     friend constexpr bool operator<(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires totally_ordered<W>;
+      requires @\libconcept{totally_ordered}@<W>;
     friend constexpr bool operator>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires totally_ordered<W>;
+      requires @\libconcept{totally_ordered}@<W>;
     friend constexpr bool operator<=(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires totally_ordered<W>;
+      requires @\libconcept{totally_ordered}@<W>;
     friend constexpr bool operator>=(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires totally_ordered<W>;
+      requires @\libconcept{totally_ordered}@<W>;
     friend constexpr auto operator<=>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires totally_ordered<W> && three_way_comparable<W>;
+      requires @\libconcept{totally_ordered}@<W> && @\libconcept{three_way_comparable}@<W>;
 
     friend constexpr @\exposid{iterator}@ operator+(@\exposid{iterator}@ i, difference_type n)
       requires @\exposconcept{advanceable}@<W>;
@@ -2339,7 +2339,7 @@ namespace std::ranges {
 \pnum
 \tcode{\exposid{iterator}::iterator_concept} is defined as follows:
 \begin{itemize}
-\item If \tcode{W} models \tcode{\placeholder{advanceable}}, then
+\item If \tcode{W} models \exposconcept{advanceable}, then
 \tcode{iterator_concept} is \tcode{random_access_iterator_tag}.
 \item Otherwise, if \tcode{W} models \exposconcept{decrementable}, then
 \tcode{iterator_concept} is \tcode{bidirectional_iterator_tag}.
@@ -2409,7 +2409,7 @@ Equivalent to \tcode{++*this}.
 
 \indexlibrarymember{operator++}{iota_view::iterator}
 \begin{itemdecl}
-constexpr @\exposid{iterator}@ operator++(int) requires incrementable<W>;
+constexpr @\exposid{iterator}@ operator++(int) requires @\libconcept{incrementable}@<W>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2465,7 +2465,7 @@ constexpr @\exposid{iterator}@& operator+=(difference_type n)
 \effects
 Equivalent to:
 \begin{codeblock}
-if constexpr (@\exposconcept{is-integer-like}@<W> && !@\exposconcept{is-signed-integer-like}@<W>) {
+if constexpr (@\placeholder{is-integer-like}@<W> && !@\placeholder{is-signed-integer-like}@<W>) {
   if (n >= difference_type(0))
     @\exposid{value_}@ += static_cast<W>(n);
   else
@@ -2488,7 +2488,7 @@ constexpr @\exposid{iterator}@& operator-=(difference_type n)
 \effects
 Equivalent to:
 \begin{codeblock}
-if constexpr (@\exposconcept{is-integer-like}@<W> && !@\exposconcept{is-signed-integer-like}@<W>) {
+if constexpr (@\placeholder{is-integer-like}@<W> && !@\placeholder{is-signed-integer-like}@<W>) {
   if (n >= difference_type(0))
     @\exposid{value_}@ -= static_cast<W>(n);
   else
@@ -2527,7 +2527,7 @@ Equivalent to: \tcode{return x.\exposid{value_} == y.\exposid{value_};}
 \indexlibrarymember{operator<}{iota_view::iterator}
 \begin{itemdecl}
 friend constexpr bool operator<(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires totally_ordered<W>;
+  requires @\libconcept{totally_ordered}@<W>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2539,7 +2539,7 @@ Equivalent to: \tcode{return x.\exposid{value_} < y.\exposid{value_};}
 \indexlibrarymember{operator>}{iota_view::iterator}
 \begin{itemdecl}
 friend constexpr bool operator>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires totally_ordered<W>;
+  requires @\libconcept{totally_ordered}@<W>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2551,7 +2551,7 @@ Equivalent to: \tcode{return y < x;}
 \indexlibrarymember{operator<=}{iota_view::iterator}
 \begin{itemdecl}
 friend constexpr bool operator<=(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires totally_ordered<W>;
+  requires @\libconcept{totally_ordered}@<W>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2563,7 +2563,7 @@ Equivalent to: \tcode{return !(y < x);}
 \indexlibrarymember{operator>=}{iota_view::iterator}
 \begin{itemdecl}
 friend constexpr bool operator>=(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires totally_ordered<W>;
+  requires @\libconcept{totally_ordered}@<W>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2575,7 +2575,7 @@ Equivalent to: \tcode{return !(x < y);}
 \indexlibrarymember{operator<=>}{iota_view::iterator}
 \begin{itemdecl}
 friend constexpr auto operator<=>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires totally_ordered<W> && three_way_comparable<W>;
+  requires @\libconcept{totally_ordered}@<W> && @\libconcept{three_way_comparable}@<W>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2661,9 +2661,9 @@ namespace std::ranges {
     friend constexpr bool operator==(const @\exposid{iterator}@& x, const @\exposid{sentinel}@& y);
 
     friend constexpr iter_difference_t<W> operator-(const @\exposid{iterator}@& x, const @\exposid{sentinel}@& y)
-      requires sized_sentinel_for<Bound, W>;
+      requires @\libconcept{sized_sentinel_for}@<Bound, W>;
     friend constexpr iter_difference_t<W> operator-(const @\exposid{sentinel}@& x, const @\exposid{iterator}@& y)
-      requires sized_sentinel_for<Bound, W>;
+      requires @\libconcept{sized_sentinel_for}@<Bound, W>;
   };
 }
 \end{codeblock}
@@ -2692,7 +2692,7 @@ Equivalent to: \tcode{return x.\exposid{value_} == y.\exposid{bound_};}
 
 \begin{itemdecl}
 friend constexpr iter_difference_t<W> operator-(const @\exposid{iterator}@& x, const sentinel& y)
-  requires sized_sentinel_for<Bound, W>;
+  requires @\libconcept{sized_sentinel_for}@<Bound, W>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2703,7 +2703,7 @@ Equivalent to: \tcode{return x.\exposid{value_} - y.\exposid{bound_};}
 
 \begin{itemdecl}
 friend constexpr iter_difference_t<W> operator-(const @\exposid{sentinel}@& x, const @\exposid{iterator}@& y)
-  requires sized_sentinel_for<Bound, W>;
+  requires @\libconcept{sized_sentinel_for}@<Bound, W>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2985,26 +2985,26 @@ closure object.
 
 \pnum
 Many types in this subclause are specified in terms of
-an exposition-only class template \tcode{\placeholder{semiregular-box}}.
-\tcode{\placeholder{semiregular-box}<T>} behaves exactly like \tcode{optional<T>}
+an exposition-only class template \exposid{semiregular-box}.
+\tcode{\exposid{semiregular-box}<T>} behaves exactly like \tcode{optional<T>}
 with the following differences:
 \begin{itemize}
-\item \tcode{\placeholder{semiregular-box}<T>} constrains
+\item \tcode{\exposid{semiregular-box}<T>} constrains
 its type parameter \tcode{T} with
 \tcode{\libconcept{copy_constructible}<T> \&\& is_object_v<T>}.
 
 \item If \tcode{T} models \libconcept{default_initializable}, the default
-constructor of \tcode{\placeholder{semiregular-box}<T>} is equivalent to:
+constructor of \tcode{\exposid{semiregular-box}<T>} is equivalent to:
 \begin{codeblock}
-constexpr @\placeholder{semiregular-box}@() noexcept(is_nothrow_default_constructible_v<T>)
-  : @\placeholder{semiregular-box}@{in_place}
+constexpr @\exposid{semiregular-box}@() noexcept(is_nothrow_default_constructible_v<T>)
+  : @\exposid{semiregular-box}@{in_place}
 { }
 \end{codeblock}
 
 \item If \tcode{\libconcept{assignable_from}<T\&, const T\&>} is not
 modeled, the copy assignment operator is equivalent to:
 \begin{codeblock}
-@\placeholder{semiregular-box}@& operator=(const @\placeholder{semiregular-box}@& that)
+@\exposid{semiregular-box}@& operator=(const @\exposid{semiregular-box}@& that)
   noexcept(is_nothrow_copy_constructible_v<T>)
 {
   if (that) emplace(*that);
@@ -3016,7 +3016,7 @@ modeled, the copy assignment operator is equivalent to:
 \item If \tcode{\libconcept{assignable_from}<T\&, T>} is not modeled,
 the move assignment operator is equivalent to:
 \begin{codeblock}
-@\placeholder{semiregular-box}@& operator=(@\placeholder{semiregular-box}@&& that)
+@\exposid{semiregular-box}@& operator=(@\exposid{semiregular-box}@&& that)
   noexcept(is_nothrow_move_constructible_v<T>)
 {
   if (that) emplace(std::move(*that));
@@ -3054,7 +3054,7 @@ models \libconcept{view}.
 \indexlibraryglobal{ref_view}%
 \begin{codeblock}
 namespace std::ranges {
-  template<range R>
+  template<@\libconcept{range}@ R>
     requires is_object_v<R>
   class ref_view : public view_interface<ref_view<R>> {
   private:
@@ -3062,7 +3062,7 @@ namespace std::ranges {
   public:
     constexpr ref_view() noexcept = default;
 
-    template<@\placeholder{not-same-as}@<ref_view> T>
+    template<@\exposconcept{not-same-as}@<ref_view> T>
       requires @\seebelow@
     constexpr ref_view(T&& t);
 
@@ -3075,10 +3075,10 @@ namespace std::ranges {
       requires requires { ranges::empty(*@\exposid{r_}@); }
     { return ranges::empty(*@\exposid{r_}@); }
 
-    constexpr auto size() const requires sized_range<R>
+    constexpr auto size() const requires @\libconcept{sized_range}@<R>
     { return ranges::size(*@\exposid{r_}@); }
 
-    constexpr auto data() const requires contiguous_range<R>
+    constexpr auto data() const requires @\libconcept{contiguous_range}@<R>
     { return ranges::data(*@\exposid{r_}@); }
   };
   template<class R>
@@ -3088,7 +3088,7 @@ namespace std::ranges {
 
 \indexlibraryglobal{ref_view}%
 \begin{itemdecl}
-template<@\placeholder{not-same-as}@<ref_view> T>
+template<@\exposconcept{not-same-as}@<ref_view> T>
   requires @\seebelow@
 constexpr ref_view(T&& t);
 \end{itemdecl}
@@ -3103,7 +3103,7 @@ void @\placeholder{FUN}@(R&&) = delete;
 \end{codeblock}
 The expression in the \grammarterm{requires-clause} is equivalent to
 \begin{codeblock}
-convertible_to<T, R&> && requires { @\placeholder{FUN}@(declval<T>()); }
+@\libconcept{convertible_to}@<T, R&> && requires { @\placeholder{FUN}@(declval<T>()); }
 \end{codeblock}
 
 \pnum
@@ -3145,7 +3145,7 @@ for (int i : evens)
 \indexlibrarymember{end}{filter_view}%
 \begin{codeblock}
 namespace std::ranges {
-  template<input_range V, indirect_unary_predicate<iterator_t<V>> Pred>
+  template<@\libconcept{input_range}@ V, @\libconcept{indirect_unary_predicate}@<iterator_t<V>> Pred>
     requires view<V> && is_object_v<Pred>
   class filter_view : public view_interface<filter_view<V, Pred>> {
   private:
@@ -3250,14 +3250,14 @@ namespace std::ranges {
     constexpr iterator_t<V> base() &&;
     constexpr range_reference_t<V> operator*() const;
     constexpr iterator_t<V> operator->() const
-      requires @\placeholder{has-arrow}@<iterator_t<V>> && copyable<iterator_t<V>>;
+      requires @\exposconcept{has-arrow}@<iterator_t<V>> && @\libconcept{copyable}@<iterator_t<V>>;
 
     constexpr @\exposid{iterator}@& operator++();
     constexpr void operator++(int);
-    constexpr @\exposid{iterator}@ operator++(int) requires forward_range<V>;
+    constexpr @\exposid{iterator}@ operator++(int) requires @\libconcept{forward_range}@<V>;
 
-    constexpr @\exposid{iterator}@& operator--() requires bidirectional_range<V>;
-    constexpr @\exposid{iterator}@ operator--(int) requires bidirectional_range<V>;
+    constexpr @\exposid{iterator}@& operator--() requires @\libconcept{bidirectional_range}@<V>;
+    constexpr @\exposid{iterator}@ operator--(int) requires @\libconcept{bidirectional_range}@<V>;
 
     friend constexpr bool operator==(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
       requires equality_comparable<iterator_t<V>>;
@@ -3266,7 +3266,7 @@ namespace std::ranges {
       noexcept(noexcept(ranges::iter_move(i.@\exposid{current_}@)));
     friend constexpr void iter_swap(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
       noexcept(noexcept(ranges::iter_swap(x.@\exposid{current_}@, y.@\exposid{current_}@)))
-      requires indirectly_swappable<iterator_t<V>>;
+      requires @\libconcept{indirectly_swappable}@<iterator_t<V>>;
   };
 }
 \end{codeblock}
@@ -3354,7 +3354,7 @@ Equivalent to: \tcode{return *\exposid{current_};}
 \indexlibrarymember{operator->}{filter_view::iterator}%
 \begin{itemdecl}
 constexpr iterator_t<V> operator->() const
-  requires @\placeholder{has-arrow}@<iterator_t<V>> && copyable<iterator_t<V>>;
+  requires @\exposconcept{has-arrow}@<iterator_t<V>> && @\libconcept{copyable}@<iterator_t<V>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3392,7 +3392,7 @@ Equivalent to \tcode{++*this}.
 
 \indexlibrarymember{operator++}{filter_view::iterator}%
 \begin{itemdecl}
-constexpr @\exposid{iterator}@ operator++(int) requires forward_range<V>;
+constexpr @\exposid{iterator}@ operator++(int) requires @\libconcept{forward_range}@<V>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3408,7 +3408,7 @@ return tmp;
 
 \indexlibrarymember{operator\dcr}{filter_view::iterator}%
 \begin{itemdecl}
-constexpr @\exposid{iterator}@& operator--() requires bidirectional_range<V>;
+constexpr @\exposid{iterator}@& operator--() requires @\libconcept{bidirectional_range}@<V>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3425,7 +3425,7 @@ return *this;
 
 \indexlibrarymember{operator\dcr}{filter_view::iterator}%
 \begin{itemdecl}
-constexpr @\exposid{iterator}@ operator--(int) requires bidirectional_range<V>;
+constexpr @\exposid{iterator}@ operator--(int) requires @\libconcept{bidirectional_range}@<V>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3467,7 +3467,7 @@ Equivalent to: \tcode{return ranges::iter_move(i.\exposid{current_});}
 \begin{itemdecl}
 friend constexpr void iter_swap(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
   noexcept(noexcept(ranges::iter_swap(x.@\exposid{current_}@, y.@\exposid{current_}@)))
-  requires indirectly_swappable<iterator_t<V>>;
+  requires @\libconcept{indirectly_swappable}@<iterator_t<V>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3562,7 +3562,7 @@ for (int i : squares)
 \indexlibrarymember{size}{transform_view}%
 \begin{codeblock}
 namespace std::ranges {
-  template<input_range V, copy_constructible F>
+  template<@\libconcept{input_range}@ V, @\libconcept{copy_constructible}@ F>
     requires view<V> && is_object_v<F> &&
              regular_invocable<F&, range_reference_t<V>> &&
              @\exposconcept{can-reference}@<invoke_result_t<F&, range_reference_t<V>>>
@@ -3597,8 +3597,8 @@ namespace std::ranges {
       requires common_range<const V> &&
                regular_invocable<const F&, range_reference_t<const V>>;
 
-    constexpr auto size() requires sized_range<V> { return ranges::size(@\exposid{base_}@); }
-    constexpr auto size() const requires sized_range<const V>
+    constexpr auto size() requires @\libconcept{sized_range}@<V> { return ranges::size(@\exposid{base_}@); }
+    constexpr auto size() const requires @\libconcept{sized_range}@<const V>
     { return ranges::size(@\exposid{base_}@); }
   };
 
@@ -3735,7 +3735,7 @@ namespace std::ranges {
     @\exposid{iterator}@() = default;
     constexpr @\exposid{iterator}@(@\exposid{Parent}@& parent, iterator_t<@\exposid{Base}@> current);
     constexpr @\exposid{iterator}@(@\exposid{iterator}@<!Const> i)
-      requires Const && convertible_to<iterator_t<V>, iterator_t<@\exposid{Base}@>>;
+      requires Const && @\libconcept{convertible_to}@<iterator_t<V>, iterator_t<@\exposid{Base}@>>;
 
     constexpr iterator_t<@\exposid{Base}@> base() const &
       requires copyable<iterator_t<@\exposid{Base}@>>;
@@ -3745,42 +3745,42 @@ namespace std::ranges {
 
     constexpr @\exposid{iterator}@& operator++();
     constexpr void operator++(int);
-    constexpr @\exposid{iterator}@ operator++(int) requires forward_range<@\exposid{Base}@>;
+    constexpr @\exposid{iterator}@ operator++(int) requires @\libconcept{forward_range}@<@\exposid{Base}@>;
 
-    constexpr @\exposid{iterator}@& operator--() requires bidirectional_range<@\exposid{Base}@>;
-    constexpr @\exposid{iterator}@ operator--(int) requires bidirectional_range<@\exposid{Base}@>;
+    constexpr @\exposid{iterator}@& operator--() requires @\libconcept{bidirectional_range}@<@\exposid{Base}@>;
+    constexpr @\exposid{iterator}@ operator--(int) requires @\libconcept{bidirectional_range}@<@\exposid{Base}@>;
 
     constexpr @\exposid{iterator}@& operator+=(difference_type n)
-      requires random_access_range<@\exposid{Base}@>;
+      requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
     constexpr @\exposid{iterator}@& operator-=(difference_type n)
-      requires random_access_range<@\exposid{Base}@>;
+      requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
     constexpr decltype(auto) operator[](difference_type n) const
-      requires random_access_range<@\exposid{Base}@>
+      requires @\libconcept{random_access_range}@<@\exposid{Base}@>
     { return invoke(*@\exposid{parent_}@->@\exposid{fun_}@, @\exposid{current_}@[n]); }
 
     friend constexpr bool operator==(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires equality_comparable<iterator_t<@\exposid{Base}@>>;
+      requires @\libconcept{equality_comparable}@<iterator_t<@\exposid{Base}@>>;
 
     friend constexpr bool operator<(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires random_access_range<@\exposid{Base}@>;
+      requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
     friend constexpr bool operator>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires random_access_range<@\exposid{Base}@>;
+      requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
     friend constexpr bool operator<=(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires random_access_range<@\exposid{Base}@>;
+      requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
     friend constexpr bool operator>=(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires random_access_range<@\exposid{Base}@>;
+      requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
     friend constexpr auto operator<=>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires random_access_range<@\exposid{Base}@> && three_way_comparable<iterator_t<@\exposid{Base}@>>;
+      requires @\libconcept{random_access_range}@<@\exposid{Base}@> && @\libconcept{three_way_comparable}@<iterator_t<@\exposid{Base}@>>;
 
     friend constexpr @\exposid{iterator}@ operator+(@\exposid{iterator}@ i, difference_type n)
-      requires random_access_range<@\exposid{Base}@>;
+      requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
     friend constexpr @\exposid{iterator}@ operator+(difference_type n, @\exposid{iterator}@ i)
-      requires random_access_range<@\exposid{Base}@>;
+      requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
 
     friend constexpr @\exposid{iterator}@ operator-(@\exposid{iterator}@ i, difference_type n)
-      requires random_access_range<@\exposid{Base}@>;
+      requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
     friend constexpr difference_type operator-(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires random_access_range<@\exposid{Base}@>;
+      requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
 
     friend constexpr decltype(auto) iter_move(const @\exposid{iterator}@& i)
       noexcept(noexcept(invoke(*i.@\exposid{parent_}@->@\exposid{fun_}@, *i.@\exposid{current_}@)))
@@ -3793,7 +3793,7 @@ namespace std::ranges {
 
     friend constexpr void iter_swap(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
       noexcept(noexcept(ranges::iter_swap(x.@\exposid{current_}@, y.@\exposid{current_}@)))
-      requires indirectly_swappable<iterator_t<@\exposid{Base}@>>;
+      requires @\libconcept{indirectly_swappable}@<iterator_t<@\exposid{Base}@>>;
   };
 }
 \end{codeblock}
@@ -3850,7 +3850,7 @@ Initializes \exposid{current_} with \tcode{std::move(current)} and
 \indexlibraryctor{transform_view::iterator}%
 \begin{itemdecl}
 constexpr @\exposid{iterator}@(@\exposid{iterator}@<!Const> i)
-  requires Const && convertible_to<iterator_t<V>, iterator_t<@\exposid{Base}@>>;
+  requires Const && @\libconcept{convertible_to}@<iterator_t<V>, iterator_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3911,7 +3911,7 @@ Equivalent to \tcode{++current_}.
 
 \indexlibrarymember{operator++}{transform_view::iterator}%
 \begin{itemdecl}
-constexpr @\exposid{iterator}@ operator++(int) requires forward_range<@\exposid{Base}@>;
+constexpr @\exposid{iterator}@ operator++(int) requires @\libconcept{forward_range}@<@\exposid{Base}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3927,7 +3927,7 @@ return tmp;
 
 \indexlibrarymember{operator\dcr}{transform_view::iterator}%
 \begin{itemdecl}
-constexpr @\exposid{iterator}@& operator--() requires bidirectional_range<@\exposid{Base}@>;
+constexpr @\exposid{iterator}@& operator--() requires @\libconcept{bidirectional_range}@<@\exposid{Base}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3942,7 +3942,7 @@ return *this;
 
 \indexlibrarymember{operator\dcr}{transform_view::iterator}%
 \begin{itemdecl}
-constexpr @\exposid{iterator}@ operator--(int) requires bidirectional_range<@\exposid{Base}@>;
+constexpr @\exposid{iterator}@ operator--(int) requires @\libconcept{bidirectional_range}@<@\exposid{Base}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3959,7 +3959,7 @@ return tmp;
 \indexlibrarymember{operator+=}{transform_view::iterator}%
 \begin{itemdecl}
 constexpr @\exposid{iterator}@& operator+=(difference_type n)
-  requires random_access_range<@\exposid{Base}@>;
+  requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3975,7 +3975,7 @@ return *this;
 \indexlibrarymember{operator-=}{transform_view::iterator}%
 \begin{itemdecl}
 constexpr @\exposid{iterator}@& operator-=(difference_type n)
-  requires random_access_range<@\exposid{Base}@>;
+  requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4003,7 +4003,7 @@ Equivalent to: \tcode{return x.\exposid{current_} == y.\exposid{current_};}
 \indexlibrarymember{operator<}{transform_view::iterator}%
 \begin{itemdecl}
 friend constexpr bool operator<(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires random_access_range<@\exposid{Base}@>;
+  requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4015,7 +4015,7 @@ Equivalent to: \tcode{return x.\exposid{current_} < y.\exposid{current_};}
 \indexlibrarymember{operator>}{transform_view::iterator}%
 \begin{itemdecl}
 friend constexpr bool operator>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires random_access_range<@\exposid{Base}@>;
+  requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4027,7 +4027,7 @@ Equivalent to: \tcode{return y < x;}
 \indexlibrarymember{operator<=}{transform_view::iterator}%
 \begin{itemdecl}
 friend constexpr bool operator<=(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires random_access_range<@\exposid{Base}@>;
+  requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4039,7 +4039,7 @@ Equivalent to: \tcode{return !(y < x);}
 \indexlibrarymember{operator>=}{transform_view::iterator}%
 \begin{itemdecl}
 friend constexpr bool operator>=(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires random_access_range<@\exposid{Base}@>;
+  requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4051,7 +4051,7 @@ Equivalent to: \tcode{return !(x < y);}
 \indexlibrarymember{operator<=>}{transform_view::iterator}%
 \begin{itemdecl}
 friend constexpr auto operator<=>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires random_access_range<@\exposid{Base}@> && three_way_comparable<iterator_t<@\exposid{Base}@>>;
+  requires @\libconcept{random_access_range}@<@\exposid{Base}@> && @\libconcept{three_way_comparable}@<iterator_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4063,9 +4063,9 @@ Equivalent to: \tcode{return x.\exposid{current_} <=> y.\exposid{current_};}
 \indexlibrarymember{operator+}{transform_view::iterator}%
 \begin{itemdecl}
 friend constexpr @\exposid{iterator}@ operator+(@\exposid{iterator}@ i, difference_type n)
-  requires random_access_range<@\exposid{Base}@>;
+  requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
 friend constexpr @\exposid{iterator}@ operator+(difference_type n, @\exposid{iterator}@ i)
-  requires random_access_range<@\exposid{Base}@>;
+  requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4077,7 +4077,7 @@ Equivalent to: \tcode{return iterator\{*i.\exposid{parent_}, i.\exposid{current_
 \indexlibrarymember{operator-}{transform_view::iterator}%
 \begin{itemdecl}
 friend constexpr @\exposid{iterator}@ operator-(@\exposid{iterator}@ i, difference_type n)
-  requires random_access_range<@\exposid{Base}@>;
+  requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4089,7 +4089,7 @@ Equivalent to: \tcode{return iterator\{*i.\exposid{parent_}, i.\exposid{current_
 \indexlibrarymember{operator-}{transform_view::iterator}%
 \begin{itemdecl}
 friend constexpr difference_type operator-(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires random_access_range<@\exposid{Base}@>;
+  requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4102,7 +4102,7 @@ Equivalent to: \tcode{return x.\exposid{current_} - y.\exposid{current_};}
 \begin{itemdecl}
 friend constexpr void iter_swap(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
   noexcept(noexcept(ranges::iter_swap(x.@\exposid{current_}@, y.@\exposid{current_}@)))
-  requires indirectly_swappable<iterator_t<@\exposid{Base}@>>;
+  requires @\libconcept{indirectly_swappable}@<iterator_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4129,7 +4129,7 @@ namespace std::ranges {
     @\exposid{sentinel}@() = default;
     constexpr explicit @\exposid{sentinel}@(sentinel_t<@\exposid{Base}@> end);
     constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> i)
-      requires Const && convertible_to<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
+      requires Const && @\libconcept{convertible_to}@<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
 
     constexpr sentinel_t<@\exposid{Base}@> base() const;
 
@@ -4137,10 +4137,10 @@ namespace std::ranges {
 
     friend constexpr range_difference_t<@\exposid{Base}@>
       operator-(const @\exposid{iterator}@<Const>& x, const @\exposid{sentinel}@& y)
-        requires sized_sentinel_for<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
+        requires @\libconcept{sized_sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
     friend constexpr range_difference_t<@\exposid{Base}@>
       operator-(const @\exposid{sentinel}@& y, const @\exposid{iterator}@<Const>& x)
-        requires sized_sentinel_for<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
+        requires @\libconcept{sized_sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
   };
 }
 \end{codeblock}
@@ -4159,7 +4159,7 @@ Initializes \exposid{end_} with \tcode{end}.
 \indexlibraryctor{transform_view::sentinel}%
 \begin{itemdecl}
 constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> i)
-  requires Const && convertible_to<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
+  requires Const && @\libconcept{convertible_to}@<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4194,7 +4194,7 @@ Equivalent to: \tcode{return x.\exposid{current_} == y.\exposid{end_};}
 \begin{itemdecl}
 friend constexpr range_difference_t<@\exposid{Base}@>
   operator-(const @\exposid{iterator}@<Const>& x, const @\exposid{sentinel}@& y)
-    requires sized_sentinel_for<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
+    requires @\libconcept{sized_sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4207,7 +4207,7 @@ Equivalent to: \tcode{return x.\exposid{current_} - y.\exposid{end_};}
 \begin{itemdecl}
 friend constexpr range_difference_t<@\exposid{Base}@>
   operator-(const @\exposid{sentinel}@& y, const @\exposid{iterator}@<Const>& x)
-    requires sized_sentinel_for<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
+    requires @\libconcept{sized_sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4279,7 +4279,7 @@ for (int i : few)
 \indexlibrarymember{size}{take_view}%
 \begin{codeblock}
 namespace std::ranges {
-  template<view V>
+  template<@\libconcept{view}@ V>
   class take_view : public view_interface<take_view<V>> {
   private:
     V @\exposid{base_}@ = V();                                      // \expos
@@ -4293,9 +4293,9 @@ namespace std::ranges {
     constexpr V base() const& requires copy_constructible<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
-    constexpr auto begin() requires (!@\placeholder{simple-view}@<V>) {
-      if constexpr (sized_range<V>) {
-        if constexpr (random_access_range<V>)
+    constexpr auto begin() requires (!@\exposconcept{simple-view}@<V>) {
+      if constexpr (@\libconcept{sized_range}@<V>) {
+        if constexpr (@\libconcept{random_access_range}@<V>)
           return ranges::begin(@\exposid{base_}@);
         else {
           auto sz = size();
@@ -4306,8 +4306,8 @@ namespace std::ranges {
     }
 
     constexpr auto begin() const requires range<const V> {
-      if constexpr (sized_range<const V>) {
-        if constexpr (random_access_range<const V>)
+      if constexpr (@\libconcept{sized_range}@<const V>) {
+        if constexpr (@\libconcept{random_access_range}@<const V>)
           return ranges::begin(@\exposid{base_}@);
         else {
           auto sz = size();
@@ -4317,9 +4317,9 @@ namespace std::ranges {
         return counted_iterator{ranges::begin(@\exposid{base_}@), @\exposid{count_}@};
     }
 
-    constexpr auto end() requires (!@\placeholder{simple-view}@<V>) {
-      if constexpr (sized_range<V>) {
-        if constexpr (random_access_range<V>)
+    constexpr auto end() requires (!@\exposconcept{simple-view}@<V>) {
+      if constexpr (@\libconcept{sized_range}@<V>) {
+        if constexpr (@\libconcept{random_access_range}@<V>)
           return ranges::begin(@\exposid{base_}@) + size();
         else
           return default_sentinel;
@@ -4328,8 +4328,8 @@ namespace std::ranges {
     }
 
     constexpr auto end() const requires range<const V> {
-      if constexpr (sized_range<const V>) {
-        if constexpr (random_access_range<const V>)
+      if constexpr (@\libconcept{sized_range}@<const V>) {
+        if constexpr (@\libconcept{random_access_range}@<const V>)
           return ranges::begin(@\exposid{base_}@) + size();
         else
           return default_sentinel;
@@ -4337,18 +4337,18 @@ namespace std::ranges {
         return @\exposid{sentinel}@<true>{ranges::end(@\exposid{base_}@)};
     }
 
-    constexpr auto size() requires sized_range<V> {
+    constexpr auto size() requires @\libconcept{sized_range}@<V> {
       auto n = ranges::size(@\exposid{base_}@);
       return ranges::min(n, static_cast<decltype(n)>(@\exposid{count_}@));
     }
 
-    constexpr auto size() const requires sized_range<const V> {
+    constexpr auto size() const requires @\libconcept{sized_range}@<const V> {
       auto n = ranges::size(@\exposid{base_}@);
       return ranges::min(n, static_cast<decltype(n)>(@\exposid{count_}@));
     }
   };
 
-  template<range R>
+  template<@\libconcept{range}@ R>
     take_view(R&&, range_difference_t<R>)
       -> take_view<views::all_t<R>>;
 }
@@ -4382,7 +4382,7 @@ namespace std::ranges {
     @\exposid{sentinel}@() = default;
     constexpr explicit @\exposid{sentinel}@(sentinel_t<@\exposid{Base}@> end);
     constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> s)
-      requires Const && convertible_to<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
+      requires Const && @\libconcept{convertible_to}@<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
 
     constexpr sentinel_t<@\exposid{Base}@> base() const;
 
@@ -4405,7 +4405,7 @@ Initializes \exposid{end_} with \tcode{end}.
 \indexlibraryctor{take_view::sentinel}%
 \begin{itemdecl}
 constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> s)
-  requires Const && convertible_to<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
+  requires Const && @\libconcept{convertible_to}@<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4477,9 +4477,9 @@ cout << i;                                      // prints \tcode{6}
 \indexlibrarymember{end}{take_while_view}%
 \begin{codeblock}
 namespace std::ranges {
-  template<view V, class Pred>
-  requires input_range<V> && is_object_v<Pred> &&
-    indirect_unary_predicate<const Pred, iterator_t<V>>
+  template<@\libconcept{view}@ V, class Pred>
+  requires @\libconcept{input_range}@<V> && is_object_v<Pred> &&
+    @\libconcept{indirect_unary_predicate}@<const Pred, iterator_t<V>>
   class take_while_view : public view_interface<take_while_view<V, Pred>> {
     // \ref{range.take.while.sentinel}, class template \tcode{take_while_view::\exposid{sentinel}}
     template<bool> class @\exposid{sentinel}@;                      // \expos
@@ -4496,13 +4496,13 @@ namespace std::ranges {
 
     constexpr const Pred& pred() const;
 
-    constexpr auto begin() requires (!@\placeholder{simple-view}@<V>)
+    constexpr auto begin() requires (!@\exposconcept{simple-view}@<V>)
     { return ranges::begin(@\exposid{base_}@); }
 
     constexpr auto begin() const requires range<const V>
     { return ranges::begin(@\exposid{base_}@); }
 
-    constexpr auto end() requires (!@\placeholder{simple-view}@<V>)
+    constexpr auto end() requires (!@\exposconcept{simple-view}@<V>)
     { return @\exposid{sentinel}@<false>(ranges::end(@\exposid{base_}@), addressof(*@\exposid{pred_}@)); }
 
     constexpr auto end() const requires range<const V>
@@ -4553,7 +4553,7 @@ namespace std::ranges {
     @\exposid{sentinel}@() = default;
     constexpr explicit @\exposid{sentinel}@(sentinel_t<@\exposid{base-t}@> end, const Pred* pred);
     constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> s)
-      requires Const && convertible_to<sentinel_t<V>, sentinel_t<@\exposid{base-t}@>>;
+      requires Const && @\libconcept{convertible_to}@<sentinel_t<V>, sentinel_t<@\exposid{base-t}@>>;
 
     constexpr sentinel_t<@\exposid{base-t}@> base() const { return @\exposid{end_}@; }
 
@@ -4576,7 +4576,7 @@ Initializes \exposid{end_} with \tcode{end} and \exposid{pred_} with \tcode{pred
 \indexlibraryctor{take_while_view::sentinel}%
 \begin{itemdecl}
 constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> s)
-  requires Const && convertible_to<sentinel_t<V>, sentinel_t<@\exposid{base-t}@>>;
+  requires Const && @\libconcept{convertible_to}@<sentinel_t<V>, sentinel_t<@\exposid{base-t}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4661,7 +4661,7 @@ for (auto i : latter_half) {
 \indexlibrarymember{size}{drop_view}%
 \begin{codeblock}
 namespace std::ranges {
-  template<view V>
+  template<@\libconcept{view}@ V>
   class drop_view : public view_interface<drop_view<V>> {
   public:
     drop_view() = default;
@@ -4671,12 +4671,12 @@ namespace std::ranges {
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
     constexpr auto begin()
-      requires (!(@\placeholder{simple-view}@<V> && random_access_range<V>));
+      requires (!(@\exposconcept{simple-view}@<V> && @\libconcept{random_access_range}@<V>));
     constexpr auto begin() const
-      requires random_access_range<const V>;
+      requires @\libconcept{random_access_range}@<const V>;
 
     constexpr auto end()
-      requires (!@\placeholder{simple-view}@<V>)
+      requires (!@\exposconcept{simple-view}@<V>)
     { return ranges::end(@\exposid{base_}@); }
 
     constexpr auto end() const
@@ -4684,7 +4684,7 @@ namespace std::ranges {
     { return ranges::end(@\exposid{base_}@); }
 
     constexpr auto size()
-      requires sized_range<V>
+      requires @\libconcept{sized_range}@<V>
     {
       const auto s = ranges::size(@\exposid{base_}@);
       const auto c = static_cast<decltype(s)>(@\exposid{count_}@);
@@ -4692,7 +4692,7 @@ namespace std::ranges {
     }
 
     constexpr auto size() const
-      requires sized_range<const V>
+      requires @\libconcept{sized_range}@<const V>
     {
       const auto s = ranges::size(@\exposid{base_}@);
       const auto c = static_cast<decltype(s)>(@\exposid{count_}@);
@@ -4727,7 +4727,7 @@ Initializes \exposid{base_} with \tcode{std::move(base)} and
 \indexlibrarymember{begin}{drop_view}%
 \begin{itemdecl}
 constexpr auto begin()
-  requires (!(@\placeholder{simple-view}@<V> && random_access_range<V>));
+  requires (!(@\exposconcept{simple-view}@<V> && @\libconcept{random_access_range}@<V>));
 constexpr auto begin() const
   requires random_access_range<const V>;
 \end{itemdecl}
@@ -4786,9 +4786,9 @@ for (auto c : skip_ws) {
 \indexlibrarymember{end}{drop_while_view}%
 \begin{codeblock}
 namespace std::ranges {
-  template<view V, class Pred>
-  requires input_range<V> && is_object_v<Pred> &&
-    indirect_unary_predicate<const Pred, iterator_t<V>>
+  template<@\libconcept{view}@ V, class Pred>
+  requires @\libconcept{input_range}@<V> && is_object_v<Pred> &&
+    @\libconcept{indirect_unary_predicate}@<const Pred, iterator_t<V>>
   class drop_while_view : public view_interface<drop_while_view<V, Pred>> {
   public:
     drop_while_view() = default;
@@ -4894,8 +4894,8 @@ for (char ch : greeting)
 \indexlibrarymember{end}{join_view}%
 \begin{codeblock}
 namespace std::ranges {
-  template<input_range V>
-    requires view<V> && input_range<range_reference_t<V>> &&
+  template<@\libconcept{input_range}@ V>
+    requires view<V> && @\libconcept{input_range}@<range_reference_t<V>> &&
              (is_reference_v<range_reference_t<V>> ||
               view<range_value_t<V>>)
   class join_view : public view_interface<join_view<V>> {
@@ -4916,36 +4916,36 @@ namespace std::ranges {
     join_view() = default;
     constexpr explicit join_view(V base);
 
-    constexpr V base() const& requires copy_constructible<V> { return @\exposid{base_}@; }
+    constexpr V base() const& requires @\libconcept{copy_constructible}@<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
     constexpr auto begin() {
-      constexpr bool use_const = @\placeholder{simple-view}@<V> &&
+      constexpr bool use_const = @\exposconcept{simple-view}@<V> &&
                                  is_reference_v<range_reference_t<V>>;
       return @\exposid{iterator}@<use_const>{*this, ranges::begin(@\exposid{base_}@)};
     }
 
     constexpr auto begin() const
-    requires input_range<const V> &&
+    requires @\libconcept{input_range}@<const V> &&
              is_reference_v<range_reference_t<const V>> {
       return @\exposid{iterator}@<true>{*this, ranges::begin(@\exposid{base_}@)};
     }
 
     constexpr auto end() {
-      if constexpr (forward_range<V> &&
-                    is_reference_v<@\exposid{InnerRng}@> && forward_range<@\exposid{InnerRng}@> &&
+      if constexpr (@\libconcept{forward_range}@<V> &&
+                    is_reference_v<@\exposid{InnerRng}@> && @\libconcept{forward_range}@<@\exposid{InnerRng}@> &&
                     common_range<V> && common_range<@\exposid{InnerRng}@>)
-        return @\exposid{iterator}@<@\placeholder{simple-view}@<V>>{*this, ranges::end(@\exposid{base_}@)};
+        return @\exposid{iterator}@<@\exposconcept{simple-view}@<V>>{*this, ranges::end(@\exposid{base_}@)};
       else
-        return @\exposid{sentinel}@<@\placeholder{simple-view}@<V>>{*this};
+        return @\exposid{sentinel}@<@\exposconcept{simple-view}@<V>>{*this};
     }
 
     constexpr auto end() const
-    requires input_range<const V> &&
+    requires @\libconcept{input_range}@<const V> &&
              is_reference_v<range_reference_t<const V>> {
-      if constexpr (forward_range<const V> &&
+      if constexpr (@\libconcept{forward_range}@<const V> &&
                     is_reference_v<range_reference_t<const V>> &&
-                    forward_range<range_reference_t<const V>> &&
+                    @\libconcept{forward_range}@<range_reference_t<const V>> &&
                     common_range<const V> &&
                     common_range<range_reference_t<const V>>)
         return @\exposid{iterator}@<true>{*this, ranges::end(@\exposid{base_}@)};
@@ -5002,34 +5002,34 @@ template<class V>
     constexpr @\exposid{iterator}@(@\exposid{Parent}@& parent, iterator_t<@\exposid{Base}@> outer);
     constexpr @\exposid{iterator}@(@\exposid{iterator}@<!Const> i)
       requires Const &&
-               convertible_to<iterator_t<V>, iterator_t<@\exposid{Base}@>> &&
-               convertible_to<iterator_t<@\exposid{InnerRng}@>,
+               @\libconcept{convertible_to}@<iterator_t<V>, iterator_t<@\exposid{Base}@>> &&
+               @\libconcept{convertible_to}@<iterator_t<@\exposid{InnerRng}@>,
                               iterator_t<range_reference_t<@\exposid{Base}@>>>;
 
     constexpr decltype(auto) operator*() const { return *@\exposid{inner_}@; }
 
     constexpr iterator_t<@\exposid{Base}@> operator->() const
-      requires @\placeholder{has-arrow}@<iterator_t<@\exposid{Base}@>> && copyable<iterator_t<@\exposid{Base}@>>;
+      requires @\exposconcept{has-arrow}@<iterator_t<@\exposid{Base}@>> && @\libconcept{copyable}@<iterator_t<@\exposid{Base}@>>;
 
     constexpr @\exposid{iterator}@& operator++();
     constexpr void operator++(int);
     constexpr @\exposid{iterator}@ operator++(int)
-      requires @\exposid{ref-is-glvalue}@ && forward_range<@\exposid{Base}@> &&
-               forward_range<range_reference_t<@\exposid{Base}@>>;
+      requires @\exposid{ref-is-glvalue}@ && @\libconcept{forward_range}@<@\exposid{Base}@> &&
+               @\libconcept{forward_range}@<range_reference_t<@\exposid{Base}@>>;
 
     constexpr @\exposid{iterator}@& operator--()
-      requires @\exposid{ref-is-glvalue}@ && bidirectional_range<@\exposid{Base}@> &&
-               bidirectional_range<range_reference_t<@\exposid{Base}@>> &&
+      requires @\exposid{ref-is-glvalue}@ && @\libconcept{bidirectional_range}@<@\exposid{Base}@> &&
+               @\libconcept{bidirectional_range}@<range_reference_t<@\exposid{Base}@>> &&
                common_range<range_reference_t<@\exposid{Base}@>>;
 
     constexpr @\exposid{iterator}@ operator--(int)
-      requires @\exposid{ref-is-glvalue}@ && bidirectional_range<@\exposid{Base}@> &&
-               bidirectional_range<range_reference_t<@\exposid{Base}@>> &&
+      requires @\exposid{ref-is-glvalue}@ && @\libconcept{bidirectional_range}@<@\exposid{Base}@> &&
+               @\libconcept{bidirectional_range}@<range_reference_t<@\exposid{Base}@>> &&
                common_range<range_reference_t<@\exposid{Base}@>>;
 
     friend constexpr bool operator==(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires @\exposid{ref-is-glvalue}@ && equality_comparable<iterator_t<@\exposid{Base}@>> &&
-               equality_comparable<iterator_t<range_reference_t<@\exposid{Base}@>>>;
+      requires @\exposid{ref-is-glvalue}@ && @\libconcept{equality_comparable}@<iterator_t<@\exposid{Base}@>> &&
+               @\libconcept{equality_comparable}@<iterator_t<range_reference_t<@\exposid{Base}@>>>;
 
     friend constexpr decltype(auto) iter_move(const @\exposid{iterator}@& i)
     noexcept(noexcept(ranges::iter_move(i.@\exposid{inner_}@))) {
@@ -5065,11 +5065,11 @@ template<class V>
   \tcode{iterator_traits<iterator_t<range_reference_t<\exposid{Base}>>>::iterator_category}.
 \item If \exposid{ref-is-glvalue} is \tcode{true} and
   \placeholder{OUTERC} and \placeholder{INNERC} each model
-  \tcode{derived_from<bidirectional_iterator_tag>}, \tcode{iterator_category}
+  \tcode{\libconcept{derived_from}<bidirectional_iterator_tag>}, \tcode{iterator_category}
   denotes \tcode{bidirectional_iterator_tag}.
 \item Otherwise, if \exposid{ref-is-glvalue} is \tcode{true} and
   \placeholder{OUTERC} and \placeholder{INNERC} each model
-  \tcode{derived_from<for\-ward_iterator_tag>}, \tcode{iterator_category}
+  \tcode{\libconcept{derived_from}<for\-ward_iterator_tag>}, \tcode{iterator_category}
   denotes \tcode{forward_iterator_tag}.
 \item Otherwise, if \placeholder{OUTERC} and \placeholder{INNERC} each model
   \tcode{\libconcept{derived_from}<input_iterator_tag>},
@@ -5132,8 +5132,8 @@ Initializes \exposid{outer_} with \tcode{std::move(outer)} and
 \begin{itemdecl}
 constexpr @\exposid{iterator}@(@\exposid{iterator}@<!Const> i)
   requires Const &&
-           convertible_to<iterator_t<V>, iterator_t<@\exposid{Base}@>> &&
-           convertible_to<iterator_t<@\exposid{InnerRng}@>,
+           @\libconcept{convertible_to}@<iterator_t<V>, iterator_t<@\exposid{Base}@>> &&
+           @\libconcept{convertible_to}@<iterator_t<@\exposid{InnerRng}@>,
                           iterator_t<range_reference_t<@\exposid{Base}@>>>;
 \end{itemdecl}
 
@@ -5148,7 +5148,7 @@ Initializes \exposid{outer_} with \tcode{std::move(i.\exposid{outer_})},
 \indexlibrarymember{operator->}{join_view::iterator}%
 \begin{itemdecl}
 constexpr iterator_t<@\exposid{Base}@> operator->() const
-  requires @\placeholder{has-arrow}@<iterator_t<@\exposid{Base}@>> && copyable<iterator_t<@\exposid{Base}@>>;
+  requires @\exposconcept{has-arrow}@<iterator_t<@\exposid{Base}@>> && copyable<iterator_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5197,8 +5197,8 @@ Equivalent to: \tcode{++*this}.
 \indexlibrarymember{operator++}{join_view::iterator}%
 \begin{itemdecl}
 constexpr @\exposid{iterator}@ operator++(int)
-  requires @\exposid{ref-is-glvalue}@ && forward_range<@\exposid{Base}@> &&
-           forward_range<range_reference_t<@\exposid{Base}@>>;
+  requires @\exposid{ref-is-glvalue}@ && @\libconcept{forward_range}@<@\exposid{Base}@> &&
+           @\libconcept{forward_range}@<range_reference_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5215,8 +5215,8 @@ return tmp;
 \indexlibrarymember{operator\dcr}{join_view::iterator}%
 \begin{itemdecl}
 constexpr @\exposid{iterator}@& operator--()
-  requires @\exposid{ref-is-glvalue}@ && bidirectional_range<@\exposid{Base}@> &&
-           bidirectional_range<range_reference_t<@\exposid{Base}@>> &&
+  requires @\exposid{ref-is-glvalue}@ && @\libconcept{bidirectional_range}@<@\exposid{Base}@> &&
+           @\libconcept{bidirectional_range}@<range_reference_t<@\exposid{Base}@>> &&
            common_range<range_reference_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
@@ -5237,8 +5237,8 @@ return *this;
 \indexlibrarymember{operator\dcr}{join_view::iterator}%
 \begin{itemdecl}
 constexpr @\exposid{iterator}@ operator--(int)
-  requires @\exposid{ref-is-glvalue}@ && bidirectional_range<@\exposid{Base}@> &&
-           bidirectional_range<range_reference_t<@\exposid{Base}@>> &&
+  requires @\exposid{ref-is-glvalue}@ && @\libconcept{bidirectional_range}@<@\exposid{Base}@> &&
+           @\libconcept{bidirectional_range}@<range_reference_t<@\exposid{Base}@>> &&
            common_range<range_reference_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
@@ -5297,7 +5297,7 @@ namespace std::ranges {
 
     constexpr explicit @\exposid{sentinel}@(@\exposid{Parent}@& parent);
     constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> s)
-      requires Const && convertible_to<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
+      requires Const && @\libconcept{convertible_to}@<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
 
     friend constexpr bool operator==(const @\exposid{iterator}@<Const>& x, const @\exposid{sentinel}@& y);
   };
@@ -5318,7 +5318,7 @@ Initializes \exposid{end_} with \tcode{ranges::end(parent.\exposid{base_})}.
 \indexlibraryctor{join_view::sentinel}%
 \begin{itemdecl}
 constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> s)
-  requires Const && convertible_to<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
+  requires Const && @\libconcept{convertible_to}@<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5385,10 +5385,10 @@ namespace std::ranges {
     requires { typename @\exposid{require-constant}@<remove_reference_t<R>::size()>; } &&
     (remove_reference_t<R>::size() <= 1);
 
-  template<input_range V, forward_range Pattern>
+  template<@\libconcept{input_range}@ V, @\libconcept{forward_range}@ Pattern>
     requires view<V> && view<Pattern> &&
-             indirectly_comparable<iterator_t<V>, iterator_t<Pattern>, ranges::equal_to> &&
-             (forward_range<V> || @\exposconcept{tiny-range}@<Pattern>)
+             @\libconcept{indirectly_comparable}@<iterator_t<V>, iterator_t<Pattern>, ranges::equal_to> &&
+             (@\libconcept{forward_range}@<V> || @\exposconcept{tiny-range}@<Pattern>)
   class split_view : public view_interface<split_view<V, Pattern>> {
   private:
     V @\exposid{base_}@ = V();                              // \expos
@@ -5402,16 +5402,16 @@ namespace std::ranges {
     split_view() = default;
     constexpr split_view(V base, Pattern pattern);
 
-    template<input_range R>
-      requires constructible_from<V, views::all_t<R>> &&
-               constructible_from<Pattern, single_view<range_value_t<R>>>
+    template<@\libconcept{input_range}@ R>
+      requires @\libconcept{constructible_from}@<V, views::all_t<R>> &&
+               @\libconcept{constructible_from}@<Pattern, single_view<range_value_t<R>>>
     constexpr split_view(R&& r, range_value_t<R> e);
 
     constexpr V base() const& requires copy_constructible<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
     constexpr auto begin() {
-      if constexpr (forward_range<V>)
+      if constexpr (@\libconcept{forward_range}@<V>)
         return @\exposid{outer-iterator}@<@\placeholder{simple-view}@<V>>{*this, ranges::begin(@\exposid{base_}@)};
       else {
         @\exposid{current_}@ = ranges::begin(@\exposid{base_}@);
@@ -5419,16 +5419,16 @@ namespace std::ranges {
       }
     }
 
-    constexpr auto begin() const requires forward_range<V> && forward_range<const V> {
+    constexpr auto begin() const requires @\libconcept{forward_range}@<V> && @\libconcept{forward_range}@<const V> {
       return @\exposid{outer-iterator}@<true>{*this, ranges::begin(@\exposid{base_}@)};
     }
 
-    constexpr auto end() requires forward_range<V> && common_range<V> {
+    constexpr auto end() requires @\libconcept{forward_range}@<V> && common_range<V> {
       return @\exposid{outer-iterator}@<@\placeholder{simple-view}@<V>>{*this, ranges::end(@\exposid{base_}@)};
     }
 
     constexpr auto end() const {
-      if constexpr (forward_range<V> && forward_range<const V> && common_range<const V>)
+      if constexpr (@\libconcept{forward_range}@<V> && @\libconcept{forward_range}@<const V> && common_range<const V>)
         return @\exposid{outer-iterator}@<true>{*this, ranges::end(@\exposid{base_}@)};
       else
         return default_sentinel;
@@ -5438,7 +5438,7 @@ namespace std::ranges {
   template<class R, class P>
     split_view(R&&, P&&) -> split_view<views::all_t<R>, views::all_t<P>>;
 
-  template<input_range R>
+  template<@\libconcept{input_range}@ R>
     split_view(R&&, range_value_t<R>)
       -> split_view<views::all_t<R>, single_view<range_value_t<R>>>;
 }
@@ -5458,9 +5458,9 @@ Initializes \exposid{base_} with \tcode{std::move(base)}, and
 
 \indexlibraryctor{split_view}%
 \begin{itemdecl}
-template<input_range R>
-  requires constructible_from<V, views::all_t<R>> &&
-           constructible_from<Pattern, single_view<range_value_t<R>>>
+template<@\libconcept{input_range}@ R>
+  requires @\libconcept{constructible_from}@<V, views::all_t<R>> &&
+           @\libconcept{constructible_from}@<Pattern, single_view<range_value_t<R>>>
 constexpr split_view(R&& r, range_value_t<R> e);
 \end{itemdecl}
 
@@ -5490,7 +5490,7 @@ namespace std::ranges {
 
   public:
     using iterator_concept  =
-      conditional_t<forward_range<@\exposid{Base}@>, forward_iterator_tag, input_iterator_tag>;
+      conditional_t<@\libconcept{forward_range}@<@\exposid{Base}@>, forward_iterator_tag, input_iterator_tag>;
     using iterator_category = input_iterator_tag;
     // \ref{range.split.outer.value}, class \tcode{split_view::\exposid{outer-iterator}::value_type}
     struct value_type;
@@ -5498,17 +5498,17 @@ namespace std::ranges {
 
     @\exposid{outer-iterator}@() = default;
     constexpr explicit @\exposid{outer-iterator}@(@\exposid{Parent}@& parent)
-      requires (!forward_range<@\exposid{Base}@>);
+      requires (!@\libconcept{forward_range}@<@\exposid{Base}@>);
     constexpr @\exposid{outer-iterator}@(@\exposid{Parent}@& parent, iterator_t<@\exposid{Base}@> current)
-      requires forward_range<@\exposid{Base}@>;
+      requires @\libconcept{forward_range}@<@\exposid{Base}@>;
     constexpr @\exposid{outer-iterator}@(@\exposid{outer-iterator}@<!Const> i)
-      requires Const && convertible_to<iterator_t<V>, iterator_t<@\exposid{Base}@>>;
+      requires Const && @\libconcept{convertible_to}@<iterator_t<V>, iterator_t<@\exposid{Base}@>>;
 
     constexpr value_type operator*() const;
 
     constexpr @\exposid{outer-iterator}@& operator++();
     constexpr decltype(auto) operator++(int) {
-      if constexpr (forward_range<@\exposid{Base}@>) {
+      if constexpr (@\libconcept{forward_range}@<@\exposid{Base}@>) {
         auto tmp = *this;
         ++*this;
         return tmp;
@@ -5517,7 +5517,7 @@ namespace std::ranges {
     }
 
     friend constexpr bool operator==(const @\exposid{outer-iterator}@& x, const @\exposid{outer-iterator}@& y)
-      requires forward_range<@\exposid{Base}@>;
+      requires @\libconcept{forward_range}@<@\exposid{Base}@>;
 
     friend constexpr bool operator==(const @\exposid{outer-iterator}@& x, default_sentinel_t);
   };
@@ -5533,7 +5533,7 @@ models \libconcept{forward_range}, and \tcode{\exposid{parent_}->\exposid{curren
 \indexlibraryctor{split_view::outer-iterator}%
 \begin{itemdecl}
 constexpr explicit @\exposid{outer-iterator}@(@\exposid{Parent}@& parent)
-  requires (!forward_range<@\exposid{Base}@>);
+  requires (!@\libconcept{forward_range}@<@\exposid{Base}@>);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5545,7 +5545,7 @@ Initializes \exposid{parent_} with \tcode{addressof(parent)}.
 \indexlibraryctor{split_view::outer-iterator}%
 \begin{itemdecl}
 constexpr @\exposid{outer-iterator}@(@\exposid{Parent}@& parent, iterator_t<@\exposid{Base}@> current)
-  requires forward_range<@\exposid{Base}@>;
+  requires @\libconcept{forward_range}@<@\exposid{Base}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5558,7 +5558,7 @@ and \exposid{current_} with \tcode{std::move(current)}.
 \indexlibraryctor{split_view::outer-iterator}%
 \begin{itemdecl}
 constexpr @\exposid{outer-iterator}@(@\exposid{outer-iterator}@<!Const> i)
-  requires Const && convertible_to<iterator_t<V>, iterator_t<@\exposid{Base}@>>;
+  requires Const && @\libconcept{convertible_to}@<iterator_t<V>, iterator_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5609,7 +5609,7 @@ return *this;
 \indexlibrarymember{operator==}{split_view::outer-iterator}%
 \begin{itemdecl}
 friend constexpr bool operator==(const @\exposid{outer-iterator}@& x, const @\exposid{outer-iterator}@& y)
-  requires forward_range<@\exposid{Base}@>;
+  requires @\libconcept{forward_range}@<@\exposid{Base}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5719,7 +5719,7 @@ namespace std::ranges {
 
     constexpr @\exposid{inner-iterator}@& operator++();
     constexpr decltype(auto) operator++(int) {
-      if constexpr (forward_range<V>) {
+      if constexpr (@\libconcept{forward_range}@<V>) {
         auto tmp = *this;
         ++*this;
         return tmp;
@@ -5728,7 +5728,7 @@ namespace std::ranges {
     }
 
     friend constexpr bool operator==(const @\exposid{inner-iterator}@& x, const @\exposid{inner-iterator}@& y)
-      requires forward_range<@\exposid{Base}@>;
+      requires @\libconcept{forward_range}@<@\exposid{Base}@>;
 
     friend constexpr bool operator==(const @\exposid{inner-iterator}@& x, default_sentinel_t);
 
@@ -5739,7 +5739,7 @@ namespace std::ranges {
 
     friend constexpr void iter_swap(const @\exposid{inner-iterator}@& x, const @\exposid{inner-iterator}@& y)
       noexcept(noexcept(ranges::iter_swap(x.@\exposid{i_}@.@\placeholdernc{current}@, y.@\exposid{i_}@.@\placeholdernc{current}@)))
-      requires indirectly_swappable<iterator_t<@\exposid{Base}@>>;
+      requires @\libconcept{indirectly_swappable}@<iterator_t<@\exposid{Base}@>>;
   };
 }
 \end{codeblock}
@@ -5750,7 +5750,7 @@ The \grammarterm{typedef-name} \tcode{iterator_category} denotes:
 \item
 \tcode{forward_iterator_tag} if
 \tcode{iterator_traits<iterator_t<\exposid{Base}>>::iterator_category} models \linebreak
-\tcode{derived_from<forward_iterator_tag>};
+\tcode{\libconcept{derived_from}<forward_iterator_tag>};
 \item otherwise, \tcode{iterator_traits<iterator_t<\exposid{Base}>>::iterator_category}.
 \end{itemize}
 
@@ -5776,7 +5776,7 @@ constexpr @\exposid{inner-iterator}@& operator++();
 Equivalent to:
 \begin{codeblock}
 @\exposid{incremented_}@ = true;
-if constexpr (!forward_range<@\exposid{Base}@>) {
+if constexpr (!@\libconcept{forward_range}@<@\exposid{Base}@>) {
   if constexpr (Pattern::size() == 0) {
     return *this;
   }
@@ -5789,7 +5789,7 @@ return *this;
 \indexlibrarymember{operator==}{split_view::inner-iterator}%
 \begin{itemdecl}
 friend constexpr bool operator==(const @\exposid{inner-iterator}@& x, const @\exposid{inner-iterator}@& y)
-  requires forward_range<@\exposid{Base}@>;
+  requires @\libconcept{forward_range}@<@\exposid{Base}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5832,7 +5832,7 @@ if constexpr (@\exposconcept{tiny-range}@<Pattern>) {
 \begin{itemdecl}
 friend constexpr void iter_swap(const @\exposid{inner-iterator}@& x, const @\exposid{inner-iterator}@& y)
   noexcept(noexcept(ranges::iter_swap(x.@\exposid{i_}@.@\placeholdernc{current}@, y.@\exposid{i_}@.@\placeholdernc{current}@)))
-  requires indirectly_swappable<iterator_t<@\exposid{Base}@>>;
+  requires @\libconcept{indirectly_swappable}@<iterator_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5917,7 +5917,7 @@ the expression \tcode{views::common(E)} is expression-equivalent to:
 template<class ForwardIterator>
 size_t count(ForwardIterator first, ForwardIterator last);
 
-template<forward_range R>
+template<@\libconcept{forward_range}@ R>
 void my_algo(R&& r) {
   auto&& common = common_view{r};
   auto cnt = count(common.begin(), common.end());
@@ -5935,8 +5935,8 @@ void my_algo(R&& r) {
 \indexlibrarymember{end}{common_view}%
 \begin{codeblock}
 namespace std::ranges {
-  template<view V>
-    requires (!common_range<V> && copyable<iterator_t<V>>)
+  template<@\libconcept{view}@ V>
+    requires (!common_range<V> && @\libconcept{copyable}@<iterator_t<V>>)
   class common_view : public view_interface<common_view<V>> {
   private:
     V @\exposid{base_}@ = V();  // \expos
@@ -5945,36 +5945,36 @@ namespace std::ranges {
 
     constexpr explicit common_view(V r);
 
-    template<viewable_range R>
-      requires (!common_range<R> && constructible_from<V, views::all_t<R>>)
+    template<@\libconcept{viewable_range}@ R>
+      requires (!common_range<R> && @\libconcept{constructible_from}@<V, views::all_t<R>>)
     constexpr explicit common_view(R&& r);
 
-    constexpr V base() const& requires copy_constructible<V> { return @\exposid{base_}@; }
+    constexpr V base() const& requires @\libconcept{copy_constructible}@<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
     constexpr auto begin() {
-      if constexpr (random_access_range<V> && sized_range<V>)
+      if constexpr (@\libconcept{random_access_range}@<V> && @\libconcept{sized_range}@<V>)
         return ranges::begin(@\exposid{base_}@);
       else
         return common_iterator<iterator_t<V>, sentinel_t<V>>(ranges::begin(@\exposid{base_}@));
     }
 
     constexpr auto begin() const requires range<const V> {
-      if constexpr (random_access_range<const V> && sized_range<const V>)
+      if constexpr (@\libconcept{random_access_range}@<const V> && @\libconcept{sized_range}@<const V>)
         return ranges::begin(@\exposid{base_}@);
       else
         return common_iterator<iterator_t<const V>, sentinel_t<const V>>(ranges::begin(@\exposid{base_}@));
     }
 
     constexpr auto end() {
-      if constexpr (random_access_range<V> && sized_range<V>)
+      if constexpr (@\libconcept{random_access_range}@<V> && @\libconcept{sized_range}@<V>)
         return ranges::begin(@\exposid{base_}@) + ranges::size(@\exposid{base_}@);
       else
         return common_iterator<iterator_t<V>, sentinel_t<V>>(ranges::end(@\exposid{base_}@));
     }
 
     constexpr auto end() const requires range<const V> {
-      if constexpr (random_access_range<const V> && sized_range<const V>)
+      if constexpr (@\libconcept{random_access_range}@<const V> && @\libconcept{sized_range}@<const V>)
         return ranges::begin(@\exposid{base_}@) + ranges::size(@\exposid{base_}@);
       else
         return common_iterator<iterator_t<const V>, sentinel_t<const V>>(ranges::end(@\exposid{base_}@));
@@ -6007,7 +6007,7 @@ Initializes \exposid{base_} with \tcode{std::move(base)}.
 \indexlibraryctor{common_view}%
 \begin{itemdecl}
 template<viewable_range R>
-  requires (!common_range<R> && constructible_from<V, views::all_t<R>>)
+  requires (!common_range<R> && @\libconcept{constructible_from}@<V, views::all_t<R>>)
 constexpr explicit common_view(R&& r);
 \end{itemdecl}
 
@@ -6076,8 +6076,8 @@ for (int i : rv)
 \indexlibrarymember{size}{reverse_view}%
 \begin{codeblock}
 namespace std::ranges {
-  template<view V>
-    requires bidirectional_range<V>
+  template<@\libconcept{view}@ V>
+    requires @\libconcept{bidirectional_range}@<V>
   class reverse_view : public view_interface<reverse_view<V>> {
   private:
     V @\exposid{base_}@ = V();  // \expos
@@ -6086,7 +6086,7 @@ namespace std::ranges {
 
     constexpr explicit reverse_view(V r);
 
-    constexpr V base() const& requires copy_constructible<V> { return @\exposid{base_}@; }
+    constexpr V base() const& requires @\libconcept{copy_constructible}@<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
     constexpr reverse_iterator<iterator_t<V>> begin();
@@ -6096,10 +6096,10 @@ namespace std::ranges {
     constexpr reverse_iterator<iterator_t<V>> end();
     constexpr auto end() const requires common_range<const V>;
 
-    constexpr auto size() requires sized_range<V> {
+    constexpr auto size() requires @\libconcept{sized_range}@<V> {
       return ranges::size(@\exposid{base_}@);
     }
-    constexpr auto size() const requires sized_range<const V> {
+    constexpr auto size() const requires @\libconcept{sized_range}@<const V> {
       return ranges::size(@\exposid{base_}@);
     }
   };
@@ -6245,8 +6245,8 @@ namespace std::ranges {
 
 
   template<input_range V, size_t N>
-    requires view<V> && @\placeholder{has-tuple-element}@<range_value_t<V>, N> &&
-      @\placeholder{has-tuple-element}@<remove_reference_t<range_reference_t<V>>, N>
+    requires @\libconcept{view}@<V> && @\exposconcept{has-tuple-element}@<range_value_t<V>, N> &&
+      @\exposconcept{has-tuple-element}@<remove_reference_t<range_reference_t<V>>, N>
   class elements_view : public view_interface<elements_view<V, N>> {
   public:
     elements_view() = default;
@@ -6255,10 +6255,10 @@ namespace std::ranges {
     constexpr V base() const& requires copy_constructible<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
-    constexpr auto begin() requires (!@\placeholder{simple-view}@<V>)
+    constexpr auto begin() requires (!@\exposconcept{simple-view}@<V>)
     { return @\exposid{iterator}@<false>(ranges::begin(@\exposid{base_}@)); }
 
-    constexpr auto begin() const requires @\placeholder{simple-view}@<V>
+    constexpr auto begin() const requires @\exposconcept{simple-view}@<V>
     { return @\exposid{iterator}@<true>(ranges::begin(@\exposid{base_}@)); }
 
     constexpr auto end()
@@ -6318,7 +6318,7 @@ namespace std::ranges {
     @\exposid{iterator}@() = default;
     constexpr explicit @\exposid{iterator}@(iterator_t<@\exposid{base-t}@> current);
     constexpr @\exposid{iterator}@(@\exposid{iterator}@<!Const> i)
-      requires Const && convertible_to<iterator_t<V>, iterator_t<@\exposid{base-t}@>>;
+      requires Const && @\libconcept{convertible_to}@<iterator_t<V>, iterator_t<@\exposid{base-t}@>>;
 
     constexpr iterator_t<@\exposid{base-t}@> base() const&
       requires copyable<iterator_t<@\exposid{base-t}@>>;
@@ -6328,43 +6328,43 @@ namespace std::ranges {
     { return get<N>(*@\exposid{current_}@); }
 
     constexpr @\exposid{iterator}@& operator++();
-    constexpr void operator++(int) requires (!forward_range<@\exposid{base-t}@>);
-    constexpr @\exposid{iterator}@ operator++(int) requires forward_range<@\exposid{base-t}@>;
+    constexpr void operator++(int) requires (!@\libconcept{forward_range}@<@\exposid{base-t}@>);
+    constexpr @\exposid{iterator}@ operator++(int) requires @\libconcept{forward_range}@<@\exposid{base-t}@>;
 
-    constexpr @\exposid{iterator}@& operator--() requires bidirectional_range<@\exposid{base-t}@>;
-    constexpr @\exposid{iterator}@ operator--(int) requires bidirectional_range<@\exposid{base-t}@>;
+    constexpr @\exposid{iterator}@& operator--() requires @\libconcept{bidirectional_range}@<@\exposid{base-t}@>;
+    constexpr @\exposid{iterator}@ operator--(int) requires @\libconcept{bidirectional_range}@<@\exposid{base-t}@>;
 
     constexpr @\exposid{iterator}@& operator+=(difference_type x)
-      requires random_access_range<@\exposid{base-t}@>;
+      requires @\libconcept{random_access_range}@<@\exposid{base-t}@>;
     constexpr @\exposid{iterator}@& operator-=(difference_type x)
-      requires random_access_range<@\exposid{base-t}@>;
+      requires @\libconcept{random_access_range}@<@\exposid{base-t}@>;
 
     constexpr decltype(auto) operator[](difference_type n) const
-      requires random_access_range<@\exposid{base-t}@>
+      requires @\libconcept{random_access_range}@<@\exposid{base-t}@>
     { return get<N>(*(@\exposid{current_}@ + n)); }
 
     friend constexpr bool operator==(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires equality_comparable<iterator_t<@\exposid{base-t}@>>;
+      requires @\libconcept{equality_comparable}@<iterator_t<@\exposid{base-t}@>>;
 
     friend constexpr bool operator<(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires random_access_range<@\exposid{base-t}@>;
+      requires @\libconcept{random_access_range}@<@\exposid{base-t}@>;
     friend constexpr bool operator>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires random_access_range<@\exposid{base-t}@>;
+      requires @\libconcept{random_access_range}@<@\exposid{base-t}@>;
     friend constexpr bool operator<=(const @\exposid{iterator}@& y, const @\exposid{iterator}@& y)
-      requires random_access_range<@\exposid{base-t}@>;
+      requires @\libconcept{random_access_range}@<@\exposid{base-t}@>;
     friend constexpr bool operator>=(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires random_access_range<@\exposid{base-t}@>;
+      requires @\libconcept{random_access_range}@<@\exposid{base-t}@>;
     friend constexpr auto operator<=>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires random_access_range<@\exposid{base-t}@> && three_way_comparable<iterator_t<@\exposid{base-t}@>>;
+      requires @\libconcept{random_access_range}@<@\exposid{base-t}@> && @\libconcept{three_way_comparable}@<iterator_t<@\exposid{base-t}@>>;
 
     friend constexpr @\exposid{iterator}@ operator+(const @\exposid{iterator}@& x, difference_type y)
-      requires random_access_range<@\exposid{base-t}@>;
+      requires @\libconcept{random_access_range}@<@\exposid{base-t}@>;
     friend constexpr @\exposid{iterator}@ operator+(difference_type x, const @\exposid{iterator}@& y)
-      requires random_access_range<@\exposid{base-t}@>;
+      requires @\libconcept{random_access_range}@<@\exposid{base-t}@>;
     friend constexpr @\exposid{iterator}@ operator-(const @\exposid{iterator}@& x, difference_type y)
-      requires random_access_range<@\exposid{base-t}@>;
+      requires @\libconcept{random_access_range}@<@\exposid{base-t}@>;
     friend constexpr difference_type operator-(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires random_access_range<@\exposid{base-t}@>;
+      requires @\libconcept{random_access_range}@<@\exposid{base-t}@>;
   };
 }
 \end{codeblock}
@@ -6383,7 +6383,7 @@ Initializes \exposid{current_} with \tcode{std::move(current)}.
 \indexlibraryctor{elements_view::iterator}%
 \begin{itemdecl}
 constexpr @\exposid{iterator}@(@\exposid{iterator}@<!Const> i)
-  requires Const && convertible_to<iterator_t<V>, iterator_t<@\exposid{base-t}@>>;
+  requires Const && @\libconcept{convertible_to}@<iterator_t<V>, iterator_t<@\exposid{base-t}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6432,7 +6432,7 @@ return *this;
 
 \indexlibrarymember{operator++}{elements_view::iterator}%
 \begin{itemdecl}
-constexpr void operator++(int) requires (!forward_range<@\exposid{base-t}@>);
+constexpr void operator++(int) requires (!@\libconcept{forward_range}@<@\exposid{base-t}@>);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6443,7 +6443,7 @@ Equivalent to: \tcode{++\exposid{current_}}.
 
 \indexlibrarymember{operator++}{elements_view::iterator}%
 \begin{itemdecl}
-constexpr @\exposid{iterator}@ operator++(int) requires forward_range<@\exposid{base-t}@>;
+constexpr @\exposid{iterator}@ operator++(int) requires @\libconcept{forward_range}@<@\exposid{base-t}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6459,7 +6459,7 @@ return temp;
 
 \indexlibrarymember{operator--}{elements_view::iterator}%
 \begin{itemdecl}
-constexpr @\exposid{iterator}@& operator--() requires bidirectional_range<@\exposid{base-t}@>;
+constexpr @\exposid{iterator}@& operator--() requires @\libconcept{bidirectional_range}@<@\exposid{base-t}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6474,7 +6474,7 @@ return *this;
 
 \indexlibrarymember{operator--}{elements_view::iterator}%
 \begin{itemdecl}
-constexpr @\exposid{iterator}@ operator--(int) requires bidirectional_range<@\exposid{base-t}@>;
+constexpr @\exposid{iterator}@ operator--(int) requires @\libconcept{bidirectional_range}@<@\exposid{base-t}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6491,7 +6491,7 @@ return temp;
 \indexlibrarymember{operator+=}{elements_view::iterator}%
 \begin{itemdecl}
 constexpr @\exposid{iterator}@& operator+=(difference_type n);
-  requires random_access_range<@\exposid{base-t}@>;
+  requires @\libconcept{random_access_range}@<@\exposid{base-t}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6507,7 +6507,7 @@ return *this;
 \indexlibrarymember{operator-=}{elements_view::iterator}%
 \begin{itemdecl}
 constexpr @\exposid{iterator}@& operator-=(difference_type n)
-  requires random_access_range<@\exposid{base-t}@>;
+  requires @\libconcept{random_access_range}@<@\exposid{base-t}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6535,7 +6535,7 @@ Equivalent to: \tcode{return x.\exposid{current_} == y.\exposid{current_};}
 \indexlibrarymember{operator<}{elements_view::iterator}%
 \begin{itemdecl}
 friend constexpr bool operator<(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires random_access_range<@\exposid{base-t}@>;
+  requires @\libconcept{random_access_range}@<@\exposid{base-t}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6547,7 +6547,7 @@ Equivalent to: \tcode{return x.\exposid{current_} < y.\exposid{current_};}
 \indexlibrarymember{operator>}{elements_view::iterator}%
 \begin{itemdecl}
 friend constexpr bool operator>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires random_access_range<@\exposid{base-t}@>;
+  requires @\libconcept{random_access_range}@<@\exposid{base-t}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6559,7 +6559,7 @@ Equivalent to: \tcode{return y < x;}
 \indexlibrarymember{operator<=}{elements_view::iterator}%
 \begin{itemdecl}
 friend constexpr bool operator<=(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires random_access_range<@\exposid{base-t}@>;
+  requires @\libconcept{random_access_range}@<@\exposid{base-t}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6571,7 +6571,7 @@ Equivalent to: \tcode{return !(y < x);}
 \indexlibrarymember{operator>=}{elements_view::iterator}%
 \begin{itemdecl}
 friend constexpr bool operator>=(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires random_access_range<@\exposid{base-t}@>;
+  requires @\libconcept{random_access_range}@<@\exposid{base-t}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6583,7 +6583,7 @@ Equivalent to: \tcode{return !(x < y);}
 \indexlibrarymember{operator<=>}{elements_view::iterator}%
 \begin{itemdecl}
 friend constexpr auto operator<=>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires random_access_range<@\exposid{base-t}@> && three_way_comparable<iterator_t<@\exposid{base-t}@>>;
+  requires @\libconcept{random_access_range}@<@\exposid{base-t}@> && @\libconcept{three_way_comparable}@<iterator_t<@\exposid{base-t}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6595,7 +6595,7 @@ Equivalent to: \tcode{return x.\exposid{current_} <=> y.\exposid{current_};}
 \indexlibrarymember{operator+}{elements_view::iterator}%
 \begin{itemdecl}
 friend constexpr @\exposid{iterator}@ operator+(const @\exposid{iterator}@& x, difference_type y)
-  requires random_access_range<@\exposid{base-t}@>;
+  requires @\libconcept{random_access_range}@<@\exposid{base-t}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6607,7 +6607,7 @@ Equivalent to: \tcode{return iterator\{x\} += y;}
 \indexlibrarymember{operator+}{elements_view::iterator}%
 \begin{itemdecl}
 friend constexpr @\exposid{iterator}@ operator+(difference_type x, const @\exposid{iterator}@& y)
-  requires random_access_range<@\exposid{base-t}@>;
+  requires @\libconcept{random_access_range}@<@\exposid{base-t}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6619,7 +6619,7 @@ Equivalent to: \tcode{return y + x;}
 \indexlibrarymember{operator-}{elements_view::iterator}%
 \begin{itemdecl}
 constexpr @\exposid{iterator}@ operator-(const @\exposid{iterator}@& x, difference_type y)
-  requires random_access_range<@\exposid{base-t}@>;
+  requires @\libconcept{random_access_range}@<@\exposid{base-t}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6631,7 +6631,7 @@ Equivalent to: \tcode{return iterator\{x\} -= y;}
 \indexlibrarymember{operator-}{elements_view::iterator}%
 \begin{itemdecl}
 constexpr difference_type operator-(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires random_access_range<@\exposid{base-t}@>;
+  requires @\libconcept{random_access_range}@<@\exposid{base-t}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6688,7 +6688,7 @@ Initializes \exposid{end_} with \tcode{end}.
 \indexlibraryctor{elements_view::sentinel}%
 \begin{itemdecl}
 constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> other)
-  requires Const && convertible_to<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
+  requires Const && @\libconcept{convertible_to}@<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/support.tex
+++ b/source/support.tex
@@ -4521,7 +4521,7 @@ This is \tcode{std::strong_ordering} if the expansion is empty.
 \begin{codeblock}
 template<class T, class Cat>
   concept @\defexposconcept{compares-as}@ =                 // \expos
-    same_as<common_comparison_category_t<T, Cat>, Cat>;
+    @\libconcept{same_as}@<common_comparison_category_t<T, Cat>, Cat>;
 
 template<class T, class U>
   concept @\defexposconcept{partially-ordered-with}@ =      // \expos
@@ -4604,10 +4604,10 @@ model \tcode{\libconcept{three_way_comparable}<T, Cat>} only if:
 \begin{codeblock}
 template<class T, class U, class Cat = partial_ordering>
   concept @\deflibconcept{three_way_comparable_with}@ =
-    three_way_comparable<T, Cat> &&
-    three_way_comparable<U, Cat> &&
-    common_reference_with<const remove_reference_t<T>&, const remove_reference_t<U>&> &&
-    three_way_comparable<
+    @\libconcept{three_way_comparable}@<T, Cat> &&
+    @\libconcept{three_way_comparable}@<U, Cat> &&
+    @\libconcept{common_reference_with}@<const remove_reference_t<T>&, const remove_reference_t<U>&> &&
+    @\libconcept{three_way_comparable}@<
       common_reference_t<const remove_reference_t<T>&, const remove_reference_t<U>&>, Cat> &&
     @\exposconcept{weakly-equality-comparable-with}@<T, U> &&
     @\exposconcept{partially-ordered-with}@<T, U> &&

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -4246,7 +4246,7 @@ within its scope.
 \begin{codeblock}
 template<typename T>
 concept C = requires(T x) {
-  { x == x } -> convertible_to<bool>;
+  { x == x } -> @\libconcept{convertible_to}@<bool>;
 };
 
 template<typename T>

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -875,15 +875,15 @@ namespace std {
 \mandates
 \tcode{stop_callback} is instantiated with an argument for the
 template parameter \tcode{Callback}
-that satisfies both \tcode{invocable}
-and \tcode{destructible}.
+that satisfies both \libconcept{invocable}
+and \libconcept{destructible}.
 
 \pnum
 \expects
 \tcode{stop_callback} is instantiated with an argument for the
 template parameter \tcode{Callback}
-that models both \tcode{invocable}
-and \tcode{destructible}.
+that models both \libconcept{invocable}
+and \libconcept{destructible}.
 
 
 \rSec3[stopcallback.cons]{Constructors and destructor}

--- a/source/time.tex
+++ b/source/time.tex
@@ -210,7 +210,7 @@ namespace std {
     template<class Clock, class Duration1, class Duration2>
        constexpr bool operator>=(const time_point<Clock, Duration1>& lhs,
                                  const time_point<Clock, Duration2>& rhs);
-    template<class Clock, class Duration1, three_way_comparable_with<Duration1> Duration2>
+    template<class Clock, class Duration1, @\libconcept{three_way_comparable_with}@<Duration1> Duration2>
        constexpr auto operator<=>(const time_point<Clock, Duration1>& lhs,
                                   const time_point<Clock, Duration2>& rhs);
 
@@ -794,7 +794,7 @@ namespace std {
     template<class Duration>
       bool operator>=(const sys_time<Duration>& x, const leap_second& y);
     template<class Duration>
-      requires three_way_comparable_with<sys_seconds, sys_time<Duration>>
+      requires @\libconcept{three_way_comparable_with}@<sys_seconds, sys_time<Duration>>
       constexpr auto operator<=>(const leap_second& x, const sys_time<Duration>& y);
 
     // \ref{time.zone.link}, class \tcode{time_zone_link}
@@ -1761,7 +1761,7 @@ template<class Rep1, class Period1, class Rep2, class Period2>
 \indexlibrarymember{operator<=>}{duration}%
 \begin{itemdecl}
 template<class Rep1, class Period1, class Rep2, class Period2>
-    requires three_way_comparable<typename CT::rep>
+    requires @\libconcept{three_way_comparable}@<typename CT::rep>
   constexpr auto operator<=>(const duration<Rep1, Period1>& lhs,
                              const duration<Rep2, Period2>& rhs);
 \end{itemdecl}
@@ -2506,7 +2506,7 @@ template<class Clock, class Duration1, class Duration2>
 \indexlibrarymember{operator>=}{time_point}%
 \begin{itemdecl}
 template<class Clock, class Duration1,
-         three_way_comparable_with<Duration1> Duration2>
+         @\libconcept{three_way_comparable_with}@<Duration1> Duration2>
   constexpr auto operator<=>(const time_point<Clock, Duration1>& lhs,
                              const time_point<Clock, Duration2>& rhs);
 \end{itemdecl}
@@ -10333,7 +10333,7 @@ template<class Duration>
 \indexlibrarymember{operator<=>}{sys_time}%
 \begin{itemdecl}
 template<class Duration>
-  requires three_way_comparable_with<sys_seconds, sys_time<Duration>>
+  requires @\libconcept{three_way_comparable_with}@<sys_seconds, sys_time<Duration>>
   constexpr auto operator<=>(const leap_second& x, const sys_time<Duration>& y) noexcept;
 \end{itemdecl}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2381,7 +2381,7 @@ namespace std {
     constexpr bool operator<=(const optional<T>&, const optional<U>&);
   template<class T, class U>
     constexpr bool operator>=(const optional<T>&, const optional<U>&);
-  template<class T, three_way_comparable_with<T> U>
+  template<class T, @\libconcept{three_way_comparable_with}@<T> U>
     constexpr compare_three_way_result_t<T,U>
       operator<=>(const optional<T>&, const optional<U>&);
 
@@ -2403,7 +2403,7 @@ namespace std {
   template<class T, class U> constexpr bool operator<=(const T&, const optional<U>&);
   template<class T, class U> constexpr bool operator>=(const optional<T>&, const U&);
   template<class T, class U> constexpr bool operator>=(const T&, const optional<U>&);
-  template<class T, three_way_comparable_with<T> U>
+  template<class T, @\libconcept{three_way_comparable_with}@<T> U>
     constexpr compare_three_way_result_t<T,U>
       operator<=>(const optional<T>&, const U&);
 
@@ -3556,7 +3556,7 @@ are constexpr functions.
 
 \indexlibrarymember{operator<=>}{optional}%
 \begin{itemdecl}
-template<class T, three_way_comparable_with<T> U>
+template<class T, @\libconcept{three_way_comparable_with}@<T> U>
   constexpr compare_three_way_result_t<T,U>
     operator<=>(const optional<T>& x, const optional<U>& y);
 \end{itemdecl}
@@ -3796,7 +3796,7 @@ Equivalent to: \tcode{return bool(x) ?\ v >= *x :\ true;}
 
 \indexlibrarymember{operator<=>}{optional}%
 \begin{itemdecl}
-template<class T, three_way_comparable_with<T> U>
+template<class T, @\libconcept{three_way_comparable_with}@<T> U>
   constexpr compare_three_way_result_t<T,U>
     operator<=>(const optional<T>& x, const U& v);
 \end{itemdecl}
@@ -6905,20 +6905,20 @@ namespace std {
   namespace ranges {
     template<class I, class O>
       using uninitialized_copy_result = in_out_result<I, O>;
-    template<input_iterator I, sentinel_for<I> S1,
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S1,
              @\exposconcept{no-throw-forward-iterator}@ O, @\exposconcept{no-throw-sentinel}@<O> S2>
-      requires constructible_from<iter_value_t<O>, iter_reference_t<I>>
+      requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_reference_t<I>>
         uninitialized_copy_result<I, O>
           uninitialized_copy(I ifirst, S1 ilast, O ofirst, S2 olast);
-    template<input_range IR, @\exposconcept{no-throw-forward-range}@ OR>
-      requires constructible_from<range_value_t<OR>, range_reference_t<IR>>
+    template<@\libconcept{input_range}@ IR, @\exposconcept{no-throw-forward-range}@ OR>
+      requires @\libconcept{constructible_from}@<range_value_t<OR>, range_reference_t<IR>>
         uninitialized_copy_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
           uninitialized_copy(IR&& in_range, OR&& out_range);
 
     template<class I, class O>
       using uninitialized_copy_n_result = in_out_result<I, O>;
-    template<input_iterator I, @\exposconcept{no-throw-forward-iterator}@ O, @\exposconcept{no-throw-sentinel}@<O> S>
-      requires constructible_from<iter_value_t<O>, iter_reference_t<I>>
+    template<@\libconcept{input_iterator}@ I, @\exposconcept{no-throw-forward-iterator}@ O, @\exposconcept{no-throw-sentinel}@<O> S>
+      requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_reference_t<I>>
         uninitialized_copy_n_result<I, O>
           uninitialized_copy_n(I ifirst, iter_difference_t<I> n, O ofirst, S olast);
   }
@@ -6941,21 +6941,21 @@ namespace std {
   namespace ranges {
     template<class I, class O>
       using uninitialized_move_result = in_out_result<I, O>;
-    template<input_iterator I, sentinel_for<I> S1,
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S1,
              @\exposconcept{no-throw-forward-iterator}@ O, @\exposconcept{no-throw-sentinel}@<O> S2>
-      requires constructible_from<iter_value_t<O>, iter_rvalue_reference_t<I>>
+      requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_rvalue_reference_t<I>>
         uninitialized_move_result<I, O>
           uninitialized_move(I ifirst, S1 ilast, O ofirst, S2 olast);
-    template<input_range IR, @\exposconcept{no-throw-forward-range}@ OR>
-      requires constructible_from<range_value_t<OR>, range_rvalue_reference_t<IR>>
+    template<@\libconcept{input_range}@ IR, @\exposconcept{no-throw-forward-range}@ OR>
+      requires @\libconcept{constructible_from}@<range_value_t<OR>, range_rvalue_reference_t<IR>>
         uninitialized_move_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
           uninitialized_move(IR&& in_range, OR&& out_range);
 
     template<class I, class O>
       using uninitialized_move_n_result = in_out_result<I, O>;
-    template<input_iterator I,
+    template<@\libconcept{input_iterator}@ I,
              @\exposconcept{no-throw-forward-iterator}@ O, @\exposconcept{no-throw-sentinel}@<O> S>
-      requires constructible_from<iter_value_t<O>, iter_rvalue_reference_t<I>>
+      requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_rvalue_reference_t<I>>
         uninitialized_move_n_result<I, O>
           uninitialized_move_n(I ifirst, iter_difference_t<I> n, O ofirst, S olast);
   }
@@ -6977,14 +6977,14 @@ namespace std {
 
   namespace ranges {
     template<@\exposconcept{no-throw-forward-iterator}@ I, @\exposconcept{no-throw-sentinel}@<I> S, class T>
-      requires constructible_from<iter_value_t<I>, const T&>
+      requires @\libconcept{constructible_from}@<iter_value_t<I>, const T&>
         I uninitialized_fill(I first, S last, const T& x);
     template<@\exposconcept{no-throw-forward-range}@ R, class T>
-      requires constructible_from<range_value_t<R>, const T&>
+      requires @\libconcept{constructible_from}@<range_value_t<R>, const T&>
         borrowed_iterator_t<R> uninitialized_fill(R&& r, const T& x);
 
     template<@\exposconcept{no-throw-forward-iterator}@ I, class T>
-      requires constructible_from<iter_value_t<I>, const T&>
+      requires @\libconcept{constructible_from}@<iter_value_t<I>, const T&>
         I uninitialized_fill_n(I first, iter_difference_t<I> n, const T& x);
   }
 
@@ -7012,18 +7012,18 @@ namespace std {
                                      NoThrowForwardIterator first, Size n);
 
   namespace ranges {
-    template<destructible T>
+    template<@\libconcept{destructible}@ T>
       constexpr void destroy_at(T* location) noexcept;
 
     template<@\exposconcept{no-throw-input-iterator}@ I, @\exposconcept{no-throw-sentinel}@<I> S>
-      requires destructible<iter_value_t<I>>
+      requires @\libconcept{destructible}@<iter_value_t<I>>
         constexpr I destroy(I first, S last) noexcept;
     template<@\exposconcept{no-throw-input-range}@ R>
-      requires destructible<range_value_t<R>>
+      requires @\libconcept{destructible}@<range_value_t<R>>
         constexpr borrowed_iterator_t<R> destroy(R&& r) noexcept;
 
     template<@\exposconcept{no-throw-input-iterator}@ I>
-      requires destructible<iter_value_t<I>>
+      requires @\libconcept{destructible}@<iter_value_t<I>>
         constexpr I destroy_n(I first, iter_difference_t<I> n) noexcept;
   }
 
@@ -7061,7 +7061,7 @@ namespace std {
   template<class T1, class D1, class T2, class D2>
     bool operator>=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
   template<class T1, class D1, class T2, class D2>
-    requires three_way_comparable_with<typename unique_ptr<T1, D1>::pointer,
+    requires @\libconcept{three_way_comparable_with}@<typename unique_ptr<T1, D1>::pointer,
                                        typename unique_ptr<T2, D2>::pointer>
     compare_three_way_result_t<typename unique_ptr<T1, D1>::pointer,
                                typename unique_ptr<T2, D2>::pointer>
@@ -7086,7 +7086,7 @@ namespace std {
   template<class T, class D>
     bool operator>=(nullptr_t, const unique_ptr<T, D>& y);
   template<class T, class D>
-    requires three_way_comparable_with<typename unique_ptr<T, D>::pointer, nullptr_t>
+    requires @\libconcept{three_way_comparable_with}@<typename unique_ptr<T, D>::pointer, nullptr_t>
     compare_three_way_result_t<typename unique_ptr<T, D>::pointer, nullptr_t>
       operator<=>(const unique_ptr<T, D>& x, nullptr_t);
 
@@ -9472,7 +9472,7 @@ template<class T1, class D1, class T2, class D2>
 \indexlibrarymember{operator<=>}{unique_ptr}%
 \begin{itemdecl}
 template<class T1, class D1, class T2, class D2>
-  requires three_way_comparable_with<typename unique_ptr<T1, D1>::pointer,
+  requires @\libconcept{three_way_comparable_with}@<typename unique_ptr<T1, D1>::pointer,
                                      typename unique_ptr<T2, D2>::pointer>
   compare_three_way_result_t<typename unique_ptr<T1, D1>::pointer,
                              typename unique_ptr<T2, D2>::pointer>
@@ -9572,7 +9572,7 @@ The second function template returns \tcode{!(nullptr < x)}.
 \indexlibrarymember{operator<=>}{unique_ptr}%
 \begin{itemdecl}
 template<class T, class D>
-  requires three_way_comparable_with<typename unique_ptr<T, D>::pointer, nullptr_t>
+  requires @\libconcept{three_way_comparable_with}@<typename unique_ptr<T, D>::pointer, nullptr_t>
   compare_three_way_result_t<typename unique_ptr<T, D>::pointer, nullptr_t>
     operator<=>(const unique_ptr<T, D>& x, nullptr_t);
 \end{itemdecl}
@@ -14188,7 +14188,7 @@ return !ranges::equal_to{}(std::forward<T>(t), std::forward<U>(u));
 \begin{itemdecl}
 struct ranges::greater {
   template<class T, class U>
-    requires totally_ordered_with<T, U> || @\placeholdernc{BUILTIN-PTR-CMP}@(U, <, T)
+    requires @\libconcept{totally_ordered_with}@<T, U> || @\placeholdernc{BUILTIN-PTR-CMP}@(U, <, T)
   constexpr bool operator()(T&& t, U&& u) const;
 
   using is_transparent = @\unspecnc@;
@@ -14207,7 +14207,7 @@ return ranges::less{}(std::forward<U>(u), std::forward<T>(t));
 \begin{itemdecl}
 struct ranges::less {
   template<class T, class U>
-    requires totally_ordered_with<T, U> || @\placeholdernc{BUILTIN-PTR-CMP}@(T, <, U)
+    requires @\libconcept{totally_ordered_with}@<T, U> || @\placeholdernc{BUILTIN-PTR-CMP}@(T, <, U)
   constexpr bool operator()(T&& t, U&& u) const;
 
   using is_transparent = @\unspecnc@;
@@ -14248,7 +14248,7 @@ Otherwise, equivalent to:
 \begin{itemdecl}
 struct ranges::greater_equal {
   template<class T, class U>
-    requires totally_ordered_with<T, U> || @\placeholdernc{BUILTIN-PTR-CMP}@(T, <, U)
+    requires @\libconcept{totally_ordered_with}@<T, U> || @\placeholdernc{BUILTIN-PTR-CMP}@(T, <, U)
   constexpr bool operator()(T&& t, U&& u) const;
 
   using is_transparent = @\unspecnc@;
@@ -14267,7 +14267,7 @@ return !ranges::less{}(std::forward<T>(t), std::forward<U>(u));
 \begin{itemdecl}
 struct ranges::less_equal {
   template<class T, class U>
-    requires totally_ordered_with<T, U> || @\placeholdernc{BUILTIN-PTR-CMP}@(U, <, T)
+    requires @\libconcept{totally_ordered_with}@<T, U> || @\placeholdernc{BUILTIN-PTR-CMP}@(U, <, T)
   constexpr bool operator()(T&& t, U&& u) const;
 
   using is_transparent = @\unspecnc@;
@@ -19993,7 +19993,7 @@ Let \tcode{charT} be \tcode{decltype(fmt)::value_type}.
 
 \pnum
 \constraints
-\tcode{Out} satisfies \tcode{output_iterator<const charT\&>}.
+\tcode{Out} satisfies \tcode{\libconcept{output_iterator}<const charT\&>}.
 
 \pnum
 \expects


### PR DESCRIPTION
This substantially improves the index of library concepts.

Fixes #3494.