### PR TITLE
[dcl.fct,expr.ref] Fix description of class member access expressions

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3223,13 +3223,17 @@ in
 is
 ``\placeholder{derived-declarator-type-list}
 \opt{\tcode{noexcept}}
-function of
-(\grammarterm{parameter-declaration-clause})
+function of parameter-type-list
 \opt{\grammarterm{cv-qualifier-seq}} \opt{\grammarterm{ref-qualifier}}
-returning \tcode{T}'',
-where the optional \tcode{noexcept} is present
-if and only if
+returning \tcode{T}'', where
+\begin{itemize}
+\item
+the parameter-type-list is derived from
+the \grammarterm{parameter-declaration-clause} as described below and
+\item
+the optional \tcode{noexcept} is present if and only if
 the exception specification\iref{except.spec} is non-throwing.
+\end{itemize}
 The optional \grammarterm{attribute-specifier-seq}
 appertains to the function type.
 
@@ -3259,14 +3263,19 @@ in
 is
 ``\placeholder{derived-declarator-type-list}
 \opt{\tcode{noexcept}}
-function of
-(\grammarterm{parameter-declaration-clause})
+function of parameter-type-list
 \opt{\grammarterm{cv-qualifier-seq}} \opt{\grammarterm{ref-qualifier}}
-returning \tcode{U}'',
-where \tcode{U} is the type specified by
-the \grammarterm{trailing-return-type}, and
-where the optional \tcode{noexcept} is present if and only if
+returning \tcode{U}'', where
+\begin{itemize}
+\item
+the parameter-type-list is derived from
+the \grammarterm{parameter-declaration-clause} as described below,
+\item
+\tcode{U} is the type specified by the \grammarterm{trailing-return-type}, and
+\item
+the optional \tcode{noexcept} is present if and only if
 the exception specification is non-throwing.
+\end{itemize}
 The optional \grammarterm{attribute-specifier-seq}
 appertains to the function type.
 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3276,30 +3276,23 @@ is ``\cvqual{vq12} \tcode{T}''. If \tcode{E2} is not declared to be a
 \tcode{mutable} member, then the type of \tcode{E1.E2} is
 ``\cvqual{cq12} \cvqual{vq12} \tcode{T}''.
 
-\item If \tcode{E2} is a (possibly overloaded) member function, function
-overload resolution\iref{over.match} is used to determine whether
-\tcode{E1.E2} refers to a static or a non-static member function.
+\item If \tcode{E2} is a (possibly overloaded) member function,
+function overload resolution\iref{over.match}
+is used to select the function to which \tcode{E2} refers.
+The type of \tcode{E1.E2} is the type of \tcode{E2}
+and \tcode{E1.E2} refers to the function referred to by \tcode{E2}.
 
 \begin{itemize}
-\item If it refers to a static member function and the type of
-\tcode{E2} is ``function of parameter-type-list returning \tcode{T}'',
-then \tcode{E1.E2} is an lvalue; the expression designates the static
-member function. The type of \tcode{E1.E2} is the same type as that of
-\tcode{E2}, namely ``function of parameter-type-list returning
-\tcode{T}''.
+\item If \tcode{E2} refers to a static member function,
+\tcode{E1.E2} is an lvalue.
 
-\item Otherwise, if \tcode{E1.E2} refers to a non-static member
-function and the type of \tcode{E2} is ``function of
-parameter-type-list \cv{} \opt{\grammarterm{ref-qualifier}} returning \tcode{T}'', then
-\tcode{E1.E2} is a prvalue. The expression designates a
-non-static member function. The expression can be used only as the
+\item Otherwise (when \tcode{E2} refers to a non-static member function),
+\tcode{E1.E2} is a prvalue. The expression can be used only as the
 left-hand operand of a member function call\iref{class.mfct}.
 \begin{note}
 Any redundant set of parentheses surrounding the expression
 is ignored\iref{expr.prim.paren}.
 \end{note}
-The type of \tcode{E1.E2} is
-``function of parameter-type-list \cv{} returning \tcode{T}''.
 \end{itemize}
 
 \item If \tcode{E2} is a nested type, the expression \tcode{E1.E2} is


### PR DESCRIPTION
involving non-static member functions.

Fixes #3607.