### PR TITLE
[cmp, comparisons] Move description of compare_three_way.

### DIFF
--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -947,7 +947,7 @@ strong_ordering operator<=>(const error_category& rhs) const noexcept;
 \tcode{compare_three_way()(this, \&rhs)}.
 
 \begin{note}
-\tcode{compare_three_way}\iref{cmp.object} provides a total ordering for pointers.
+\tcode{compare_three_way}\iref{comparisons.three.way} provides a total ordering for pointers.
 \end{note}
 \end{itemdescr}
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -4031,7 +4031,7 @@ namespace std {
   template<class T, class U = T>
     using compare_three_way_result_t = typename compare_three_way_result<T, U>::type;
 
-  // \ref{cmp.object}, class \tcode{compare_three_way}
+  // \ref{comparisons.three.way}, class \tcode{compare_three_way}
   struct compare_three_way;
 
   // \ref{cmp.alg}, comparison algorithms
@@ -4664,66 +4664,6 @@ when treated as an unevaluated operand\iref{expr.context},
 the member \grammarterm{typedef-name} \tcode{type}
 denotes the type \tcode{decltype(t <=> u)}.
 Otherwise, there is no member \tcode{type}.
-
-\rSec2[cmp.object]{Class \tcode{compare_three_way}}
-
-\pnum
-In this subclause, \tcode{\placeholdernc{BUILTIN-PTR-THREE-WAY}(T, U)}
-for types \tcode{T} and \tcode{U} is a boolean constant expression.
-\tcode{\placeholdernc{BUILTIN-PTR-THREE-WAY}(T, U)} is \tcode{true}
-if and only if \tcode{<=>} in the expression
-\begin{codeblock}
-declval<T>() <=> declval<U>()
-\end{codeblock}
-resolves to a built-in operator comparing pointers.
-
-\indexlibraryglobal{compare_three_way}%
-\begin{codeblock}
-struct compare_three_way {
-  template<class T, class U>
-    requires three_way_comparable_with<T, U> || @\placeholdernc{BUILTIN-PTR-THREE-WAY}@(T, U)
-  constexpr auto operator()(T&& t, U&& u) const;
-
-  using is_transparent = @\unspec@;
-};
-\end{codeblock}
-
-\pnum
-In addition to being available via inclusion of the \libheader{compare} header,
-the class \tcode{compare_three_way} is available
-when the header \libheaderref{functional} is included.
-
-\begin{itemdecl}
-template<class T, class U>
-  requires three_way_comparable_with<T, U> || @\placeholdernc{BUILTIN-PTR-THREE-WAY}@(T, U)
-constexpr auto operator()(T&& t, U&& u) const;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\expects
-If the expression \tcode{std::forward<T>(t) <=> std::forward<U>(u)} results in
-a call to a built-in operator \tcode{<=>} comparing pointers of type \tcode{P},
-the conversion sequences from both \tcode{T} and \tcode{U} to \tcode{P}
-are equality-preserving\iref{concepts.equality}.
-
-\pnum
-\effects
-\begin{itemize}
-\item
-  If the expression \tcode{std::forward<T>(t) <=> std::forward<U>(u)} results in
-  a call to a built-in operator \tcode{<=>} comparing pointers of type \tcode{P},
-  returns \tcode{strong_ordering::less}
-  if (the converted value of) \tcode{t} precedes \tcode{u}
-  in the implementation-defined strict total order
-  over pointers\iref{defns.order.ptr},
-  \tcode{strong_ordering::greater}
-  if \tcode{u} precedes \tcode{t}, and
-  otherwise \tcode{strong_ordering::equal}.
-\item
-  Otherwise, equivalent to: \tcode{return std::forward<T>(t) <=> std::forward<U>(u);}
-\end{itemize}
-\end{itemdescr}
 
 \rSec2[cmp.alg]{Comparison algorithms}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -13510,6 +13510,9 @@ namespace std {
   template<> struct greater_equal<void>;
   template<> struct less_equal<void>;
 
+  // \ref{comparisons.three.way}, class \tcode{compare_three_way}
+  struct compare_three_way;
+
   // \ref{logical.operations}, logical operations
   template<class T = void> struct logical_and;
   template<class T = void> struct logical_or;
@@ -14537,6 +14540,61 @@ template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
 \pnum
 \returns
 \tcode{std::forward<T>(t) <= std::forward<U>(u)}.
+\end{itemdescr}
+
+\rSec3[comparisons.three.way]{Class \tcode{compare_three_way}}
+
+\pnum
+In this subclause, \tcode{\placeholdernc{BUILTIN-PTR-THREE-WAY}(T, U)}
+for types \tcode{T} and \tcode{U} is a boolean constant expression.
+\tcode{\placeholdernc{BUILTIN-PTR-THREE-WAY}(T, U)} is \tcode{true}
+if and only if \tcode{<=>} in the expression
+\begin{codeblock}
+declval<T>() <=> declval<U>()
+\end{codeblock}
+resolves to a built-in operator comparing pointers.
+
+\indexlibraryglobal{compare_three_way}%
+\begin{codeblock}
+struct compare_three_way {
+  template<class T, class U>
+    requires three_way_comparable_with<T, U> || @\placeholdernc{BUILTIN-PTR-THREE-WAY}@(T, U)
+  constexpr auto operator()(T&& t, U&& u) const;
+
+  using is_transparent = @\unspec@;
+};
+\end{codeblock}
+
+\begin{itemdecl}
+template<class T, class U>
+  requires three_way_comparable_with<T, U> || @\placeholdernc{BUILTIN-PTR-THREE-WAY}@(T, U)
+constexpr auto operator()(T&& t, U&& u) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+If the expression \tcode{std::forward<T>(t) <=> std::forward<U>(u)} results in
+a call to a built-in operator \tcode{<=>} comparing pointers of type \tcode{P},
+the conversion sequences from both \tcode{T} and \tcode{U} to \tcode{P}
+are equality-preserving\iref{concepts.equality}.
+
+\pnum
+\effects
+\begin{itemize}
+\item
+  If the expression \tcode{std::forward<T>(t) <=> std::forward<U>(u)} results in
+  a call to a built-in operator \tcode{<=>} comparing pointers of type \tcode{P},
+  returns \tcode{strong_ordering::less}
+  if (the converted value of) \tcode{t} precedes \tcode{u}
+  in the implementation-defined strict total order
+  over pointers\iref{defns.order.ptr},
+  \tcode{strong_ordering::greater}
+  if \tcode{u} precedes \tcode{t}, and
+  otherwise \tcode{strong_ordering::equal}.
+\item
+  Otherwise, equivalent to: \tcode{return std::forward<T>(t) <=> std::forward<U>(u);}
+\end{itemize}
 \end{itemdescr}
 
 \rSec2[range.cmp]{Concept-constrained comparisons}


### PR DESCRIPTION
Moves the definition and specification of class compare_three_way from
[cmp, 17.11] to [comparisons, 20.14.7].

This is a partial response to NB GB 175 (C++20 CD).

Fixes cplusplus/nbballot#173.