### PR TITLE
[utility.syn] Index in-place construction types

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -162,9 +162,7 @@ namespace std {
   template<class T2, class T1>
     constexpr const T2&& get(const pair<T1, T2>&& p) noexcept;
 
-  // \ref{pair.piecewise}, pair piecewise construction%
-\indexlibraryglobal{piecewise_construct_t}%
-\indexlibraryglobal{piecewise_construct}
+  // \ref{pair.piecewise}, pair piecewise construction
   struct piecewise_construct_t {
     explicit piecewise_construct_t() = default;
   };

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -162,23 +162,33 @@ namespace std {
   template<class T2, class T1>
     constexpr const T2&& get(const pair<T1, T2>&& p) noexcept;
 
-  // \ref{pair.piecewise}, pair piecewise construction
+  // \ref{pair.piecewise}, pair piecewise construction%
+\indexlibraryglobal{piecewise_construct_t}%
+\indexlibraryglobal{piecewise_construct}
   struct piecewise_construct_t {
     explicit piecewise_construct_t() = default;
   };
   inline constexpr piecewise_construct_t piecewise_construct{};
   template<class... Types> class tuple;         // defined in \libheaderref{tuple}
 
-  // in-place construction
+  // in-place construction%
+\indexlibraryglobal{in_place_t}%
+\indexlibraryglobal{in_place}%
+\indexlibraryglobal{in_place_type_t}%
+\indexlibraryglobal{in_place_type}%
+\indexlibraryglobal{in_place_index_t}%
+\indexlibraryglobal{in_place_index}
   struct in_place_t {
     explicit in_place_t() = default;
   };
   inline constexpr in_place_t in_place{};
+
   template<class T>
     struct in_place_type_t {
       explicit in_place_type_t() = default;
     };
   template<class T> inline constexpr in_place_type_t<T> in_place_type{};
+
   template<size_t I>
     struct in_place_index_t {
       explicit in_place_index_t() = default;


### PR DESCRIPTION
Add index entries for the inplace constructuction tag types
and values, as they exist only in the header synopsis.