### PR TITLE
[ranges] Do not indent \begin/end{codeblock}.

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -348,10 +348,10 @@ expression-equivalent to:
   valid expression and its type \tcode{I} models
   \libconcept{input_or_output_iterator} with overload
   resolution performed in a context that includes the declarations:
-  \begin{codeblock}
+\begin{codeblock}
 template<class T> void begin(T&&) = delete;
 template<class T> void begin(initializer_list<T>&&) = delete;
-  \end{codeblock}
+\end{codeblock}
   and does not include a declaration of \tcode{ranges::begin}.
 
 \item
@@ -389,22 +389,22 @@ expression-equivalent to:
   Otherwise,
   \tcode{\placeholdernc{decay-copy}(t.end())}
   if it is a valid expression and its type \tcode{S} models
-  \begin{codeblock}
+\begin{codeblock}
 sentinel_for<decltype(ranges::begin(E))>
-  \end{codeblock}
+\end{codeblock}
 
 \item
   Otherwise, \tcode{\placeholdernc{decay-copy}(end(t))} if it is a valid
   expression and its type \tcode{S} models
-  \begin{codeblock}
+\begin{codeblock}
 sentinel_for<decltype(ranges::begin(E))>
-  \end{codeblock}
+\end{codeblock}
   with overload
   resolution performed in a context that includes the declarations:
-  \begin{codeblock}
+\begin{codeblock}
 template<class T> void end(T&&) = delete;
 template<class T> void end(initializer_list<T>&&) = delete;
-  \end{codeblock}
+\end{codeblock}
   and does not include a declaration of \tcode{ranges::end}.
 
 \item
@@ -482,9 +482,9 @@ expression-equivalent to:
   expression and its type \tcode{I} models
   \libconcept{input_or_output_iterator} with overload
   resolution performed in a context that includes the declaration:
-  \begin{codeblock}
+\begin{codeblock}
 template<class T> void rbegin(T&&) = delete;
-  \end{codeblock}
+\end{codeblock}
   and does not include a declaration of \tcode{ranges::rbegin}.
 
 \item
@@ -523,21 +523,21 @@ expression-equivalent to:
 \item
   \tcode{\placeholdernc{decay-copy}(t.rend())}
   if it is a valid expression and its type \tcode{S} models
-  \begin{codeblock}
+\begin{codeblock}
 sentinel_for<decltype(ranges::rbegin(E))>
-  \end{codeblock}
+\end{codeblock}
 
 \item
   Otherwise, \tcode{\placeholdernc{decay-copy}(rend(t))} if it is a valid
   expression and its type \tcode{S} models
-  \begin{codeblock}
+\begin{codeblock}
 sentinel_for<decltype(ranges::rbegin(E))>
-  \end{codeblock}
+\end{codeblock}
   with overload
   resolution performed in a context that includes the declaration:
-  \begin{codeblock}
+\begin{codeblock}
 template<class T> void rend(T&&) = delete;
-  \end{codeblock}
+\end{codeblock}
   and does not include a declaration of \tcode{ranges::rend}.
 
 \item
@@ -627,9 +627,9 @@ object\iref{customization.point.object}. The expression
     is integer-like
     with overload resolution performed in a context that includes
     the declaration:
-    \begin{codeblock}
+\begin{codeblock}
 template<class T> void size(T&&) = delete;
-    \end{codeblock}
+\end{codeblock}
     and does not include a declaration of \tcode{ranges::size}.
   \end{itemize}
 

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -16,6 +16,9 @@ grep -ne '\s$' *.tex | sed 's/$/<--- trailing whitespace/' | grep . && exit 1
 # Trailing empty lines
 for f in *.tex; do [ $(tail -c 2 $f | wc -l) -eq 1 ] || (echo "$f has trailing empty lines"; exit 1 ) done
 
+# indented \begin{codeblock} / \end{codeblock} (causes unwanted empty space)
+grep -ne '^.\+\\\(begin\|end\){codeblock}' $texfiles && exit 1
+
 # \pnum not alone on a line.
 grep -ne '^.\+\\pnum' $texfiles && exit 1
 grep -ne '\\pnum.\+$' $texfiles && exit 1


### PR DESCRIPTION
Also augment the check script accordingly.
Indented codeblock markers cause undesirable empty vertical space.

Fixes #3568.