### PR TITLE
[container.requirements.general]/Table 71 LWG 3352: Remove the requirement for strong_equality

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -214,11 +214,9 @@ In Tables~\ref{tab:container.req},
  constant                   \\ \rowsep
 
 \tcode{i <=> j}             &
-  \tcode{strong_ordering}
-  if \tcode{X::iterator} meets the random access iterator requirements,
-  otherwise \tcode{strong_equality} &
-                             &
-                             &
+ \tcode{strong_ordering}    &
+                            &
+ \expects \tcode{X::iterator} meets the random access iterator requirements &
  constant                   \\ \rowsep
 
 \tcode{a == b}                  &


### PR DESCRIPTION
Missed by #3475.