### PR TITLE
[range.istream] s/object_/value_/

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2743,7 +2743,7 @@ namespace std::ranges {
     constexpr auto begin()
     {
       if (@\exposid{stream_}@) {
-        *@\exposid{stream_}@ >> @\exposid{object_}@;
+        *@\exposid{stream_}@ >> @\exposid{value_}@;
       }
       return @\exposid{iterator}@{*this};
     }
@@ -2753,7 +2753,7 @@ namespace std::ranges {
   private:
     struct @\exposid{iterator}@;                                    // \expos
     basic_istream<CharT, Traits>* @\exposid{stream_}@ = nullptr;    // \expos
-    Val @\exposid{object_}@ = Val();                                // \expos
+    Val @\exposid{value_}@ = Val();                                 // \expos
   };
 }
 \end{codeblock}
@@ -2853,7 +2853,7 @@ Initializes \exposid{parent_} with \tcode{addressof(parent)}.
 \effects
 Equivalent to:
 \begin{codeblock}
-*@\exposid{parent_}@->@\exposid{stream_}@>> @\exposid{parent_}@->@\exposid{object_}@;
+*@\exposid{parent_}@->@\exposid{stream_}@>> @\exposid{parent_}@->@\exposid{value_}@;
 return *this;
 \end{codeblock}
 \end{itemdescr}
@@ -2885,7 +2885,7 @@ Val& operator*() const;
 
 \pnum
 \effects
-Equivalent to: \tcode{return \exposid{parent_}->\exposid{object_};}
+Equivalent to: \tcode{return \exposid{parent_}->\exposid{value_};}
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{basic_istream_view::iterator}%


### PR DESCRIPTION
Per @jensmaurer's editorial defect filed to the LWG reflector. I chose to change `object_` instead of `value_`, since it's internally more consistent with the type. If anyone `object_`s to this, I could alternatively rename the stray `value_` in [range.istream.iterator]/7 and `Val` to `T`.