### PR TITLE
[lib] Remove 'Constructs an object of type ...' phrases

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -543,10 +543,7 @@ explicit strstreambuf(streamsize alsize_arg);
 \begin{itemdescr}
 \pnum
 \effects
-Constructs an object of class
-\tcode{strstreambuf},
-initializing the base class with
-\tcode{streambuf()}.
+Initializes the base class with \tcode{streambuf()}.
 The postconditions of this function are indicated in \tref{depr.strstreambuf.cons.sz}.
 \end{itemdescr}
 
@@ -567,10 +564,7 @@ strstreambuf(void* (*palloc_arg)(size_t), void (*pfree_arg)(void*));
 \begin{itemdescr}
 \pnum
 \effects
-Constructs an object of class
-\tcode{strstreambuf},
-initializing the base class with
-\tcode{streambuf()}.
+Initializes the base class with \tcode{streambuf()}.
 The postconditions of this function are indicated in \tref{depr.strstreambuf.cons.alloc}.
 
 \begin{libtab2}{\tcode{strstreambuf(void* (*)(size_t), void (*)(void*))} effects}
@@ -597,10 +591,7 @@ strstreambuf(unsigned char* gnext_arg, streamsize n,
 \begin{itemdescr}
 \pnum
 \effects
-Constructs an object of class
-\tcode{strstreambuf},
-initializing the base class with
-\tcode{streambuf()}.
+Initializes the base class with \tcode{streambuf()}.
 The postconditions of this function are indicated in \tref{depr.strstreambuf.cons.ptr}.
 
 \begin{libtab2}{\tcode{strstreambuf(charT*, streamsize, charT*)} effects}
@@ -1096,12 +1087,8 @@ explicit istrstream(char* s);
 \begin{itemdescr}
 \pnum
 \effects
-Constructs an object of class
-\tcode{istrstream},
-initializing the base class with
-\tcode{istream(\&sb)}
-and initializing \tcode{sb} with
-\tcode{strstreambuf(s,0)}.
+Initializes the base class with \tcode{istream(\&sb)} and
+\tcode{sb} with \tcode{strstreambuf(s, 0)}.
 \tcode{s} shall designate the first element of an \ntbs{}.%
 \indextext{NTBS}
 \end{itemdescr}
@@ -1115,12 +1102,8 @@ istrstream(char* s, streamsize n);
 \begin{itemdescr}
 \pnum
 \effects
-Constructs an object of class
-\tcode{istrstream},
-initializing the base class with
-\tcode{istream(\&sb)}
-and initializing \tcode{sb} with
-\tcode{strstreambuf(s,n)}.
+Initializes the base class with \tcode{istream(\&sb)}
+and \tcode{sb} with \tcode{strstreambuf(s, n)}.
 \tcode{s} shall designate the first element of an array whose length is
 \tcode{n} elements, and \tcode{n} shall be greater than zero.
 \end{itemdescr}
@@ -1195,12 +1178,8 @@ ostrstream();
 \begin{itemdescr}
 \pnum
 \effects
-Constructs an object of class
-\tcode{ostrstream},
-initializing the base class with
-\tcode{ostream(\&sb)}
-and initializing \tcode{sb} with
-\tcode{strstreambuf()}.
+Initializes the base class with \tcode{ostream(\&sb)} and
+\tcode{sb} with \tcode{strstreambuf()}.
 \end{itemdescr}
 
 \indexlibraryctor{ostrstream}%
@@ -1211,11 +1190,8 @@ ostrstream(char* s, int n, ios_base::openmode mode = ios_base::out);
 \begin{itemdescr}
 \pnum
 \effects
-Constructs an object of class
-\tcode{ostrstream},
-initializing the base class with
-\tcode{ostream(\&sb)},
-and initializing \tcode{sb} with one of two constructors:
+Initializes the base class with \tcode{ostream(\&sb)},
+and \tcode{sb} with one of two constructors:
 
 \begin{itemize}
 \item
@@ -1343,10 +1319,7 @@ strstream();
 \begin{itemdescr}
 \pnum
 \effects
-Constructs an object of class
-\tcode{strstream},
-initializing the base class with
-\tcode{iostream(\&sb)}.
+Initializes the base class with \tcode{iostream(\&sb)}.
 \end{itemdescr}
 
 \indexlibraryctor{strstream}%
@@ -1358,11 +1331,8 @@ strstream(char* s, int n,
 \begin{itemdescr}
 \pnum
 \effects
-Constructs an object of class
-\tcode{strstream},
-initializing the base class with
-\tcode{iostream(\&sb)}
-and initializing \tcode{sb} with one of the two constructors:
+Initializes the base class with \tcode{iostream(\&sb)},
+and \tcode{sb} with one of the two constructors:
 \begin{itemize}
 \item
 If

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -3038,7 +3038,7 @@ to assure that only objects for classes
 derived from this class may be constructed.}
 \begin{itemize}
 \item
-all its pointer member objects to null pointers,
+all pointer member objects to null pointers,
 \item
 the
 \tcode{getloc()}
@@ -5616,8 +5616,7 @@ explicit basic_iostream(basic_streambuf<charT, traits>* sb);
 \begin{itemdescr}
 \pnum
 \effects
-Constructs an object of class \tcode{basic_iostream},
-initializing the base class subobjects with
+Initializes the base class subobjects with
 \tcode{basic_istream<charT, traits>(sb)}\iref{istream}
 and
 \tcode{basic_ostream<charT, traits>(sb)}\iref{ostream}.
@@ -5885,8 +5884,7 @@ explicit basic_ostream(basic_streambuf<charT, traits>* sb);
 \begin{itemdescr}
 \pnum
 \effects
-Constructs an object of class
-\tcode{basic_ostream}, initializing the base class subobject with
+Initializes the base class subobject with
 \tcode{basic_ios<charT, traits>::init(sb)}\iref{basic.ios.cons}.
 
 \pnum
@@ -14172,8 +14170,7 @@ directory_entry(const filesystem::path& p, error_code& ec);
 \begin{itemdescr}
 \pnum
 \effects
-Constructs an object of type \tcode{directory_entry},
-then \tcode{refresh()} or \tcode{refresh(ec)}, respectively.
+Calls \tcode{refresh()} or \tcode{refresh(ec)}, respectively.
 
 \pnum
 \ensures

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -449,7 +449,6 @@ template<class T> constexpr complex(const T& re = T(), const T& im = T());
 \end{itemdecl}
 
 \begin{itemdescr}
-
 \pnum
 \ensures
 \tcode{real() == re \&\& imag() == im} is \tcode{true}.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -5805,9 +5805,7 @@ constexpr bitset() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Constructs an object of class
-\tcode{bitset<N>},
-initializing all bits to zero.
+Initializes all bits in \tcode{*this} to zero.
 \end{itemdescr}
 
 \indexlibraryctor{bitset}%
@@ -5818,9 +5816,7 @@ constexpr bitset(unsigned long long val) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Constructs an object of class
-\tcode{bitset<N>},
-initializing the first \tcode{M} bit positions to the corresponding bit
+Initializes the first \tcode{M} bit positions to the corresponding bit
 values in \tcode{val}.
 \tcode{M} is the smaller of \tcode{N} and the number of bits in the value
 representation\iref{basic.types} of \tcode{unsigned long long}.
@@ -5896,7 +5892,7 @@ template<class charT>
 \begin{itemdescr}
 \pnum
 \effects
-Constructs an object of class \tcode{bitset<N>} as if by:
+As if by:
 \begin{codeblock}
 bitset(n == basic_string<charT>::npos
           ? basic_string<charT>(str)
@@ -15963,8 +15959,11 @@ if \tcode{pred(A, B) == true}, then \tcode{hf(A) == hf(B)} shall be \tcode{true}
 
 \pnum
 \effects
-Constructs a \tcode{boyer_moore_searcher} object, initializing \tcode{pat_first_} with \tcode{pat_first},
-\tcode{pat_last_} with \tcode{pat_last}, \tcode{hash_} with \tcode{hf}, and \tcode{pred_} with \tcode{pred}.
+Initializes
+\tcode{pat_first_} with \tcode{pat_first},
+\tcode{pat_last_} with \tcode{pat_last},
+\tcode{hash_} with \tcode{hf}, and
+\tcode{pred_} with \tcode{pred}.
 
 \pnum
 \throws
@@ -16056,8 +16055,11 @@ if \tcode{pred(A, B) == true}, then \tcode{hf(A) == hf(B)} shall be \tcode{true}
 
 \pnum
 \effects
-Constructs a \tcode{boyer_moore_horspool_searcher} object, initializing \tcode{pat_first_} with \tcode{pat_first},
-\tcode{pat_last_} with \tcode{pat_last}, \tcode{hash_} with \tcode{hf}, and \tcode{pred_} with \tcode{pred}.
+Initializes
+\tcode{pat_first_} with \tcode{pat_first},
+\tcode{pat_last_} with \tcode{pat_last},
+\tcode{hash_} with \tcode{hf}, and
+\tcode{pred_} with \tcode{pred}.
 
 \pnum
 \throws


### PR DESCRIPTION
for constructors; this effect is implied by the
core language.  Only simple phrases are removed;
more complex sentence structures are left unchanged.

Partially addresses #3506.