### PR TITLE
[defns.signature] functions never have trailing requires-clauses

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -253,9 +253,7 @@ following the macro name
 \defncontext{function}
 name,
 parameter-type-list\iref{dcl.fct},
-enclosing namespace (if any),
-and
-trailing \grammarterm{requires-clause}\iref{dcl.decl} (if any)
+and enclosing namespace (if any)
 
 \begin{defnote}
 Signatures are used as a basis for


### PR DESCRIPTION
...after application of P1971R0.