### PR TITLE
[expr.sizeof] Incorrect use of \term

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4538,8 +4538,8 @@ In particular, \tcode{sizeof(bool)}, \tcode{sizeof(char16_t)},
 implementation-defined.\footnote{\tcode{sizeof(bool)} is not required to be \tcode{1}.}
 \end{note}
 \begin{note}
-See~\ref{intro.memory} for the definition of \term{byte}
-and~\ref{basic.types} for the definition of \term{object representation}.
+See~\ref{intro.memory} for the definition of byte
+and~\ref{basic.types} for the definition of object representation.
 \end{note}
 
 \pnum


### PR DESCRIPTION
The problem and fix here is obvious.