### PR TITLE
[temp.param] Move grammar non-terminal 'type-constraint' here

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2009,7 +2009,7 @@ decltype(auto)*x7d = &i;        // error, declared type is not plain \tcode{decl
 \pnum
 For a \grammarterm{placeholder-type-specifier}
 with a \grammarterm{type-constraint},
-the immediately-declared constraint\iref{temp.pre}
+the immediately-declared constraint\iref{temp.param}
 of the \grammarterm{type-constraint} for the type deduced for the placeholder
 shall be satisfied.
 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2685,7 +2685,7 @@ Substitution of template arguments (if any)
 into the \grammarterm{return-type-requirement} is performed.
 
 \item
-The immediately-declared constraint\iref{temp.pre}
+The immediately-declared constraint\iref{temp.param}
 of the \grammarterm{type-constraint} for \tcode{decltype((E))}
 shall be satisfied.
 \begin{example}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -49,12 +49,6 @@ an alias for a family of types, or a concept.
   constraint-logical-and-expression \terminal{\&\&} primary-expression
 \end{bnf}
 
-\begin{bnf}
-\nontermdef{type-constraint}\br
-  \opt{nested-name-specifier} concept-name\br
-  \opt{nested-name-specifier} concept-name \terminal{<} \opt{template-argument-list} \terminal{>}
-\end{bnf}
-
 \begin{note}
 The \tcode{>} token following the
 \grammarterm{template-parameter-list} of a
@@ -140,23 +134,6 @@ explicit specialization, or explicit instantiation the
 in the declaration shall contain at most one declarator.
 When such a declaration is used to declare a class template,
 no declarator is permitted.
-
-\pnum
-A \grammarterm{type-constraint} \tcode{Q} that designates a concept \tcode{C}
-can be used to constrain a
-contextually-determined type or template type parameter pack \tcode{T}
-with a \grammarterm{constraint-expression} \tcode{E} defined as follows.
-If \tcode{Q} is of the form \tcode{C<A$_1$, $\cdots$, A$_n$>},
-then let \tcode{E$'$} be \tcode{C<T, A$_1$, $\cdots$, A$_n$>}.
-Otherwise, let \tcode{E$'$} be \tcode{C<T>}.
-If \tcode{T} is not a pack,
-then \tcode{E} is \tcode{E$'$},
-otherwise \tcode{E} is \tcode{(E$'$ \&\& ...)}.
-This \grammarterm{constraint-expression} \tcode{E} is called the
-\defnx{immediately-declared constraint}{constraint!immediately-declared}
-of \tcode{Q} for \tcode{T}.
-The concept designated by a \grammarterm{type-constraint}
-shall be a type concept\iref{temp.concept}.
 
 \pnum
 \indextext{template name!linkage of}%
@@ -267,6 +244,12 @@ is:
   \keyword{typename}
 \end{bnf}
 
+\begin{bnf}
+\nontermdef{type-constraint}\br
+  \opt{nested-name-specifier} concept-name\br
+  \opt{nested-name-specifier} concept-name \terminal{<} \opt{template-argument-list} \terminal{>}
+\end{bnf}
+
 \begin{note}
 The \tcode{>} token following the
 \grammarterm{template-parameter-list} of a
@@ -352,6 +335,41 @@ class Map {
 };
 \end{codeblock}
 \end{note}
+
+\pnum
+A \grammarterm{type-constraint} \tcode{Q} that designates a concept \tcode{C}
+can be used to constrain a
+contextually-determined type or template type parameter pack \tcode{T}
+with a \grammarterm{constraint-expression} \tcode{E} defined as follows.
+If \tcode{Q} is of the form \tcode{C<A$_1$, $\cdots$, A$_n$>},
+then let \tcode{E$'$} be \tcode{C<T, A$_1$, $\cdots$, A$_n$>}.
+Otherwise, let \tcode{E$'$} be \tcode{C<T>}.
+If \tcode{T} is not a pack,
+then \tcode{E} is \tcode{E$'$},
+otherwise \tcode{E} is \tcode{(E$'$ \&\& ...)}.
+This \grammarterm{constraint-expression} \tcode{E} is called the
+\defnx{immediately-declared constraint}{constraint!immediately-declared}
+of \tcode{Q} for \tcode{T}.
+The concept designated by a \grammarterm{type-constraint}
+shall be a type concept\iref{temp.concept}.
+
+\pnum
+A \grammarterm{type-parameter} that starts with a \grammarterm{type-constraint}
+introduces the immediately-declared constraint
+of the \grammarterm{type-constraint} for the parameter.
+\begin{example}
+\begin{codeblock}
+template<typename T> concept C1 = true;
+template<typename... Ts> concept C2 = true;
+template<typename T, typename U> concept C3 = true;
+
+template<C1 T> struct s1;               // associates \tcode{C1<T>}
+template<C1... T> struct s2;            // associates \tcode{(C1<T> \&\& ...)}
+template<C2... T> struct s3;            // associates \tcode{(C2<T> \&\& ...)}
+template<C3<int> T> struct s4;          // associates \tcode{C3<T, int>}
+template<C3<int>... T> struct s5;       // associates \tcode{(C3<T, int> \&\& ...)}
+\end{codeblock}
+\end{example}
 
 \pnum
 A non-type \grammarterm{template-parameter}
@@ -448,24 +466,6 @@ S<&p> x;                        // OK due to parameter adjustment
 int v[5];
 R<v> y;                         // OK due to implicit argument conversion
 S<v> z;                         // OK due to both adjustment and conversion
-\end{codeblock}
-\end{example}
-
-\pnum
-A \grammarterm{type-parameter} that starts with a \grammarterm{type-constraint}
-introduces the immediately-declared constraint\iref{temp.pre}
-of the \grammarterm{type-constraint} for the parameter.
-\begin{example}
-\begin{codeblock}
-template<typename T> concept C1 = true;
-template<typename... Ts> concept C2 = true;
-template<typename T, typename U> concept C3 = true;
-
-template<C1 T> struct s1;               // associates \tcode{C1<T>}
-template<C1... T> struct s2;            // associates \tcode{(C1<T> \&\& ...)}
-template<C2... T> struct s3;            // associates \tcode{(C2<T> \&\& ...)}
-template<C3<int> T> struct s4;          // associates \tcode{C3<T, int>}
-template<C3<int>... T> struct s5;       // associates \tcode{(C3<T, int> \&\& ...)}
 \end{codeblock}
 \end{example}
 


### PR DESCRIPTION
from [temp.pre].
Also move the definition of 'immediately-declared
constraint' and fix all cross-references.

Fixes #3516 