### PR TITLE
Consistent cv-qualification notation

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4588,7 +4588,7 @@ are collectively called \defn{standard-layout types}.
 \pnum
 A type is a \defn{literal type} if it is:
 \begin{itemize}
-\item possibly cv-qualified \tcode{void}; or
+\item \cv{}~\tcode{void}; or
 \item a scalar type; or
 \item a reference type; or
 \item an array of literal type; or
@@ -5073,8 +5073,7 @@ even though they have the same address.
 \pnum
 \indextext{pointer|seealso{\tcode{void*}}}%
 \indextext{\idxcode{void*}!type}%
-A pointer to \cv-qualified\iref{basic.type.qualifier} or \cv-unqualified
-\tcode{void}
+A pointer to \cv{}~\tcode{void}
 can be used to point to objects of
 unknown type. Such a pointer shall be able to hold any object pointer.
 An object of type \cv{}~\tcode{void*}

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1538,9 +1538,7 @@ or
 \tcode{volatile}
 \tcode{X}
 cannot initialize an object of type
-(possibly
-cv-qualified)
-\tcode{X}.
+\cv{}~\tcode{X}.
 \begin{example}
 \begin{codeblock}
 struct X {
@@ -1556,8 +1554,8 @@ X x = cx;           // error: \tcode{X::X(X\&)} cannot copy \tcode{cx} into \tco
 \pnum
 A declaration of a constructor for a class
 \tcode{X}
-is ill-formed if its first parameter is of type (optionally cv-qualified)
-\tcode{X}
+is ill-formed if its first parameter is of type
+\cv{}~\tcode{X}
 and either there are no other parameters or else all other parameters have
 default arguments.
 A member function template is never instantiated to

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5496,8 +5496,8 @@ std::map<std::string,int> anim = { {"bear",4}, {"cassowary",2}, {"tiger",7} };
 
 \pnum
 A constructor is an \defn{initializer-list constructor} if its first parameter is
-of type \tcode{std::initializer_list<E>} or reference to possibly cv-qualified
-\tcode{std::initializer_list<E>} for some type \tcode{E}, and either there are no other
+of type \tcode{std::initializer_list<E>} or reference to
+\cv{}~\tcode{std::initializer_list<E>} for some type \tcode{E}, and either there are no other
 parameters or else all other parameters have default arguments\iref{dcl.fct.default}.
 \begin{note}
 Initializer-list constructors are favored over other constructors in

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4440,7 +4440,7 @@ expression or \grammarterm{expression-list} as its argument(s).
 \item
 Otherwise, if no constructor is viable,
 the destination type is
-a (possibly cv-qualified) aggregate class \tcode{A}, and
+an aggregate class, and
 the initializer is a parenthesized \grammarterm{expression-list},
 the object is initialized as follows.
 Let $e_1$, $\dotsc$, $e_n$ be the elements of the aggregate\iref{dcl.init.aggr}.

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1347,10 +1347,10 @@ and its base classes are considered.
 When initializing a temporary object\iref{class.mem}
 to be bound to the first parameter of a constructor
 where the parameter is of type
-``reference to possibly \cv-qualified \tcode{T}''
+``reference to \cvqual{cv2} \tcode{T}''
 and the constructor is
 called with a single argument in the context of
-direct-initialization of an object of type ``\cvqual{cv2} \tcode{T}'', explicit
+direct-initialization of an object of type ``\cvqual{cv3} \tcode{T}'', explicit
 conversion functions are also considered.
 Those that are not hidden within
 \tcode{S}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -373,7 +373,7 @@ template<C3<int>... T> struct s5;       // associates \tcode{(C3<T, int> \&\& ..
 
 \pnum
 A non-type \grammarterm{template-parameter}
-shall have one of the following (optionally cv-qualified) types:
+shall have one of the following (possibly cv-qualified) types:
 \begin{itemize}
 \item a structural type (see below),
 \item a type that contains a placeholder type\iref{dcl.spec.auto}, or


### PR DESCRIPTION
There are a lot of inconsistencies in how we specify cv-qualifiers in the text, so I went through and fixed most of the more offending examples. Most of the changes involved replacing "possibly cv-qualified" where *cv* could be used, however there were a few other things I went ahead and fixed:

- The "house style" is to say "possibly cv-qualified", but there are two occurrences of "optionally cv-qualified". One was changed to use *cv*, the other was changed to the correct phrasing.

- [[dcl.init] p 17 sub 6.2.2](http://eel.is/c++draft/dcl.init#17.6.2.2) Introduces the named type `A`, but doesn't reference it again.

- [[over.match.copy]](http://eel.is/c++draft/over.match.copy) had a type with described as "reference to possibly cv-qualified `T`". Quite obvious what's wrong there.

A couple other more unrelated things I noticed going through:

[[basic.type.qualifier] p2](http://eel.is/c++draft/basic.type.qualifier#2.sentence-2) is made redundant by [[basic.type.qualifier] p6](http://eel.is/c++draft/basic.type.qualifier#6), and [[basic.type.qualifier] p3](http://eel.is/c++draft/basic.type.qualifier#3) can probably be turned into a note.

In [[dcl.init.list] p2](http://eel.is/c++draft/dcl.init.list#2) we say that constructors take `std::initializer_list<E>` and references to possibly cv-qualified `std::initializer_list<E>` are initializer list constructors. I think *cv* is missing from the first one, but that is definitely not editorial.

In [[conv.ptr] p3](http://eel.is/c++draft/conv.ptr#3) we say "The null pointer value is converted to the null pointer value of the destination type.". The definite article does not seem to fit there, as a specific null pointer value was not established (presumably its referring to a derived to base pointer conversion where the value of the derived pointer is a null pointer value)

[[temp.deduct.partial] p5](http://eel.is/c++draft/temp.deduct.partial#5) and [[temp.deduct.partial] p7](http://eel.is/c++draft/temp.deduct.partial#7) are a little excessive for what they do. All other instances of this is done in a much less verbose fashion e.x. [[temp.deduct.call]](http://eel.is/c++draft/temp.deduct.call)

In [[over.built]](http://eel.is/c++draft/over.built), every occurance of "every cv-qualified or cv-unqualified [...] `T`" can simply be replaced with "every [...] *cv* `T`".

This is a little outside the scope of what I was looking for here, but the 3 paragraphs in [[class.init]](http://eel.is/c++draft/class.init) are just watered down versions of the wording they link to. These paragraphs could just be removed, or turned into notes, as they don't serve any normative purpose.