### PR TITLE
LWG Poll 2: P2051R0 C++ Standard Library Issues to be moved in Prague

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -2846,7 +2846,7 @@ namespace std {
       lexicographical_compare_three_way(InputIterator1 b1, InputIterator1 e1,
                                         InputIterator2 b2, InputIterator2 e2,
                                         Cmp comp)
-        -> common_comparison_category_t<decltype(comp(*b1, *b2)), strong_ordering>;
+        -> decltype(comp(*b1, *b2));
   template<class InputIterator1, class InputIterator2>
     constexpr auto
       lexicographical_compare_three_way(InputIterator1 b1, InputIterator1 e1,
@@ -8444,7 +8444,7 @@ template<class InputIterator1, class InputIterator2, class Cmp>
     lexicographical_compare_three_way(InputIterator1 b1, InputIterator1 e1,
                                       InputIterator2 b2, InputIterator2 e2,
                                       Cmp comp)
-      -> common_comparison_category_t<decltype(comp(*b1, *b2)), strong_ordering>;
+      -> decltype(comp(*b1, *b2));
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/back.tex
+++ b/source/back.tex
@@ -7,6 +7,9 @@ The following documents are cited informatively in this document.
 \begin{itemize}
 \renewcommand{\labelitemi}{---}
 \item
+  IANA Time Zone Database,
+  available at \url{https://www.iana.org/time-zones}
+\item
   ISO/IEC 10967-1:2012,
   \doccite{Information technology --- Language independent arithmetic ---
     Part 1: Integer and floating point arithmetic}

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -961,14 +961,7 @@ common_reference_t<const remove_reference_t<T>&, const remove_reference_t<U>&>
 \begin{itemdecl}
 template<class T>
   concept @\deflibconcept{totally_ordered}@ =
-    equality_comparable<T> &&
-    requires(const remove_reference_t<T>& a,
-             const remove_reference_t<T>& b) {
-      { a <  b } -> boolean;
-      { a >  b } -> boolean;
-      { a <= b } -> boolean;
-      { a >= b } -> boolean;
-    };
+    equality_comparable<T> && @\exposconcept{partially-ordered-with}@<T, T>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -982,7 +975,6 @@ lvalues of type \tcode{const remove_reference_t<T>}.
       \tcode{bool(a == b)} is \tcode{true}.
 \item If \tcode{bool(a < b)} and \tcode{bool(b < c)}, then
       \tcode{bool(a < c)}.
-\item \tcode{bool(a >  b) ==  bool(b < a)}.
 \item \tcode{bool(a <= b) == !bool(b < a)}.
 \item \tcode{bool(a >= b) == !bool(a < b)}.
 \end{itemize}
@@ -998,17 +990,7 @@ template<class T, class U>
       common_reference_t<
         const remove_reference_t<T>&,
         const remove_reference_t<U>&>> &&
-    requires(const remove_reference_t<T>& t,
-             const remove_reference_t<U>& u) {
-      { t <  u } -> boolean;
-      { t >  u } -> boolean;
-      { t <= u } -> boolean;
-      { t >= u } -> boolean;
-      { u <  t } -> boolean;
-      { u >  t } -> boolean;
-      { u <= t } -> boolean;
-      { u >= t } -> boolean;
-    };
+    @\exposconcept{partially-ordered-with}@<T, U>;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -993,12 +993,11 @@ lvalues of type \tcode{const remove_reference_t<T>}.
 template<class T, class U>
   concept @\deflibconcept{totally_ordered_with}@ =
     totally_ordered<T> && totally_ordered<U> &&
-    common_reference_with<const remove_reference_t<T>&, const remove_reference_t<U>&> &&
+    equality_comparable_with<T, U> &&
     totally_ordered<
       common_reference_t<
         const remove_reference_t<T>&,
         const remove_reference_t<U>&>> &&
-    equality_comparable_with<T, U> &&
     requires(const remove_reference_t<T>& t,
              const remove_reference_t<U>& u) {
       { t <  u } -> boolean;

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -314,29 +314,33 @@ template<class Derived, class Base>
 \rSec2[concept.convertible]{Concept \cname{convertible_to}}
 
 \pnum
-The \libconcept{convertible_to} concept requires an expression of a particular
-type and value category to be both implicitly and explicitly convertible to some
-other type. The implicit and explicit conversions are required to produce equal
+Given types \tcode{From} and \tcode{To} and
+an expression \tcode{E} such that
+\tcode{decltype((E))} is \tcode{add_rvalue_reference_t<From>},
+\tcode{\libconcept{convertible_to}<From, To>} requires \tcode{E}
+to be both implicitly and explicitly convertible to type \tcode{To}.
+The implicit and explicit conversions are required to produce equal
 results.
 
 \begin{itemdecl}
 template<class From, class To>
   concept @\deflibconcept{convertible_to}@ =
     is_convertible_v<From, To> &&
-    requires(From (&f)()) {
+    requires(add_rvalue_reference_t<From> (&f)()) {
       static_cast<To>(f());
     };
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-Let \tcode{test} be the invented function:
+Let \tcode{FromR} be \tcode{add_rvalue_reference_t<From>} and
+\tcode{test} be the invented function:
 \begin{codeblock}
-To test(From (&f)()) {
+To test(FromR (&f)()) {
   return f();
 }
 \end{codeblock}
-and let \tcode{f} be a function with no arguments and return type \tcode{From}
+and let \tcode{f} be a function with no arguments and return type \tcode{FromR}
 such that \tcode{f()} is equality-preserving.
 Types \tcode{From} and \tcode{To} model \tcode{\libconcept{convertible_to}<From, To>}
 only if:
@@ -347,11 +351,11 @@ only if:
 \tcode{static_cast<To>(f())} is equal to \tcode{test(f)}.
 
 \item
-\tcode{From} is not a reference-to-object type, or
+\tcode{FromR} is not a reference-to-object type, or
 
 \begin{itemize}
 \item
-If \tcode{From} is an rvalue reference to a non const-qualified type, the
+If \tcode{FromR} is an rvalue reference to a non const-qualified type, the
 resulting state of the object referenced by \tcode{f()} after either above
 expression is valid but unspecified\iref{lib.types.movedfrom}.
 

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -200,9 +200,9 @@ namespace std {
   template<class T, class... Args>
     concept constructible_from = @\seebelow@;
 
-  // \ref{concept.defaultconstructible}, concept \libconcept{default_constructible}
+  // \ref{concept.default.init}, concept \libconcept{default_initializable}
   template<class T>
-    concept default_constructible = @\seebelow@;
+    concept default_initializable = @\seebelow@;
 
   // \ref{concept.moveconstructible}, concept \libconcept{move_constructible}
   template<class T>
@@ -739,14 +739,14 @@ template<class T, class... Args>
   concept @\deflibconcept{constructible_from}@ = destructible<T> && is_constructible_v<T, Args...>;
 \end{itemdecl}
 
-\rSec2[concept.defaultconstructible]{Concept \cname{default_constructible}}
+\rSec2[concept.default.init]{Concept \cname{default_initializable}}
 
 \begin{itemdecl}
 template<class T>
   inline constexpr bool @\defexposconcept{is-default-initializable}@ = @\seebelow@;  // \expos
 
 template<class T>
-  concept @\deflibconcept{default_constructible}@ = constructible_from<T> &&
+  concept @\deflibconcept{default_initializable}@ = constructible_from<T> &&
                                   requires { T{}; } &&
                                   @\exposconcept{is-default-initializable}@<T>;
 \end{itemdecl}
@@ -1030,7 +1030,7 @@ template<class T>
 template<class T>
   concept @\deflibconcept{copyable}@ = copy_constructible<T> && movable<T> && assignable_from<T&, const T&>;
 template<class T>
-  concept @\deflibconcept{semiregular}@ = copyable<T> && default_constructible<T>;
+  concept @\deflibconcept{semiregular}@ = copyable<T> && default_initializable<T>;
 template<class T>
   concept @\deflibconcept{regular}@ = semiregular<T> && equality_comparable<T>;
 \end{itemdecl}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10568,9 +10568,7 @@ namespace std {
     using reference = element_type&;
     using const_reference = const element_type&;
     using iterator = @\impdefx{type of \tcode{span::iterator}}@;        // see \ref{span.iterators}
-    using const_iterator = @\impdefx{type of \tcode{span::const_iterator}}@;
     using reverse_iterator = std::reverse_iterator<iterator>;
-    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
     static constexpr size_type extent = Extent;
 
     // \ref{span.cons}, constructors, copy, and assignment
@@ -10622,12 +10620,8 @@ namespace std {
     // \ref{span.iterators}, iterator support
     constexpr iterator begin() const noexcept;
     constexpr iterator end() const noexcept;
-    constexpr const_iterator cbegin() const noexcept;
-    constexpr const_iterator cend() const noexcept;
     constexpr reverse_iterator rbegin() const noexcept;
     constexpr reverse_iterator rend() const noexcept;
-    constexpr const_reverse_iterator crbegin() const noexcept;
-    constexpr const_reverse_iterator crend() const noexcept;
 
   private:
     pointer data_;              // \expos
@@ -11119,23 +11113,21 @@ Equivalent to: \tcode{return data_;}
 \rSec3[span.iterators]{Iterator support}
 
 \indexlibrarymember{iterator}{span}%
-\indexlibrarymember{const_iterator}{span}%
 \begin{itemdecl}
 using iterator = @\impdefx{type of \tcode{span::iterator}}@;
-using const_iterator = @\impdefx{type of \tcode{span::const_iterator}}@;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-The types
-model \libconcept{contiguous_iterator}\iref{iterator.concept.contiguous},
-meet the \oldconcept{RandomAccessIterator}
+The type
+models \libconcept{contiguous_iterator}\iref{iterator.concept.contiguous},
+meets the \oldconcept{RandomAccessIterator}
 requirements\iref{random.access.iterators},
 and
-meet the requirements for
+meets the requirements for
 constexpr iterators\iref{iterator.requirements.general}.
 All requirements on container iterators\iref{container.requirements} apply to
-\tcode{span::iterator} and \tcode{span::const_iterator} as well.
+\tcode{span::iterator} as well.
 \end{itemdescr}
 
 \indexlibrarymember{span}{begin}%
@@ -11182,52 +11174,6 @@ constexpr reverse_iterator rend() const noexcept;
 \pnum
 \effects
 Equivalent to: \tcode{return reverse_iterator(begin());}
-\end{itemdescr}
-
-\indexlibrarymember{span}{cbegin}%
-\begin{itemdecl}
-constexpr const_iterator cbegin() const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-A constant iterator referring to the first element in the span.
-If \tcode{empty()} is \tcode{true}, then it returns the same value
-as \tcode{cend()}.
-\end{itemdescr}
-
-\indexlibrarymember{span}{cend}%
-\begin{itemdecl}
-constexpr const_iterator cend() const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-A constant iterator which is the past-the-end value.
-\end{itemdescr}
-
-\indexlibrarymember{span}{crbegin}%
-\begin{itemdecl}
-constexpr const_reverse_iterator crbegin() const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Equivalent to: \tcode{return const_reverse_iterator(cend());}
-\end{itemdescr}
-
-\indexlibrarymember{span}{crend}%
-\begin{itemdecl}
-constexpr const_reverse_iterator crend() const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Equivalent to: \tcode{return const_reverse_iterator(cbegin());}
 \end{itemdescr}
 
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10515,6 +10515,9 @@ namespace std {
     class span;
 
   template<class ElementType, size_t Extent>
+    inline constexpr bool ranges::enable_view<span<ElementType, Extent>> =
+      Extent == 0 || Extent == dynamic_extent;
+  template<class ElementType, size_t Extent>
     inline constexpr bool ranges::enable_safe_range<span<ElementType, Extent>> = true;
 
   // \ref{span.objectrep}, views of object representation

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -3114,7 +3114,8 @@ template<class InputIterator>
 
 \indexheader{array}%
 \begin{codeblock}
-#include <initializer_list>
+#include <compare>              // see \ref{compare.syn}
+#include <initializer_list>     // see \ref{initializer.list.syn}
 
 namespace std {
   // \ref{array}, class template \tcode{array}
@@ -3151,7 +3152,8 @@ namespace std {
 
 \indexheader{deque}%
 \begin{codeblock}
-#include <initializer_list>
+#include <compare>              // see \ref{compare.syn}
+#include <initializer_list>     // see \ref{initializer.list.syn}
 
 namespace std {
   // \ref{deque}, class template \tcode{deque}
@@ -3183,7 +3185,8 @@ namespace std {
 
 \indexheader{forward_list}%
 \begin{codeblock}
-#include <initializer_list>
+#include <compare>              // see \ref{compare.syn}
+#include <initializer_list>     // see \ref{initializer.list.syn}
 
 namespace std {
   // \ref{forwardlist}, class template \tcode{forward_list}
@@ -3215,7 +3218,8 @@ namespace std {
 
 \indexheader{list}%
 \begin{codeblock}
-#include <initializer_list>
+#include <compare>              // see \ref{compare.syn}
+#include <initializer_list>     // see \ref{initializer.list.syn}
 
 namespace std {
   // \ref{list}, class template \tcode{list}
@@ -3247,7 +3251,8 @@ namespace std {
 
 \indexheader{vector}%
 \begin{codeblock}
-#include <initializer_list>
+#include <compare>              // see \ref{compare.syn}
+#include <initializer_list>     // see \ref{initializer.list.syn}
 
 namespace std {
   // \ref{vector}, class template \tcode{vector}
@@ -6249,7 +6254,8 @@ template<class InputIterator>
 
 \indexheader{map}%
 \begin{codeblock}
-#include <initializer_list>
+#include <compare>              // see \ref{compare.syn}
+#include <initializer_list>     // see \ref{initializer.list.syn}
 
 namespace std {
   // \ref{map}, class template \tcode{map}
@@ -6310,7 +6316,8 @@ namespace std {
 
 \indexheader{set}%
 \begin{codeblock}
-#include <initializer_list>
+#include <compare>              // see \ref{compare.syn}
+#include <initializer_list>     // see \ref{initializer.list.syn}
 
 namespace std {
   // \ref{set}, class template \tcode{set}
@@ -7805,7 +7812,8 @@ defined in \ref{associative.general} may appear in deduction guides for unordere
 \indexlibraryglobal{unordered_map}%
 \indexlibraryglobal{unordered_multimap}%
 \begin{codeblock}
-#include <initializer_list>
+#include <compare>              // see \ref{compare.syn}
+#include <initializer_list>     // see \ref{initializer.list.syn}
 
 namespace std {
   // \ref{unord.map}, class template \tcode{unordered_map}
@@ -7874,7 +7882,8 @@ namespace std {
 \indexlibraryglobal{unordered_set}%
 \indexlibraryglobal{unordered_multiset}%
 \begin{codeblock}
-#include <initializer_list>
+#include <compare>              // see \ref{compare.syn}
+#include <initializer_list>     // see \ref{initializer.list.syn}
 
 namespace std {
   // \ref{unord.set}, class template \tcode{unordered_set}
@@ -9587,7 +9596,8 @@ A deduction guide for a container adaptor shall not participate in overload reso
 
 \indexheader{queue}
 \begin{codeblock}
-#include <initializer_list>
+#include <compare>              // see \ref{compare.syn}
+#include <initializer_list>     // see \ref{initializer.list.syn}
 
 namespace std {
   template<class T, class Container = deque<T>> class queue;
@@ -9629,7 +9639,8 @@ namespace std {
 
 \indexheader{stack}%
 \begin{codeblock}
-#include <initializer_list>
+#include <compare>              // see \ref{compare.syn}
+#include <initializer_list>     // see \ref{initializer.list.syn}
 
 namespace std {
   template<class T, class Container = deque<T>> class stack;

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -680,6 +680,8 @@ libraries unchanged.
 \indexlibraryglobal{is_error_condition_enum}%
 \indexlibraryglobal{errc}%
 \begin{codeblock}
+#include <compare>              // see \ref{compare.syn}
+
 namespace std {
   class error_category;
   const error_category& generic_category() noexcept;

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -35,14 +35,10 @@ For undated references, the latest edition of the referenced document
 \begin{itemize}
 \item Ecma International, \doccite{ECMAScript Language Specification},
 Standard Ecma-262, third edition, 1999.
+% FIXME: Is the following comment refering to the entry above or
+%        the entry removed in LWG3319?  I.e. is it still valid?
 %%% Format for this entry is based on that specified at
 %%% http://www.iec.ch/standardsdev/resources/draftingpublications/directives/principles/referencing.htm
-\item INTERNET ENGINEERING TASK FORCE (IETF). RFC 6557:
-Procedures for Maintaining the Time Zone Database [online].
-Edited by E. Lear, P. Eggert.
-February 2012 [viewed 2018-03-26].
-Available at
-\url{https://www.ietf.org/rfc/rfc6557.txt}
 \item ISO/IEC 2382 (all parts), \doccite{Information technology ---
 Vocabulary}
 \item ISO 8601:2004, \doccite{Data elements and interchange formats ---

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -11438,6 +11438,8 @@ subclause~\ref{filesystems} are assumed to be qualified with \tcode{::std::files
 
 \indexheader{filesystem}%
 \begin{codeblock}
+#include <compare>              // see \ref{compare.syn}
+
 namespace std::filesystem {
   // \ref{fs.class.path}, paths
   class path;

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -6614,9 +6614,10 @@ template<class C> constexpr auto ssize(const C& c)
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-\returns
+\effects
+Equivalent to:
 \begin{codeblock}
-static_cast<common_type_t<ptrdiff_t, make_signed_t<decltype(c.size())>>>(c.size())
+return static_cast<common_type_t<ptrdiff_t, make_signed_t<decltype(c.size())>>>(c.size());
 \end{codeblock}
 \end{itemdescr}
 

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1055,7 +1055,9 @@ The expression \tcode{ranges::\-iter_move(E)} for a subexpression \tcode{E} is
 expression-equivalent to:
 
 \begin{itemize}
-\item \tcode{iter_move(E)}, if that expression is valid, with overload
+\item \tcode{iter_move(E)}, if
+\tcode{E} has class or enumeration type and
+\tcode{iter_move(E)} is a well-formed expression with overload
 resolution performed in a context that does not include a declaration of
 \tcode{ranges::iter_move}.
 
@@ -1110,7 +1112,9 @@ return old_value;
 The expression \tcode{ranges::iter_swap(E1, E2)} for subexpressions
 \tcode{E1} and \tcode{E2} is expression-equivalent to:
 \begin{itemize}
-\item \tcode{(void)iter_swap(E1, E2)}, if that expression is valid,
+\item \tcode{(void)iter_swap(E1, E2)}, if either
+\tcode{E1} or \tcode{E2} has class or enumeration type and
+\tcode{iter_swap(E1, E2)} is a well-formed expression
 with overload resolution performed in a context that includes the declaration
 \begin{codeblock}
 template<class I1, class I2>

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -33,7 +33,8 @@ as summarized in \tref{iterators.summary}.
 \indexlibraryglobal{default_sentinel}%
 \indexlibraryglobal{unreachable_sentinel}%
 \begin{codeblock}
-#include <concepts>
+#include <compare>              // see \ref{compare.syn}
+#include <concepts>             // see \ref{concepts.syn}
 
 namespace std {
   template<class T> using @\placeholder{with-reference}@ = T&;  // \expos

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1791,7 +1791,7 @@ and let \tcode{n} denote a value of type \tcode{D}.
 \item \tcode{(a + D(0))} is equal to \tcode{a}.
 \item If \tcode{(a + D(n - 1))} is valid, then
   \tcode{(a + n)} is equal to \tcode{[](I c)\{ return ++c; \}(a + D(n - 1))}.
-\item \tcode{(b += -n)} is equal to \tcode{a}.
+\item \tcode{(b += D(-n))} is equal to \tcode{a}.
 \item \tcode{(b -= n)} is equal to \tcode{a}.
 \item \tcode{addressof(b -= n)} is equal to \tcode{addressof(b)}.
 \item \tcode{(b - n)} is equal to \tcode{(b -= n)}.

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1299,7 +1299,7 @@ template<class T>
 
 template<class I>
   concept @\deflibconcept{weakly_incrementable}@ =
-    default_constructible<I> && movable<I> &&
+    default_initializable<I> && movable<I> &&
     requires(I i) {
       typename iter_difference_t<I>;
       requires @\placeholdernc{is-signed-integer-like}@<iter_difference_t<I>>;

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1026,7 +1026,7 @@ with a literal class type that interacts with program-defined types while
 enforcing semantic requirements on that interaction.
 
 \pnum
-The type of a customization point object shall model
+The type of a customization point object, ignoring cv-qualifiers, shall model
 \libconcept{semiregular}\iref{concepts.object}.
 
 \pnum

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2200,12 +2200,12 @@ If \tcode{n == 0}, the return value is unspecified.
   (not used)                &
   \effects Constructs an object of type \tcode{C} at
     \tcode{c}               &
-  \tcode{::new ((void*)c) C(forward<\brk{}Args>\brk(args)...)}  \\ \rowsep
+  \tcode{construct_at(c,~std::\brk{}forward<Args>\brk{}(args)...)}  \\ \rowsep
 
 \tcode{a.destroy(c)}        &
   (not used)                &
   \effects Destroys the object at \tcode{c}  &
-  \tcode{c->\~{}C()}           \\  \rowsep
+  \tcode{destroy_at(c)}     \\  \rowsep
 
 \tcode{a.select_on_container_copy_construction()} &
   \tcode{X}                 &

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -278,8 +278,8 @@ namespace std::ranges {
   namespace views {
     template<size_t N>
       inline constexpr @\unspec@ elements = @\unspec@ ;
-    inline constexpr @\unspec@ keys = @\unspec@ ;
-    inline constexpr @\unspec@ values = @\unspec@ ;
+    inline constexpr auto keys = elements<0>;
+    inline constexpr auto values = elements<1>;
   }
 }
 

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -6006,7 +6006,7 @@ namespace std::ranges {
       typename tuple_size<T>::type;
       requires N < tuple_size_v<T>;
       typename tuple_element_t<N, T>;
-      { get<N>(t) } -> const tuple_element_t<N, T>&;
+      { get<N>(t) } -> convertible_to<const tuple_element_t<N, T>&>;
     };
 
 

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1015,35 +1015,12 @@ semantic, the two are differentiated with the help of \tcode{enable_view}.
 \indexlibraryglobal{enable_view}%
 \begin{itemdecl}
 template<class T>
-  inline constexpr bool enable_view = @\seebelow@;
+  inline constexpr bool enable_view = derived_from<T, view_base>;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \remarks
-For a type \tcode{T}, the default value of \tcode{enable_view<T>} is:
-\begin{itemize}
-
-\item If \tcode{derived_from<T, view_base>} is \tcode{true}, \tcode{true}.
-\item Otherwise, if \tcode{T} is a specialization of class template
-  \tcode{initializer_list}\iref{support.initlist},
-  \tcode{set}\iref{set},
-  \tcode{multiset}\iref{multiset},
-  \tcode{unordered_set}\iref{unord.set},
-  \tcode{unordered_multiset}\iref{unord.multiset}, or
-  \tcode{match_results}\iref{re.results}, \tcode{false}.
-\item Otherwise, if both \tcode{T} and \tcode{const T} model \libconcept{range}
-  and \tcode{range_reference_t<T>} is not the same type as
-  \tcode{range_reference_t<const T>},
-  \tcode{false}.
-  \begin{note}
-  Deep \tcode{const}-ness implies element ownership,
-  whereas shallow \tcode{const}-ness implies reference semantics.
-  \end{note}
-\item Otherwise, \tcode{true}.
-\end{itemize}
-
-\pnum
 Pursuant to \ref{namespace.std}, users may specialize \tcode{enable_view}
 to \tcode{true}
 for cv-unqualified program-defined types which model \libconcept{view},

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2139,7 +2139,8 @@ namespace std::ranges {
   private:
     W @\exposid{value_}@ = W();             // \expos
   public:
-    using iterator_category = @\seebelow@;
+    using iterator_concept = @\seebelow@;
+    using iterator_category = input_iterator_tag;
     using value_type = W;
     using difference_type = @\placeholdernc{IOTA-DIFF-T}@(W);
 
@@ -2191,15 +2192,15 @@ namespace std::ranges {
 \end{codeblock}
 
 \pnum
-\tcode{iterator::iterator_category} is defined as follows:
+\tcode{\exposid{iterator}::iterator_concept} is defined as follows:
 \begin{itemize}
 \item If \tcode{W} models \tcode{\placeholder{advanceable}}, then
-\tcode{iterator_category} is \tcode{random_access_iterator_tag}.
+\tcode{iterator_concept} is \tcode{random_access_iterator_tag}.
 \item Otherwise, if \tcode{W} models \exposconcept{decrementable}, then
-\tcode{iterator_category} is \tcode{bidirectional_iterator_tag}.
+\tcode{iterator_concept} is \tcode{bidirectional_iterator_tag}.
 \item Otherwise, if \tcode{W} models \libconcept{incrementable}, then
-\tcode{iterator_category} is \tcode{forward_iterator_tag}.
-\item Otherwise, \tcode{iterator_category} is \tcode{input_iterator_tag}.
+\tcode{iterator_concept} is \tcode{forward_iterator_tag}.
+\item Otherwise, \tcode{iterator_concept} is \tcode{input_iterator_tag}.
 \end{itemize}
 
 \pnum

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -51,7 +51,7 @@ namespace std::ranges {
   template<class T>
     concept range = @\seebelow@;
 
-  template<range T>
+  template<class T>
     inline constexpr bool enable_safe_range = false;
 
   template<class T>

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -899,7 +899,6 @@ of a \libconcept{range} type that knows its size in constant time with the
 template<class T>
   concept @\deflibconcept{sized_range}@ =
     range<T> &&
-    !disable_sized_range<remove_cvref_t<T>> &&
     requires(T& t) { ranges::size(t); };
 \end{itemdecl}
 

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1464,7 +1464,7 @@ constexpr subrange(R&& r) requires (!@\exposid{StoreSize}@ || sized_range<R>);
 Equivalent to:
 \begin{itemize}
 \item If \exposid{StoreSize} is \tcode{true},
-\tcode{subrange\{ranges::begin(r), ranges::end(r), ranges::size(r)\}}.
+\tcode{subrange\{r, ranges::size(r)\}}.
 \item Otherwise, \tcode{subrange\{ranges::begin(r), ranges::end(r)\}}.
 \end{itemize}
 \end{itemdescr}
@@ -4097,8 +4097,10 @@ namespace std::ranges {
       if constexpr (sized_range<V>) {
         if constexpr (random_access_range<V>)
           return ranges::begin(@\exposid{base_}@);
-        else
-          return counted_iterator{ranges::begin(@\exposid{base_}@), size()};
+        else {
+          auto sz = size();
+          return counted_iterator{ranges::begin(@\exposid{base_}@), sz};
+        }
       } else
         return counted_iterator{ranges::begin(@\exposid{base_}@), @\exposid{count_}@};
     }
@@ -4107,8 +4109,10 @@ namespace std::ranges {
       if constexpr (sized_range<const V>) {
         if constexpr (random_access_range<const V>)
           return ranges::begin(@\exposid{base_}@);
-        else
-          return counted_iterator{ranges::begin(@\exposid{base_}@), size()};
+        else {
+          auto sz = size();
+          return counted_iterator{ranges::begin(@\exposid{base_}@), sz};
+        }
       } else
         return counted_iterator{ranges::begin(@\exposid{base_}@), @\exposid{count_}@};
     }

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -25,8 +25,9 @@ as summarized in \tref{range.summary}.
 
 \indexheader{ranges}%
 \begin{codeblock}
-#include <initializer_list>
-#include <iterator>
+#include <compare>              // see \ref{compare.syn}
+#include <initializer_list>     // see \ref{initializer.list.syn}
+#include <iterator>             // see \ref{iterator.synopsis}
 
 namespace std::ranges {
   inline namespace @\unspec@ {

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -4790,11 +4790,13 @@ template<class V>
 
     constexpr @\exposid{iterator}@& operator--()
       requires @\exposid{ref-is-glvalue}@ && bidirectional_range<@\exposid{Base}@> &&
-               bidirectional_range<range_reference_t<@\exposid{Base}@>>;
+               bidirectional_range<range_reference_t<@\exposid{Base}@>> &&
+               common_range<range_reference_t<@\exposid{Base}@>>;
 
     constexpr @\exposid{iterator}@ operator--(int)
       requires @\exposid{ref-is-glvalue}@ && bidirectional_range<@\exposid{Base}@> &&
-               bidirectional_range<range_reference_t<@\exposid{Base}@>>;
+               bidirectional_range<range_reference_t<@\exposid{Base}@>> &&
+               common_range<range_reference_t<@\exposid{Base}@>>;
 
     friend constexpr bool operator==(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
       requires @\exposid{ref-is-glvalue}@ && equality_comparable<iterator_t<@\exposid{Base}@>> &&
@@ -4985,7 +4987,8 @@ return tmp;
 \begin{itemdecl}
 constexpr @\exposid{iterator}@& operator--()
   requires @\exposid{ref-is-glvalue}@ && bidirectional_range<@\exposid{Base}@> &&
-           bidirectional_range<range_reference_t<@\exposid{Base}@>>;
+           bidirectional_range<range_reference_t<@\exposid{Base}@>> &&
+           common_range<range_reference_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5006,7 +5009,8 @@ return *this;
 \begin{itemdecl}
 constexpr @\exposid{iterator}@ operator--(int)
   requires @\exposid{ref-is-glvalue}@ && bidirectional_range<@\exposid{Base}@> &&
-           bidirectional_range<range_reference_t<@\exposid{Base}@>>;
+           bidirectional_range<range_reference_t<@\exposid{Base}@>> &&
+           common_range<range_reference_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -3014,9 +3014,6 @@ namespace std::ranges {
   public:
     filter_view() = default;
     constexpr filter_view(V base, Pred pred);
-    template<input_range R>
-      requires viewable_range<R> && constructible_from<V, all_view<R>>
-    constexpr filter_view(R&& r, Pred pred);
 
     constexpr V base() const& requires copy_constructible<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
@@ -3045,20 +3042,6 @@ constexpr filter_view(V base, Pred pred);
 \effects
 Initializes \exposid{base_} with \tcode{std::move(base)} and initializes
 \exposid{pred_} with \tcode{std::move(pred)}.
-\end{itemdescr}
-
-\indexlibraryctor{filter_view}%
-\begin{itemdecl}
-template<input_range R>
-  requires viewable_range<R> && constructible_from<V, all_view<R>>
-constexpr filter_view(R&& r, Pred pred);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Initializes \exposid{base_} with \tcode{views::all(std::forward<R>(r))}
-and initializes \exposid{pred_} with \tcode{std::\brk{}move(pred)}.
 \end{itemdescr}
 
 \indexlibrarymember{begin}{filter_view}%
@@ -3436,9 +3419,6 @@ namespace std::ranges {
   public:
     transform_view() = default;
     constexpr transform_view(V base, F fun);
-    template<input_range R>
-      requires viewable_range<R> && constructible_from<V, all_view<R>>
-    constexpr transform_view(R&& r, F fun);
 
     constexpr V base() const& requires copy_constructible<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
@@ -3477,20 +3457,6 @@ constexpr transform_view(V base, F fun);
 \effects
 Initializes \exposid{base_} with \tcode{std::move(base)} and
 \exposid{fun_} with \tcode{std::move(fun)}.
-\end{itemdescr}
-
-\indexlibraryctor{transform_view}%
-\begin{itemdecl}
-template<input_range R>
-  requires viewable_range<R> && constructible_from<V, all_view<R>>
-constexpr transform_view(R&& r, F fun);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Initializes \exposid{base_} with \tcode{views::all(std::forward<R>(r))}
-and \exposid{fun_} with \tcode{std::move(fun)}.
 \end{itemdescr}
 
 \indexlibrarymember{begin}{transform_view}%
@@ -4123,9 +4089,6 @@ namespace std::ranges {
   public:
     take_view() = default;
     constexpr take_view(V base, range_difference_t<V> count);
-    template<viewable_range R>
-      requires constructible_from<V, all_view<R>>
-    constexpr take_view(R&& r, range_difference_t<V> count);
 
     constexpr V base() const& requires copy_constructible<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
@@ -4197,20 +4160,6 @@ constexpr take_view(V base, range_difference_t<V> count);
 \effects
 Initializes \exposid{base_} with \tcode{std::move(base)} and
 \exposid{count_} with \tcode{count}.
-\end{itemdescr}
-
-\indexlibraryctor{take_view}%
-\begin{itemdecl}
-template<viewable_range R>
-  requires constructible_from<V, all_view<R>>
-constexpr take_view(R&& r, range_difference_t<V> count);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Initializes \exposid{base_} with \tcode{views::all(std::forward<R>(r))}
-and \exposid{count_} with \tcode{count}.
 \end{itemdescr}
 
 \rSec3[range.take.sentinel]{Class template \tcode{take_view::\exposid{sentinel}}}
@@ -4735,10 +4684,6 @@ namespace std::ranges {
     join_view() = default;
     constexpr explicit join_view(V base);
 
-    template<input_range R>
-      requires viewable_range<R> && constructible_from<V, all_view<R>>
-    constexpr explicit join_view(R&& r);
-
     constexpr V base() const& requires copy_constructible<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
@@ -4789,19 +4734,6 @@ constexpr explicit join_view(V base);
 \pnum
 \effects
 Initializes \exposid{base_} with \tcode{std::move(base)}.
-\end{itemdescr}
-
-\indexlibraryctor{join_view}%
-\begin{itemdecl}
-template<input_range R>
-  requires viewable_range<R> && constructible_from<V, all_view<R>>
-constexpr explicit join_view(R&& r);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Initializes \exposid{base_} with \tcode{views::all(std::forward<R>(r))}.
 \end{itemdescr}
 
 \rSec3[range.join.iterator]{Class template \tcode{join_view::\exposid{iterator}}}
@@ -5232,11 +5164,6 @@ namespace std::ranges {
     split_view() = default;
     constexpr split_view(V base, Pattern pattern);
 
-    template<input_range R, forward_range P>
-      requires constructible_from<V, all_view<R>> &&
-               constructible_from<Pattern, all_view<P>>
-    constexpr split_view(R&& r, P&& p);
-
     template<input_range R>
       requires constructible_from<V, all_view<R>> &&
                constructible_from<Pattern, single_view<range_value_t<R>>>
@@ -5289,21 +5216,6 @@ constexpr split_view(V base, Pattern pattern);
 \effects
 Initializes \exposid{base_} with \tcode{std::move(base)}, and
 \exposid{pattern_} with \tcode{std::move(pattern)}.
-\end{itemdescr}
-
-\indexlibraryctor{split_view}%
-\begin{itemdecl}
-template<input_range R, forward_range P>
-  requires constructible_from<V, all_view<R>> &&
-           constructible_from<Pattern, all_view<P>>
-constexpr split_view(R&& r, P&& p);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Initializes \exposid{base_} with \tcode{views::all(std::forward<R>(r))}, and
-\exposid{pattern_} with \tcode{views::all(\brk{}std::forward<P>(p))}.
 \end{itemdescr}
 
 \indexlibraryctor{split_view}%
@@ -5927,10 +5839,6 @@ namespace std::ranges {
 
     constexpr explicit reverse_view(V r);
 
-    template<viewable_range R>
-      requires bidirectional_range<R> && constructible_from<V, all_view<R>>
-    constexpr explicit reverse_view(R&& r);
-
     constexpr V base() const& requires copy_constructible<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
@@ -5965,19 +5873,6 @@ constexpr explicit reverse_view(V base);
 \pnum
 \effects
 Initializes \exposid{base_} with \tcode{std::move(base)}.
-\end{itemdescr}
-
-\indexlibraryctor{reverse_view}%
-\begin{itemdecl}
-template<viewable_range R>
-  requires bidirectional_range<R> && constructible_from<V, all_view<R>>
-constexpr explicit reverse_view(R&& r);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Initializes \exposid{base_} with \tcode{views::all(std::forward<R>(r))}.
 \end{itemdescr}
 
 \indexlibrarymember{begin}{reverse_view}%

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1900,7 +1900,7 @@ namespace std::ranges {
       @\seebelow@;
 
   template<weakly_incrementable W, semiregular Bound = unreachable_sentinel_t>
-    requires @\exposconcept{weakly-equality-comparable-with}@<W, Bound>
+    requires @\exposconcept{weakly-equality-comparable-with}@<W, Bound> && semiregular<W>
   class iota_view : public view_interface<iota_view<W, Bound>> {
   private:
     // \ref{range.iota.iterator}, class \tcode{iota_view::\exposid{iterator}}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -966,7 +966,7 @@ independent of the number of elements in the \tcode{view}.
 \begin{itemdecl}
 template<class T>
   concept @\deflibconcept{view}@ =
-    range<T> && movable<T> && default_constructible<T> && enable_view<T>;
+    range<T> && movable<T> && default_initializable<T> && enable_view<T>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2576,7 +2576,7 @@ namespace std::ranges {
       };
 
   template<movable Val, class CharT, class Traits>
-    requires default_constructible<Val> &&
+    requires default_initializable<Val> &&
       @\exposconcept{stream-extractable}@<Val, CharT, Traits>
   class basic_istream_view : public view_interface<basic_istream_view<Val, CharT, Traits>> {
   public:
@@ -2827,7 +2827,7 @@ with the following differences:
 its type parameter \tcode{T} with
 \tcode{\libconcept{copy_constructible}<T> \&\& is_object_v<T>}.
 
-\item If \tcode{T} models \libconcept{default_constructible}, the default
+\item If \tcode{T} models \libconcept{default_initializable}, the default
 constructor of \tcode{\placeholder{semiregular-box}<T>} is equivalent to:
 \begin{codeblock}
 constexpr @\placeholder{semiregular-box}@() noexcept(is_nothrow_default_constructible_v<T>)

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -3406,7 +3406,8 @@ for (int i : squares)
 namespace std::ranges {
   template<input_range V, copy_constructible F>
     requires view<V> && is_object_v<F> &&
-             regular_invocable<F&, range_reference_t<V>>
+             regular_invocable<F&, range_reference_t<V>> &&
+             @\exposconcept{can-reference}@<invoke_result_t<F&, range_reference_t<V>>>
   class transform_view : public view_interface<transform_view<V, F>> {
   private:
     // \ref{range.transform.iterator}, class template \tcode{transform_view::\exposid{iterator}}

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -265,7 +265,8 @@ the header \libheader{regex}, and is described in \ref{re.traits}.
 \indexlibraryglobal{regex}%
 \indexlibraryglobal{wregex}%
 \begin{codeblock}
-#include <initializer_list>
+#include <compare>              // see \ref{compare.syn}
+#include <initializer_list>     // see \ref{initializer.list.syn}
 
 namespace std {
   // \ref{re.const}, regex constants

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -1296,7 +1296,7 @@ namespace std {
       basic_regex& assign(const basic_regex& e);
       basic_regex& assign(basic_regex&& e) noexcept;
       basic_regex& assign(const charT* p, flag_type f = regex_constants::ECMAScript);
-      basic_regex& assign(const charT* p, size_t len, flag_type f);
+      basic_regex& assign(const charT* p, size_t len, flag_type f = regex_constants::ECMAScript);
       template<class ST, class SA>
         basic_regex& assign(const basic_string<charT, ST, SA>& s,
                             flag_type f = regex_constants::ECMAScript);

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -3933,6 +3933,8 @@ namespace std {
   class basic_string_view;
 
   template<class charT, class traits>
+    inline constexpr bool ranges::enable_view<basic_string_view<charT, traits>> = true;
+  template<class charT, class traits>
     inline constexpr bool ranges::enable_safe_range<basic_string_view<charT, traits>> = true;
 
   // \ref{string.view.comparison}, non-member comparison functions

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -528,7 +528,8 @@ and
 \indexheader{string}%
 
 \begin{codeblock}
-#include <initializer_list>
+#include <compare>              // see \ref{compare.syn}
+#include <initializer_list>     // see \ref{initializer.list.syn}
 
 namespace std {
   // \ref{char.traits}, character traits
@@ -3927,6 +3928,8 @@ User-defined types should define their own implicit conversions to \tcode{std::b
 
 \indexheader{string_view}%
 \begin{codeblock}
+#include <compare>              // see \ref{compare.syn}
+
 namespace std {
   // \ref{string.view.template}, class template \tcode{basic_string_view}
   template<class charT, class traits = char_traits<charT>>

--- a/source/support.tex
+++ b/source/support.tex
@@ -586,6 +586,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_complex_udls}@                      201309L // also in \libheader{complex}
 #define @\defnlibxname{cpp_lib_concepts}@                          201907L // also in \libheader{concepts}
 #define @\defnlibxname{cpp_lib_constexpr_algorithms}@              201806L // also in \libheader{algorithm}
+#define @\defnlibxname{cpp_lib_constexpr_complex}@                 201711L // also in \libheader{complex}
 #define @\defnlibxname{cpp_lib_constexpr_dynamic_alloc}@           201907L // also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_constexpr_functional}@              201907L // also in \libheader{functional}
 #define @\defnlibxname{cpp_lib_constexpr_iterator}@                201811L // also in \libheader{iterator}

--- a/source/support.tex
+++ b/source/support.tex
@@ -4693,7 +4693,8 @@ is expression-equivalent\iref{defns.expression-equivalent} to the following:
   is additionally consistent with the \tcode{totalOrder} operation
   as specified in ISO/IEC/IEEE 60559.
 \item
-  Otherwise, \tcode{strong_ordering(E <=> F)} if it is a well-formed expression.
+  Otherwise, \tcode{strong_ordering(compare_three_way()(E, F))}
+  if it is a well-formed expression.
 \item
   Otherwise, \tcode{strong_order(E, F)} is ill-formed.
   \begin{note}
@@ -4740,7 +4741,8 @@ is expression-equivalent\iref{defns.expression-equivalent} to the following:
   \item together, all positive NaN values.
   \end{itemize}
 \item
-  Otherwise, \tcode{weak_ordering(E <=> F)} if it is a well-formed expression.
+  Otherwise, \tcode{weak_ordering(compare_three_way()(E, F))}
+  if it is a well-formed expression.
 \item
   Otherwise, \tcode{weak_ordering(strong_order(E, F))}
   if it is a well-formed expression.
@@ -4770,7 +4772,7 @@ is expression-equivalent\iref{defns.expression-equivalent} to the following:
   with overload resolution performed in a context
   that does not include a declaration of \tcode{std::partial_order}.
 \item
-  Otherwise, \tcode{partial_ordering(E <=> F)}
+  Otherwise, \tcode{partial_ordering(compare_three_way()(E, F))}
   if it is a well-formed expression.
 \item
   Otherwise, \tcode{partial_ordering(weak_order(E, F))}

--- a/source/support.tex
+++ b/source/support.tex
@@ -626,6 +626,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_is_final}@                          201402L // also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_is_invocable}@                      201703L // also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_is_layout_compatible}@              201907L // also in \libheader{type_traits}
+#define @\defnlibxname{cpp_lib_is_nothrow_convertible}@            201806L // also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_is_null_pointer}@                   201309L // also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_is_pointer_interconvertible}@       201907L // also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_is_swappable}@                      201603L // also in \libheader{type_traits}
@@ -647,7 +648,6 @@ the values of these macros with greater values.
   // also in \libheader{array}, \libheader{deque}, \libheader{forward_list}, \libheader{iterator}, \libheader{list}, \libheader{map}, \libheader{regex}, \libheader{set}, \libheader{string},
   // \libheader{unordered_map}, \libheader{unordered_set}, \libheader{vector}
 #define @\defnlibxname{cpp_lib_not_fn}@                            201603L // also in \libheader{functional}
-#define @\defnlibxname{cpp_lib_nothrow_convertible}@               201806L // also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_null_iterators}@                    201304L // also in \libheader{iterator}
 #define @\defnlibxname{cpp_lib_optional}@                          201606L // also in \libheader{optional}
 #define @\defnlibxname{cpp_lib_parallel_algorithm}@                201603L // also in \libheader{algorithm}, \libheader{numeric}

--- a/source/support.tex
+++ b/source/support.tex
@@ -4601,13 +4601,13 @@ model \tcode{\libconcept{three_way_comparable}<T, Cat>} only if:
 \begin{codeblock}
 template<class T, class U, class Cat = partial_ordering>
   concept @\deflibconcept{three_way_comparable_with}@ =
-    @\exposconcept{weakly-equality-comparable-with}@<T, U> &&
-    @\exposconcept{partially-ordered-with}@<T, U> &&
     three_way_comparable<T, Cat> &&
     three_way_comparable<U, Cat> &&
     common_reference_with<const remove_reference_t<T>&, const remove_reference_t<U>&> &&
     three_way_comparable<
       common_reference_t<const remove_reference_t<T>&, const remove_reference_t<U>&>, Cat> &&
+    @\exposconcept{weakly-equality-comparable-with}@<T, U> &&
+    @\exposconcept{partially-ordered-with}@<T, U> &&
     requires(const remove_reference_t<T>& t, const remove_reference_t<U>& u) {
       { t <=> u } -> @\exposconcept{compares-as}@<Cat>;
       { u <=> t } -> @\exposconcept{compares-as}@<Cat>;

--- a/source/support.tex
+++ b/source/support.tex
@@ -4878,6 +4878,8 @@ coroutines in a \Cpp{} program.
 \indexheader{coroutine}%
 \indexlibraryglobal{noop_coroutine_handle}%
 \begin{codeblock}
+#include <compare>              // see \ref{compare.syn}
+
 namespace std {
   // \ref{coroutine.traits}, coroutine traits
   template<class R, class... ArgTypes>

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -406,7 +406,6 @@ namespace std {
     [[nodiscard]] bool stop_possible() const noexcept;
 
     [[nodiscard]] friend bool operator==(const stop_token& lhs, const stop_token& rhs) noexcept;
-    [[nodiscard]] friend bool operator!=(const stop_token& lhs, const stop_token& rhs) noexcept;
     friend void swap(stop_token& lhs, stop_token& rhs) noexcept;
   };
 }
@@ -542,7 +541,7 @@ otherwise, \tcode{false}.
 otherwise, \tcode{true}.
 \end{itemdescr}
 
-\rSec3[stoptoken.cmp]{Comparisons}
+\rSec3[stoptoken.nonmembers]{Non-member functions}
 
 \indexlibrarymember{operator==}{stop_token}%
 \begin{itemdecl}
@@ -556,19 +555,6 @@ otherwise, \tcode{true}.
 or if both \tcode{lhs} and \tcode{rhs} do not have ownership of a stop state;
 otherwise \tcode{false}.
 \end{itemdescr}
-
-\indexlibrarymember{operator!=}{stop_token}%
-\begin{itemdecl}
-[[nodiscard]] bool operator!=(const stop_token& lhs, const stop_token& rhs) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\tcode{!(lhs==rhs)}.
-\end{itemdescr}
-
-\rSec3[stoptoken.special]{Specialized algorithms}
 
 \indexlibrarymember{swap}{stop_token}%
 \begin{itemdecl}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -979,6 +979,9 @@ These threads are intended to map one-to-one with operating system threads.
 
 \indexheader{thread}%
 \begin{codeblock}
+#include <compare>              // see \ref{compare.syn}
+#include <initializer_list>     // see \ref{initializer.list.syn}
+
 namespace std {
   class thread;
 

--- a/source/time.tex
+++ b/source/time.tex
@@ -9372,31 +9372,32 @@ namespace std::chrono {
     zoned_time(sys_time<Duration>)
       -> zoned_time<common_type_t<Duration, seconds>>;
 
-  template<class TimeZonePtr, class Duration>
-    zoned_time(TimeZonePtr, sys_time<Duration>)
-      -> zoned_time<common_type_t<Duration, seconds>, TimeZonePtr>;
+  template<class TimeZonePtrOrName>
+    using @\exposid{time-zone-representation}@ =        // \expos
+      conditional_t<is_convertible_v<TimeZonePtrOrName, string_view>,
+                    const time_zone*,
+                    remove_cv_ref<TimeZonePtrOrName>>;
 
-  template<class TimeZonePtr, class Duration>
-    zoned_time(TimeZonePtr, local_time<Duration>, choose = choose::earliest)
-      -> zoned_time<common_type_t<Duration, seconds>, TimeZonePtr>;
+  template<class TimeZonePtrOrName>
+    zoned_time(TimeZonePtrOrName&&)
+      -> zoned_time<seconds, @\exposid{time-zone-representation}@<TimeZonePtrOrName>>;
 
-  template<class TimeZonePtr, class Duration>
-    zoned_time(TimeZonePtr, zoned_time<Duration>, choose = choose::earliest)
-      -> zoned_time<common_type_t<Duration, seconds>, TimeZonePtr>;
+  template<class TimeZonePtrOrName, class Duration>
+    zoned_time(TimeZonePtrOrName&&, sys_time<Duration>)
+      -> zoned_time<common_type_t<Duration, seconds>,
+                    @\exposid{time-zone-representation}@<TimeZonePtrOrName>>;
 
-  zoned_time(string_view) -> zoned_time<seconds>;
+  template<class TimeZonePtrOrName, class Duration>
+    zoned_time(TimeZonePtrOrName&&, local_time<Duration>,
+               choose = choose::earliest)
+      -> zoned_time<common_type_t<Duration, seconds>,
+                    @\exposid{time-zone-representation}@<TimeZonePtrOrName>>;
 
-  template<class Duration>
-    zoned_time(string_view, sys_time<Duration>)
-      -> zoned_time<common_type_t<Duration, seconds>>;
-
-  template<class Duration>
-    zoned_time(string_view, local_time<Duration>, choose = choose::earliest)
-      -> zoned_time<common_type_t<Duration, seconds>>;
-
-  template<class Duration, class TimeZonePtr, class TimeZonePtr2>
-    zoned_time(TimeZonePtr, zoned_time<Duration, TimeZonePtr2>, choose = choose::earliest)
-      -> zoned_time<common_type_t<Duration, seconds>, TimeZonePtr>;
+  template<class Duration, class TimeZonePtrOrName, class TimeZonePtr2>
+    zoned_time(TimeZonePtrOrName&&, zoned_time<Duration, TimeZonePtr2>,
+               choose = choose::earliest)
+      -> zoned_time<common_type_t<Duration, seconds>,
+                    @\exposid{time-zone-representation}@<TimeZonePtrOrName>>;
 }
 \end{codeblock}
 
@@ -9411,6 +9412,12 @@ in that time zone.
 \pnum
 If \tcode{Duration} is not a specialization of \tcode{chrono::duration},
 the program is ill-formed.
+
+\pnum
+Every constructor of \tcode{zoned_time} that
+accepts a \tcode{string_view} as its first parameter
+does not participate in
+class template argument deduction\iref{over.match.class.deduct}.
 
 \rSec3[time.zone.zonedtime.ctor]{Constructors}
 

--- a/source/time.tex
+++ b/source/time.tex
@@ -2619,7 +2619,7 @@ namespace std::chrono {
 \pnum
 Objects of type \tcode{system_clock} represent wall clock time from the system-wide
 realtime clock.
-Objects of type \tcode{sys_time<Duration>} measure time since (and before)
+Objects of type \tcode{sys_time<Duration>} measure time since
 1970-01-01 00:00:00 UTC excluding leap seconds.
 This measure is commonly referred to as \defn{Unix time}.
 This measure facilitates an efficient mapping between

--- a/source/time.tex
+++ b/source/time.tex
@@ -8492,7 +8492,7 @@ the value returned is unspecified.
 
 \pnum
 \ref{time.zone} describes an interface for accessing
-the IANA Time Zone database described in RFC 6557,
+the IANA Time Zone Database
 that interoperates with \tcode{sys_time} and \tcode{local_time}.
 This interface provides time zone support to
 both the civil calendar types\iref{time.cal}

--- a/source/time.tex
+++ b/source/time.tex
@@ -2736,6 +2736,12 @@ In contrast to \tcode{sys_time},
 which does not take leap seconds into account,
 \tcode{utc_clock} and its associated \tcode{time_point}, \tcode{utc_time},
 count time, including leap seconds, since 1970-01-01 00:00:00 UTC.
+\begin{note}
+The UTC time standard began on 1972-01-01 00:00:10 TAI.
+To measure time since this epoch instead, one can add/subtract the constant
+\tcode{sys_days\{1972y/1/1\} - sys_days\{1970y/1/1\}} (\tcode{63'072'000s})
+from the \tcode{utc_time}.
+\end{note}
 \begin{example}
 \\
 \tcode{clock_cast<utc_clock>(sys_seconds\{sys_days\{1970y/January/1\}\}).time_since_epoch()} is \tcode{0s}. \\

--- a/source/time.tex
+++ b/source/time.tex
@@ -63,6 +63,8 @@ Let \exposid{STATICALLY-WIDEN}\tcode{<charT>("...")} be
 \indexlibrarymember{earliest}{choose}%
 \indexlibrarymember{latest}{choose}%
 \begin{codeblock}
+#include <compare>              // see \ref{compare.syn}
+
 namespace std {
   namespace chrono {
     // \ref{time.duration}, class template \tcode{duration}

--- a/source/time.tex
+++ b/source/time.tex
@@ -10226,7 +10226,7 @@ according to the following syntax:
 \begin{ncbnf}
 \fmtnontermdef{type} \textnormal{one of}\br
     \terminal{a A b B c C d D e F g G h H I j m M n}\br
-    \terminal{p r R S t T u U V w W x X y Y z Z \%}
+    \terminal{p q Q r R S t T u U V w W x X y Y z Z \%}
 \end{ncbnf}
 
 The productions

--- a/source/time.tex
+++ b/source/time.tex
@@ -2014,60 +2014,118 @@ template<class charT, class traits, class Rep, class Period>
 
 \begin{itemdescr}
 \pnum
-\mandates
-\tcode{Rep} is an integral type
-whose integer conversion rank\iref{conv.rank}
-is greater than or equal to that of \tcode{short},
-or a floating-point type.
-\tcode{charT} is \tcode{char} or \tcode{wchar_t}.
-
-\pnum
 \effects
-Forms a \tcode{basic_string<charT, traits>} from \tcode{d.count()}
-using \tcode{to_string} if \tcode{charT} is \tcode{char},
-or \tcode{to_wstring} if \tcode{charT} is \tcode{wchar_t}.
-Appends the units suffix described below to the \tcode{basic_string}.
-Inserts the resulting \tcode{basic_string} into \tcode{os}.
-\begin{note}
-This specification ensures that the result of this streaming operation
-will obey the width and alignment properties of the stream.
-\end{note}
+Inserts the duration \tcode{d} onto the stream \tcode{os}
+as if it were implemented as follows:
+\begin{codeblock}
+basic_ostringstream<charT, traits> s;
+s.flags(os.flags());
+s.imbue(os.getloc());
+s.precision(os.precision());
+s << d.count() << @\placeholder{units-suffix}@;
+return os << s.str();
+\end{codeblock}
+where \tcode{\placeholder{units-suffix}}
+depends on the type \tcode{Period::type} as follows:
 
-\pnum
-The units suffix depends on the type \tcode{Period::type} as follows:
 \begin{itemize}
-\item If \tcode{Period::type} is \tcode{atto}, the suffix is \tcode{"as"}.
-\item Otherwise, if \tcode{Period::type} is \tcode{femto}, the suffix is \tcode{"fs"}.
-\item Otherwise, if \tcode{Period::type} is \tcode{pico}, the suffix is \tcode{"ps"}.
-\item Otherwise, if \tcode{Period::type} is \tcode{nano}, the suffix is \tcode{"ns"}.
-\item Otherwise, if \tcode{Period::type} is \tcode{micro}, the suffix is \tcode{"\textmu{}s"} (\tcode{"\textbackslash{}u00b5\textbackslash{}u0073"}).
-\item Otherwise, if \tcode{Period::type} is \tcode{milli}, the suffix is \tcode{"ms"}.
-\item Otherwise, if \tcode{Period::type} is \tcode{centi}, the suffix is \tcode{"cs"}.
-\item Otherwise, if \tcode{Period::type} is \tcode{deci}, the suffix is \tcode{"ds"}.
-\item Otherwise, if \tcode{Period::type} is \tcode{ratio<1>}, the suffix is \tcode{"s"}.
-\item Otherwise, if \tcode{Period::type} is \tcode{deca}, the suffix is \tcode{"das"}.
-\item Otherwise, if \tcode{Period::type} is \tcode{hecto}, the suffix is \tcode{"hs"}.
-\item Otherwise, if \tcode{Period::type} is \tcode{kilo}, the suffix is \tcode{"ks"}.
-\item Otherwise, if \tcode{Period::type} is \tcode{mega}, the suffix is \tcode{"Ms"}.
-\item Otherwise, if \tcode{Period::type} is \tcode{giga}, the suffix is \tcode{"Gs"}.
-\item Otherwise, if \tcode{Period::type} is \tcode{tera}, the suffix is \tcode{"Ts"}.
-\item Otherwise, if \tcode{Period::type} is \tcode{peta}, the suffix is \tcode{"Ps"}.
-\item Otherwise, if \tcode{Period::type} is \tcode{exa}, the suffix is \tcode{"Es"}.
-\item Otherwise, if \tcode{Period::type} is \tcode{ratio<60>}, the suffix is \tcode{"min"}.
-\item Otherwise, if \tcode{Period::type} is \tcode{ratio<3600>}, the suffix is \tcode{"h"}.
-\item Otherwise, if \tcode{Period::type} is \tcode{ratio<86400>}, the suffix is \tcode{"d"}.
-\item Otherwise, if \tcode{Period::type::den == 1}, the suffix is \tcode{"[\placeholder{num}]s"}.
-\item Otherwise, the suffix is \tcode{"[\placeholder{num}/\placeholder{den}]s"}.
+\item
+If \tcode{Period::type} is \tcode{atto},
+\tcode{\placeholder{units-suffix}} is \tcode{"as"}.
+
+\item
+Otherwise, if \tcode{Period::type} is \tcode{femto},
+\tcode{\placeholder{units-suffix}} is \tcode{"fs"}.
+
+\item
+Otherwise, if \tcode{Period::type} is \tcode{pico},
+\tcode{\placeholder{units-suffix}} is \tcode{"ps"}.
+
+\item
+Otherwise, if \tcode{Period::type} is \tcode{nano},
+\tcode{\placeholder{units-suffix}} is \tcode{"ns"}.
+
+\item
+Otherwise, if \tcode{Period::type} is \tcode{micro},
+\tcode{\placeholder{units-suffix}} is:
+\begin{itemize}
+\item \tcode{"\textmu{}s"} (\tcode{"\textbackslash{}u00b5\textbackslash{}u0073"}) if the character U+00B5 can be represented in the encoding used for \tcode{charT};
+\item \tcode{"us"} otherwise.
 \end{itemize}
-In the list above the use of \tcode{\placeholder{num}} and \tcode{\placeholder{den}}
+
+\item
+Otherwise, if \tcode{Period::type} is \tcode{milli},
+\tcode{\placeholder{units-suffix}} is \tcode{"ms"}.
+
+\item
+Otherwise, if \tcode{Period::type} is \tcode{centi},
+\tcode{\placeholder{units-suffix}} is \tcode{"cs"}.
+
+\item
+Otherwise, if \tcode{Period::type} is \tcode{deci},
+\tcode{\placeholder{units-suffix}} is \tcode{"ds"}.
+
+\item
+Otherwise, if \tcode{Period::type} is \tcode{ratio<1>},
+\tcode{\placeholder{units-suffix}} is \tcode{"s"}.
+
+\item
+Otherwise, if \tcode{Period::type} is \tcode{deca},
+\tcode{\placeholder{units-suffix}} is \tcode{"das"}.
+
+\item
+Otherwise, if \tcode{Period::type} is \tcode{hecto},
+\tcode{\placeholder{units-suffix}} is \tcode{"hs"}.
+
+\item
+Otherwise, if \tcode{Period::type} is \tcode{kilo},
+\tcode{\placeholder{units-suffix}} is \tcode{"ks"}.
+
+\item
+Otherwise, if \tcode{Period::type} is \tcode{mega},
+\tcode{\placeholder{units-suffix}} is \tcode{"Ms"}.
+
+\item
+Otherwise, if \tcode{Period::type} is \tcode{giga},
+\tcode{\placeholder{units-suffix}} is \tcode{"Gs"}.
+
+\item
+Otherwise, if \tcode{Period::type} is \tcode{tera},
+\tcode{\placeholder{units-suffix}} is \tcode{"Ts"}.
+
+\item
+Otherwise, if \tcode{Period::type} is \tcode{peta},
+\tcode{\placeholder{units-suffix}} is \tcode{"Ps"}.
+
+\item
+Otherwise, if \tcode{Period::type} is \tcode{exa},
+\tcode{\placeholder{units-suffix}} is \tcode{"Es"}.
+
+\item
+Otherwise, if \tcode{Period::type} is \tcode{ratio<60>},
+\tcode{\placeholder{units-suffix}} is \tcode{"min"}.
+
+\item
+Otherwise, if \tcode{Period::type} is \tcode{ratio<3600>},
+\tcode{\placeholder{units-suffix}} is \tcode{"h"}.
+
+\item
+Otherwise, if \tcode{Period::type} is \tcode{ratio<86400>},
+\tcode{\placeholder{units-suffix}} is \tcode{"d"}.
+
+\item
+Otherwise, if \tcode{Period::type::den == 1},
+\tcode{\placeholder{units-suffix}} is \tcode{"[\placeholder{num}]s"}.
+
+\item
+Otherwise, \tcode{\placeholder{units-suffix}} is
+\tcode{"[\placeholder{num}/\placeholder{den}]s"}.
+\end{itemize}
+
+In the list above,
+the use of \tcode{\placeholder{num}} and \tcode{\placeholder{den}}
 refer to the static data members of \tcode{Period::type},
 which are converted to arrays of \tcode{charT} using a decimal conversion with no leading zeroes.
-
-\pnum
-If \tcode{Period::type} is \tcode{micro},
-but the character U+00B5 cannot be represented in
-the encoding used for \tcode{charT},
-the unit suffix \tcode{"us"} is used instead of \tcode{"\textmu{}s"}.
 
 \pnum
 \returns

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -19830,14 +19830,14 @@ the size of the content and the alignment option has no effect.
 \topline
 \lhdr{Option} & \rhdr{Meaning} \\ \rowsep
 \tcode{<} &
-Forces the field to be left-aligned within the available space.
+Forces the field to be aligned to the start of the available space.
 This is the default for
 non-arithmetic types, \tcode{charT}, and \tcode{bool},
 unless an integer presentation type is specified.
 \\ \rowsep
 %
 \tcode{>} &
-Forces the field to be right-aligned within the available space.
+Forces the field to be aligned to the end of the available space.
 This is the default for
 arithmetic types other than \tcode{charT} and \tcode{bool}
 or when an integer presentation type is specified.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -520,7 +520,7 @@ throws an exception.
 \pnum
 The defaulted move and copy constructor, respectively, of \tcode{pair}
 is a constexpr function if and only if all required element-wise
-initializations for copy and move, respectively, would satisfy the
+initializations for move and copy, respectively, would satisfy the
 requirements for a constexpr function.
 
 \pnum
@@ -1160,7 +1160,7 @@ one of the types in \tcode{Types} throws an exception.
 \pnum
 The defaulted move and copy constructor, respectively, of
 \tcode{tuple} is a constexpr function if and only if all
-required element-wise initializations for copy and move, respectively,
+required element-wise initializations for move and copy, respectively,
 would satisfy the requirements for a constexpr function. The
 defaulted move and copy constructor of \tcode{tuple<>} are
 constexpr functions.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7614,8 +7614,8 @@ template<class T, class Alloc, class... Args>
 \effects
 Equivalent to:
 \begin{codeblock}
-return apply([&](auto&&...xs) {
-       return construct_at(p, std::forward<decltype(xs)>(xs)...);
+return apply([&]<class... U>(U&&... xs) {
+       return construct_at(p, std::forward<U>(xs)...);
      }, uses_allocator_construction_args<T>(alloc, std::forward<Args>(args)...));
 \end{codeblock}
 \end{itemdescr}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6609,14 +6609,14 @@ namespace std {
 
   namespace ranges {
     template<@\exposconcept{no-throw-forward-iterator}@ I, @\exposconcept{no-throw-sentinel}@<I> S>
-      requires default_constructible<iter_value_t<I>>
+      requires default_initializable<iter_value_t<I>>
         I uninitialized_default_construct(I first, S last);
     template<@\exposconcept{no-throw-forward-range}@ R>
-      requires default_constructible<range_value_t<R>>
+      requires default_initializable<range_value_t<R>>
         safe_iterator_t<R> uninitialized_default_construct(R&& r);
 
     template<@\exposconcept{no-throw-forward-iterator}@ I>
-      requires default_constructible<iter_value_t<I>>
+      requires default_initializable<iter_value_t<I>>
         I uninitialized_default_construct_n(I first, iter_difference_t<I> n);
   }
 
@@ -6633,14 +6633,14 @@ namespace std {
 
   namespace ranges {
     template<@\exposconcept{no-throw-forward-iterator}@ I, @\exposconcept{no-throw-sentinel}@<I> S>
-      requires default_constructible<iter_value_t<I>>
+      requires default_initializable<iter_value_t<I>>
         I uninitialized_value_construct(I first, S last);
     template<@\exposconcept{no-throw-forward-range}@ R>
-      requires default_constructible<range_value_t<R>>
+      requires default_initializable<range_value_t<R>>
         safe_iterator_t<R> uninitialized_value_construct(R&& r);
 
     template<@\exposconcept{no-throw-forward-iterator}@ I>
-      requires default_constructible<iter_value_t<I>>
+      requires default_initializable<iter_value_t<I>>
         I uninitialized_value_construct_n(I first, iter_difference_t<I> n);
   }
 
@@ -8225,10 +8225,10 @@ for (; first != last; ++first)
 \begin{itemdecl}
 namespace ranges {
   template<@\placeholdernc{no-throw-forward-iterator}@ I, @\placeholdernc{no-throw-sentinel}@<I> S>
-      requires default_constructible<iter_value_t<I>>
+      requires default_initializable<iter_value_t<I>>
     I uninitialized_default_construct(I first, S last);
   template<@\placeholdernc{no-throw-forward-range}@ R>
-      requires default_constructible<range_value_t<R>>
+      requires default_initializable<range_value_t<R>>
     safe_iterator_t<R> uninitialized_default_construct(R&& r);
 }
 \end{itemdecl}
@@ -8266,7 +8266,7 @@ return first;
 \begin{itemdecl}
 namespace ranges {
   template<@\placeholdernc{no-throw-forward-iterator}@ I>
-      requires default_constructible<iter_value_t<I>>
+      requires default_initializable<iter_value_t<I>>
     I uninitialized_default_construct_n(I first, iter_difference_t<I> n);
 }
 \end{itemdecl}
@@ -8304,10 +8304,10 @@ for (; first != last; ++first)
 \begin{itemdecl}
 namespace ranges {
   template<@\placeholdernc{no-throw-forward-iterator}@ I, @\placeholdernc{no-throw-sentinel}@<I> S>
-      requires default_constructible<iter_value_t<I>>
+      requires default_initializable<iter_value_t<I>>
     I uninitialized_value_construct(I first, S last);
   template<@\placeholdernc{no-throw-forward-range}@ R>
-      requires default_constructible<range_value_t<R>>
+      requires default_initializable<range_value_t<R>>
     safe_iterator_t<R> uninitialized_value_construct(R&& r);
 }
 \end{itemdecl}
@@ -8345,7 +8345,7 @@ return first;
 \begin{itemdecl}
 namespace ranges {
   template<@\placeholdernc{no-throw-forward-iterator}@ I>
-      requires default_constructible<iter_value_t<I>>
+      requires default_initializable<iter_value_t<I>>
     I uninitialized_value_construct_n(I first, iter_difference_t<I> n);
 }
 \end{itemdecl}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -12173,7 +12173,8 @@ Sets \tcode{memory_rsrc} to \tcode{other.resource()}.
 \begin{itemdescr}
 \pnum
 \effects
-If \tcode{SIZE_MAX / sizeof(Tp) < n}, throws \tcode{length_error}.
+If \tcode{numeric_limits<size_t>::max() / sizeof(Tp) < n},
+throws \tcode{length_error}.
 Otherwise equivalent to:
 \begin{codeblock}
 return static_cast<Tp*>(memory_rsrc->allocate(n * sizeof(Tp), alignof(Tp)));
@@ -12244,7 +12245,8 @@ Allocates memory suitable for holding
 an array of \tcode{n} objects of type \tcode{T}, as follows:
 \begin{itemize}
 \item
-  if \tcode{SIZE_MAX / sizeof(T) < n}, throws \tcode{length_error},
+  if \tcode{numeric_limits<size_t>::max() / sizeof(T) < n},
+  throws \tcode{length_error},
 \item
   otherwise equivalent to:
 \begin{codeblock}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -12090,11 +12090,11 @@ namespace std::pmr {
     [[nodiscard]] Tp* allocate(size_t n);
     void deallocate(Tp* p, size_t n);
 
-    void* allocate_bytes(size_t nbytes, size_t alignment = alignof(max_align_t));
+    [[nodiscard]] void* allocate_bytes(size_t nbytes, size_t alignment = alignof(max_align_t));
     void deallocate_bytes(void* p, size_t nbytes, size_t alignment = alignof(max_align_t));
-    template<class T> T* allocate_object(size_t n = 1);
+    template<class T> [[nodiscard]] T* allocate_object(size_t n = 1);
     template<class T> void deallocate_object(T* p, size_t n = 1);
-    template<class T, class... CtorArgs> T* new_object(CtorArgs&&... ctor_args);
+    template<class T, class... CtorArgs> [[nodiscard]] T* new_object(CtorArgs&&... ctor_args);
     template<class T> void delete_object(T* p);
 
     template<class T, class... Args>
@@ -12199,7 +12199,7 @@ Nothing.
 
 \indexlibrarymember{allocate_bytes}{polymorphic_allocator}%
 \begin{itemdecl}
-void* allocate_bytes(size_t nbytes, size_t alignment = alignof(max_align_t));
+[[nodiscard]] void* allocate_bytes(size_t nbytes, size_t alignment = alignof(max_align_t));
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -12230,7 +12230,7 @@ Equivalent to \tcode{memory_rsrc->deallocate(p, nbytes, alignment)}.
 \indexlibrarymember{allocate_object}{polymorphic_allocator}%
 \begin{itemdecl}
 template<class T>
-  T* allocate_object(size_t n = 1);
+  [[nodiscard]] T* allocate_object(size_t n = 1);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -12269,7 +12269,7 @@ Equivalent to \tcode{deallocate_bytes(p, n*sizeof(T), alignof(T))}.
 \indexlibrarymember{new_object}{polymorphic_allocator}%
 \begin{itemdecl}
 template<class T, class CtorArgs...>
-  T* new_object(CtorArgs&&... ctor_args);
+  [[nodiscard]] T* new_object(CtorArgs&&... ctor_args);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7605,8 +7605,9 @@ template<class T, class Alloc, class... Args>
 \effects
 Equivalent to:
 \begin{codeblock}
-return ::new(static_cast<void*>(p))
-  T(make_obj_using_allocator<T>(alloc, std::forward<Args>(args)...));
+return apply([&](auto&&...xs) {
+       return construct_at(p, std::forward<decltype(xs)>(xs)...);
+     }, uses_allocator_construction_args<T>(alloc, std::forward<Args>(args)...));
 \end{codeblock}
 \end{itemdescr}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -17828,9 +17828,8 @@ This rule reflects the semantics of reference collapsing\iref{dcl.ref}.
  rank\iref{conv.rank} for which
  \tcode{sizeof(T) == sizeof(type)}, with the same
  cv-qualifiers as \tcode{T}.\br
- \requires{} \tcode{T} shall be a (possibly cv-qualified)
- integral type or enumeration
- but not a \tcode{bool} type.\\ \rowsep
+ \mandates{} \tcode{T} is an integral or enumeration type
+ other than \cv~\tcode{bool}.\\ \rowsep
 
 \indexlibraryglobal{make_unsigned}%
 \tcode{template<class T>}\br
@@ -17845,9 +17844,8 @@ This rule reflects the semantics of reference collapsing\iref{dcl.ref}.
  rank\iref{conv.rank} for which
  \tcode{sizeof(T) == sizeof(type)}, with the same
  cv-qualifiers as \tcode{T}.\br
- \requires{} \tcode{T} shall be a (possibly cv-qualified)
- integral type or enumeration
- but not a \tcode{bool} type.\\
+ \mandates{} \tcode{T} is an integral or enumeration type
+ other than \cv~\tcode{bool}.\\ \rowsep
 \end{libreqtab2a}
 
 \rSec3[meta.trans.arr]{Array modifications}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7952,6 +7952,10 @@ deallocation call shall happen before the next allocation (if any) in this order
 
 \begin{itemdescr}
 \pnum
+\mandates
+\tcode{T} is not an incomplete type\iref{basic.types}.
+
+\pnum
 \returns
 A pointer to the initial element of an array of \tcode{n} \tcode{T}.
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -41,6 +41,7 @@ contains some basic function and class templates that are used
 throughout the rest of the library.
 
 \begin{codeblock}
+#include <compare>              // see \ref{compare.syn}
 #include <initializer_list>     // see \ref{initializer.list.syn}
 
 namespace std {
@@ -971,6 +972,8 @@ See~\ref{pairs}.
 
 \indexheader{tuple}%
 \begin{codeblock}
+#include <compare>              // see \ref{compare.syn}
+
 namespace std {
   // \ref{tuple.tuple}, class template \tcode{tuple}
   template<class... Types>
@@ -2136,6 +2139,8 @@ object is tracked by the optional object.
 
 \indexheader{optional}%
 \begin{codeblock}
+#include <compare>              // see \ref{compare.syn}
+
 namespace std {
   // \ref{optional.optional}, class template \tcode{optional}
   template<class T>
@@ -3648,6 +3653,8 @@ These template arguments are called alternatives.
 \indexheader{variant}%
 
 \begin{codeblock}
+#include <compare>              // see \ref{compare.syn}
+
 namespace std {
   // \ref{variant.variant}, class template \tcode{variant}
   template<class... Types>
@@ -6501,6 +6508,8 @@ The header also defines the templates
 templates that operate on objects of these types\iref{smartptr}.
 
 \begin{codeblock}
+#include <compare>              // see \ref{compare.syn}
+
 namespace std {
   // \ref{pointer.traits}, pointer traits
   template<class Ptr> struct pointer_traits;
@@ -18774,6 +18783,8 @@ the typedef shall not be defined.
 
 \indexheader{typeindex}%
 \begin{codeblock}
+#include <compare>              // see \ref{compare.syn}
+
 namespace std {
   class type_index;
   template<class T> struct hash;

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6747,13 +6747,13 @@ namespace std {
   template<class ForwardIterator>
     constexpr void destroy(ForwardIterator first, ForwardIterator last);
   template<class ExecutionPolicy, class ForwardIterator>
-    constexpr void destroy(ExecutionPolicy&& exec,              // see \ref{algorithms.parallel.overloads}
-                           ForwardIterator first, ForwardIterator last);
+    void destroy(ExecutionPolicy&& exec,                        // see \ref{algorithms.parallel.overloads}
+                 ForwardIterator first, ForwardIterator last);
   template<class ForwardIterator, class Size>
     constexpr ForwardIterator destroy_n(ForwardIterator first, Size n);
   template<class ExecutionPolicy, class ForwardIterator, class Size>
-    constexpr ForwardIterator destroy_n(ExecutionPolicy&& exec, // see \ref{algorithms.parallel.overloads}
-                                        ForwardIterator first, Size n);
+    ForwardIterator destroy_n(ExecutionPolicy&& exec,           // see \ref{algorithms.parallel.overloads}
+                              ForwardIterator first, Size n);
 
   namespace ranges {
     template<destructible T>

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -10302,7 +10302,24 @@ template<class D, class A> shared_ptr(nullptr_t p, D d, A a);
 
 \begin{itemdescr}
 \pnum
-\requires Construction of \tcode{d} and a deleter of type \tcode{D}
+\constraints
+\tcode{is_move_constructible_v<D>} is \tcode{true}, and
+\tcode{d(p)} is a well-formed expression.
+For the first two overloads:
+
+\begin{itemize}
+\item
+If \tcode{T} is an array type, then either
+\tcode{T} is \tcode{U[N]} and \tcode{Y(*)[N]} is convertible to \tcode{T*}, or
+\tcode{T} is \tcode{U[]} and \tcode{Y(*)[]} is convertible to \tcode{T*}.
+
+\item
+If \tcode{T} is not an array type, then \tcode{Y*} is convertible to \tcode{T*}.
+\end{itemize}
+
+\pnum
+\expects
+Construction of \tcode{d} and a deleter of type \tcode{D}
 initialized with \tcode{std::move(d)} shall not throw exceptions.
 The expression \tcode{d(p)}
 shall have well-defined behavior and shall not throw exceptions.
@@ -10328,20 +10345,6 @@ If an exception is thrown, \tcode{d(p)} is called.
 \tcode{bad_alloc}, or an \impldef{exception type when \tcode{shared_ptr}
 constructor fails} exception
 when a resource other than memory could not be obtained.
-
-\pnum
-\remarks
-When \tcode{T} is an array type,
-this constructor shall not participate in overload resolution unless
-\tcode{is_move_constructible_v<D>} is \tcode{true},
-the expression \tcode{d(p)} is well-formed, and either
-\tcode{T} is \tcode{U[N]} and \tcode{Y(*)[N]} is convertible to \tcode{T*}, or
-\tcode{T} is \tcode{U[]} and \tcode{Y(*)[]} is convertible to \tcode{T*}.
-When \tcode{T} is not an array type,
-this constructor shall not participate in overload resolution unless
-\tcode{is_move_constructible_v<D>} is \tcode{true},
-the expression \tcode{d(p)} is well-formed, and
-\tcode{Y*} is convertible to \tcode{T*}.
 \end{itemdescr}
 
 \indexlibraryctor{shared_ptr}%


### PR DESCRIPTION
Fixes #3704.

Notes/issues:
* LWG3281 not applied; text was removed by LWG3282

Fixes cplusplus/papers#781.
Fixes cplusplus/nbballot#298.
Fixes cplusplus/nbballot#258.
Fixes cplusplus/nbballot#154.
Fixes cplusplus/nbballot#300.
Fixes cplusplus/nbballot#283.
Fixes cplusplus/nbballot#282.
Fixes cplusplus/nbballot#214.
Fixes cplusplus/nbballot#215.
Fixes cplusplus/nbballot#216.
Fixes cplusplus/nbballot#290.
Fixes cplusplus/nbballot#160.
Fixes cplusplus/nbballot#161.
Fixes cplusplus/nbballot#329.
Fixes cplusplus/nbballot#330.
Fixes cplusplus/nbballot#331.
Fixes cplusplus/nbballot#340.
Fixes cplusplus/nbballot#243.
Fixes cplusplus/nbballot#210.
Fixes cplusplus/nbballot#295.
Fixes cplusplus/nbballot#176.
Fixes cplusplus/nbballot#299.
Fixes cplusplus/nbballot#278.
Fixes cplusplus/nbballot#222.
Fixes cplusplus/nbballot#199.
Fixes cplusplus/nbballot#179.
Fixes cplusplus/nbballot#200.