### PR TITLE
Replace #include by import-declaration

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -5691,7 +5691,7 @@ int dog(bar, bar);
 
 \begin{codeblocktu}{Module interface unit of \tcode{C2}}
 module;
-#include "bar.h" // imports header unit \tcode{"bar.h"}
+import "bar.h" // imports header unit \tcode{"bar.h"}
 export module C2;
 import B;
 export template<typename T>


### PR DESCRIPTION
This example was previously valid, but we've removed the implicit use of header units through #include directives.