### PR TITLE
CWG Poll 3: P1857R3 Modules Dependency Discovery

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2608,12 +2608,6 @@ of a sequence of declarations.
 \end{bnf}
 
 \pnum
-A token sequence beginning with
-\opt{\tcode{export}} \tcode{module}
-and not immediately followed by \tcode{::}
-is never interpreted as a \grammarterm{declaration}.
-
-\pnum
 \indextext{linkage}%
 \indextext{translation unit}%
 \indextext{linkage!internal}%

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1934,6 +1934,28 @@ by the chapters of this document.
 
 \rSec2[diff.cpp17.lex]{\ref{lex}: lexical conventions}
 
+\diffref{lex.pptoken,module.unit,module.import,cpp.pre,cpp.module,cpp.import}
+\change
+New identifiers with special meaning.
+\rationale
+Required for new features.
+\effect
+Logical lines beginning with
+\tcode{module} or \tcode{import} may
+be interpreted differently
+in this International Standard.
+\begin{example}
+\begin{codeblock}
+class module {};
+module m1;          // was variable declaration; now \grammarterm{module-declaration}
+module *m2;         // OK
+
+class import {};
+import j1;          // was variable declaration; now \grammarterm{import-declaration}
+::import j2;        // variable declaration
+\end{codeblock}
+\end{example}
+
 \diffref{lex.header}
 \change
 \grammarterm{header-name} tokens are formed in more contexts.
@@ -2037,28 +2059,6 @@ ct<decltype(u8'c')>::type x;    // ill-formed; previously well-formed.
 \end{codeblock}
 
 \rSec2[diff.cpp17.basic]{\ref{basic}: basics}
-
-\diffref{basic.link,module.unit,module.import}
-\change
-New identifiers with special meaning.
-\rationale
-Required for new features.
-\effect
-Top-level declarations beginning with
-\tcode{module} or \tcode{import} may
-be either ill-formed or interpreted differently
-in this International Standard.
-\begin{example}
-\begin{codeblock}
-class module;
-module *m1;         // ill-formed; previously well-formed
-::module *m2;       // OK
-
-class import {};
-import j1;          // was variable declaration; now \grammarterm{import-declaration}
-::import j2;        // variable declaration
-\end{codeblock}
-\end{example}
 
 \diffref{intro.races}
 \change

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -297,6 +297,8 @@ are locale-specific.%
 \nontermdef{preprocessing-token}\br
     header-name\br
     import-keyword\br
+    module-keyword\br
+    export-keyword\br
     identifier\br
     pp-number\br
     character-literal\br
@@ -382,8 +384,14 @@ const char* s = R"y";           // ill-formed raw string, not \tcode{"x" "y"}
 
 \pnum
 The \grammarterm{import-keyword} is produced
-by processing an \tcode{import} directive\iref{cpp.import} and
-has no associated grammar productions.
+by processing an \tcode{import} directive\iref{cpp.import},
+the \grammarterm{module-keyword} is produced
+by preprocessing a \tcode{module} directive\iref{cpp.module}, and
+the \grammarterm{export-keyword} is produced
+by preprocessing either of the previous two directives.
+\begin{note}
+None have any observable spelling.
+\end{note}
 
 \pnum
 \begin{example}
@@ -790,26 +798,29 @@ is reserved for future use.
 \keyword{enum} \\
 \keyword{explicit} \\
 \keyword{export} \\
-\keyword{extern} \\
+\grammarterm{export-keyword} \\
 \columnbreak
+\keyword{extern} \\
 \keyword{false} \\
 \keyword{float} \\
 \keyword{for} \\
 \keyword{friend} \\
 \keyword{goto} \\
 \keyword{if} \\
+\grammarterm{import-keyword} \\
 \keyword{inline} \\
 \keyword{int} \\
 \keyword{long} \\
+\grammarterm{module-keyword} \\
 \keyword{mutable} \\
 \keyword{namespace} \\
 \keyword{new} \\
 \keyword{noexcept} \\
 \keyword{nullptr} \\
+\columnbreak
 \keyword{operator} \\
 \keyword{private} \\
 \keyword{protected} \\
-\columnbreak
 \keyword{public} \\
 \keyword{register} \\
 \keyword{reinterpret_cast} \\
@@ -824,10 +835,10 @@ is reserved for future use.
 \keyword{struct} \\
 \keyword{switch} \\
 \keyword{template} \\
+\columnbreak
 \keyword{this} \\
 \keyword{thread_local} \\
 \keyword{throw} \\
-\columnbreak
 \keyword{true} \\
 \keyword{try} \\
 \keyword{typedef} \\

--- a/source/modules.tex
+++ b/source/modules.tex
@@ -7,7 +7,7 @@
 
 \begin{bnf}
 \nontermdef{module-declaration}\br
-    \opt{\keyword{export}} \keyword{module} module-name \opt{module-partition} \opt{attribute-specifier-seq} \terminal{;}
+    \opt{export-keyword} module-keyword module-name \opt{module-partition} \opt{attribute-specifier-seq} \terminal{;}
 \end{bnf}
 
 \begin{bnf}
@@ -409,9 +409,9 @@ export namespace N {
 
 \begin{bnf}
 \nontermdef{module-import-declaration}\br
-    \opt{\keyword{export}} import-keyword module-name \opt{attribute-specifier-seq} \terminal{;}\br
-    \opt{\keyword{export}} import-keyword module-partition \opt{attribute-specifier-seq} \terminal{;}\br
-    \opt{\keyword{export}} import-keyword header-name \opt{attribute-specifier-seq} \terminal{;}
+    \opt{export-keyword} import-keyword module-name \opt{attribute-specifier-seq} \terminal{;}\br
+    \opt{export-keyword} import-keyword module-partition \opt{attribute-specifier-seq} \terminal{;}\br
+    \opt{export-keyword} import-keyword header-name \opt{attribute-specifier-seq} \terminal{;}
 \end{bnf}
 
 \pnum
@@ -558,14 +558,14 @@ import M1;              // error: cyclic interface dependency $\mathtt{M3} \righ
 
 \begin{bnf}
 \nontermdef{global-module-fragment}\br
-    \keyword{module} \terminal{;} \opt{declaration-seq}
+    module-keyword \terminal{;} \opt{declaration-seq}
 \end{bnf}
 
 \pnum
 \begin{note}
 Prior to phase 4 of translation,
 only preprocessing directives can appear
-in the \grammarterm{declaration-seq}\iref{cpp.global.frag}.
+in the \grammarterm{declaration-seq}\iref{cpp.pre}.
 \end{note}
 
 \pnum
@@ -765,7 +765,7 @@ int c = use_h<int>();           // OK
 
 \begin{bnf}
 \nontermdef{private-module-fragment}\br
-    \keyword{module} \terminal{:} \keyword{private} \terminal{;} \opt{declaration-seq}
+    module-keyword \terminal{:} \keyword{private} \terminal{;} \opt{declaration-seq}
 \end{bnf}
 
 \pnum

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -13,30 +13,85 @@
 \pnum
 A \defn{preprocessing directive} consists of a sequence of preprocessing tokens
 that satisfies the following constraints:
-The first token in the sequence,
+At the start of translation phase 4,
+the first token in the sequence,
 referred to as a \defnadj{directive-introducing}{token},
-is a \tcode{\#} preprocessing token,
-an \tcode{import} preprocessing token, or
-an \tcode{export} preprocessing token
-immediately followed by an \tcode{import} preprocessing token,
-that (at the start of translation phase 4)
-either begins with the first character in the source file
-(optionally after white space containing no new-line characters)
-or follows white space containing at least one new-line character.
-The last token in the sequence is the first new-line character
-that follows the first token in the sequence.\footnote{Thus,
+begins with the first character in the source file
+(optionally after white space containing no new-line characters) or
+follows white space containing at least one new-line character,
+and is
+
+\begin{itemize}
+\item
+a \tcode{\#} preprocessing token, or
+
+\item
+an \keyword{import} preprocessing token
+immediately followed on the same logical line by a
+\grammarterm{header-name},
+\tcode{<},
+\grammarterm{identifier},
+\grammarterm{string-literal}, or
+\tcode{:}
+preprocessing token, or
+
+\item
+a \keyword{module} preprocessing token
+immediately followed on the same logical line by an
+\grammarterm{identifier},
+\tcode{:}, or
+\tcode{;}
+preprocessing token, or
+
+\item
+an \keyword{export} preprocessing token
+immediately followed on the same logical line by
+one of the two preceding forms.
+\end{itemize}
+
+The last token in the sequence is the first token in the sequence that
+is immediately followed by whitespace containing a new-line character.%
+\footnote{Thus,
 preprocessing directives are commonly called ``lines''.
 These ``lines'' have no other syntactic significance,
 as all white space is equivalent except in certain situations
 during preprocessing (see the
 \tcode{\#}
 character string literal creation operator in~\ref{cpp.stringize}, for example).}
+\begin{note}
 A new-line character ends the preprocessing directive even if it occurs
 within what would otherwise be an invocation of a function-like macro.
+\end{note}
+
+\begin{example}
+\begin{codeblock}
+#                       // preprocessing directive
+module ;                // preprocessing directive
+export module leftpad;  // preprocessing directive
+import <string>;        // preprocessing directive
+export import "squee";  // preprocessing directive
+import rightpad;        // preprocessing directive
+import :part;           // preprocessing directive
+
+module                  // not a preprocessing directive
+;                       // not a preprocessing directive
+
+export                  // not a preprocessing directive
+import                  // not a preprocessing directive
+foo;                    // not a preprocessing directive
+
+export                  // not a preprocessing directive
+import foo;             // preprocessing directive (ill-formed at phase 7)
+
+import ::               // not a preprocessing directive
+import ->               // not a preprocessing directive
+\end{codeblock}
+\end{example}
 
 \begin{bnf}
 \nontermdef{preprocessing-file}\br
-    \opt{group}
+    \opt{group}\br
+    module-file
 \end{bnf}
 
 \begin{bnf}
@@ -53,10 +108,25 @@ within what would otherwise be an invocation of a function-like macro.
     \terminal{\#} conditionally-supported-directive
 \end{bnf}
 
-\begin{bnf}\obeyspaces
+\begin{bnf}
+\nontermdef{module-file}\br
+    \opt{pp-global-module-fragment} pp-module \opt{group} \opt{pp-private-module-fragment}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{pp-global-module-fragment}\br
+    \keyword{module} \terminal{;} new-line \opt{group}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{pp-private-module-fragment}\br
+    \keyword{module} \terminal{:} \keyword{private} \terminal{;} new-line \opt{group}
+\end{bnf}
+
+\begin{bnf}
 \nontermdef{control-line}\br
     \terminal{\# include} pp-tokens new-line\br
-    \opt{\terminal{export}} \terminal{import} pp-tokens new-line\br
+    pp-import\br
     \terminal{\# define } identifier replacement-list new-line\br
     \terminal{\# define } identifier lparen \opt{identifier-list} \terminal{)} replacement-list new-line\br
     \terminal{\# define } identifier lparen \terminal{... )} replacement-list new-line\br
@@ -139,13 +209,21 @@ within what would otherwise be an invocation of a function-like macro.
 \end{bnf}
 
 \pnum
-A text line shall not begin with a \tcode{\#} preprocessing token.
+A sequence of preprocessing tokens is only a \grammarterm{text-line}
+if it does not begin with a directive-introducing token.
 A \grammarterm{conditionally-supported-directive} shall not begin
-with any of the directive names appearing in the syntax.
+with any of the directive names appearing after a \tcode{\#} in the syntax.
 A \grammarterm{conditionally-supported-directive} is
 conditionally-supported with
 \impldef{additional supported forms of preprocessing directive}
 semantics.
+
+\pnum
+At the start of phase 4 of translation,
+the \grammarterm{group} of a \grammarterm{pp-global-module-fragment} shall
+neither contain a \grammarterm{control-line}
+not starting with a \tcode{\#} preprocessing token
+nor a \grammarterm{text-line}.
 
 \pnum
 When in a group that is skipped\iref{cpp.cond}, the directive
@@ -667,16 +745,55 @@ directives:
 \end{codeblock}
 \end{example}
 
+\rSec1[cpp.module]{Module directive}
+\indextext{macro!module|(}%
+
+\begin{bnf}
+\nontermdef{pp-module}\br
+    \opt{\keyword{export}} \keyword{module} \opt{pp-tokens} \terminal{;} new-line
+\end{bnf}
+
+\pnum
+A \grammarterm{pp-module} shall neither
+appear in a context where \tcode{module}
+is an identifier defined as an object-like macro nor
+where \tcode{export} is an identifier defined as an object-like macro
+if the first token of the \grammarterm{pp-module} is \tcode{export}.
+
+\pnum
+Any preprocessing tokens after the \tcode{module} preprocessing token
+in the \tcode{module} directive are processed just as in normal text.
+\begin{note}
+Each identifier currently defined as a macro name
+is replaced by its replacement list of preprocessing tokens.
+\end{note}
+
+\pnum
+The \tcode{module} and \tcode{export} (if it exists) preprocessing tokens
+are replaced by the \grammarterm{module-keyword} and
+\grammarterm{export-keyword} preprocessing tokens respectively.
+\begin{note}
+This makes the line no longer a directive
+so it is not removed at the end of phase 4.
+\end{note}
+
 \rSec1[cpp.import]{Header unit importation}
 \indextext{header unit!preprocessing}%
 \indextext{macro!import|(}%
 
 \begin{bnf}
 \nontermdef{pp-import}\br
-    \opt{\terminal{export}} \terminal{import} header-name \opt{pp-tokens} \terminal{;} new-line\br
-    \opt{\terminal{export}} \terminal{import} header-name-tokens \opt{pp-tokens} \terminal{;} new-line\br
-    \opt{\terminal{export}} \terminal{import} pp-tokens \terminal{;} new-line
+    \opt{\keyword{export}} \keyword{import} header-name \opt{pp-tokens} \terminal{;} new-line\br
+    \opt{\keyword{export}} \keyword{import} header-name-tokens \opt{pp-tokens} \terminal{;} new-line\br
+    \opt{\keyword{export}} \keyword{import} pp-tokens \terminal{;} new-line
 \end{bnf}
+
+\pnum
+A \grammarterm{pp-import} shall neither
+appear in a context where \tcode{import}
+is an identifier defined as an object-like macro nor
+where \tcode{export} is an identifier defined as an object-like macro
+if the first token of the \grammarterm{pp-import} is \tcode{export}.
 
 \pnum
 The preprocessing tokens after the \tcode{import} preprocessing token
@@ -698,8 +815,21 @@ The last form of \grammarterm{pp-import} is only considered
 if the first two forms did not match.
 
 \pnum
+If a \grammarterm{pp-import} is produced by source file inclusion
+(including by the rewrite produced
+when a \tcode{\#include} directive names an importable header)
+while processing the \grammarterm{group} of a \grammarterm{module-file},
+the program is ill-formed.
+
+\pnum
 In all three forms of \grammarterm{pp-import},
-the \tcode{import} token is replaced by the \grammarterm{import-keyword} token.
+the \tcode{import} and \tcode{export} (if it exists) preprocessing tokens
+are replaced by the \grammarterm{import-keyword} and
+\grammarterm{export-keyword} preprocessing tokens respectively.
+\begin{note}
+This makes the line no longer a directive
+so it is not removed at the end of phase 4.
+\end{note}
 Additionally, in the second form of \grammarterm{pp-import},
 a \grammarterm{header-name} token is formed as if
 the \grammarterm{header-name-tokens}
@@ -793,50 +923,6 @@ int c = Z;      // error: active macro definitions \#3 and \#5 are not valid red
 \end{codeblocktu}
 \end{example}
 \indextext{macro!import|)}
-
-\rSec1[cpp.global.frag]{Global module fragment}
-
-\begin{bnf}
-\nontermdef{pp-global-module-fragment}\br
-    \terminal{module} \terminal{;} pp-balanced-token-seq \terminal{module}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{pp-balanced-token-seq}\br
-    pp-balanced-token\br
-    pp-balanced-token-seq pp-balanced-token
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{pp-balanced-token}\br
-    pp-ldelim \opt{pp-balanced-token-seq} pp-rdelim\br
-    \descr{any \grammarterm{preprocessing-token} other than a \grammarterm{pp-ldelim} or \grammarterm{pp-rdelim}}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{pp-ldelim} \descr{one of}\br
-  \terminal{(    [    \{    <:    <\%}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{pp-rdelim} \descr{one of}\br
-  \terminal{)    ]    \}    :>    \%>}
-\end{bnf}
-
-\pnum
-If the first two preprocessing tokens at the start of phase 4 of translation
-are \tcode{module} \tcode{;},
-the result of preprocessing shall begin with
-a \grammarterm{pp-global-module-fragment}
-for which all \grammarterm{preprocessing-token}{s}
-in the \grammarterm{pp-balanced-token-seq}
-were produced directly or indirectly by source file inclusion\iref{cpp.include},
-and for which the second \tcode{module} \grammarterm{preprocessing-token}
-was not produced by source file inclusion or
-macro replacement\iref{cpp.replace}.
-Otherwise,
-the first two preprocessing tokens at the end of phase 4 of translation
-shall not be \tcode{module} \tcode{;}.
 
 \rSec1[cpp.replace]{Macro replacement}%
 \indextext{macro!replacement|(}%


### PR DESCRIPTION
Fixes #3687.
Fixes cplusplus/papers#611.
Fixes cplusplus/nbballot#25.
Fixes cplusplus/nbballot#120.
Fixes cplusplus/nbballot#124.
Fixes cplusplus/nbballot#125.
Fixes cplusplus/nbballot#126.
Fixes cplusplus/nbballot#127.
Fixes cplusplus/nbballot#135.
Fixes cplusplus/nbballot#136.
Fixes cplusplus/nbballot#137.
Fixes cplusplus/nbballot#138.
Fixes cplusplus/nbballot#139.

Notes/issues/questions:
* [lex.pptoken]/p4 Note says: "None have any observable spelling." What is this saying?
* [diff.cpp17.basic] "The editor should consider a different section of annex C to move this to." Where to?
* [basic.link] FYI, the grammar for private-module-fragment moved to [module.private.frag].
* FYI, section [cpp.global.frag] is now [cpp.glob.frag].
* FYI, section [module.global] is now  [module.global.frag].
