### PR TITLE
LWG Poll 16: P1976R2 Fixed-size span construction from dynamic range

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -11024,7 +11024,8 @@ template<size_t Count> constexpr span<element_type, Count> first() const;
 
 \pnum
 \effects
-Equivalent to: \tcode{return \{data(), Count\};}
+Equivalent to: \tcode{return R\{data(), Count\};}
+where \tcode{R} is the return type.
 \end{itemdescr}
 
 \indexlibrarymember{span}{last}%
@@ -11043,7 +11044,8 @@ template<size_t Count> constexpr span<element_type, Count> last() const;
 
 \pnum
 \effects
-Equivalent to: \tcode{return \{data() + (size() - Count), Count\};}
+Equivalent to: \tcode{return R\{data() + (size() - Count), Count\};}
+where \tcode{R} is the return type.
 \end{itemdescr}
 
 \indexlibrarymember{span}{subspan}%
@@ -11309,7 +11311,8 @@ template<class ElementType, size_t Extent>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return \{reinterpret_cast<const byte*>(s.data()), s.size_bytes()\};}
+Equivalent to: \tcode{return R\{reinterpret_cast<const byte*>(s.data()), s.size_bytes()\};}
+where \tcode{R} is the return type.
 \end{itemdescr}
 
 \indexlibraryglobal{as_writable_bytes}%
@@ -11326,7 +11329,8 @@ template<class ElementType, size_t Extent>
 
 \pnum
 \effects
-Equivalent to: \tcode{return \{reinterpret_cast<byte*>(s.data()), s.size_bytes()\};}
+Equivalent to: \tcode{return R\{reinterpret_cast<byte*>(s.data()), s.size_bytes()\};}
+where \tcode{R} is the return type.
 \end{itemdescr}
 
 \rSec3[span.tuple]{Tuple interface}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10669,9 +10669,9 @@ namespace std {
     // \ref{span.cons}, constructors, copy, and assignment
     constexpr span() noexcept;
     template<class It>
-      constexpr span(It first, size_type count);
+      constexpr explicit(extent != dynamic_extent) span(It first, size_type count);
     template<class It, class End>
-      constexpr span(It first, End last);
+      constexpr explicit(extent != dynamic_extent) span(It first, End last);
     template<size_t N>
       constexpr span(type_identity_t<element_type> (&arr)[N]) noexcept;
     template<class T, size_t N>
@@ -10679,10 +10679,10 @@ namespace std {
     template<class T, size_t N>
       constexpr span(const array<T, N>& arr) noexcept;
     template<class R>
-      constexpr span(R&& r);
+      constexpr explicit(extent != dynamic_extent) span(R&& r);
     constexpr span(const span& other) noexcept = default;
     template<class OtherElementType, size_t OtherExtent>
-      constexpr span(const span<OtherElementType, OtherExtent>& s) noexcept;
+      constexpr explicit(@\seebelow@) span(const span<OtherElementType, OtherExtent>& s) noexcept;
 
     ~span() noexcept = default;
 
@@ -10760,7 +10760,7 @@ constexpr span() noexcept;
 \indexlibraryctor{span}%
 \begin{itemdecl}
 template<class It>
-  constexpr span(It first, size_type count);
+  constexpr explicit(extent != dynamic_extent) span(It first, size_type count);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10800,7 +10800,7 @@ Nothing.
 \indexlibraryctor{span}%
 \begin{itemdecl}
 template<class It, class End>
-  constexpr span(It first, End last);
+  constexpr explicit(extent != dynamic_extent) span(It first, End last);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10850,9 +10850,14 @@ template<class T, size_t N> constexpr span(const array<T, N>& arr) noexcept;
 \begin{itemdescr}
 \pnum
 \constraints
+Let \tcode{U} be \tcode{remove_pointer_t<decltype(data(arr))>}.
 \begin{itemize}
 \item \tcode{extent == dynamic_extent || N == extent} is \tcode{true}, and
-\item \tcode{remove_pointer_t<decltype(data(arr))>(*)[]} is convertible to \tcode{ElementType(*)[]}.
+\item \tcode{is_convertible_v<U(*)[], element_type(*)[]>} is \tcode{true}.
+\begin{note}
+The intent is to allow only qualification conversions
+of the array element type to \tcode{element_type}.
+\end{note}
 \end{itemize}
 
 \pnum
@@ -10869,7 +10874,7 @@ Constructs a \tcode{span} that is a view over the supplied array.
 
 \indexlibraryctor{span}%
 \begin{itemdecl}
-template<class R> constexpr span(R&& r);
+template<class R> constexpr explicit(extent != dynamic_extent) span(R&& r);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10877,7 +10882,6 @@ template<class R> constexpr span(R&& r);
 \constraints
 Let \tcode{U} be \tcode{remove_reference_t<ranges::range_reference_t<R>>}.
 \begin{itemize}
-\item \tcode{extent == dynamic_extent} is \tcode{true}.
 \item \tcode{R} satisfies \tcode{ranges::\libconcept{contiguous_range}} and
   \tcode{ranges::\libconcept{sized_range}}.
 \item Either \tcode{R} satisfies \tcode{ranges::\libconcept{borrowed_range}} or
@@ -10889,13 +10893,15 @@ Let \tcode{U} be \tcode{remove_reference_t<ranges::range_reference_t<R>>}.
 \tcode{is_convertible_v<U(*)[], element_type(*)[]>} is \tcode{true}.
 \begin{note}
 The intent is to allow only qualification conversions
-of the iterator reference type to \tcode{element_type}.
+of the range reference type to \tcode{element_type}.
 \end{note}
 \end{itemize}
 
 \pnum
 \expects
 \begin{itemize}
+\item If \tcode{extent} is not equal to \tcode{dynamic_extent},
+then \tcode{ranges::size(r)} is equal to \tcode{extent}.
 \item \tcode{R} models \tcode{ranges::\libconcept{contiguous_range}} and
 \tcode{ranges::\libconcept{sized_range}}.
 \item If \tcode{is_const_v<element_type>} is \tcode{false},
@@ -10926,16 +10932,25 @@ constexpr span(const span& other) noexcept = default;
 \indexlibraryctor{span}%
 \begin{itemdecl}
 template<class OtherElementType, size_t OtherExtent>
-  constexpr span(const span<OtherElementType, OtherExtent>& s) noexcept;
+  constexpr explicit(@\seebelow@) span(const span<OtherElementType, OtherExtent>& s) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \constraints
 \begin{itemize}
-\item \tcode{Extent == dynamic_extent || Extent == OtherExtent} is \tcode{true}, and
-\item \tcode{OtherElementType(*)[]} is convertible to \tcode{ElementType(*)[]}.
+\item \tcode{extent == dynamic_extent} \tcode{||} \tcode{OtherExtent == dynamic_extent} \tcode{||} \tcode{extent == OtherExtent} is \tcode{true}, and
+\item \tcode{is_convertible_v<OtherElementType(*)[], element_type(*)[]>} is \tcode{true}.
+\begin{note}
+The intent is to allow only qualification conversions
+of the \tcode{OtherElementType} to \tcode{element_type}.
+\end{note}
 \end{itemize}
+
+\pnum
+\expects
+If \tcode{extent} is not equal to \tcode{dynamic_extent},
+then \tcode{s.size()} is equal to \tcode{extent}.
 
 \pnum
 \effects
@@ -10945,6 +10960,13 @@ Constructs a \tcode{span} that is a view over the range
 \pnum
 \ensures
 \tcode{size() == s.size() \&\& data() == s.data()}.
+
+\pnum
+\remarks
+The expression inside \tcode{explicit} is equivalent to:
+\begin{codeblock}
+extent != dynamic_extent && OtherExtent == dynamic_extent
+\end{codeblock}
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{span}%

--- a/source/support.tex
+++ b/source/support.tex
@@ -670,7 +670,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_shift}@                             201806L // also in \libheader{algorithm}
 #define @\defnlibxname{cpp_lib_smart_ptr_default_init}@            201811L // also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_source_location}@                   201907L // also in \libheader{source_location}
-#define @\defnlibxname{cpp_lib_span}@                              201902L // also in \libheader{span}
+#define @\defnlibxname{cpp_lib_span}@                              202002L // also in \libheader{span}
 #define @\defnlibxname{cpp_lib_ssize}@                             201902L // also in \libheader{iterator}
 #define @\defnlibxname{cpp_lib_starts_ends_with}@                  201711L // also in \libheader{string}, \libheader{string_view}
 #define @\defnlibxname{cpp_lib_string_udls}@                       201304L // also in \libheader{string}


### PR DESCRIPTION
Also fixes NB PL 250  (C++20 CD).

[span.sub] p3 and p6: Add explicit return types to account for
constructor being explicit now.

[span.objectrep] p1 and p3: Move extent of return type into a remark.
Add explicit return type to account for explicit constructor.

Fixes #3718
Fixes cplusplus/papers#707
Fixes cplusplus/nbballot#246