### PR TITLE
[class.friend] Add cross-reference for the namespace of the friend

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -5177,7 +5177,8 @@ R<int> Ri;                      // OK: \tcode{"friend int;"} is ignored
 \pnum
 \indextext{friend function!linkage of}%
 A function first declared in a friend declaration
-has the linkage of the namespace of which it is a member\iref{basic.link}.
+has the linkage of the namespace of which it is a member~(\ref{basic.link},
+\ref{namespace.memdef}).
 Otherwise, the function retains its previous linkage\iref{dcl.stc}.
 
 \pnum


### PR DESCRIPTION
The cross-reference for "linkage of the namespace of which it is a member" is useful for determining the linkage if the namespace is known; however, there was no cross-reference to assist with determining the namespace.

A cross-reference to [namespace.memdef] is added.