### PR TITLE
[range.join.sentinel], [range.split.view] fix typos

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -5143,7 +5143,7 @@ constexpr explicit @\exposid{sentinel}@(@\exposid{Parent}@& parent);
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \exposid{end_} with \tcode{ranges::end(\exposid{parent_}.\exposid{base_})}.
+Initializes \exposid{end_} with \tcode{ranges::end(parent.\exposid{base_})}.
 \end{itemdescr}
 
 \indexlibraryctor{join_view::sentinel}%
@@ -5618,7 +5618,7 @@ Initializes \exposid{i_} with \tcode{std::move(i)}.
 
 \indexlibrarymember{operator++}{split_view::inner-iterator}%
 \begin{itemdecl}
-constexpr @\exposid{inner-iterator}@& operator++() const;
+constexpr @\exposid{inner-iterator}@& operator++();
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
In [range.join.sentinel], we were referring to the nonexistent data member `parent_` instead of `parent`.

In [range.split.view], there was an invalid `const` qualifier in the signature for `split_view::inner-iterator::operator++()`.