### PR TITLE
Fix definition of has-tuple-element

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -6103,7 +6103,7 @@ namespace std::ranges {
       typename tuple_size<T>::type;
       requires N < tuple_size_v<T>;
       typename tuple_element_t<N, T>;
-      { get<N>(t) } -> const tuple_element_t<N, T>&;
+      { get<N>(t) } -> convertible_to<const tuple_element_t<N, T>&>;
     };
 
 


### PR DESCRIPTION
It is the only example in the WD that uses a removed feature of specifying a type of the expression.