### PR TITLE
[atomics.nonmembers,diff.cpp17.dcl.dcl,library,version.syn] Replace non-code "C++" with "\Cpp{}"

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -3296,7 +3296,7 @@ If no such member function exists, the program is ill-formed.
 \pnum
 \begin{note}
 The non-member functions enable programmers to write code that can be
-compiled as either C or C++, for example in a shared header file.
+compiled as either C or \Cpp{}, for example in a shared header file.
 \end{note}
 
 \rSec1[atomics.flag]{Flag type and operations}

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2096,7 +2096,7 @@ can contain only C-compatible constructs.
 \rationale
 Necessary for implementability.
 \effect
-Valid C++ 2017 code may be ill-formed in this International Standard.
+Valid \CppXVII{} code may be ill-formed in this International Standard.
 \begin{codeblock}
 typedef struct {
   void f() {}           // ill-formed; previously well-formed
@@ -2110,7 +2110,7 @@ in different translation units.
 \rationale
 Required for modules support.
 \effect
-Valid C++ 2017 code may be ill-formed in this International Standard,
+Valid \CppXVII{} code may be ill-formed in this International Standard,
 with no diagnostic required.
 \begin{codeblock}
 // Translation unit 1

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -5,7 +5,7 @@
 
 \pnum
 This Clause describes the contents of the
-\defnx{\Cpp{} standard library}{library!C++ standard},
+\defnx{\Cpp{} standard library}{library!\Cpp{} standard},
 how a well-formed \Cpp{} program makes use of the library, and
 how a conforming implementation may provide the entities in the library.
 
@@ -1171,7 +1171,7 @@ file names\iref{cpp.include}.}
 
 \pnum
 The \Cpp{} standard library provides the
-\defnx{\Cpp{} library headers}{header!C++ library},
+\defnx{\Cpp{} library headers}{header!\Cpp{} library},
 shown in \tref{headers.cpp}.
 
 \begin{multicolfloattable}{\Cpp{} library headers}{headers.cpp}
@@ -2771,7 +2771,7 @@ Virtual member function signatures defined
 \indextext{function!virtual member}%
 for a base class in the \Cpp{} standard
 \indextext{class!base}%
-\indextext{library!C++ standard}%
+\indextext{library!\Cpp{} standard}%
 library may be overridden in a derived class defined in the program\iref{class.virtual}.
 
 \rSec3[replacement.functions]{Replacement functions}
@@ -2782,7 +2782,7 @@ library may be overridden in a derived class defined in the program\iref{class.v
 describe the behavior of numerous functions defined by
 the \Cpp{} standard library.
 Under some circumstances,
-\indextext{library!C++ standard}%
+\indextext{library!\Cpp{} standard}%
 however, certain of these function descriptions also apply to replacement functions defined
 in the program\iref{definitions}.
 
@@ -2929,7 +2929,7 @@ allowed for that component.
 Each of the following applies to all arguments
 \indextext{argument}%
 to functions defined in the \Cpp{} standard library,%
-\indextext{library!C++ standard}
+\indextext{library!\Cpp{} standard}
 unless explicitly stated otherwise.
 
 \begin{itemize}
@@ -3258,7 +3258,7 @@ name reserved to the implementation.
 Certain classes defined in the \Cpp{} standard library are required to be derived from
 other classes
 in the \Cpp{} standard library.
-\indextext{library!C++ standard}%
+\indextext{library!\Cpp{} standard}%
 An implementation may derive such a class directly from the required base or indirectly
 through a hierarchy of base classes with names reserved to the implementation.
 
@@ -3291,7 +3291,7 @@ unless otherwise specified.
 
 \pnum
 Any of the functions defined in the \Cpp{} standard library
-\indextext{library!C++ standard}%
+\indextext{library!\Cpp{} standard}%
 can report a failure by throwing an exception of a type
 described in its \throws paragraph,
 or of a type derived from a type named in the \throws paragraph
@@ -3319,7 +3319,7 @@ non-throwing exception specification.
 \pnum
 Functions defined in the
 \Cpp{} standard library
-\indextext{specifications!C++}%
+\indextext{specifications!\Cpp{}}%
 that do not have a \throws paragraph
 but do have a potentially-throwing exception specification
 may throw \impldef{exceptions thrown by standard library functions that have a

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -326,13 +326,13 @@ member functions\iref{class.this}.
 \definition{program-defined specialization}{defns.prog.def.spec}
 \indexdefn{specialization!program-defined}%
 explicit template specialization or partial specialization
-that is not part of the C++ standard library and
+that is not part of the \Cpp{} standard library and
 not defined by the implementation
 
 \definition{program-defined type}{defns.prog.def.type}
 \indexdefn{type!program-defined}%
 non-closure class type or enumeration type
-that is not part of the C++ standard library and
+that is not part of the \Cpp{} standard library and
 not defined by the implementation,
 or a closure type of a non-implementation-provided lambda expression,
 or an instantiation of a program-defined specialization

--- a/source/support.tex
+++ b/source/support.tex
@@ -540,7 +540,7 @@ arithmetic types\iref{basic.fundamental}.
 \pnum
 The header \libheaderdef{version}
 supplies implementation-dependent information
-about the C++ standard library
+about the \Cpp{} standard library
 (e.g., version number and release date).
 
 \pnum


### PR DESCRIPTION
Resolves #3794.
Index entries before/after:

![1582653884](https://user-images.githubusercontent.com/21071787/75273922-314e7800-57d8-11ea-84a0-b04dc2014d52.png) ![1582653925](https://user-images.githubusercontent.com/21071787/75273928-327fa500-57d8-11ea-8ef2-2c671b631009.png)
---
![1582653890](https://user-images.githubusercontent.com/21071787/75273924-31e70e80-57d8-11ea-88a5-e0f9504d4134.png) ![1582653931](https://user-images.githubusercontent.com/21071787/75273955-40352a80-57d8-11ea-9338-43cd77674a09.png)
---
![1582653895](https://user-images.githubusercontent.com/21071787/75273926-327fa500-57d8-11ea-88f9-d1b26dd6187c.png) ![1582653937](https://user-images.githubusercontent.com/21071787/75273956-40cdc100-57d8-11ea-8632-efe697edcbd6.png)
