### PR TITLE
[library.headers],[cstdint.syn.2], [cstdint.syn.2] is not in line with intention. Also fixes #3521

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1328,6 +1328,11 @@ It is unspecified whether these names (including any overloads added in
 are first declared within the global namespace scope
 and are then injected into namespace \tcode{std} by explicit
 \grammarterm{using-declaration}{s}\iref{namespace.udecl}.
+\begin{note}
+Every typedef declared in header \tcode{<c\placeholder{name}>}
+denotes the same type as the existing corresponding typedef
+in the C standard library header \tcode{<\placeholder{name}.h>}
+\end{note}
 
 \pnum
 Names which are defined as macros in C shall be defined as macros in the \Cpp{}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1330,7 +1330,7 @@ and are then injected into namespace \tcode{std} by explicit
 \grammarterm{using-declaration}{s}\iref{namespace.udecl}.
 \begin{note}
 Every typedef declared in header \tcode{<c\placeholder{name}>}
-denotes the same type as the existing corresponding typedef
+denotes the same type as the corresponding typedef
 in the C standard library header \tcode{<\placeholder{name}.h>}
 \end{note}
 

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1328,11 +1328,11 @@ It is unspecified whether these names (including any overloads added in
 are first declared within the global namespace scope
 and are then injected into namespace \tcode{std} by explicit
 \grammarterm{using-declaration}{s}\iref{namespace.udecl}.
-\begin{note}
+
+\pnum
 Every typedef declared in header \tcode{<c\placeholder{name}>}
 denotes the same type as the corresponding typedef
 in the C standard library header \tcode{<\placeholder{name}.h>}
-\end{note}
 
 \pnum
 Names which are defined as macros in C shall be defined as macros in the \Cpp{}

--- a/source/support.tex
+++ b/source/support.tex
@@ -1776,10 +1776,6 @@ plus function macros of the form:
   [U]INT{8 16 32 64 MAX}_C
 \end{codeblock}
 
-\pnum
-The header defines all types and macros the same as
-the C standard library header \libheader{stdint.h}.
-
 \xrefc{7.20}
 
 \rSec1[support.start.term]{Start and termination}


### PR DESCRIPTION
this is a fix for issue https://github.com/cplusplus/draft/issues/3521

- removed cstdint.syn bullet telling, that cheader provide the definitions same as header.h
- added bullet to the [library.headers] saying, that if there is corresponding typedef in the header.g for the cheader the typedefs must alias the same type.