### PR TITLE
[over.match.funcs] Correct comment in example.

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -687,7 +687,7 @@ struct B : A {
   struct X { X(X &&) = delete; } x;
 };
 extern B b1;
-B b2 = static_cast<B&&>(b1);            // calls \#3: \#1, \#2, and \#4 are not viable
+B b2 = static_cast<B&&>(b1);            // calls \#3: \#1 is not viable, \#2 and \#4 are not candidates
 struct C { operator B&&(); };
 B b3 = C();                             // calls \#3
 \end{codeblock}

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -675,21 +675,21 @@ if the argument list has exactly one argument and
 \begin{example}
 \begin{codeblock}
 struct A {
-  A();
-  A(A &&);                              // \#1
-  template<typename T> A(T &&);         // \#2
+  A();                                  // \#1
+  A(A &&);                              // \#2
+  template<typename T> A(T &&);         // \#3
 };
 struct B : A {
   using A::A;
-  B(const B &);                         // \#3
-  B(B &&) = default;                    // \#4, implicitly deleted
+  B(const B &);                         // \#4
+  B(B &&) = default;                    // \#5, implicitly deleted
 
   struct X { X(X &&) = delete; } x;
 };
 extern B b1;
-B b2 = static_cast<B&&>(b1);            // calls \#3: \#1 is not viable, \#2 and \#4 are not candidates
+B b2 = static_cast<B&&>(b1);            // calls \#4: \#1 is not viable, \#2, \#3, and \#5 are not candidates
 struct C { operator B&&(); };
-B b3 = C();                             // calls \#3
+B b3 = C();                             // calls \#4
 \end{codeblock}
 \end{example}
 


### PR DESCRIPTION
Per the normative wording, excluded functions are not candidates; don't suggest they are candidates by describing them as not being viable.