### PR TITLE
[class] Returns for constructors and destructors should not have operands

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1313,7 +1313,7 @@ most derived object\iref{intro.object} ends.
 \indextext{restriction!constructor}%
 A
 \tcode{return}
-statement in the body of a constructor shall not specify a return value.
+statement in the body of a constructor shall have no operand.
 \indextext{constructor!address of}%
 The address of a constructor shall not be taken.
 
@@ -2162,6 +2162,9 @@ the selected destructor may be deleted\iref{dcl.fct.def.delete}.
 \pnum
 \indextext{restriction!destructor}%
 The address of a destructor shall not be taken.
+A \tcode{return}
+statement in the body of a destructor
+shall have no operand.
 \indextext{\idxcode{const}!destructor and}%
 \indextext{\idxcode{volatile}!destructor and}%
 A destructor can be invoked for a


### PR DESCRIPTION
[[class.ctor] p6](http://eel.is/c++draft/class.ctor#6) says:
> A `return` statement in the body of a constructor shall not specify a return value.

This makes it seem like one could have an operand of type `void` (since `void` has an empty set of values), but that is not permitted. Changing this to say that no operand is allowed is much clearer.

Additionally, there doesn't seem to be congruent wording for destructors regarding this. 