### PR TITLE
LWG Poll 10: P2101R0 'Models' subsumes 'satisfies' (Wording for US298 and US300)

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -3013,6 +3013,22 @@ Violation of any preconditions specified in a function's \expects element
 results in undefined behavior.
 
 \rSec3[res.on.requirements]{Semantic requirements}
+
+\pnum
+A sequence \tcode{Args} of template arguments is said to
+\indextext{concept!model}%
+\defnx{model}{model!concept} a concept \tcode{C}
+if \tcode{Args}
+satisfies \tcode{C}\iref{temp.constr.decl} and
+meets all semantic requirements (if any)
+given in the specification of \tcode{C}.
+
+\pnum
+If the validity or meaning of a program
+depends on whether a sequence of template arguments models a concept, and
+the concept is satisfied but not modeled,
+the program is ill-formed, no diagnostic required.
+
 \pnum
 If the semantic requirements of a declaration's
 constraints\iref{structure.requirements} are not modeled at the point of use,


### PR DESCRIPTION
Also fixes NB US 298, US 300 (C++20 CD) and LWG3345.

Fixes #3712.
Fixes cplusplus/nbballot#294.
Fixes cplusplus/nbballot#296.