### PR TITLE
LWG Poll 15: P1956R1 On the names of low-level bit manipulation functions

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -1286,13 +1286,13 @@ namespace std {
 
   // \ref{bit.pow.two}, integral powers of 2
   template<class T>
-    constexpr bool ispow2(T x) noexcept;
+    constexpr bool has_single_bit(T x) noexcept;
   template<class T>
-    constexpr T ceil2(T x);
+    constexpr T bit_ceil(T x);
   template<class T>
-    constexpr T floor2(T x) noexcept;
+    constexpr T bit_floor(T x) noexcept;
   template<class T>
-    constexpr T log2p1(T x) noexcept;
+    constexpr T bit_width(T x) noexcept;
 
   // \ref{bit.rotate}, rotating
   template<class T>
@@ -1366,10 +1366,10 @@ of \tcode{To} and \tcode{From} are types \tcode{T} such that:
 
 \rSec2[bit.pow.two]{Integral powers of 2}
 
-\indexlibraryglobal{ispow2}%
+\indexlibraryglobal{has_single_bit}%
 \begin{itemdecl}
 template<class T>
-  constexpr bool ispow2(T x) noexcept;
+  constexpr bool has_single_bit(T x) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1384,10 +1384,10 @@ template<class T>
 
 \end{itemdescr}
 
-\indexlibraryglobal{ceil2}%
+\indexlibraryglobal{bit_ceil}%
 \begin{itemdecl}
 template<class T>
-  constexpr T ceil2(T x);
+  constexpr T bit_ceil(T x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1417,10 +1417,10 @@ that violates the precondition in the \expects element
 is not a core constant expression\iref{expr.const}.
 \end{itemdescr}
 
-\indexlibraryglobal{floor2}%
+\indexlibraryglobal{bit_floor}%
 \begin{itemdecl}
 template<class T>
-  constexpr T floor2(T x) noexcept;
+  constexpr T bit_floor(T x) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1432,14 +1432,14 @@ template<class T>
 \returns
 If \tcode{x == 0}, \tcode{0};
 otherwise the maximal value \tcode{y}
-such that \tcode{ispow2(y)} is \tcode{true} and \tcode{y <= x}.
+such that \tcode{has_single_bit(y)} is \tcode{true} and \tcode{y <= x}.
 
 \end{itemdescr}
 
-\indexlibraryglobal{log2p1}%
+\indexlibraryglobal{bit_width}%
 \begin{itemdecl}
 template<class T>
-  constexpr T log2p1(T x) noexcept;
+  constexpr T bit_width(T x) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/support.tex
+++ b/source/support.tex
@@ -617,7 +617,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_hypot}@                             201603L // also in \libheader{cmath}
 #define @\defnlibxname{cpp_lib_incomplete_container_elements}@     201505L
   // also in \libheader{forward_list}, \libheader{list}, \libheader{vector}
-#define @\defnlibxname{cpp_lib_int_pow2}@                          201806L // also in \libheader{bit}
+#define @\defnlibxname{cpp_lib_int_pow2}@                          202002L // also in \libheader{bit}
 #define @\defnlibxname{cpp_lib_integer_sequence}@                  201304L // also in \libheader{utility}
 #define @\defnlibxname{cpp_lib_integral_constant_callable}@        201304L // also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_interpolate}@                       201902L // also in \libheader{cmath}, \libheader{numeric}


### PR DESCRIPTION
Also fixes NB PL 326, US 327, GB 332, US 328, and GB 331 (C++20 CD).

Fixes #3717. 
Fixes cplusplus/papers#733.
Fixes cplusplus/nbballot#322.
Fixes cplusplus/nbballot#323.
Fixes cplusplus/nbballot#328.
Fixes cplusplus/nbballot#324.
Fixes cplusplus/nbballot#327.