### PR TITLE
[allocator.members] Replace SIZE_MAX with numeric_limits<size_t>::max()

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7980,7 +7980,8 @@ but not that of any of the array elements.
 
 \pnum
 \throws
-\tcode{bad_array_new_length} if \tcode{SIZE_MAX / sizeof(T) < n}, or
+\tcode{bad_array_new_length} if
+\tcode{numeric_limits<size_t>::max() / sizeof(T) < n}, or
 \tcode{bad_alloc} if the storage cannot be obtained.
 \end{itemdescr}
 


### PR DESCRIPTION
Resolves #3803.