### PR TITLE
[class.ctor/dtor] consteval, constructors, and destructors

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1243,7 +1243,7 @@ constructor\iref{class.qual}.
 Constructors do not have names.
 In a constructor declaration, each \grammarterm{decl-specifier} in the optional
 \grammarterm{decl-specifier-seq} shall be \tcode{friend}, \tcode{inline},
-\tcode{constexpr}, or an \grammarterm{explicit-specifier}.
+\tcode{constexpr}, \tcode{consteval}, or an \grammarterm{explicit-specifier}.
 \begin{example}
 \begin{codeblock}
 struct S {
@@ -2124,9 +2124,8 @@ of a prospective destructor declaration (if any)
 shall be
 \tcode{friend},
 \tcode{inline},
-\tcode{virtual},
-\tcode{constexpr}, or
-\tcode{consteval}.
+\tcode{virtual}, or
+\tcode{constexpr}.
 
 \pnum
 \indextext{generated destructor|see{destructor, default}}%


### PR DESCRIPTION
It seems that the specification as to where `consteval` can be applied to regarding constructors and destructors has been... swapped. Intent in [the paper](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1073r3.html) seems pretty clear to me.