### PR TITLE
[temp.local] Change "template-parameter" to "name of a template parameter"

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -4535,7 +4535,7 @@ template<class T> class X {
 \end{example}
 
 \pnum
-A
+The name of a
 \grammarterm{template-parameter}
 shall not be redeclared within its scope (including nested scopes).
 A


### PR DESCRIPTION
[[temp.local] p6](http://eel.is/c++draft/temp#local-6.sentence-1) says:
> A *template-parameter* shall not be redeclared within its scope (including nested scopes).

Using the provided example:
```
template<class T, int i> class Y {
  int T;                                // error: template-parameter redeclared
  [...]
};
```

The template-parameter here is not being redeclared (thats a declaration of a member), its name is. Declarations by definition introduce names. 