### PR TITLE
[expr.call] Clarify result of function call vs. return operand.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3044,9 +3044,9 @@ but it is unspecified whether the value of \tcode{j} is 1 or 2.
 \end{example}
 
 \pnum
-The result of a function call is the
-result of the operand of the evaluated \tcode{return} statement\iref{stmt.return}
-in the called function (if any),
+The result of a function call is the result of the possibly-converted operand
+of the \tcode{return} statement\iref{stmt.return}
+that transferred control out of the called function (if any),
 except in a virtual function call if the return type of the
 final overrider is different from the return type of the statically
 chosen function, the value returned from the final overrider is


### PR DESCRIPTION
Fixes #3124.