### PR TITLE
[std] Enforce comment alignment in 'codeblocktu' environments.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1128,7 +1128,7 @@ export import Q;
 
 \begin{codeblocktu}{Translation unit \#3}
 import R;
-int main() { return sq(9); }   // OK: \tcode{sq} from module \tcode{Q}
+int main() { return sq(9); }    // OK: \tcode{sq} from module \tcode{Q}
 \end{codeblocktu}
 \end{example}
 \end{note}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -5641,8 +5641,8 @@ void g(X x) {
 export module A;
 export template<typename T>
 void f(T t) {
-  cat(t, t);         // \#1
-  dog(t, t);         // \#2
+  cat(t, t);            // \#1
+  dog(t, t);            // \#2
 }
 \end{codeblocktu}
 
@@ -5664,7 +5664,7 @@ int dog(foo, foo);
 
 \begin{codeblocktu}{Module interface unit of \tcode{C1}}
 module;
-#include "foo.h" // \tcode{dog} not referenced, discarded
+#include "foo.h"        // \tcode{dog} not referenced, discarded
 export module C1;
 import B;
 export template<typename T>
@@ -5676,7 +5676,7 @@ void h(T t) {
 \begin{codeblocktu}{Translation unit}
 import C1;
 void i() {
-   h(0);        // error: \tcode{dog} not found at \#2
+   h(0);                // error: \tcode{dog} not found at \#2
 }
 \end{codeblocktu}
 
@@ -5689,7 +5689,7 @@ int dog(bar, bar);
 
 \begin{codeblocktu}{Module interface unit of \tcode{C2}}
 module;
-#include "bar.h" // imports header unit \tcode{"bar.h"}
+#include "bar.h"        // imports header unit \tcode{"bar.h"}
 export module C2;
 import B;
 export template<typename T>
@@ -5701,8 +5701,8 @@ void j(T t) {
 \begin{codeblocktu}{Translation unit}
 import C2;
 void k() {
-   j(0);        // OK, \tcode{dog} found in instantiation context:
-                // visible at end of module interface unit of \tcode{C2}
+   j(0);                // OK, \tcode{dog} found in instantiation context:
+                        // visible at end of module interface unit of \tcode{C2}
 }
 \end{codeblocktu}
 \end{example}

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -61,7 +61,7 @@ done | grep . && exit 1
 
 # Comment not aligned to multiple of four. (Ignore lines with "@".)
 for f in $texfiles; do
-    sed -n '/begin{codeblock}/,/end{codeblock}/{/^[^@]*[^ @][^@]*\/\//{=;p}}' $f |
+    sed -n '/begin{codeblock\(tu\)\?}/,/end{codeblock\(tu\)\?}/{/^[^@]*[^ @][^@]*\/\//{=;p}}' $f |
     # prefix output with filename and line
     sed '/^[0-9]\+$/{N;s/\n/:/}' | sed "s/.*/$f:&/" |
     awk '{ match($0,"^[-a-z0-9]*[.]tex:[0-9]*:"); n=match(substr($0,RLENGTH+1),"[ ;]//"); if (n % 4 != 0) print $0 " <--- comment starts in column " n; }'


### PR DESCRIPTION
Also fix existing offenders.

Induced by #3574.