### PR TITLE
[thread.lock.unique.locking] Fix typo in try_lock_for.

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -3385,7 +3385,7 @@ As if by \tcode{pm->try_lock_for(rel_time)}.
 
 \pnum
 \returns
-The value returned by the call to \tcode{try_lock_until(rel_time)}.
+The value returned by the call to \tcode{try_lock_for(rel_time)}.
 
 \pnum
 \ensures


### PR DESCRIPTION
Fixes #3617.