### PR TITLE
[any.cons,any.assign] Remove redundant postcondition for moves.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -5179,10 +5179,6 @@ Otherwise, constructs an object of type \tcode{any} that
 contains either the contained value of \tcode{other}, or
 contains an object of the same type constructed from
 the contained value of \tcode{other} considering that contained value as an rvalue.
-
-\pnum
-\ensures
-\tcode{other} is left in a valid but otherwise unspecified state.
 \end{itemdescr}
 
 \indexlibraryctor{any}%
@@ -5330,8 +5326,7 @@ As if by \tcode{any(std::move(rhs)).swap(*this)}.
 
 \pnum
 \ensures
-The state of \tcode{*this} is equivalent to the original state of \tcode{rhs}
-and \tcode{rhs} is left in a valid but otherwise unspecified state.
+The state of \tcode{*this} is equivalent to the original state of \tcode{rhs}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{any}%


### PR DESCRIPTION
[lib.types.movedfrom] already specifies that moved-from
objects are left in a valid but unspecified state.

Fixes #3362 