### PR TITLE
[temp.constr.normal] Confusing identifier used in explanation

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1791,7 +1791,7 @@ despite the expression \tcode{T::value} being ill-formed
 for a pointer type \tcode{T}.
 Normalization of \tcode{C}{'s} \grammarterm{constraint-expression}
 results in the program being ill-formed,
-because it would form the invalid type \tcode{T\&*}
+because it would form the invalid type \tcode{V\&*}
 in the parameter mapping.
 \end{example}
 


### PR DESCRIPTION
We're substituting V& for U in the mapping $\tcode{T} \mapsto \tcode{U*}$, meaning T attempts to map to V&* (not T&*, which is a confusing notation in a context where T is another thing).