### PR TITLE
[atomic] Apply conventional order to members of atomic smart pointers

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -2670,21 +2670,26 @@ resulting from this is performed.
 namespace std {
   template<class T> struct atomic<shared_ptr<T>> {
     using value_type = shared_ptr<T>;
-    static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic} type's operations are always lock free}@;
 
+    static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic} type's operations are always lock free}@;
     bool is_lock_free() const noexcept;
-    void store(shared_ptr<T> desired, memory_order order = memory_order::seq_cst) noexcept;
+
+    constexpr atomic() noexcept;
+    atomic(shared_ptr<T> desired) noexcept;
+    atomic(const atomic&) = delete;
+    void operator=(const atomic&) = delete;
+
     shared_ptr<T> load(memory_order order = memory_order::seq_cst) const noexcept;
     operator shared_ptr<T>() const noexcept;
+    void store(shared_ptr<T> desired, memory_order order = memory_order::seq_cst) noexcept;
+    void operator=(shared_ptr<T> desired) noexcept;
 
     shared_ptr<T> exchange(shared_ptr<T> desired,
                            memory_order order = memory_order::seq_cst) noexcept;
-
     bool compare_exchange_weak(shared_ptr<T>& expected, shared_ptr<T> desired,
                                memory_order success, memory_order failure) noexcept;
     bool compare_exchange_strong(shared_ptr<T>& expected, shared_ptr<T> desired,
                                  memory_order success, memory_order failure) noexcept;
-
     bool compare_exchange_weak(shared_ptr<T>& expected, shared_ptr<T> desired,
                                memory_order order = memory_order::seq_cst) noexcept;
     bool compare_exchange_strong(shared_ptr<T>& expected, shared_ptr<T> desired,
@@ -2693,12 +2698,6 @@ namespace std {
     void wait(shared_ptr<T> old, memory_order order = memory_order::seq_cst) const noexcept;
     void notify_one() noexcept;
     void notify_all() noexcept;
-
-    constexpr atomic() noexcept;
-    atomic(shared_ptr<T> desired) noexcept;
-    atomic(const atomic&) = delete;
-    void operator=(const atomic&) = delete;
-    void operator=(shared_ptr<T> desired) noexcept;
 
   private:
     shared_ptr<T> p;            // \expos
@@ -2978,21 +2977,26 @@ This function is an atomic notifying operation\iref{atomics.wait}.
 namespace std {
   template<class T> struct atomic<weak_ptr<T>> {
     using value_type = weak_ptr<T>;
-    static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic} type's operations are always lock free}@;
 
+    static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic} type's operations are always lock free}@;
     bool is_lock_free() const noexcept;
-    void store(weak_ptr<T> desired, memory_order order = memory_order::seq_cst) noexcept;
+
+    constexpr atomic() noexcept;
+    atomic(weak_ptr<T> desired) noexcept;
+    atomic(const atomic&) = delete;
+    void operator=(const atomic&) = delete;
+
     weak_ptr<T> load(memory_order order = memory_order::seq_cst) const noexcept;
     operator weak_ptr<T>() const noexcept;
+    void store(weak_ptr<T> desired, memory_order order = memory_order::seq_cst) noexcept;
+    void operator=(weak_ptr<T> desired) noexcept;
 
     weak_ptr<T> exchange(weak_ptr<T> desired,
                          memory_order order = memory_order::seq_cst) noexcept;
-
     bool compare_exchange_weak(weak_ptr<T>& expected, weak_ptr<T> desired,
                                memory_order success, memory_order failure) noexcept;
     bool compare_exchange_strong(weak_ptr<T>& expected, weak_ptr<T> desired,
                                  memory_order success, memory_order failure) noexcept;
-
     bool compare_exchange_weak(weak_ptr<T>& expected, weak_ptr<T> desired,
                                memory_order order = memory_order::seq_cst) noexcept;
     bool compare_exchange_strong(weak_ptr<T>& expected, weak_ptr<T> desired,
@@ -3001,12 +3005,6 @@ namespace std {
     void wait(weak_ptr<T> old, memory_order order = memory_order::seq_cst) const noexcept;
     void notify_one() noexcept;
     void notify_all() noexcept;
-
-    constexpr atomic() noexcept;
-    atomic(weak_ptr<T> desired) noexcept;
-    atomic(const atomic&) = delete;
-    void operator=(const atomic&) = delete;
-    void operator=(weak_ptr<T> desired) noexcept;
 
   private:
     weak_ptr<T> p;              // \expos


### PR DESCRIPTION
There is a consistent ordering of declarations for members
of std::atomc specializations, other than for the atomic
smart pointers.  This patch reorders the declarations to
follow that convention.