### PR TITLE
[dcl.decl] Change "templated function" to instead use "templated entity"

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -166,7 +166,8 @@ in that scope.
 
 \pnum
 \indextext{entity!templated}%
-A \defn{templated entity} is
+An entity is \defn{templated}
+if it is
 \begin{itemize}
 \item a template,
 \item an entity defined\iref{basic.def} or created\iref{class.temporary}


### PR DESCRIPTION
The [resolution for CA378](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1971r0.html) used the term "templated function", but it is unclear what exactly this means (the intent is known, so I believe this is sufficiently editorial). This should be changed to "templated entity that is a function or function template" as is used in [[dcl.dcl]](http://eel.is/c++draft/dcl.dcl#dcl.spec.auto-12).

I didn't change the comment in the example to use this wording since it seems to be a little "extra" for a comment, but that can be changed too if deemed sufficiently important. 