### PR TITLE
[stringbuf] Use phrases from [bitmask.types].

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -8036,15 +8036,14 @@ to indicate failure.
 
 \pnum
 The function can make a write position available only if
-\tcode{(mode \& ios_base::out) != 0}.
+\tcode{ios_base::out} is set in \tcode{mode}.
 To make a write position available,
 the function reallocates (or initially allocates) an array object
 with a sufficient number of elements to hold
 the current array object (if any), plus
 at least
 one additional write position.
-If
-\tcode{(mode \& ios_base::in) != 0},
+If \tcode{ios_base::in} is set in \tcode{mode},
 the function alters the read end pointer
 \tcode{egptr()}
 to point just past the new write position.
@@ -8065,15 +8064,12 @@ controlled sequences, if possible, as indicated in \tref{stringbuf.seekoff.pos}.
 
 \begin{libtab2}{\tcode{seekoff} positioning}{stringbuf.seekoff.pos}
 {p{2.5in}l}{Conditions}{Result}
-\tcode{(which \& ios_base::in)}\tcode{ == ios_base::in}  &
+\tcode{ios_base::in} is set in \tcode{which}  &
  positions the input sequence \\ \rowsep
-\tcode{(which \& ios_base::out)}\tcode{ == ios_base::out}  &
+\tcode{ios_base::out} is set in \tcode{which}  &
  positions the output sequence  \\ \rowsep
-\tcode{(which \& (ios_base::in |}\br
-\tcode{ios_base::out)) ==}\br
-\tcode{(ios_base::in |}\br
-\tcode{ios_base::out)}\br
-and either\br
+both \tcode{ios_base::in} and \tcode{ios_base::out} are
+set in \tcode{which} and either\br
 \tcode{way == ios_base::beg} or\br
 \tcode{way == ios_base::end}     &
  positions both the input and the output sequences  \\ \rowsep
@@ -9492,7 +9488,7 @@ the open fails.
 
 \pnum
 If the open operation succeeds and
-\tcode{(mode \& ios_base::ate) != 0},
+\tcode{ios_base::ate} is set in \tcode{mode},
 positions the file to the end
 (as if by calling \tcode{fseek(file, 0, SEEK_END)}, where
 \tcode{file} is the pointer returned by calling \tcode{fopen}).%


### PR DESCRIPTION
Fixes #2969.