### PR TITLE
[lex.operators] Add `co_await` to the list

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -873,9 +873,9 @@ are converted into tokens for operators and punctuators:
 %% Ed. note: character protrusion would misalign various operators.
 \microtypesetup{protrusion=false}\obeyspaces
 \nontermdef{preprocessing-op-or-punc} \textnormal{one of}\br
-    \terminal{\{        \}        [        ]        \#        \#\#       (        )}\br
+    \terminal{\{        \}        [        ]        \#        \#\#       (        )        ?}\br
     \terminal{<:       :>       <\%       \%>       \%:       \%:\%:     ;        :        ...}\br
-    \terminal{new      delete   ?        ::       .        .*       ->       ->*      \~}\br
+    \terminal{new      delete   co_await ::       .        .*       ->       ->*      \~}\br
     \terminal{!        +        -        *        /        \%        \caret{}        \&        |}\br
     \terminal{=        +=       -=       *=       /=       \%=       \caret{}=       \&=       |=}\br
     \terminal{==       !=       <        >        <=       >=       <=>      \&\&       ||}\br


### PR DESCRIPTION
`co_await` is missing from the list of _preprocessing-op-or-punc_. Since it is an operator like `new` and `delete` (see [over.oper]), it should be here, otherwise it would be an identifier in phases 3 through 6. This is a clear inconsistency.

(I'm not certain about how to layout the table, as `co_await` is almost too big to fit, but the existing patterns should be maintained.)