### PR TITLE
[range.prim.size] rewords p1.3 to make it easier to parse

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -638,7 +638,7 @@ template<class T> void size(T&&) = delete;
   if it is a valid expression, and
   \tcode{T} models \tcode{forward_range}\iref{range.refinements}, and
   \tcode{iterator_t<T>} and \tcode{sentinel_t<T>}\iref{ranges.syn} model
-  \tcode{\libconcept{sized_sentinel_for}<S, I>}\iref{iterator.concept.sizedsentinel}.
+  \tcode{\libconcept{sized_sentinel_for}<sentinel_t<T>, iterator_t<T>>}\iref{iterator.concept.sizedsentinel}.
   However, \tcode{E} is evaluated only once.
 
 \item

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -634,12 +634,11 @@ template<class T> void size(T&&) = delete;
   \end{itemize}
 
 \item
-  Otherwise, \tcode{\placeholdernc{make-unsigned-like}(ranges::end(E) - ranges::begin(E))}\iref{range.subrange}
-  if it is a valid expression and
-  the types \tcode{I} and \tcode{S} of \tcode{ranges::begin(E)} and
-  \tcode{ranges::end(E)} (respectively) model both
-  \tcode{\libconcept{sized_sentinel_for}<S, I>}\iref{iterator.concept.sizedsentinel} and
-  \tcode{\libconcept{forward_iterator}<I>}.
+  Otherwise, \tcode{\placeholdernc{make-unsigned-like}(ranges::end(E) - ranges::begin(E))}\iref{ranges.syn}
+  if it is a valid expression, and
+  \tcode{T} models \tcode{forward_range}\iref{range.refinements}, and
+  \tcode{iterator_t<T>} and \tcode{sentinel_t<T>}\iref{ranges.syn} model
+  \tcode{\libconcept{sized_sentinel_for}<S, I>}\iref{iterator.concept.sizedsentinel}.
   However, \tcode{E} is evaluated only once.
 
 \item


### PR DESCRIPTION
I expressed a desire to reword [range.prim.size] p1.3 on the LWG reflector, as I felt it is currently difficult to grasp the exact requirements (from an implementer's point-of-view). Hopefully this wording conveys the necessary requirements in a more concise manner.

Little feedback was given, so I'm unsure if this is something that should first go through a full review in Prague.