### PR TITLE
[class.this] Member functions are not cv-qualified. 

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1057,14 +1057,10 @@ In the body of a non-static\iref{class.mfct} member function, the
 keyword \tcode{this} is a prvalue whose value is
 a pointer to the object for which the function is called.
 \indextext{\idxcode{this}!type of}%
-The type of \tcode{this} in a member function of a class \tcode{X} is
-\tcode{X*}.
-If the member function is declared \tcode{const}, the type of
-\tcode{this} is \tcode{const} \tcode{X*},
-if the member function is declared \tcode{volatile}, the type of
-\tcode{this} is \tcode{volatile} \tcode{X*}, and if the member function
-is declared \tcode{const} \tcode{volatile}, the type of \tcode{this} is
-\tcode{const} \tcode{volatile} \tcode{X*}.
+The type of \tcode{this} in a member function
+whose type has a \grammarterm{cv-qualifier-seq} \cv{} and
+whose class is \tcode{X}
+is ``pointer to \cv{} \tcode{X}''.
 \begin{note}
 Thus in a const member function, the object for which the function is
 called is accessed through a const access path.
@@ -1089,9 +1085,11 @@ called. This is not allowed in a const member function because
 \end{example}
 
 \pnum
+\begin{note}
 Similarly, \tcode{volatile} semantics\iref{dcl.type.cv} apply in
 volatile member functions when accessing the object and its
 non-static data members.
+\end{note}
 
 \pnum
 A member function whose type has a \grammarterm{cv-qualifier-seq} \cvqual{cv1}

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1094,9 +1094,10 @@ volatile member functions when accessing the object and its
 non-static data members.
 
 \pnum
-A cv-qualified member function can be called on an
-object-expression\iref{expr.ref} only if the object-expression is as
-cv-qualified or less-cv-qualified than the member function.
+A member function whose type has a \grammarterm{cv-qualifier-seq} \cvqual{cv1}
+can be called on an
+object expression\iref{expr.ref} of type \cvqual{cv2} \tcode{T} only
+if \cvqual{cv1} is the same as or more cv-qualified than \cvqual{cv2}\iref{basic.type.qualifier}.
 \begin{example}
 \begin{codeblock}
 void k(s& x, const s& y) {
@@ -1109,7 +1110,7 @@ void k(s& x, const s& y) {
 
 The call \tcode{y.g()} is ill-formed because \tcode{y} is \tcode{const}
 and \tcode{s::g()} is a non-const member function, that is,
-\tcode{s::g()} is less-qualified than the object-expression \tcode{y}.
+\tcode{s::g()} is less-qualified than the object expression \tcode{y}.
 \end{example}
 
 \pnum


### PR DESCRIPTION
Fixes #3579.