### PR TITLE
Sub-bullets for value-initialization.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4252,19 +4252,18 @@ means:
 \item
 if
 \tcode{T}
-is a (possibly cv-qualified) class type\iref{class} with
+is a (possibly cv-qualified) class type\iref{class}, then
+\begin{itemize}
+\item
+if \tcode{T} has
 either no default constructor\iref{class.default.ctor} or a default
 constructor that is user-provided or deleted, then the object is default-initialized;
-
 \item
-if
-\tcode{T}
-is a (possibly cv-qualified) class type without a
-user-provided or deleted default constructor,
-then the object is zero-initialized and the semantic constraints for
+otherwise,
+the object is zero-initialized and the semantic constraints for
 default-initialization are checked, and if \tcode{T} has a
 non-trivial default constructor, the object is default-initialized;
-
+\end{itemize}
 \item
 if
 \tcode{T}


### PR DESCRIPTION
The definition of value-initialize in [dcl.init]/8 always causes me trouble because I have to recheck that the first two subbullets exhaustively cover all class types. I think with sub-bullets this becomes both more explicit and less wordy (since we don't have to repeat the condition of the first bullet).