### PR TITLE
[std] Consistently use 'overload set'.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -351,8 +351,8 @@ an expression or conversion as follows:
 \begin{itemize}
 \item
   A function is named by an expression or conversion
-  if it is the unique result of a name lookup or the selected member
-  of a set of overloaded functions~(\ref{basic.lookup}, \ref{over.match}, \ref{over.over})
+  if it is the selected member
+  of an overload set~(\ref{basic.lookup}, \ref{over.match}, \ref{over.over})
   in an overload resolution performed
   as part of forming that expression or conversion,
   unless it is a pure virtual function and either
@@ -1364,11 +1364,12 @@ The name lookup rules apply uniformly to all names (including
 such names in the context discussed by a particular rule. Name lookup
 associates the use of a name with a set of declarations\iref{basic.def} of
 that name.
-The declarations found by name lookup shall either all denote the same entity or
-shall all denote functions or function templates;
-in the latter case,
-the declarations are said to form a set of overloaded
-functions\iref{over.load}. Overload resolution\iref{over.match}
+If the declarations found by name lookup
+all denote functions or function templates,
+the declarations are said to form an \defn{overload set}.
+The declarations found by name lookup shall either
+all denote the same entity or form an overload set.
+Overload resolution~(\ref{over.match}, \ref{over.over})
 takes place after name lookup has succeeded. The access rules\iref{class.access}
 are considered only once name lookup and
 function overload resolution (if applicable) have succeeded. Only after
@@ -1845,12 +1846,12 @@ If an associated namespace is an inline namespace\iref{namespace.def}, its
 enclosing namespace is also included in the set. If an associated namespace
 directly contains inline namespaces, those inline namespaces are also included
 in the set.
-In addition, if the argument is the name or address of a set of
-overloaded functions and/or function templates, its associated entities
+In addition, if the argument is the name or address of an overload set,
+its associated entities
 and namespaces are the union of those associated with each of the
 members of the set, i.e., the entities and namespaces associated with its
 parameter types and return type.
-Additionally, if the aforementioned set of overloaded functions is named with
+Additionally, if the aforementioned overload set is named with
 a \grammarterm{template-id}, its associated entities and namespaces also include
 those of its type \grammarterm{template-argument}{s} and its template
 \grammarterm{template-argument}{s}.

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -421,8 +421,7 @@ The \tcode{extern} keyword can also be used in
 The linkages implied by successive declarations for a given entity shall
 agree. That is, within a given scope, each declaration declaring the
 same variable name or the same overloading of a function name shall imply
-the same linkage. Each function in a given set of overloaded functions
-can have a different linkage, however.
+the same linkage.
 \begin{example}
 \begin{codeblock}
 static char* f();               // \tcode{f()} has internal linkage

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2955,8 +2955,7 @@ When a function is called, each parameter\iref{dcl.fct} is
 initialized~(\ref{dcl.init}, \ref{class.copy.ctor}) with
 its corresponding argument.
 If there is no corresponding argument,
-the default argument for the parameter is used;
-the program is ill-formed if one is not present.
+the default argument for the parameter is used.
 \begin{example}
 \begin{codeblock}
 template<typename ...T> int f(int n = 0, T ...t);

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -653,7 +653,7 @@ function template specializations
 and non-template functions\iref{dcl.fct} are treated equivalently
 for the remainder of overload resolution.}
 A given name can refer to one or more function templates and also
-to a set of overloaded non-template functions.
+to a set of non-template functions.
 In such a case, the
 candidate functions generated from each function template are combined
 with the set of non-template candidate functions.
@@ -700,16 +700,17 @@ In a function call\iref{expr.call}
 \begin{ncsimplebnf}
 postfix-expression \terminal{(} \opt{expression-list} \terminal{)}
 \end{ncsimplebnf}
-if the \grammarterm{postfix-expression} denotes a set of overloaded functions and/or
-function templates, overload resolution is applied as specified in \ref{over.call.func}.
+if the \grammarterm{postfix-expression} names at least one function or
+function template,
+overload resolution is applied as specified in \ref{over.call.func}.
 If the \grammarterm{postfix-expression} denotes an object of class type, overload
 resolution is applied as specified in \ref{over.call.object}.
 
 \pnum
-If the \grammarterm{postfix-expression} denotes the address of a set of overloaded
-functions and/or function templates, overload resolution is applied using that set as
-described above. If the function selected by overload resolution is a non-static member
-function, the program is ill-formed.
+If the \grammarterm{postfix-expression} is the address of an overload set,
+overload resolution is applied using that set as described above.
+If the function selected by overload resolution is a non-static member function,
+the program is ill-formed.
 \begin{note}
 The resolution of the address of an
 overload set in other contexts is described in \ref{over.over}.

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1204,8 +1204,8 @@ shall be a converted constant expression\iref{expr.const}
 of the type of the \grammarterm{template-parameter}.
 \begin{note}
 If the \grammarterm{template-argument}
-represents a set of overloaded functions
-(or a pointer or member pointer to such),
+is an overload set
+(or the address of such, including forming a pointer-to-member),
 the matching function is selected from the set\iref{over.over}.
 \end{note}
 
@@ -8368,9 +8368,8 @@ A template parameter used in the parameter type of a function parameter that
 has a default argument that is being used in the call for which argument
 deduction is being done.
 \item
-A function parameter for which argument deduction cannot be done because the
-associated function argument is a function, or a set of overloaded
-functions\iref{over.over}, and one or more of the following apply:
+A function parameter for which the associated argument is an
+overload set\iref{over.over}, and one or more of the following apply:
 \begin{itemize}
 \item
 more than one function matches the function parameter type (resulting in
@@ -8378,7 +8377,7 @@ an ambiguous deduction), or
 \item
 no function matches the function parameter type, or
 \item
-the set of functions supplied as an argument contains one or more function templates.
+the overload set supplied as an argument contains one or more function templates.
 \end{itemize}
 \item A function parameter for which the associated argument is an initializer
 list\iref{dcl.init.list} but the parameter does not have


### PR DESCRIPTION
Define the term in [basic.lookup] and use it throughout.
Avoid the term 'set of overloaded functions', because it
is ambiguous with the declaration view in [over.load].
(An overload set might contain functions from different
scopes that cannot be overloaded per [over.load].)

Fixes #3297.