### PR TITLE
[ranges.syn, range.adaptors] Name view template parameter V for consistency

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -206,23 +206,23 @@ namespace std::ranges {
   namespace views { inline constexpr @\unspec@ take = @\unspec@; }
 
   // \ref{range.take.while}, take while view
-  template<view R, class Pred>
-    requires input_range<R> && is_object_v<Pred> &&
-      indirect_unary_predicate<const Pred, iterator_t<R>>
+  template<view V, class Pred>
+    requires input_range<V> && is_object_v<Pred> &&
+      indirect_unary_predicate<const Pred, iterator_t<V>>
     class take_while_view;
 
   namespace views { inline constexpr @\unspec@ take_while = @\unspec@; }
 
   // \ref{range.drop}, drop view
-  template<view R>
+  template<view V>
     class drop_view;
 
   namespace views { inline constexpr @\unspec@ drop = @\unspec@; }
 
   // \ref{range.drop.while}, drop while view
-  template<view R, class Pred>
-    requires input_range<R> && is_object_v<Pred> &&
-      indirect_unary_predicate<const Pred, iterator_t<R>>
+  template<view V, class Pred>
+    requires input_range<V> && is_object_v<Pred> &&
+      indirect_unary_predicate<const Pred, iterator_t<V>>
     class drop_while_view;
 
   namespace views { inline constexpr @\unspec@ drop_while = @\unspec@; }
@@ -266,7 +266,7 @@ namespace std::ranges {
   namespace views { inline constexpr @\unspec@ reverse = @\unspec@; }
 
   // \ref{range.elements}, elements view
-  template<input_range R, size_t N>
+  template<input_range V, size_t N>
     requires @\seebelow@;
   class elements_view;
 
@@ -4329,34 +4329,34 @@ cout << i;                                      // prints \tcode{6}
 \indexlibrarymember{end}{take_while_view}%
 \begin{codeblock}
 namespace std::ranges {
-  template<view R, class Pred>
-  requires input_range<R> && is_object_v<Pred> &&
-    indirect_unary_predicate<const Pred, iterator_t<R>>
-  class take_while_view : public view_interface<take_while_view<R, Pred>> {
+  template<view V, class Pred>
+  requires input_range<V> && is_object_v<Pred> &&
+    indirect_unary_predicate<const Pred, iterator_t<V>>
+  class take_while_view : public view_interface<take_while_view<V, Pred>> {
     template<bool> class sentinel;                      // \expos
 
-    R base_;                                            // \expos
+    V base_;                                            // \expos
     @\placeholder{semiregular-box}@<Pred> pred_; @\itcorr[-1]@                       // \expos
 
   public:
     take_while_view() = default;
-    constexpr take_while_view(R base, Pred pred);
+    constexpr take_while_view(V base, Pred pred);
 
-    constexpr R base() const& requires copy_constructible<R> { return base_; }
-    constexpr R base() && { return std::move(base_); }
+    constexpr V base() const& requires copy_constructible<V> { return base_; }
+    constexpr V base() && { return std::move(base_); }
 
     constexpr const Pred& pred() const;
 
-    constexpr auto begin() requires (!@\placeholder{simple-view}@<R>)
+    constexpr auto begin() requires (!@\placeholder{simple-view}@<V>)
     { return ranges::begin(base_); }
 
-    constexpr auto begin() const requires range<const R>
+    constexpr auto begin() const requires range<const V>
     { return ranges::begin(base_); }
 
-    constexpr auto end() requires (!@\placeholder{simple-view}@<R>)
+    constexpr auto end() requires (!@\placeholder{simple-view}@<V>)
     { return sentinel<false>(ranges::end(base_), addressof(*pred_)); }
 
-    constexpr auto end() const requires range<const R>
+    constexpr auto end() const requires range<const V>
     { return sentinel<true>(ranges::end(base_), addressof(*pred_)); }
   };
 
@@ -4367,7 +4367,7 @@ namespace std::ranges {
 
 \indexlibraryctor{take_while_view}%
 \begin{itemdecl}
-constexpr take_while_view(R base, Pred pred);
+constexpr take_while_view(V base, Pred pred);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4427,7 +4427,7 @@ Initializes \tcode{end_} with \tcode{end} and \tcode{pred_} with \tcode{pred}.
 \indexlibraryctor{take_while_view::sentinel}%
 \begin{itemdecl}
 constexpr sentinel(sentinel<!Const> s)
-  requires Const && convertible_to<sentinel_t<R>, sentinel_t<base_t>>;
+  requires Const && convertible_to<sentinel_t<V>, sentinel_t<base_t>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4487,30 +4487,30 @@ for (auto i : latter_half) {
 \indexlibrarymember{size}{drop_view}%
 \begin{codeblock}
 namespace std::ranges {
-  template<view R>
-  class drop_view : public view_interface<drop_view<R>> {
+  template<view V>
+  class drop_view : public view_interface<drop_view<V>> {
   public:
     drop_view() = default;
-    constexpr drop_view(R base, range_difference_t<R> count);
+    constexpr drop_view(V base, range_difference_t<V> count);
 
-    constexpr R base() const& requires copy_constructible<R> { return base_; }
-    constexpr R base() && { return std::move(base_); }
+    constexpr V base() const& requires copy_constructible<V> { return base_; }
+    constexpr V base() && { return std::move(base_); }
 
     constexpr auto begin()
-      requires (!(@\placeholder{simple-view}@<R> && random_access_range<R>));
+      requires (!(@\placeholder{simple-view}@<V> && random_access_range<V>));
     constexpr auto begin() const
-      requires random_access_range<const R>;
+      requires random_access_range<const V>;
 
     constexpr auto end()
-      requires (!@\placeholder{simple-view}@<R>)
+      requires (!@\placeholder{simple-view}@<V>)
     { return ranges::end(base_); }
 
     constexpr auto end() const
-      requires range<const R>
+      requires range<const V>
     { return ranges::end(base_); }
 
     constexpr auto size()
-      requires sized_range<R>
+      requires sized_range<V>
     {
       const auto s = ranges::size(base_);
       const auto c = static_cast<decltype(s)>(count_);
@@ -4518,15 +4518,15 @@ namespace std::ranges {
     }
 
     constexpr auto size() const
-      requires sized_range<const R>
+      requires sized_range<const V>
     {
       const auto s = ranges::size(base_);
       const auto c = static_cast<decltype(s)>(count_);
       return s < c ? 0 : s - c;
     }
   private:
-    R base_;                                    // \expos
-    range_difference_t<R> count_;               // \expos
+    V base_;                                    // \expos
+    range_difference_t<V> count_;               // \expos
   };
 
   template<class R>
@@ -4536,7 +4536,7 @@ namespace std::ranges {
 
 \indexlibraryctor{drop_view}%
 \begin{itemdecl}
-constexpr drop_view(R base, range_difference_t<R> count);
+constexpr drop_view(V base, range_difference_t<V> count);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4553,9 +4553,9 @@ Initializes \tcode{base_} with \tcode{std::move(base)} and
 \indexlibrarymember{begin}{drop_view}%
 \begin{itemdecl}
 constexpr auto begin()
-  requires (!(@\placeholder{simple-view}@<R> && random_access_range<R>));
+  requires (!(@\placeholder{simple-view}@<V> && random_access_range<V>));
 constexpr auto begin() const
-  requires random_access_range<const R>;
+  requires random_access_range<const V>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4614,16 +4614,16 @@ for (auto c : skip_ws) {
 \indexlibrarymember{end}{drop_while_view}%
 \begin{codeblock}
 namespace std::ranges {
-  template<view R, class Pred>
-  requires input_range<R> && is_object_v<Pred> &&
-    indirect_unary_predicate<const Pred, iterator_t<R>>
-  class drop_while_view : public view_interface<drop_while_view<R, Pred>> {
+  template<view V, class Pred>
+  requires input_range<V> && is_object_v<Pred> &&
+    indirect_unary_predicate<const Pred, iterator_t<V>>
+  class drop_while_view : public view_interface<drop_while_view<V, Pred>> {
   public:
     drop_while_view() = default;
-    constexpr drop_while_view(R base, Pred pred);
+    constexpr drop_while_view(V base, Pred pred);
 
-    constexpr R base() const& requires copy_constructible<R> { return base_; }
-    constexpr R base() && { return std::move(base_); }
+    constexpr V base() const& requires copy_constructible<V> { return base_; }
+    constexpr V base() && { return std::move(base_); }
 
     constexpr const Pred& pred() const;
 
@@ -4633,7 +4633,7 @@ namespace std::ranges {
     { return ranges::end(base_); }
 
   private:
-    R base_;                                            // \expos
+    V base_;                                            // \expos
     @\placeholder{semiregular-box}@<Pred> pred_; @\itcorr[-1]@                       // \expos
   };
 
@@ -4644,7 +4644,7 @@ namespace std::ranges {
 
 \indexlibraryctor{drop_while_view}%
 \begin{itemdecl}
-constexpr drop_while_view(R base, Pred pred);
+constexpr drop_while_view(V base, Pred pred);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6132,45 +6132,45 @@ namespace std::ranges {
     };
 
 
-  template<input_range R, size_t N>
-    requires view<R> && @\placeholder{has-tuple-element}@<range_value_t<R>, N> &&
-      @\placeholder{has-tuple-element}@<remove_reference_t<range_reference_t<R>>, N>
-  class elements_view : public view_interface<elements_view<R, N>> {
+  template<input_range V, size_t N>
+    requires view<V> && @\placeholder{has-tuple-element}@<range_value_t<V>, N> &&
+      @\placeholder{has-tuple-element}@<remove_reference_t<range_reference_t<V>>, N>
+  class elements_view : public view_interface<elements_view<V, N>> {
   public:
     elements_view() = default;
-    constexpr explicit elements_view(R base);
+    constexpr explicit elements_view(V base);
 
-    constexpr R base() const& requires copy_constructible<R> { return base_; }
-    constexpr R base() && { return std::move(base_); }
+    constexpr V base() const& requires copy_constructible<V> { return base_; }
+    constexpr V base() && { return std::move(base_); }
 
-    constexpr auto begin() requires (!@\placeholder{simple-view}@<R>)
+    constexpr auto begin() requires (!@\placeholder{simple-view}@<V>)
     { return iterator<false>(ranges::begin(base_)); }
 
-    constexpr auto begin() const requires @\placeholder{simple-view}@<R>
+    constexpr auto begin() const requires @\placeholder{simple-view}@<V>
     { return iterator<true>(ranges::begin(base_)); }
 
-    constexpr auto end() requires (!@\placeholder{simple-view}@<R>)
+    constexpr auto end() requires (!@\placeholder{simple-view}@<V>)
     { return ranges::end(base_); }
 
-    constexpr auto end() const requires @\placeholder{simple-view}@<R>
+    constexpr auto end() const requires @\placeholder{simple-view}@<V>
     { return ranges::end(base_); }
 
-    constexpr auto size() requires sized_range<R>
+    constexpr auto size() requires sized_range<V>
     { return ranges::size(base_); }
 
-    constexpr auto size() const requires sized_range<const R>
+    constexpr auto size() const requires sized_range<const V>
     { return ranges::size(base_); }
 
   private:
     template<bool> struct iterator;                     // \expos
-    R base_ = R();                                      // \expos
+    V base_ = V();                                      // \expos
   };
 }
 \end{codeblock}
 
 \indexlibraryctor{elements_view}%
 \begin{itemdecl}
-constexpr explicit elements_view(R base);
+constexpr explicit elements_view(V base);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6184,10 +6184,10 @@ Initializes \tcode{base_} with \tcode{std::move(base)}.
 \indexlibraryglobal{elements_view::iterator}%
 \begin{codeblock}
 namespace std::ranges {
-  template<class R, size_t N>
+  template<class V, size_t N>
   template<bool Const>
-  class elements_view<R, N>::iterator {                 // \expos
-    using base_t = conditional_t<Const, const R, R>;
+  class elements_view<V, N>::iterator {                 // \expos
+    using base_t = conditional_t<Const, const V, V>;
     friend iterator<!Const>;
 
     iterator_t<base_t> current_;
@@ -6199,7 +6199,7 @@ namespace std::ranges {
     iterator() = default;
     constexpr explicit iterator(iterator_t<base_t> current);
     constexpr iterator(iterator<!Const> i)
-      requires Const && convertible_to<iterator_t<R>, iterator_t<base_t>>;
+      requires Const && convertible_to<iterator_t<V>, iterator_t<base_t>>;
 
     constexpr iterator_t<base_t> base() const &
       requires copyable<iterator_t<base_t>>;
@@ -6273,7 +6273,7 @@ Initializes \tcode{current_} with \tcode{std::move(current)}.
 \indexlibraryctor{elements_view::iterator}%
 \begin{itemdecl}
 constexpr iterator(iterator<!Const> i)
-  requires Const && convertible_to<iterator_t<R>, iterator_t<base_t>>;
+  requires Const && convertible_to<iterator_t<V>, iterator_t<base_t>>;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
P1035 used `R` for such template parameters, introducing inconsistency. We could either restore consistency this way, or rename the `V`s to `R` once the converting constuctors of the other adaptors are removed, as I understand will happen.