### PR TITLE
[class.conv.fct] Add \tcode to void

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -2609,7 +2609,7 @@ The type of the conversion function\iref{dcl.fct} is
 A conversion function is never used to convert a (possibly cv-qualified) object
 to the (possibly cv-qualified) same object type (or a reference to it),
 to a (possibly cv-qualified) base class of that type (or a reference to it),
-or to (possibly cv-qualified) void.\footnote{These conversions are considered
+or to \cv{}~\tcode{void}.\footnote{These conversions are considered
 as standard conversions for the purposes of overload resolution~(\ref{over.best.ics}, \ref{over.ics.ref}) and therefore initialization\iref{dcl.init} and explicit casts\iref{expr.static.cast}. A conversion to \tcode{void} does not invoke any conversion function\iref{expr.static.cast}.
 Even though never directly called to perform a conversion,
 such conversion functions can be declared and can potentially


### PR DESCRIPTION
Seems to be a missing \tcode there. Also, the "(possibly cv-qualified)" preceding `void` should be changed to _cv_ for consistency.