### PR TITLE
CWG Poll 1: P2103R0 (Core Language Changes for NB Comments at the February, 2020 (Prague) meeting

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3310,7 +3310,11 @@ at the storage location which the original object occupied, a pointer
 that pointed to the original object, a reference that referred to the
 original object, or the name of the original object will automatically
 refer to the new object and, once the lifetime of the new object has
-started, can be used to manipulate the new object, if:
+started, can be used to manipulate the new object, if
+the original object is transparently replaceable (see below)
+by the new object.
+An original object is \defn{transparently replaceable}
+by a new object if:
 \begin{itemize}
 \item the storage for the new object exactly overlays the storage
 location which the original object occupied, and
@@ -3323,7 +3327,14 @@ a complete object that is const-qualified nor
 a subobject of such an object, and
 
 \item neither the original object nor the new object
-is a potentially-overlapping subobject\iref{intro.object}.
+is a potentially-overlapping subobject\iref{intro.object}, and
+
+\item neither the original object nor the new object are subobjects
+or both are subobjects, and
+
+\item the (unique) object (if any) that contains the original object
+as a subobject\iref{intro.object} is transparently replaceable by
+the (unique) object (if any) that contains the new object.
 \end{itemize}
 \begin{example}
 \begin{codeblock}

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2603,28 +2603,15 @@ of a sequence of declarations.
 
 \begin{bnf}
 \nontermdef{translation-unit}\br
-    \opt{top-level-declaration-seq}\br
-    \opt{global-module-fragment} module-declaration \opt{top-level-declaration-seq} \opt{private-module-fragment}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{top-level-declaration-seq}\br
-    top-level-declaration\br
-    top-level-declaration-seq top-level-declaration
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{top-level-declaration}\br
-    module-import-declaration\br
-    declaration
+    \opt{declaration-seq}\br
+    \opt{global-module-fragment} module-declaration \opt{declaration-seq} \opt{private-module-fragment}
 \end{bnf}
 
 \pnum
 A token sequence beginning with
 \opt{\tcode{export}} \tcode{module}
 and not immediately followed by \tcode{::}
-is never interpreted as the \grammarterm{declaration}
-of a \grammarterm{top-level-declaration}.
+is never interpreted as a \grammarterm{declaration}.
 
 \pnum
 \indextext{linkage}%

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -30,7 +30,8 @@ the form
     linkage-specification\br
     namespace-definition\br
     empty-declaration\br
-    attribute-declaration
+    attribute-declaration\br
+    module-import-declaration
 \end{bnf}
 
 \begin{bnf}
@@ -8189,6 +8190,16 @@ extern "C" {
 }
 \end{codeblock}
 \end{example}
+
+\pnum
+A \grammarterm{module-import-declaration}
+shall not be directly contained in
+a \grammarterm{linkage-specification}.
+A \grammarterm{module-import-declaration} appearing in
+a linkage specification with other than \Cpp{} language linkage
+is conditionally-supported with
+\impldef{support for \grammarterm{module-import-declaration}s
+with non-\Cpp{} language linkage} semantics.
 
 \pnum
 \indextext{specification!linkage!nesting}%

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -261,12 +261,32 @@ name mangling and linking.
 \end{defnote}
 
 \indexdefn{signature}%
+\definition{signature}{defns.signature.friend}
+\defncontext{non-template friend function with trailing \grammarterm{requires-clause}}
+name,
+parameter-type-list\iref{dcl.fct},
+enclosing class,
+and
+trailing \grammarterm{requires-clause}\iref{dcl.decl}
+
+\indexdefn{signature}%
 \definition{signature}{defns.signature.templ}
 \defncontext{function template}
 name,
 parameter-type-list\iref{dcl.fct},
 enclosing namespace (if any),
 return type,
+\grammarterm{template-head},
+and
+trailing \grammarterm{requires-clause}\iref{dcl.decl} (if any)
+
+\indexdefn{signature}%
+\definition{signature}{defns.signature.templ.friend}
+\defncontext{friend function template with constraint involving enclosing template parameters}
+name,
+parameter-type-list\iref{dcl.fct},
+return type,
+enclosing class,
 \grammarterm{template-head},
 and
 trailing \grammarterm{requires-clause}\iref{dcl.decl} (if any)

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -309,8 +309,8 @@ are locale-specific.%
 
 \pnum
 Each preprocessing token that is converted to a token\iref{lex.token}
-shall have the lexical form of a keyword, an identifier, a literal, an
-operator, or a punctuator.
+shall have the lexical form of a keyword, an identifier, a literal,
+or an operator or punctuator.
 
 \pnum
 A preprocessing token is the minimal lexical element of the language in translation
@@ -457,8 +457,7 @@ The set of alternative tokens is defined in
     identifier\br
     keyword\br
     literal\br
-    operator\br
-    punctuator
+    operator-or-punctuator
 \end{bnf}
 
 \pnum
@@ -848,8 +847,7 @@ is reserved for future use.
 Furthermore, the alternative representations shown in
 \tref{lex.key.digraph} for certain operators and
 punctuators\iref{lex.digraph} are reserved and shall not be used
-otherwise:
-
+otherwise.
 
 \begin{floattable}{Alternative representations}{lex.key.digraph}
 {llllll}
@@ -866,16 +864,28 @@ otherwise:
 \indextext{operator|(}%
 \indextext{punctuator|(}%
 The lexical representation of \Cpp{} programs includes a number of
-preprocessing tokens which are used in the syntax of the preprocessor or
+preprocessing tokens that are used in the syntax of the preprocessor or
 are converted into tokens for operators and punctuators:
+
+\begin{bnf}
+\nontermdef{preprocessing-op-or-punc}\br
+    preprocessing-operator\br
+    operator-or-punctuator
+\end{bnf}
+
+\begin{bnf}
+\microtypesetup{protrusion=false}\obeyspaces
+\nontermdef{preprocessing-operator} \textnormal{one of}\br
+    \terminal{\#        \#\#       \%:       \%:\%:}
+\end{bnf}
 
 \begin{bnf}
 %% Ed. note: character protrusion would misalign various operators.
 \microtypesetup{protrusion=false}\obeyspaces
-\nontermdef{preprocessing-op-or-punc} \textnormal{one of}\br
-    \terminal{\{        \}        [        ]        \#        \#\#       (        )}\br
-    \terminal{<:       :>       <\%       \%>       \%:       \%:\%:     ;        :        ...}\br
-    \terminal{new      delete   ?        ::       .        .*       ->       ->*      \~}\br
+\nontermdef{operator-or-punctuator} \textnormal{one of}\br
+    \terminal{\{        \}        [        ]        (        )}\br
+    \terminal{<:       :>       <\%       \%>       ;        :        ...}\br
+    \terminal{?        ::       .        .*       ->       ->*      \~}\br
     \terminal{!        +        -        *        /        \%        \caret{}        \&        |}\br
     \terminal{=        +=       -=       *=       /=       \%=       \caret{}=       \&=       |=}\br
     \terminal{==       !=       <        >        <=       >=       <=>      \&\&       ||}\br
@@ -884,7 +894,7 @@ are converted into tokens for operators and punctuators:
     \terminal{and_eq   or_eq    xor_eq   not_eq}
 \end{bnf}
 
-Each \grammarterm{preprocessing-op-or-punc} is converted to a single token
+Each \grammarterm{operator-or-punctuator} is converted to a single token
 in translation phase 7\iref{lex.phases}.%
 \indextext{punctuator|)}%
 \indextext{operator|)}

--- a/source/modules.tex
+++ b/source/modules.tex
@@ -415,9 +415,11 @@ export namespace N {
 \end{bnf}
 
 \pnum
+A \grammarterm{module-import-declaration}
+shall only appear at global namespace scope.
 In a module unit, all \grammarterm{module-import-declaration}{s}
-shall precede all other \grammarterm{top-level-declaration}{s} in
-the \grammarterm{top-level-declaration-seq} of the
+shall precede all other \grammarterm{declaration}{s} in
+the \grammarterm{declaration-seq} of the
 \grammarterm{translation-unit}
 and of the \grammarterm{private-module-fragment} (if any).
 The optional \grammarterm{attribute-specifier-seq}
@@ -556,14 +558,14 @@ import M1;              // error: cyclic interface dependency $\mathtt{M3} \righ
 
 \begin{bnf}
 \nontermdef{global-module-fragment}\br
-    \keyword{module} \terminal{;} \opt{top-level-declaration-seq}
+    \keyword{module} \terminal{;} \opt{declaration-seq}
 \end{bnf}
 
 \pnum
 \begin{note}
 Prior to phase 4 of translation,
 only preprocessing directives can appear
-in the \grammarterm{top-level-declaration-seq}\iref{cpp.global.frag}.
+in the \grammarterm{declaration-seq}\iref{cpp.global.frag}.
 \end{note}
 
 \pnum
@@ -677,9 +679,9 @@ prior to this determination.
 \pnum
 A declaration \tcode{D} in a global module fragment of a module unit
 is \defnx{discarded}{discarded!declaration} if \tcode{D}
-is not decl-reachable from any \grammarterm{top-level-declaration}
-in the \grammarterm{top-level-declaration-seq}
-of the \grammarterm{translation unit}.
+is not decl-reachable from any \grammarterm{declaration}
+in the \grammarterm{declaration-seq}
+of the \grammarterm{translation-unit}.
 \begin{note}
 A discarded declaration is neither reachable
 nor visible to name lookup outside the module unit,
@@ -763,7 +765,7 @@ int c = use_h<int>();           // OK
 
 \begin{bnf}
 \nontermdef{private-module-fragment}\br
-    \keyword{module} \terminal{:} \keyword{private} \terminal{;} \opt{top-level-declaration-seq}
+    \keyword{module} \terminal{:} \keyword{private} \terminal{;} \opt{declaration-seq}
 \end{bnf}
 
 \pnum
@@ -854,7 +856,7 @@ the instantiation context of the enclosing specialization and,
 if the template is defined in a module interface unit of a module $M$
 and the point of instantiation is not in a module interface unit of $M$,
 the point at the end of the
-\grammarterm{top-level-declaration-seq} of the
+\grammarterm{declaration-seq} of the
 primary module interface unit of $M$
 (prior to the \grammarterm{private-module-fragment}, if any).
 

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1746,6 +1746,38 @@ and those of
 \tcode{f7} are \tcode{C2<T> $\land$ C1<T>}.
 \end{example}
 
+\pnum
+When determining whether a given introduced
+\grammarterm{constraint-expression} $C_1$ of a declaration
+in an instantiated specialization of a templated class
+is equivalent\iref{temp.over.link} to the corresponding
+\grammarterm{constraint-expression} $C_2$ of a declaration
+outside the class body,
+$C_1$ is instantiated.
+If the instantiation results in an invalid expression,
+the \grammarterm{constraint-expression}s are not equivalent.
+\begin{note}
+This can happen when determining which member template is specialized
+by an explicit specialization declaration.
+\end{note}
+\begin{example}
+\begin{codeblock}
+template <class T> concept C = true;
+template <class T> struct A {
+  template <class U> U f(U) requires C<typename T::type>;   // \#1
+  template <class U> U f(U) requires C<T>;                  // \#2
+};
+
+template <> template <class U>
+U A<int>::f(U u) requires C<int> { return u; }              // OK, specializes \#2
+\end{codeblock}
+Substituting \tcode{int} for \tcode{T} in \tcode{C<typename T::type>}
+produces an invalid expression, so the specialization does not match \#1.
+Substituting \tcode{int} for \tcode{T} in \tcode{C<T>} produces \tcode{C<int>},
+which is equivalent to the \grammarterm{constraint-expression} for the specialization,
+so it does match \#2.
+\end{example}
+
 \rSec2[temp.constr.normal]{Constraint normalization}
 \indextext{constraint!normalization|(}%
 
@@ -6258,7 +6290,8 @@ are not instantiated along with the specialization or function itself,
 even for a member function of a local class;
 substitution into the atomic constraints formed from them is instead performed
 as specified in \ref{temp.constr.decl} and \ref{temp.constr.atomic}
-when determining whether the constraints are satisfied.
+when determining whether the constraints are satisfied
+or as specified in \ref{temp.constr.decl} when comparing declarations.
 \begin{note}
 The satisfaction of constraints is determined during name lookup or overload
 resolution\iref{over.match}.

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3160,7 +3160,14 @@ the \tcode{inline}, \tcode{constexpr}, or \tcode{consteval} specifiers
 be used in such a declaration.
 
 \pnum
-A non-template friend declaration shall not have a \grammarterm{requires-clause}.
+A non-template friend declaration
+with a \grammarterm{requires-clause}
+shall be a definition.
+A friend function template
+with a constraint that depends on a template parameter from an enclosing template
+shall be a definition.
+Such a constrained friend function or function template declaration
+does not declare the same function or function template as a declaration in any other scope.
 
 \rSec2[temp.class.spec]{Class template partial specializations}
 

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1602,8 +1602,9 @@ An \defn{atomic constraint} is formed from
 an expression \tcode{E}
 and a mapping from the template parameters
 that appear within \tcode{E} to
-template arguments involving the
-template parameters of the constrained entity,
+template arguments that are formed via substitution during constraint normalization
+in the declaration of a constrained entity (and, therefore, can involve the
+unsubstituted template parameters of the constrained entity),
 called the \defn{parameter mapping}\iref{temp.constr.decl}.
 \begin{note}
 Atomic constraints are formed by constraint normalization\iref{temp.constr.normal}.
@@ -1612,13 +1613,68 @@ nor a logical \logop{OR} expression\iref{expr.log.or}.
 \end{note}
 
 \pnum
-Two atomic constraints are
+Two atomic constraints, $e_1$ and $e_2$, are
 \indextext{identical!atomic constraints|see{atomic constraint, identical}}%
 \defnx{identical}{atomic constraint!identical}
 if they are formed from the same
 \grammarterm{expression}
-and the targets of the parameter mappings are equivalent
-according to the rules for expressions described in \ref{temp.over.link}.
+and if, given a hypothetical template $A$
+whose \grammarterm{template-parameter-list} consists of
+\grammarterm{template-parameter}s corresponding and equivalent\iref{temp.over.link} to
+those mapped by the parameter mappings of the expression,
+a \grammarterm{template-id} naming $A$
+whose \grammarterm{template-argument}s are
+the targets of the parameter mapping of $e_1$
+is the same\iref{temp.type} as
+a \grammarterm{template-id} naming $A$
+whose \grammarterm{template-argument}s are
+the targets of the parameter mapping of $e_2$.
+\begin{note}
+The comparison of parameter mappings of atomic constraints
+operates in a manner similar to that of declaration matching
+with alias template substitution\iref{temp.alias}.
+\begin{example}
+\begin{codeblock}
+template <unsigned N> constexpr bool Atomic = true;
+template <unsigned N> concept C = Atomic<N>;
+template <unsigned N> concept Add1 = C<N + 1>;
+template <unsigned N> concept AddOne = C<N + 1>;
+template <unsigned M> void f()
+  requires Add1<2 * M>;
+template <unsigned M> int f()
+  requires AddOne<2 * M> && true;
+
+int x = f<0>();     // OK, the atomic constraints from concept \tcode{C} in both \tcode{f}s are \tcode{Atomic<N>}
+                    // with mapping similar to $\tcode{N} \mapsto \tcode{2 * M + 1}$
+
+template <unsigned N> struct WrapN;
+template <unsigned N> using Add1Ty = WrapN<N + 1>;
+template <unsigned N> using AddOneTy = WrapN<N + 1>;
+template <unsigned M> void g(Add1Ty<2 * M> *);
+template <unsigned M> void g(AddOneTy<2 * M> *);
+
+void h() {
+  g<0>(nullptr);    // OK, there is only one \tcode{g}
+}
+\end{codeblock}
+\end{example}
+This similarity includes the situation where a program is ill-formed, no diagnostic required,
+when the meaning of the program depends on whether two constructs are equivalent,
+and they are functionally equivalent but not equivalent.
+\begin{example}
+\begin{codeblock}
+template <unsigned N> void f2()
+  requires Add1<2 * N>;
+template <unsigned N> int f2()
+  requires Add1<N * 2> && true;
+void h2() {
+  f2<0>();          // ill-formed, no diagnostic required:
+                    // requires determination of subsumption between atomic constraints that are
+                    // functionally equivalent but not equivalent
+}
+\end{codeblock}
+\end{example}
+\end{note}
 
 \pnum
 To determine if an atomic constraint is

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -5505,10 +5505,10 @@ to the points of instantiation described above,
 \item
 for any such
 specialization that has a point of instantiation within the
-\grammarterm{top-level-declaration-seq} of the
-translation unit,
+\grammarterm{declaration-seq} of the
+\grammarterm{translation-unit},
 prior to the \grammarterm{private-module-fragment} (if any),
-the point after the \grammarterm{top-level-declaration-seq}
+the point after the \grammarterm{declaration-seq}
 of the \grammarterm{translation-unit}
 is also considered a point of instantiation,
 and


### PR DESCRIPTION
Fixes NB US028, US033, US041, CA104, CA107, US115, and US117 (C++20 CD).

Fixes #3685.
Also fixes cplusplus/nbballot#27.
Also fixes cplusplus/nbballot#32.
Also fixes cplusplus/nbballot#40.
Also fixes cplusplus/nbballot#103.
Also fixes cplusplus/nbballot#106.
Also fixes cplusplus/nbballot#114.
Also fixes cplusplus/nbballot#116.