### PR TITLE
[alg.partitions] Add missing \pnum.

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -6746,6 +6746,7 @@ Let \tcode{proj} be \tcode{identity\{\}}
 for the overloads with no parameter named \tcode{proj}
 and let $E(x)$ be \tcode{bool(invoke(\brk{}pred, invoke(proj, $x$)))}.
 
+\pnum
 \expects
 For the overloads in namespace \tcode{std},
 \tcode{BidirectionalIterator} meets

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -3002,15 +3002,13 @@ This applies even to objects such as mutexes intended for thread synchronization
 
 \pnum
 \indextext{restriction}%
-Violation of any preconditions specified in a function's
-\requires
-element results in undefined behavior unless the function's
-\throws
-element specifies throwing an exception when the precondition is violated.
+Violation of any preconditions specified in a function's \requires element
+results in undefined behavior
+unless the function's \throws element
+specifies throwing an exception when the precondition is violated.
 
 \pnum
-Violation of any preconditions specified
-in a function's \expects element
+Violation of any preconditions specified in a function's \expects element
 results in undefined behavior.
 
 \rSec3[res.on.requirements]{Semantic requirements}
@@ -3304,15 +3302,10 @@ unless otherwise specified.
 \pnum
 Any of the functions defined in the \Cpp{} standard library
 \indextext{library!C++ standard}%
-can report a failure by throwing an exception of a type described in its
-\throws
-paragraph,
-or of a type derived from a type named in the
-\throws
-paragraph
-that would be caught by
-an exception handler
-for the base type.
+can report a failure by throwing an exception of a type
+described in its \throws paragraph,
+or of a type derived from a type named in the \throws paragraph
+that would be caught by an exception handler for the base type.
 
 \pnum
 Functions from the C standard library shall not throw exceptions%
@@ -3337,11 +3330,8 @@ non-throwing exception specification.
 Functions defined in the
 \Cpp{} standard library
 \indextext{specifications!C++}%
-that do not have a
-\throws
-paragraph
-but do have a potentially-throwing
-exception specification
+that do not have a \throws paragraph
+but do have a potentially-throwing exception specification
 may throw \impldef{exceptions thrown by standard library functions that have a
 potentially-throwing exception specification} exceptions.%
 \footnote{In particular, they

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -2,7 +2,8 @@
 
 # Ignore files where rules may be violated within macro definitions.
 texfiles=$(ls *.tex | grep -v macros.tex | grep -v layout.tex | grep -v tables.tex)
-texlib="lib-intro.tex support.tex concepts.tex diagnostics.tex utilities.tex strings.tex containers.tex iterators.tex ranges.tex algorithms.tex numerics.tex time.tex locales.tex iostreams.tex regex.tex atomics.tex threads.tex"
+texlibdesc="support.tex concepts.tex diagnostics.tex utilities.tex strings.tex containers.tex iterators.tex ranges.tex algorithms.tex numerics.tex time.tex locales.tex iostreams.tex regex.tex atomics.tex threads.tex"
+texlib="lib-intro.tex $texlibdesc"
 
 # Discover "Overfull \hbox" and "Reference ... undefined" messages from LaTeX.
 sed -n '/\.tex/{s/^.*\/\([-a-z0-9]\+\.tex\).*$/\1/;h};
@@ -28,7 +29,7 @@ grep -n 'opt{}' *.tex && exit 1
 grep -n "// not defined" $texfiles | sed 's/$/ <--- use \\notdef instead/' | grep . && exit 1
 
 # Library element introducer followed by stuff.
-grep -ne '^\\\(constraints\|mandates\|expects\|effects\|sync\|ensures\|returns\|throws\|complexity\|remarks\|errors\).\+$' $texfiles && exit 1
+grep -ne '^\\\(constraints\|mandates\|expects\|effects\|sync\|ensures\|returns\|throws\|complexity\|remarks\|errors\).\+$' $texlibdesc && exit 1
 # Fixup: sed 's/^\\\(constraints\|mandates\|expects\|effects\|sync\|ensures\|returns\|throws\|complexity\|remarks\|errors\)\s*\(.\)/\\\1\n\2/'
 # Fixup: sed 's/^\\ //'
 
@@ -76,6 +77,14 @@ for f in $texfiles; do
     # prefix output with filename and line
     sed '/^[0-9]\+$/{N;s/\n/:/}' | sed "s/.*/$f:&/" |
     sed 's/$/ <--- "shall" inside a note/'
+done | grep . && exit 1
+
+# Library descriptive macros not immediately preceded by \pnum.
+for f in $texlibdesc; do
+    sed -n '/^\\pnum/{h;:x;n;/^\\index/b x;/^\\\(constraints\|mandates\|expects\|effects\|sync\|ensures\|returns\|throws\|complexity\|remarks\|errors\)/{x;/\n/{x;=;p};d};/^\\pnum/D;H;b x}' $f |
+    # prefix output with filename and line
+    sed '/^[0-9]\+$/{N;s/\n/:/}' | sed "s/.*/$f:&/" |
+    sed 's/$/ <--- \\pnum missing/'
 done | grep . && exit 1
 
 # \placeholder before (


### PR DESCRIPTION
Also extend the check script to flag missing \pnum in
library descriptions.
Limit the checking to library clauses other than [library].