### PR TITLE
[dcl.fct.def.coroutine] Use 'encloses' instead of imprecise 'contains'.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6193,7 +6193,7 @@ sometype::sometype() = delete;  // ill-formed; not first declaration
 \indextext{definition!coroutine}%
 
 \pnum
-A function is a \defn{coroutine} if it contains a
+A function is a \defn{coroutine} if its \grammarterm{function-body} encloses a
 \grammarterm{coroutine-return-statement}\iref{stmt.return.coroutine},
 an \grammarterm{await-expression}\iref{expr.await},
 or a \grammarterm{yield-expression}\iref{expr.yield}.


### PR DESCRIPTION
The phrase 'the function-body encloses X' is also used
in [dcl.constexpr].

Fixes #3376