### PR TITLE
[expr.compound] Use sequencing on expressions

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6325,13 +6325,9 @@ first operand is \tcode{false}.
 \pnum
 The result is a \tcode{bool}.
 \indextext{operator!side effects and logical AND}%
-If the second expression is evaluated, every
-\indextext{value computation}%
-value computation and
-\indextext{side effects}
-side
-effect associated with the first expression is sequenced before every
-value computation and side effect associated with the second expression.
+If the second expression is evaluated,
+the first expression is sequenced before
+the second expression\iref{intro.execution}.
 
 \rSec2[expr.log.or]{Logical OR operator}%
 \indextext{expression!logical OR}%
@@ -6356,13 +6352,9 @@ if the first operand evaluates to \tcode{true}.
 \pnum
 The result is a \tcode{bool}.
 \indextext{operator!side effects and logical OR}%
-If the second expression is evaluated, every
-\indextext{value computation}%
-value computation and
-\indextext{side effects}%
-side effect
-associated with the first expression is sequenced before every value computation
-and side effect associated with the second expression.
+If the second expression is evaluated,
+the first expression is sequenced before
+the second expression\iref{intro.execution}.
 
 \rSec2[expr.cond]{Conditional operator}%
 \indextext{expression!conditional operator}%
@@ -6382,11 +6374,9 @@ It is
 evaluated and if it is \tcode{true}, the result of the conditional
 expression is the value of the second expression, otherwise that of the
 third expression. Only one of the second and third expressions is
-evaluated. Every
-\indextext{value computation}%
-value computation and side effect associated with the
-first expression is sequenced before every value computation and side
-effect associated with the second or third expression.
+evaluated.
+The first expression is sequenced before
+the second or third expression\iref{intro.execution}.
 
 \pnum
 If either the second or the third operand has type \tcode{void},
@@ -6777,11 +6767,8 @@ The comma operator groups left-to-right.
 A pair of expressions separated by a comma is evaluated left-to-right;
 the left expression is
 a discarded-value expression\iref{expr.prop}.
-Every
-\indextext{value computation}%
-value computation and side effect
-associated with the left expression is sequenced before every value
-computation and side effect associated with the right expression.
+The left expression is sequenced before
+the right expression\iref{intro.execution}.
 \indextext{operator!side effects and comma}%
 The type and value of the
 result are the type and value of the right operand; the result is of the same


### PR DESCRIPTION
as defined in [intro.execution] as an abbreviation
for value computations and side effects.

Fixes #3380.