### PR TITLE
[std] Harmonize index entries for list items

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2690,11 +2690,13 @@ and that is the name of
 \begin{itemize}
 \item a variable; or
 \item a function; or
-\item \indextext{class!linkage of}%
+\item
+\indextext{class!linkage of}%
 a named class\iref{class.pre}, or an unnamed class defined in a
 typedef declaration in which the class has the typedef name for linkage
 purposes\iref{dcl.typedef}; or
-\item \indextext{enumeration!linkage of}%
+\item
+\indextext{enumeration!linkage of}%
 a named enumeration\iref{dcl.enum}, or an unnamed enumeration defined
 in a typedef declaration in which the enumeration has the typedef name
 for linkage purposes\iref{dcl.typedef}; or
@@ -4920,7 +4922,7 @@ Compound types can be constructed in the following ways:
 \item \defnx{pointers}{type!pointer} to \cv{}~\tcode{void} or objects or functions (including
 static members of classes) of a given type, \ref{dcl.ptr};
 
-\item %
+\item
 \indextext{reference!lvalue}%
 \indextext{reference!rvalue}%
 \defnx{references}{reference} to objects or functions of a given
@@ -4945,7 +4947,8 @@ different types at different times, \ref{class.union};
 Each distinct enumeration constitutes a different
 \defnadj{enumerated}{type}, \ref{dcl.enum};
 
-\item \indextext{member pointer to|see{pointer to member}}%
+\item
+\indextext{member pointer to|see{pointer to member}}%
 \defnx{pointers to non-static class members}{pointer to member},%
 \footnote{Static class members are objects or functions, and pointers to them are
 ordinary pointers to objects or functions.}
@@ -5214,10 +5217,11 @@ and \tcode{unsigned char}.
 \item The rank of \tcode{bool} shall be less than the rank of all other
 standard integer types.
 
+\item
 \indextext{type!\idxcode{wchar_t}}%
 \indextext{type!\idxcode{char16_t}}%
 \indextext{type!\idxcode{char32_t}}%
-\item The ranks of \tcode{char8_t}, \tcode{char16_t}, \tcode{char32_t}, and
+The ranks of \tcode{char8_t}, \tcode{char16_t}, \tcode{char32_t}, and
 \tcode{wchar_t} shall equal the ranks of their underlying
 types\iref{basic.fundamental}.
 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5732,8 +5732,9 @@ For subtraction, one of the following shall hold:
 \begin{itemize}
 \item both operands have arithmetic or unscoped enumeration type; or
 
+\item
 \indextext{arithmetic!pointer}%
-\item both operands are pointers to cv-qualified or cv-unqualified
+both operands are pointers to cv-qualified or cv-unqualified
 versions of the same completely-defined object type; or
 
 \item the left operand is a pointer to a completely-defined object type
@@ -6391,8 +6392,9 @@ effect associated with the second or third expression.
 If either the second or the third operand has type \tcode{void},
 one of the following shall hold:
 \begin{itemize}
+\item
 \indextext{conditional-expression!throw-expression in}%
-\item The second or the third operand (but not both) is a (possibly
+The second or the third operand (but not both) is a (possibly
 parenthesized) \grammarterm{throw-expression}\iref{expr.throw}; the result
 is of the type and value category of the other.
 The \grammarterm{conditional-expression}

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -61,9 +61,10 @@ following phases.\footnote{Implementations must behave as if these separate phas
 occur, although in practice different phases might be folded together.}
 
 \begin{enumerate}
+\item
 \indextext{character!source file}%
 \indextext{character set!basic source}%
-\item Physical source file characters are mapped, in an
+Physical source file characters are mapped, in an
 \impldef{mapping physical source file characters to basic source character set} manner,
 to the basic source character set (introducing new-line characters for end-of-line
 indicators) if necessary.
@@ -80,8 +81,9 @@ file as a \grammarterm{universal-character-name} (e.g., using the \tcode{\textba
 uXXXX} notation), are handled equivalently
 except where this replacement is reverted\iref{lex.pptoken} in a raw string literal.
 
+\item
 \indextext{line splicing}%
-\item Each instance of a backslash character (\textbackslash)
+Each instance of a backslash character (\textbackslash)
 immediately followed by a new-line character is deleted, splicing
 physical source lines to form logical source lines. Only the last
 backslash on any physical source line shall be eligible for being part
@@ -336,8 +338,9 @@ literal.
 If the input stream has been parsed into preprocessing tokens up to a
 given character:
 \begin{itemize}
+\item
 \indextext{literal!string!raw}%
-\item If the next character begins a sequence of characters that could be the prefix
+If the next character begins a sequence of characters that could be the prefix
 and initial double quote of a raw string literal, such as \tcode{R"}, the next preprocessing
 token shall be a raw string literal. Between the initial and final
 double quote characters of the raw string, any transformations performed in phases

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1553,8 +1553,9 @@ The following macro names shall be defined by the implementation:
 
 \begin{description}
 
+\item
 \indextext{__CPLUSPLUS@\xname{cplusplus}}%
-\item \xname{cplusplus}\\
+\xname{cplusplus}\\
 The integer literal \tcode{\cppver}.
 \begin{note}
 It is intended that future
@@ -1562,8 +1563,9 @@ versions of this International Standard will
 replace the value of this macro with a greater value.
 \end{note}
 
+\item
 \indextext{__DATE__@\mname{DATE}}%
-\item \mname{DATE}\\
+\mname{DATE}\\
 The date of translation of the source file:
 a character string literal of the form
 \tcode{"Mmm~dd~yyyy"},
@@ -1578,25 +1580,29 @@ If the date of translation is not available,
 an \impldef{text of \mname{DATE} when date of translation is not available} valid date
 shall be supplied.
 
+\item
 \indextext{__FILE__@\mname{FILE}}%
-\item \mname{FILE}\\
+\mname{FILE}\\
 The presumed name of the current source file (a character string
 literal).%
 \footnote{The presumed source file name can be changed by the \tcode{\#line} directive.}
 
+\item
 \indextext{__LINE__@\mname{LINE}}%
-\item \mname{LINE}\\
+\mname{LINE}\\
 The presumed line number (within the current source file) of the current source line
 (an integer literal).%
 \footnote{The presumed line number can be changed by the \tcode{\#line} directive.}
 
+\item
 \indextext{__STDC_HOSTED__@\mname{STDC_HOSTED}}%
-\item \mname{STDC_HOSTED}\\
+\mname{STDC_HOSTED}\\
 The integer literal \tcode{1} if the implementation is a hosted
 implementation or the integer literal \tcode{0} if it is not.
 
+\item
 \indextext{__STDCPP_DEFAULT_NEW_ALIGNMENT__@\mname{STDCPP_DEFAULT_NEW_ALIGNMENT}}%
-\item \mname{STDCPP_DEFAULT_NEW_ALIGNMENT}\\
+\mname{STDCPP_DEFAULT_NEW_ALIGNMENT}\\
 An integer literal of type \tcode{std::size_t}
 whose value is the alignment guaranteed
 by a call to \tcode{operator new(std::size_t)}
@@ -1606,8 +1612,9 @@ Larger alignments will be passed to
 \tcode{operator new(std::size_t, std::align_val_t)}, etc.\iref{expr.new}.
 \end{note}
 
+\item
 \indextext{__TIME__@\mname{TIME}}%
-\item \mname{TIME}\\
+\mname{TIME}\\
 The time of translation of the source file:
 a character string literal of the form
 \tcode{"hh:mm:ss"}
@@ -1698,24 +1705,28 @@ the values of these macros with greater values.
 The following macro names are conditionally defined by the implementation:
 
 \begin{description}
+\item
 \indextext{__STDC__@\mname{STDC}}%
-\item \mname{STDC}\\
+\mname{STDC}\\
 Whether \mname{STDC} is predefined and if so, what its value is,
 are \impldef{definition and meaning of \mname{STDC}}.
 
+\item
 \indextext{__STDC_MB_MIGHT_NEQ_WC__@\mname{STDC_MB_MIGHT_NEQ_WC}}%
-\item \mname{STDC_MB_MIGHT_NEQ_WC}\\
+\mname{STDC_MB_MIGHT_NEQ_WC}\\
 The integer literal \tcode{1}, intended to indicate that, in the encoding for
 \tcode{wchar_t}, a member of the basic character set need not have a code value equal to
 its value when used as the lone character in an ordinary character literal.
 
+\item
 \indextext{__STDC_VERSION__@\mname{STDC_VERSION}}%
-\item \mname{STDC_VERSION}\\
+\mname{STDC_VERSION}\\
 Whether \mname{STDC_VERSION} is predefined and if so, what its value is,
 are \impldef{definition and meaning of \mname{STDC_VERSION}}.
 
+\item
 \indextext{__STDC_ISO_10646__@\mname{STDC_ISO_10646}}%
-\item \mname{STDC_ISO_10646}\\
+\mname{STDC_ISO_10646}\\
 An integer literal of the form \tcode{yyyymmL} (for example,
 \tcode{199712L}).
 If this symbol is defined, then every character in the Unicode required set, when
@@ -1724,13 +1735,15 @@ of that character. The \defn{Unicode required set} consists of all
 the characters that are defined by ISO/IEC 10646, along with
 all amendments and technical corrigenda as of the specified year and month.
 
+\item
 \indextext{__STDCPP_STRICT_POINTER_SAFETY__@\mname{STDCPP_STRICT_POINTER_SAFETY}}%
-\item \mname{STDCPP_STRICT_POINTER_SAFETY}\\
+\mname{STDCPP_STRICT_POINTER_SAFETY}\\
 Defined, and has the value integer literal 1, if and only if the implementation
 has strict pointer safety\iref{basic.stc.dynamic.safety}.
 
+\item
 \indextext{__STDCPP_THREADS__@\mname{STDCPP_THREADS}}%
-\item \mname{STDCPP_THREADS}\\
+\mname{STDCPP_THREADS}\\
 Defined, and has the value integer literal 1, if and only if a program
 can have more than one thread of execution\iref{intro.multithread}.
 

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -5278,8 +5278,9 @@ void acquire();
 Repeatedly performs the following steps, in order:
 \begin{itemize}
 \item Evaluates \tcode{try_acquire}. If the result is \tcode{true}, returns.
+\item
 \indextext{block (execution)}%
-\item Blocks on \tcode{*this} until \tcode{counter} is greater than zero.
+Blocks on \tcode{*this} until \tcode{counter} is greater than zero.
 \end{itemize}
 
 \pnum

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6441,8 +6441,8 @@ Characters are extracted and stored until any of the following occurs:
 \item
 \tcode{N} characters have been extracted and stored;
 \item
-end-of-file occurs on the input sequence;%
-\indextext{end-of-file}
+\indextext{end-of-file}%
+end-of-file occurs on the input sequence;
 \item
 the next input character is neither
 \tcode{is.widen('0')}


### PR DESCRIPTION
Fixes #2110.

No visible difference (apart from a different page number for `__TIME__` in the index).