### PR TITLE
[range.prim.cdata] Properly ranges::-qualify cdata

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -722,9 +722,9 @@ has pointer to object type.
 
 \rSec2[range.prim.cdata]{\tcode{ranges::cdata}}
 \pnum
-The name \tcode{cdata} denotes a customization point
+The name \tcode{ranges::cdata} denotes a customization point
 object\iref{customization.point.object}. The expression
-\tcode{ranges::cdata(E)} for a subexpression \tcode{E} of type \tcode{T}
+\tcode{ranges::\brk{}cdata(E)} for a subexpression \tcode{E} of type \tcode{T}
 is expression-equivalent to:
 \begin{itemize}
 \item \tcode{ranges::data(static_cast<const T\&>(E))} if \tcode{E} is an lvalue.


### PR DESCRIPTION
Which is the only remaining CPO not so fixed by #3752.