### PR TITLE
[class.derived,class.member.lookup] Reference figures in running text.

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3544,7 +3544,8 @@ derived object\iref{intro.object} is unspecified.
 \indextext{lattice|see{DAG, subobject}}%
 A derived class and its base class subobjects can be represented by a
 directed acyclic graph (DAG) where an arrow means ``directly derived
-from''. An arrow need not have a physical representation in memory.
+from'' (see \fref{class.dag}).
+An arrow need not have a physical representation in memory.
 A DAG of subobjects is often referred to as a ``subobject lattice''.
 
 \begin{importgraphic}
@@ -4381,7 +4382,8 @@ struct D : B, C { void glorp(); };
 {figname.pdf}
 \end{importgraphic}
 
-The names declared in \tcode{V} and the left-hand instance of \tcode{W}
+As illustrated in \fref{class.lookup},
+the names declared in \tcode{V} and the left-hand instance of \tcode{W}
 are hidden by those in \tcode{B}, but the names declared in the
 right-hand instance of \tcode{W} are not hidden at all.
 \begin{codeblock}


### PR DESCRIPTION
Fixes #3524.