### PR TITLE
[format.arg] Move 'otherwise' to the start of the bullets.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -21001,33 +21001,30 @@ shall be well-formed when treated as an unevaluated operand.
 \begin{itemize}
 \item
 if \tcode{T} is \tcode{bool} or \tcode{char_type},
-initializes \tcode{value} with \tcode{v}; otherwise,
+initializes \tcode{value} with \tcode{v};
 \item
-if \tcode{T} is \tcode{char} and \tcode{char_type} is
+otherwise, if \tcode{T} is \tcode{char} and \tcode{char_type} is
 \tcode{wchar_t}, initializes \tcode{value} with
-\tcode{static_cast<wchar_t>(v)}; otherwise,
+\tcode{static_cast<wchar_t>(v)};
 \item
-if \tcode{T} is a signed integer type\iref{basic.fundamental}
+otherwise, if \tcode{T} is a signed integer type\iref{basic.fundamental}
 and \tcode{sizeof(T) <= sizeof(int)},
 initializes \tcode{value} with \tcode{static_cast<int>(v)};
-otherwise,
 \item
-if \tcode{T} is an unsigned integer type and
+otherwise, if \tcode{T} is an unsigned integer type and
 \tcode{sizeof(T) <= sizeof(unsigned int)}, initializes
 \tcode{value} with \tcode{static_cast<unsigned int>(v)};
-otherwise,
 \item
-if \tcode{T} is a signed integer type and
+otherwise, if \tcode{T} is a signed integer type and
 \tcode{sizeof(T) <= sizeof(long long int)}, initializes
 \tcode{value} with \tcode{static_cast<long long int>(v)};
-otherwise,
 \item
-if \tcode{T} is an unsigned integer type and
+otherwise, if \tcode{T} is an unsigned integer type and
 \tcode{sizeof(T) <= sizeof(unsigned long long int)}, initializes
 \tcode{value} with
-\tcode{static_cast<unsigned long long int>(v)}; otherwise,
+\tcode{static_cast<unsigned long long int>(v)};
 \item
-initializes \tcode{value} with \tcode{handle(v)}.
+otherwise, initializes \tcode{value} with \tcode{handle(v)}.
 \end{itemize}
 \end{itemdescr}
 


### PR DESCRIPTION
Fixes #3615.