### PR TITLE
[diff.cpp17.iterators] Added compatibility note on iterator_traits

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2407,6 +2407,19 @@ Code that depends on the return types might have different semantics in this Int
 Translation units compiled against this version of \Cpp{} may be incompatible with
 translation units compiled against \CppXVII{}, either failing to link or having undefined behavior.
 
+\rSec2[diff.cpp17.iterators]{\ref{iterators}: iterators library}
+
+\diffref{iterator.traits}
+\change
+The specialization of \tcode{iterator_traits} for \tcode{void*} and
+for function pointer types no longer contains any nested typedefs.
+\rationale
+Corrects an issue misidentifying pointer types that are not incrementable
+as iterator types.
+\effect
+A valid \CppXVII{} program that relies on the presence of the typedefs
+may fail to compile, or have different behavior.
+
 \rSec2[diff.cpp17.alg.reqs]{\ref{algorithms}: algorithms library}
 
 \diffref{algorithms.requirements}


### PR DESCRIPTION
The specialization of iterator_traits for pointers 'T*' in C++20 is now
constrained by 'is_object_v<T>' and so no longer applies to pointers
to function, or to void.