### PR TITLE
LWG Poll 13: P1994R1 elements_view needs its own sentinel

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -6420,7 +6420,9 @@ Equivalent to: \tcode{return x.\exposid{current_} - y.\exposid{current_};}
 \indexlibraryglobal{elements_view::sentinel}%
 \begin{codeblock}
 namespace std::ranges {
-  template<class V, size_t N>
+  template<input_range V, size_t N>
+    requires view<V> && @\placeholder{has-tuple-element}@<range_value_t<V>, N> &&
+             @\placeholder{has-tuple-element}@<remove_reference_t<range_reference_t<V>>, N>
   template<bool Const>
   class elements_view<V, N>::@\exposid{sentinel}@ {                 // \expos
   private:

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -6036,11 +6036,17 @@ namespace std::ranges {
     constexpr auto begin() const requires @\placeholder{simple-view}@<V>
     { return @\exposid{iterator}@<true>(ranges::begin(@\exposid{base_}@)); }
 
-    constexpr auto end() requires (!@\placeholder{simple-view}@<V>)
-    { return ranges::end(@\exposid{base_}@); }
+    constexpr auto end()
+    { return @\exposid{sentinel}@<false>{ranges::end(@\exposid{base_}@)}; }
 
-    constexpr auto end() const requires @\placeholder{simple-view}@<V>
-    { return ranges::end(@\exposid{base_}@); }
+    constexpr auto end() requires common_range<V>
+    { return @\exposid{iterator}@<false>{ranges::end(@\exposid{base_}@)}; }
+
+    constexpr auto end() const requires range<const V>
+    { return @\exposid{sentinel}@<true>{ranges::end(@\exposid{base_}@)}; }
+
+    constexpr auto end() const requires common_range<const V>
+    { return @\exposid{iterator}@<true>{ranges::end(@\exposid{base_}@)}; }
 
     constexpr auto size() requires sized_range<V>
     { return ranges::size(@\exposid{base_}@); }
@@ -6050,6 +6056,8 @@ namespace std::ranges {
 
   private:
     template<bool> struct @\exposid{iterator}@;                     // \expos
+    // \ref{range.elements.sentinel}, class template \tcode{elements_view::\exposid{sentinel}}
+    template<bool> struct @\exposid{sentinel}@;                     // \expos
     V @\exposid{base_}@ = V();                                      // \expos
   };
 }
@@ -6112,7 +6120,6 @@ namespace std::ranges {
 
     friend constexpr bool operator==(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
       requires equality_comparable<iterator_t<@\exposid{base-t}@>>;
-    friend constexpr bool operator==(const @\exposid{iterator}@& x, const sentinel_t<@\exposid{base-t}@>& y);
 
     friend constexpr bool operator<(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
       requires random_access_range<@\exposid{base-t}@>;
@@ -6133,13 +6140,6 @@ namespace std::ranges {
       requires random_access_range<@\exposid{base-t}@>;
     friend constexpr difference_type operator-(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
       requires random_access_range<@\exposid{base-t}@>;
-
-    friend constexpr difference_type
-      operator-(const @\exposid{iterator}@<Const>& x, const sentinel_t<@\exposid{base-t}@>& y)
-        requires sized_sentinel_for<sentinel_t<@\exposid{base-t}@>, iterator_t<@\exposid{base-t}@>>;
-    friend constexpr difference_type
-      operator-(const sentinel_t<@\exposid{base-t}@>& x, const @\exposid{iterator}@<Const>& y)
-        requires sized_sentinel_for<sentinel_t<@\exposid{base-t}@>, iterator_t<@\exposid{base-t}@>>;
   };
 }
 \end{codeblock}
@@ -6307,17 +6307,6 @@ friend constexpr bool operator==(const @\exposid{iterator}@& x, const @\exposid{
 Equivalent to: \tcode{return x.\exposid{current_} == y.\exposid{current_};}
 \end{itemdescr}
 
-\indexlibrarymember{operator==}{elements_view::iterator}%
-\begin{itemdecl}
-friend constexpr bool operator==(const @\exposid{iterator}@& x, const sentinel_t<@\exposid{base-t}@>& y);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Equivalent to: \tcode{return x.\exposid{current_} == y;}
-\end{itemdescr}
-
 \indexlibrarymember{operator<}{elements_view::iterator}%
 \begin{itemdecl}
 friend constexpr bool operator<(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
@@ -6426,28 +6415,105 @@ constexpr difference_type operator-(const @\exposid{iterator}@& x, const @\expos
 Equivalent to: \tcode{return x.\exposid{current_} - y.\exposid{current_};}
 \end{itemdescr}
 
-\indexlibrarymember{operator-}{elements_view::iterator}%
+\rSec3[range.elements.sentinel]{Class template \tcode{elements_view::\exposid{sentinel}}}
+
+\indexlibraryglobal{elements_view::sentinel}%
+\begin{codeblock}
+namespace std::ranges {
+  template<class V, size_t N>
+  template<bool Const>
+  class elements_view<V, N>::@\exposid{sentinel}@ {                 // \expos
+  private:
+    using @\exposid{Base}@ = conditional_t<Const, const V, V>;      // \expos
+    sentinel_t<@\exposid{Base}@> @\exposid{end_}@ = sentinel_t<@\exposid{Base}@>();         // \expos
+  public:
+    @\exposid{sentinel}@() = default;
+    constexpr explicit @\exposid{sentinel}@(sentinel_t<@\exposid{Base}@> end);
+    constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> other)
+      requires Const && convertible_to<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
+
+    constexpr sentinel_t<@\exposid{Base}@> base() const;
+
+    friend constexpr bool operator==(const @\exposid{iterator}@<Const>& x, const @\exposid{sentinel}@& y);
+
+    friend constexpr range_difference_t<@\exposid{Base}@>
+      operator-(const @\exposid{iterator}@<Const>& x, const @\exposid{sentinel}@& y)
+        requires sized_sentinel_for<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
+
+    friend constexpr range_difference_t<@\exposid{Base}@>
+      operator-(const @\exposid{sentinel}@& x, const @\exposid{iterator}@<Const>& y)
+        requires sized_sentinel_for<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
+  };
+}
+\end{codeblock}
+
+\indexlibraryctor{elements_view::sentinel}%
 \begin{itemdecl}
-friend constexpr difference_type
-  operator-(const @\exposid{iterator}@<Const>& x, const sentinel_t<@\exposid{base-t}@>& y)
-    requires sized_sentinel_for<sentinel_t<@\exposid{base-t}@>, iterator_t<@\exposid{base-t}@>>;
+constexpr explicit @\exposid{sentinel}@(sentinel_t<@\exposid{Base}@> end);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return x.\exposid{current_} - y;}
+Initializes \exposid{end_} with \tcode{end}.
 \end{itemdescr}
 
-\indexlibrarymember{operator-}{elements_view::iterator}%
+\indexlibraryctor{elements_view::sentinel}%
 \begin{itemdecl}
-friend constexpr difference_type
-  operator-(const sentinel_t<@\exposid{base-t}@>& x, const @\exposid{iterator}@<Const>& y)
-    requires sized_sentinel_for<sentinel_t<@\exposid{base-t}@>, iterator_t<@\exposid{base-t}@>>;
+constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> other)
+  requires Const && convertible_to<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return -(y - x);}
+Initializes \exposid{end_} with \tcode{std::move(other.\exposid{end_})}.
+\end{itemdescr}
+
+\indexlibrarymember{base}{elements_view::sentinel}%
+\begin{itemdecl}
+constexpr sentinel_t<@\exposid{Base}@> base() const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return \exposid{end_};}
+\end{itemdescr}
+
+\indexlibrarymember{operator==}{elements_view::sentinel}%
+\begin{itemdecl}
+friend constexpr bool operator==(const @\exposid{iterator}@<Const>& x, const @\exposid{sentinel}@& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return x.\exposid{current_} == y.\exposid{end_};}
+\end{itemdescr}
+
+\indexlibrarymember{operator-}{elements_view::sentinel}%
+\begin{itemdecl}
+friend constexpr range_difference_t<@\exposid{Base}@>
+  operator-(const @\exposid{iterator}@<Const>& x, const @\exposid{sentinel}@& y)
+    requires sized_sentinel_for<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return x.\exposid{current_} - y.\exposid{end_};}
+\end{itemdescr}
+
+\indexlibrarymember{operator-}{elements_view::sentinel}%
+\begin{itemdecl}
+friend constexpr range_difference_t<@\exposid{Base}@>
+  operator-(const @\exposid{sentinel}@& x, const @\exposid{iterator}@<Const>& y)
+    requires sized_sentinel_for<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return x.\exposid{end_} - y.\exposid{current_};}
 \end{itemdescr}


### PR DESCRIPTION
Also fixes LWG3386.

Fixes #3715.
Fixes cplusplus/papers#717.

Notes/Issues:
* [range.elements.sentinel] Should \exposid{Base} be \exposid{base-t} as it is in [range.elements.iterator]?  We're inconsistent wrt Base v. base-t elsewhere as well.  There are also other differences between sentinel and iterator, like "other" and "base() const" (no ref) - I assume these are intentional?
