### PR TITLE
[class.access] Eliminate the friend case for protected member access from derived class

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -4472,8 +4472,8 @@ of the class in which it is declared.
 \indextext{access control!\idxcode{protected}}%
 protected;
 that is, its name can be used only by members and friends
-of the class in which it is declared, by classes derived from that class, and by their
-friends (see~\ref{class.protected}).
+of the class in which it is declared, and members of classes derived from that class
+(see~\ref{class.protected}).
 \item
 \indextext{access control!\idxcode{public}}%
 public;


### PR DESCRIPTION
This PR will fix an inconsistency in the specification described here:
https://stackoverflow.com/q/60178872/2326961