### PR TITLE
[extern.types] strike footnote listing C stdlib types

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2721,24 +2721,7 @@ or as a name of namespace scope in the global namespace.
 \rSec4[extern.types]{Types}
 
 \pnum
-For each type T from the C standard library,\footnote{These types are
-\tcode{clock_t},
-\tcode{div_t},
-\tcode{FILE},
-\tcode{fpos_t},
-\tcode{lconv},
-\tcode{ldiv_t},
-\tcode{mbstate_t},
-\tcode{ptrdiff_t},
-\tcode{sig_atomic_t},
-\tcode{size_t},
-\tcode{time_t},
-\tcode{tm},
-\tcode{va_list},
-\tcode{wctrans_t},
-\tcode{wctype_t},
-and
-\tcode{wint_t}.}
+For each type T from the C standard library,
 the types
 \tcode{::T}
 and

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2721,7 +2721,7 @@ or as a name of namespace scope in the global namespace.
 \rSec4[extern.types]{Types}
 
 \pnum
-For each type T from the C standard library,
+For each type \tcode{T} from the C standard library,
 the types
 \tcode{::T}
 and


### PR DESCRIPTION
This footnote seemed like it was trying to exhaustively list all types imported from the C stdlib, but it was incomplete. Most notably, it was missing the types from `<stdint.h>`. Removing rather than fixing since the list is of questionable value and would be likely to become stale again.