### PR TITLE
[temp.constr.normal] Extraneous parentheses on concept use

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1821,7 +1821,7 @@ that names a concept specialization\iref{expr.prim.id}.
 \begin{example}
 \begin{codeblock}
 template<typename T> concept C1 = sizeof(T) == 1;
-template<typename T> concept C2 = C1<T>() && 1 == 2;
+template<typename T> concept C2 = C1<T> && 1 == 2;
 template<typename T> concept C3 = requires { typename T::type; };
 template<typename T> concept C4 = requires (T x) { ++x; }
 


### PR DESCRIPTION
I noticed this example had a syntax error.