### PR TITLE
[basic.fundamental] Clarify that in C, padding bits may cause traps.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4723,8 +4723,8 @@ Each set of values for any padding bits\iref{basic.types}
 in the object representation are
 alternative representations of the value specified by the value representation.
 \begin{note}
-Padding bits have unspecified value, but do not cause traps.
-See also ISO C 6.2.6.2.
+Padding bits have unspecified value, but cannot cause traps.
+In contrast, see ISO C 6.2.6.2.
 \end{note}
 \begin{note}
 The signed and unsigned integer types satisfy


### PR DESCRIPTION
Fixes #3310.