### PR TITLE
[ostream] Fix poor grammar to be consistent with [istream]

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4277,10 +4277,10 @@ which may throw
 If one of these called functions throws an exception, then unless explicitly noted otherwise,
 the input function sets
 \tcode{badbit}
-in error state.
+in the error state.
 If
 \tcode{badbit}
-is on in
+is set in
 \tcode{exceptions()},
 the input function
 rethrows the exception without completing its actions, otherwise
@@ -4828,7 +4828,7 @@ an exception thrown while extracting characters from
 \tcode{*this}
 and
 \tcode{failbit}
-is on in
+is set in
 \tcode{exceptions()}\iref{iostate.flags},
 then the caught exception is rethrown.
 
@@ -5859,14 +5859,15 @@ and
 If one of these called functions throws an exception, then unless explicitly noted otherwise
 the output function sets
 \tcode{badbit}
-in error state.
+in the error state.
 If
 \tcode{badbit}
-is on in
+is set in
 \tcode{exceptions()},
 the output function
 rethrows the exception without completing its actions, otherwise
-it does not throw anything and treat as an error.
+it does not throw anything and proceeds as if the called function had returned
+a failure indication.
 
 \pnum
 \begin{note}
@@ -6388,9 +6389,9 @@ If the function inserts no characters, it calls
 If an exception was thrown while extracting a character,
 the function sets
 \tcode{failbit}
-in error state, and if
+in the error state, and if
 \tcode{failbit}
-is on in
+is set in
 \tcode{exceptions()}
 the caught exception is rethrown.
 


### PR DESCRIPTION
Also fix grammar in [istream], [istream.extractors] and
[ostream.inserters] to refer to "*the* error state", and use "is set in"
when talking about a bitmask element being set in a value of a bitmask
type.

Fixes #3333