### PR TITLE
[conv.rank] Change "size" to "width" in conversion rank relation

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5199,7 +5199,7 @@ char} (if \tcode{char} is signed) shall have the same rank, even if they have
 the same representation.
 
 \item The rank of a signed integer type shall be greater than the rank
-of any signed integer type with a smaller size.
+of any signed integer type with a smaller width.
 
 \item The rank of \tcode{long long int} shall be greater
 than the rank of \tcode{long int}, which shall be greater than

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4651,7 +4651,7 @@ where \placeholder{N} is called the \defn{width} of the type.
 \indextext{integral type!implementation-defined \tcode{sizeof}}%
 \begin{note}
 Plain \tcode{int}s are intended to have
-the natural size suggested by the architecture of the execution environment;
+the natural width suggested by the architecture of the execution environment;
 the other signed integer types are provided to meet special needs.
 \end{note}
 
@@ -5211,7 +5211,7 @@ the rank of \tcode{int}, which shall be greater than the rank of
 corresponding signed integer type.
 
 \item The rank of any standard integer type shall be greater than the
-rank of any extended integer type with the same size.
+rank of any extended integer type with the same width.
 
 \item The rank of \tcode{char} shall equal the rank of \tcode{signed char}
 and \tcode{unsigned char}.
@@ -5228,7 +5228,7 @@ The ranks of \tcode{char8_t}, \tcode{char16_t}, \tcode{char32_t}, and
 types\iref{basic.fundamental}.
 
 \item The rank of any extended signed integer type relative to another
-extended signed integer type with the same size is \impldef{rank of extended signed
+extended signed integer type with the same width is \impldef{rank of extended signed
 integer type}, but still subject to the other rules for determining the integer
 conversion rank.
 


### PR DESCRIPTION
The rules about integer range limits imply (in a roundabout fashion)
that increasing rank implies increasing width, so this is a
clarification that makes this implication explicit.