### PR TITLE
CWG Poll 16: P2002R1 Defaulted comparison specification cleanups

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1219,6 +1219,13 @@ For a class, its non-static data members, its non-virtual direct base classes,
 and, if the class is not abstract\iref{class.abstract}, its virtual base
 classes are called its \term{potentially constructed subobjects}.
 
+\pnum
+A defaulted special member function is
+\indextext{member function!constexpr-compatible}%
+\defnx{constexpr-compatible}{constexpr-compatible!defaulted special member function}
+if the corresponding implicitly-declared special member function
+would be a constexpr function.
+
 \rSec2[class.ctor]{Constructors}%
 \indextext{constructor}%
 \indextext{special member function|see{constructor}}%
@@ -6678,53 +6685,140 @@ template<class T> void f() {
 A defaulted comparison operator function\iref{over.binary}
 for some class \tcode{C}
 shall be a non-template function
-declared in the \grammarterm{member-specification} of \tcode{C}
+defined in the \grammarterm{member-specification} of \tcode{C}
 that is
 \begin{itemize}
 \item
-a non-static const member of \tcode{C} having
-one parameter of type \tcode{const C\&}, or
+a non-static const non-volatile member of \tcode{C} having
+one parameter of type \tcode{const C\&} and either
+no \grammarterm{ref-qualifier} or
+the \grammarterm{ref-qualifier} \tcode{\&}, or
 
 \item
 a friend of \tcode{C} having either
 two parameters of type \tcode{const C\&} or
 two parameters of type \tcode{C}.
 \end{itemize}
+A defaulted comparison operator function for class \tcode{C} that
+is not defined as deleted is
+\defnx{implicitly defined}{operator!comparison!implicitly defined}
+when it is odr-used or needed for constant evaluation.
+Name lookups in the defaulted definition
+are performed from a context equivalent to
+the \grammarterm{function-body} of the defaulted \tcode{operator@} function.
+A defaulted comparison operator function shall be
+defaulted on its first declaration.
 
 \pnum
-A defaulted comparison operator function for class \tcode{C}
+A defaulted \tcode{<=>} or \tcode{==} operator function for class \tcode{C}
+\indextext{operator!three-way comparison!deleted}%
+\indextext{operator!equality!deleted}%
 is defined as deleted if
 any non-static data member of \tcode{C} is of reference type or
-\tcode{C} is a union-like class\iref{class.union.anon}.
+\tcode{C} has variant members\iref{class.union.anon}.
 
 \pnum
-If the class definition
-does not explicitly declare an \tcode{==} operator function,
-but declares a defaulted three-way comparison operator function,
+A binary operator expression \tcode{a @ b} is
+\defnx{usable}{usable!binary operator expression}
+if either
+
+\begin{itemize}
+\item
+\tcode{a} or \tcode{b} is of class or enumeration type and
+overload resolution\iref{over.match} as applied to \tcode{a @ b}
+results in a usable candidate, or
+
+\item
+neither \tcode{a} nor \tcode{b} is of class or enumeration type and
+\tcode{a @ b} is a valid expression.
+\end{itemize}
+
+\pnum
+A defaulted comparison function is
+\indextext{operator!comparison!constexpr-compatible}%
+\defnx{constexpr-compatible}{constexpr-compatible!defaulted comparison operator}
+if it
+satisfies the requirements for a constexpr function\iref{dcl.constexpr} and
+no overload resolution
+performed when determining whether to delete the function
+results in a usable candidate that is a non-constexpr function.
+\begin{note}
+This includes the overload resolutions performed:
+
+\begin{itemize}
+\item
+for an \tcode{operator<=>} whose return type is not \tcode{auto},
+when determining whether a synthesized three-way comparison is defined,
+
+\item
+for an \tcode{operator<=>} whose return type is \tcode{auto} or
+for an \tcode{operator==},
+for a comparison between an element of the expanded list of
+subobjects and itself, or
+
+\item
+for a secondary comparison operator \tcode{@},
+for the expression \tcode{x @ y}.
+\end{itemize}
+\end{note}
+
+\pnum
+If the \grammarterm{member-specification}
+does not explicitly declare
+any member or friend named \tcode{operator==},
 an \tcode{==} operator function is declared implicitly
-with the same access as the three-way comparison operator function.
-The implicitly-declared \tcode{==} operator for a class \tcode{X}
-is an inline member and is defined as defaulted in the definition of \tcode{X}.
+for each defaulted three-way comparison operator function
+defined in the \grammarterm{member-specification},
+with the same access and \grammarterm{function-definition} and
+in the same class scope as
+the respective three-way comparison operator function,
+except that the return type is replaced with \tcode{bool} and
+the \grammarterm{declarator-id} is replaced with \tcode{operator==}.
+\begin{note}
+Such an implicitly-declared \tcode{==} operator for a class \tcode{X}
+is an inline function and is defined as defaulted
+in the definition of \tcode{X}, and
+has the same \grammarterm{parameter-declaration-clause} and
+trailing \grammarterm{requires-clause} as
+the respective three-way comparison operator.
 If the three-way comparison operator function
 is declared as a non-static const member,
-the implicitly-declared \tcode{==} operator function is a member of the form
-\begin{codeblock}
-bool X::operator==(const X&) const;
-\end{codeblock}
-Otherwise, the implicitly-declared \tcode{==} operator function is of the form
-\begin{codeblock}
-friend bool operator==(const X&, const X&);
-\end{codeblock}
-\begin{note}
-Such a friend function is visible
+the implicitly-declared \tcode{==} operator function
+is a non-static const member.
+If the three-way comparison operator function declaration
+is a friend declaration,
+the implicitly-declared \tcode{==} operator function
+is a friend declaration;
+such a friend function is visible
 to argument-dependent lookup\iref{basic.lookup.argdep}
 only\iref{namespace.memdef}.
+If the three-way comparison operator function
+is declared \tcode{virtual}, \tcode{constexpr}, or \tcode{consteval},
+the implicitly-declared \tcode{==} operator function
+is declared \tcode{virtual}, \tcode{constexpr}, or \tcode{consteval},
+respectively.
+If the three-way comparison operator function
+has no \grammarterm{noexcept-specifier},
+the implicitly-declared \tcode{==} operator function
+has an implicit exception specification\iref{except.spec} that
+may differ from the implicit exception specification of
+the three-way comparison operator function.
 \end{note}
-The operator is a \tcode{constexpr} function if its definition
-would satisfy the requirements for a \tcode{constexpr} function.
+\begin{example}
+\begin{codeblock}
+template<typename T> struct X {
+  friend constexpr std::partial_ordering operator<=>(X, X) requires (sizeof(T) != 1) = default;
+  // implicitly declares: \tcode{friend constexpr bool operator==(X, X) requires (sizeof(T) != 1) = default;}
+
+  [[nodiscard]] virtual std::strong_ordering operator<=>(const X&) const = default;
+  // implicitly declares: \tcode{[[nodiscard]] virtual bool operator==(const X\&) const = default;}
+};
+\end{codeblock}
+\end{example}
 \begin{note}
 The \tcode{==} operator function is declared implicitly even if
-the defaulted three-way comparison operator function is defined as deleted.
+the defaulted three-way comparison operator function
+is defined as deleted.
 \end{note}
 
 \pnum
@@ -6743,12 +6837,9 @@ formed by a sequence of
 derived-to-base conversions\iref{over.best.ics},
 class member access expressions\iref{expr.ref}, and
 array subscript expressions\iref{expr.sub} applied to \tcode{x}.
-It is unspecified whether virtual base class subobjects
-appear more than once in the expanded list of subobjects.
 
-\rSec2[class.eq]{Equality operators}
+\rSec2[class.eq]{Equality operator}
 \indextext{operator!equality!defaulted}%
-\indextext{operator!inequality!defaulted}%
 
 \pnum
 A defaulted equality operator function\iref{over.binary}
@@ -6759,8 +6850,8 @@ A defaulted \tcode{==} operator function for a class \tcode{C}
 is defined as deleted
 unless, for each $\tcode{x}_i$ in the expanded list of subobjects
 for an object \tcode{x} of type \tcode{C},
-$\tcode{x}_i\tcode{ == }\tcode{x}_i$ is a valid expression and
-contextually convertible to \tcode{bool}.
+$\tcode{x}_i\tcode{ == }\tcode{x}_i$
+is usable\iref{class.compare.default}.
 
 \pnum
 The return value \tcode{V} of a defaulted \tcode{==} operator function
@@ -6775,25 +6866,12 @@ If no such index exists, \tcode{V} is \tcode{true}.
 Otherwise, \tcode{V} is \tcode{false}.
 
 \pnum
-A defaulted \tcode{!=} operator function for a class \tcode{C}
-with parameters \tcode{x} and \tcode{y} is defined as deleted if
-\begin{itemize}
-\item
-  overload resolution\iref{over.match}, as applied to \tcode{x == y},
-  does not result in a usable function, or
-\item
-  \tcode{x == y} is not a prvalue of type \tcode{bool}.
-\end{itemize}
-Otherwise, the operator function yields \tcode{!(x == y)}.
-
-\pnum
 \begin{example}
 \begin{codeblock}
 struct D {
   int i;
   friend bool operator==(const D& x, const D& y) = default;
                                                 // OK, returns \tcode{x.i == y.i}
-  bool operator!=(const D& z) const = default;  // OK, returns \tcode{!(*this == z)}
 };
 \end{codeblock}
 \end{example}
@@ -6809,13 +6887,18 @@ is defined as follows:
 
 \begin{itemize}
 \item
-If overload resolution for \tcode{a <=> b}
-results in a usable function\iref{over.match},
+If \tcode{a <=> b} is usable\iref{class.compare.default},
 \tcode{static_cast<R>(a <=> b)}.
 
 \item
-Otherwise, if overload resolution for \tcode{a <=> b}
+Otherwise, if overload resolution for \tcode{a <=> b} is performed and
 finds at least one viable candidate,
+the synthesized three-way comparison is not defined.
+
+\item
+Otherwise, if \tcode{R} is not a comparison category type, or either
+the expression \tcode{a == b} or the expression \tcode{a < b}
+is not usable,
 the synthesized three-way comparison is not defined.
 
 \item
@@ -6835,43 +6918,45 @@ a < b  ? weak_ordering::less :
 \end{codeblock}
 
 \item
-Otherwise, if \tcode{R} is \tcode{partial_ordering}, then
+Otherwise (when \tcode{R} is \tcode{partial_ordering}),
 \begin{codeblock}
 a == b ? partial_ordering::equivalent :
 a < b  ? partial_ordering::less :
 b < a  ? partial_ordering::greater :
          partial_ordering::unordered
 \end{codeblock}
-
-\item
-Otherwise, the synthesized three-way comparison is not defined.
 \end{itemize}
+
 \begin{note}
 A synthesized three-way comparison may be ill-formed
-if overload resolution finds usable functions
+if overload resolution finds usable candidates
 that do not otherwise meet the requirements implied by the defined expression.
 \end{note}
 
 \pnum
 Let \tcode{R} be the declared return type of
-a defaulted three-way comparison operator function.
-Given an expanded list of subobjects for an object \tcode{x} of type \tcode{C},
-let $\tcode{R}_i$ be
-the type of the expression $\tcode{x}_i$ \tcode{<=>} $\tcode{x}_i$, or
-\tcode{void} if overload resolution applied to that expression
-does not find a usable function.
+a defaulted three-way comparison operator function, and
+let $\tcode{x}_i$ be the elements of
+the expanded list of subobjects for
+an object \tcode{x} of type \tcode{C}.
+
 \begin{itemize}
 \item
-If \tcode{R} is \tcode{auto},
-then the return type is deduced as
+If \tcode{R} is \tcode{auto}, then
+let $\cv{}_i~\tcode{R}_i$ be
+the type of the expression $\tcode{x}_i\tcode{ <=> }\tcode{x}_i$.
+The operator function is defined as deleted
+if that expression is not usable or
+if $\tcode{R}_i$ is not
+a comparison category type\iref{cmp.categories.pre} for any $i$.
+The return type is deduced as
 the common comparison type (see below) of
 $\tcode{R}_0$, $\tcode{R}_1$, $\dotsc$, $\tcode{R}_{n-1}$.
-If the return type is deduced as \tcode{void},
-the operator function is defined as deleted.
 \item
-Otherwise, if the synthesized three-way comparison of type \tcode{R}
+Otherwise, \tcode{R} shall not contain a placeholder type.
+If the synthesized three-way comparison of type \tcode{R}
 between any objects $\tcode{x}_i$ and $\tcode{x}_i$
-is not defined or would be ill-formed,
+is not defined,
 the operator function is defined as deleted.
 \end{itemize}
 
@@ -6888,24 +6973,19 @@ the synthesized three-way comparison of type \tcode{R}
 between $\tcode{x}_i$ and $\tcode{y}_i$
 yields a result value $\tcode{v}_i$ where $\tcode{v}_i \mathrel{\tcode{!=}} 0$,
 contextually converted to \tcode{bool}, yields \tcode{true};
-\tcode{V} is $\tcode{v}_i$.
+\tcode{V} is a copy of $\tcode{v}_i$.
 If no such index exists, \tcode{V} is
 \tcode{static_cast<R>(std::strong_ordering::equal)}.
 
 \pnum
 The \defn{common comparison type} \tcode{U}
-of a possibly-empty list of $n$ types
+of a possibly-empty list of $n$ comparison category types
 $\tcode{T}_0$, $\tcode{T}_1$, $\dotsc$, $\tcode{T}_{n-1}$
 is defined as follows:
 
 \begin{itemize}
 \item
-If any $\tcode{T}_i$
-is not a comparison category type\iref{cmp.categories},
-\tcode{U} is \tcode{void}.
-
-\item
-Otherwise, if at least one $\tcode{T}_i$ is \tcode{std::partial_ordering},
+If at least one $\tcode{T}_i$ is \tcode{std::partial_ordering},
 \tcode{U} is \tcode{std::partial_ordering}\iref{cmp.partialord}.
 
 \item
@@ -6919,12 +6999,16 @@ In particular, this is the result when $n$ is 0.
 \end{note}
 \end{itemize}
 
-\rSec2[class.rel]{Relational operators}
+\rSec2[class.compare.secondary]{Secondary comparison operators}
+\indextext{operator!inequality!defaulted}%
 \indextext{operator!relational!defaulted}%
 
 \pnum
-A defaulted relational operator function\iref{over.binary}
-for some operator \tcode{@}
+\indextext{operator!comparison!secondary}%
+A \defn{secondary comparison operator} is
+a relational operator\iref{expr.rel} or the \tcode{!=} operator.
+A defaulted operator function\iref{over.binary}
+for a secondary comparison operator \tcode{@}
 shall have a declared return type \tcode{bool}.
 
 \pnum
@@ -6933,16 +7017,17 @@ is defined as deleted if
 \begin{itemize}
 \item
 overload resolution\iref{over.match},
-as applied to \tcode{x <=> y},
-does not result in a usable function, or
+as applied to \tcode{x @ y},
+does not result in a usable candidate, or
 
 \item
-the operator \tcode{@}
-cannot be applied to the return type of \tcode{x <=> y}.
+the candidate selected by overload resolution
+is not a rewritten candidate.
 \end{itemize}
 
-Otherwise, the operator function yields
-\tcode{x <=> y @ 0}.
+Otherwise, the operator function yields \tcode{x @ y}.
+The defaulted operator function is not considered as a candidate
+in the overload resolution for the \tcode{@} operator.
 
 \pnum
 \begin{example}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6032,11 +6032,10 @@ If \tcode{T}$_1$ differs from \tcode{T}$_2$ in any other way, then:
 \pnum
 An explicitly-defaulted function that is not defined as deleted may be declared
 \tcode{constexpr} or \tcode{consteval} only
-if it would have been implicitly declared as \tcode{constexpr}.
+if it is constexpr-compatible (\ref{special}, \ref{class.compare.default}).
 A function explicitly defaulted on its first declaration
-is inline\iref{dcl.inline};
-it is implicitly considered to be \tcode{constexpr} if the implicit
-declaration would be.
+is implicitly inline\iref{dcl.inline},
+and is implicitly constexpr\iref{dcl.constexpr} if it is constexpr-compatible.
 
 \pnum
 \begin{example}

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -911,7 +911,7 @@ The exception specification for a comparison operator function\iref{over.binary}
 without a \grammarterm{noexcept-specifier}
 that is defaulted on its first declaration
 is potentially-throwing if and only if
-the invocation of any comparison operator
+any expression
 in the implicit definition is potentially-throwing.
 
 \pnum
@@ -964,7 +964,7 @@ function);
 \item the function is defined; or
 
 \item the exception specification is needed for a defaulted
-special member function that calls the function.
+function that calls the function.
 \begin{note}
 A defaulted declaration does not require the
 exception specification of a base member function to be evaluated
@@ -973,7 +973,7 @@ function is needed, but an explicit \grammarterm{noexcept-specifier} needs
 the implicit exception specification to compare against.
 \end{note}
 \end{itemize}
-The exception specification of a defaulted special member
+The exception specification of a defaulted
 function is evaluated as described above only when needed; similarly, the
 \grammarterm{noexcept-specifier} of a specialization of a function
 template or member function of a class template is instantiated only when

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5934,29 +5934,15 @@ converting the operands to the underlying type of \tcode{E}
 and applying \tcode{<=>} to the converted operands.
 
 \pnum
-If at least one of the operands is of pointer type,
+If at least one of the operands is of pointer type and
+the other operand is of pointer or array type,
 array-to-pointer conversions\iref{conv.array},
 pointer conversions\iref{conv.ptr},
-function pointer conversions\iref{conv.fctptr},
 and
 qualification conversions\iref{conv.qual}
 are performed on both operands
 to bring them to their composite pointer type\iref{expr.type}.
-%
-If at least one of the operands is of pointer-to-member type,
-pointer-to-member conversions\iref{conv.mem}
-and
-qualification conversions\iref{conv.qual}
-are performed on both operands
-to bring them to their composite pointer type\iref{expr.type}.
-%
-If both operands are null pointer constants,
-but not both of integer type,
-pointer conversions\iref{conv.ptr}
-are performed on both operands
-to bring them to their composite pointer type\iref{expr.type}.
-%
-In all cases, after the conversions, the operands shall have the same type.
+After the conversions, the operands shall have the same type.
 \begin{note}
 If both of the operands are arrays,
 array-to-pointer conversions\iref{conv.array} are not applied.

--- a/source/modules.tex
+++ b/source/modules.tex
@@ -871,11 +871,11 @@ in the context of a particular declaration or template instantiation.
 
 \pnum
 During the implicit definition of
-a defaulted special member function\iref{special},
+a defaulted function (\ref{special}, \ref{class.compare.default}),
 the instantiation context is the union of
 the instantiation context from the definition of the class and
 the instantiation context of the program construct that
-resulted in the implicit definition of the special member function.
+resulted in the implicit definition of the defaulted function.
 
 \pnum
 During the implicit instantiation of a template
@@ -893,9 +893,9 @@ primary module interface unit of $M$
 \pnum
 During the implicit instantiation of a template
 that is implicitly instantiated because it is referenced
-from within the implicit definition of a defaulted special member function,
+from within the implicit definition of a defaulted function,
 the instantiation context is the instantiation context of
-the defaulted special member function.
+the defaulted function.
 
 \pnum
 During the instantiation of any other template specialization,

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -500,10 +500,13 @@ in which it is used,
 the program is ill-formed.
 
 \pnum
-Overload resolution results in a \defnadj{usable}{function}
+Overload resolution results in a \defnadj{usable}{candidate}
 if overload resolution succeeds and
-the selected function is not deleted and
-is accessible from the context in which overload resolution was performed.
+the selected candidate
+is either not a function\iref{over.built}, or
+is a function that is not deleted and
+is accessible from the context
+in which overload resolution was performed.
 
 \rSec2[over.match.funcs]{Candidate functions and argument lists}%
 \indextext{overloading!candidate functions|(}%

--- a/source/support.tex
+++ b/source/support.tex
@@ -4504,11 +4504,11 @@ struct common_comparison_category {
 \remarks
 The member \grammarterm{typedef-name} \tcode{type} denotes
 the common comparison type\iref{class.spaceship} of \tcode{Ts...},
-the expanded parameter pack.
+the expanded parameter pack, or
+\tcode{void} if any element of \tcode{Ts}
+is not a comparison category type.
 \begin{note}
-This is well-defined even if
-the expansion is empty or
-includes a type that is not a comparison category type.
+This is \tcode{std::strong_ordering} if the expansion is empty.
 \end{note}
 \end{itemdescr}
 


### PR DESCRIPTION
[class.compare.default] Added "was" to "no overload resolution performed".

Fixes #3700. 
Fixes cplusplus/papers#739.

Notes/Issues:
* [everywhere] Please check my \defns and \indextexts - I wasn't sure how I should specify them.
* [class.compare.default] We just say "operator@" not "operator@ function".  We're also inconsistent in whether we encode is as "operator \tcode{@}" v. "\tcode{operator@}".
* [class.compare.default] We usually say "defaulted comparison operator function" instead of "defaulted comparison function".
* [class.compare.default] In the last 2 bullets of the new paragraph after p2, the "for" at the end of each bullet is hard to parse correctly: "
    ** for an operator<=> whose return type is auto or for an operator==, for a comparison between an element of the expanded list of subobjects and itself, or
    ** for a secondary comparison operator @, for the expression x @ y."
