### PR TITLE
[temp.concept] Move grammar non-terminal concept-definition here.

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -50,16 +50,6 @@ an alias for a family of types, or a concept.
 \end{bnf}
 
 \begin{bnf}
-\nontermdef{concept-definition}\br
-  \keyword{concept} concept-name \terminal{=} constraint-expression \terminal{;}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{concept-name}\br
-  identifier
-\end{bnf}
-
-\begin{bnf}
 \nontermdef{type-constraint}\br
   \opt{nested-name-specifier} concept-name\br
   \opt{nested-name-specifier} concept-name \terminal{<} \opt{template-argument-list} \terminal{>}
@@ -3861,6 +3851,16 @@ template <class T>
 \pnum
 A \defn{concept} is a template
 that defines constraints on its template arguments.
+
+\begin{bnf}
+\nontermdef{concept-definition}\br
+  \keyword{concept} concept-name \terminal{=} constraint-expression \terminal{;}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{concept-name}\br
+  identifier
+\end{bnf}
 
 \pnum
 A \grammarterm{concept-definition}


### PR DESCRIPTION
Also move concept-name here, both from [temp.pre].

Fixes #3378