### PR TITLE
Use "requirement" in grammar font in expr.prim.req

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2512,7 +2512,7 @@ are unevaluated operands\iref{expr.prop}.
 
 \pnum
 \begin{example}
-A common use of \grammarterm{requires-expression}{s} is to define
+A common use of \grammarterm{requires-expression}s is to define
 requirements in concepts such as the one below:
 \begin{codeblock}
 template<typename T>
@@ -2543,7 +2543,7 @@ Each name introduced by a local parameter is in scope from the point
 of its declaration until the closing brace of the
 \grammarterm{requirement-body}.
 These parameters have no linkage, storage, or lifetime; they are only used
-as notation for the purpose of defining \grammarterm{requirement}{s}.
+as notation for the purpose of defining \grammarterm{requirement}s.
 The \grammarterm{parameter-declaration-clause} of a
 \grammarterm{requirement-parameter-list}
 shall not terminate with an ellipsis.
@@ -2559,15 +2559,15 @@ concept C = requires(T t, ...) {    // error: terminates with an ellipsis
 \pnum
 \indextext{requirement}%
 The \grammarterm{requirement-body} contains
-a sequence of \grammarterm{requirement}{s}.
-These \grammarterm{requirement}{s} may refer to local
+a sequence of \grammarterm{requirement}s.
+These \grammarterm{requirement}s may refer to local
 parameters, template parameters, and any other declarations visible from the
 enclosing context.
 
 \pnum
 The substitution of template arguments into a \grammarterm{requires-expression}
 may result in the formation of invalid types or expressions in its
-\grammarterm{requirement}{s} or the violation of the semantic constraints of those \grammarterm{requirement}{s}.
+\grammarterm{requirement}s or the violation of the semantic constraints of those \grammarterm{requirement}s.
 In such cases, the \grammarterm{requires-expression} evaluates to \tcode{false};
 it does not cause the program to be ill-formed.
 The substitution and semantic constraint checking
@@ -2577,7 +2577,7 @@ If substitution (if any) and semantic constraint checking succeed,
 the \grammarterm{requires-expression} evaluates to \tcode{true}.
 \begin{note}
 If a \grammarterm{requires-expression} contains invalid types or expressions in
-its \grammarterm{requirement}{s}, and it does not appear within the declaration of a templated
+its \grammarterm{requirement}s, and it does not appear within the declaration of a templated
 entity, then the program is ill-formed.
 \end{note}
 If the substitution of template arguments into a \grammarterm{requirement}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2512,7 +2512,7 @@ are unevaluated operands\iref{expr.prop}.
 
 \pnum
 \begin{example}
-A common use of \grammarterm{requires-expression}{}s is to define
+A common use of \grammarterm{requires-expression}{s} is to define
 requirements in concepts such as the one below:
 \begin{codeblock}
 template<typename T>
@@ -2543,7 +2543,7 @@ Each name introduced by a local parameter is in scope from the point
 of its declaration until the closing brace of the
 \grammarterm{requirement-body}.
 These parameters have no linkage, storage, or lifetime; they are only used
-as notation for the purpose of defining \grammarterm{requirement}{}s.
+as notation for the purpose of defining \grammarterm{requirement}{s}.
 The \grammarterm{parameter-declaration-clause} of a
 \grammarterm{requirement-parameter-list}
 shall not terminate with an ellipsis.
@@ -2559,15 +2559,15 @@ concept C = requires(T t, ...) {    // error: terminates with an ellipsis
 \pnum
 \indextext{requirement}%
 The \grammarterm{requirement-body} contains
-a sequence of \grammarterm{requirement}{}s.
-These \grammarterm{requirement}{}s may refer to local
+a sequence of \grammarterm{requirement}{s}.
+These \grammarterm{requirement}{s} may refer to local
 parameters, template parameters, and any other declarations visible from the
 enclosing context.
 
 \pnum
 The substitution of template arguments into a \grammarterm{requires-expression}
 may result in the formation of invalid types or expressions in its
-requirements or the violation of the semantic constraints of those requirements.
+\grammarterm{requirement}{s} or the violation of the semantic constraints of those \grammarterm{requirement}{s}.
 In such cases, the \grammarterm{requires-expression} evaluates to \tcode{false};
 it does not cause the program to be ill-formed.
 The substitution and semantic constraint checking
@@ -2577,7 +2577,7 @@ If substitution (if any) and semantic constraint checking succeed,
 the \grammarterm{requires-expression} evaluates to \tcode{true}.
 \begin{note}
 If a \grammarterm{requires-expression} contains invalid types or expressions in
-its requirements, and it does not appear within the declaration of a templated
+its \grammarterm{requirement}{s}, and it does not appear within the declaration of a templated
 entity, then the program is ill-formed.
 \end{note}
 If the substitution of template arguments into a \grammarterm{requirement}


### PR DESCRIPTION
[expr.prim.req] uses grammarterm <em><code>requirement</code></em> in paragraph 5, but normal font in paragraph 6. Term "requirement" is never defined in this clause, but it has a different meaning in the library.