### PR TITLE
[time.syn] Move `treat_as_floating_point_v` to be right after `treat_as_floating_point` in the `<chrono>` synopsis.

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -84,9 +84,10 @@ namespace std {
   namespace chrono {
     // \ref{time.traits}, customization traits
     template<class Rep> struct treat_as_floating_point;
-    template<class Rep> struct duration_values;
     template<class Rep>
       inline constexpr bool treat_as_floating_point_v = treat_as_floating_point<Rep>::value;
+
+    template<class Rep> struct duration_values;
 
     template<class T> struct is_clock;
     template<class T> inline constexpr bool is_clock_v = is_clock<T>::value;


### PR DESCRIPTION
Today, the synopsis contains the following:

```
// [time.traits], customization traits
template<class Rep> struct treat_as_floating_point;
template<class Rep> struct duration_values;
template<class Rep>
  inline constexpr bool treat_as_floating_point_v = treat_as_floating_point<Rep>::value;

template<class T> struct is_clock;
template<class T> inline constexpr bool is_clock_v = is_clock<T>::value;
```

The variable template for `is_clock` (`is_clock_v`) is right after `is_clock`, but for some reason `duration_values` is currently in between `treat_as_floating_point` and `treat_as_floating_point_v`. This editorial change just moves `treat_as_floating_point_v` to be directly after `treat_as_floating_point`.