### PR TITLE
[temp.deduct.guide] Move into [temp.class].

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -2197,6 +2197,62 @@ v2[3] = dcomplex(7,8);                  // \tcode{Array<dcomplex>::operator[]}
 \end{codeblock}
 \end{example}
 
+\rSec3[temp.deduct.guide]{Deduction guides}
+\indextext{deduction!class template argument}%
+
+\pnum
+Deduction guides are used
+when a \grammarterm{template-name} appears
+as a type specifier
+for a deduced class type\iref{dcl.type.class.deduct}.
+Deduction guides are not found by name lookup.
+Instead, when performing class template argument deduction\iref{over.match.class.deduct},
+any deduction guides declared for the class template are considered.
+
+\begin{bnf}
+\nontermdef{deduction-guide}\br
+    \opt{explicit-specifier} template-name \terminal{(} parameter-declaration-clause \terminal{)} \terminal{->} simple-template-id \terminal{;}
+\end{bnf}
+
+\pnum
+\begin{example}
+\begin{codeblock}
+template<class T, class D = int>
+struct S {
+  T data;
+};
+template<class U>
+S(U) -> S<typename U::type>;
+
+struct A {
+  using type = short;
+  operator type();
+};
+S x{A()};           // \tcode{x} is of type \tcode{S<short, int>}
+\end{codeblock}
+\end{example}
+
+\pnum
+The same restrictions apply
+to the \grammarterm{parameter-declaration-clause}
+of a deduction guide
+as in a function declaration\iref{dcl.fct}.
+The \grammarterm{simple-template-id}
+shall name a class template specialization.
+The \grammarterm{template-name}
+shall be the same \grammarterm{identifier}
+as the \grammarterm{template-name}
+of the \grammarterm{simple-template-id}.
+A \grammarterm{deduction-guide}
+shall be declared
+in the same scope
+as the corresponding class template
+and, for a member class template, with the same access.
+Two deduction guide declarations
+in the same translation unit
+for the same class template
+shall not have equivalent \grammarterm{parameter-declaration-clause}{s}.
+
 \rSec3[temp.mem.class]{Member classes of class templates}
 
 \pnum
@@ -8873,61 +8929,5 @@ The program will be ill-formed unless a specialization for
 either implicitly or explicitly generated,
 is present in some translation unit.
 \end{example}
-
-\rSec1[temp.deduct.guide]{Deduction guides}
-\indextext{deduction!class template argument}%
-
-\pnum
-Deduction guides are used
-when a \grammarterm{template-name} appears
-as a type specifier
-for a deduced class type\iref{dcl.type.class.deduct}.
-Deduction guides are not found by name lookup.
-Instead, when performing class template argument deduction\iref{over.match.class.deduct},
-any deduction guides declared for the class template are considered.
-
-\begin{bnf}
-\nontermdef{deduction-guide}\br
-    \opt{explicit-specifier} template-name \terminal{(} parameter-declaration-clause \terminal{)} \terminal{->} simple-template-id \terminal{;}
-\end{bnf}
-
-\pnum
-\begin{example}
-\begin{codeblock}
-template<class T, class D = int>
-struct S {
-  T data;
-};
-template<class U>
-S(U) -> S<typename U::type>;
-
-struct A {
-  using type = short;
-  operator type();
-};
-S x{A()};           // \tcode{x} is of type \tcode{S<short, int>}
-\end{codeblock}
-\end{example}
-
-\pnum
-The same restrictions apply
-to the \grammarterm{parameter-declaration-clause}
-of a deduction guide
-as in a function declaration\iref{dcl.fct}.
-The \grammarterm{simple-template-id}
-shall name a class template specialization.
-The \grammarterm{template-name}
-shall be the same \grammarterm{identifier}
-as the \grammarterm{template-name}
-of the \grammarterm{simple-template-id}.
-A \grammarterm{deduction-guide}
-shall be declared
-in the same scope
-as the corresponding class template
-and, for a member class template, with the same access.
-Two deduction guide declarations
-in the same translation unit
-for the same class template
-shall not have equivalent \grammarterm{parameter-declaration-clause}{s}.
 
 \indextext{template|)}


### PR DESCRIPTION
Deduction guides apply only to class templates, so their
descriptions should be located in close proximity.

Fixes #3498.