### PR TITLE
[basic.scope.pdecl] Fix example of self-referential initialization.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -836,8 +836,9 @@ complete declarator\iref{dcl.decl} and before its
 unsigned char x = 12;
 { unsigned char x = x; }
 \end{codeblock}
-Here the second \tcode{x} is initialized with its own (indeterminate)
-value.
+Here, the initialization of the second \tcode{x} has undefined behavior,
+because the initializer accesses the second \tcode{x}
+outside its lifetime\iref{basic.life}.
 \end{example}
 
 \pnum


### PR DESCRIPTION
Fixes #3578.