### PR TITLE
[thread.sema] PascalCase for template parameters

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -5122,7 +5122,7 @@ the default implementation of a counting semaphore with a unit resource count.
 \indexheader{semaphore}%
 \begin{codeblock}
 namespace std {
-  template<ptrdiff_t least_max_value = @\textrm{\textit{implementation-defined}}@>
+  template<ptrdiff_t LeastMaxValue = @\textrm{\textit{implementation-defined}}@>
     class counting_semaphore;
 
   using binary_semaphore = counting_semaphore<1>;
@@ -5133,7 +5133,7 @@ namespace std {
 
 \begin{codeblock}
 namespace std {
-  template<ptrdiff_t least_max_value = @\textrm{\textit{\impldef{value for \idxcode{least_max_value} default template argument of \idxcode{counting_semaphore}}}}@>
+  template<ptrdiff_t LeastMaxValue = @\textrm{\textit{\impldef{value for \idxcode{LeastMaxValue} default template argument of \idxcode{counting_semaphore}}}}@>
   class counting_semaphore {
   public:
     static constexpr ptrdiff_t max() noexcept;
@@ -5169,7 +5169,7 @@ the thread will block
 until another thread increments the counter by releasing the semaphore.
 
 \pnum
-\tcode{least_max_value} shall be non-negative; otherwise the program is ill-formed.
+\tcode{LeastMaxValue} shall be non-negative; otherwise the program is ill-formed.
 
 \pnum
 Concurrent invocations of the member functions of \tcode{counting_semaphore},
@@ -5184,7 +5184,7 @@ static constexpr ptrdiff_t max() noexcept;
 \pnum
 \returns
 The maximum value of \tcode{counter}.
-This value is greater than or equal to \tcode{least_max_value}.
+This value is greater than or equal to \tcode{LeastMaxValue}.
 \end{itemdescr}
 
 \indexlibraryctor{counting_semaphore}%


### PR DESCRIPTION
Relpace `least_max_value` with `LeastMaxValue` which is more consistent with rest of the standard.