### PR TITLE
CWG Poll 7: P2107R0 Core Issue 2436: US064 Copy semantics of coroutine parameters

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6440,13 +6440,17 @@ function with a parameter of type \tcode{std::size_t} is used, the size of
 the block is passed as the corresponding argument.
 
 \pnum
-When a coroutine is invoked, a copy is created for each coroutine parameter.
-Each such copy is an object with automatic storage duration that is
-direct-initialized from an lvalue referring to the corresponding parameter if
-the parameter is an lvalue reference, and from an xvalue referring to it
-otherwise. A reference to a parameter in the function-body of the coroutine
-and in the call to the coroutine promise constructor is replaced by a
-reference to its copy.
+When a coroutine is invoked,
+after initializing its parameters\iref{expr.call},
+a copy is created for each coroutine parameter.
+For a parameter of type \cv{}~\tcode{T},
+the copy is a variable of type \cv{}~\tcode{T}
+with automatic storage duration that is direct-initialized
+from an xvalue of type \tcode{T} referring to the parameter.
+\begin{note}
+An original parameter object is never
+a const or volatile object\iref{basic.type.qualifier}.
+\end{note}
 The initialization and destruction of each parameter copy occurs in the
 context of the called coroutine.
 Initializations of parameter copies are sequenced before the call to the

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1334,6 +1334,8 @@ An \grammarterm{identifier} is only
 an \grammarterm{id-expression} if it has
 been suitably declared\iref{dcl.dcl}
 or if it appears as part of a \grammarterm{declarator-id}\iref{dcl.decl}.
+An \grammarterm{identifier} that names a coroutine parameter
+refers to the copy of the parameter\iref{dcl.fct.def.coroutine}.
 \begin{note}
 For \grammarterm{operator-function-id}{s}, see~\ref{over.oper}; for
 \grammarterm{conversion-function-id}{s}, see~\ref{class.conv.fct}; for


### PR DESCRIPTION
Also fixes NB US 064 (C++20 CD) and CWG2436.

Fixes #3691.
Fixes cplusplus/nbballot#63