### PR TITLE
[range.refinements] Simplify viewable_range

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1120,7 +1120,7 @@ The \libconcept{viewable_range} concept specifies the requirements of a
 \begin{itemdecl}
 template<class T>
   concept @\deflibconcept{viewable_range}@ =
-    range<T> && (safe_range<T> || view<decay_t<T>>);
+    range<T> && (safe_range<T> || view<remove_cvref_t<T>>);
 \end{itemdecl}
 
 \rSec1[range.utility]{Range utilities}


### PR DESCRIPTION
Since pointer types cannot model `view`, `view<decay_t<T>>` and `view<remove_cvref_t<T>>` are equivalent for a type `T`. LWG prefers `remove_cvref_t` to `decay_t` in cases where the two are equivalent.