### PR TITLE
[ptr.launder] Fix note and example for std::launder.

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -2877,7 +2877,7 @@ If a new object is created
 in storage occupied by an existing object of the same type,
 a pointer to the original object
 can be used to refer to the new object
-unless the type contains \tcode{const} or reference members;
+unless its complete object is a const object or it is a base class subobject;
 in the latter cases,
 this function can be used to obtain a usable pointer to the new object.
 See~\ref{basic.life}.
@@ -2886,10 +2886,10 @@ See~\ref{basic.life}.
 \pnum
 \begin{example}
 \begin{codeblock}
-struct X { const int n; };
-X *p = new X{3};
+struct X { int n; };
+const X *p = new const X{3};
 const int a = p->n;
-new (p) X{5};                       // \tcode{p} does not point to new object\iref{basic.life} because \tcode{X::n} is \tcode{const}
+new (const_cast<X*>(p)) const X{5}; // \tcode{p} does not point to new object\iref{basic.life} because its type is \tcode{const}
 const int b = p->n;                 // undefined behavior
 const int c = std::launder(p)->n;   // OK
 \end{codeblock}


### PR DESCRIPTION
The applicable rules have changed in response to
NB RU 007, US 042 (C++20 CD).

Fixes #3613.