### PR TITLE
[conv.ptr] Fix unclear specification of derived-to-base conversions for null pointers

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1021,14 +1021,15 @@ class of \tcode{D}, or a base class of a virtual base class of
 \tcode{D}, a program that necessitates this conversion is ill-formed.
 The result of the conversion refers to the same member as the pointer to
 member before the conversion took place, but it refers to the base class
-member as if it were a member of the derived class. The result refers to
-the member in \tcode{D}'s instance of \tcode{B}. Since the result has
+member as if it were a member of the derived class. If the source prvalue
+is a null member pointer value, the result is a null member pointer value;
+otherwise, the result refers to the member in the \tcode{B}
+base class subobject of \tcode{D}. Since the result has
 type ``pointer to member of \tcode{D} of type \cv{} \tcode{T}'',
 indirection through it with a \tcode{D} object is valid. The result is the same
 as if indirecting through the pointer to member of \tcode{B} with the
-\tcode{B} subobject of \tcode{D}. The null member pointer value is
-converted to the null member pointer value of the destination
-type.\footnote{The rule for conversion of pointers to members (from pointer to member
+\tcode{B} subobject of \tcode{D}.
+\footnote{The rule for conversion of pointers to members (from pointer to member
 of base to pointer to member of derived) appears inverted compared to
 the rule for pointers to objects (from pointer to derived to pointer to
 base)~(\ref{conv.ptr}, \ref{class.derived}). This inversion is
@@ -3772,7 +3773,7 @@ If \tcode{B} is a virtual base class of \tcode{D} or
 a base class of a virtual base class of \tcode{D}, or
 if no valid standard conversion from ``pointer to \tcode{D}''
 to ``pointer to \tcode{B}'' exists\iref{conv.ptr}, the program is ill-formed.
-The null pointer value\iref{conv.ptr} is converted
+A null pointer value\iref{conv.ptr} is converted
 to the null pointer value of the destination type. If the prvalue of type
 ``pointer to \cvqual{cv1} \tcode{B}'' points to a \tcode{B} that is
 actually a subobject of an object of type \tcode{D}, the resulting
@@ -3796,7 +3797,7 @@ If no valid standard conversion
 from ``pointer to member of \tcode{B} of type \tcode{T}''
 to ``pointer to member of \tcode{D} of type \tcode{T}''
 exists\iref{conv.mem}, the program is ill-formed.
-The null member pointer value\iref{conv.mem} is converted to the null
+A null member pointer value\iref{conv.mem} is converted to the null
 member pointer value of the destination type. If class \tcode{B}
 contains the original member, or is a base or derived class of the class
 containing the original member, the resulting pointer to member points
@@ -3943,7 +3944,7 @@ type and back, possibly with different cv-qualification, shall yield the origina
 pointer value.
 
 \pnum
-The null pointer value\iref{conv.ptr} is converted to the null pointer value
+A null pointer value\iref{conv.ptr} is converted to the null pointer value
 of the destination type.
 \begin{note}
 A null pointer constant of type \tcode{std::nullptr_t} cannot be converted to a
@@ -3960,7 +3961,7 @@ can be explicitly converted to a prvalue of a different type ``pointer to member
 function types or both object types.\footnote{\tcode{T1} and \tcode{T2} may have
 different \cv-qualifiers, subject to
 the overall restriction that a \tcode{reinterpret_cast} cannot cast away
-constness.} The null member pointer value\iref{conv.mem} is converted to the
+constness.} A null member pointer value\iref{conv.mem} is converted to the
 null member pointer value of the destination type. The result of this
 conversion is unspecified, except in the following cases:
 
@@ -4057,7 +4058,7 @@ to the result of applying the temporary materialization conversion\iref{conv.rva
 
 \pnum
 A null pointer value\iref{conv.ptr} is converted to the null pointer
-value of the destination type. The null member pointer
+value of the destination type. A null member pointer
 value\iref{conv.mem} is converted to the null member pointer value of
 the destination type.
 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -986,10 +986,10 @@ is a complete class type, can be converted to a prvalue of type ``pointer to
 of \tcode{D}. If \tcode{B} is an
 inaccessible\iref{class.access} or
 ambiguous\iref{class.member.lookup} base class of \tcode{D}, a program
-that necessitates this conversion is ill-formed. The result of the
-conversion is a pointer to the base class subobject of the derived class
-object. The null pointer value is converted to the null pointer value of
-the destination type.
+that necessitates this conversion is ill-formed.
+If the source prvalue is a null pointer value, the result is a
+null pointer value; otherwise, the result is a pointer to the
+base class subobject of the derived class object.
 
 \rSec2[conv.mem]{Pointer-to-member conversions}
 


### PR DESCRIPTION
[[conv.ptr] p3](http://eel.is/c++draft/conv.ptr#3) states:
> The result of the conversion is a pointer to the base class subobject of the derived class object. The null pointer value is converted to the null pointer value of the destination type.

While null pointer values are established as a singular value a pointer can have in [basic.compound], it is unique to the pointer type. Saying "The null pointer value" is rather unclear in what it refers to, as there is no single null pointer value.