### PR TITLE
[over.built] Avoid confusing term 'promoted arithmetic type'.

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3918,11 +3918,8 @@ and
 \tcode{long}
 but excluding e.g.
 \tcode{char}).
-Similarly, the term
-\defn{promoted arithmetic type}
-refers to floating-point types plus promoted integral types.
 \begin{note}
-In all cases where a promoted integral type or promoted arithmetic type is
+In all cases where a promoted integral type is
 required, an operand of enumeration type will be acceptable by way of the
 integral promotions.
 \end{note}
@@ -3996,8 +3993,7 @@ For every type \tcode{\placeholder{T}} there exist candidate operator functions 
 \end{codeblock}
 
 \pnum
-For every promoted arithmetic type
-\tcode{\placeholder{T}},
+For every floating-point or promoted integral type \tcode{\placeholder{T}},
 there exist candidate operator functions of the form
 \begin{codeblock}
 @\placeholder{T}@ operator+(@\placeholder{T}@);
@@ -4035,10 +4031,9 @@ The return type is shown for exposition only; see~\ref{expr.mptr.oper} for the
 determination of the operator's result type.
 
 \pnum
-For every pair of promoted arithmetic types
-\tcode{\placeholder{L}}
-and
-\tcode{\placeholder{R}},
+For every pair of types \tcode{\placeholder{L}} and \tcode{\placeholder{R}},
+where \tcode{\placeholder{L}} and \tcode{\placeholder{R}} are each
+floating-point or promoted integral types,
 there exist candidate operator functions of the form
 \begin{codeblock}
 @\placeholder{LR}@      operator*(@\placeholder{L}@, @\placeholder{R}@);
@@ -4143,15 +4138,9 @@ and
 
 \pnum
 For every triple
-(\tcode{\placeholder{L}},
-\cvqual{vq},
-\tcode{\placeholder{R}}),
-where
-\tcode{\placeholder{L}}
-is an arithmetic type,
-and
-\tcode{\placeholder{R}}
-is a promoted arithmetic type,
+(\tcode{\placeholder{L}}, \cvqual{vq}, \tcode{\placeholder{R}}),
+where \tcode{\placeholder{L}} is an arithmetic type,
+and \tcode{\placeholder{R}} is a floating-point or promoted integral type,
 there exist candidate operator functions of the form
 \begin{codeblock}
 @\cvqual{vq} \placeholder{L}@&   operator=(@\cvqual{vq} \placeholder{L}@&, @\placeholder{R}@);
@@ -4223,10 +4212,9 @@ bool    operator||(bool, bool);
 \end{codeblock}
 
 \pnum
-For every pair of promoted arithmetic types
-\tcode{\placeholder{L}}
-and
-\tcode{\placeholder{R}},
+For every pair of types \tcode{\placeholder{L}} and \tcode{\placeholder{R}},
+where \tcode{\placeholder{L}} and \tcode{\placeholder{R}} are each
+floating-point or promoted integral types,
 there exist candidate operator functions of the form
 \begin{codeblock}
 @\placeholder{LR}@      operator?:(bool, @\placeholder{L}@, @\placeholder{R}@);

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -4032,8 +4032,8 @@ determination of the operator's result type.
 
 \pnum
 For every pair of types \tcode{\placeholder{L}} and \tcode{\placeholder{R}},
-where \tcode{\placeholder{L}} and \tcode{\placeholder{R}} are each
-floating-point or promoted integral types,
+where each of \tcode{\placeholder{L}} and \tcode{\placeholder{R}} is a
+floating-point or promoted integral type,
 there exist candidate operator functions of the form
 \begin{codeblock}
 @\placeholder{LR}@      operator*(@\placeholder{L}@, @\placeholder{R}@);
@@ -4213,8 +4213,8 @@ bool    operator||(bool, bool);
 
 \pnum
 For every pair of types \tcode{\placeholder{L}} and \tcode{\placeholder{R}},
-where \tcode{\placeholder{L}} and \tcode{\placeholder{R}} are each
-floating-point or promoted integral types,
+where each of \tcode{\placeholder{L}} and \tcode{\placeholder{R}} is a
+floating-point or promoted integral type,
 there exist candidate operator functions of the form
 \begin{codeblock}
 @\placeholder{LR}@      operator?:(bool, @\placeholder{L}@, @\placeholder{R}@);

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3920,7 +3920,7 @@ but excluding e.g.
 \tcode{char}).
 \begin{note}
 In all cases where a promoted integral type is
-required, an operand of enumeration type will be acceptable by way of the
+required, an operand of unscoped enumeration type will be acceptable by way of the
 integral promotions.
 \end{note}
 


### PR DESCRIPTION
Fixes #2665.