### PR TITLE
[temp.type,temp.over.link] Define and use 'same template-id'.

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1944,8 +1944,7 @@ g(0);                           // selects \#4
 
 \pnum
 \indextext{equivalence!template type}%
-Two \grammarterm{template-id}{s} refer to the same
-class, function, or variable if
+Two \grammarterm{template-id}{s} are the same if
 \begin{itemize}
 \item
 their \grammarterm{template-name}{s},
@@ -1966,6 +1965,8 @@ after conversion to the type of the \grammarterm{template-parameter}, and
 their corresponding template \grammarterm{template-argument}{s}
 refer to the same template.
 \end{itemize}
+Two \grammarterm{template-id}{s} that are the same
+refer to the same class, function, or variable.
 
 \pnum
 Two values are \defn{template-argument-equivalent} if
@@ -3633,9 +3634,7 @@ would satisfy the one-definition rule,
 except that the tokens used to name types and declarations may differ
 as long as they name the same entities, and
 the tokens used to form concept-ids may differ
-as long as the two \grammarterm{template-id}{s}
-would be considered to name the same type if,
-instead of a concept, a class template were named.
+as long as the two \grammarterm{template-id}{s} are the same\iref{temp.type}.
 \begin{note}
 For instance, \tcode{A<42>} and \tcode{A<40+2>} name the same type.
 \end{note}


### PR DESCRIPTION
Fixes #3386.