### PR TITLE
[lib] Put \constraints on a line of its own.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -3478,7 +3478,8 @@ template<class T, size_t N>
 
 \begin{itemdescr}
 \pnum
-\constraints \tcode{N == 0} or \tcode{is_swappable_v<T>} is \tcode{true}.
+\constraints
+\tcode{N == 0} or \tcode{is_swappable_v<T>} is \tcode{true}.
 
 \pnum
 \effects

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -1128,7 +1128,8 @@ template<class ErrorCodeEnum>
 
 \begin{itemdescr}
 \pnum
-\constraints \tcode{is_error_code_enum_v<ErrorCodeEnum>} is \tcode{true}.
+\constraints
+\tcode{is_error_code_enum_v<ErrorCodeEnum>} is \tcode{true}.
 
 \pnum
 \ensures
@@ -1156,7 +1157,8 @@ template<class ErrorCodeEnum>
 
 \begin{itemdescr}
 \pnum
-\constraints \tcode{is_error_code_enum_v<ErrorCodeEnum>} is \tcode{true}.
+\constraints
+\tcode{is_error_code_enum_v<ErrorCodeEnum>} is \tcode{true}.
 
 \pnum
 \ensures
@@ -1336,7 +1338,8 @@ template<class ErrorConditionEnum>
 
 \begin{itemdescr}
 \pnum
-\constraints \tcode{is_error_condition_enum_v<ErrorConditionEnum>} is \tcode{true}.
+\constraints
+\tcode{is_error_condition_enum_v<ErrorConditionEnum>} is \tcode{true}.
 
 \pnum
 \ensures
@@ -1365,7 +1368,8 @@ template<class ErrorConditionEnum>
 
 \begin{itemdescr}
 \pnum
-\constraints \tcode{is_error_condition_enum_v<ErrorConditionEnum>} is \tcode{true}.
+\constraints
+\tcode{is_error_condition_enum_v<ErrorConditionEnum>} is \tcode{true}.
 
 \pnum
 \ensures

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -5554,7 +5554,8 @@ template<class charT, class traits, class T>
 
 \begin{itemdescr}
 \pnum
-\constraints The expression \tcode{is >> std::forward<T>(x)} is well-formed when treated as an unevaluated operand.
+\constraints
+The expression \tcode{is >> std::forward<T>(x)} is well-formed when treated as an unevaluated operand.
 
 \pnum
 \effects
@@ -6764,7 +6765,8 @@ template<class charT, class traits, class T>
 
 \begin{itemdescr}
 \pnum
-\constraints The expression \tcode{os << x} is well-formed when treated as an unevaluated operand.
+\constraints
+The expression \tcode{os << x} is well-formed when treated as an unevaluated operand.
 
 \pnum
 \effects
@@ -7780,7 +7782,8 @@ template<class SAlloc>
 
 \begin{itemdescr}
 \pnum
-\constraints \tcode{SAlloc} is a type that
+\constraints
+\tcode{SAlloc} is a type that
 qualifies as an allocator\iref{container.requirements.general}.
 
 \pnum
@@ -7865,7 +7868,8 @@ template<class SAlloc>
 
 \begin{itemdescr}
 \pnum
-\constraints \tcode{is_same_v<SAlloc,Allocator>} is \tcode{false}.
+\constraints
+\tcode{is_same_v<SAlloc,Allocator>} is \tcode{false}.
 
 \pnum
 \effects
@@ -8649,7 +8653,8 @@ template<class SAlloc>
 
 \begin{itemdescr}
 \pnum
-\constraints \tcode{is_same_v<SAlloc,Allocator>} is \tcode{false}.
+\constraints
+\tcode{is_same_v<SAlloc,Allocator>} is \tcode{false}.
 
 \pnum
 \effects
@@ -8974,7 +8979,8 @@ template<class SAlloc>
 
 \begin{itemdescr}
 \pnum
-\constraints \tcode{is_same_v<SAlloc,Allocator>} is \tcode{false}.
+\constraints
+\tcode{is_same_v<SAlloc,Allocator>} is \tcode{false}.
 
 \pnum
 \effects

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -4211,7 +4211,8 @@ constexpr Iterator base() const &;
 
 \begin{itemdescr}
 \pnum
-\constraints \tcode{Iterator} satisfies \libconcept{copy_constructible}.
+\constraints
+\tcode{Iterator} satisfies \libconcept{copy_constructible}.
 
 \pnum
 \expects

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -592,7 +592,8 @@ preconditions, there will be no \expects element.}
 \requires the preconditions for calling the function.
 
 \item
-\constraints the conditions for the function's participation
+\constraints
+the conditions for the function's participation
 in overload resolution\iref{over.match}.
 \begin{note}
 Failure to meet such a condition results in the function's silent non-viability.

--- a/source/support.tex
+++ b/source/support.tex
@@ -346,7 +346,8 @@ template<class IntType>
 
 \begin{itemdescr}
 \pnum
-\constraints \tcode{is_integral_v<IntType>} is \tcode{true}.
+\constraints
+\tcode{is_integral_v<IntType>} is \tcode{true}.
 
 \pnum
 \effects
@@ -362,7 +363,8 @@ template<class IntType>
 
 \begin{itemdescr}
 \pnum
-\constraints \tcode{is_integral_v<IntType>} is \tcode{true}.
+\constraints
+\tcode{is_integral_v<IntType>} is \tcode{true}.
 
 \pnum
 \effects
@@ -381,7 +383,8 @@ template<class IntType>
 
 \begin{itemdescr}
 \pnum
-\constraints \tcode{is_integral_v<IntType>} is \tcode{true}.
+\constraints
+\tcode{is_integral_v<IntType>} is \tcode{true}.
 
 \pnum
 \effects
@@ -397,7 +400,8 @@ template<class IntType>
 
 \begin{itemdescr}
 \pnum
-\constraints \tcode{is_integral_v<IntType>} is \tcode{true}.
+\constraints
+\tcode{is_integral_v<IntType>} is \tcode{true}.
 
 \pnum
 \effects
@@ -509,7 +513,8 @@ template<class IntType>
 
 \begin{itemdescr}
 \pnum
-\constraints \tcode{is_integral_v<IntType>} is \tcode{true}.
+\constraints
+\tcode{is_integral_v<IntType>} is \tcode{true}.
 
 \pnum
 \effects

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1261,7 +1261,8 @@ tuple(tuple&& u) = default;
 
 \begin{itemdescr}
 \pnum
-\constraints \tcode{is_move_constructible_v<$\tcode{T}_i$>} is \tcode{true} for all $i$.
+\constraints
+\tcode{is_move_constructible_v<$\tcode{T}_i$>} is \tcode{true} for all $i$.
 
 \pnum
 \effects
@@ -9195,7 +9196,8 @@ unique_ptr(unique_ptr&& u) noexcept;
 
 \begin{itemdescr}
 \pnum
-\constraints \tcode{is_move_constructible_v<D>} is \tcode{true}.
+\constraints
+\tcode{is_move_constructible_v<D>} is \tcode{true}.
 
 \pnum
 \requires If \tcode{D} is not a reference type,
@@ -9301,7 +9303,8 @@ unique_ptr& operator=(unique_ptr&& u) noexcept;
 
 \begin{itemdescr}
 \pnum
-\constraints \tcode{is_move_assignable_v<D>} is \tcode{true}.
+\constraints
+\tcode{is_move_assignable_v<D>} is \tcode{true}.
 
 \pnum
 \requires If \tcode{D} is not a reference type, \tcode{D} shall meet the

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -28,8 +28,8 @@ grep -n 'opt{}' *.tex && exit 1
 grep -n "// not defined" $texfiles | sed 's/$/ <--- use \\notdef instead/' | grep . && exit 1
 
 # Library element introducer followed by stuff.
-grep -ne '^\\\(contraints\|mandates\|expects\|effects\|sync\|ensures\|returns\|throws\|complexity\|remarks\|errors\).\+$' $texfiles && exit 1
-# Fixup: sed 's/^\\\(contraints\|mandates\|expects\|effects\|sync\|ensures\|returns\|throws\|complexity\|remarks\|errors\)\s*\(.\)/\\\1\n\2/'
+grep -ne '^\\\(constraints\|mandates\|expects\|effects\|sync\|ensures\|returns\|throws\|complexity\|remarks\|errors\).\+$' $texfiles && exit 1
+# Fixup: sed 's/^\\\(constraints\|mandates\|expects\|effects\|sync\|ensures\|returns\|throws\|complexity\|remarks\|errors\)\s*\(.\)/\\\1\n\2/'
 # Fixup: sed 's/^\\ //'
 
 # Change marker in [diff] followed by stuff.


### PR DESCRIPTION
This was missed earlier due to a typo in the check script,
which is also fixed.