### PR TITLE
LWG Poll 3: P2117R0 C++ Standard Library Issues Resolved Directly In Prague

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -9896,7 +9896,11 @@ template<class T>
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{T} is a complete object type.
+\tcode{T} is an object type.
+
+\pnum
+\mandates
+\tcode{T} is a complete type.
 
 \pnum
 \expects

--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -691,7 +691,7 @@ namespace std {
         for_each(I first, S last, Fun f, Proj proj = {});
     template<input_range R, class Proj = identity,
              indirectly_unary_invocable<projected<iterator_t<R>, Proj>> Fun>
-      constexpr for_each_result<safe_iterator_t<R>, Fun>
+      constexpr for_each_result<borrowed_iterator_t<R>, Fun>
         for_each(R&& r, Fun f, Proj proj = {});
   }
 
@@ -731,21 +731,21 @@ namespace std {
     template<input_range R, class T, class Proj = identity>
       requires indirect_binary_predicate<ranges::equal_to,
                                          projected<iterator_t<R>, Proj>, const T*>
-      constexpr safe_iterator_t<R>
+      constexpr borrowed_iterator_t<R>
         find(R&& r, const T& value, Proj proj = {});
     template<input_iterator I, sentinel_for<I> S, class Proj = identity,
              indirect_unary_predicate<projected<I, Proj>> Pred>
       constexpr I find_if(I first, S last, Pred pred, Proj proj = {});
     template<input_range R, class Proj = identity,
              indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
-      constexpr safe_iterator_t<R>
+      constexpr borrowed_iterator_t<R>
         find_if(R&& r, Pred pred, Proj proj = {});
     template<input_iterator I, sentinel_for<I> S, class Proj = identity,
              indirect_unary_predicate<projected<I, Proj>> Pred>
       constexpr I find_if_not(I first, S last, Pred pred, Proj proj = {});
     template<input_range R, class Proj = identity,
              indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
-      constexpr safe_iterator_t<R>
+      constexpr borrowed_iterator_t<R>
         find_if_not(R&& r, Pred pred, Proj proj = {});
   }
 
@@ -782,7 +782,7 @@ namespace std {
     template<forward_range R1, forward_range R2,
              class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
       requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
-      constexpr safe_subrange_t<R1>
+      constexpr borrowed_subrange_t<R1>
         find_end(R1&& r1, R2&& r2, Pred pred = {},
                  Proj1 proj1 = {}, Proj2 proj2 = {});
   }
@@ -820,7 +820,7 @@ namespace std {
     template<input_range R1, forward_range R2,
              class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
       requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
-      constexpr safe_iterator_t<R1>
+      constexpr borrowed_iterator_t<R1>
         find_first_of(R1&& r1, R2&& r2,
                       Pred pred = {},
                       Proj1 proj1 = {}, Proj2 proj2 = {});
@@ -853,7 +853,7 @@ namespace std {
     template<forward_range R, class Proj = identity,
              indirect_binary_predicate<projected<iterator_t<R>, Proj>,
                                        projected<iterator_t<R>, Proj>> Pred = ranges::equal_to>
-      constexpr safe_iterator_t<R>
+      constexpr borrowed_iterator_t<R>
         adjacent_find(R&& r, Pred pred = {}, Proj proj = {});
   }
 
@@ -963,7 +963,7 @@ namespace std {
     template<input_range R1, input_range R2,
              class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
       requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
-      constexpr mismatch_result<safe_iterator_t<R1>, safe_iterator_t<R2>>
+      constexpr mismatch_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
         mismatch(R1&& r1, R2&& r2, Pred pred = {},
                  Proj1 proj1 = {}, Proj2 proj2 = {});
   }
@@ -1082,7 +1082,7 @@ namespace std {
     template<forward_range R1, forward_range R2, class Pred = ranges::equal_to,
              class Proj1 = identity, class Proj2 = identity>
       requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
-      constexpr safe_subrange_t<R1>
+      constexpr borrowed_subrange_t<R1>
         search(R1&& r1, R2&& r2, Pred pred = {},
                Proj1 proj1 = {}, Proj2 proj2 = {});
   }
@@ -1119,7 +1119,7 @@ namespace std {
     template<forward_range R, class T, class Pred = ranges::equal_to,
              class Proj = identity>
       requires indirectly_comparable<iterator_t<R>, const T*, Pred, Proj>
-      constexpr safe_subrange_t<R>
+      constexpr borrowed_subrange_t<R>
         search_n(R&& r, range_difference_t<R> count,
                  const T& value, Pred pred = {}, Proj proj = {});
   }
@@ -1163,7 +1163,7 @@ namespace std {
         copy(I first, S last, O result);
     template<input_range R, weakly_incrementable O>
       requires indirectly_copyable<iterator_t<R>, O>
-      constexpr copy_result<safe_iterator_t<R>, O>
+      constexpr copy_result<borrowed_iterator_t<R>, O>
         copy(R&& r, O result);
   }
 
@@ -1207,7 +1207,7 @@ namespace std {
     template<input_range R, weakly_incrementable O, class Proj = identity,
              indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
       requires indirectly_copyable<iterator_t<R>, O>
-      constexpr copy_if_result<safe_iterator_t<R>, O>
+      constexpr copy_if_result<borrowed_iterator_t<R>, O>
         copy_if(R&& r, O result, Pred pred, Proj proj = {});
   }
 
@@ -1226,7 +1226,7 @@ namespace std {
         copy_backward(I1 first, S1 last, I2 result);
     template<bidirectional_range R, bidirectional_iterator I>
       requires indirectly_copyable<iterator_t<R>, I>
-      constexpr copy_backward_result<safe_iterator_t<R>, I>
+      constexpr copy_backward_result<borrowed_iterator_t<R>, I>
         copy_backward(R&& r, I result);
   }
 
@@ -1250,7 +1250,7 @@ namespace std {
         move(I first, S last, O result);
     template<input_range R, weakly_incrementable O>
       requires indirectly_movable<iterator_t<R>, O>
-      constexpr move_result<safe_iterator_t<R>, O>
+      constexpr move_result<borrowed_iterator_t<R>, O>
         move(R&& r, O result);
   }
 
@@ -1269,7 +1269,7 @@ namespace std {
         move_backward(I1 first, S1 last, I2 result);
     template<bidirectional_range R, bidirectional_iterator I>
       requires indirectly_movable<iterator_t<R>, I>
-      constexpr move_backward_result<safe_iterator_t<R>, I>
+      constexpr move_backward_result<borrowed_iterator_t<R>, I>
         move_backward(R&& r, I result);
   }
 
@@ -1292,7 +1292,7 @@ namespace std {
         swap_ranges(I1 first1, S1 last1, I2 first2, S2 last2);
     template<input_range R1, input_range R2>
       requires indirectly_swappable<iterator_t<R1>, iterator_t<R2>>
-      constexpr swap_ranges_result<safe_iterator_t<R1>, safe_iterator_t<R2>>
+      constexpr swap_ranges_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
         swap_ranges(R1&& r1, R2&& r2);
   }
 
@@ -1336,7 +1336,7 @@ namespace std {
     template<input_range R, weakly_incrementable O, copy_constructible F,
              class Proj = identity>
       requires writable<O, indirect_result_t<F&, projected<iterator_t<R>, Proj>>>
-      constexpr unary_transform_result<safe_iterator_t<R>, O>
+      constexpr unary_transform_result<borrowed_iterator_t<R>, O>
         transform(R&& r, O result, F op, Proj proj = {});
 
     template<class I1, class I2, class O>
@@ -1372,7 +1372,7 @@ namespace std {
              copy_constructible F, class Proj1 = identity, class Proj2 = identity>
       requires writable<O, indirect_result_t<F&, projected<iterator_t<R1>, Proj1>,
                                              projected<iterator_t<R2>, Proj2>>>
-      constexpr binary_transform_result<safe_iterator_t<R1>, safe_iterator_t<R2>, O>
+      constexpr binary_transform_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
         transform(R1&& r1, R2&& r2, O result,
                   F binary_op, Proj1 proj1 = {}, Proj2 proj2 = {});
   }
@@ -1403,7 +1403,7 @@ namespace std {
       requires writable<iterator_t<R>, const T2&> &&
                indirect_binary_predicate<ranges::equal_to,
                                          projected<iterator_t<R>, Proj>, const T1*>
-      constexpr safe_iterator_t<R>
+      constexpr borrowed_iterator_t<R>
         replace(R&& r, const T1& old_value, const T2& new_value, Proj proj = {});
     template<input_iterator I, sentinel_for<I> S, class T, class Proj = identity,
              indirect_unary_predicate<projected<I, Proj>> Pred>
@@ -1412,7 +1412,7 @@ namespace std {
     template<input_range R, class T, class Proj = identity,
              indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
       requires writable<iterator_t<R>, const T&>
-      constexpr safe_iterator_t<R>
+      constexpr borrowed_iterator_t<R>
         replace_if(R&& r, Pred pred, const T& new_value, Proj proj = {});
   }
 
@@ -1452,7 +1452,7 @@ namespace std {
       requires indirectly_copyable<iterator_t<R>, O> &&
                indirect_binary_predicate<ranges::equal_to,
                                          projected<iterator_t<R>, Proj>, const T1*>
-      constexpr replace_copy_result<safe_iterator_t<R>, O>
+      constexpr replace_copy_result<borrowed_iterator_t<R>, O>
         replace_copy(R&& r, O result, const T1& old_value, const T2& new_value,
                      Proj proj = {});
 
@@ -1468,7 +1468,7 @@ namespace std {
     template<input_range R, class T, output_iterator<const T&> O, class Proj = identity,
              indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
       requires indirectly_copyable<iterator_t<R>, O>
-      constexpr replace_copy_if_result<safe_iterator_t<R>, O>
+      constexpr replace_copy_if_result<borrowed_iterator_t<R>, O>
         replace_copy_if(R&& r, O result, Pred pred, const T& new_value,
                         Proj proj = {});
   }
@@ -1490,7 +1490,7 @@ namespace std {
     template<class T, output_iterator<const T&> O, sentinel_for<O> S>
       constexpr O fill(O first, S last, const T& value);
     template<class T, output_range<const T&> R>
-      constexpr safe_iterator_t<R> fill(R&& r, const T& value);
+      constexpr borrowed_iterator_t<R> fill(R&& r, const T& value);
     template<class T, output_iterator<const T&> O>
       constexpr O fill_n(O first, iter_difference_t<O> n, const T& value);
   }
@@ -1515,7 +1515,7 @@ namespace std {
       constexpr O generate(O first, S last, F gen);
     template<class R, copy_constructible F>
       requires invocable<F&> && output_range<R, invoke_result_t<F&>>
-      constexpr safe_iterator_t<R> generate(R&& r, F gen);
+      constexpr borrowed_iterator_t<R> generate(R&& r, F gen);
     template<input_or_output_iterator O, copy_constructible F>
       requires invocable<F&> && writable<O, invoke_result_t<F&>>
       constexpr O generate_n(O first, iter_difference_t<O> n, F gen);
@@ -1545,7 +1545,7 @@ namespace std {
       requires permutable<iterator_t<R>> &&
                indirect_binary_predicate<ranges::equal_to,
                                          projected<iterator_t<R>, Proj>, const T*>
-      constexpr safe_subrange_t<R>
+      constexpr borrowed_subrange_t<R>
         remove(R&& r, const T& value, Proj proj = {});
     template<permutable I, sentinel_for<I> S, class Proj = identity,
              indirect_unary_predicate<projected<I, Proj>> Pred>
@@ -1553,7 +1553,7 @@ namespace std {
     template<forward_range R, class Proj = identity,
              indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
       requires permutable<iterator_t<R>>
-      constexpr safe_subrange_t<R>
+      constexpr borrowed_subrange_t<R>
         remove_if(R&& r, Pred pred, Proj proj = {});
   }
 
@@ -1592,7 +1592,7 @@ namespace std {
       requires indirectly_copyable<iterator_t<R>, O> &&
                indirect_binary_predicate<ranges::equal_to,
                                          projected<iterator_t<R>, Proj>, const T*>
-      constexpr remove_copy_result<safe_iterator_t<R>, O>
+      constexpr remove_copy_result<borrowed_iterator_t<R>, O>
         remove_copy(R&& r, O result, const T& value, Proj proj = {});
 
     template<class I, class O>
@@ -1606,7 +1606,7 @@ namespace std {
     template<input_range R, weakly_incrementable O, class Proj = identity,
              indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
       requires indirectly_copyable<iterator_t<R>, O>
-      constexpr remove_copy_if_result<safe_iterator_t<R>, O>
+      constexpr remove_copy_if_result<borrowed_iterator_t<R>, O>
         remove_copy_if(R&& r, O result, Pred pred, Proj proj = {});
   }
 
@@ -1631,7 +1631,7 @@ namespace std {
     template<forward_range R, class Proj = identity,
              indirect_equivalence_relation<projected<iterator_t<R>, Proj>> C = ranges::equal_to>
       requires permutable<iterator_t<R>>
-      constexpr safe_subrange_t<R>
+      constexpr borrowed_subrange_t<R>
         unique(R&& r, C comp = {}, Proj proj = {});
   }
 
@@ -1673,7 +1673,7 @@ namespace std {
                (forward_iterator<iterator_t<R>> ||
                 (input_iterator<O> && same_as<range_value_t<R>, iter_value_t<O>>) ||
                 indirectly_copyable_storable<iterator_t<R>, O>)
-      constexpr unique_copy_result<safe_iterator_t<R>, O>
+      constexpr unique_copy_result<borrowed_iterator_t<R>, O>
         unique_copy(R&& r, O result, C comp = {}, Proj proj = {});
   }
 
@@ -1690,7 +1690,7 @@ namespace std {
       constexpr I reverse(I first, S last);
     template<bidirectional_range R>
       requires permutable<iterator_t<R>>
-      constexpr safe_iterator_t<R> reverse(R&& r);
+      constexpr borrowed_iterator_t<R> reverse(R&& r);
   }
 
   template<class BidirectionalIterator, class OutputIterator>
@@ -1713,7 +1713,7 @@ namespace std {
         reverse_copy(I first, S last, O result);
     template<bidirectional_range R, weakly_incrementable O>
       requires indirectly_copyable<iterator_t<R>, O>
-      constexpr reverse_copy_result<safe_iterator_t<R>, O>
+      constexpr reverse_copy_result<borrowed_iterator_t<R>, O>
         reverse_copy(R&& r, O result);
   }
 
@@ -1733,7 +1733,7 @@ namespace std {
       constexpr subrange<I> rotate(I first, I middle, S last);
     template<forward_range R>
       requires permutable<iterator_t<R>>
-      constexpr safe_subrange_t<R> rotate(R&& r, iterator_t<R> middle);
+      constexpr borrowed_subrange_t<R> rotate(R&& r, iterator_t<R> middle);
   }
 
   template<class ForwardIterator, class OutputIterator>
@@ -1756,7 +1756,7 @@ namespace std {
         rotate_copy(I first, I middle, S last, O result);
     template<forward_range R, weakly_incrementable O>
       requires indirectly_copyable<iterator_t<R>, O>
-      constexpr rotate_copy_result<safe_iterator_t<R>, O>
+      constexpr rotate_copy_result<borrowed_iterator_t<R>, O>
         rotate_copy(R&& r, iterator_t<R> middle, O result);
   }
 
@@ -1781,7 +1781,7 @@ namespace std {
     template<random_access_range R, class Gen>
       requires permutable<iterator_t<R>> &&
                uniform_random_bit_generator<remove_reference_t<Gen>>
-      safe_iterator_t<R> shuffle(R&& r, Gen&& g);
+      borrowed_iterator_t<R> shuffle(R&& r, Gen&& g);
   }
 
   // \ref{alg.shift}, shift
@@ -1827,7 +1827,7 @@ namespace std {
         sort(I first, S last, Comp comp = {}, Proj proj = {});
     template<random_access_range R, class Comp = ranges::less, class Proj = identity>
       requires sortable<iterator_t<R>, Comp, Proj>
-      constexpr safe_iterator_t<R>
+      constexpr borrowed_iterator_t<R>
         sort(R&& r, Comp comp = {}, Proj proj = {});
   }
 
@@ -1851,7 +1851,7 @@ namespace std {
       I stable_sort(I first, S last, Comp comp = {}, Proj proj = {});
     template<random_access_range R, class Comp = ranges::less, class Proj = identity>
       requires sortable<iterator_t<R>, Comp, Proj>
-      safe_iterator_t<R>
+      borrowed_iterator_t<R>
         stable_sort(R&& r, Comp comp = {}, Proj proj = {});
   }
 
@@ -1882,7 +1882,7 @@ namespace std {
         partial_sort(I first, I middle, S last, Comp comp = {}, Proj proj = {});
     template<random_access_range R, class Comp = ranges::less, class Proj = identity>
       requires sortable<iterator_t<R>, Comp, Proj>
-      constexpr safe_iterator_t<R>
+      constexpr borrowed_iterator_t<R>
         partial_sort(R&& r, iterator_t<R> middle, Comp comp = {},
                      Proj proj = {});
   }
@@ -1930,7 +1930,7 @@ namespace std {
                sortable<iterator_t<R2>, Comp, Proj2> &&
                indirect_strict_weak_order<Comp, projected<iterator_t<R1>, Proj1>,
                                           projected<iterator_t<R2>, Proj2>>
-      constexpr partial_sort_copy_result<safe_iterator_t<R1>, safe_iterator_t<R2>>
+      constexpr partial_sort_copy_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
         partial_sort_copy(R1&& r, R2&& result_r, Comp comp = {},
                           Proj1 proj1 = {}, Proj2 proj2 = {});
   }
@@ -1980,7 +1980,7 @@ namespace std {
       constexpr I is_sorted_until(I first, S last, Comp comp = {}, Proj proj = {});
     template<forward_range R, class Proj = identity,
              indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
-      constexpr safe_iterator_t<R>
+      constexpr borrowed_iterator_t<R>
         is_sorted_until(R&& r, Comp comp = {}, Proj proj = {});
   }
 
@@ -2008,7 +2008,7 @@ namespace std {
         nth_element(I first, I nth, S last, Comp comp = {}, Proj proj = {});
     template<random_access_range R, class Comp = ranges::less, class Proj = identity>
       requires sortable<iterator_t<R>, Comp, Proj>
-      constexpr safe_iterator_t<R>
+      constexpr borrowed_iterator_t<R>
         nth_element(R&& r, iterator_t<R> nth, Comp comp = {}, Proj proj = {});
   }
 
@@ -2030,7 +2030,7 @@ namespace std {
     template<forward_range R, class T, class Proj = identity,
              indirect_strict_weak_order<const T*, projected<iterator_t<R>, Proj>> Comp =
                ranges::less>
-      constexpr safe_iterator_t<R>
+      constexpr borrowed_iterator_t<R>
         lower_bound(R&& r, const T& value, Comp comp = {}, Proj proj = {});
   }
 
@@ -2050,7 +2050,7 @@ namespace std {
     template<forward_range R, class T, class Proj = identity,
              indirect_strict_weak_order<const T*, projected<iterator_t<R>, Proj>> Comp =
                ranges::less>
-      constexpr safe_iterator_t<R>
+      constexpr borrowed_iterator_t<R>
         upper_bound(R&& r, const T& value, Comp comp = {}, Proj proj = {});
   }
 
@@ -2071,7 +2071,7 @@ namespace std {
     template<forward_range R, class T, class Proj = identity,
              indirect_strict_weak_order<const T*, projected<iterator_t<R>, Proj>> Comp =
                ranges::less>
-      constexpr safe_subrange_t<R>
+      constexpr borrowed_subrange_t<R>
         equal_range(R&& r, const T& value, Comp comp = {}, Proj proj = {});
   }
 
@@ -2130,7 +2130,7 @@ namespace std {
     template<forward_range R, class Proj = identity,
              indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
       requires permutable<iterator_t<R>>
-      constexpr safe_subrange_t<R>
+      constexpr borrowed_subrange_t<R>
         partition(R&& r, Pred pred, Proj proj = {});
   }
 
@@ -2152,7 +2152,7 @@ namespace std {
     template<bidirectional_range R, class Proj = identity,
              indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
       requires permutable<iterator_t<R>>
-      safe_subrange_t<R> stable_partition(R&& r, Pred pred, Proj proj = {});
+      borrowed_subrange_t<R> stable_partition(R&& r, Pred pred, Proj proj = {});
   }
 
   template<class InputIterator, class OutputIterator1,
@@ -2203,7 +2203,7 @@ namespace std {
              indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
       requires indirectly_copyable<iterator_t<R>, O1> &&
                indirectly_copyable<iterator_t<R>, O2>
-      constexpr partition_copy_result<safe_iterator_t<R>, O1, O2>
+      constexpr partition_copy_result<borrowed_iterator_t<R>, O1, O2>
         partition_copy(R&& r, O1 out_true, O2 out_false, Pred pred, Proj proj = {});
   }
 
@@ -2218,7 +2218,7 @@ namespace std {
       constexpr I partition_point(I first, S last, Pred pred, Proj proj = {});
     template<forward_range R, class Proj = identity,
              indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
-      constexpr safe_iterator_t<R>
+      constexpr borrowed_iterator_t<R>
         partition_point(R&& r, Pred pred, Proj proj = {});
   }
 
@@ -2263,7 +2263,7 @@ namespace std {
     template<input_range R1, input_range R2, weakly_incrementable O, class Comp = ranges::less,
              class Proj1 = identity, class Proj2 = identity>
       requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
-      constexpr merge_result<safe_iterator_t<R1>, safe_iterator_t<R2>, O>
+      constexpr merge_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
         merge(R1&& r1, R2&& r2, O result,
               Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
   }
@@ -2294,7 +2294,7 @@ namespace std {
       I inplace_merge(I first, I middle, S last, Comp comp = {}, Proj proj = {});
     template<bidirectional_range R, class Comp = ranges::less, class Proj = identity>
       requires sortable<iterator_t<R>, Comp, Proj>
-      safe_iterator_t<R>
+      borrowed_iterator_t<R>
         inplace_merge(R&& r, iterator_t<R> middle, Comp comp = {},
                       Proj proj = {});
   }
@@ -2372,7 +2372,7 @@ namespace std {
     template<input_range R1, input_range R2, weakly_incrementable O,
              class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
       requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
-      constexpr set_union_result<safe_iterator_t<R1>, safe_iterator_t<R2>, O>
+      constexpr set_union_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
         set_union(R1&& r1, R2&& r2, O result, Comp comp = {},
                   Proj1 proj1 = {}, Proj2 proj2 = {});
   }
@@ -2416,7 +2416,7 @@ namespace std {
     template<input_range R1, input_range R2, weakly_incrementable O,
              class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
       requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
-      constexpr set_intersection_result<safe_iterator_t<R1>, safe_iterator_t<R2>, O>
+      constexpr set_intersection_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
         set_intersection(R1&& r1, R2&& r2, O result,
                          Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
   }
@@ -2460,7 +2460,7 @@ namespace std {
     template<input_range R1, input_range R2, weakly_incrementable O,
              class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
       requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
-      constexpr set_difference_result<safe_iterator_t<R1>, O>
+      constexpr set_difference_result<borrowed_iterator_t<R1>, O>
         set_difference(R1&& r1, R2&& r2, O result,
                        Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
   }
@@ -2505,7 +2505,8 @@ namespace std {
     template<input_range R1, input_range R2, weakly_incrementable O,
              class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
       requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
-      constexpr set_symmetric_difference_result<safe_iterator_t<R1>, safe_iterator_t<R2>, O>
+      constexpr set_symmetric_difference_result<borrowed_iterator_t<R1>,
+                                                borrowed_iterator_t<R2>, O>
         set_symmetric_difference(R1&& r1, R2&& r2, O result, Comp comp = {},
                                  Proj1 proj1 = {}, Proj2 proj2 = {});
   }
@@ -2525,7 +2526,7 @@ namespace std {
         push_heap(I first, S last, Comp comp = {}, Proj proj = {});
     template<random_access_range R, class Comp = ranges::less, class Proj = identity>
       requires sortable<iterator_t<R>, Comp, Proj>
-      constexpr safe_iterator_t<R>
+      constexpr borrowed_iterator_t<R>
         push_heap(R&& r, Comp comp = {}, Proj proj = {});
   }
 
@@ -2543,7 +2544,7 @@ namespace std {
         pop_heap(I first, S last, Comp comp = {}, Proj proj = {});
     template<random_access_range R, class Comp = ranges::less, class Proj = identity>
       requires sortable<iterator_t<R>, Comp, Proj>
-      constexpr safe_iterator_t<R>
+      constexpr borrowed_iterator_t<R>
         pop_heap(R&& r, Comp comp = {}, Proj proj = {});
   }
 
@@ -2561,7 +2562,7 @@ namespace std {
         make_heap(I first, S last, Comp comp = {}, Proj proj = {});
     template<random_access_range R, class Comp = ranges::less, class Proj = identity>
       requires sortable<iterator_t<R>, Comp, Proj>
-      constexpr safe_iterator_t<R>
+      constexpr borrowed_iterator_t<R>
         make_heap(R&& r, Comp comp = {}, Proj proj = {});
   }
 
@@ -2579,7 +2580,7 @@ namespace std {
         sort_heap(I first, S last, Comp comp = {}, Proj proj = {});
     template<random_access_range R, class Comp = ranges::less, class Proj = identity>
       requires sortable<iterator_t<R>, Comp, Proj>
-      constexpr safe_iterator_t<R>
+      constexpr borrowed_iterator_t<R>
         sort_heap(R&& r, Comp comp = {}, Proj proj = {});
   }
 
@@ -2628,7 +2629,7 @@ namespace std {
       constexpr I is_heap_until(I first, S last, Comp comp = {}, Proj proj = {});
     template<random_access_range R, class Proj = identity,
              indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
-      constexpr safe_iterator_t<R>
+      constexpr borrowed_iterator_t<R>
         is_heap_until(R&& r, Comp comp = {}, Proj proj = {});
   }
 
@@ -2738,7 +2739,7 @@ namespace std {
       constexpr I min_element(I first, S last, Comp comp = {}, Proj proj = {});
     template<forward_range R, class Proj = identity,
              indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
-      constexpr safe_iterator_t<R>
+      constexpr borrowed_iterator_t<R>
         min_element(R&& r, Comp comp = {}, Proj proj = {});
   }
 
@@ -2761,7 +2762,7 @@ namespace std {
       constexpr I max_element(I first, S last, Comp comp = {}, Proj proj = {});
     template<forward_range R, class Proj = identity,
              indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
-      constexpr safe_iterator_t<R>
+      constexpr borrowed_iterator_t<R>
         max_element(R&& r, Comp comp = {}, Proj proj = {});
   }
 
@@ -2790,7 +2791,7 @@ namespace std {
         minmax_element(I first, S last, Comp comp = {}, Proj proj = {});
     template<forward_range R, class Proj = identity,
              indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
-      constexpr minmax_element_result<safe_iterator_t<R>>
+      constexpr minmax_element_result<borrowed_iterator_t<R>>
         minmax_element(R&& r, Comp comp = {}, Proj proj = {});
   }
 
@@ -2875,7 +2876,7 @@ namespace std {
     template<bidirectional_range R, class Comp = ranges::less,
              class Proj = identity>
       requires sortable<iterator_t<R>, Comp, Proj>
-      constexpr next_permutation_result<safe_iterator_t<R>>
+      constexpr next_permutation_result<borrowed_iterator_t<R>>
         next_permutation(R&& r, Comp comp = {}, Proj proj = {});
   }
 
@@ -2898,7 +2899,7 @@ namespace std {
     template<bidirectional_range R, class Comp = ranges::less,
              class Proj = identity>
       requires sortable<iterator_t<R>, Comp, Proj>
-      constexpr prev_permutation_result<safe_iterator_t<R>>
+      constexpr prev_permutation_result<borrowed_iterator_t<R>>
         prev_permutation(R&& r, Comp comp = {}, Proj proj = {});
   }
 }
@@ -3115,7 +3116,7 @@ template<input_iterator I, sentinel_for<I> S, class Proj = identity,
     ranges::for_each(I first, S last, Fun f, Proj proj = {});
 template<input_range R, class Proj = identity,
          indirectly_unary_invocable<projected<iterator_t<R>, Proj>> Fun>
-  constexpr ranges::for_each_result<safe_iterator_t<R>, Fun>
+  constexpr ranges::for_each_result<borrowed_iterator_t<R>, Fun>
     ranges::for_each(R&& r, Fun f, Proj proj = {});
 \end{itemdecl}
 
@@ -3266,21 +3267,21 @@ template<input_iterator I, sentinel_for<I> S, class T, class Proj = identity>
   constexpr I ranges::find(I first, S last, const T& value, Proj proj = {});
 template<input_range R, class T, class Proj = identity>
   requires indirect_binary_predicate<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
-  constexpr safe_iterator_t<R>
+  constexpr borrowed_iterator_t<R>
     ranges::find(R&& r, const T& value, Proj proj = {});
 template<input_iterator I, sentinel_for<I> S, class Proj = identity,
          indirect_unary_predicate<projected<I, Proj>> Pred>
   constexpr I ranges::find_if(I first, S last, Pred pred, Proj proj = {});
 template<input_range R, class Proj = identity,
          indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
-  constexpr safe_iterator_t<R>
+  constexpr borrowed_iterator_t<R>
     ranges::find_if(R&& r, Pred pred, Proj proj = {});
 template<input_iterator I, sentinel_for<I> S, class Proj = identity,
          indirect_unary_predicate<projected<I, Proj>> Pred>
   constexpr I ranges::find_if_not(I first, S last, Pred pred, Proj proj = {});
 template<input_range R, class Proj = identity,
          indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
-  constexpr safe_iterator_t<R>
+  constexpr borrowed_iterator_t<R>
     ranges::find_if_not(R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
@@ -3345,7 +3346,7 @@ template<forward_iterator I1, sentinel_for<I1> S1, forward_iterator I2, sentinel
 template<forward_range R1, forward_range R2,
          class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
   requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
-  constexpr safe_subrange_t<R1>
+  constexpr borrowed_subrange_t<R1>
     ranges::find_end(R1&& r1, R2&& r2, Pred pred = {},
                      Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
@@ -3430,7 +3431,7 @@ template<input_iterator I1, sentinel_for<I1> S1, forward_iterator I2, sentinel_f
 template<input_range R1, forward_range R2,
          class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
   requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
-  constexpr safe_iterator_t<R1>
+  constexpr borrowed_iterator_t<R1>
     ranges::find_first_of(R1&& r1, R2&& r2,
                           Pred pred = {},
                           Proj1 proj1 = {}, Proj2 proj2 = {});
@@ -3493,7 +3494,7 @@ template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
 template<forward_range R, class Proj = identity,
          indirect_binary_predicate<projected<iterator_t<R>, Proj>,
                                    projected<iterator_t<R>, Proj>> Pred = ranges::equal_to>
-  constexpr safe_iterator_t<R> ranges::adjacent_find(R&& r, Pred pred = {}, Proj proj = {});
+  constexpr borrowed_iterator_t<R> ranges::adjacent_find(R&& r, Pred pred = {}, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3651,7 +3652,7 @@ template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for
 template<input_range R1, input_range R2,
          class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
   requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
-  constexpr ranges::mismatch_result<safe_iterator_t<R1>, safe_iterator_t<R2>>
+  constexpr ranges::mismatch_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
     ranges::mismatch(R1&& r1, R2&& r2, Pred pred = {},
                      Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
@@ -3966,7 +3967,7 @@ template<forward_iterator I1, sentinel_for<I1> S1, forward_iterator I2,
 template<forward_range R1, forward_range R2, class Pred = ranges::equal_to,
          class Proj1 = identity, class Proj2 = identity>
   requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
-  constexpr safe_subrange_t<R1>
+  constexpr borrowed_subrange_t<R1>
     ranges::search(R1&& r1, R2&& r2, Pred pred = {},
                    Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
@@ -4054,7 +4055,7 @@ template<forward_iterator I, sentinel_for<I> S, class T,
 template<forward_range R, class T, class Pred = ranges::equal_to,
          class Proj = identity>
   requires indirectly_comparable<iterator_t<R>, const T*, Pred, Proj>
-  constexpr safe_subrange_t<R>
+  constexpr borrowed_subrange_t<R>
     ranges::search_n(R&& r, range_difference_t<R> count,
                      const T& value, Pred pred = {}, Proj proj = {});
 \end{itemdecl}
@@ -4107,7 +4108,7 @@ template<input_iterator I, sentinel_for<I> S, weakly_incrementable O>
   constexpr ranges::copy_result<I, O> ranges::copy(I first, S last, O result);
 template<input_range R, weakly_incrementable O>
   requires indirectly_copyable<iterator_t<R>, O>
-  constexpr ranges::copy_result<safe_iterator_t<R>, O> ranges::copy(R&& r, O result);
+  constexpr ranges::copy_result<borrowed_iterator_t<R>, O> ranges::copy(R&& r, O result);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4235,7 +4236,7 @@ template<input_iterator I, sentinel_for<I> S, weakly_incrementable O, class Proj
 template<input_range R, weakly_incrementable O, class Proj = identity,
          indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
   requires indirectly_copyable<iterator_t<R>, O>
-  constexpr ranges::copy_if_result<safe_iterator_t<R>, O>
+  constexpr ranges::copy_if_result<borrowed_iterator_t<R>, O>
     ranges::copy_if(R&& r, O result, Pred pred, Proj proj = {});
 \end{itemdecl}
 
@@ -4305,7 +4306,7 @@ template<bidirectional_iterator I1, sentinel_for<I1> S1, bidirectional_iterator 
     ranges::copy_backward(I1 first, S1 last, I2 result);
 template<bidirectional_range R, bidirectional_iterator I>
   requires indirectly_copyable<iterator_t<R>, I>
-  constexpr ranges::copy_backward_result<safe_iterator_t<R>, I>
+  constexpr ranges::copy_backward_result<borrowed_iterator_t<R>, I>
     ranges::copy_backward(R&& r, I result);
 \end{itemdecl}
 
@@ -4357,7 +4358,7 @@ template<input_iterator I, sentinel_for<I> S, weakly_incrementable O>
     ranges::move(I first, S last, O result);
 template<input_range R, weakly_incrementable O>
   requires indirectly_movable<iterator_t<R>, O>
-  constexpr ranges::move_result<safe_iterator_t<R>, O>
+  constexpr ranges::move_result<borrowed_iterator_t<R>, O>
     ranges::move(R&& r, O result);
 \end{itemdecl}
 
@@ -4447,7 +4448,7 @@ template<bidirectional_iterator I1, sentinel_for<I1> S1, bidirectional_iterator 
     ranges::move_backward(I1 first, S1 last, I2 result);
 template<bidirectional_range R, bidirectional_iterator I>
   requires indirectly_movable<iterator_t<R>, I>
-  constexpr ranges::move_backward_result<safe_iterator_t<R>, I>
+  constexpr ranges::move_backward_result<borrowed_iterator_t<R>, I>
     ranges::move_backward(R&& r, I result);
 \end{itemdecl}
 
@@ -4514,7 +4515,7 @@ template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for
     ranges::swap_ranges(I1 first1, S1 last1, I2 first2, S2 last2);
 template<input_range R1, input_range R2>
   requires indirectly_swappable<iterator_t<R1>, iterator_t<R2>>
-  constexpr ranges::swap_ranges_result<safe_iterator_t<R1>, safe_iterator_t<R2>>
+  constexpr ranges::swap_ranges_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
     ranges::swap_ranges(R1&& r1, R2&& r2);
 \end{itemdecl}
 
@@ -4619,7 +4620,7 @@ template<input_iterator I, sentinel_for<I> S, weakly_incrementable O,
 template<input_range R, weakly_incrementable O, copy_constructible F,
          class Proj = identity>
   requires writable<O, indirect_result_t<F&, projected<iterator_t<R>, Proj>>>
-  constexpr ranges::unary_transform_result<safe_iterator_t<R>, O>
+  constexpr ranges::unary_transform_result<borrowed_iterator_t<R>, O>
     ranges::transform(R&& r, O result, F op, Proj proj = {});
 template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for<I2> S2,
          weakly_incrementable O, copy_constructible F, class Proj1 = identity,
@@ -4633,7 +4634,7 @@ template<input_range R1, input_range R2, weakly_incrementable O,
          copy_constructible F, class Proj1 = identity, class Proj2 = identity>
   requires writable<O, indirect_result_t<F&, projected<iterator_t<R1>, Proj1>,
                                          projected<iterator_t<R2>, Proj2>>>
-  constexpr ranges::binary_transform_result<safe_iterator_t<R1>, safe_iterator_t<R2>, O>
+  constexpr ranges::binary_transform_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
     ranges::transform(R1&& r1, R2&& r2, O result,
                       F binary_op, Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
@@ -4739,7 +4740,7 @@ template<input_iterator I, sentinel_for<I> S, class T1, class T2, class Proj = i
 template<input_range R, class T1, class T2, class Proj = identity>
   requires writable<iterator_t<R>, const T2&> &&
            indirect_binary_predicate<ranges::equal_to, projected<iterator_t<R>, Proj>, const T1*>
-  constexpr safe_iterator_t<R>
+  constexpr borrowed_iterator_t<R>
     ranges::replace(R&& r, const T1& old_value, const T2& new_value, Proj proj = {});
 template<input_iterator I, sentinel_for<I> S, class T, class Proj = identity,
          indirect_unary_predicate<projected<I, Proj>> Pred>
@@ -4748,7 +4749,7 @@ template<input_iterator I, sentinel_for<I> S, class T, class Proj = identity,
 template<input_range R, class T, class Proj = identity,
          indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
   requires writable<iterator_t<R>, const T&>
-  constexpr safe_iterator_t<R>
+  constexpr borrowed_iterator_t<R>
     ranges::replace_if(R&& r, Pred pred, const T& new_value, Proj proj = {});
 \end{itemdecl}
 
@@ -4822,7 +4823,7 @@ template<input_range R, class T1, class T2, output_iterator<const T2&> O,
          class Proj = identity>
   requires indirectly_copyable<iterator_t<R>, O> &&
            indirect_binary_predicate<ranges::equal_to, projected<iterator_t<R>, Proj>, const T1*>
-  constexpr ranges::replace_copy_result<safe_iterator_t<R>, O>
+  constexpr ranges::replace_copy_result<borrowed_iterator_t<R>, O>
     ranges::replace_copy(R&& r, O result, const T1& old_value, const T2& new_value,
                          Proj proj = {});
 
@@ -4835,7 +4836,7 @@ template<input_iterator I, sentinel_for<I> S, class T, output_iterator<const T&>
 template<input_range R, class T, output_iterator<const T&> O, class Proj = identity,
          indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
   requires indirectly_copyable<iterator_t<R>, O>
-  constexpr ranges::replace_copy_if_result<safe_iterator_t<R>, O>
+  constexpr ranges::replace_copy_if_result<borrowed_iterator_t<R>, O>
     ranges::replace_copy_if(R&& r, O result, Pred pred, const T& new_value,
                             Proj proj = {});
 \end{itemdecl}
@@ -4910,7 +4911,7 @@ template<class ExecutionPolicy, class ForwardIterator, class Size, class T>
 template<class T, output_iterator<const T&> O, sentinel_for<O> S>
   constexpr O ranges::fill(O first, S last, const T& value);
 template<class T, output_range<const T&> R>
-  constexpr safe_iterator_t<R> ranges::fill(R&& r, const T& value);
+  constexpr borrowed_iterator_t<R> ranges::fill(R&& r, const T& value);
 template<class T, output_iterator<const T&> O>
   constexpr O ranges::fill_n(O first, iter_difference_t<O> n, const T& value);
 \end{itemdecl}
@@ -4965,7 +4966,7 @@ template<input_or_output_iterator O, sentinel_for<O> S, copy_constructible F>
   constexpr O ranges::generate(O first, S last, F gen);
 template<class R, copy_constructible F>
   requires invocable<F&> && output_range<R, invoke_result_t<F&>>
-  constexpr safe_iterator_t<R> ranges::generate(R&& r, F gen);
+  constexpr borrowed_iterator_t<R> ranges::generate(R&& r, F gen);
 template<input_or_output_iterator O, copy_constructible F>
   requires invocable<F&> && writable<O, invoke_result_t<F&>>
   constexpr O ranges::generate_n(O first, iter_difference_t<O> n, F gen);
@@ -5022,7 +5023,7 @@ template<permutable I, sentinel_for<I> S, class T, class Proj = identity>
 template<forward_range R, class T, class Proj = identity>
   requires permutable<iterator_t<R>> &&
            indirect_binary_predicate<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
-  constexpr safe_subrange_t<R>
+  constexpr borrowed_subrange_t<R>
     ranges::remove(R&& r, const T& value, Proj proj = {});
 template<permutable I, sentinel_for<I> S, class Proj = identity,
          indirect_unary_predicate<projected<I, Proj>> Pred>
@@ -5030,7 +5031,7 @@ template<permutable I, sentinel_for<I> S, class Proj = identity,
 template<forward_range R, class Proj = identity,
          indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
   requires permutable<iterator_t<R>>
-  constexpr safe_subrange_t<R>
+  constexpr borrowed_subrange_t<R>
     ranges::remove_if(R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
@@ -5116,7 +5117,7 @@ template<input_iterator I, sentinel_for<I> S, weakly_incrementable O, class T,
 template<input_range R, weakly_incrementable O, class T, class Proj = identity>
   requires indirectly_copyable<iterator_t<R>, O> &&
            indirect_binary_predicate<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
-  constexpr ranges::remove_copy_result<safe_iterator_t<R>, O>
+  constexpr ranges::remove_copy_result<borrowed_iterator_t<R>, O>
     ranges::remove_copy(R&& r, O result, const T& value, Proj proj = {});
 template<input_iterator I, sentinel_for<I> S, weakly_incrementable O,
          class Proj = identity, indirect_unary_predicate<projected<I, Proj>> Pred>
@@ -5126,7 +5127,7 @@ template<input_iterator I, sentinel_for<I> S, weakly_incrementable O,
 template<input_range R, weakly_incrementable O, class Proj = identity,
          indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
   requires indirectly_copyable<iterator_t<R>, O>
-  constexpr ranges::remove_copy_if_result<safe_iterator_t<R>, O>
+  constexpr ranges::remove_copy_if_result<borrowed_iterator_t<R>, O>
     ranges::remove_copy_if(R&& r, O result, Pred pred, Proj proj = {});
 \end{itemdecl}
 
@@ -5205,7 +5206,7 @@ template<permutable I, sentinel_for<I> S, class Proj = identity,
 template<forward_range R, class Proj = identity,
          indirect_equivalence_relation<projected<iterator_t<R>, Proj>> C = ranges::equal_to>
   requires permutable<iterator_t<R>>
-  constexpr safe_subrange_t<R>
+  constexpr borrowed_subrange_t<R>
     ranges::unique(R&& r, C comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -5291,7 +5292,7 @@ template<input_range R, weakly_incrementable O, class Proj = identity,
            (forward_iterator<iterator_t<R>> ||
             (input_iterator<O> && same_as<range_value_t<R>, iter_value_t<O>>) ||
             indirectly_copyable_storable<iterator_t<R>, O>)
-  constexpr ranges::unique_copy_result<safe_iterator_t<R>, O>
+  constexpr ranges::unique_copy_result<borrowed_iterator_t<R>, O>
     ranges::unique_copy(R&& r, O result, C comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -5383,7 +5384,7 @@ template<bidirectional_iterator I, sentinel_for<I> S>
   constexpr I ranges::reverse(I first, S last);
 template<bidirectional_range R>
   requires permutable<iterator_t<R>>
-  constexpr safe_iterator_t<R> ranges::reverse(R&& r);
+  constexpr borrowed_iterator_t<R> ranges::reverse(R&& r);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5427,7 +5428,7 @@ template<bidirectional_iterator I, sentinel_for<I> S, weakly_incrementable O>
     ranges::reverse_copy(I first, S last, O result);
 template<bidirectional_range R, weakly_incrementable O>
   requires indirectly_copyable<iterator_t<R>, O>
-  constexpr ranges::reverse_copy_result<safe_iterator_t<R>, O>
+  constexpr ranges::reverse_copy_result<borrowed_iterator_t<R>, O>
     ranges::reverse_copy(R&& r, O result);
 \end{itemdecl}
 
@@ -5516,7 +5517,7 @@ At most \tcode{last - first} swaps.
 \begin{itemdecl}
 template<forward_range R>
   requires permutable<iterator_t<R>>
-  constexpr safe_subrange_t<R> ranges::rotate(R&& r, iterator_t<R> middle);
+  constexpr borrowed_subrange_t<R> ranges::rotate(R&& r, iterator_t<R> middle);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5578,7 +5579,7 @@ Exactly $N$ assignments.
 \begin{itemdecl}
 template<forward_range R, weakly_incrementable O>
   requires indirectly_copyable<iterator_t<R>, O>
-  constexpr ranges::rotate_copy_result<safe_iterator_t<R>, O>
+  constexpr ranges::rotate_copy_result<borrowed_iterator_t<R>, O>
     ranges::rotate_copy(R&& r, iterator_t<R> middle, O result);
 \end{itemdecl}
 
@@ -5676,7 +5677,7 @@ template<random_access_iterator I, sentinel_for<I> S, class Gen>
 template<random_access_range R, class Gen>
   requires permutable<iterator_t<R>> &&
            uniform_random_bit_generator<remove_reference_t<Gen>>
-  safe_iterator_t<R> ranges::shuffle(R&& r, Gen&& g);
+  borrowed_iterator_t<R> ranges::shuffle(R&& r, Gen&& g);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5907,7 +5908,7 @@ template<random_access_iterator I, sentinel_for<I> S, class Comp = ranges::less,
     ranges::sort(I first, S last, Comp comp = {}, Proj proj = {});
 template<random_access_range R, class Comp = ranges::less, class Proj = identity>
   requires sortable<iterator_t<R>, Comp, Proj>
-  constexpr safe_iterator_t<R>
+  constexpr borrowed_iterator_t<R>
     ranges::sort(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -5965,7 +5966,7 @@ template<random_access_iterator I, sentinel_for<I> S, class Comp = ranges::less,
   I ranges::stable_sort(I first, S last, Comp comp = {}, Proj proj = {});
 template<random_access_range R, class Comp = ranges::less, class Proj = identity>
   requires sortable<iterator_t<R>, Comp, Proj>
-  safe_iterator_t<R>
+  borrowed_iterator_t<R>
     ranges::stable_sort(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -6077,7 +6078,7 @@ twice as many projections.
 \begin{itemdecl}
 template<random_access_range R, class Comp = ranges::less, class Proj = identity>
   requires sortable<iterator_t<R>, Comp, Proj>
-  constexpr safe_iterator_t<R>
+  constexpr borrowed_iterator_t<R>
     ranges::partial_sort(R&& r, iterator_t<R> middle, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -6135,7 +6136,7 @@ template<input_range R1, random_access_range R2, class Comp = ranges::less,
            sortable<iterator_t<R2>, Comp, Proj2> &&
            indirect_strict_weak_order<Comp, projected<iterator_t<R1>, Proj1>,
                                       projected<iterator_t<R2>, Proj2>>
-  constexpr ranges::partial_sort_copy_result<safe_iterator_t<R1>, safe_iterator_t<R2>>
+  constexpr ranges::partial_sort_copy_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
     ranges::partial_sort_copy(R1&& r, R2&& result_r, Comp comp = {},
                               Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
@@ -6304,7 +6305,7 @@ template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
   constexpr I ranges::is_sorted_until(I first, S last, Comp comp = {}, Proj proj = {});
 template<forward_range R, class Proj = identity,
          indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
-  constexpr safe_iterator_t<R>
+  constexpr borrowed_iterator_t<R>
     ranges::is_sorted_until(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -6393,7 +6394,7 @@ the predicate, and \bigoh{N \log N} swaps, where $N = \tcode{last - first}$.
 \begin{itemdecl}
 template<random_access_range R, class Comp = ranges::less, class Proj = identity>
   requires sortable<iterator_t<R>, Comp, Proj>
-  constexpr safe_iterator_t<R>
+  constexpr borrowed_iterator_t<R>
     ranges::nth_element(R&& r, iterator_t<R> nth, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -6441,7 +6442,7 @@ template<forward_iterator I, sentinel_for<I> S, class T, class Proj = identity,
 template<forward_range R, class T, class Proj = identity,
          indirect_strict_weak_order<const T*, projected<iterator_t<R>, Proj>> Comp =
            ranges::less>
-  constexpr safe_iterator_t<R>
+  constexpr borrowed_iterator_t<R>
     ranges::lower_bound(R&& r, const T& value, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -6488,7 +6489,7 @@ template<forward_iterator I, sentinel_for<I> S, class T, class Proj = identity,
 template<forward_range R, class T, class Proj = identity,
          indirect_strict_weak_order<const T*, projected<iterator_t<R>, Proj>> Comp =
            ranges::less>
-  constexpr safe_iterator_t<R>
+  constexpr borrowed_iterator_t<R>
     ranges::upper_bound(R&& r, const T& value, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -6537,7 +6538,7 @@ template<forward_iterator I, sentinel_for<I> S, class T, class Proj = identity,
 template<forward_range R, class T, class Proj = identity,
          indirect_strict_weak_order<const T*, projected<iterator_t<R>, Proj>> Comp =
            ranges::less>
-  constexpr safe_subrange_t<R>
+  constexpr borrowed_subrange_t<R>
     ranges::equal_range(R&& r, const T& value, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -6686,7 +6687,7 @@ template<permutable I, sentinel_for<I> S, class Proj = identity,
 template<forward_range R, class Proj = identity,
          indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
   requires permutable<iterator_t<R>>
-  constexpr safe_subrange_t<R>
+  constexpr borrowed_subrange_t<R>
     ranges::partition(R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
@@ -6756,7 +6757,7 @@ template<bidirectional_iterator I, sentinel_for<I> S, class Proj = identity,
 template<bidirectional_range R, class Proj = identity,
          indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
   requires permutable<iterator_t<R>>
-  safe_subrange_t<R> ranges::stable_partition(R&& r, Pred pred, Proj proj = {});
+  borrowed_subrange_t<R> ranges::stable_partition(R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6833,7 +6834,7 @@ template<input_range R, weakly_incrementable O1, weakly_incrementable O2,
          indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
   requires indirectly_copyable<iterator_t<R>, O1> &&
            indirectly_copyable<iterator_t<R>, O2>
-  constexpr ranges::partition_copy_result<safe_iterator_t<R>, O1, O2>
+  constexpr ranges::partition_copy_result<borrowed_iterator_t<R>, O1, O2>
     ranges::partition_copy(R&& r, O1 out_true, O2 out_false, Pred pred, Proj proj = {});
 \end{itemdecl}
 
@@ -6893,7 +6894,7 @@ template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
   constexpr I ranges::partition_point(I first, S last, Pred pred, Proj proj = {});
 template<forward_range R, class Proj = identity,
          indirect_unary_predicate<projected<iterator_t<R>, Proj>> Pred>
-  constexpr safe_iterator_t<R>
+  constexpr borrowed_iterator_t<R>
     ranges::partition_point(R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
@@ -6963,7 +6964,7 @@ template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for
 template<input_range R1, input_range R2, weakly_incrementable O, class Comp = ranges::less,
          class Proj1 = identity, class Proj2 = identity>
   requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
-  constexpr ranges::merge_result<safe_iterator_t<R1>, safe_iterator_t<R2>, O>
+  constexpr ranges::merge_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
     ranges::merge(R1&& r1, R2&& r2, O result,
                   Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
@@ -7098,7 +7099,7 @@ Stable\iref{algorithm.stable}.
 \begin{itemdecl}
 template<bidirectional_range R, class Comp = ranges::less, class Proj = identity>
   requires sortable<iterator_t<R>, Comp, Proj>
-  safe_iterator_t<R>
+  borrowed_iterator_t<R>
     ranges::inplace_merge(R&& r, iterator_t<R> middle, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -7228,7 +7229,7 @@ template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for
 template<input_range R1, input_range R2, weakly_incrementable O,
          class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
   requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
-  constexpr ranges::set_union_result<safe_iterator_t<R1>, safe_iterator_t<R2>, O>
+  constexpr ranges::set_union_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
     ranges::set_union(R1&& r1, R2&& r2, O result, Comp comp = {},
                       Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
@@ -7323,7 +7324,7 @@ template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for
 template<input_range R1, input_range R2, weakly_incrementable O,
          class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
   requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
-  constexpr ranges::set_intersection_result<safe_iterator_t<R1>, safe_iterator_t<R2>, O>
+  constexpr ranges::set_intersection_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
     ranges::set_intersection(R1&& r1, R2&& r2, O result,
                              Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
@@ -7416,7 +7417,7 @@ template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for
 template<input_range R1, input_range R2, weakly_incrementable O,
          class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
   requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
-  constexpr ranges::set_difference_result<safe_iterator_t<R1>, O>
+  constexpr ranges::set_difference_result<borrowed_iterator_t<R1>, O>
     ranges::set_difference(R1&& r1, R2&& r2, O result,
                            Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
@@ -7511,7 +7512,8 @@ template<input_iterator I1, sentinel_for<I1> S1, input_iterator I2, sentinel_for
 template<input_range R1, input_range R2, weakly_incrementable O,
          class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
   requires mergeable<iterator_t<R1>, iterator_t<R2>, O, Comp, Proj1, Proj2>
-  constexpr ranges::set_symmetric_difference_result<safe_iterator_t<R1>, safe_iterator_t<R2>, O>
+  constexpr ranges::set_symmetric_difference_result<borrowed_iterator_t<R1>,
+                                                    borrowed_iterator_t<R2>, O>
     ranges::set_symmetric_difference(R1&& r1, R2&& r2, O result, Comp comp = {},
                                      Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
@@ -7613,7 +7615,7 @@ template<random_access_iterator I, sentinel_for<I> S, class Comp = ranges::less,
     ranges::push_heap(I first, S last, Comp comp = {}, Proj proj = {});
 template<random_access_range R, class Comp = ranges::less, class Proj = identity>
   requires sortable<iterator_t<R>, Comp, Proj>
-  constexpr safe_iterator_t<R>
+  constexpr borrowed_iterator_t<R>
     ranges::push_heap(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -7664,7 +7666,7 @@ template<random_access_iterator I, sentinel_for<I> S, class Comp = ranges::less,
     ranges::pop_heap(I first, S last, Comp comp = {}, Proj proj = {});
 template<random_access_range R, class Comp = ranges::less, class Proj = identity>
   requires sortable<iterator_t<R>, Comp, Proj>
-  constexpr safe_iterator_t<R>
+  constexpr borrowed_iterator_t<R>
     ranges::pop_heap(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -7722,7 +7724,7 @@ template<random_access_iterator I, sentinel_for<I> S, class Comp = ranges::less,
     ranges::make_heap(I first, S last, Comp comp = {}, Proj proj = {});
 template<random_access_range R, class Comp = ranges::less, class Proj = identity>
   requires sortable<iterator_t<R>, Comp, Proj>
-  constexpr safe_iterator_t<R>
+  constexpr borrowed_iterator_t<R>
     ranges::make_heap(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -7771,7 +7773,7 @@ template<random_access_iterator I, sentinel_for<I> S, class Comp = ranges::less,
     ranges::sort_heap(I first, S last, Comp comp = {}, Proj proj = {});
 template<random_access_range R, class Comp = ranges::less, class Proj = identity>
   requires sortable<iterator_t<R>, Comp, Proj>
-  constexpr safe_iterator_t<R>
+  constexpr borrowed_iterator_t<R>
     ranges::sort_heap(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -7909,7 +7911,7 @@ template<random_access_iterator I, sentinel_for<I> S, class Proj = identity,
   constexpr I ranges::is_heap_until(I first, S last, Comp comp = {}, Proj proj = {});
 template<random_access_range R, class Proj = identity,
          indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
-  constexpr safe_iterator_t<R>
+  constexpr borrowed_iterator_t<R>
     ranges::is_heap_until(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -8195,7 +8197,7 @@ template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
   constexpr I ranges::min_element(I first, S last, Comp comp = {}, Proj proj = {});
 template<forward_range R, class Proj = identity,
          indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
-  constexpr safe_iterator_t<R>
+  constexpr borrowed_iterator_t<R>
     ranges::min_element(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -8242,7 +8244,7 @@ template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
   constexpr I ranges::max_element(I first, S last, Comp comp = {}, Proj proj = {});
 template<forward_range R, class Proj = identity,
          indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
-  constexpr safe_iterator_t<R>
+  constexpr borrowed_iterator_t<R>
     ranges::max_element(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -8292,7 +8294,7 @@ template<forward_iterator I, sentinel_for<I> S, class Proj = identity,
     ranges::minmax_element(I first, S last, Comp comp = {}, Proj proj = {});
 template<forward_range R, class Proj = identity,
          indirect_strict_weak_order<projected<iterator_t<R>, Proj>> Comp = ranges::less>
-  constexpr ranges::minmax_result<safe_iterator_t<R>>
+  constexpr ranges::minmax_result<borrowed_iterator_t<R>>
     ranges::minmax_element(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -8504,7 +8506,7 @@ template<bidirectional_iterator I, sentinel_for<I> S, class Comp = ranges::less,
 template<bidirectional_range R, class Comp = ranges::less,
          class Proj = identity>
   requires sortable<iterator_t<R>, Comp, Proj>
-  constexpr ranges::next_permutation_result<safe_iterator_t<R>>
+  constexpr ranges::next_permutation_result<borrowed_iterator_t<R>>
     ranges::next_permutation(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
@@ -8563,7 +8565,7 @@ template<bidirectional_iterator I, sentinel_for<I> S, class Comp = ranges::less,
 template<bidirectional_range R, class Comp = ranges::less,
          class Proj = identity>
   requires sortable<iterator_t<R>, Comp, Proj>
-  constexpr ranges::prev_permutation_result<safe_iterator_t<R>>
+  constexpr ranges::prev_permutation_result<borrowed_iterator_t<R>>
     ranges::prev_permutation(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -805,9 +805,11 @@ If \tcode{T} is an object type, then let \tcode{v} be an lvalue of type
 \tcode{T} models \libconcept{copy_constructible} only if
 
 \begin{itemize}
-\item After the definition \tcode{T u = v;}, \tcode{u} is equal to \tcode{v}.
+\item After the definition \tcode{T u = v;},
+\tcode{u} is equal to \tcode{v}\iref{concepts.equality} and
+\tcode{v} is not modified.
 
-\item \tcode{T(v)} is equal to \tcode{v}.
+\item \tcode{T(v)} is equal to \tcode{v} and does not modify \tcode{v}.
 \end{itemize}
 
 \end{itemdescr}

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -562,13 +562,14 @@ if the operation modifies neither \tcode{t2} nor \tcode{u2} and:
 \item If \tcode{T} and \tcode{U} are the same type, the result of the operation
   is that \tcode{t1} equals \tcode{u2} and \tcode{u1} equals \tcode{t2}.
 
-\item If \tcode{T} and \tcode{U} are different types that model
-  \tcode{\libconcept{common_reference_with}<const T\&, const U\&>},
+\item If \tcode{T} and \tcode{U} are different types and
+  \tcode{\libconcept{common_reference_with}<decltype((t1)), decltype((u1))>}
+  is modeled,
   the result of the operation is that
   \tcode{C(t1)} equals \tcode{C(u2)}
   and
   \tcode{C(u1)} equals \tcode{C(t2)}
-  where \tcode{C} is \tcode{common_reference_t<const T\&, const U\&>}.
+  where \tcode{C} is \tcode{common_reference_t<decltype((t1)), decltype((u1))>}.
 \end{itemize}
 
 \pnum
@@ -648,7 +649,7 @@ template<class T>
 \begin{itemdecl}
 template<class T, class U>
   concept @\deflibconcept{swappable_with}@ =
-    common_reference_with<const remove_reference_t<T>&, const remove_reference_t<U>&> &&
+    common_reference_with<T, U> &&
     requires(T&& t, U&& u) {
       ranges::swap(std::forward<T>(t), std::forward<T>(t));
       ranges::swap(std::forward<U>(u), std::forward<U>(u));
@@ -686,13 +687,14 @@ void lv_swap(T& t1, T& t2) {
 
 namespace N {
   struct A { int m; };
-  struct Proxy { A* a; };
-  Proxy proxy(A& a) { return Proxy{ &a }; }
-
-  void swap(A& x, Proxy p) {
-    ranges::swap(x.m, p.a->m);
-  }
-  void swap(Proxy p, A& x) { swap(x, p); }      // satisfy symmetry requirement
+  struct Proxy {
+    A* a;
+    Proxy(A& a) : a{&a} {}
+    friend void swap(Proxy x, Proxy y) {
+      ranges::swap(*x.a, *y.a);
+    }
+  };
+  Proxy proxy(A& a) { return Proxy{ a }; }
 }
 
 int main() {

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -3122,6 +3122,13 @@ namespace std {
   template<class T, size_t N> struct array;
 
   template<class T, size_t N>
+    constexpr bool operator==(const array<T, N>& x, const array<T, N>& y);
+  template<class T, size_t N>
+    constexpr @\placeholder{synth-three-way-result}@<T>
+      operator<=>(const array<T, N>& x, const array<T, N>& y);
+
+  // \ref{array.special}, specialized algorithms
+  template<class T, size_t N>
     constexpr void swap(array<T, N>& x, array<T, N>& y) noexcept(noexcept(x.swap(y)));
 
   // \ref{array.creation}, array creation functions
@@ -3383,10 +3390,6 @@ namespace std {
 
     constexpr T *       data() noexcept;
     constexpr const T * data() const noexcept;
-
-    friend constexpr bool operator==(const array&, const array&) = default;
-    friend constexpr @\placeholder{synth-three-way-result}@<value_type>
-      operator<=>(const array&, const array&);
   };
 
   template<class T, class... U>

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10593,10 +10593,10 @@ namespace std {
       constexpr span(It first, End last);
     template<size_t N>
       constexpr span(element_type (&arr)[N]) noexcept;
-    template<size_t N>
-      constexpr span(array<value_type, N>& arr) noexcept;
-    template<size_t N>
-      constexpr span(const array<value_type, N>& arr) noexcept;
+    template<class T, size_t N>
+      constexpr span(array<T, N>& arr) noexcept;
+    template<class T, size_t N>
+      constexpr span(const array<T, N>& arr) noexcept;
     template<class R>
       constexpr span(R&& r);
     constexpr span(const span& other) noexcept = default;
@@ -10762,8 +10762,8 @@ Nothing.
 \indexlibraryctor{span}%
 \begin{itemdecl}
 template<size_t N> constexpr span(element_type (&arr)[N]) noexcept;
-template<size_t N> constexpr span(array<value_type, N>& arr) noexcept;
-template<size_t N> constexpr span(const array<value_type, N>& arr) noexcept;
+template<class T, size_t N> constexpr span(array<T, N>& arr) noexcept;
+template<class T, size_t N> constexpr span(const array<T, N>& arr) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10780,7 +10780,7 @@ Constructs a \tcode{span} that is a view over the supplied array.
 
 \pnum
 \ensures
-\tcode{size() == N \&\& data() == data(arr)}.
+\tcode{size() == N \&\& data() == data(arr)} is \tcode{true}.
 \end{itemdescr}
 
 \indexlibraryctor{span}%

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10530,7 +10530,7 @@ namespace std {
     inline constexpr bool ranges::enable_view<span<ElementType, Extent>> =
       Extent == 0 || Extent == dynamic_extent;
   template<class ElementType, size_t Extent>
-    inline constexpr bool ranges::enable_safe_range<span<ElementType, Extent>> = true;
+    inline constexpr bool ranges::enable_borrowed_range<span<ElementType, Extent>> = true;
 
   // \ref{span.objectrep}, views of object representation
   template<class ElementType, size_t Extent>
@@ -10800,7 +10800,7 @@ Let \tcode{U} be \tcode{remove_reference_t<ranges::range_reference_t<R>>}.
 \item \tcode{extent == dynamic_extent} is \tcode{true}.
 \item \tcode{R} satisfies \tcode{ranges::\libconcept{contiguous_range}} and
   \tcode{ranges::\libconcept{sized_range}}.
-\item Either \tcode{R} satisfies \tcode{ranges::\libconcept{safe_range}} or
+\item Either \tcode{R} satisfies \tcode{ranges::\libconcept{borrowed_range}} or
 \tcode{is_const_v<element_type>} is \tcode{true}.
 \item \tcode{remove_cvref_t<R>} is not a specialization of \tcode{span}.
 \item \tcode{remove_cvref_t<R>} is not a specialization of \tcode{array}.
@@ -10819,7 +10819,7 @@ of the iterator reference type to \tcode{element_type}.
 \item \tcode{R} models \tcode{ranges::\libconcept{contiguous_range}} and
 \tcode{ranges::\libconcept{sized_range}}.
 \item If \tcode{is_const_v<element_type>} is \tcode{false},
-\tcode{R} models \tcode{ranges::\libconcept{safe_range}}.
+\tcode{R} models \tcode{ranges::\libconcept{borrowed_range}}.
 \end{itemize}
 
 \pnum

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -214,11 +214,9 @@ In Tables~\ref{tab:container.req},
  constant                   \\ \rowsep
 
 \tcode{i <=> j}             &
-  \tcode{strong_ordering}
-  if \tcode{X::iterator} meets the random access iterator requirements,
-  otherwise \tcode{strong_equality} &
-                             &
-                             &
+  \tcode{strong_ordering}   &
+                            &
+  \constraints \tcode{X::iterator} meets the random access iterator requirements. &
  constant                   \\ \rowsep
 
 \tcode{a == b}                  &

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10593,7 +10593,7 @@ namespace std {
     template<class It, class End>
       constexpr span(It first, End last);
     template<size_t N>
-      constexpr span(element_type (&arr)[N]) noexcept;
+      constexpr span(type_identity_t<element_type> (&arr)[N]) noexcept;
     template<class T, size_t N>
       constexpr span(array<T, N>& arr) noexcept;
     template<class T, size_t N>
@@ -10762,7 +10762,7 @@ When and what \tcode{last - first} throws.
 
 \indexlibraryctor{span}%
 \begin{itemdecl}
-template<size_t N> constexpr span(element_type (&arr)[N]) noexcept;
+template<size_t N> constexpr span(type_identity_t<element_type> (&arr)[N]) noexcept;
 template<class T, size_t N> constexpr span(array<T, N>& arr) noexcept;
 template<class T, size_t N> constexpr span(const array<T, N>& arr) noexcept;
 \end{itemdecl}
@@ -10778,6 +10778,9 @@ template<class T, size_t N> constexpr span(const array<T, N>& arr) noexcept;
 \pnum
 \effects
 Constructs a \tcode{span} that is a view over the supplied array.
+\begin{note}
+\tcode{type_identity_t} affects class template argument deduction.
+\end{note}
 
 \pnum
 \ensures

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -3325,6 +3325,14 @@ one of these tables and
 for operations where there is additional semantic information.
 
 \pnum
+\tcode{array<T, N>} is a structural type\iref{temp.param} if
+\tcode{T} is a structural type.
+Two values \tcode{a1} and \tcode{a2} of type \tcode{array<T, N>}
+are template-argument-equivalent\iref{temp.type} if and only if
+each pair of corresponding elements in \tcode{a1} and \tcode{a2}
+are template-argument-equivalent.
+
+\pnum
 The types \tcode{iterator} and \tcode{const_iterator} meet
 the constexpr iterator requirements\iref{iterator.requirements.general}.
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10757,7 +10757,7 @@ Initializes \tcode{data_} with \tcode{to_address(first)} and
 
 \pnum
 \throws
-Nothing.
+When and what \tcode{last - first} throws.
 \end{itemdescr}
 
 \indexlibraryctor{span}%

--- a/source/future.tex
+++ b/source/future.tex
@@ -2477,6 +2477,13 @@ For POSIX-based operating systems with the native narrow encoding not
 For Windows-based operating systems a conversion from UTF-8 to
     UTF-16 occurs.
 \end{example}
+\begin{note}
+The example above is representative of
+a historical use of \tcode{filesystem::u8path}.
+Passing a \tcode{std::u8string} to \tcode{path}'s constructor is preferred
+for an indication of UTF-8 encoding more consistent with
+\tcode{path}'s handling of other encodings.
+\end{note}
 \end{itemdescr}
 
 \rSec1[depr.atomics]{Deprecated atomic initialization}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -5548,21 +5548,23 @@ but not
 
 \indexlibrarymember{operator>>}{basic_istream}%
 \begin{itemdecl}
-template<class charT, class traits, class T>
-  basic_istream<charT, traits>& operator>>(basic_istream<charT, traits>&& is, T&& x);
+template<class Istream, class T>
+  Istream&& operator>>(Istream&& is, T&& x);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \constraints
-The expression \tcode{is >> std::forward<T>(x)} is well-formed when treated as an unevaluated operand.
+The expression \tcode{is >> std::forward<T>(x)} is well-formed
+when treated as an unevaluated operand and
+\tcode{Istream} is publicly and unambiguously derived from \tcode{ios_base}.
 
 \pnum
 \effects
 Equivalent to:
 \begin{codeblock}
 is >> std::forward<T>(x);
-return is;
+return std::move(is);
 \end{codeblock}
 \end{itemdescr}
 
@@ -6759,14 +6761,16 @@ calls \tcode{buf->emit()}.
 
 \indexlibrarymember{operator<<}{basic_ostream}%
 \begin{itemdecl}
-template<class charT, class traits, class T>
-  basic_ostream<charT, traits>& operator<<(basic_ostream<charT, traits>&& os, const T& x);
+template<class Ostream, class T>
+  Ostream&& operator<<(Ostream&& os, const T& x);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \constraints
-The expression \tcode{os << x} is well-formed when treated as an unevaluated operand.
+The expression \tcode{os << x} is well-formed
+when treated as an unevaluated operand and
+\tcode{Ostream} is publicly and unambiguously derived from \tcode{ios_base}.
 
 \pnum
 \effects
@@ -6774,7 +6778,7 @@ As if by: \tcode{os << x;}
 
 \pnum
 \returns
-\tcode{os}.
+\tcode{std::move(os)}.
 \end{itemdescr}
 
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -11058,7 +11058,7 @@ namespace std {
     basic_osyncstream(basic_osyncstream&&) noexcept;
     ~basic_osyncstream();
 
-    // \ref{syncstream.osyncstream.assign}, assignment
+    // assignment
     basic_osyncstream& operator=(basic_osyncstream&&) noexcept;
 
     // \ref{syncstream.osyncstream.members}, member functions
@@ -11142,46 +11142,6 @@ The value returned by \tcode{get_wrapped()}
 is the value returned by \tcode{os.get_wrapped()}
 prior to calling this constructor.
 \tcode{nullptr == other.get_wrapped()} is \tcode{true}.
-\end{itemdescr}
-
-\indexlibrarydtor{basic_osyncstream}%
-\begin{itemdecl}
-~basic_osyncstream();
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Calls \tcode{emit()}.
-If an exception is thrown from \tcode{emit()},
-that exception is caught and ignored.
-\end{itemdescr}
-
-\rSec3[syncstream.osyncstream.assign]{Assignment}
-
-\indexlibrarymember{operator=}{basic_osyncstream}%
-\begin{itemdecl}
-basic_osyncstream& operator=(basic_osyncstream&& rhs) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-First, calls \tcode{emit()}.
-If an exception is thrown from \tcode{emit()},
-that exception is caught and ignored.
-Move assigns \tcode{sb} from \tcode{rhs.sb}.
-\begin{note}
-This disassociates \tcode{rhs}
-from its wrapped stream buffer
-ensuring destruction of \tcode{rhs} produces no output.
-\end{note}
-
-\pnum
-\ensures
-\tcode{nullptr == rhs.get_wrapped()} is \tcode{true}.
-\tcode{get_wrapped()} returns the value
-previously returned by \tcode{rhs.get_wrapped()}.
 \end{itemdescr}
 
 \rSec3[syncstream.osyncstream.members]{Member functions}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1058,9 +1058,13 @@ expression-equivalent to:
 \begin{itemize}
 \item \tcode{iter_move(E)}, if
 \tcode{E} has class or enumeration type and
-\tcode{iter_move(E)} is a well-formed expression with overload
-resolution performed in a context that does not include a declaration of
-\tcode{ranges::iter_move}.
+\tcode{iter_move(E)} is a well-formed expression when treated as an unevaluated operand,
+with overload resolution performed in a context
+that does not include a declaration of \tcode{ranges::iter_move}
+but does include the declaration
+\begin{codeblock}
+void iter_move();
+\end{codeblock}
 
 \item Otherwise, if the expression \tcode{*E} is well-formed:
 \begin{itemize}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -371,7 +371,7 @@ namespace std {
 
   // \ref{iterators.common}, common iterators
   template<input_or_output_iterator I, sentinel_for<I> S>
-    requires (!same_as<I, S>)
+    requires (!same_as<I, S> && copyable<I>)
       class common_iterator;
 
   template<class I, class S>
@@ -4712,7 +4712,7 @@ fun(CI(counted_iterator(s.begin(), 10)), CI(default_sentinel));
 \begin{codeblock}
 namespace std {
   template<input_or_output_iterator I, sentinel_for<I> S>
-    requires (!same_as<I, S>)
+    requires (!same_as<I, S> && copyable<I>)
   class common_iterator {
   public:
     constexpr common_iterator() = default;

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -5246,7 +5246,7 @@ constexpr counted_iterator(I i, iter_difference_t<I> n);
 
 \pnum
 \effects
-Initializes \tcode{current} with \tcode{i} and
+Initializes \tcode{current} with \tcode{std::move(i)} and
 \tcode{length} with \tcode{n}.
 \end{itemdescr}
 

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1361,13 +1361,17 @@ let \tcode{c} be an lvalue of any integral type.
 \end{itemize}
 
 \pnum
-All integer-class types are explicitly convertible to all integral types and
-implicitly and explicitly convertible from all integral types.
+Expressions of integer-class type are
+explicitly convertible to any integral type.
+Expressions of integral type are
+both implicitly and explicitly convertible to any integer-class type.
+Conversions between integral and integer-class types
+do not exit via an exception.
 
 \pnum
-All integer-class types are contextually convertible to \tcode{bool}
-as if by \tcode{bool(a != I(0))}, where \tcode{a} is an
-instance of the integral-class type \tcode{I}.
+An expression \tcode{E} of integer-class type \tcode{I} is
+contextually convertible to \tcode{bool}
+as if by \tcode{bool(E != I(0))}.
 
 \pnum
 All integer-class types model

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -4564,7 +4564,7 @@ constexpr move_iterator<Iterator> make_move_iterator(Iterator i);
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{move_iterator<Iterator>(i)}.
+\tcode{move_iterator<Iterator>(std::move(i))}.
 \end{itemdescr}
 
 \rSec3[move.sentinel]{Class template \tcode{move_sentinel}}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -180,8 +180,11 @@ iostream, and regular expression class templates.
 
 \definition{comparison function}{defns.comparison}
 \indexdefn{function!comparison}%
-operator function\iref{over.oper} for any of the equality\iref{expr.eq} or
-relational\iref{expr.rel} operators
+operator function\iref{over.oper} for any of the
+equality\iref{expr.eq},
+relational\iref{expr.rel}, or
+three-way comparison\iref{expr.spaceship}
+operators
 
 \definition{component}{defns.component}
 \indexdefn{component}%

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -9563,9 +9563,9 @@ namespace std {
   long double fmal(long double x, long double y, long double z);
 
   // \ref{c.math.lerp}, linear interpolation
-  constexpr float lerp(float a, float b, float t);
-  constexpr double lerp(double a, double b, double t);
-  constexpr long double lerp(long double a, long double b, long double t);
+  constexpr float lerp(float a, float b, float t) noexcept;
+  constexpr double lerp(double a, double b, double t) noexcept;
+  constexpr long double lerp(long double a, long double b, long double t) noexcept;
 
   // \ref{c.math.fpclass}, classification / comparison functions
   int fpclassify(float x);
@@ -9829,9 +9829,9 @@ $\sqrt{x^2+y^2+z^2}$.
 
 \indexlibraryglobal{lerp}%
 \begin{itemdecl}
-constexpr float lerp(float a, float b, float t);
-constexpr double lerp(double a, double b, double t);
-constexpr long double lerp(long double a, long double b, long double t);
+constexpr float lerp(float a, float b, float t) noexcept;
+constexpr double lerp(double a, double b, double t) noexcept;
+constexpr long double lerp(long double a, long double b, long double t) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
 \pnum

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -2153,6 +2153,7 @@ template<class G>
     requires {
       { G::min() } -> same_as<invoke_result_t<G&>>;
       { G::max() } -> same_as<invoke_result_t<G&>>;
+      requires bool_constant<(G::min() < G::max())>::value;
     };
 \end{codeblock}
 
@@ -2160,9 +2161,6 @@ template<class G>
 Let \tcode{g} be an object of type \tcode{G}. \tcode{G} models
 \libconcept{uniform_random_bit_generator} only if
 \begin{itemize}
-\item both \tcode{G::min()} and \tcode{G::max()} are constant
-  expressions\iref{expr.const},
-\item \tcode{G::min() < G::max()},
 \item \tcode{G::min() <= g()},
 \item \tcode{g() <= G::max()}, and
 \item \tcode{g()} has amortized constant complexity.

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1732,7 +1732,6 @@ the values of these macros with greater values.
 \defnxname{cpp_constexpr_in_decltype}             & \tcode{201711L} \\ \rowsep
 \defnxname{cpp_consteval}                         & \tcode{201811L} \\ \rowsep
 \defnxname{cpp_constinit}                         & \tcode{201907L} \\ \rowsep
-\defnxname{cpp_coroutines}                        & \tcode{201902L} \\ \rowsep
 \defnxname{cpp_decltype}                          & \tcode{200707L} \\ \rowsep
 \defnxname{cpp_decltype_auto}                     & \tcode{201304L} \\ \rowsep
 \defnxname{cpp_deduction_guides}                  & \tcode{201907L} \\ \rowsep
@@ -1744,6 +1743,7 @@ the values of these macros with greater values.
 \defnxname{cpp_guaranteed_copy_elision}           & \tcode{201606L} \\ \rowsep
 \defnxname{cpp_hex_float}                         & \tcode{201603L} \\ \rowsep
 \defnxname{cpp_if_constexpr}                      & \tcode{201606L} \\ \rowsep
+\defnxname{cpp_impl_coroutine}                    & \tcode{201902L} \\ \rowsep
 \defnxname{cpp_impl_destroying_delete}            & \tcode{201806L} \\ \rowsep
 \defnxname{cpp_impl_three_way_comparison}         & \tcode{201907L} \\ \rowsep
 \defnxname{cpp_inheriting_constructors}           & \tcode{201511L} \\ \rowsep

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -4036,7 +4036,7 @@ friend constexpr range_difference_t<@\exposid{Base}@>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return x.\exposid{end_} - y.\exposid{current_};}
+Equivalent to: \tcode{return y.\exposid{end_} - x.\exposid{current_};}
 \end{itemdescr}
 
 \rSec2[range.take]{Take view}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -4273,7 +4273,7 @@ namespace std::ranges {
     // \ref{range.take.while.sentinel}, class template \tcode{take_while_view::\exposid{sentinel}}
     template<bool> class @\exposid{sentinel}@;                      // \expos
 
-    V @\exposid{base_}@;                                            // \expos
+    V @\exposid{base_}@ = V();                                      // \expos
     @\placeholder{semiregular-box}@<Pred> @\exposid{pred_}@; @\itcorr[-1]@                       // \expos
 
   public:
@@ -4460,8 +4460,8 @@ namespace std::ranges {
       return s < c ? 0 : s - c;
     }
   private:
-    V @\exposid{base_}@;                                    // \expos
-    range_difference_t<V> @\exposid{count_}@;               // \expos
+    V @\exposid{base_}@ = V();                              // \expos
+    range_difference_t<V> @\exposid{count_}@ = 0;           // \expos
   };
 
   template<class R>
@@ -4566,7 +4566,7 @@ namespace std::ranges {
     { return ranges::end(@\exposid{base_}@); }
 
   private:
-    V @\exposid{base_}@;                                            // \expos
+    V @\exposid{base_}@ = V();                                      // \expos
     @\placeholder{semiregular-box}@<Pred> @\exposid{pred_}@; @\itcorr[-1]@                       // \expos
   };
 
@@ -6056,7 +6056,7 @@ namespace std::ranges {
     using @\exposid{base-t}@ = conditional_t<Const, const V, V>;    // \expos
     friend @\exposid{iterator}@<!Const>;
 
-    iterator_t<@\exposid{base-t}@> @\exposid{current_}@;
+    iterator_t<@\exposid{base-t}@> @\exposid{current_}@ = iterator_t<@\exposid{base-t}@>();
   public:
     using iterator_category = typename iterator_traits<iterator_t<@\exposid{base-t}@>>::iterator_category;
     using value_type = remove_cvref_t<tuple_element_t<N, range_value_t<@\exposid{base-t}@>>>;

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -24,6 +24,7 @@ as summarized in \tref{range.summary}.
 \rSec1[ranges.syn]{Header \tcode{<ranges>} synopsis}
 
 \indexheader{ranges}%
+\indexlibraryglobal{all_t}%
 \begin{codeblock}
 #include <compare>              // see \ref{compare.syn}
 #include <initializer_list>     // see \ref{initializer.list.syn}
@@ -63,6 +64,8 @@ namespace std::ranges {
     using sentinel_t = decltype(ranges::end(declval<R&>()));
   template<range R>
     using range_difference_t = iter_difference_t<iterator_t<R>>;
+  template<sized_range R>
+    using range_size_t = decltype(ranges::size(declval<R&>()));
   template<range R>
     using range_value_t = iter_value_t<iterator_t<R>>;
   template<range R>
@@ -174,10 +177,12 @@ namespace std::ranges {
     basic_istream_view<Val, CharT, Traits> istream_view(basic_istream<CharT, Traits>& s);
 
   // \ref{range.all}, all view
-  namespace views { inline constexpr @\unspec@ all = @\unspec@; }
+  namespace views {
+    inline constexpr @\unspec@ all = @\unspec@;
 
-  template<viewable_range R>
-    using all_view = decltype(views::all(declval<R>()));
+    template<viewable_range R>
+      using all_t = decltype(all(declval<R>()));
+  }
 
   template<range R>
     requires is_object_v<R>
@@ -272,9 +277,9 @@ namespace std::ranges {
   class elements_view;
 
   template<class R>
-    using keys_view = elements_view<all_view<R>, 0>;
+    using keys_view = elements_view<views::all_t<R>, 0>;
   template<class R>
-    using values_view = elements_view<all_view<R>, 1>;
+    using values_view = elements_view<views::all_t<R>, 1>;
 
   namespace views {
     template<size_t N>
@@ -2859,6 +2864,7 @@ the move assignment operator is equivalent to:
 \rSec2[range.all]{All view}
 
 \pnum
+\indexlibraryglobal{all}%
 \tcode{views::all} returns a \libconcept{view} that includes all elements of
 its \libconcept{range} argument.
 
@@ -3003,7 +3009,7 @@ namespace std::ranges {
   };
 
   template<class R, class Pred>
-    filter_view(R&&, Pred) -> filter_view<all_view<R>, Pred>;
+    filter_view(R&&, Pred) -> filter_view<views::all_t<R>, Pred>;
 }
 \end{codeblock}
 
@@ -3419,7 +3425,7 @@ namespace std::ranges {
   };
 
   template<class R, class F>
-    transform_view(R&&, F) -> transform_view<all_view<R>, F>;
+    transform_view(R&&, F) -> transform_view<views::all_t<R>, F>;
 }
 \end{codeblock}
 
@@ -4140,7 +4146,7 @@ namespace std::ranges {
 
   template<range R>
     take_view(R&&, range_difference_t<R>)
-      -> take_view<all_view<R>>;
+      -> take_view<views::all_t<R>>;
 }
 \end{codeblock}
 
@@ -4300,7 +4306,7 @@ namespace std::ranges {
   };
 
   template<class R, class Pred>
-    take_while_view(R&&, Pred) -> take_while_view<all_view<R>, Pred>;
+    take_while_view(R&&, Pred) -> take_while_view<views::all_t<R>, Pred>;
 }
 \end{codeblock}
 
@@ -4466,7 +4472,7 @@ namespace std::ranges {
   };
 
   template<class R>
-    drop_view(R&&, range_difference_t<R>) -> drop_view<all_view<R>>;
+    drop_view(R&&, range_difference_t<R>) -> drop_view<views::all_t<R>>;
 }
 \end{codeblock}
 
@@ -4572,7 +4578,7 @@ namespace std::ranges {
   };
 
   template<class R, class Pred>
-    drop_while_view(R&&, Pred) -> drop_while_view<all_view<R>, Pred>;
+    drop_while_view(R&&, Pred) -> drop_while_view<views::all_t<R>, Pred>;
 }
 \end{codeblock}
 
@@ -4672,8 +4678,8 @@ namespace std::ranges {
       struct @\exposid{sentinel}@;                  // \expos
 
     V @\exposid{base_}@ = V();                      // \expos
-    all_view<@\exposid{InnerRng}@> @\exposid{inner_}@ =         // \expos, present only when \tcode{!is_reference_v<\exposid{InnerRng}>}
-      all_view<@\exposid{InnerRng}@>();
+    views::all_t<@\exposid{InnerRng}@> @\exposid{inner_}@ =     // \expos, present only when \tcode{!is_reference_v<\exposid{InnerRng}>}
+      views::all_t<@\exposid{InnerRng}@>();
   public:
     join_view() = default;
     constexpr explicit join_view(V base);
@@ -4715,7 +4721,7 @@ namespace std::ranges {
   };
 
   template<class R>
-    explicit join_view(R&&) -> join_view<all_view<R>>;
+    explicit join_view(R&&) -> join_view<views::all_t<R>>;
 }
 \end{codeblock}
 
@@ -5163,7 +5169,7 @@ namespace std::ranges {
     constexpr split_view(V base, Pattern pattern);
 
     template<input_range R>
-      requires constructible_from<V, all_view<R>> &&
+      requires constructible_from<V, views::all_t<R>> &&
                constructible_from<Pattern, single_view<range_value_t<R>>>
     constexpr split_view(R&& r, range_value_t<R> e);
 
@@ -5196,11 +5202,11 @@ namespace std::ranges {
   };
 
   template<class R, class P>
-    split_view(R&&, P&&) -> split_view<all_view<R>, all_view<P>>;
+    split_view(R&&, P&&) -> split_view<views::all_t<R>, views::all_t<P>>;
 
   template<input_range R>
     split_view(R&&, range_value_t<R>)
-      -> split_view<all_view<R>, single_view<range_value_t<R>>>;
+      -> split_view<views::all_t<R>, single_view<range_value_t<R>>>;
 }
 \end{codeblock}
 
@@ -5219,7 +5225,7 @@ Initializes \exposid{base_} with \tcode{std::move(base)}, and
 \indexlibraryctor{split_view}%
 \begin{itemdecl}
 template<input_range R>
-  requires constructible_from<V, all_view<R>> &&
+  requires constructible_from<V, views::all_t<R>> &&
            constructible_from<Pattern, single_view<range_value_t<R>>>
 constexpr split_view(R&& r, range_value_t<R> e);
 \end{itemdecl}
@@ -5697,7 +5703,7 @@ namespace std::ranges {
     constexpr explicit common_view(V r);
 
     template<viewable_range R>
-      requires (!common_range<R> && constructible_from<V, all_view<R>>)
+      requires (!common_range<R> && constructible_from<V, views::all_t<R>>)
     constexpr explicit common_view(R&& r);
 
     constexpr V base() const& requires copy_constructible<V> { return @\exposid{base_}@; }
@@ -5740,7 +5746,7 @@ namespace std::ranges {
   };
 
   template<class R>
-    common_view(R&&) -> common_view<all_view<R>>;
+    common_view(R&&) -> common_view<views::all_t<R>>;
 }
 \end{codeblock}
 
@@ -5758,7 +5764,7 @@ Initializes \exposid{base_} with \tcode{std::move(base)}.
 \indexlibraryctor{common_view}%
 \begin{itemdecl}
 template<viewable_range R>
-  requires (!common_range<R> && constructible_from<V, all_view<R>>)
+  requires (!common_range<R> && constructible_from<V, views::all_t<R>>)
 constexpr explicit common_view(R&& r);
 \end{itemdecl}
 
@@ -5858,7 +5864,7 @@ namespace std::ranges {
   };
 
   template<class R>
-    reverse_view(R&&) -> reverse_view<all_view<R>>;
+    reverse_view(R&&) -> reverse_view<views::all_t<R>>;
 }
 \end{codeblock}
 
@@ -5933,7 +5939,7 @@ The name \tcode{views::elements<N>} denotes
 a range adaptor object\iref{range.adaptor.object}.
 Given a subexpression \tcode{E} and constant expression \tcode{N},
 the expression \tcode{views::elements<N>(E)} is expression-equivalent to
-\tcode{elements_view<all_view<decltype((E))>, N>\{E\}}.
+\tcode{elements_view<views::all_t<decltype((E))>, N>\{E\}}.
 
 \begin{example}
 \begin{codeblock}
@@ -5957,7 +5963,7 @@ for (auto&& born : birth_years) {
 \end{example}
 
 \pnum
-\tcode{keys_view} is an alias for \tcode{elements_view<all_view<R>, 0>}, and
+\tcode{keys_view} is an alias for \tcode{elements_view<views::all_t<R>, 0>}, and
 is useful for extracting keys from associative containers.
 
 \begin{example}
@@ -5970,7 +5976,7 @@ for (auto&& name : names) {
 \end{example}
 
 \pnum
-\tcode{values_view} is an alias for \tcode{elements_view<all_view<R>, 1>}, and
+\tcode{values_view} is an alias for \tcode{elements_view<views::all_t<R>, 1>}, and
 is useful for extracting values from associative containers.
 
 \begin{example}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -303,6 +303,14 @@ namespace std {
   struct tuple_element<1, ranges::subrange<I, S, K>> {
     using type = S;
   };
+  template<class I, class S, ranges::subrange_kind K>
+  struct tuple_element<0, const ranges::subrange<I, S, K>> {
+    using type = I;
+  };
+  template<class I, class S, ranges::subrange_kind K>
+  struct tuple_element<1, const ranges::subrange<I, S, K>> {
+    using type = S;
+  };
 }
 \end{codeblock}
 

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1255,6 +1255,13 @@ iterator and a sentinel into a single object that models the
 \indexlibraryglobal{subrange}%
 \begin{codeblock}
 namespace std::ranges {
+  template<class From, class To>
+    concept @\defexposconcept{convertible-to-non-slicing}@ =                    // \expos
+      convertible_to<From, To> &&
+      !(is_pointer_v<decay_t<From>> &&
+        is_pointer_v<decay_t<To>> &&
+        @\exposconcept{not-same-as}@<remove_pointer_t<decay_t<From>>, remove_pointer_t<decay_t<To>>>);
+
   template<class T>
     concept @\defexposconcept{pair-like}@ =                                     // \expos
       !is_reference_v<T> && requires(T t) {
@@ -1267,16 +1274,11 @@ namespace std::ranges {
       };
 
   template<class T, class U, class V>
-    concept @\defexposconcept{pair-like-convertible-to}@ =                      // \expos
-      !range<T> && @\exposconcept{pair-like}@<remove_reference_t<T>> &&
-      requires(T&& t) {
-        { get<0>(std::forward<T>(t)) } -> convertible_to<U>;
-        { get<1>(std::forward<T>(t)) } -> convertible_to<V>;
-      };
-
-  template<class T, class U, class V>
     concept @\defexposconcept{pair-like-convertible-from}@ =                    // \expos
-      !range<T> && @\exposconcept{pair-like}@<T> && constructible_from<T, U, V>;
+      !range<T> && @\exposconcept{pair-like}@<T> &&
+      constructible_from<T, U, V> &&
+      @\exposconcept{convertible-to-non-slicing}@<U, tuple_element_t<0, T>> &&
+      convertible_to<V, tuple_element_t<1, T>>;
 
   template<class T>
     concept @\defexposconcept{iterator-sentinel-pair}@ =                        // \expos
@@ -1297,35 +1299,24 @@ namespace std::ranges {
   public:
     subrange() = default;
 
-    constexpr subrange(I i, S s) requires (!@\exposid{StoreSize}@);
+    constexpr subrange(@\exposconcept{convertible-to-non-slicing}@<I> auto i, S s) requires (!@\exposid{StoreSize}@);
 
-    constexpr subrange(I i, S s, @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>> n)
+    constexpr subrange(@\exposconcept{convertible-to-non-slicing}@<I> auto i, S s,
+                       @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>> n)
       requires (K == subrange_kind::sized);
 
     template<@\exposconcept{not-same-as}@<subrange> R>
       requires safe_range<R> &&
-               convertible_to<iterator_t<R>, I> && convertible_to<sentinel_t<R>, S>
+               @\exposconcept{convertible-to-non-slicing}@<iterator_t<R>, I> &&
+               convertible_to<sentinel_t<R>, S>
     constexpr subrange(R&& r) requires (!@\exposid{StoreSize}@ || sized_range<R>);
 
     template<safe_range R>
-      requires convertible_to<iterator_t<R>, I> && convertible_to<sentinel_t<R>, S>
+      requires @\exposconcept{convertible-to-non-slicing}@<iterator_t<R>, I> &&
+               convertible_to<sentinel_t<R>, S>
     constexpr subrange(R&& r, @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>> n)
       requires (K == subrange_kind::sized)
         : subrange{ranges::begin(r), ranges::end(r), n}
-    {}
-
-    template<@\exposconcept{not-same-as}@<subrange> PairLike>
-      requires @\exposconcept{pair-like-convertible-to}@<PairLike, I, S>
-    constexpr subrange(PairLike&& r) requires (!@\exposid{StoreSize}@)
-      : subrange{std::get<0>(std::forward<PairLike>(r)),
-                 std::get<1>(std::forward<PairLike>(r))}
-    {}
-
-    template<@\exposconcept{pair-like-convertible-to}@<I, S> PairLike>
-    constexpr subrange(PairLike&& r, @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>> n)
-      requires (K == subrange_kind::sized)
-      : subrange{std::get<0>(std::forward<PairLike>(r)),
-                 std::get<1>(std::forward<PairLike>(r)), n}
     {}
 
     template<@\exposconcept{not-same-as}@<subrange> PairLike>
@@ -1347,6 +1338,9 @@ namespace std::ranges {
       requires bidirectional_iterator<I>;
     constexpr subrange& advance(iter_difference_t<I> n);
   };
+
+  template<input_or_output_iterator I, sentinel_for<I> S>
+    subrange(I, S) -> subrange<I, S>;
 
   template<input_or_output_iterator I, sentinel_for<I> S>
     subrange(I, S, @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>>) ->
@@ -1387,7 +1381,7 @@ namespace std {
 
 \indexlibraryctor{subrange}%
 \begin{itemdecl}
-constexpr subrange(I i, S s) requires (!@\exposid{StoreSize}@);
+constexpr subrange(@\exposconcept{convertible-to-non-slicing}@<I> auto i, S s) requires (!@\exposid{StoreSize}@);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1403,7 +1397,8 @@ Initializes \exposid{begin_} with \tcode{std::move(i)} and \exposid{end_} with
 
 \indexlibraryctor{subrange}%
 \begin{itemdecl}
-constexpr subrange(I i, S s, @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>> n)
+constexpr subrange(@\exposconcept{convertible-to-non-slicing}@<I> auto i, S s,
+                   @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>> n)
   requires (K == subrange_kind::sized);
 \end{itemdecl}
 
@@ -1432,7 +1427,8 @@ when it stores an iterator and sentinel that do not model
 \begin{itemdecl}
 template<@\exposconcept{not-same-as}@<subrange> R>
   requires safe_range<R> &&
-           convertible_to<iterator_t<R>, I> && convertible_to<sentinel_t<R>, S>
+           @\exposconcept{convertible-to-non-slicing}@<iterator_t<R>, I> &&
+           convertible_to<sentinel_t<R>, S>
 constexpr subrange(R&& r) requires (!@\exposid{StoreSize}@ || sized_range<R>);
 \end{itemdecl}
 

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1095,7 +1095,7 @@ The \libconcept{viewable_range} concept specifies the requirements of a
 \begin{itemdecl}
 template<class T>
   concept @\deflibconcept{viewable_range}@ =
-    range<T> && (safe_range<T> || view<decay_t<T>>);
+    range<T> && (safe_range<T> || view<remove_cvref_t<T>>);
 \end{itemdecl}
 
 \rSec1[range.utility]{Range utilities}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1075,6 +1075,12 @@ template<class T>
 \end{itemdecl}
 
 \pnum
+Given an expression \tcode{t} such that \tcode{decltype((t))} is \tcode{T\&},
+\tcode{T} models \libconcept{contiguous_range} only if
+\tcode{to_address(\brk{}ranges::begin(t)) == ranges::data(t)}
+is \tcode{true}.
+
+\pnum
 The \libconcept{common_range} concept specifies requirements of
 a \libconcept{range} type for which \tcode{ranges::begin} and
 \tcode{ranges::end} return objects of the same type.

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -53,10 +53,10 @@ namespace std::ranges {
     concept range = @\seebelow@;
 
   template<class T>
-    inline constexpr bool enable_safe_range = false;
+    inline constexpr bool enable_borrowed_range = false;
 
   template<class T>
-    concept safe_range = @\seebelow@;
+    concept borrowed_range = @\seebelow@;
 
   template<range R>
     using iterator_t = decltype(ranges::begin(declval<R&>()));
@@ -127,17 +127,17 @@ namespace std::ranges {
   class subrange;
 
   template<input_or_output_iterator I, sentinel_for<I> S, subrange_kind K>
-    inline constexpr bool enable_safe_range<subrange<I, S, K>> = true;
+    inline constexpr bool enable_borrowed_range<subrange<I, S, K>> = true;
 
   // \ref{range.dangling}, dangling iterator handling
   struct dangling;
 
   template<range R>
-    using safe_iterator_t = conditional_t<safe_range<R>, iterator_t<R>, dangling>;
+    using borrowed_iterator_t = conditional_t<borrowed_range<R>, iterator_t<R>, dangling>;
 
   template<range R>
-    using safe_subrange_t =
-      conditional_t<safe_range<R>, subrange<iterator_t<R>>, dangling>;
+    using borrowed_subrange_t =
+      conditional_t<borrowed_range<R>, subrange<iterator_t<R>>, dangling>;
 
   // \ref{range.empty}, empty view
   template<class T>
@@ -145,7 +145,7 @@ namespace std::ranges {
   class empty_view;
 
   template<class T>
-    inline constexpr bool enable_safe_range<empty_view<T>> = true;
+    inline constexpr bool enable_borrowed_range<empty_view<T>> = true;
 
   namespace views {
     template<class T>
@@ -165,7 +165,7 @@ namespace std::ranges {
   class iota_view;
 
   template<weakly_incrementable W, semiregular Bound>
-    inline constexpr bool enable_safe_range<iota_view<W, Bound>> = true;
+    inline constexpr bool enable_borrowed_range<iota_view<W, Bound>> = true;
 
   namespace views { inline constexpr @\unspec@ iota = @\unspec@; }
 
@@ -189,7 +189,7 @@ namespace std::ranges {
   class ref_view;
 
   template<class T>
-    inline constexpr bool enable_safe_range<ref_view<T>> = true;
+    inline constexpr bool enable_borrowed_range<ref_view<T>> = true;
 
   // \ref{range.filter}, filter view
   template<input_range V, indirect_unary_predicate<iterator_t<V>> Pred>
@@ -334,7 +334,7 @@ object\iref{customization.point.object}.
 Given a subexpression \tcode{E} and
 an lvalue \tcode{t} that denotes the same object as \tcode{E},
 if \tcode{E} is an rvalue and
-\tcode{enable_safe_range<remove_cvref_t<decltype((E))>>} is \tcode{false},
+\tcode{enable_borrowed_range<remove_cvref_t<decltype((E))>>} is \tcode{false},
 \tcode{ranges::begin(E)} is ill-formed.
 Otherwise,
 \tcode{ranges::begin(E)} is
@@ -381,7 +381,7 @@ object\iref{customization.point.object}.
 Given a subexpression \tcode{E} and
 an lvalue \tcode{t} that denotes the same object as \tcode{E},
 if \tcode{E} is an rvalue and
-\tcode{enable_safe_range<remove_cvref_t<decltype((E))>>} is \tcode{false},
+\tcode{enable_borrowed_range<remove_cvref_t<decltype((E))>>} is \tcode{false},
 \tcode{ranges::end(E)} is ill-formed.
 Otherwise,
 \tcode{ranges::end(E)} is
@@ -472,7 +472,7 @@ object\iref{customization.point.object}.
 Given a subexpression \tcode{E} and
 an lvalue \tcode{t} that denotes the same object as \tcode{E},
 if \tcode{E} is an rvalue and
-\tcode{enable_safe_range<remove_cvref_t<decltype((E))>>} is \tcode{false},
+\tcode{enable_borrowed_range<remove_cvref_t<decltype((E))>>} is \tcode{false},
 \tcode{ranges::rbegin(E)} is ill-formed.
 Otherwise,
 \tcode{ranges::rbegin(E)} is
@@ -520,7 +520,7 @@ object\iref{customization.point.object}.
 Given a subexpression \tcode{E} and
 an lvalue \tcode{t} that denotes the same object as \tcode{E},
 if \tcode{E} is an rvalue and
-\tcode{enable_safe_range<remove_cvref_t<decltype((E))>>} is \tcode{false},
+\tcode{enable_borrowed_range<remove_cvref_t<decltype((E))>>} is \tcode{false},
 \tcode{ranges::rend(E)} is ill-formed.
 Otherwise,
 \tcode{ranges::rend(E)} is
@@ -841,37 +841,37 @@ might not return equal values or might not be well-defined;
 
 \begin{itemdecl}
 template<class T>
-  concept @\deflibconcept{safe_range}@ =
+  concept @\deflibconcept{borrowed_range}@ =
     range<T> &&
-      (is_lvalue_reference_v<T> || enable_safe_range<remove_cvref_t<T>>);
+      (is_lvalue_reference_v<T> || enable_borrowed_range<remove_cvref_t<T>>);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 Given an expression \tcode{E} such that \tcode{decltype((E))} is \tcode{T},
-\tcode{T} models \libconcept{safe_range} only if
+\tcode{T} models \libconcept{borrowed_range} only if
 the validity of iterators obtained from the object denoted by \tcode{E}
 is not tied to the lifetime of that object.
 
 \pnum
 \begin{note}
 Since the validity of iterators is not tied to the lifetime of
-an object whose type models \libconcept{safe_range},
+an object whose type models \libconcept{borrowed_range},
 a function can accept arguments of such a type by value and
 return iterators obtained from it without danger of dangling.
 \end{note}
 \end{itemdescr}
 
-\indexlibraryglobal{enable_safe_range}%
+\indexlibraryglobal{enable_borrowed_range}%
 \begin{itemdecl}
 template<class>
-  inline constexpr bool enable_safe_range = false;
+  inline constexpr bool enable_borrowed_range = false;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \remarks
-Pursuant to \ref{namespace.std}, users may specialize \tcode{enable_safe_range}
+Pursuant to \ref{namespace.std}, users may specialize \tcode{enable_borrowed_range}
 for cv-unqualified program-defined types.
 Such specializations shall be
 usable in constant expressions\iref{expr.const} and
@@ -880,10 +880,10 @@ have type \tcode{const bool}.
 \pnum
 \begin{example}
 Each specialization \tcode{S} of class template \tcode{subrange}\iref{range.subrange}
-models \libconcept{safe_range} because
+models \libconcept{borrowed_range} because
 \begin{itemize}
 \item
-\tcode{enable_safe_range<S>} is specialized
+\tcode{enable_borrowed_range<S>} is specialized
 to have the value \tcode{true}, and
 
 \item
@@ -1095,7 +1095,7 @@ The \libconcept{viewable_range} concept specifies the requirements of a
 \begin{itemdecl}
 template<class T>
   concept @\deflibconcept{viewable_range}@ =
-    range<T> && (safe_range<T> || view<remove_cvref_t<T>>);
+    range<T> && (borrowed_range<T> || view<remove_cvref_t<T>>);
 \end{itemdecl}
 
 \rSec1[range.utility]{Range utilities}
@@ -1304,12 +1304,12 @@ namespace std::ranges {
       requires (K == subrange_kind::sized);
 
     template<@\exposconcept{not-same-as}@<subrange> R>
-      requires safe_range<R> &&
+      requires borrowed_range<R> &&
                @\exposconcept{convertible-to-non-slicing}@<iterator_t<R>, I> &&
                convertible_to<sentinel_t<R>, S>
     constexpr subrange(R&& r) requires (!@\exposid{StoreSize}@ || sized_range<R>);
 
-    template<safe_range R>
+    template<borrowed_range R>
       requires @\exposconcept{convertible-to-non-slicing}@<iterator_t<R>, I> &&
                convertible_to<sentinel_t<R>, S>
     constexpr subrange(R&& r, @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>> n)
@@ -1351,13 +1351,13 @@ namespace std::ranges {
     subrange(P, @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<tuple_element_t<0, P>>>) ->
       subrange<tuple_element_t<0, P>, tuple_element_t<1, P>, subrange_kind::sized>;
 
-  template<safe_range R>
+  template<borrowed_range R>
     subrange(R&&) ->
       subrange<iterator_t<R>, sentinel_t<R>,
                (sized_range<R> || sized_sentinel_for<sentinel_t<R>, iterator_t<R>>)
                  ? subrange_kind::sized : subrange_kind::unsized>;
 
-  template<safe_range R>
+  template<borrowed_range R>
     subrange(R&&, @\placeholdernc{make-unsigned-like-t}@<range_difference_t<R>>) ->
       subrange<iterator_t<R>, sentinel_t<R>, subrange_kind::sized>;
 
@@ -1424,7 +1424,7 @@ when it stores an iterator and sentinel that do not model
 \indexlibraryctor{subrange}%
 \begin{itemdecl}
 template<@\exposconcept{not-same-as}@<subrange> R>
-  requires safe_range<R> &&
+  requires borrowed_range<R> &&
            @\exposconcept{convertible-to-non-slicing}@<iterator_t<R>, I> &&
            convertible_to<sentinel_t<R>, S>
 constexpr subrange(R&& r) requires (!@\exposid{StoreSize}@ || sized_range<R>);
@@ -1617,13 +1617,13 @@ else
 
 \pnum
 The tag type \tcode{dangling} is used together
-with the template aliases \tcode{safe_iterator_t} and \tcode{safe_subrange_t}
+with the template aliases \tcode{borrowed_iterator_t} and \tcode{borrowed_subrange_t}
 to indicate that an algorithm
 that typically returns an iterator into or subrange of a \tcode{range} argument
 does not return an iterator or subrange
 which could potentially reference a range
 whose lifetime has ended for a particular rvalue \tcode{range} argument
-which does not model \libconcept{safe_range}\iref{range.range}.
+which does not model \libconcept{borrowed_range}\iref{range.range}.
 \indexlibraryglobal{dangling}%
 \begin{codeblock}
 namespace std::ranges {
@@ -1653,7 +1653,7 @@ the \tcode{vector} could potentially be destroyed
 before a returned iterator is dereferenced.
 However, the calls at \#2 and \#3 both return iterators
 since the lvalue \tcode{vec} and specializations of \tcode{subrange}
-model \libconcept{safe_range}.
+model \libconcept{borrowed_range}.
 \end{example}
 
 \rSec1[range.factories]{Range factories}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2152,8 +2152,7 @@ namespace std::ranges {
       requires totally_ordered<W>;
     friend constexpr bool operator>=(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
       requires totally_ordered<W>;
-    friend constexpr compare_three_way_result_t<W> operator<=>(
-        const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
+    friend constexpr auto operator<=>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
       requires totally_ordered<W> && three_way_comparable<W>;
 
     friend constexpr @\exposid{iterator}@ operator+(@\exposid{iterator}@ i, difference_type n)
@@ -2407,9 +2406,8 @@ Equivalent to: \tcode{return !(x < y);}
 
 \indexlibrarymember{operator<=>}{iota_view::iterator}
 \begin{itemdecl}
-friend constexpr compare_three_way_result_t<W>
-  operator<=>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-    requires totally_ordered<W> && three_way_comparable<W>;
+friend constexpr auto operator<=>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
+  requires totally_ordered<W> && three_way_comparable<W>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3590,9 +3588,8 @@ namespace std::ranges {
       requires random_access_range<@\exposid{Base}@>;
     friend constexpr bool operator>=(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
       requires random_access_range<@\exposid{Base}@>;
-    friend constexpr compare_three_way_result_t<iterator_t<@\exposid{Base}@>>
-      operator<=>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-        requires random_access_range<@\exposid{Base}@> && three_way_comparable<iterator_t<@\exposid{Base}@>>;
+    friend constexpr auto operator<=>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
+      requires random_access_range<@\exposid{Base}@> && three_way_comparable<iterator_t<@\exposid{Base}@>>;
 
     friend constexpr @\exposid{iterator}@ operator+(@\exposid{iterator}@ i, difference_type n)
       requires random_access_range<@\exposid{Base}@>;
@@ -3872,9 +3869,8 @@ Equivalent to: \tcode{return !(x < y);}
 
 \indexlibrarymember{operator<=>}{transform_view::iterator}%
 \begin{itemdecl}
-friend constexpr compare_three_way_result_t<iterator_t<@\exposid{Base}@>>
-  operator<=>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-    requires random_access_range<@\exposid{Base}@> && three_way_comparable<iterator_t<@\exposid{Base}@>>;
+friend constexpr auto operator<=>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
+  requires random_access_range<@\exposid{Base}@> && three_way_comparable<iterator_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6103,9 +6099,8 @@ namespace std::ranges {
       requires random_access_range<@\exposid{base-t}@>;
     friend constexpr bool operator>=(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
       requires random_access_range<@\exposid{base-t}@>;
-    friend constexpr compare_three_way_result_t<iterator_t<@\exposid{base-t}@>>
-      operator<=>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-        requires random_access_range<@\exposid{base-t}@> && three_way_comparable<iterator_t<@\exposid{base-t}@>>;
+    friend constexpr auto operator<=>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
+      requires random_access_range<@\exposid{base-t}@> && three_way_comparable<iterator_t<@\exposid{base-t}@>>;
 
     friend constexpr @\exposid{iterator}@ operator+(const @\exposid{iterator}@& x, difference_type y)
       requires random_access_range<@\exposid{base-t}@>;
@@ -6350,9 +6345,8 @@ Equivalent to: \tcode{return !(x < y);}
 
 \indexlibrarymember{operator<=>}{elements_view::iterator}%
 \begin{itemdecl}
-friend constexpr compare_three_way_result_t<iterator_t<@\exposid{base-t}@>>
-  operator<=>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-    requires random_access_range<@\exposid{base-t}@> && three_way_comparable<iterator_t<@\exposid{base-t}@>>;
+friend constexpr auto operator<=>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
+  requires random_access_range<@\exposid{base-t}@> && three_way_comparable<iterator_t<@\exposid{base-t}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -5847,12 +5847,10 @@ namespace std::ranges {
 
     constexpr reverse_iterator<iterator_t<V>> begin();
     constexpr reverse_iterator<iterator_t<V>> begin() requires common_range<V>;
-    constexpr reverse_iterator<iterator_t<const V>> begin() const
-      requires common_range<const V>;
+    constexpr auto begin() const requires common_range<const V>;
 
     constexpr reverse_iterator<iterator_t<V>> end();
-    constexpr reverse_iterator<iterator_t<const V>> end() const
-      requires common_range<const V>;
+    constexpr auto end() const requires common_range<const V>;
 
     constexpr auto size() requires sized_range<V> {
       return ranges::size(@\exposid{base_}@);
@@ -5900,8 +5898,7 @@ the \libconcept{range} concept, this function caches the result within the
 \indexlibrarymember{begin}{reverse_view}%
 \begin{itemdecl}
 constexpr reverse_iterator<iterator_t<V>> begin() requires common_range<V>;
-constexpr reverse_iterator<iterator_t<const V>> begin() const
-  requires common_range<const V>;
+constexpr auto begin() const requires common_range<const V>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5913,8 +5910,7 @@ Equivalent to: \tcode{return make_reverse_iterator(ranges::end(base_));}
 \indexlibrarymember{end}{reverse_view}%
 \begin{itemdecl}
 constexpr reverse_iterator<iterator_t<V>> end();
-constexpr reverse_iterator<iterator_t<const V>> end() const
-  requires common_range<const V>;
+constexpr auto end() const requires common_range<const V>;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -913,7 +913,7 @@ template<class T>
 Given an lvalue \tcode{t} of type \tcode{remove_reference_t<T>}, \tcode{T}
 models \libconcept{sized_range} only if
 \begin{itemize}
-\item \tcode{ranges::size(t)} is \bigoh{1}, does not modify \tcode{t},
+\item \tcode{ranges::size(t)} is amortized \bigoh{1}, does not modify \tcode{t},
 and is equal to \tcode{ranges::distance(t)}, and
 
 \item if \tcode{iterator_t<T>} models \libconcept{forward_iterator},
@@ -928,13 +928,6 @@ does not model \libconcept{forward_iterator}
 only if evaluated before the first call to \tcode{ranges::begin(t)}.
 \end{note}
 \end{itemize}
-
-\pnum
-\begin{note}
-The complexity requirement for the evaluation of \tcode{ranges::size}
-is non-amortized, unlike the case for the complexity of the evaluations of
-\tcode{ranges::begin} and \tcode{ranges::end} in the \libconcept{range} concept.
-\end{note}
 \end{itemdescr}
 
 \indexlibraryglobal{disable_sized_range}%

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -3105,7 +3105,7 @@ satisfy the filter predicate.
 \end{itemize}
 
 \pnum
-\tcode{iterator::iterator_category} is defined as follows:
+\tcode{\exposid{iterator}::iterator_category} is defined as follows:
 \begin{itemize}
 \item Let \tcode{C} denote the type
 \tcode{iterator_traits<iterator_t<V>>::iterator_category}.
@@ -3631,12 +3631,26 @@ namespace std::ranges {
 \end{itemize}
 
 \pnum
+\tcode{iterator::iterator_category} is defined as follows:
 Let \tcode{C} denote the type
 \tcode{iterator_traits<iterator_t<\exposid{Base}>>::iterator_category}.
-If \tcode{C} models \tcode{\libconcept{derived_from}<contiguous_iterator_tag>},
-then \tcode{iterator_category} denotes
-\tcode{random_access_iterator_tag}; otherwise,
+\begin{itemize}
+\item
+If \tcode{is_lvalue_reference_v<invoke_result_t<F\&, range_reference_t<\exposid{Base}>>>}
+is \tcode{true}, then
+\begin{itemize}
+\item
+if \tcode{C} models \tcode{\libconcept{derived_from}<contiguous_iterator_tag>},
+\tcode{iterator_category} denotes \tcode{random_access_iterator_tag};
+
+\item
+otherwise,
 \tcode{iterator_category} denotes \tcode{C}.
+\end{itemize}
+
+\item
+Otherwise, \tcode{iterator_category} denotes \tcode{input_iterator_tag}.
+\end{itemize}
 
 \indexlibrarymember{iterator}{transform_view::iterator}
 \begin{itemdecl}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -6054,7 +6054,6 @@ namespace std::ranges {
   template<bool Const>
   class elements_view<V, N>::@\exposid{iterator}@ {                 // \expos
     using @\exposid{base-t}@ = conditional_t<Const, const V, V>;    // \expos
-    friend @\exposid{iterator}@<!Const>;
 
     iterator_t<@\exposid{base-t}@> @\exposid{current_}@ = iterator_t<@\exposid{base-t}@>();
   public:

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2641,7 +2641,7 @@ namespace std::ranges {
   template<class Val, class CharT, class Traits>
   class basic_istream_view<Val, CharT, Traits>::@\exposid{iterator}@ {      // \expos
   public:
-    using iterator_category = input_iterator_tag;
+    using iterator_concept = input_iterator_tag;
     using difference_type = ptrdiff_t;
     using value_type = Val;
 

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -3938,7 +3938,7 @@ namespace std {
   template<class charT, class traits>
     inline constexpr bool ranges::enable_view<basic_string_view<charT, traits>> = true;
   template<class charT, class traits>
-    inline constexpr bool ranges::enable_safe_range<basic_string_view<charT, traits>> = true;
+    inline constexpr bool ranges::enable_borrowed_range<basic_string_view<charT, traits>> = true;
 
   // \ref{string.view.comparison}, non-member comparison functions
   template<class charT, class traits>

--- a/source/support.tex
+++ b/source/support.tex
@@ -2864,12 +2864,13 @@ An invocation of this function
 may be used in a core constant expression
 whenever the value of its argument
 may be used in a core constant expression.
-A byte of storage is
+A byte of storage \placeholder{b} is
 reachable through a pointer value
 that points to an object \placeholder{Y}
-if it is within the storage occupied by
-\placeholder{Y},
-an object that is pointer-interconvertible with \placeholder{Y}, or
+if there is an object \placeholder{Z},
+pointer-interconvertible with \placeholder{Y},
+such that \placeholder{b} is within the storage occupied by
+\placeholder{Z}, or
 the immediately-enclosing array object if \placeholder{Y} is an array element.
 
 \pnum

--- a/source/support.tex
+++ b/source/support.tex
@@ -597,6 +597,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_constexpr_tuple}@                   201811L // also in \libheader{tuple}
 #define @\defnlibxname{cpp_lib_constexpr_utility}@                 201811L // also in \libheader{utility}
 #define @\defnlibxname{cpp_lib_constexpr_vector}@                  201907L // also in \libheader{vector}
+#define @\defnlibxname{cpp_lib_coroutine}@                         201902L // also in \libheader{coroutine}
 #define @\defnlibxname{cpp_lib_destroying_delete}@                 201806L // also in \libheader{new}
 #define @\defnlibxname{cpp_lib_enable_shared_from_this}@           201603L // also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_endian}@                            201907L // also in \libheader{bit}

--- a/source/support.tex
+++ b/source/support.tex
@@ -3268,17 +3268,17 @@ static consteval source_location current() noexcept;
 
 \pnum
 \remarks
-When a default member initializer
-is used to initialize a non-static data member,
-any calls to \tcode{current} should correspond to the location
-of the constructor or aggregate initialization that initializes the member.
-
-\pnum
-\begin{note}
-When used as a default argument\iref{dcl.fct.default},
-the value of the \tcode{source_location} will be
-the location of the call to \tcode{current} at the call site.
-\end{note}
+Any call to \tcode{current} that appears
+as a default member initializer\iref{class.mem}, or
+as a subexpression thereof,
+should correspond to the location of
+the constructor definition or aggregate initialization
+that uses the default member initializer.
+Any call to \tcode{current} that appears
+as a default argument\iref{dcl.fct.default}, or
+as a subexpression thereof,
+should correspond to the location of the invocation of the function
+that uses the default argument\iref{expr.call}.
 \end{itemdescr}
 
 \pnum

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -609,9 +609,7 @@ namespace std {
     bool request_stop() noexcept;
 
     [[nodiscard]] friend bool
-    operator==(const stop_source& lhs, const stop_source& rhs) noexcept;
-    [[nodiscard]] friend bool
-    operator!=(const stop_source& lhs, const stop_source& rhs) noexcept;
+      operator==(const stop_source& lhs, const stop_source& rhs) noexcept;
     friend void swap(stop_source& lhs, stop_source& rhs) noexcept;
   };
 }
@@ -810,11 +808,12 @@ or \tcode{stop_requested()} is \tcode{true}.
 otherwise \tcode{false}.
 \end{itemdescr}
 
-\rSec3[stopsource.cmp]{Comparisons}
+\rSec3[stopsource.nonmembers]{Non-member functions}
 
 \indexlibrarymember{operator==}{stop_source}%
 \begin{itemdecl}
-[[nodiscard]] bool operator==(const stop_source& lhs, const stop_source& rhs) noexcept;
+[[nodiscard]] friend bool
+  operator==(const stop_source& lhs, const stop_source& rhs) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -825,19 +824,6 @@ of the same stop state
 or if both \tcode{lhs} and \tcode{rhs} do not have ownership of a stop state;
 otherwise \tcode{false}.
 \end{itemdescr}
-
-\indexlibrarymember{operator!=}{stop_source}%
-\begin{itemdecl}
-[[nodiscard]] bool operator!=(const stop_source& lhs, const stop_source& rhs) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\tcode{!(lhs==rhs)}.
-\end{itemdescr}
-
-\rSec3[stopsource.special]{Specialized algorithms}
 
 \indexlibrarymember{swap}{stop_source}%
 \begin{itemdecl}

--- a/source/time.tex
+++ b/source/time.tex
@@ -10597,7 +10597,10 @@ The modified command \tcode{\%OI} produces
 the locale's alternative representation.
 \\ \rowsep
 \tcode{\%j} &
-The day of the year as a decimal number.
+If the type being formatted is a specialization of \tcode{duration},
+the decimal number of \tcode{days} without padding.
+Otherwise,
+the day of the year as a decimal number.
 Jan 1 is \tcode{001}.
 If the result is less than three digits,
 it is left-padded with \tcode{0} to three digits.
@@ -11179,9 +11182,13 @@ The modified command \tcode{\%OI}
 interprets the locale's alternative representation.
 \\ \rowsep
 \tcode{\%j} &
-The day of the year as a decimal number.
+If the type being parsed is a specialization of \tcode{duration},
+a decimal number of \tcode{days}.
+Otherwise,
+the day of the year as a decimal number.
 Jan 1 is \tcode{1}.
-The modified command \tcode{\%\placeholder{N}j} specifies
+In either case,
+the modified command \tcode{\%\placeholder{N}j} specifies
 the maximum number of characters to read.
 If \tcode{\placeholder{N}} is not specified, the default is 3.
 Leading zeroes are permitted but not required.

--- a/source/time.tex
+++ b/source/time.tex
@@ -1288,7 +1288,7 @@ template<class Rep2>
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{is_convertible_v<Rep2, rep>} is \tcode{true} and
+\tcode{is_convertible_v<const Rep2\&, rep>} is \tcode{true} and
 \begin{itemize}
 \item \tcode{treat_as_floating_point_v<rep>} is \tcode{true} or
 \item \tcode{treat_as_floating_point_v<Rep2>} is \tcode{false}.
@@ -1594,7 +1594,7 @@ template<class Rep1, class Period, class Rep2>
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{is_convertible_v<Rep2, common_type_t<Rep1, Rep2>>} is \tcode{true}.
+\tcode{is_convertible_v<const Rep2\&, common_type_t<Rep1, Rep2>>} is \tcode{true}.
 
 \pnum
 \returns
@@ -1611,7 +1611,7 @@ template<class Rep1, class Rep2, class Period>
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{is_convertible_v<Rep1, common_type_t<Rep1, Rep2>>} is \tcode{true}.
+\tcode{is_convertible_v<const Rep1\&, common_type_t<Rep1, Rep2>>} is \tcode{true}.
 
 \pnum
 \returns
@@ -1628,7 +1628,7 @@ template<class Rep1, class Period, class Rep2>
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{is_convertible_v<Rep2, common_type_t<Rep1, Rep2>>} is \tcode{true}
+\tcode{is_convertible_v<const Rep2\&, common_type_t<Rep1, Rep2>>} is \tcode{true}
 and \tcode{Rep2} is not a specialization of \tcode{duration}.
 
 \pnum
@@ -1663,7 +1663,7 @@ template<class Rep1, class Period, class Rep2>
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{is_convertible_v<Rep2, common_type_t<Rep1, Rep2>>} is \tcode{true} and
+\tcode{is_convertible_v<const Rep2\&, common_type_t<Rep1, Rep2>>} is \tcode{true} and
 \tcode{Rep2} is not a specialization of \tcode{duration}.
 
 \pnum

--- a/source/time.tex
+++ b/source/time.tex
@@ -10939,7 +10939,8 @@ Each \tcode{parse} overload specified in this subclause
 calls \tcode{from_stream} unqualified,
 so as to enable argument dependent lookup\iref{basic.lookup.argdep}.
 In the following paragraphs,
-let \tcode{is} denote an object of type \tcode{basic_istream<charT, traits>},
+let \tcode{is} denote an object of type \tcode{basic_istream<charT, traits>} and
+let \tcode{I} be \tcode{basic_istream<charT, traits>\&},
 where \tcode{charT} and \tcode{traits} are template parameters in that context.
 
 \begin{itemdecl}
@@ -10951,15 +10952,18 @@ template<class charT, class traits, class Alloc, class Parsable>
 \begin{itemdescr}
 \pnum
 \constraints
+The expression
 \begin{codeblock}
 from_stream(declval<basic_istream<charT, traits>&>(), fmt.c_str(), tp)
 \end{codeblock}
-is a valid expression.
+is well-formed when treated as an unevaluated operand.
 
 \pnum
 \returns
-A manipulator that, when extracted from a
-\tcode{basic_istream<charT, traits>} \tcode{is},
+A manipulator such that
+the expression \tcode{is >> parse(fmt, tp)}
+has type \tcode{I},
+has value \tcode{is}, and
 calls \tcode{from_stream(is, fmt.c_str(), tp)}.
 \end{itemdescr}
 
@@ -10973,15 +10977,18 @@ template<class charT, class traits, class Alloc, class Parsable>
 \begin{itemdescr}
 \pnum
 \constraints
+The expression
 \begin{codeblock}
 from_stream(declval<basic_istream<charT, traits>&>(), fmt.c_str(), tp, addressof(abbrev))
 \end{codeblock}
-is a valid expression.
+is well-formed when treated as an unevaluated operand.
 
 \pnum
 \returns
-A manipulator that, when extracted from a
-\tcode{basic_istream<charT, traits>} \tcode{is},
+A manipulator such that
+the expression \tcode{is >> parse(fmt, tp, abbrev)}
+has type \tcode{I},
+has value \tcode{is}, and
 calls \tcode{from_stream(is, fmt.c_str(), tp, addressof(abbrev))}.
 \end{itemdescr}
 
@@ -11006,8 +11013,10 @@ is well-formed when treated as an unevaluated operand.
 
 \pnum
 \returns
-A manipulator that, when extracted from a
-\tcode{basic_istream<charT, traits>} \tcode{is},
+A manipulator such that
+the expression \tcode{is >> parse(fmt, tp, offset)}
+has type \tcode{I},
+has value \tcode{is}, and
 calls:
 \begin{codeblock}
 from_stream(is,
@@ -11027,16 +11036,19 @@ template<class charT, class traits, class Alloc, class Parsable>
 \begin{itemdescr}
 \pnum
 \constraints
+The expression
 \begin{codeblock}
 from_stream(declval<basic_istream<charT, traits>&>(),
             fmt.c_str(), tp, addressof(abbrev), &offset)
 \end{codeblock}
-is a valid expression.
+is well-formed when treated as an unevaluated operand.
 
 \pnum
 \returns
-A manipulator that, when extracted from a
-\tcode{basic_istream<charT, traits>} \tcode{is},
+A manipulator such that
+the expression \tcode{is >> parse(fmt, tp, abbrev, offset)}
+has type \tcode{I},
+has value \tcode{is}, and
 calls \tcode{from_stream(is, fmt.c_str(), tp, addressof(abbrev), \&offset)}.
 \end{itemdescr}
 

--- a/source/time.tex
+++ b/source/time.tex
@@ -2843,7 +2843,8 @@ template<class Duration>
 A \tcode{sys_time} \tcode{t},
 such that \tcode{from_sys(t) == u} if such a mapping exists.
 Otherwise \tcode{u} represents a \tcode{time_point}
-during a leap second insertion
+during a positive leap second insertion,
+the conversion counts that leap second as not inserted,
 and the last representable value of \tcode{sys_time}
 prior to the insertion of the leap second is returned.
 \end{itemdescr}
@@ -2860,7 +2861,7 @@ template<class Duration>
 \returns
 A \tcode{utc_time} \tcode{u}, such that
 \tcode{u.time_since_epoch() - t.time_since_epoch()}
-is equal to the number of leap seconds that were inserted
+is equal to the sum of leap seconds that were inserted
 between \tcode{t} and 1970-01-01.
 If \tcode{t} is exactly the date of leap second insertion,
 then the conversion counts that leap second as inserted.
@@ -2980,11 +2981,13 @@ template<class Duration>
 \begin{itemdescr}
 \pnum
 \returns
-A \tcode{leap_second_info} where \tcode{is_leap_second} is \tcode{true}
-if \tcode{ut} is during a leap second insertion, and otherwise \tcode{false}.
-\tcode{elapsed} is the number of leap seconds between 1970-01-01 and \tcode{ut}.
-If \tcode{is_leap_second} is \tcode{true},
-the leap second referred to by \tcode{ut} is included in the count.
+A \tcode{leap_second_info} \tcode{lsi},
+where \tcode{lsi.is_leap_second} is \tcode{true}
+if \tcode{ut} is during a positive leap second insertion, and
+otherwise \tcode{false}.
+\tcode{lsi.elapsed} is the sum of leap seconds between 1970-01-01 and \tcode{ut}.
+If \tcode{lsi.is_leap_second} is \tcode{true},
+the leap second referred to by \tcode{ut} is included in the sum.
 \end{itemdescr}
 
 \rSec2[time.clock.tai]{Class \tcode{tai_clock}}
@@ -3020,8 +3023,9 @@ and is offset 10s ahead of UTC at this date.
 That is, 1958-01-01 00:00:00 TAI is equivalent to 1957-12-31 23:59:50 UTC\@.
 Leap seconds are not inserted into TAI\@.
 Therefore every time a leap second is inserted into UTC,
-UTC falls another second behind TAI\@.
-For example by 2000-01-01 there had been 22 leap seconds inserted
+UTC shifts another second with respect to TAI\@.
+For example by 2000-01-01 there had been
+22 positive and 0 negative leap seconds inserted
 so 2000-01-01 00:00:00 UTC is equivalent to 2000-01-01 00:00:32 TAI
 (22s plus the initial 10s offset).
 
@@ -3183,7 +3187,7 @@ The clock \tcode{gps_clock} measures
 seconds since the first Sunday of January, 1980 00:00:00 UTC\@.
 Leap seconds are not inserted into GPS\@.
 Therefore every time a leap second is inserted into UTC,
-UTC falls another second behind GPS\@.
+UTC shifts another second with respect to GPS\@.
 Aside from the offset from \tcode{1958y/January/1} to \tcode{1980y/January/Sunday[1]},
 GPS is behind TAI by 19s due to the 10s offset between 1958 and 1970
 and the additional 9 leap seconds inserted between 1970 and 1980.
@@ -10100,13 +10104,14 @@ namespace std::chrono {
     // unspecified additional constructors
 
     constexpr sys_seconds date() const noexcept;
+    constexpr seconds value() const noexcept;
   };
 }
 \end{codeblock}
 
 \pnum
 Objects of type \tcode{leap} representing
-the date of the leap second insertions
+the date and value of the leap second insertions
 are constructed and stored in the time zone database when initialized.
 
 \pnum
@@ -10114,39 +10119,39 @@ are constructed and stored in the time zone database when initialized.
 \begin{codeblock}
 for (auto& l : get_tzdb().leaps)
   if (l <= 2018y/March/17d)
-    cout << l.date() << '\n';
+    cout << l.date() << ": " << l.value() << '\n';
 \end{codeblock}
 
 Produces the output:
 
 \begin{outputblock}
-1972-07-01 00:00:00
-1973-01-01 00:00:00
-1974-01-01 00:00:00
-1975-01-01 00:00:00
-1976-01-01 00:00:00
-1977-01-01 00:00:00
-1978-01-01 00:00:00
-1979-01-01 00:00:00
-1980-01-01 00:00:00
-1981-07-01 00:00:00
-1982-07-01 00:00:00
-1983-07-01 00:00:00
-1985-07-01 00:00:00
-1988-01-01 00:00:00
-1990-01-01 00:00:00
-1991-01-01 00:00:00
-1992-07-01 00:00:00
-1993-07-01 00:00:00
-1994-07-01 00:00:00
-1996-01-01 00:00:00
-1997-07-01 00:00:00
-1999-01-01 00:00:00
-2006-01-01 00:00:00
-2009-01-01 00:00:00
-2012-07-01 00:00:00
-2015-07-01 00:00:00
-2017-01-01 00:00:00
+1972-07-01 00:00:00: 1s
+1973-01-01 00:00:00: 1s
+1974-01-01 00:00:00: 1s
+1975-01-01 00:00:00: 1s
+1976-01-01 00:00:00: 1s
+1977-01-01 00:00:00: 1s
+1978-01-01 00:00:00: 1s
+1979-01-01 00:00:00: 1s
+1980-01-01 00:00:00: 1s
+1981-07-01 00:00:00: 1s
+1982-07-01 00:00:00: 1s
+1983-07-01 00:00:00: 1s
+1985-07-01 00:00:00: 1s
+1988-01-01 00:00:00: 1s
+1990-01-01 00:00:00: 1s
+1991-01-01 00:00:00: 1s
+1992-07-01 00:00:00: 1s
+1993-07-01 00:00:00: 1s
+1994-07-01 00:00:00: 1s
+1996-01-01 00:00:00: 1s
+1997-07-01 00:00:00: 1s
+1999-01-01 00:00:00: 1s
+2006-01-01 00:00:00: 1s
+2009-01-01 00:00:00: 1s
+2012-07-01 00:00:00: 1s
+2015-07-01 00:00:00: 1s
+2017-01-01 00:00:00: 1s
 \end{outputblock}
 \end{example}
 
@@ -10161,6 +10166,21 @@ constexpr sys_seconds date() const noexcept;
 \pnum
 \returns
 The date and time at which the leap second was inserted.
+\end{itemdescr}
+
+\indexlibrarymember{value}{leap}%
+\begin{itemdecl}
+constexpr seconds value() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{+1s} to indicate a positive leap second or
+\tcode{-1s} to indicate a negative leap second.
+\begin{note}
+All leap seconds inserted up through 2019 were positive leap seconds.
+\end{note}
 \end{itemdescr}
 
 \rSec3[time.zone.leap.nonmembers]{Non-member functions}
@@ -10770,7 +10790,7 @@ If \tcode{\%Z} is used,
 it is replaced with \tcode{\exposid{STATICALLY-WIDEN}<charT>("UTC")}.
 If \tcode{\%z} (or a modified variant of \tcode{\%z}) is used,
 an offset of \tcode{0min} is formatted.
-If the argument represents a time during a leap second insertion,
+If the argument represents a time during a positive leap second insertion,
 and if a seconds field is formatted,
 the integral portion of that format is
 \tcode{\exposid{STATICALLY-WIDEN}<charT>("60")}.

--- a/source/time.tex
+++ b/source/time.tex
@@ -8602,10 +8602,7 @@ operator<<(basic_ostream<charT, traits>& os, const hh_mm_ss<Duration>& hms);
 \effects
 Equivalent to:
 \begin{codeblock}
-return os << format(os.getloc(),
-                    hms.is_negative() ? @\placeholder{STATICALLY-WIDEN}@<charT>("-{:%T}")
-                                      : @\placeholder{STATICALLY-WIDEN}@<charT>("{:%T}"),
-                    abs(hms.to_duration()));
+return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:%T}"), hms);
 \end{codeblock}
 
 \pnum
@@ -10466,6 +10463,22 @@ or the global locale otherwise.
 If the formatted object does not contain the information
 the conversion specifier refers to,
 an exception of type \tcode{format_error} is thrown.
+
+\pnum
+The result of formatting
+a \tcode{std::chrono::duration} instance holding a negative value, or
+an \tcode{hh_mm_ss} object \tcode{h} for which \tcode{h.is_negative()} is \tcode{true},
+is equivalent to the output of the corresponding positive value,
+with a \tcode{\exposid{STATICALLY-WIDEN}<charT>("-")} character sequence
+placed before the replacement of the leftmost conversion specifier.
+\begin{example}
+\begin{codeblockdigitsep}
+cout << format("{%:T}", -10'000s);          // prints: \tcode{-02:46:40}
+cout << format("{:%H:%M:%S}", -10'000s);    // prints: \tcode{-02:46:40}
+cout << format("{:minutes %M, hours %H, seconds %S}", -10'000s);
+                                            // prints: \tcode{minutes -46, hours 02, seconds 40}
+\end{codeblockdigitsep}
+\end{example}
 
 \pnum
 Unless explicitly requested,

--- a/source/time.tex
+++ b/source/time.tex
@@ -2049,11 +2049,11 @@ Otherwise, if \tcode{Period::type} is \tcode{nano},
 
 \item
 Otherwise, if \tcode{Period::type} is \tcode{micro},
-\tcode{\placeholder{units-suffix}} is:
-\begin{itemize}
-\item \tcode{"\textmu{}s"} (\tcode{"\textbackslash{}u00b5\textbackslash{}u0073"}) if the character U+00B5 can be represented in the encoding used for \tcode{charT};
-\item \tcode{"us"} otherwise.
-\end{itemize}
+it is
+\impldef{unit suffix when \tcode{Period::type} is \tcode{micro}}
+whether \tcode{\placeholder{units-suffix}} is
+\tcode{"\textmu{}s"} (\tcode{"\textbackslash{}u00b5\textbackslash{}u0073"}) or
+\tcode{"us"}.
 
 \item
 Otherwise, if \tcode{Period::type} is \tcode{milli},

--- a/source/time.tex
+++ b/source/time.tex
@@ -9417,8 +9417,10 @@ namespace std::chrono {
     template<class Duration2, class TimeZonePtr2>
       zoned_time(TimeZonePtr z, const zoned_time<Duration2, TimeZonePtr2>& zt, choose);
 
-    zoned_time(string_view name, const zoned_time<Duration>& zt);
-    zoned_time(string_view name, const zoned_time<Duration>& zt, choose);
+    template<class Duration2, class TimeZonePtr2>
+      zoned_time(string_view name, const zoned_time<Duration2, TimeZonePtr2>& zt);
+    template<class Duration2, class TimeZonePtr2>
+      zoned_time(string_view name, const zoned_time<Duration2, TimeZonePtr2>& zt, choose);
 
     zoned_time& operator=(const sys_time<Duration>& st);
     zoned_time& operator=(const local_time<Duration>& ut);
@@ -9710,13 +9712,16 @@ The \tcode{choose} parameter has no effect.
 \end{itemdescr}
 
 \begin{itemdecl}
-zoned_time(string_view name, const zoned_time<Duration>& y);
+template<class Duration2, class TimeZonePtr2>
+  zoned_time(string_view name, const zoned_time<Duration2, TimeZonePtr2>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{zoned_time} is constructible from the return type of \tcode{traits::locate_zone(name)} and \tcode{zoned_time}.
+\tcode{zoned_time} is constructible from
+the return type of \tcode{traits::locate_zone(name)} and
+the type \tcode{zoned_time<Duration2, TimeZonePtr2>}.
 
 \pnum
 \effects
@@ -9724,14 +9729,17 @@ Equivalent to construction with \tcode{\{traits::locate_zone(name), y\}}.
 \end{itemdescr}
 
 \begin{itemdecl}
-zoned_time(string_view name, const zoned_time<Duration>& y, choose c);
+template<class Duration2, class TimeZonePtr2>
+  zoned_time(string_view name, const zoned_time<Duration2, TimeZonePtr2>& y, choose c);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \constraints
 \tcode{zoned_time} is constructible from
-the return type of \tcode{traits::locate_zone(name)}, \tcode{zoned_time}, and \tcode{choose}.
+the return type of \tcode{traits::locate_zone(name)},
+the type \tcode{zoned_time<Duration2, TimeZonePtr2>}, and
+the type \tcode{choose}.
 
 \pnum
 \effects

--- a/source/time.tex
+++ b/source/time.tex
@@ -6024,6 +6024,14 @@ constexpr year_month& operator+=(const months& dm) noexcept;
 
 \begin{itemdescr}
 \pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
+\pnum
 \effects
 \tcode{*this = *this + dm}.
 
@@ -6038,6 +6046,14 @@ constexpr year_month& operator-=(const months& dm) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
 \pnum
 \effects
 \tcode{*this = *this - dm}.
@@ -6123,6 +6139,14 @@ constexpr year_month operator+(const year_month& ym, const months& dm) noexcept;
 
 \begin{itemdescr}
 \pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
+\pnum
 \returns
 A \tcode{year_month} value \tcode{z} such that \tcode{z.ok() \&\& z - ym == dm}
 is \tcode{true}.
@@ -6139,6 +6163,14 @@ constexpr year_month operator+(const months& dm, const year_month& ym) noexcept;
 
 \begin{itemdescr}
 \pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
+\pnum
 \returns
 \tcode{ym + dm}.
 \end{itemdescr}
@@ -6149,6 +6181,14 @@ constexpr year_month operator-(const year_month& ym, const months& dm) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
 \pnum
 \returns
 \tcode{ym + -dm}.
@@ -6371,6 +6411,14 @@ constexpr year_month_day& operator+=(const months& m) noexcept;
 
 \begin{itemdescr}
 \pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
+\pnum
 \effects
 \tcode{*this = *this + m}.
 
@@ -6385,6 +6433,14 @@ constexpr year_month_day& operator-=(const months& m) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
 \pnum
 \effects
 \tcode{*this = *this - m}.
@@ -6550,6 +6606,14 @@ constexpr year_month_day operator+(const year_month_day& ymd, const months& dm) 
 
 \begin{itemdescr}
 \pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
+\pnum
 \returns
 \tcode{(ymd.year() / ymd.month() + dm) / ymd.day()}.
 
@@ -6568,6 +6632,14 @@ constexpr year_month_day operator+(const months& dm, const year_month_day& ymd) 
 
 \begin{itemdescr}
 \pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
+\pnum
 \returns
 \tcode{ymd + dm}.
 \end{itemdescr}
@@ -6578,6 +6650,14 @@ constexpr year_month_day operator-(const year_month_day& ymd, const months& dm) 
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
 \pnum
 \returns
 \tcode{ymd + (-dm)}.
@@ -6740,6 +6820,14 @@ constexpr year_month_day_last& operator+=(const months& m) noexcept;
 
 \begin{itemdescr}
 \pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
+\pnum
 \effects
 \tcode{*this = *this + m}.
 
@@ -6754,6 +6842,14 @@ constexpr year_month_day_last& operator-=(const months& m) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
 \pnum
 \effects
 \tcode{*this = *this - m}.
@@ -6916,6 +7012,14 @@ constexpr year_month_day_last
 
 \begin{itemdescr}
 \pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
+\pnum
 \returns
 \tcode{(ymdl.year() / ymdl.month() + dm) / last}.
 \end{itemdescr}
@@ -6928,6 +7032,14 @@ constexpr year_month_day_last
 
 \begin{itemdescr}
 \pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
+\pnum
 \returns
 \tcode{ymdl + dm}.
 \end{itemdescr}
@@ -6939,6 +7051,14 @@ constexpr year_month_day_last
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
 \pnum
 \returns
 \tcode{ymdl + (-dm)}.
@@ -7099,6 +7219,14 @@ constexpr year_month_weekday& operator+=(const months& m) noexcept;
 
 \begin{itemdescr}
 \pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
+\pnum
 \effects
 \tcode{*this = *this + m}.
 
@@ -7113,6 +7241,14 @@ constexpr year_month_weekday& operator-=(const months& m) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
 \pnum
 \effects
 \tcode{*this = *this - m}.
@@ -7277,6 +7413,14 @@ constexpr year_month_weekday operator+(const year_month_weekday& ymwd, const mon
 
 \begin{itemdescr}
 \pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
+\pnum
 \returns
 \tcode{(ymwd.year() / ymwd.month() + dm) / ymwd.weekday_indexed()}.
 \end{itemdescr}
@@ -7288,6 +7432,14 @@ constexpr year_month_weekday operator+(const months& dm, const year_month_weekda
 
 \begin{itemdescr}
 \pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
+\pnum
 \returns
 \tcode{ymwd + dm}.
 \end{itemdescr}
@@ -7298,6 +7450,14 @@ constexpr year_month_weekday operator-(const year_month_weekday& ymwd, const mon
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
 \pnum
 \returns
 \tcode{ymwd + (-dm)}.
@@ -7423,6 +7583,14 @@ constexpr year_month_weekday_last& operator+=(const months& m) noexcept;
 
 \begin{itemdescr}
 \pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
+\pnum
 \effects
 \tcode{*this = *this + m}.
 
@@ -7437,6 +7605,14 @@ constexpr year_month_weekday_last& operator-=(const months& m) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
 \pnum
 \effects
 \tcode{*this = *this - m}.
@@ -7580,6 +7756,14 @@ constexpr year_month_weekday_last
 
 \begin{itemdescr}
 \pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
+\pnum
 \returns
 \tcode{(ymwdl.year() / ymwdl.month() + dm) / ymwdl.weekday_last()}.
 \end{itemdescr}
@@ -7592,6 +7776,14 @@ constexpr year_month_weekday_last
 
 \begin{itemdescr}
 \pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
+\pnum
 \returns
 \tcode{ymwdl + dm}.
 \end{itemdescr}
@@ -7603,6 +7795,14 @@ constexpr year_month_weekday_last
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\constraints
+If the argument supplied by the caller for the \tcode{months} parameter
+is convertible to \tcode{years},
+its implicit conversion sequence to \tcode{years}
+is worse than its implicit conversion sequence to
+\tcode{months}\iref{over.ics.rank}.
+
 \pnum
 \returns
 \tcode{ymwdl + (-dm)}.

--- a/source/time.tex
+++ b/source/time.tex
@@ -793,8 +793,9 @@ namespace std {
       bool operator>=(const leap& x, const sys_time<Duration>& y);
     template<class Duration>
       bool operator>=(const sys_time<Duration>& x, const leap& y);
-    template<three_way_comparable_with<sys_seconds> Duration>
-      auto operator<=>(const leap& x, const sys_time<Duration>& y);
+    template<class Duration>
+      requires three_way_comparable_with<sys_seconds, sys_time<Duration>>
+      constexpr auto operator<=>(const leap& x, const sys_time<Duration>& y);
 
     // \ref{time.zone.link}, class \tcode{link}
     class link;
@@ -10327,7 +10328,8 @@ template<class Duration>
 \indexlibrarymember{operator<=>}{leap}%
 \indexlibrarymember{operator<=>}{sys_time}%
 \begin{itemdecl}
-template<three_way_comparable_with<sys_seconds> Duration>
+template<class Duration>
+  requires three_way_comparable_with<sys_seconds, sys_time<Duration>>
   constexpr auto operator<=>(const leap& x, const sys_time<Duration>& y) noexcept;
 \end{itemdecl}
 

--- a/source/time.tex
+++ b/source/time.tex
@@ -10895,7 +10895,7 @@ The modified command \tcode{\%\placeholder{N}C} specifies
 the maximum number of characters to read.
 If \tcode{\placeholder{N}} is not specified, the default is 2.
 Leading zeroes are permitted but not required.
-The modified commands \tcode{\%EC} and \tcode{\%OC} interpret
+The modified command \tcode{\%EC} interprets
 the locale's alternative representation of the century.
 \\ \rowsep
 \tcode{\%d} &
@@ -10950,6 +10950,8 @@ The modified command \tcode{\%\placeholder{N}I} specifies
 the maximum number of characters to read.
 If \tcode{\placeholder{N}} is not specified, the default is 2.
 Leading zeroes are permitted but not required.
+The modified command \tcode{\%OI}
+interprets the locale's alternative representation.
 \\ \rowsep
 \tcode{\%j} &
 The day of the year as a decimal number.
@@ -11023,8 +11025,6 @@ The modified command \tcode{\%\placeholder{N}u} specifies
 the maximum number of characters to read.
 If \tcode{\placeholder{N}} is not specified, the default is \tcode{1}.
 Leading zeroes are permitted but not required.
-The modified command \tcode{\%Ou} interprets
-the locale's alternative representation.
 \\ \rowsep
 \tcode{\%U} &
 The week number of the year as a decimal number.
@@ -11034,6 +11034,8 @@ The modified command \tcode{\%\placeholder{N}U} specifies
 the maximum number of characters to read.
 If \tcode{\placeholder{N}} is not specified, the default is 2.
 Leading zeroes are permitted but not required.
+The modified command \tcode{\%OU} interprets
+the locale's alternative representation.
 \\ \rowsep
 \tcode{\%V} &
 The ISO week-based week number as a decimal number.
@@ -11059,6 +11061,8 @@ The modified command \tcode{\%\placeholder{N}W} specifies
 the maximum number of characters to read.
 If \tcode{\placeholder{N}} is not specified, the default is 2.
 Leading zeroes are permitted but not required.
+The modified command \tcode{\%OW} interprets
+the locale's alternative representation.
 \\ \rowsep
 \tcode{\%x} &
 The locale's date representation.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -21067,14 +21067,6 @@ namespace std {
     template<class T>
       explicit basic_format_arg(const T* p) noexcept;                           // \expos
 
-    template<class Visitor, class Ctx>
-      friend auto visit_format_arg(Visitor&& vis,
-                                   basic_format_arg<Ctx> arg);                  // \expos
-
-    template<class Ctx, class... Args>
-      friend @\placeholder{format-arg-store}@<Ctx, Args...>
-        make_format_args(const Args&... args);                                  // \expos
-
   public:
     basic_format_arg() noexcept;
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -8426,7 +8426,7 @@ Equivalent to:
 for (; ifirst != ilast && ofirst != olast; ++ofirst, (void)++ifirst) {
   ::new (@\placeholdernc{voidify}@(*ofirst)) remove_reference_t<iter_reference_t<O>>(*ifirst);
 }
-return {ifirst, ofirst};
+return {std::move(ifirst), ofirst};
 \end{codeblock}
 \end{itemdescr}
 
@@ -8478,7 +8478,7 @@ Equivalent to:
 \begin{codeblock}
 auto t = uninitialized_copy(counted_iterator(ifirst, n),
                             default_sentinel, ofirst, olast);
-return {t.in.base(), t.out};
+return {std::move(t.in).base(), t.out};
 \end{codeblock}
 \end{itemdescr}
 
@@ -8535,7 +8535,7 @@ for (; ifirst != ilast && ofirst != olast; ++ofirst, (void)++ifirst) {
   ::new (@\placeholder{voidify}@(*ofirst))
     remove_reference_t<iter_reference_t<O>>(ranges::iter_move(ifirst));
 }
-return {ifirst, ofirst};
+return {std::move(ifirst), ofirst};
 \end{codeblock}
 
 \pnum
@@ -8590,7 +8590,7 @@ Equivalent to:
 \begin{codeblock}
 auto t = uninitialized_move(counted_iterator(ifirst, n),
                             default_sentinel, ofirst, olast);
-return {t.in.base(), t.out};
+return {std::move(t.in).base(), t.out};
 \end{codeblock}
 
 \pnum

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -10200,8 +10200,14 @@ Specializations of \tcode{shared_ptr} shall be \oldconcept{CopyConstructible},
 \oldconcept{CopyAssignable}, and \oldconcept{\-Less\-Than\-Comparable}, allowing their use in standard
 containers. Specializations of \tcode{shared_ptr} shall be
 contextually convertible to \tcode{bool},
-allowing their use in boolean expressions and declarations in conditions. The template
-parameter \tcode{T} of \tcode{shared_ptr} may be an incomplete type.
+allowing their use in boolean expressions and declarations in conditions.
+
+\pnum
+The template parameter \tcode{T} of \tcode{shared_ptr}
+may be an incomplete type.
+\begin{note}
+\tcode{T} may be a function type.
+\end{note}
 
 \pnum
 \begin{example}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15689,12 +15689,16 @@ template<class F> function(F) -> function<@\seebelow@>;
 
 \begin{itemdescr}
 \pnum
-\remarks
-This deduction guide participates in overload resolution only if
-\tcode{\&F::operator()} is well-formed when treated as an unevaluated operand.
-In that case, if \tcode{decltype(\&F::operator())} is of the form
+\constraints
+\tcode{\&F::operator()} is well-formed
+when treated as an unevaluated operand and
+\tcode{decltype(\brk{}\&F::operator())} is of the form
 \tcode{R(G::*)(A...)}~\cv{}~\tcode{\opt{\&}~\opt{noexcept}}
-for a class type \tcode{G}, then the deduced type is \tcode{function<R(A...)>}.
+for a class type \tcode{G}.
+
+\pnum
+\remarks
+The deduced type is \tcode{function<R(A...)>}.
 
 \pnum
 \begin{example}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -19218,6 +19218,11 @@ The header \libheader{execution} declares global objects associated with each ty
 The type \tcode{chars_format} is a bitmask type\iref{bitmask.types}
 with elements \tcode{scientific}, \tcode{fixed}, and \tcode{hex}.
 
+\pnum
+The types \tcode{to_chars_result} and \tcode{from_chars_result}
+have the data members and special members specified above.
+They have no base classes or members other than those specified.
+
 \rSec2[charconv.to.chars]{Primitive numeric output conversion}
 
 \pnum
@@ -19622,6 +19627,11 @@ namespace std {
   class format_error;
 }
 \end{codeblock}
+
+
+\pnum
+The class template \tcode{format_to_n_result}
+has the template parameters, data members, and special members specified above. It has no base classes or members other than those specified.
 
 \rSec2[format.string]{Format string}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6624,7 +6624,7 @@ namespace std {
         I uninitialized_default_construct(I first, S last);
     template<@\exposconcept{no-throw-forward-range}@ R>
       requires default_initializable<range_value_t<R>>
-        safe_iterator_t<R> uninitialized_default_construct(R&& r);
+        borrowed_iterator_t<R> uninitialized_default_construct(R&& r);
 
     template<@\exposconcept{no-throw-forward-iterator}@ I>
       requires default_initializable<iter_value_t<I>>
@@ -6648,7 +6648,7 @@ namespace std {
         I uninitialized_value_construct(I first, S last);
     template<@\exposconcept{no-throw-forward-range}@ R>
       requires default_initializable<range_value_t<R>>
-        safe_iterator_t<R> uninitialized_value_construct(R&& r);
+        borrowed_iterator_t<R> uninitialized_value_construct(R&& r);
 
     template<@\exposconcept{no-throw-forward-iterator}@ I>
       requires default_initializable<iter_value_t<I>>
@@ -6680,7 +6680,7 @@ namespace std {
           uninitialized_copy(I ifirst, S1 ilast, O ofirst, S2 olast);
     template<input_range IR, @\exposconcept{no-throw-forward-range}@ OR>
       requires constructible_from<range_value_t<OR>, range_reference_t<IR>>
-        uninitialized_copy_result<safe_iterator_t<IR>, safe_iterator_t<OR>>
+        uninitialized_copy_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
           uninitialized_copy(IR&& in_range, OR&& out_range);
 
     template<class I, class O>
@@ -6716,7 +6716,7 @@ namespace std {
           uninitialized_move(I ifirst, S1 ilast, O ofirst, S2 olast);
     template<input_range IR, @\exposconcept{no-throw-forward-range}@ OR>
       requires constructible_from<range_value_t<OR>, range_rvalue_reference_t<IR>>
-        uninitialized_move_result<safe_iterator_t<IR>, safe_iterator_t<OR>>
+        uninitialized_move_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
           uninitialized_move(IR&& in_range, OR&& out_range);
 
     template<class I, class O>
@@ -6745,7 +6745,7 @@ namespace std {
         I uninitialized_fill(I first, S last, const T& x);
     template<@\exposconcept{no-throw-forward-range}@ R, class T>
       requires constructible_from<range_value_t<R>, const T&>
-        safe_iterator_t<R> uninitialized_fill(R&& r, const T& x);
+        borrowed_iterator_t<R> uninitialized_fill(R&& r, const T& x);
 
     template<@\exposconcept{no-throw-forward-iterator}@ I, class T>
       requires constructible_from<iter_value_t<I>, const T&>
@@ -6784,7 +6784,7 @@ namespace std {
         constexpr I destroy(I first, S last) noexcept;
     template<@\exposconcept{no-throw-input-range}@ R>
       requires destructible<range_value_t<R>>
-        constexpr safe_iterator_t<R> destroy(R&& r) noexcept;
+        constexpr borrowed_iterator_t<R> destroy(R&& r) noexcept;
 
     template<@\exposconcept{no-throw-input-iterator}@ I>
       requires destructible<iter_value_t<I>>
@@ -8240,7 +8240,7 @@ namespace ranges {
     I uninitialized_default_construct(I first, S last);
   template<@\placeholdernc{no-throw-forward-range}@ R>
       requires default_initializable<range_value_t<R>>
-    safe_iterator_t<R> uninitialized_default_construct(R&& r);
+    borrowed_iterator_t<R> uninitialized_default_construct(R&& r);
 }
 \end{itemdecl}
 
@@ -8319,7 +8319,7 @@ namespace ranges {
     I uninitialized_value_construct(I first, S last);
   template<@\placeholdernc{no-throw-forward-range}@ R>
       requires default_initializable<range_value_t<R>>
-    safe_iterator_t<R> uninitialized_value_construct(R&& r);
+    borrowed_iterator_t<R> uninitialized_value_construct(R&& r);
 }
 \end{itemdecl}
 
@@ -8409,7 +8409,7 @@ namespace ranges {
       uninitialized_copy(I ifirst, S1 ilast, O ofirst, S2 olast);
   template<input_range IR, @\placeholdernc{no-throw-forward-range}@ OR>
       requires constructible_from<range_value_t<OR>, range_reference_t<IR>>
-    uninitialized_copy_result<safe_iterator_t<IR>, safe_iterator_t<OR>>
+    uninitialized_copy_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
       uninitialized_copy(IR&& in_range, OR&& out_range);
 }
 \end{itemdecl}
@@ -8517,7 +8517,7 @@ namespace ranges {
       uninitialized_move(I ifirst, S1 ilast, O ofirst, S2 olast);
   template<input_range IR, @\placeholdernc{no-throw-forward-range}@ OR>
       requires constructible_from<range_value_t<OR>, range_rvalue_reference_t<IR>>
-    uninitialized_move_result<safe_iterator_t<IR>, safe_iterator_t<OR>>
+    uninitialized_move_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
       uninitialized_move(IR&& in_range, OR&& out_range);
 }
 \end{itemdecl}
@@ -8628,7 +8628,7 @@ namespace ranges {
     I uninitialized_fill(I first, S last, const T& x);
   template<@\placeholdernc{no-throw-forward-range}@ R, class T>
       requires constructible_from<range_value_t<R>, const T&>
-    safe_iterator_t<R> uninitialized_fill(R&& r, const T& x);
+    borrowed_iterator_t<R> uninitialized_fill(R&& r, const T& x);
 }
 \end{itemdecl}
 
@@ -8753,7 +8753,7 @@ namespace ranges {
     constexpr I destroy(I first, S last) noexcept;
   template<@\placeholdernc{no-throw-input-range}@ R>
       requires destructible<range_value_t<R>>
-    constexpr safe_iterator_t<R> destroy(R&& r) noexcept;
+    constexpr borrowed_iterator_t<R> destroy(R&& r) noexcept;
 }
 \end{itemdecl}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6530,7 +6530,7 @@ namespace std {
   template<class T>
     constexpr T* to_address(T* p) noexcept;
   template<class Ptr>
-    auto to_address(const Ptr& p) noexcept;
+    constexpr auto to_address(const Ptr& p) noexcept;
 
   // \ref{util.dynamic.safety}, pointer safety
   enum class pointer_safety { relaxed, preferred, strict };
@@ -7109,7 +7109,7 @@ template<class T> constexpr T* to_address(T* p) noexcept;
 
 \indexlibraryglobal{to_address}%
 \begin{itemdecl}
-template<class Ptr> auto to_address(const Ptr& p) noexcept;
+template<class Ptr> constexpr auto to_address(const Ptr& p) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16411,8 +16411,6 @@ namespace std {
 
   template<class T> struct has_unique_object_representations;
 
-  template<class T> struct has_strong_structural_equality;
-
   // \ref{meta.unary.prop.query}, type property queries
   template<class T> struct alignment_of;
   template<class T> struct rank;
@@ -16690,10 +16688,6 @@ namespace std {
   template<class T>
     inline constexpr bool has_unique_object_representations_v
       = has_unique_object_representations<T>::value;
-
-  template<class T>
-    inline constexpr bool has_strong_structural_equality_v
-      =  has_strong_structural_equality<T>::value;
 
   // \ref{meta.unary.prop.query}, type property queries
   template<class T>
@@ -17350,14 +17344,6 @@ The compilation of the
   \tcode{has_unique_object_representations_v<remove_all_extents_t<T>>},
   otherwise \seebelow. &
   \tcode{T} shall be a complete type, \cv{}~\tcode{void}, or
-  an array of unknown bound. \\ \rowsep
-
-\indexlibraryglobal{has_strong_structural_equality}%
-\tcode{template<class T>}\br
-  \tcode{struct has_strong_structural_equality;} &
-  The type \tcode{T} has
-  strong structural equality\iref{class.compare.default}. &
-  \tcode{T} shall be a complete type, \cv{} \tcode{void}, or
   an array of unknown bound. \\ \rowsep
 
 \end{libreqtab3b}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -12190,7 +12190,7 @@ Sets \tcode{memory_rsrc} to \tcode{other.resource()}.
 \pnum
 \effects
 If \tcode{numeric_limits<size_t>::max() / sizeof(Tp) < n},
-throws \tcode{length_error}.
+throws \tcode{bad_array_new_length}.
 Otherwise equivalent to:
 \begin{codeblock}
 return static_cast<Tp*>(memory_rsrc->allocate(n * sizeof(Tp), alignof(Tp)));
@@ -12262,7 +12262,7 @@ an array of \tcode{n} objects of type \tcode{T}, as follows:
 \begin{itemize}
 \item
   if \tcode{numeric_limits<size_t>::max() / sizeof(T) < n},
-  throws \tcode{length_error},
+  throws \tcode{bad_array_new_length},
 \item
   otherwise equivalent to:
 \begin{codeblock}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -19638,7 +19638,8 @@ namespace std {
 \newcommand{\fmtgrammarterm}[1]{\gterm{#1}}
 
 \pnum
-A \defn{format string} is a (possibly empty) sequence of
+A \defn{format string} for arguments \tcode{args} is
+a (possibly empty) sequence of
 \defnx{replacement fields}{replacement field!format string},
 \defnx{escape sequences}{escape sequence!format string},
 and characters other than \tcode{\{} and \tcode{\}}.
@@ -19696,10 +19697,12 @@ The syntax of replacement fields is as follows:
 
 \pnum
 The \fmtgrammarterm{arg-id} field specifies the index of
-% FIXME: "args" hasn't been introduced yet!
 the argument in \tcode{args}
 whose value is to be formatted and inserted into the output
 instead of the replacement field.
+If there is no argument with
+the index \fmtgrammarterm{arg-id} in \tcode{args},
+the string is not a format string for \tcode{args}.
 The optional \fmtgrammarterm{format-specifier} field
 explicitly specifies a format for the replacement value.
 
@@ -19738,6 +19741,10 @@ The \fmtgrammarterm{format-spec} field contains
 that define how the value should be presented.
 Each type can define its own
 interpretation of the \fmtgrammarterm{format-spec} field.
+If \fmtgrammarterm{format-spec} does not conform
+to the format specifications for
+the argument type referred to by \fmtgrammarterm{arg-id},
+the string is not a format string for \tcode{args}.
 \begin{example}
 \begin{itemize}
 \item
@@ -20251,6 +20258,17 @@ otherwise, implementation-defined.
 \\
 \end{floattable}
 
+\rSec2[format.err.report]{Error reporting}
+
+\pnum
+Formatting functions throw \tcode{format_error} if
+an argument \tcode{fmt} is passed that
+is not a format string for \tcode{args}.
+They propagate exceptions thrown by operations of
+\tcode{formatter} specializations and iterators.
+Failure to allocate storage is reported by
+throwing an exception as described in~\ref{res.on.exception.handling}.
+
 \rSec2[format.functions]{Formatting functions}
 
 \pnum
@@ -20337,7 +20355,7 @@ If present, \tcode{loc} is used for locale-specific formatting.
 
 \pnum
 \throws
-\tcode{format_error} if \tcode{fmt} is not a format string.
+As specified in~\ref{format.err.report}.
 \end{itemdescr}
 
 \indexlibraryglobal{format_to}%
@@ -20419,7 +20437,7 @@ If present, \tcode{loc} is used for locale-specific formatting.
 
 \pnum
 \throws
-\tcode{format_error} if \tcode{fmt} is not a format string.
+As specified in~\ref{format.err.report}.
 \end{itemdescr}
 
 \indexlibraryglobal{format_to_n}%
@@ -20476,7 +20494,7 @@ If present, \tcode{loc} is used for locale-specific formatting.
 
 \pnum
 \throws
-\tcode{format_error} if \tcode{fmt} is not a format string.
+As specified in~\ref{format.err.report}.
 \end{itemdescr}
 
 \indexlibraryglobal{formatted_size}%
@@ -20510,7 +20528,7 @@ If present, \tcode{loc} is used for locale-specific formatting.
 
 \pnum
 \throws
-\tcode{format_error} if \tcode{fmt} is not a format string.
+As specified in~\ref{format.err.report}.
 \end{itemdescr}
 
 \rSec2[format.formatter]{Formatter}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -18183,10 +18183,6 @@ the same types as \tcode{decay_t<T1>} and \tcode{decay_t<T2>}, respectively.
       None of the following will apply if there is a specialization
       \tcode{common_type<D1, D2>}.
     \end{note}
-  \item Otherwise, if both \tcode{D1} and \tcode{D2} denote
-    comparison category types\iref{cmp.categories.pre},
-    let \tcode{C} denote the common comparison type\iref{class.spaceship}
-    of \tcode{D1} and \tcode{D2}.
   \item Otherwise, if
 \begin{codeblock}
 decay_t<decltype(false ? declval<D1>() : declval<D2>())>

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -19541,15 +19541,17 @@ namespace std {
     Out format_to(Out out, const locale& loc, wstring_view fmt, const Args&... args);
 
   template<class Out>
-    Out vformat_to(Out out, string_view fmt, format_args_t<Out, char> args);
+    Out vformat_to(Out out, string_view fmt,
+                   format_args_t<type_identity_t<Out>, char> args);
   template<class Out>
-    Out vformat_to(Out out, wstring_view fmt, format_args_t<Out, wchar_t> args);
+    Out vformat_to(Out out, wstring_view fmt,
+                   format_args_t<type_identity_t<Out>, wchar_t> args);
   template<class Out>
     Out vformat_to(Out out, const locale& loc, string_view fmt,
-                   format_args_t<Out, char> args);
+                   format_args_t<type_identity_t<Out>, char> args);
   template<class Out>
     Out vformat_to(Out out, const locale& loc, wstring_view fmt,
-                   format_args_t<Out, wchar_t> args);
+                   format_args_t<type_identity_t<Out>, wchar_t> args);
 
   template<class Out> struct format_to_n_result {
     Out out;
@@ -20366,7 +20368,7 @@ template<class Out, class... Args>
 Equivalent to:
 \begin{codeblock}
 using context = basic_format_context<Out, decltype(fmt)::value_type>;
-return vformat_to(out, fmt, {make_format_args<context>(args...)});
+return vformat_to(out, fmt, make_format_args<context>(args...));
 \end{codeblock}
 \end{itemdescr}
 
@@ -20384,22 +20386,24 @@ template<class Out, class... Args>
 Equivalent to:
 \begin{codeblock}
 using context = basic_format_context<Out, decltype(fmt)::value_type>;
-return vformat_to(out, loc, fmt, {make_format_args<context>(args...)});
+return vformat_to(out, loc, fmt, make_format_args<context>(args...));
 \end{codeblock}
 \end{itemdescr}
 
 \indexlibraryglobal{vformat_to}%
 \begin{itemdecl}
 template<class Out>
-  Out vformat_to(Out out, string_view fmt, format_args_t<Out, char> args);
+  Out vformat_to(Out out, string_view fmt,
+                 format_args_t<type_identity_t<Out>, char> args);
 template<class Out>
-  Out vformat_to(Out out, wstring_view fmt, format_args_t<Out, wchar_t> args);
+  Out vformat_to(Out out, wstring_view fmt,
+                 format_args_t<type_identity_t<Out>, wchar_t> args);
 template<class Out>
   Out vformat_to(Out out, const locale& loc, string_view fmt,
-                 format_args_t<Out, char> args);
+                 format_args_t<type_identity_t<Out>, char> args);
 template<class Out>
   Out vformat_to(Out out, const locale& loc, wstring_view fmt,
-                 format_args_t<Out, wchar_t> args);
+                 format_args_t<type_identity_t<Out>, wchar_t> args);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -19890,13 +19890,14 @@ numbers.
 \\ \rowsep
 %
 \tcode{-} &
-Indicates that a sign should be used only for negative numbers (this is
-the default behavior).
+Indicates that a sign should be used for
+negative numbers and negative zero only (this is the default behavior).
 \\ \rowsep
 %
 space &
-Indicates that a leading space should be used for non-negative numbers, and
-a minus sign for negative numbers.
+Indicates that a leading space should be used for
+non-negative numbers other than negative zero, and
+a minus sign for negative numbers and negative zero.
 \\
 \end{floattable}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -19935,7 +19935,7 @@ base prefix (if any) specified in \tref{format.type.int}
 into the output after the sign character (possibly space) if there is one, or
 before the output of \tcode{to_chars} otherwise.
 For floating-point types,
-the alternate form causes the result of the conversion
+the alternate form causes the result of the conversion of finite values
 to always contain a decimal-point character,
 even if no digits follow it.
 % FIXME: This is a weird place for this part of the spec to appear.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -19887,6 +19887,13 @@ The meaning of the various options is as specified in \tref{format.sign}.
 \tcode{+} &
 Indicates that a sign should be used for both non-negative and negative
 numbers.
+The \tcode{+} sign is inserted before the output of \tcode{to_chars} for
+non-negative numbers other than negative zero.
+\begin{note}
+For negative numbers and negative zero
+the output of \tcode{to_chars} will already contain the sign
+so no additional transformation is performed.
+\end{note}
 \\ \rowsep
 %
 \tcode{-} &
@@ -19919,13 +19926,14 @@ The \tcode{\#} option causes the
 % FIXME: This is not a definition.
 \defnx{alternate form}{alternate form!format string}
 to be used for the conversion.
-This option is only valid for arithmetic types other than
+This option is valid for arithmetic types other than
 \tcode{charT} and \tcode{bool}
-or when an integer presentation type is specified.
+or when an integer presentation type is specified, and not otherwise.
 For integral types,
-the alternate form adds the
+the alternate form inserts the
 base prefix (if any) specified in \tref{format.type.int}
-to the output value.
+into the output after the sign character (possibly space) if there is one, or
+before the output of \tcode{to_chars} otherwise.
 For floating-point types,
 the alternate form causes the result of the conversion
 to always contain a decimal-point character,

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -19829,6 +19829,7 @@ absent.
 \end{note}
 
 \pnum
+The \fmtgrammarterm{align} specifier applies to all argument types.
 The meaning of the various alignment options is as specified in \tref{format.align}.
 \begin{example}
 \begin{codeblock}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -525,6 +525,14 @@ requirements for a constexpr function.
 If \tcode{(is_trivially_destructible_v<T1> \&\& is_trivially_destructible_v<T2>)}
 is \tcode{true}, then the destructor of \tcode{pair} is trivial.
 
+\pnum
+\tcode{pair<T, U>} is a structural type\iref{temp.param}
+if \tcode{T} and \tcode{U} are both structural types.
+Two values \tcode{p1} and \tcode{p2} of type \tcode{pair<T, U>}
+are template-argument-equivalent\iref{temp.type} if and only if
+\tcode{p1.first} and \tcode{p2.first} are template-argument-equivalent and
+\tcode{p1.second} and \tcode{p2.second} are template-argument-equivalent.
+
 \indexlibraryctor{pair}%
 \begin{itemdecl}
 constexpr explicit(@\seebelow@) pair();

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -13520,11 +13520,6 @@ namespace std {
   template<class T> constexpr reference_wrapper<T> ref(reference_wrapper<T>) noexcept;
   template<class T> constexpr reference_wrapper<const T> cref(reference_wrapper<T>) noexcept;
 
-  template<class T> struct unwrap_reference;
-  template<class T> using @\libglobal{unwrap_reference_t}@ = typename unwrap_reference<T>::type;
-  template<class T> struct unwrap_ref_decay;
-  template<class T> using @\libglobal{unwrap_ref_decay_t}@ = typename unwrap_ref_decay<T>::type;
-
   // \ref{arithmetic.operations}, arithmetic operations
   template<class T = void> struct plus;
   template<class T = void> struct minus;
@@ -14021,34 +14016,6 @@ template<class T> constexpr reference_wrapper<const T> cref(reference_wrapper<T>
 \pnum
 \returns
 \tcode{cref(t.get())}.
-\end{itemdescr}
-
-\rSec3[refwrap.unwrapref]{Transformation type trait \tcode{unwrap_reference}}
-
-\indexlibraryglobal{unwrap_reference}%
-\begin{itemdecl}
-template<class T>
-  struct unwrap_reference;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-If \tcode{T} is
-a specialization \tcode{reference_wrapper<X>} for some type \tcode{X},
-the member typedef \tcode{type} of \tcode{unwrap_reference<T>} is \tcode{X\&},
-otherwise it is \tcode{T}.
-\end{itemdescr}
-
-\indexlibraryglobal{unwrap_ref_decay}%
-\begin{itemdecl}
-template<class T>
-  struct unwrap_ref_decay;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-The member typedef \tcode{type} of \tcode{unwrap_ref_decay<T>}
-denotes the type \tcode{unwrap_reference_t<decay_t<T>>}.
 \end{itemdescr}
 
 \rSec2[arithmetic.operations]{Arithmetic operations}
@@ -16540,6 +16507,8 @@ namespace std {
   template<class... T> struct common_reference;
   template<class T> struct underlying_type;
   template<class Fn, class... ArgTypes> struct invoke_result;
+  template<class T> struct unwrap_reference;
+  template<class T> struct unwrap_ref_decay;
 
   template<class T>
     using @\libglobal{type_identity_t}@    = typename type_identity<T>::type;
@@ -16563,6 +16532,10 @@ namespace std {
     using @\libglobal{underlying_type_t}@  = typename underlying_type<T>::type;
   template<class Fn, class... ArgTypes>
     using @\libglobal{invoke_result_t}@    = typename invoke_result<Fn, ArgTypes...>::type;
+  template<class T>
+    using unwrap_reference_t = typename unwrap_reference<T>::type;
+  template<class T>
+    using unwrap_ref_decay_t = typename unwrap_ref_decay<T>::type;
   template<class...>
     using @\libglobal{void_t}@             = void;
 
@@ -18104,7 +18077,21 @@ argument passing.
 \br
  \requires{} \tcode{Fn} and all types in the template parameter pack \tcode{ArgTypes} shall
  be complete types, \cv{}~\tcode{void}, or arrays of
- unknown bound.\\
+ unknown bound.\\ \rowsep
+
+\indexlibraryglobal{unwrap_reference}%
+\tcode{template<class T>} \tcode{struct unwrap_reference;}
+ &
+ If \tcode{T} is
+ a specialization \tcode{reference_wrapper<X>} for some type \tcode{X},
+ the member typedef \tcode{type} of \tcode{unwrap_reference<T>} is \tcode{X\&},
+ otherwise it is \tcode{T}. \\ \rowsep
+
+\indexlibraryglobal{unwrap_ref_decay}%
+\tcode{template<class T>} \tcode{unwrap_ref_decay;}
+ &
+ The member typedef \tcode{type} of \tcode{unwrap_ref_decay<T>}
+ denotes the type \tcode{unwrap_reference_t<decay_t<T>>}.\\
 \end{libreqtab2a}
 
 \indexlibraryglobal{aligned_storage}%
@@ -18121,6 +18108,16 @@ struct aligned_storage {
 };
 \end{codeblock}
 \end{note}
+
+\pnum
+In addition to being available via inclusion
+of the \tcode{<type_traits>} header, the templates
+\tcode{unwrap_reference},
+\tcode{unwrap_ref_decay},
+\tcode{unwrap_reference_t}, and
+\tcode{unwrap_ref_decay_t}
+are available
+when the header \tcode{<func\-tional>}\iref{functional.syn} is included.
 
 \indexlibraryglobal{common_type}%
 \pnum

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -101,6 +101,13 @@ namespace std {
 
   // \ref{pairs.spec}, pair specialized algorithms
   template<class T1, class T2>
+    constexpr bool operator==(const pair<T1, T2>&, const pair<T1, T2>&);
+  template<class T1, class T2>
+    constexpr common_comparison_category_t<@\placeholder{synth-three-way-result}@<T1>,
+                                           @\placeholder{synth-three-way-result}@<T2>>
+      operator<=>(const pair<T1, T2>&, const pair<T1, T2>&);
+
+  template<class T1, class T2>
     constexpr void swap(pair<T1, T2>& x, pair<T1, T2>& y) noexcept(noexcept(x.swap(y)));
 
   template<class T1, class T2>
@@ -496,15 +503,6 @@ namespace std {
       constexpr pair& operator=(pair<U1, U2>&& p);
 
     constexpr void swap(pair& p) noexcept(@\seebelow@);
-
-    // \ref{pairs.spec}, pair specialized algorithms
-    friend constexpr bool operator==(const pair&, const pair&) = default;
-    friend constexpr bool operator==(const pair& x, const pair& y)
-      requires (is_reference_v<T1> || is_reference_v<T2>)
-      { return x.first == y.first && x.second == y.second; }
-    friend constexpr common_comparison_category_t<@\placeholder{synth-three-way-result}@<T1>,
-                                                  @\placeholder{synth-three-way-result}@<T2>>
-      operator<=>(const pair& x, const pair& y) { @\seebelow@ }
   };
 
   template<class T1, class T2>
@@ -790,11 +788,24 @@ is_nothrow_swappable_v<first_type> && is_nothrow_swappable_v<second_type>
 
 \rSec2[pairs.spec]{Specialized algorithms}
 
+\indexlibrarymember{operator==}{pair}%
+\begin{itemdecl}
+template<class T1, class T2>
+  constexpr bool operator==(const pair<T1, T2>& x, const pair<T1, T2>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{x.first == y.first \&\& x.second == y.second}.
+\end{itemdescr}
+
 \indexlibrarymember{operator<=>}{pair}%
 \begin{itemdecl}
-friend constexpr
-  common_comparison_category_t<@\placeholder{synth-three-way-result}@<T1>, @\placeholder{synth-three-way-result}@<T2>>
-    operator<=>(const pair& x, const pair& y);
+template<class T1, class T2>
+  constexpr common_comparison_category_t<@\placeholder{synth-three-way-result}@<T1>,
+                                         @\placeholder{synth-three-way-result}@<T2>>
+    operator<=>(const pair<T1, T2>& x, const pair<T1, T2>& y);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -19802,13 +19802,13 @@ The syntax of format specifications is as follows:
 \begin{ncbnf}
 \fmtnontermdef{width}\br
     positive-integer\br
-    \terminal{\{} arg-id \terminal{\}}
+    \terminal{\{} \opt{arg-id} \terminal{\}}
 \end{ncbnf}
 
 \begin{ncbnf}
 \fmtnontermdef{precision}\br
     \terminal{.} nonnegative-integer\br
-    \terminal{.} \terminal{\{} arg-id \terminal{\}}
+    \terminal{.} \terminal{\{} \opt{arg-id} \terminal{\}}
 \end{ncbnf}
 
 \begin{ncbnf}
@@ -19936,6 +19936,16 @@ In addition, for \tcode{g} and \tcode{G} conversions,
 % FIXME: Are they normally? What does this even mean? Reach into to_chars and
 % alter its behavior?
 trailing zeros are not removed from the result.
+
+\pnum
+If \tcode{\{ \opt{\fmtgrammarterm{arg-id}} \}} is used in
+a \fmtgrammarterm{width} or \fmtgrammarterm{precision},
+the value of the corresponding formatting argument is used in its place.
+If the corresponding formatting argument is not of integral type, or
+its value is
+negative for \fmtgrammarterm{precision} or
+non-positive for \fmtgrammarterm{width},
+an exception of type \tcode{format_error} is thrown.
 
 \pnum
 % FIXME: What if it's an arg-id?


### PR DESCRIPTION
Notes/issues:
* This was **based on branch motions-2020-02-lwg-2** in order to resolve conflicts which would otherwise arise.
* LWG3247 not applied; conflicts with wording in LWG3299 (contacted lwgchair)
* LWG3269 [time.parse]/p3 Fixed wording in list of constraints by adding "has" before "value is".
* LWG3334 What about function declarations which are still in synopsis [syncstream.osyncstream.overview]?
* LWG1203 I don't see that the modified operators were ever declared in class basic_istream - why is that?  Note also that the referenced text was modified by other issues.
* LWG3314 Wording in [time.duration.io] conflicts with that of LWG3317; applied anyway.
** Edit issue: \impldef may need work; Latex can't handle my attempts at:
```
\impldef{whether \tcode{\placeholder{units_suffix}} is \tcode{"\textmu{}s"} or \tcode{"us"} when \tcode{Period::type} is \tcode{micro}}
\impldef{whether the unit suffix is \tcode{"\textmu{}s"} or \tcode{"us"} when \tcode{Period::type} is \tcode{micro}}
```

Fixes #3705.
Fixes cplusplus/nbballot#371.
Fixes cplusplus/nbballot#269.
Fixes cplusplus/nbballot#270.
Fixes cplusplus/nbballot#226.
Fixes cplusplus/nbballot#151.
Fixes cplusplus/nbballot#167.
Fixes cplusplus/nbballot#280 (LWG3281 was superseded by LWG3282).
Fixes cplusplus/nbballot#281.