### PR TITLE
[lib] Consistently use ios_base::failbit and ios_base::badbit.

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4526,7 +4526,7 @@ when converted to a value of type
 the function endeavors
 to obtain the requested input.
 If an exception is thrown during input then
-\tcode{ios::badbit}
+\tcode{ios_base::badbit}
 is turned on\footnote{This is done without causing an
 \tcode{ios_base::failure}
 to be thrown.}
@@ -4864,7 +4864,7 @@ an argument shall also store a null character (using
 \tcode{charT()})
 in the first location of the array.
 If an exception is thrown during input then
-\tcode{ios::badbit}
+\tcode{ios_base::badbit}
 is turned on\footnote{This is done without causing an
 \tcode{ios_base::failure}
 to be thrown.}
@@ -6122,7 +6122,7 @@ If the generation fails, then the formatted output function does
 \tcode{setstate(ios_base::failbit)},
 which might throw an exception.
 If an exception is thrown during output, then
-\tcode{ios::badbit}
+\tcode{ios_base::badbit}
 is turned on\footnote{without causing an
 \tcode{ios_base::failure}
 to be thrown.}
@@ -6526,7 +6526,7 @@ while converting to a value of type
 the function endeavors
 to generate the requested output.
 If an exception is thrown during output, then
-\tcode{ios::badbit}
+\tcode{ios_base::badbit}
 % .Fs new
 is turned on\footnote{without causing an
 \tcode{ios_base::failure}
@@ -7123,7 +7123,7 @@ void f(basic_ios<charT, traits>& str, const moneyT& mon, bool intl) {
   const Iter end = mp.put(Iter(str.rdbuf()), intl, str, str.fill(), mon);
 
   if (end.failed())
-    str.setstate(ios::badbit);
+    str.setstate(ios_base::badbit);
 }
 \end{codeblock}
 
@@ -11196,7 +11196,7 @@ void emit();
 \effects
 Calls \tcode{sb.emit()}.
 If that call returns \tcode{false},
-calls \tcode{setstate(ios::badbit)}.
+calls \tcode{setstate(ios_base::badbit)}.
 
 \pnum
 \begin{example}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -2417,7 +2417,7 @@ according to \ref{strings} and \ref{input.output}.
     If bad input is encountered,
     ensures that \tcode{v}'s state is unchanged by the operation
     and
-    calls \tcode{is.setstate(ios::failbit)}
+    calls \tcode{is.setstate(ios_base::failbit)}
     (which may throw \tcode{ios_base::failure}\iref{iostate.flags}).
     If a textual representation written via \tcode{os << x}
     was subsequently read via \tcode{is >> v},
@@ -2809,7 +2809,7 @@ according to \ref{strings} and \ref{input.output}.
     If bad input is encountered,
     ensures that \tcode{d} is unchanged by the operation
     and
-    calls \tcode{is.setstate(ios::failbit)}
+    calls \tcode{is.setstate(ios_base::failbit)}
     (which may throw \tcode{ios_base::failure}\iref{iostate.flags}).
 
     \expects

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -3482,7 +3482,7 @@ object is destroyed.
 
 \pnum
 If the function extracts no characters, it calls
-\tcode{is.setstate(ios::failbit)},
+\tcode{is.setstate(ios_base::failbit)},
 which may throw
 \tcode{ios_base::fail\-ure}\iref{iostate.flags}.
 


### PR DESCRIPTION
Fixes #3332.