### PR TITLE
LWG Poll 7: P1983R0 Wording for GB301, US296, US292, US291, and US283

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1131,9 +1131,9 @@ template<class R>
     same_as<iterator_t<R>, iterator_t<const R>> &&
     same_as<sentinel_t<R>, sentinel_t<const R>>;
 
-template<input_iterator I>
+template<class I>
   concept @\defexposconcept{has-arrow}@ =                           // \expos
-    is_pointer_v<I> || requires(I i) { i.operator->(); };
+    input_iterator<I> && (is_pointer_v<I> || requires(I i) { i.operator->(); });
 
 template<class T, class U>
   concept @\defexposconcept{not-same-as}@ =                         // \expos
@@ -3004,6 +3004,8 @@ namespace std::ranges {
     constexpr V base() const& requires copy_constructible<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
+    constexpr const Pred& pred() const;
+
     constexpr @\exposid{iterator}@ begin();
     constexpr auto end() {
       if constexpr (common_range<V>)
@@ -3028,6 +3030,17 @@ constexpr filter_view(V base, Pred pred);
 \effects
 Initializes \exposid{base_} with \tcode{std::move(base)} and initializes
 \exposid{pred_} with \tcode{std::move(pred)}.
+\end{itemdescr}
+
+\indexlibrarymember{pred}{filter_view}%
+\begin{itemdecl}
+constexpr const Pred& pred() const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return *\exposid{pred_};}
 \end{itemdescr}
 
 \indexlibrarymember{begin}{filter_view}%
@@ -4691,7 +4704,9 @@ namespace std::ranges {
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
     constexpr auto begin() {
-      return @\exposid{iterator}@<@\placeholder{simple-view}@<V>>{*this, ranges::begin(@\exposid{base_}@)};
+      constexpr bool use_const = @\placeholder{simple-view}@<V> &&
+                                 is_reference_v<range_reference_t<V>>;
+      return @\exposid{iterator}@<use_const>{*this, ranges::begin(@\exposid{base_}@)};
     }
 
     constexpr auto begin() const
@@ -4768,7 +4783,7 @@ template<class V>
     using difference_type   = @\seebelow@;
 
     @\exposid{iterator}@() = default;
-    constexpr @\exposid{iterator}@(@\exposid{Parent}@& parent, iterator_t<V> outer);
+    constexpr @\exposid{iterator}@(@\exposid{Parent}@& parent, iterator_t<@\exposid{Base}@> outer);
     constexpr @\exposid{iterator}@(@\exposid{iterator}@<!Const> i)
       requires Const &&
                convertible_to<iterator_t<V>, iterator_t<@\exposid{Base}@>> &&
@@ -4887,7 +4902,7 @@ if constexpr (@\exposid{ref-is-glvalue}@)
 
 \indexlibraryctor{join_view::iterator}%
 \begin{itemdecl}
-constexpr @\exposid{iterator}@(@\exposid{Parent}@& parent, iterator_t<V> outer)
+constexpr @\exposid{iterator}@(@\exposid{Parent}@& parent, iterator_t<@\exposid{Base}@> outer)
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5271,7 +5286,7 @@ namespace std::ranges {
     constexpr @\exposid{outer-iterator}@(@\exposid{Parent}@& parent, iterator_t<@\exposid{Base}@> current)
       requires forward_range<@\exposid{Base}@>;
     constexpr @\exposid{outer-iterator}@(@\exposid{outer-iterator}@<!Const> i)
-      requires Const && convertible_to<iterator_t<V>, iterator_t<const V>>;
+      requires Const && convertible_to<iterator_t<V>, iterator_t<@\exposid{Base}@>>;
 
     constexpr value_type operator*() const;
 
@@ -5327,7 +5342,7 @@ and \exposid{current_} with \tcode{std::move(current)}.
 \indexlibraryctor{split_view::outer-iterator}%
 \begin{itemdecl}
 constexpr @\exposid{outer-iterator}@(@\exposid{outer-iterator}@<!Const> i)
-  requires Const && convertible_to<iterator_t<V>, iterator_t<const V>>;
+  requires Const && convertible_to<iterator_t<V>, iterator_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Also fixes NB GB 301, US 296, US 292, US 291, US 283 (C++20 CD), and LWG3278.

Fixes #3709.
Fixes cplusplus/papers#713.
Fixes cplusplus/nbballot#297.
Fixes cplusplus/nbballot#292.
Fixes cplusplus/nbballot#288.
Fixes cplusplus/nbballot#287.
Fixes cplusplus/nbballot#279.