### PR TITLE
[lib] Format true/false in code font conventionally

### DIFF
--- a/source/locales.tex
+++ b/source/locales.tex
@@ -4231,7 +4231,7 @@ initial elements of the format pattern, at least one white space character is re
 space is allowed but not required.
 If
 \tcode{(str.flags() \& str.showbase)}
-is false, the currency symbol is optional and is consumed only if
+is \tcode{false}, the currency symbol is optional and is consumed only if
 other characters are needed to complete the format;
 otherwise, the currency symbol is required.
 

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -3783,7 +3783,7 @@ two characters are equal if
 against a sequence of characters, comparison of a collating element
 range \tcode{c1-c2} against a character \tcode{c} is
 conducted as follows: if \tcode{flags() \& regex_constants::collate}
-is false then the character \tcode{c} is matched if \tcode{c1
+is \tcode{false} then the character \tcode{c} is matched if \tcode{c1
 <= c \&\& c <= c2}, otherwise \tcode{c} is matched in
 accordance with the following algorithm:
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -4093,7 +4093,7 @@ an argument other than a literal \tcode{0} is undefined.
 \pnum
 For the purposes of subclause \ref{cmp.categories},
 \defn{substitutability} is the property that \tcode{f(a) == f(b)} is \tcode{true}
-whenever \tcode{a == b} is true,
+whenever \tcode{a == b} is \tcode{true},
 where \tcode{f} denotes a function that reads only comparison-salient state
 that is accessible via the argument's public const members.
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -4438,7 +4438,7 @@ is \tcode{true} for all $i$.
 If \tcode{is_trivially_copy_constructible_v<$\tcode{T}_i$> \&\&}
 \tcode{is_trivially_copy_assignable_v<$\tcode{T}_i$> \&\&}
 \tcode{is_trivially_destructible_v<$\tcode{T}_i$>}
-is true for all $i$, this assignment operator is trivial.
+is \tcode{true} for all $i$, this assignment operator is trivial.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{variant}%
@@ -4480,7 +4480,7 @@ Otherwise, equivalent to \tcode{emplace<$j$>(get<$j$>(std::move(rhs)))}.
 If \tcode{is_trivially_move_constructible_v<$\tcode{T}_i$> \&\&}
 \tcode{is_trivially_move_assignable_v<$\tcode{T}_i$> \&\&}
 \tcode{is_trivially_destructible_v<$\tcode{T}_i$>}
-is true for all $i$, this assignment operator is trivial.
+is \tcode{true} for all $i$, this assignment operator is trivial.
 The expression inside \tcode{noexcept} is equivalent to:
 \tcode{is_nothrow_move_constructible_v<$\tcode{T}_i$> \&\& is_nothrow_move_assignable_v<$\tcode{T}_i$>} for all $i$.
 \begin{itemize}
@@ -14635,7 +14635,7 @@ In the text that follows:
 \pnum
 \mandates
 \tcode{is_constructible_v<FD, F> \&\& is_move_constructible_v<FD>}
-is true.
+is \tcode{true}.
 
 \pnum
 \expects
@@ -14687,7 +14687,7 @@ is_move_constructible_v<FD> &&
 (is_constructible_v<BoundArgs, Args> && ...) &&
 (is_move_constructible_v<BoundArgs> && ...)
 \end{codeblock}
-is true.
+is \tcode{true}.
 
 \pnum
 \expects


### PR DESCRIPTION
These are conventionally wrapped in `\tcode{}`