### PR TITLE
[atomic] Minor corrections to atomic index

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -1665,6 +1665,8 @@ This results in undefined behavior.
 \indexlibrarymember{is_always_lock_free}{atomic<T*>}%
 \indexlibrarymember{is_always_lock_free}{atomic<\placeholder{integral}>}%
 \indexlibrarymember{is_always_lock_free}{atomic<\placeholder{floating-point}>}%
+\indexlibrarymember{is_always_lock_free}{atomic<shared_ptr<T>>}%
+\indexlibrarymember{is_always_lock_free}{atomic<weak_ptr<T>>}%
 \begin{itemdecl}
 static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic} type's operations are always lock free}@;
 \end{itemdecl}
@@ -1684,6 +1686,8 @@ the corresponding \tcode{ATOMIC_..._LOCK_FREE} macro, if defined.
 \indexlibrarymember{is_lock_free}{atomic<T*>}%
 \indexlibrarymember{is_lock_free}{atomic<\placeholder{integral}>}%
 \indexlibrarymember{is_lock_free}{atomic<\placeholder{floating-point}>}%
+\indexlibrarymember{is_lock_free}{atomic<shared_ptr<T>>}%
+\indexlibrarymember{is_lock_free}{atomic<weak_ptr<T>>}%
 \begin{itemdecl}
 bool is_lock_free() const volatile noexcept;
 bool is_lock_free() const noexcept;
@@ -2014,7 +2018,7 @@ Repeatedly performs the following steps, in order:
 This function is an atomic waiting operation\iref{atomics.wait}.
 \end{itemdescr}
 
-\indexlibrarymember{notify_one}{atomic<T>}%
+\indexlibrarymember{notify_one}{atomic}%
 \indexlibrarymember{notify_one}{atomic<T*>}%
 \indexlibrarymember{notify_one}{atomic<\placeholder{integral}>}%
 \indexlibrarymember{notify_one}{atomic<\placeholder{floating-point}>}%
@@ -2035,7 +2039,7 @@ if any such atomic waiting operations exist.
 This function is an atomic notifying operation\iref{atomics.wait}.
 \end{itemdescr}
 
-\indexlibrarymember{notify_all}{atomic<T>}%
+\indexlibrarymember{notify_all}{atomic}%
 \indexlibrarymember{notify_all}{atomic<T*>}%
 \indexlibrarymember{notify_all}{atomic<\placeholder{integral}>}%
 \indexlibrarymember{notify_all}{atomic<\placeholder{floating-point}>}%


### PR DESCRIPTION
The index for the primary atomic template was split across
two entries, atomic and atomic<T>.  Reconciled into one.

A couple of operations for atomic smart pointers are
specificed in the primary template, but were missing the
cross-reference into that specification, which is supplied
in the same way for all the other atomic specializations.