### PR TITLE
[except.spec] Avoid reference to undeclared identifier in example.

### DIFF
--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -926,7 +926,7 @@ struct A {
 struct B {
   B() noexcept;
   B(const B&) = default;        // implicit exception specification is \tcode{noexcept(true)}
-  B(B&&, int = (throw Y(), 0)) noexcept;
+  B(B&&, int = (throw 42, 0)) noexcept;
   ~B() noexcept(false);
 };
 int n = 7;


### PR DESCRIPTION
Fixes #3638.