### PR TITLE
[range.istream.iterator] Fix typo

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2748,7 +2748,7 @@ Val& operator*() const;
 
 \pnum
 \effects
-Equivalent to: \tcode{return \exposid{parent_}->\exposid{value_};}
+Equivalent to: \tcode{return \exposid{parent_}->\exposid{object_};}
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{basic_istream_view::iterator}%


### PR DESCRIPTION
The description of basic_istream_view::iterator::operator*() refers to a
nonexistent data member value_ of basic_istream_view instead of the data
member object_.