### PR TITLE
[dcl.meaning] General wording cleanup

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2519,25 +2519,15 @@ the type specified for each \grammarterm{declarator-id} depends on
 both the \grammarterm{decl-specifier-seq} and its \grammarterm{declarator}.
 
 \pnum
-Thus, a declaration of a particular identifier has the form
-\tcode{T} \tcode{D} where \tcode{T}
-is of the form \opt{\grammarterm{attribute-specifier-seq}}
-\grammarterm{decl-specifier-seq}
-and \tcode{D} is a declarator.
-Following is a recursive procedure for determining
-the type specified for the contained
-\grammarterm{declarator-id}
-by such a declaration.
+Thus, a declaration of a particular \grammarterm{declarator-id} has the form
+\opt{\grammarterm{attribute-specifier-seq}} \grammarterm{decl-specifier-seq}
+\grammarterm{declarator}. The optional \grammarterm{attribute-specifier-seq}
+appertains to the declared entity. Following is a recursive procedure for
+determining the type of the \grammarterm{declarator-id} and the entity which it declares.
 
 \pnum
-First, the type \tcode{T} is determined.
-In a declaration of the form
-\begin{ncsimplebnf}
-\opt{attribute-specifier-seq} decl-specifier-seq \terminal{D}
-\end{ncsimplebnf}
-the \grammarterm{decl-specifier-seq} determines the type \tcode{T}.
-The optional \grammarterm{attribute-specifier-seq} appertains
-to the entity declared by \tcode{D}.
+First, a type \tcode{T} is determined from
+the \grammarterm{decl-specifier-seq}.
 \begin{example}
 In the declaration
 \begin{codeblock}
@@ -2551,27 +2541,20 @@ determine the type
 \end{example}
 
 \pnum
-In a declaration \tcode{T} \tcode{D}
-where \tcode{D} has the form
+A \grammarterm{declarator} of the form
 \begin{ncsimplebnf}
 declarator-id \opt{attribute-specifier-seq}
 \end{ncsimplebnf}
-the type of the \grammarterm{declarator-id}
-in \tcode{D} is ``\tcode{T}''.
+determines the type of its
+\grammarterm{declarator-id} to be ``\tcode{T}''.
 The optional \grammarterm{attribute-specifier-seq}
-appertains to the entity declared by \tcode{D}.
+appertains to the declared entity.
 
 \pnum
-In a declaration
-\tcode{T} \tcode{D} where
-\tcode{D} has the form
-\begin{ncsimplebnf}
-\terminal{(} \terminal{D1} \terminal{)}
-\end{ncsimplebnf}
-the type of the \grammarterm{declarator-id}
-in \tcode{D} is the same as that of the
-contained \grammarterm{declarator-id}
-in the declaration \tcode{T} \tcode{D1}.
+A \grammarterm{declarator} of the form \tcode{(D)}
+determines the type of its \grammarterm{declarator-id}
+to be that of the \grammarterm{declarator-id}
+in the declaration \tcode{T} \tcode{D}.
 \indextext{declaration!parentheses in}%
 \begin{note}
 Parentheses do not alter the type of the embedded
@@ -2583,34 +2566,20 @@ but they can alter the binding of complex declarators.
 \indextext{declarator!pointer}%
 
 \pnum
-In a declaration
-\tcode{T}
-\tcode{D}
-where
-\tcode{D}
-has the form
+A \grammarterm{declarator} of the form
 \begin{ncsimplebnf}
-\terminal{*} \opt{attribute-specifier-seq} \opt{cv-qualifier-seq} \terminal{D1}
+\terminal{*} \opt{attribute-specifier-seq} \opt{cv-qualifier-seq} \terminal{D}
 \end{ncsimplebnf}
-and the type of the contained
-\grammarterm{declarator-id}
-in the declaration
-\tcode{T}
-\tcode{D1}
-is ``\placeholder{derived-declarator-type-list}
-\tcode{T}'',
-then the type of the
-\grammarterm{declarator-id}
-in
-\tcode{D}
-is ``\placeholder{derived-declarator-type-list} \grammarterm{cv-qualifier-seq} pointer to
-\tcode{T}''.
+determines the type of its \grammarterm{declarator-id} to be
+that of the \grammarterm{declarator-id} in the declaration
+\tcode{U} \tcode{D}, where \tcode{U} is a \grammarterm{type-specifier} denoting
+the type ``\grammarterm{cv-qualifier-seq} pointer to \tcode{T}''.
 \indextext{declaration!pointer}%
 \indextext{declaration!constant pointer}%
-The
-\grammarterm{cv-qualifier}{s}
-apply to the pointer and not to the object pointed to.
-Similarly, the optional \grammarterm{attribute-specifier-seq}\iref{dcl.attr.grammar} appertains to the pointer and not to the object pointed to.
+The \grammarterm{cv-qualifier}{s} apply to the pointer
+and not to the object pointed to.
+Similarly, the optional \grammarterm{attribute-specifier-seq}\iref{dcl.attr.grammar}
+appertains to the pointer and not to the object pointed to.
 
 \pnum
 \begin{example}
@@ -2692,29 +2661,15 @@ a pointer can never point to a bit-field.
 \indextext{declarator!reference}
 
 \pnum
-In a declaration
-\tcode{T}
-\tcode{D}
-where
-\tcode{D}
-has either of the forms
+A \grammarterm{declarator} having either of the forms
 \begin{ncsimplebnf}
-\terminal{\&} \opt{attribute-specifier-seq} \terminal{D1}\br
-\terminal{\&\&} \opt{attribute-specifier-seq} \terminal{D1}
+\terminal{\&} \opt{attribute-specifier-seq} \terminal{D}\br
+\terminal{\&\&} \opt{attribute-specifier-seq} \terminal{D}
 \end{ncsimplebnf}
-and the type of the contained
-\grammarterm{declarator-id}
-in the declaration
-\tcode{T}
-\tcode{D1}
-is ``\placeholder{derived-declarator-type-list}
-\tcode{T}'',
-then the type of the
-\grammarterm{declarator-id}
-in
-\tcode{D}
-is ``\placeholder{derived-declarator-type-list} reference to
-\tcode{T}''.
+determines the type of its \grammarterm{declarator-id} to be
+that of the \grammarterm{declarator-id} in the declaration
+\tcode{U} \tcode{D}, where \tcode{U} is a \grammarterm{type-specifier}
+denoting the type ``reference to \tcode{T}''.
 The optional \grammarterm{attribute-specifier-seq} appertains to the reference type.
 Cv-qualified references are ill-formed except when the cv-qualifiers
 are introduced through the use of a
@@ -2883,34 +2838,18 @@ see~\ref{dcl.fct}.
 \indextext{pointer to member}%
 
 \pnum
-In a declaration
-\tcode{T}
-\tcode{D}
-where
-\tcode{D}
-has the form
+A \grammarterm{declarator} of the form
 \begin{ncsimplebnf}
-nested-name-specifier \terminal{*} \opt{attribute-specifier-seq} \opt{cv-qualifier-seq} \terminal{D1}
+nested-name-specifier \terminal{*} \opt{attribute-specifier-seq} \opt{cv-qualifier-seq} \terminal{D}
 \end{ncsimplebnf}
-and the
-\grammarterm{nested-name-specifier}
-denotes a class,
-and the type of the contained
-\grammarterm{declarator-id}
-in the declaration
-\tcode{T}
-\tcode{D1}
-is ``\placeholder{derived-declarator-type-list}
-\tcode{T}'',
-then the type of the
-\grammarterm{declarator-id}
-in
-\tcode{D}
-is ``\placeholder{derived-declarator-type-list} \grammarterm{cv-qualifier-seq} pointer to member of class
-\grammarterm{nested-name-specifier} of type
-\tcode{T}''.
-The optional \grammarterm{attribute-specifier-seq}\iref{dcl.attr.grammar} appertains to the
-pointer-to-member.
+where the \grammarterm{nested-name-specifier} denotes a class type
+determines the type of its \grammarterm{declarator-id} to be
+that of the \grammarterm{declarator-id} in the declaration
+\tcode{U} \tcode{D}, where \tcode{U} is a \grammarterm{type-specifier}
+denoting the type ``\grammarterm{cv-qualifier-seq} pointer to member of class
+\grammarterm{nested-name-specifier} of type \tcode{T}''.
+The optional \grammarterm{attribute-specifier-seq}\iref{dcl.attr.grammar}
+appertains to the pointer-to-member.
 
 \pnum
 \begin{example}
@@ -2992,42 +2931,38 @@ There is no ``reference-to-member'' type in \Cpp{}.
 \indextext{declarator!array}
 
 \pnum
-In a declaration \tcode{T} \tcode{D} where \tcode{D} has the form
+A \grammarterm{declarator} of the form
 \begin{ncsimplebnf}
-\terminal{D1} \terminal{[} \opt{constant-expression} \terminal{]} \opt{attribute-specifier-seq}
+\terminal{D} \terminal{[} constant-expression \terminal{]} \opt{attribute-specifier-seq}
 \end{ncsimplebnf}
-and the type of the contained \grammarterm{declarator-id}
-in the declaration \tcode{T} \tcode{D1}
-is ``\placeholder{derived-declarator-type-list} \tcode{T}'',
-the type of the \grammarterm{declarator-id} in \tcode{D} is
-``\placeholder{derived-declarator-type-list} array of \tcode{N} \tcode{T}''.
-The \grammarterm{constant-expression}
-shall be a converted constant expression of type \tcode{std::size_t}\iref{expr.const}.
+where the \grammarterm{constant-expression} is a converted constant expression
+of type \tcode{std::size_t}\iref{expr.const}
+determines the type of its \grammarterm{declarator-id} to be
+that of the \grammarterm{declarator-id} in the declaration
+\tcode{U} \tcode{D}, where \tcode{U} is a \grammarterm{type-specifier}
+denoting the type ``array of \tcode{N} \tcode{T}'' and \tcode{N} is the
+value of the \grammarterm{constant-expression}.
 \indextext{bound, of array}%
-Its value \tcode{N} specifies the \defnx{array bound}{array!bound},
-i.e., the number of elements in the array;
-\tcode{N} shall be greater than zero.
-
-\pnum
-In a declaration \tcode{T} \tcode{D} where \tcode{D} has the form
-\begin{ncsimplebnf}
-\terminal{D1 [ ]} \opt{attribute-specifier-seq}
-\end{ncsimplebnf}
-and the type of the contained \grammarterm{declarator-id}
-in the declaration \tcode{T} \tcode{D1}
-is ``\placeholder{derived-declarator-type-list} \tcode{T}'',
-the type of the \grammarterm{declarator-id} in \tcode{D} is
-``\placeholder{derived-declarator-type-list} array of unknown bound of \tcode{T}'', except as specified below.
-
-\pnum
-\indextext{declaration!array}%
-A type of the form ``array of \tcode{N} \tcode{U}'' or
-``array of unknown bound of \tcode{U}'' is an \defn{array type}.
+The \defnx{array bound}{array!bound} \tcode{N} shall be greater than zero.
 The optional \grammarterm{attribute-specifier-seq}
 appertains to the array type.
 
 \pnum
-\tcode{U} is called the array \defn{element type};
+A \grammarterm{declarator} of the form
+\begin{ncsimplebnf}
+\terminal{D [ ]} \opt{attribute-specifier-seq}
+\end{ncsimplebnf}
+determines the type of its \grammarterm{declarator-id} to be
+that of the \grammarterm{declarator-id} in the declaration
+\tcode{U} \tcode{D}, where \tcode{U} is a \grammarterm{type-specifier}
+denoting the type ``array of unknown bound of \tcode{T}'', except as specified below.
+The optional \grammarterm{attribute-specifier-seq} appertains to the array type.
+
+\pnum
+\indextext{declaration!array}%
+A type of the form ``array of \tcode{N} \tcode{E}'' or
+``array of unknown bound of \tcode{E}'' is an \defn{array type}.
+\tcode{E} is called the array \defn{element type};
 this type shall not be
 a placeholder type\iref{dcl.spec.auto},
 a reference type,
@@ -3053,10 +2988,10 @@ an array of pointers to \tcode{float} numbers.
 
 \pnum
 Any type of the form
-``\grammarterm{cv-qualifier-seq} array of \tcode{N} \tcode{U}''
+``\grammarterm{cv-qualifier-seq} array of \tcode{N} \tcode{E}''
 is adjusted to
-``array of \tcode{N} \grammarterm{cv-qualifier-seq} \tcode{U}'',
-and similarly for ``array of unknown bound of \tcode{U}''.
+``array of \tcode{N} \grammarterm{cv-qualifier-seq} \tcode{E}'',
+and similarly for ``array of unknown bound of \tcode{E}''.
 \begin{example}
 \begin{codeblock}
 typedef int A[5], AA[2][3];
@@ -3065,14 +3000,14 @@ typedef const AA CAA;           // type is ``array of 2 array of 3 \tcode{const 
 \end{codeblock}
 \end{example}
 \begin{note}
-An ``array of \tcode{N} \grammarterm{cv-qualifier-seq} \tcode{U}''
+An ``array of \tcode{N} \grammarterm{cv-qualifier-seq} \tcode{E}''
 has cv-qualified type; see~\ref{basic.type.qualifier}.
 \end{note}
 
 \pnum
-An object of type ``array of \tcode{N} \tcode{U}'' contains
+An object of type ``array of \tcode{N} \tcode{E}'' contains
 a contiguously allocated non-empty set
-of \tcode{N} subobjects of type \tcode{U},
+of \tcode{N} subobjects of type \tcode{E},
 known as the \defnx{elements}{array!element} of the array,
 and numbered \tcode{0} to \tcode{N-1}.
 
@@ -3088,7 +3023,7 @@ and the declarator is followed by an initializer
 In these cases, the array bound is calculated
 from the number of initial elements (say, \tcode{N})
 supplied\iref{dcl.init.aggr},
-and the type of the array is ``array of \tcode{N} \tcode{U}''.
+and the type of the array is ``array of \tcode{N} \tcode{E}''.
 
 \pnum
 Furthermore, if there is a preceding declaration of the entity in the same
@@ -3194,34 +3129,17 @@ For the operator's built-in meaning, see \ref{expr.sub}.
 
 \pnum
 \indextext{type!function}%
-In a declaration
-\tcode{T}
-\tcode{D}
-where
-\tcode{D}
-has the form
+A \grammarterm{declarator} of the form
 \begin{ncsimplebnf}
-\terminal{D1} \terminal{(} parameter-declaration-clause \terminal{)} \opt{cv-qualifier-seq}\br
+\terminal{D} \terminal{(} parameter-declaration-clause \terminal{)} \opt{cv-qualifier-seq}\br
 \bnfindent\opt{ref-qualifier} \opt{noexcept-specifier} \opt{attribute-specifier-seq}
 \end{ncsimplebnf}
-and the type of the contained
-\grammarterm{declarator-id}
-in the declaration
-\tcode{T}
-\tcode{D1}
-is
-``\placeholder{derived-declarator-type-list}
-\tcode{T}'',
-the type of the
-\grammarterm{declarator-id}
-in
-\tcode{D}
-is
-``\placeholder{derived-declarator-type-list}
-\opt{\tcode{noexcept}}
-function of parameter-type-list
+determines the type of its \grammarterm{declarator-id} to be
+that of the \grammarterm{declarator-id} in the declaration
+\tcode{U} \tcode{D}, where \tcode{U} is a \grammarterm{type-specifier}
+denoting the type ``\opt{\tcode{noexcept}} function of parameter-type-list
 \opt{\grammarterm{cv-qualifier-seq}} \opt{\grammarterm{ref-qualifier}}
-returning \tcode{T}'', where
+returning \tcode{T}'', and
 \begin{itemize}
 \item
 the parameter-type-list is derived from
@@ -3234,40 +3152,24 @@ The optional \grammarterm{attribute-specifier-seq}
 appertains to the function type.
 
 \pnum
-In a declaration
-\tcode{T}
-\tcode{D}
-where
-\tcode{D}
-has the form
+A \grammarterm{declarator} of the form
 \begin{ncsimplebnf}
-\terminal{D1} \terminal{(} parameter-declaration-clause \terminal{)} \opt{cv-qualifier-seq}\br
+\terminal{D} \terminal{(} parameter-declaration-clause \terminal{)} \opt{cv-qualifier-seq}\br
 \bnfindent\opt{ref-qualifier} \opt{noexcept-specifier} \opt{attribute-specifier-seq} trailing-return-type
 \end{ncsimplebnf}
-and the type of the contained
-\grammarterm{declarator-id}
-in the declaration
-\tcode{T}
-\tcode{D1}
-is
-``\placeholder{derived-declarator-type-list} \tcode{T}'',
-\tcode{T} shall be the single \grammarterm{type-specifier} \tcode{auto}.
-The type of the
-\grammarterm{declarator-id}
-in
-\tcode{D}
-is
-``\placeholder{derived-declarator-type-list}
-\opt{\tcode{noexcept}}
-function of parameter-type-list
+where \tcode{T} has the form ``\placeholder{type-list} \tcode{auto}'',
+the type of its \grammarterm{declarator-id} is determined to be
+that of the \grammarterm{declarator-id} in the declaration
+\tcode{U} \tcode{D}, where \tcode{U} is a \grammarterm{type-specifier}
+denoting the type ``\opt{\tcode{noexcept}} function of parameter-type-list
 \opt{\grammarterm{cv-qualifier-seq}} \opt{\grammarterm{ref-qualifier}}
-returning \tcode{U}'', where
+returning \tcode{V}'', and
 \begin{itemize}
 \item
 the parameter-type-list is derived from
 the \grammarterm{parameter-declaration-clause} as described below,
 \item
-\tcode{U} is the type specified by the \grammarterm{trailing-return-type}, and
+\tcode{V} is the type specified by the \grammarterm{trailing-return-type}, and
 \item
 the optional \tcode{noexcept} is present if and only if
 the exception specification is non-throwing.

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2520,37 +2520,24 @@ both the \grammarterm{decl-specifier-seq} and its \grammarterm{declarator}.
 
 \pnum
 Thus, a declaration of a particular identifier has the form
-\tcode{T}
-\tcode{D}
-where
-\tcode{T}
+\tcode{T} \tcode{D} where \tcode{T}
 is of the form \opt{\grammarterm{attribute-specifier-seq}}
 \grammarterm{decl-specifier-seq}
-and
-\tcode{D}
-is a declarator.
+and \tcode{D} is a declarator.
 Following is a recursive procedure for determining
 the type specified for the contained
 \grammarterm{declarator-id}
 by such a declaration.
 
 \pnum
-First, the type
-\tcode{T} is determined.
-In a declaration
-of the form
+First, the type \tcode{T} is determined.
+In a declaration of the form
 \begin{ncsimplebnf}
 \opt{attribute-specifier-seq} decl-specifier-seq \terminal{D}
 \end{ncsimplebnf}
-the
-\grammarterm{decl-specifier-seq}
-determines the type
-\tcode{T}.
-The optional
-\grammarterm{attribute-specifier-seq}
-appertains to the entity
-declared by
-\tcode{D}.
+the \grammarterm{decl-specifier-seq} determines the type \tcode{T}.
+The optional \grammarterm{attribute-specifier-seq} appertains
+to the entity declared by \tcode{D}.
 \begin{example}
 In the declaration
 \begin{codeblock}
@@ -2564,45 +2551,27 @@ determine the type
 \end{example}
 
 \pnum
-In a declaration
-\tcode{T}
-\tcode{D}
-where
-\tcode{D}
-has the form
+In a declaration \tcode{T} \tcode{D}
+where \tcode{D} has the form
 \begin{ncsimplebnf}
 declarator-id \opt{attribute-specifier-seq}
 \end{ncsimplebnf}
-the type of the
-\grammarterm{declarator-id}
-in
-\tcode{D}
-is ``\tcode{T}''.
-The optional
-\grammarterm{attribute-specifier-seq}
-appertains to the entity declared by
-\tcode{D}.
+the type of the \grammarterm{declarator-id}
+in \tcode{D} is ``\tcode{T}''.
+The optional \grammarterm{attribute-specifier-seq}
+appertains to the entity declared by \tcode{D}.
 
 \pnum
 In a declaration
-\tcode{T}
-\tcode{D}
-where
-\tcode{D}
-has the form
+\tcode{T} \tcode{D} where
+\tcode{D} has the form
 \begin{ncsimplebnf}
 \terminal{(} \terminal{D1} \terminal{)}
 \end{ncsimplebnf}
-the type of the
-\grammarterm{declarator-id}
-in
-\tcode{D}
-is the same as that of the
-contained
-\grammarterm{declarator-id}
-in the declaration
-\tcode{T}
-\tcode{D1}.
+the type of the \grammarterm{declarator-id}
+in \tcode{D} is the same as that of the
+contained \grammarterm{declarator-id}
+in the declaration \tcode{T} \tcode{D1}.
 \indextext{declaration!parentheses in}%
 \begin{note}
 Parentheses do not alter the type of the embedded

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2498,7 +2498,6 @@ scope resolution operator, the
 \grammarterm{declarator-id}
 refers to a name declared in the global namespace scope.
 \end{note}
-The optional \grammarterm{attribute-specifier-seq} following a \grammarterm{declarator-id} appertains to the entity that is declared.
 
 \pnum
 A
@@ -2521,9 +2520,8 @@ both the \grammarterm{decl-specifier-seq} and its \grammarterm{declarator}.
 
 \pnum
 Thus, a declaration of a particular identifier has the form
-\begin{codeblock}
-T D
-\end{codeblock}
+\tcode{T}
+\tcode{D}
 where
 \tcode{T}
 is of the form \opt{\grammarterm{attribute-specifier-seq}}
@@ -2537,18 +2535,22 @@ the type specified for the contained
 by such a declaration.
 
 \pnum
-First, the
-\grammarterm{decl-specifier-seq}
-determines a type.
+First, the type
+\tcode{T} is determined.
 In a declaration
-\begin{codeblock}
-T D
-\end{codeblock}
+of the form
+\begin{ncsimplebnf}
+\opt{attribute-specifier-seq} decl-specifier-seq \terminal{D}
+\end{ncsimplebnf}
 the
 \grammarterm{decl-specifier-seq}
-\tcode{T}
 determines the type
 \tcode{T}.
+The optional
+\grammarterm{attribute-specifier-seq}
+appertains to the entity
+declared by
+\tcode{D}.
 \begin{example}
 In the declaration
 \begin{codeblock}
@@ -2563,13 +2565,23 @@ determine the type
 
 \pnum
 In a declaration
-\opt{\grammarterm{attribute-specifier-seq}}
 \tcode{T}
 \tcode{D}
 where
 \tcode{D}
-is an unadorned identifier the type of this identifier is
-``\tcode{T}''.
+has the form
+\begin{ncsimplebnf}
+declarator-id \opt{attribute-specifier-seq}
+\end{ncsimplebnf}
+the type of the
+\grammarterm{declarator-id}
+in
+\tcode{D}
+is ``\tcode{T}''.
+The optional
+\grammarterm{attribute-specifier-seq}
+appertains to the entity declared by
+\tcode{D}.
 
 \pnum
 In a declaration
@@ -2581,18 +2593,22 @@ has the form
 \begin{ncsimplebnf}
 \terminal{(} \terminal{D1} \terminal{)}
 \end{ncsimplebnf}
-the type of the contained
+the type of the
 \grammarterm{declarator-id}
-is the same as that of the contained
+in
+\tcode{D}
+is the same as that of the
+contained
 \grammarterm{declarator-id}
 in the declaration
-\begin{codeblock}
-T D1
-\end{codeblock}
+\tcode{T}
+\tcode{D1}.
 \indextext{declaration!parentheses in}%
+\begin{note}
 Parentheses do not alter the type of the embedded
 \grammarterm{declarator-id},
 but they can alter the binding of complex declarators.
+\end{note}
 
 \rSec3[dcl.ptr]{Pointers}%
 \indextext{declarator!pointer}%
@@ -2607,12 +2623,16 @@ has the form
 \begin{ncsimplebnf}
 \terminal{*} \opt{attribute-specifier-seq} \opt{cv-qualifier-seq} \terminal{D1}
 \end{ncsimplebnf}
-and the type of the identifier in the declaration
+and the type of the contained
+\grammarterm{declarator-id}
+in the declaration
 \tcode{T}
 \tcode{D1}
 is ``\placeholder{derived-declarator-type-list}
 \tcode{T}'',
-then the type of the identifier of
+then the type of the
+\grammarterm{declarator-id}
+in
 \tcode{D}
 is ``\placeholder{derived-declarator-type-list} \grammarterm{cv-qualifier-seq} pointer to
 \tcode{T}''.
@@ -2713,12 +2733,16 @@ has either of the forms
 \terminal{\&} \opt{attribute-specifier-seq} \terminal{D1}\br
 \terminal{\&\&} \opt{attribute-specifier-seq} \terminal{D1}
 \end{ncsimplebnf}
-and the type of the identifier in the declaration
+and the type of the contained
+\grammarterm{declarator-id}
+in the declaration
 \tcode{T}
 \tcode{D1}
 is ``\placeholder{derived-declarator-type-list}
 \tcode{T}'',
-then the type of the identifier of
+then the type of the
+\grammarterm{declarator-id}
+in
 \tcode{D}
 is ``\placeholder{derived-declarator-type-list} reference to
 \tcode{T}''.
@@ -2902,12 +2926,16 @@ nested-name-specifier \terminal{*} \opt{attribute-specifier-seq} \opt{cv-qualifi
 and the
 \grammarterm{nested-name-specifier}
 denotes a class,
-and the type of the identifier in the declaration
+and the type of the contained
+\grammarterm{declarator-id}
+in the declaration
 \tcode{T}
 \tcode{D1}
 is ``\placeholder{derived-declarator-type-list}
 \tcode{T}'',
-then the type of the identifier of
+then the type of the
+\grammarterm{declarator-id}
+in
 \tcode{D}
 is ``\placeholder{derived-declarator-type-list} \grammarterm{cv-qualifier-seq} pointer to member of class
 \grammarterm{nested-name-specifier} of type


### PR DESCRIPTION
The conventions used to specify the meaning of declarators are a little inconsistent, and the sub-clause itself has a lot of single sentence paragraphs that look messy.

For example, [dcl.meaning] has a mix of specifying the "type of the identifier" and "type of the _declarator-id_", [dcl.ptr], [dcl.ref] and [dcl.mptr] determine the "type of the identifier", and [dcl.array] and [dcl.fct] determine the "type of the _declarator-id_". The mentions of "determining the type of the identifier" have been changed to determining the type of the _declarator-id_, as this is a better defined term.

Further, [[dcl.meaning] p3](http://eel.is/c++draft/dcl.meaning#3) correctly acknowledged that `T` can contain an  _attribute-specifier-seq_, but in the very next paragraph it assumes that `T` will just be a _decl-specifier-seq_. [dcl.meaning] p3 is rewritten to account for that, and it additionally specified that the _attribute-specifier-seq_ appertains to the declarator (this is also specified in [[dcl.pre] p2](http://eel.is/c++draft/dcl.pre#2.sentence-5), perhaps that mention could be removed, as it makes more sense to have it where the meaning of declarators is determined).

More stylistically, [dcl.meaning] uses `codeblock` when specifying a declaration of the for `T D`, which needlessly uses whitespace, and is inconsistent with the other sub-clauses. These were changed to use `\tcode`.

Lastly, [the last sentence of [dcl.meaning] p6](http://eel.is/c++draft/dcl.meaning#6.sentence-2) is completely redundant, and should be just turned into a note.