### PR TITLE
[class.mem] Explicit specializations within classes

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -448,6 +448,7 @@ if its \grammarterm{template-name} names a class template.
     using-enum-declaration\br
     static_assert-declaration\br
     template-declaration\br
+    explicit-specialization\br
     deduction-guide\br
     alias-declaration\br
     opaque-enum-declaration\br


### PR DESCRIPTION
The intent of [CWG 727](http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#727) was to allow explicit specializations to be declared in any scope that the primary template can be declared in, particularly class scope. Quote [[temp.expl.spec] p3](http://eel.is/c++draft/temp.expl.spec#3):
> An explicit specialization may be declared in any scope in which the corresponding primary template may be defined.

While this wording was changed, it seems like the grammar for member-declaration was neglected, meaning that declaring an explicit specialization in class scope is not syntactically valid.

(note that _explicit-specialization_ isn't a form of _template-declaration_, as the _template-parameter-list_ of _template-head_ cannot be empty) 