### PR TITLE
CWG Poll 5: P1957R2 Converting from T* to bool should be considered narrowing

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2188,6 +2188,19 @@ struct Y {              // not an aggregate; previously an aggregate
 Y y{X{}};               // copy constructor call; previously aggregate-initialization
 \end{codeblock}
 
+\diffref{dcl.init.list}
+\change
+Boolean conversion from a pointer or pointer-to-member type
+is now a narrowing conversion.
+\rationale
+Catches bugs.
+\effect
+Valid \CppXVII{} code may fail to compile
+in this International Standard. For example:
+\begin{codeblock}
+bool y[] = { "bc" };    // ill-formed; previously well-formed
+\end{codeblock}
+
 \rSec2[diff.cpp17.class]{\ref{class}: classes}
 
 \diffref{class.ctor,class.conv.fct}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5825,7 +5825,9 @@ original type, or
 
 \item from an integer type or unscoped enumeration type to an integer type that cannot
 represent all the values of the original type, except where the source is a constant
-expression whose value after integral promotions will fit into the target type.
+expression whose value after integral promotions will fit into the target type, or
+
+\item from a pointer type or a pointer-to-member type to \tcode{bool}.
 \end{itemize}
 
 \begin{note}
@@ -5849,6 +5851,7 @@ signed int si1 =
 int ii = {2.0};                 // error: narrows
 float f1 { x };                 // error: might narrow
 float f2 { 7 };                 // OK: 7 can be exactly represented as a \tcode{float}
+bool b = {"meow"};              // error: narrows
 int f(int);
 int a[] = { 2, f(2), f(2.0) };  // OK: the \tcode{double}-to-\tcode{int} conversion is not at the top level
 \end{codeblock}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -3932,8 +3932,7 @@ Let $\tcode{T}_j$ be a type that is determined as follows:
 build an imaginary function \tcode{\placeholdernc{FUN}($\tcode{T}_i$)}
 for each alternative type $\tcode{T}_i$
 for which \tcode{$\tcode{T}_i$ x[] =} \tcode{\{std::forward<T>(t)\};}
-is well-formed for some invented variable \tcode{x} and,
-if $\tcode{T}_i$ is \cv~\tcode{bool}, \tcode{remove_cvref_t<T>} is \tcode{bool}.
+is well-formed for some invented variable \tcode{x}.
 The overload \tcode{\placeholdernc{FUN}($\tcode{T}_j$)} selected by overload
 resolution for the expression \tcode{\placeholdernc{FUN}(std::forward<T>(\brk{}t))} defines
 the alternative $\tcode{T}_j$ which is the type of the contained value after
@@ -4245,8 +4244,7 @@ Let $\tcode{T}_j$ be a type that is determined as follows:
 build an imaginary function \tcode{\placeholdernc{FUN}($\tcode{T}_i$)}
 for each alternative type $\tcode{T}_i$
 for which \tcode{$\tcode{T}_i$ x[] =} \tcode{\{std::forward<T>(t)\};}
-is well-formed for some invented variable \tcode{x} and,
-if $\tcode{T}_i$ is \cv~\tcode{bool}, \tcode{remove_cvref_t<T>} is \tcode{bool}.
+is well-formed for some invented variable \tcode{x}.
 The overload \tcode{\placeholdernc{FUN}($\tcode{T}_j$)} selected by overload
 resolution for the expression \tcode{\placeholdernc{FUN}(std::forward<T>(\brk{}t))} defines
 the alternative $\tcode{T}_j$ which is the type of the contained value after


### PR DESCRIPTION
Also fixes NB US 212 (C++20 CD) and LWG3228.

Fixes #3689.
Fixes cplusplus/nbballot#209.
Fixes cplusplus/papers#692.