### PR TITLE
LWG Poll 20: P1831R1 Deprecating volatile: library

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -1719,7 +1719,7 @@ The \tcode{order} argument is neither \tcode{memory_order::consume},
 \pnum
 \constraints
 For the \tcode{volatile} overload of this function,
-\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+\tcode{is_always_lock_free} is \tcode{true}.
 
 \pnum
 \effects
@@ -1741,7 +1741,7 @@ T operator=(T desired) noexcept;
 \pnum
 \constraints
 For the \tcode{volatile} overload of this function,
-\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+\tcode{is_always_lock_free} is \tcode{true}.
 
 \pnum
 \effects
@@ -1771,7 +1771,7 @@ The \tcode{order} argument is neither \tcode{memory_order::release} nor \tcode{m
 \pnum
 \constraints
 For the \tcode{volatile} overload of this function,
-\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+\tcode{is_always_lock_free} is \tcode{true}.
 
 \pnum
 \effects
@@ -1795,7 +1795,7 @@ operator T() const noexcept;
 \pnum
 \constraints
 For the \tcode{volatile} overload of this function,
-\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+\tcode{is_always_lock_free} is \tcode{true}.
 
 \pnum
 \effects
@@ -1818,7 +1818,7 @@ T exchange(T desired, memory_order order = memory_order::seq_cst) noexcept;
 \pnum
 \constraints
 For the \tcode{volatile} overload of this function,
-\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+\tcode{is_always_lock_free} is \tcode{true}.
 
 \pnum
 \effects
@@ -1872,7 +1872,7 @@ The \tcode{failure} argument is neither \tcode{memory_order::release} nor
 \pnum
 \constraints
 For the \tcode{volatile} overload of this function,
-\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+\tcode{is_always_lock_free} is \tcode{true}.
 
 \pnum
 \effects
@@ -2260,7 +2260,7 @@ T fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order::seq_
 \pnum
 \constraints
 For the \tcode{volatile} overload of this function,
-\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+\tcode{is_always_lock_free} is \tcode{true}.
 
 \pnum
 \effects
@@ -2304,7 +2304,7 @@ T operator @\placeholder{op}@=(T operand) noexcept;
 \pnum
 \constraints
 For the \tcode{volatile} overload of this function,
-\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+\tcode{is_always_lock_free} is \tcode{true}.
 
 \pnum
 \effects
@@ -2423,7 +2423,7 @@ T A::fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order_se
 \pnum
 \constraints
 For the \tcode{volatile} overload of this function,
-\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+\tcode{is_always_lock_free} is \tcode{true}.
 
 \pnum
 \effects
@@ -2462,7 +2462,7 @@ T operator @\placeholder{op}@=(T operand) noexcept;
 \pnum
 \constraints
 For the \tcode{volatile} overload of this function,
-\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+\tcode{is_always_lock_free} is \tcode{true}.
 
 \pnum
 \effects
@@ -2596,7 +2596,7 @@ T* fetch_@\placeholdernc{key}@(ptrdiff_t operand, memory_order order = memory_or
 \pnum
 \constraints
 For the \tcode{volatile} overload of this function,
-\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+\tcode{is_always_lock_free} is \tcode{true}.
 
 \pnum
 \mandates
@@ -2634,7 +2634,7 @@ T* operator @\placeholder{op}@=(ptrdiff_t operand) noexcept;
 \pnum
 \constraints
 For the \tcode{volatile} overload of this function,
-\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+\tcode{is_always_lock_free} is \tcode{true}.
 
 \pnum
 \effects
@@ -2654,7 +2654,7 @@ value_type operator++(int) noexcept;
 \pnum
 \constraints
 For the \tcode{volatile} overload of this function,
-\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+\tcode{is_always_lock_free} is \tcode{true}.
 
 \pnum
 \effects
@@ -2672,7 +2672,7 @@ value_type operator--(int) noexcept;
 \pnum
 \constraints
 For the \tcode{volatile} overload of this function,
-\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+\tcode{is_always_lock_free} is \tcode{true}.
 
 \pnum
 \effects
@@ -2690,7 +2690,7 @@ value_type operator++() noexcept;
 \pnum
 \constraints
 For the \tcode{volatile} overload of this function,
-\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+\tcode{is_always_lock_free} is \tcode{true}.
 
 \pnum
 \effects
@@ -2708,7 +2708,7 @@ value_type operator--() noexcept;
 \pnum
 \constraints
 For the \tcode{volatile} overload of this function,
-\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+\tcode{is_always_lock_free} is \tcode{true}.
 
 \pnum
 \effects

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -2415,8 +2415,8 @@ The key, operator, and computation correspondence are identified in
 \indexlibrarymember{fetch_add}{atomic<\placeholder{floating-point}>}%
 \indexlibrarymember{fetch_sub}{atomic<\placeholder{floating-point}>}%
 \begin{itemdecl}
-T A::fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order_seq_cst) volatile noexcept;
-T A::fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order_seq_cst) noexcept;
+T fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order_seq_cst) volatile noexcept;
+T fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order_seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -1717,6 +1717,11 @@ The \tcode{order} argument is neither \tcode{memory_order::consume},
 \tcode{memory_order::acquire}, nor \tcode{memory_order::acq_rel}.
 
 \pnum
+\constraints
+For the \tcode{volatile} overload of this function,
+\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+
+\pnum
 \effects
 Atomically replaces the value pointed to by \tcode{this}
 with the value of \tcode{desired}. Memory is affected according to the value of
@@ -1733,6 +1738,11 @@ T operator=(T desired) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\constraints
+For the \tcode{volatile} overload of this function,
+\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+
 \pnum
 \effects
 Equivalent to \tcode{store(desired)}.
@@ -1759,6 +1769,11 @@ T load(memory_order order = memory_order::seq_cst) const noexcept;
 The \tcode{order} argument is neither \tcode{memory_order::release} nor \tcode{memory_order::acq_rel}.
 
 \pnum
+\constraints
+For the \tcode{volatile} overload of this function,
+\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+
+\pnum
 \effects
 Memory is affected according to the value of \tcode{order}.
 
@@ -1778,6 +1793,11 @@ operator T() const noexcept;
 
 \begin{itemdescr}
 \pnum
+\constraints
+For the \tcode{volatile} overload of this function,
+\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+
+\pnum
 \effects
 Equivalent to: \tcode{return load();}
 \end{itemdescr}
@@ -1795,6 +1815,11 @@ T exchange(T desired, memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\constraints
+For the \tcode{volatile} overload of this function,
+\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+
 \pnum
 \effects
 Atomically replaces the value pointed to by \tcode{this}
@@ -1845,13 +1870,18 @@ The \tcode{failure} argument is neither \tcode{memory_order::release} nor
 \tcode{memory_order::acq_rel}.
 
 \pnum
+\constraints
+For the \tcode{volatile} overload of this function,
+\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+
+\pnum
 \effects
 Retrieves the value in \tcode{expected}. It then atomically
 compares the value representation of the value pointed to by \tcode{this}
 for equality with that previously retrieved from \tcode{expected},
 and if true, replaces the value pointed to
 by \tcode{this} with that in \tcode{desired}.
-If and only if the comparison is true, memory is affected according to the
+If and only if the comparison is \tcode{true}, memory is affected according to the
 value of \tcode{success}, and if the comparison is false, memory is affected according
 to the value of \tcode{failure}. When only one \tcode{memory_order} argument is
 supplied, the value of \tcode{success} is \tcode{order}, and the value of
@@ -2228,6 +2258,11 @@ T fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order::seq_
 
 \begin{itemdescr}
 \pnum
+\constraints
+For the \tcode{volatile} overload of this function,
+\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+
+\pnum
 \effects
 Atomically replaces the value pointed to by
 \tcode{this} with the result of the computation applied to the
@@ -2266,6 +2301,11 @@ T operator @\placeholder{op}@=(T operand) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\constraints
+For the \tcode{volatile} overload of this function,
+\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+
 \pnum
 \effects
 Equivalent to: \tcode{return fetch_\placeholder{key}(operand) \placeholder{op} operand;}
@@ -2381,6 +2421,11 @@ T A::fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order_se
 
 \begin{itemdescr}
 \pnum
+\constraints
+For the \tcode{volatile} overload of this function,
+\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+
+\pnum
 \effects
 Atomically replaces the value pointed to by \tcode{this}
 with the result of the computation applied to the value pointed
@@ -2414,6 +2459,11 @@ T operator @\placeholder{op}@=(T operand) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\constraints
+For the \tcode{volatile} overload of this function,
+\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+
 \pnum
 \effects
 Equivalent to: \tcode{return fetch_\placeholder{key}(operand) \placeholder{op} operand;}
@@ -2544,6 +2594,11 @@ T* fetch_@\placeholdernc{key}@(ptrdiff_t operand, memory_order order = memory_or
 
 \begin{itemdescr}
 \pnum
+\constraints
+For the \tcode{volatile} overload of this function,
+\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+
+\pnum
 \mandates
 \tcode{T} is a complete object type.
 \begin{note}
@@ -2577,6 +2632,11 @@ T* operator @\placeholder{op}@=(ptrdiff_t operand) noexcept;
 
 \begin{itemdescr}
 \pnum
+\constraints
+For the \tcode{volatile} overload of this function,
+\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+
+\pnum
 \effects
 Equivalent to: \tcode{return fetch_\placeholder{key}(operand) \placeholder{op} operand;}
 \end{itemdescr}
@@ -2592,6 +2652,11 @@ value_type operator++(int) noexcept;
 
 \begin{itemdescr}
 \pnum
+\constraints
+For the \tcode{volatile} overload of this function,
+\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+
+\pnum
 \effects
 Equivalent to: \tcode{return fetch_add(1);}
 \end{itemdescr}
@@ -2604,6 +2669,11 @@ value_type operator--(int) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\constraints
+For the \tcode{volatile} overload of this function,
+\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+
 \pnum
 \effects
 Equivalent to: \tcode{return fetch_sub(1);}
@@ -2618,6 +2688,11 @@ value_type operator++() noexcept;
 
 \begin{itemdescr}
 \pnum
+\constraints
+For the \tcode{volatile} overload of this function,
+\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+
+\pnum
 \effects
 Equivalent to: \tcode{return fetch_add(1) + 1;}
 \end{itemdescr}
@@ -2630,6 +2705,11 @@ value_type operator--() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\constraints
+For the \tcode{volatile} overload of this function,
+\tcode{atomic<T>::is_always_lock_free} is \tcode{true}.
+
 \pnum
 \effects
 Equivalent to: \tcode{return fetch_sub(1) - 1;}

--- a/source/future.tex
+++ b/source/future.tex
@@ -1479,6 +1479,124 @@ It is unspecified whether a closure type\iref{expr.prim.lambda.closure} is a POD
 \end{note}
 \end{itemdescr}
 
+\rSec1[depr.tuple]{Tuple}
+
+The header \libheaderref{tuple} has the following additions:
+
+\begin{codeblock}
+namespace std {
+  template<class T> class tuple_size<volatile T>;
+  template<class T> class tuple_size<const volatile T>;
+
+  template<size_t I, class T> class tuple_element<I, volatile T>;
+  template<size_t I, class T> class tuple_element<I, const volatile T>;
+}
+\end{codeblock}
+
+\begin{itemdecl}
+template<class T> class tuple_size<volatile T>;
+template<class T> class tuple_size<const volatile T>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{TS} denote \tcode{tuple_size<T>} of the cv-unqualified type \tcode{T}.
+If the expression \tcode{TS::value} is well-formed
+when treated as an unevaluated operand,
+then specializations of each of the two templates meet
+the \oldconcept{TransformationTrait} requirements with a base characteristic of
+\tcode{integral_constant<size_t, TS::value>}.
+Otherwise, they have no member \tcode{value}.
+
+\pnum
+Access checking is performed as if
+in a context unrelated to \tcode{TS} and \tcode{T}.
+Only the validity of the immediate context of the expression is considered.
+
+\pnum
+In addition to being available via inclusion of the \libheaderref{tuple} header,
+the two templates are available when any of the headers
+\libheaderref{array},
+\libheaderref{ranges},
+\libheaderref{span}, or
+\libheaderref{utility}
+are included.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<size_t I, class T> class tuple_element<I, volatile T>;
+template<size_t I, class T> class tuple_element<I, const volatile T>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{TE} denote \tcode{tuple_element_t<I, T>}
+of the cv-unqualified type \tcode{T}.
+Then specializations of each of the two templates meet
+the \oldconcept{TransformationTrait} requirements
+with a member typedef \tcode{type} that names the following type:
+\begin{itemize}
+\item for the first specialization, \tcode{add_volatile_t<TE>}, and
+\item for the second specialization, \tcode{add_cv_t<TE>}.
+\end{itemize}
+
+\pnum
+In addition to being available via inclusion of the \libheaderref{tuple} header,
+the two templates are available when any of the headers
+\libheaderref{array},
+\libheaderref{ranges},
+\libheaderref{span}, or
+\libheaderref{utility}
+are included.
+\end{itemdescr}
+
+\rSec1[depr.variant]{Variant}
+
+\pnum
+The header \libheaderref{variant} has the following additions:
+
+\begin{codeblock}
+namespace std {
+  template<class T> struct variant_size<volatile T>;
+  template<class T> struct variant_size<const volatile T>;
+
+  template<size_t I, class T> struct variant_alternative<I, volatile T>;
+  template<size_t I, class T> struct variant_alternative<I, const volatile T>;
+}
+\end{codeblock}
+
+\begin{itemdecl}
+template<class T> class variant_size<volatile T>;
+template<class T> class variant_size<const volatile T>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{VS} denote \tcode{variant_size<T>}
+of the cv-unqualified type \tcode{T}.
+Then specializations of each of the two templates meet
+the \oldconcept{UnaryTypeTrait} requirements
+with a base characteristic of \tcode{integral_constant<size_t, VS::value>}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<size_t I, class T> class variant_alternative<I, volatile T>;
+template<size_t I, class T> class variant_alternative<I, const volatile T>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{VA} denote \tcode{variant_alternative<I, T>}
+of the cv-unqualified type \tcode{T}.
+Then specializations of each of the two templates meet
+the \oldconcept{TransformationTrait} requirements
+with a member typedef \tcode{type} that names the following type:
+\begin{itemize}
+\item for the first specialization, \tcode{add_volatile_t<VA::type>}, and
+\item for the second specialization, \tcode{add_cv_t<VA::type>}.
+\end{itemize}
+\end{itemdescr}
+
 \rSec1[depr.iterator.primitives]{Deprecated iterator primitives}
 
 \rSec2[depr.iterator.basic]{Basic iterator}
@@ -2486,7 +2604,7 @@ for an indication of UTF-8 encoding more consistent with
 \end{note}
 \end{itemdescr}
 
-\rSec1[depr.atomics]{Deprecated atomic initialization}
+\rSec1[depr.atomics]{Deprecated atomic operations}
 
 \pnum
 The header \libheaderref{atomics} has the following additions.
@@ -2502,6 +2620,30 @@ namespace std {
 
   #define ATOMIC_FLAG_INIT @\seebelow@
 }
+\end{codeblock}
+
+\rSec2[depr.atomics.volatile]{Volatile access}
+
+If an atomic specialization has one of the following overloads,
+then that overload participates in overload resolution
+even if \tcode{atomic<T>::is_always_lock_free} is \tcode{false}:
+\begin{codeblock}
+void store(T desired, memory_order order = memory_order::seq_cst) volatile noexcept;
+T operator=(T desired) volatile noexcept;
+T load(memory_order order = memory_order::seq_cst) const volatile noexcept;
+operator T() const volatile noexcept;
+T exchange(T desired, memory_order order = memory_order::seq_cst) volatile noexcept;
+bool compare_exchange_weak(T& expected, T desired,
+                           memory_order success, memory_order failure) volatile noexcept;
+bool compare_exchange_strong(T& expected, T desired,
+                             memory_order success, memory_order failure) volatile noexcept;
+bool compare_exchange_weak(T& expected, T desired,
+                           memory_order order = memory_order::seq_cst) volatile noexcept;
+bool compare_exchange_strong(T& expected, T desired,
+                             memory_order order = memory_order::seq_cst) volatile noexcept;
+T fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order::seq_cst) volatile noexcept;
+T operator @\placeholdernc{op}@=(T operand) volatile noexcept;
+T* fetch_@\placeholdernc{key}@(ptrdiff_t operand, memory_order order = memory_order::seq_cst) volatile noexcept;
 \end{codeblock}
 
 \rSec2[depr.atomics.nonmembers]{Non-member functions}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1218,15 +1218,11 @@ namespace std {
   // \ref{tuple.helper}, tuple helper classes
   template<class T> struct tuple_size;                  // \notdef
   template<class T> struct tuple_size<const T>;
-  template<class T> struct tuple_size<volatile T>;
-  template<class T> struct tuple_size<const volatile T>;
 
   template<class... Types> struct tuple_size<tuple<Types...>>;
 
   template<size_t I, class T> struct tuple_element;     // \notdef
   template<size_t I, class T> struct tuple_element<I, const T>;
-  template<size_t I, class T> struct tuple_element<I, volatile T>;
-  template<size_t I, class T> struct tuple_element<I, const volatile T>;
 
   template<size_t I, class... Types>
     struct tuple_element<I, tuple<Types...>>;
@@ -2079,22 +2075,19 @@ where indexing is zero-based.
 \indexlibraryglobal{tuple_size}%
 \begin{itemdecl}
 template<class T> struct tuple_size<const T>;
-template<class T> struct tuple_size<volatile T>;
-template<class T> struct tuple_size<const volatile T>;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-Let \tcode{TS} denote \tcode{tuple_size<T>} of the \cv-unqualified type \tcode{T}.
+Let \tcode{TS} denote \tcode{tuple_size<T>} of the cv-unqualified type \tcode{T}.
 If the expression \tcode{TS::value} is well-formed
-when treated as an unevaluated operand, each
-of the three templates
-meets the \oldconcept{UnaryTypeTrait} requirements\iref{meta.rqmts}
+when treated as an unevaluated operand, then
+each specialization of the template meets the \oldconcept{Unary\-Type\-Trait} requirements\iref{meta.rqmts}
 with a base characteristic of
 \begin{codeblock}
 integral_constant<size_t, TS::value>
 \end{codeblock}
-Otherwise, they have no member \tcode{value}.
+Otherwise, it has no member \tcode{value}.
 
 \pnum
 Access checking is performed as if in a context
@@ -2110,7 +2103,7 @@ can result in the program being ill-formed.
 
 \pnum
 In addition to being available via inclusion of the \libheader{tuple} header,
-the three templates are available
+the template is available
 when any of the headers
 \libheaderref{array},
 \libheaderref{ranges},
@@ -2122,28 +2115,17 @@ are included.
 \indexlibraryglobal{tuple_element}%
 \begin{itemdecl}
 template<size_t I, class T> struct tuple_element<I, const T>;
-template<size_t I, class T> struct tuple_element<I, volatile T>;
-template<size_t I, class T> struct tuple_element<I, const volatile T>;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-Let \tcode{TE} denote \tcode{tuple_element_t<I, T>} of the \cv-unqualified type \tcode{T}. Then
-each of the three templates meets the \oldconcept{TransformationTrait}
-requirements\iref{meta.rqmts} with a member typedef \tcode{type} that names the following
-type:
-\begin{itemize}
-\item
-for the first specialization, \tcode{add_const_t<TE>},
-\item
-for the second specialization, \tcode{add_volatile_t<TE>}, and
-\item
-for the third specialization, \tcode{add_cv_t<TE>}.
-\end{itemize}
+Let \tcode{TE} denote \tcode{tuple_element_t<I, T>} of the cv-unqualified type \tcode{T}. Then
+each specialization of the template meets the \oldconcept{TransformationTrait} requirements\iref{meta.rqmts}
+with a member typedef \tcode{type} that names the type \tcode{add_const_t<TE>}.
 
 \pnum
 In addition to being available via inclusion of the \libheader{tuple} header,
-the three templates are available
+the template is available
 when any of the headers
 \libheaderref{array},
 \libheaderref{ranges},
@@ -3923,8 +3905,6 @@ namespace std {
   // \ref{variant.helper}, variant helper classes
   template<class T> struct variant_size;                        // \notdef
   template<class T> struct variant_size<const T>;
-  template<class T> struct variant_size<volatile T>;
-  template<class T> struct variant_size<const volatile T>;
   template<class T>
     inline constexpr size_t @\libglobal{variant_size_v}@ = variant_size<T>::value;
 
@@ -3933,8 +3913,6 @@ namespace std {
 
   template<size_t I, class T> struct variant_alternative;       // \notdef
   template<size_t I, class T> struct variant_alternative<I, const T>;
-  template<size_t I, class T> struct variant_alternative<I, volatile T>;
-  template<size_t I, class T> struct variant_alternative<I, const volatile T>;
   template<size_t I, class T>
     using @\libglobal{variant_alternative_t}@ = typename variant_alternative<I, T>::type;
 
@@ -4822,14 +4800,12 @@ with a base characteristic of \tcode{integral_constant<size_t, N>} for some \tco
 \indexlibraryglobal{variant_size}%
 \begin{itemdecl}
 template<class T> class variant_size<const T>;
-template<class T> class variant_size<volatile T>;
-template<class T> class variant_size<const volatile T>;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 Let \tcode{VS} denote \tcode{variant_size<T>} of the cv-unqualified
-type \tcode{T}. Then each of the three templates meets the
+type \tcode{T}. Then each specialization of the template meets the
 \oldconcept{UnaryTypeTrait} requirements\iref{meta.rqmts} with a
 base characteristic of \tcode{integral_constant<size_t, VS::value>}.
 \end{itemdescr}
@@ -4844,21 +4820,14 @@ template<class... Types>
 \indexlibraryglobal{variant_alternative}%
 \begin{itemdecl}
 template<size_t I, class T> class variant_alternative<I, const T>;
-template<size_t I, class T> class variant_alternative<I, volatile T>;
-template<size_t I, class T> class variant_alternative<I, const volatile T>;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 Let \tcode{VA} denote \tcode{variant_alternative<I, T>} of the
-cv-unqualified type \tcode{T}. Then each of the three templates
+cv-unqualified type \tcode{T}. Then each specialization of the template
 meets the \oldconcept{TransformationTrait} requirements\iref{meta.rqmts} with a
-member typedef \tcode{type} that names the following type:
-\begin{itemize}
-\item for the first specialization, \tcode{add_const_t<VA::type>},
-\item for the second specialization, \tcode{add_volatile_t<VA::type>}, and
-\item for the third specialization, \tcode{add_cv_t<VA::type>}.
-\end{itemize}
+member typedef \tcode{type} that names the type \tcode{add_const_t<VA::type>}.
 \end{itemdescr}
 
 \indexlibraryglobal{variant_alternative}%


### PR DESCRIPTION
Also fixes NB CZ 004, CA 210, and US 211 (C++20 CD).

- atomic_init was already deprecated, with and without volatile

Fixes #3722 .
Fixes cplusplus/papers#589.
Fixes cplusplus/nbballot#4
Fixes cplusplus/nbballot#208.