### PR TITLE
[basic.type.qualifier] Remove redundant wording

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5120,15 +5120,38 @@ interchangeability as arguments to functions, return values from
 functions, and non-static data members of unions.}
 
 \pnum
-\indextext{array!\idxcode{const}}%
-A compound type\iref{basic.compound} is not cv-qualified by the
-cv-qualifiers (if any) of the types from which it is compounded. Any
-cv-qualifiers applied to an array type
-affect the array element type\iref{dcl.array}.
+Except for array types, a compound type\iref{basic.compound} is not cv-qualified by the
+cv-qualifiers (if any) of the types from which it is compounded.
 
 \pnum
+\indextext{array!\idxcode{const}}%
+An array type whose elements are cv-qualified
+is also considered to have the same cv-qualifications
+as its elements.
+\begin{note}
+Cv-qualifiers applied to an array
+type attach to the underlying element type, so the notation
+``\cv{}~\tcode{T}'', where \tcode{T} is an array type, refers to
+an array whose elements are so-qualified\iref{dcl.array}.
+\end{note}
+\begin{example}
+\begin{codeblock}
+typedef char CA[5];
+typedef const char CC;
+CC arr1[5] = { 0 };
+const CA arr2 = { 0 };
+\end{codeblock}
+The type of both \tcode{arr1} and \tcode{arr2} is ``array of 5
+\tcode{const char}'', and the array type is considered to be
+const-qualified.
+\end{example}
+\indextext{type|)}
+
+\pnum
+\begin{note}
 See~\ref{dcl.fct} and~\ref{class.this} regarding function
 types that have \grammarterm{cv-qualifier}{s}.
+\end{note}
 
 \pnum
 There is a partial ordering on cv-qualifiers, so that a type can be
@@ -5166,26 +5189,6 @@ the type corresponding to the \grammarterm{type-id}
 \tcode{void (C::* volatile)(int) const}
 has the top-level cv-qualifier \tcode{volatile}.
 \end{example}
-
-\pnum
-Cv-qualifiers applied to an array
-type attach to the underlying element type, so the notation
-``\cv{}~\tcode{T}'', where \tcode{T} is an array type, refers to
-an array whose elements are so-qualified. An array type whose elements
-are cv-qualified is also considered to have the same cv-qualifications
-as its elements.
-\begin{example}
-\begin{codeblock}
-typedef char CA[5];
-typedef const char CC;
-CC arr1[5] = { 0 };
-const CA arr2 = { 0 };
-\end{codeblock}
-The type of both \tcode{arr1} and \tcode{arr2} is ``array of 5
-\tcode{const char}'', and the array type is considered to be
-const-qualified.
-\end{example}
-\indextext{type|)}
 
 \rSec2[conv.rank]{Integer conversion rank}%
 \indextext{conversion!integer rank}


### PR DESCRIPTION
[[basic.type.qualifier] p2](http://eel.is/c++draft/basic.type.qualifier#2.sentence-2) and [[basic.type.qualifier] p6](http://eel.is/c++draft/basic.type.qualifier#6.sentence-1) are made reduntand by [[dcl.array] p5](http://eel.is/c++draft/dcl.array#5). 

Removing [basic.type.qualifier] p2 sentence 2, adjusting the first sentence to acknowledge what is stated in p6, and turning [basic.type.qualifier] p6 sentence 1 into a note resolves this.

In addition to this, [[basic.type.qualifier] p3](http://eel.is/c++draft/basic.type.qualifier#3) should be turned into a note, as it has no normative effects.