### PR TITLE
Simplify build process for the standard draft

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 #
-# Builds the C++ standard document on Travis CI <https://travis-ci.org/cplusplus/draft>
+# Builds the C++ standard document on Travis CI <https://travis-ci.com/cplusplus/draft>
 #
 
 dist: trusty
@@ -13,43 +13,16 @@ before_install:
   - docker pull godbyk/texlive-basic:latest
   - docker run -itd -v $TRAVIS_BUILD_DIR:/$TRAVIS_REPO_SLUG --name texlive-basic godbyk/texlive-basic
 
-env:
-  - BUILD_TYPE=latexmk   # build using latexmk, also apply all checks
-  - BUILD_TYPE=make      # build using Makefile
-  - BUILD_TYPE=complete  # build manually and regenerate figures, grammar, and cross-references
-
 script:
   # Build std.pdf
   - pushd source
-  - if [ "$BUILD_TYPE" = "latexmk" ]; then
-      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && latexmk -pdf std -silent";
-      ../tools/check.sh;
-    fi
-  - if [ "$BUILD_TYPE" = "make" ]; then
-      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && make -j2";
-    fi
-  - if [ "$BUILD_TYPE" = "complete" ]; then
-      for FIGURE in *.dot; do
-        docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && dot -o$(basename $FIGURE .dot).pdf -Tpdf $FIGURE";
-      done;
-      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && pdflatex std";
-      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && pdflatex std";
-      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && pdflatex std";
-      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && makeindex generalindex";
-      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && makeindex libraryindex";
-      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && makeindex grammarindex";
-      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && makeindex impldefindex";
-      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && pdflatex std";
-      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && makeindex -s basic.gst -o xrefindex.gls xrefindex.glo";
-      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && makeindex -s basic.gst -o xrefdelta.gls xrefdelta.glo";
-      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && pdflatex std";
-      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && pdflatex std";
-    fi
+  - docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && make";
+  - ../tools/check.sh;
   - popd
   # Check to see if generated files are out-dated
   - pushd source
   - for FIGURE in *.dot; do
-      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && dot -o$(basename $FIGURE .dot).pdf -Tpdf $FIGURE";
+      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && make $(basename $FIGURE .dot).pdf";
       git status --porcelain $(basename $FIGURE .dot).pdf;
     done
   - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,5 @@ before_install:
   - docker run -itd -v $TRAVIS_BUILD_DIR:/$TRAVIS_REPO_SLUG --name texlive-basic godbyk/texlive-basic
 
 script:
-  # Build std.pdf
-  - pushd source
-  - docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && make";
-  - ../tools/check.sh;
-  - popd
-  # Check to see if generated files are out-dated
-  - pushd source
-  - for FIGURE in *.dot; do
-      docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && make $(basename $FIGURE .dot).pdf";
-      git status --porcelain $(basename $FIGURE .dot).pdf;
-    done
-  - popd
-
+  # Build std.pdf and check it.
+  - docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && make && ../tools/check.sh";

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@
 #
 
 dist: trusty
-sudo: required
-language: cpp
+language: shell
 
 services:
   - docker
@@ -15,4 +14,4 @@ before_install:
 
 script:
   # Build std.pdf and check it.
-  - docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && make && ../tools/check.sh";
+  - docker exec -it texlive-basic bash -c "cd /$TRAVIS_REPO_SLUG/source && make quiet && ../tools/check.sh";

--- a/README.rst
+++ b/README.rst
@@ -64,42 +64,22 @@ Install `MiKTeX <https://miktex.org/download>`_
 Instructions
 ------------
 
-To typeset the draft document, from the ``source`` directory:
+To typeset the draft document, from the ``source`` directory run::
 
-#. run ``latexmk -pdf std``
+  make
 
 That's it! You should now have an ``std.pdf`` containing the typeset draft.
-
-Alternative instructions
-========================
-
-If you can't use latexmk for some reason, you can use the Makefiles instead:
-
-#. run ``make rebuild``
-#. run ``make reindex``
-
-If you can't use latexmk or make for some reason, you can run LaTeX manually instead:
-
-#. run ``pdflatex std`` until there are no more changed labels or changed tables
-#. run ``makeindex generalindex``
-#. run ``makeindex libraryindex``
-#. run ``makeindex grammarindex``
-#. run ``makeindex impldefindex``
-#. run ``pdflatex std`` once more.
-#. run ``makeindex -s basic.gst -o xrefindex.gls xrefindex.glo``
-#. run ``makeindex -s basic.gst -o xrefdelta.gls xrefdelta.glo``
-#. run ``pdflatex std`` twice more.
 
 Generated input files
 =====================
 
 To regenerate figures from .dot files, run::
 
-   dot -o<pdfname> -Tpdf <dotfilename>
+   make <pdfname>
 
 For example::
 
-   dot -ofigstreampos.pdf -Tpdf figstreampos.dot
+   make figstreampos.pdf
 
 ----------------
 Acknowledgements

--- a/source/Makefile
+++ b/source/Makefile
@@ -1,3 +1,5 @@
+FIGURES=$(patsubst %.dot,%.pdf,$(wildcard *.dot))
+
 default: full
 
 clean:
@@ -11,3 +13,8 @@ full:
 
 %.pdf: %.dot
 	dot -o $@ -Tpdf $<
+
+clean-figures:
+	rm -f $(FIGURES)
+
+figures: $(FIGURES)

--- a/source/Makefile
+++ b/source/Makefile
@@ -11,6 +11,9 @@ refresh:
 full:
 	latexmk -pdf std
 
+quiet:
+	latexmk -pdf std -e '$$max_repeat = 1;' -silent || ( rm std.pdf; latexmk -pdf std -e '$$max_repeat = 4;' )
+
 %.pdf: %.dot
 	dot -o $@ -Tpdf $<
 

--- a/source/Makefile
+++ b/source/Makefile
@@ -1,41 +1,13 @@
-### -*- mode: makefile-gmake -*-
-
-FIGURES = $(patsubst %.dot,%.pdf,$(wildcard *.dot))
-
-STDPDF = pdflatex std | grep -v "^Overfull"
-
-default: rebuild
+default: full
 
 clean:
 	rm -f *.aux std.pdf std-gram.ext *.idx *.ilg *.ind *.log *.lot *.lof *.tmp *.out *.glo *.gls *.fls *.fdb* *.toc *.xtr
 
 refresh:
-	$(STDPDF)
+	pdflatex std
 
-rebuild:
-	$(STDPDF)
-	$(STDPDF)
-	$(STDPDF)
-
-full: $(FIGURES) reindex
+full:
+	latexmk -pdf std
 
 %.pdf: %.dot
 	dot -o $@ -Tpdf $<
-
-reindex:
-	$(STDPDF)
-	$(STDPDF)
-	$(STDPDF)
-	makeindex -s generalindex.ist generalindex
-	makeindex headerindex
-	makeindex -s libraryindex.ist libraryindex
-	makeindex grammarindex
-	makeindex impldefindex
-	makeindex conceptindex
-	$(STDPDF)
-	makeindex -s basic.gst -o xrefindex.gls xrefindex.glo
-	makeindex -s basic.gst -o xrefdelta.gls xrefdelta.glo
-	$(STDPDF)
-	$(STDPDF)
-
-### Makefile ends here

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -102,4 +102,14 @@ done | grep . && exit 1
 # egrep 'placeholder{[-A-Za-z]*}@?[,.]' *.tex 
 # to fix: sed -i 's/placeholder\({[-A-Za-z]*}@\?[.,]\)/placeholdernc\1/g' *.tex
 
+# We can't reliably check if the PDF is up to date, because we don't have a
+# deterministic rebuild process, and different versions of dot produce
+# different files anyway. So just check the timestamp.
+for f in *.dot; do
+  if [ "$f" -nt "${f%.dot}.pdf" ]; then
+    echo -e "need to rebuild ${f%.dot}.pdf:\nmake clean-figures && make figures" >&2
+    exit 1
+  fi
+done
+
 exit 0


### PR DESCRIPTION
Remove all build methods other than `latexmk`. Make checking for out-of-date `.pdf` figures actually work and move it to `check.sh`. Simplify Travis CI to only run the single remaining sensible build configuration.