### PR TITLE
[time.format] Add/fix region-index entry for "format"

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -10418,7 +10418,6 @@ strong_ordering operator<=>(const time_zone_link& x, const time_zone_link& y) no
 
 \rSec1[time.format]{Formatting}
 \indexlibrary{\idxcode{format}|)}%
-%% See also FIXME below
 
 \pnum
 Each \tcode{formatter}\iref{format.formatter} specialization
@@ -10940,7 +10939,6 @@ struct formatter<chrono::zoned_time<Duration, TimeZonePtr>, charT>
 };
 \end{codeblock}
 
-% FIXME: Decide how to index this. This template-id is a lie.
 \indexlibrarymember{format}{formatter<chrono::zoned_time>}%
 \begin{itemdecl}
 template<class FormatContext>

--- a/source/time.tex
+++ b/source/time.tex
@@ -10417,6 +10417,8 @@ strong_ordering operator<=>(const time_zone_link& x, const time_zone_link& y) no
 \end{itemdescr}
 
 \rSec1[time.format]{Formatting}
+\indexlibrary{\idxcode{format}|)}%
+%% See also FIXME below
 
 \pnum
 Each \tcode{formatter}\iref{format.formatter} specialization


### PR DESCRIPTION
I can't tell what the perceived problem behind the `FIXME` was; I'd welcome feedback; @AlisdairM?