### PR TITLE
LWG Poll 19: P0586R2 Safe integral comparisons

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -618,6 +618,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_incomplete_container_elements}@     201505L
   // also in \libheader{forward_list}, \libheader{list}, \libheader{vector}
 #define @\defnlibxname{cpp_lib_int_pow2}@                          202002L // also in \libheader{bit}
+#define @\defnlibxname{cpp_lib_integer_comparison_functions}@      202002L // also in \libheader{utility}
 #define @\defnlibxname{cpp_lib_integer_sequence}@                  201304L // also in \libheader{utility}
 #define @\defnlibxname{cpp_lib_integral_constant_callable}@        201304L // also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_interpolate}@                       201902L // also in \libheader{cmath}, \libheader{numeric}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -76,12 +76,29 @@ namespace std {
   // \ref{declval}, declval
   template<class T>
     add_rvalue_reference_t<T> declval() noexcept;   // as unevaluated operand
-@%
+
+  // \ref{utility.intcmp}, integer comparison functions
+  template<class T, class U>
+    constexpr bool cmp_equal(T t, U u) noexcept;
+  template<class T, class U>
+    constexpr bool cmp_not_equal(T t, U u) noexcept;
+
+  template<class T, class U>
+    constexpr bool cmp_less(T t, U u) noexcept;
+  template<class T, class U>
+    constexpr bool cmp_greater(T t, U u) noexcept;
+  template<class T, class U>
+    constexpr bool cmp_less_equal(T t, U u) noexcept;
+  template<class T, class U>
+    constexpr bool cmp_greater_equal(T t, U u) noexcept;
+
+  template<class R, class T>
+    constexpr bool in_range(T t) noexcept;
+
+  // \ref{intseq}, compile-time integer sequences%
 \indexlibraryglobal{index_sequence}%
 \indexlibraryglobal{make_index_sequence}%
-\indexlibraryglobal{index_sequence_for}%
-@
-  // \ref{intseq}, Compile-time integer sequences
+\indexlibraryglobal{index_sequence_for}
   template<class T, T...>
     struct integer_sequence;
   template<size_t... I>
@@ -405,6 +422,143 @@ declares a function template \tcode{convert} which only participates in overload
 type \tcode{From} can be explicitly converted to type \tcode{To}. For another example see class
 template \tcode{common_type}\iref{meta.trans.other}.
 \end{example}
+
+\rSec2[utility.intcmp]{Integer comparison functions}
+
+\indexlibraryglobal{cmp_equal}%
+\begin{itemdecl}
+template<class T, class U>
+  constexpr bool cmp_equal(T t, U u) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\mandates
+Both \tcode{T} and \tcode{U} are standard integer types or
+extended integer types\iref{basic.fundamental}.
+
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+using UT = make_unsigned_t<T>;
+using UU = make_unsigned_t<U>;
+if constexpr (is_signed_v<T> == is_signed_v<U>)
+  return t == u;
+else if constexpr (is_signed_v<T>)
+  return t < 0 ? false : UT(t) == u;
+else
+  return u < 0 ? false : t == UU(u);
+\end{codeblock}
+\end{itemdescr}
+
+\indexlibraryglobal{cmp_not_equal}%
+\begin{itemdecl}
+template<class T, class U>
+  constexpr bool cmp_not_equal(T t, U u) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return !cmp_equal(t, u);}
+\end{itemdescr}
+
+\indexlibraryglobal{cmp_less}%
+\begin{itemdecl}
+template<class T, class U>
+  constexpr bool cmp_less(T t, U u) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\mandates
+Both \tcode{T} and \tcode{U} are standard integer types or
+extended integer types\iref{basic.fundamental}.
+
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+using UT = make_unsigned_t<T>;
+using UU = make_unsigned_t<U>;
+if constexpr (is_signed_v<T> == is_signed_v<U>)
+  return t < u;
+else if constexpr (is_signed_v<T>)
+  return t < 0 ? true : UT(t) < u;
+else
+  return u < 0 ? false : t < UU(u);
+\end{codeblock}
+\end{itemdescr}
+
+\indexlibraryglobal{cmp_greater}%
+\begin{itemdecl}
+template<class T, class U>
+  constexpr bool cmp_greater(T t, U u) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return cmp_less(u, t);}
+\end{itemdescr}
+
+\indexlibraryglobal{cmp_less_equal}%
+\begin{itemdecl}
+template<class T, class U>
+  constexpr bool cmp_less_equal(T t, U u) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return !cmp_greater(t, u);}
+\end{itemdescr}
+
+\indexlibraryglobal{cmp_greater_equal}%
+\begin{itemdecl}
+template<class T, class U>
+  constexpr bool cmp_greater_equal(T t, U u) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return !cmp_less(t, u);}
+\end{itemdescr}
+
+\indexlibraryglobal{in_range}%
+\begin{itemdecl}
+template<class R, class T>
+  constexpr bool in_range(T t) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\mandates
+Both \tcode{T} and \tcode{R} are standard integer types or
+extended integer types\iref{basic.fundamental}.
+
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+return cmp_greater_equal(t, numeric_limits<R>::min()) &&
+       cmp_less_equal(t, numeric_limits<R>::max());
+\end{codeblock}
+\end{itemdescr}
+
+\pnum
+\begin{note}
+These function templates cannot be used to compare
+\tcode{byte},
+\tcode{char},
+\tcode{char8_t},
+\tcode{char16_t},
+\tcode{char32_t},
+\tcode{wchar_t}, and
+\tcode{bool}.
+\end{note}
 
 \rSec1[intseq]{Compile-time integer sequences}
 


### PR DESCRIPTION
Also fixes NB DE 208 (C++20 CD).

Fixes #3721. 
Fixes cplusplus/papers#259.
Fixes cplusplus/nbballot#206.