### PR TITLE
[expr.comma] Remove "temporary expression"

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6785,8 +6785,6 @@ The type and value of the
 result are the type and value of the right operand; the result is of the same
 value category as its right operand, and is a bit-field if its
 right operand is a bit-field.
-If the right operand is a temporary expression\iref{class.temporary},
-the result is a temporary expression.
 
 \pnum
 In contexts where comma is given a special meaning,


### PR DESCRIPTION
[[expr.comma] p1 sentence 5](http://eel.is/c++draft/expr.comma#1.sentence-5) says:
> If the right operand is a temporary expression, the result is a temporary expression.

This is incorrect as no such grammar term exists, and if interpreted as meaning "xvalue", redundant.