### PR TITLE
[locale.codecvt] Do not claim that 'Unicode' is a character encoding.

### DIFF
--- a/source/locales.tex
+++ b/source/locales.tex
@@ -1837,8 +1837,8 @@ The class
 \tcode{codecvt<internT, externT, stateT>}
 is for use when
 converting from one character encoding to another, such as from wide characters
-to multibyte  characters or between wide character encodings such as
-Unicode and EUC.
+to multibyte characters or between wide character encodings such as
+UTF-32 and EUC.
 
 \pnum
 The


### PR DESCRIPTION
Fixes #3611.