### PR TITLE
Consistent null pointer value usage

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3954,7 +3954,7 @@ to an allocation function are unspecified.
 Even if the size of the space
 requested is zero, the request can fail. If the request succeeds, the
 value returned by a replaceable allocation function
-is a non-null pointer value\iref{conv.ptr}
+is a non-null pointer value\iref{basic.compound}
 \tcode{p0} different from any previously returned value \tcode{p1},
 unless that value \tcode{p1} was subsequently passed to a
 replaceable deallocation function.
@@ -3967,7 +3967,7 @@ returned from a request for zero size is undefined.\footnote{The intent is
 to have \tcode{operator new()} implementable by
 calling \tcode{std::malloc()} or \tcode{std::calloc()}, so the rules are
 substantially the same. \Cpp{} differs from C in requiring a zero request
-to return a non-null pointer.}
+to return a non-null pointer value.}
 
 \pnum
 For an allocation function other than
@@ -4087,7 +4087,7 @@ supplied in the standard library, the call has no effect.
 
 \pnum
 If the argument given to a deallocation function in the standard library
-is a pointer that is not the null pointer value\iref{conv.ptr}, the
+is a pointer that is not a null pointer value\iref{conv.ptr}, the
 deallocation function shall deallocate the storage referenced by the
 pointer, ending the duration of the region of storage.
 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5108,7 +5108,7 @@ the \grammarterm{new-expression} shall be a null pointer value.
 
 \pnum
 \begin{note}
-When the allocation function returns a value other than a null pointer value, it must be
+When the allocation function returns a non-null pointer value, it must be
 a pointer to a block of storage in which space for the object has been
 reserved. The block of storage is assumed to be appropriately aligned
 and of the requested size. The address of the created object will not
@@ -6125,7 +6125,7 @@ an object that is not an array element is
 considered to belong to a single-element array for this purpose.}
 the result of the comparison is unspecified.
 \item
-Otherwise, if both pointers are null pointer values, both point to the same
+Otherwise, if both pointer values are null, both point to the same
 \indextext{address}%
 function, or both represent the same address\iref{basic.compound},
 they compare equal.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3492,7 +3492,7 @@ class F : public E, public D { };
 void h() {
   F   f;
   A*  ap  = &f;                     // succeeds: finds unique \tcode{A}
-  D*  dp  = dynamic_cast<D*>(ap);   // fails: yields null; \tcode{f} has two \tcode{D} subobjects
+  D*  dp  = dynamic_cast<D*>(ap);   // fails: yields a null pointer value; \tcode{f} has two \tcode{D} subobjects
   E*  ep  = (E*)ap;                 // error: cast from virtual base
   E*  ep1 = dynamic_cast<E*>(ap);   // succeeds
 }
@@ -4865,7 +4865,7 @@ otherwise, an allocation function is not called; instead
 \item
 if the allocation function that would have been called
 has a non-throwing exception specification\iref{except.spec},
-the value of the \grammarterm{new-expression}
+the result of the \grammarterm{new-expression}
 is the null pointer value of the required result type;
 \item
 otherwise, the \grammarterm{new-expression} terminates by throwing an
@@ -5093,22 +5093,22 @@ it indicates failure to allocate storage by throwing a
 \indexlibraryglobal{bad_alloc}%
 \tcode{std::bad_alloc} exception~(\ref{basic.stc.dynamic.allocation},
 \ref{except}, \ref{bad.alloc});
-it returns a non-null pointer otherwise. If the allocation function
+it returns a non-null pointer value otherwise. If the allocation function
 has a non-throwing exception specification,
-it returns null to indicate failure to allocate storage
-and a non-null pointer otherwise.
+it returns a null pointer value to indicate failure to allocate storage
+and a non-null pointer value otherwise.
 \end{note}
 If the allocation function is a non-allocating
-form\iref{new.delete.placement} that returns null,
+form\iref{new.delete.placement} that returns a null pointer value,
 the behavior is undefined.
 Otherwise,
-if the allocation function returns null, initialization shall not be
-done, the deallocation function shall not be called, and the value of
-the \grammarterm{new-expression} shall be null.
+if the allocation function returns a null pointer value, initialization shall not be
+done, the deallocation function shall not be called, and the result of
+the \grammarterm{new-expression} shall be a null pointer value.
 
 \pnum
 \begin{note}
-When the allocation function returns a value other than null, it must be
+When the allocation function returns a value other than a null pointer value, it must be
 a pointer to a block of storage in which space for the object has been
 reserved. The block of storage is assumed to be appropriately aligned
 and of the requested size. The address of the created object will not
@@ -6125,7 +6125,7 @@ an object that is not an array element is
 considered to belong to a single-element array for this purpose.}
 the result of the comparison is unspecified.
 \item
-Otherwise, if the pointers are both null, both point to the same
+Otherwise, if both pointers are null pointer values, both point to the same
 \indextext{address}%
 function, or both represent the same address\iref{basic.compound},
 they compare equal.

--- a/source/future.tex
+++ b/source/future.tex
@@ -549,10 +549,10 @@ Each object of class
 has a
 \term{seekable area},
 delimited by the pointers \tcode{seeklow} and \tcode{seekhigh}.
-If \tcode{gnext} is a null pointer, the seekable area is undefined.
+If \tcode{gnext} is a null pointer value, the seekable area is undefined.
 Otherwise, \tcode{seeklow} equals \tcode{gbeg} and
 \tcode{seekhigh} is either \tcode{pend},
-if \tcode{pend} is not a null pointer, or \tcode{gend}.
+if \tcode{pend} is a non-null pointer value, or \tcode{gend}.
 
 \rSec3[depr.strstreambuf.cons]{\tcode{strstreambuf} constructors}
 
@@ -571,10 +571,10 @@ The postconditions of this function are indicated in \tref{depr.strstreambuf.con
 \begin{libtab2}{\tcode{strstreambuf(streamsize)} effects}{depr.strstreambuf.cons.sz}
 {ll}
 {Element}{Value}
-\tcode{strmode}	&	\tcode{dynamic}		\\
-\tcode{alsize}	&	\tcode{alsize_arg}	\\
-\tcode{palloc}	&	a null pointer		\\
-\tcode{pfree}	&	a null pointer		\\
+\tcode{strmode}	&	\tcode{dynamic}			\\
+\tcode{alsize}	&	\tcode{alsize_arg}		\\
+\tcode{palloc}	&	a null pointer value	\\
+\tcode{pfree}	&	a null pointer value	\\
 \end{libtab2}
 
 \indexlibraryctor{strstreambuf}%
@@ -621,8 +621,8 @@ The postconditions of this function are indicated in \tref{depr.strstreambuf.con
 {Element}{Value}
 \tcode{strmode}	&	0						\\
 \tcode{alsize}	&	an unspecified value	\\
-\tcode{palloc}	&	a null pointer			\\
-\tcode{pfree}	&	a null pointer			\\
+\tcode{palloc}	&	a null pointer value	\\
+\tcode{pfree}	&	a null pointer value	\\
 \end{libtab2}
 
 \pnum
@@ -651,7 +651,7 @@ The macro \tcode{INT_MAX} is defined in \libheaderref{climits}.}
 \end{itemize}
 
 \pnum
-If \tcode{pbeg_arg} is a null pointer, the function executes:
+If \tcode{pbeg_arg} is a null pointer value, the function executes:
 
 \begin{codeblock}
 setg(gnext_arg, gnext_arg, gnext_arg + N);
@@ -734,7 +734,7 @@ then returns the beginning pointer for the input sequence, \tcode{gbeg}.
 
 \pnum
 \remarks
-The return value can be a null pointer.
+The return value can be a null pointer value.
 \end{itemdescr}
 
 \indexlibrarymember{pcount}{strstreambuf}%
@@ -746,7 +746,7 @@ int pcount() const;
 \pnum
 \effects
 If the next pointer for the output sequence, \tcode{pnext}, is
-a null pointer, returns zero.
+a null pointer value, returns zero.
 Otherwise, returns the current
 effective length of the array object as the next pointer minus the beginning
 pointer for the output sequence, \tcode{pnext - pbeg}.
@@ -806,7 +806,7 @@ available is otherwise unspecified.%
 \indextext{unspecified}%
 \footnote{An implementation should consider \tcode{alsize} in making this
 decision.}
-If \tcode{palloc} is not a null pointer, the function calls
+If \tcode{palloc} is a non-null pointer value, the function calls
 \tcode{(*palloc)(n)}
 to allocate the new dynamic array object.
 Otherwise, it evaluates the expression
@@ -818,7 +818,7 @@ Otherwise, it sets \tcode{allocated} in \tcode{strmode}.
 \pnum
 To free a previously existing dynamic array object whose first
 element address is \tcode{p}:
-If \tcode{pfree} is not a null pointer,
+If \tcode{pfree} is a non-null pointer value,
 the function calls
 \tcode{(*pfree)(p)}.
 Otherwise, it evaluates the expression \tcode{delete[]p}.
@@ -905,7 +905,7 @@ signals success by returning
 \tcode{(unsigned char)\brk*gnext}.
 \item
 Otherwise, if
-the current write next pointer \tcode{pnext} is not a null pointer and
+the current write next pointer \tcode{pnext} is a non-null pointer value and
 is greater than the current read end pointer \tcode{gend},
 makes a
 \term{read position}
@@ -955,7 +955,7 @@ Otherwise	&
 \end{libtab2}
 
 \pnum
-For a sequence to be positioned, if its next pointer is a null pointer,
+For a sequence to be positioned, if its next pointer is a null pointer value,
 the positioning operation fails.
 Otherwise, the function determines \tcode{newoff} as indicated in
 \tref{depr.strstreambuf.seekoff.newoff}.
@@ -1018,7 +1018,7 @@ If the function positions neither sequence, the positioning operation fails.
 \end{itemize}
 
 \pnum
-For a sequence to be positioned, if its next pointer is a null pointer,
+For a sequence to be positioned, if its next pointer is a null pointer value,
 the positioning operation fails.
 Otherwise, the function determines \tcode{newoff} from
 \tcode{sp.offset()}:
@@ -1727,7 +1727,7 @@ template<class T> bool atomic_is_lock_free(const shared_ptr<T>* p);
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{p} shall not be null.
+\requires \tcode{p} shall be a non-null pointer value.
 
 \pnum
 \returns
@@ -1745,7 +1745,7 @@ template<class T> shared_ptr<T> atomic_load(const shared_ptr<T>* p);
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{p} shall not be null.
+\requires \tcode{p} shall be a non-null pointer value.
 
 \pnum
 \returns
@@ -1763,7 +1763,7 @@ template<class T> shared_ptr<T> atomic_load_explicit(const shared_ptr<T>* p, mem
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{p} shall not be null.
+\requires \tcode{p} shall be a non-null pointer value.
 
 \pnum
 \requires \tcode{mo} shall not be \tcode{memory_order_release} or \tcode{memory_order_acq_rel}.
@@ -1784,7 +1784,7 @@ template<class T> void atomic_store(shared_ptr<T>* p, shared_ptr<T> r);
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{p} shall not be null.
+\requires \tcode{p} shall be a non-null pointer value.
 
 \pnum
 \effects
@@ -1802,7 +1802,7 @@ template<class T> void atomic_store_explicit(shared_ptr<T>* p, shared_ptr<T> r, 
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{p} shall not be null.
+\requires \tcode{p} shall be a non-null pointer value.
 
 \pnum
 \requires \tcode{mo} shall not be \tcode{memory_order_acquire} or \tcode{memory_order_acq_rel}.
@@ -1823,7 +1823,7 @@ template<class T> shared_ptr<T> atomic_exchange(shared_ptr<T>* p, shared_ptr<T> 
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{p} shall not be null.
+\requires \tcode{p} shall be a non-null pointer value
 
 \pnum
 \returns
@@ -1842,7 +1842,7 @@ template<class T>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{p} shall not be null.
+\requires \tcode{p} shall be a non-null pointer value.
 
 \pnum
 \effects
@@ -1865,7 +1865,7 @@ template<class T>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{p} shall not be null and \tcode{v} shall not be null.
+\requires \tcode{p} and \tcode{v} shall be non-null pointer values.
 
 \pnum
 \returns
@@ -1907,7 +1907,7 @@ template<class T>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{p} shall not be null and \tcode{v} shall not be null.
+\requires \tcode{p} and \tcode{v} shall be non-null pointer values.
 The \tcode{failure} argument shall not be \tcode{memory_order_release} nor
 \tcode{memory_order_acq_rel}.
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -1408,7 +1408,7 @@ long& iword(int idx);
 
 \pnum
 \effects
-If \tcode{iarray} is a null pointer, allocates an array of
+If \tcode{iarray} is a null pointer value, allocates an array of
 \tcode{long}
 of unspecified size and stores a pointer to its first element in
 \tcode{iarray}.
@@ -1458,7 +1458,7 @@ void*& pword(int idx);
 
 \pnum
 \effects
-If \tcode{parray} is a null pointer, allocates an array of
+If \tcode{parray} is a null pointer value, allocates an array of
 pointers to \tcode{void} of unspecified size and stores a pointer to
 its
 first element in \tcode{parray}.
@@ -1466,7 +1466,7 @@ The function then extends the array
 pointed at by \tcode{parray} as necessary to include the element
 \tcode{parray[idx]}.
 Each newly allocated element of the array is initialized to a null
-pointer.
+pointer value.
 The reference returned is invalid after any other operations on the
 object.
 However, the value of the storage referred to is retained, so
@@ -1856,7 +1856,7 @@ The postconditions of this function are indicated in \tref{basic.ios.cons}.
 \tcode{tie()}   &
  \tcode{0}      \\
 \tcode{rdstate()} &
- \tcode{goodbit} if \tcode{sb} is not a null pointer, otherwise \tcode{badbit}. \\
+ \tcode{goodbit} if \tcode{sb} is a non-null pointer value, otherwise \tcode{badbit}. \\
 \tcode{exceptions()}  &
  \tcode{goodbit}  \\
 \tcode{flags()}   &
@@ -1870,9 +1870,9 @@ The postconditions of this function are indicated in \tref{basic.ios.cons}.
 \tcode{getloc()}  &
  a copy of the value returned by \tcode{locale()} \\
 \tcode{\textit{iarray}} &
- a null pointer   \\
+ a null pointer value   \\
 \tcode{\textit{parray}} &
- a null pointer   \\
+ a null pointer value   \\
 \end{libefftabvalue}
 \end{itemdescr}
 
@@ -1899,7 +1899,7 @@ basic_ostream<charT, traits>* tie(basic_ostream<charT, traits>* tiestr);
 \begin{itemdescr}
 \pnum
 \expects
-If \tcode{tiestr} is not null, \tcode{tiestr} is not reachable by
+If \tcode{tiestr} is a non-null pointer value, \tcode{tiestr} is not reachable by
 traversing the linked list of tied stream objects starting from
 \tcode{tiestr->tie()}.
 
@@ -2836,7 +2836,8 @@ alter the stream position.
 \end{itemize}
 
 \pnum
-Each sequence is characterized by three pointers which, if non-null,
+Each sequence is characterized by three pointers which,
+if they are non-null pointer values,
 all point into the same
 \tcode{charT}
 array object.
@@ -2870,14 +2871,14 @@ The following semantic constraints shall always apply for any set of
 three pointers for a sequence, using the pointer names given immediately above:
 \begin{itemize}
 \item
-If \tcode{xnext} is not a null pointer, then
-\tcode{xbeg} and \tcode{xend} shall also be non-null pointers
+If \tcode{xnext} is a non-null pointer value, then
+\tcode{xbeg} and \tcode{xend} shall also be non-null pointer values
 into the same
 \tcode{charT}
 array, as described above; otherwise, \tcode{xbeg} and
-\tcode{xend} shall also be null.
+\tcode{xend} shall also be a null pointer value.
 \item
-If \tcode{xnext} is not a null pointer and
+If \tcode{xnext} is a non-null pointer value and
 \tcode{xnext < xend}
 for an output sequence, then a
 \term{write position}
@@ -2888,7 +2889,7 @@ shall be assignable as the
 next element to write
 (to put, or to store a character value, into the sequence).
 \item
-If \tcode{xnext} is not a null pointer and
+If \tcode{xnext} is a non-null pointer value and
 \tcode{xbeg < xnext} for an input sequence,
 then a
 \term{putback position}
@@ -2898,7 +2899,7 @@ In this case,
 shall have a defined value and is the next (preceding) element
 to store a character that is put back into the input sequence.
 \item
-If \tcode{xnext} is not a null pointer and
+If \tcode{xnext} is a non-null pointer value and
 \tcode{xnext < xend} for an input sequence,
 then a
 \term{read position}
@@ -3039,7 +3040,7 @@ to assure that only objects for classes
 derived from this class may be constructed.}
 \begin{itemize}
 \item
-all pointer member objects to null pointers,
+all pointer member objects to null pointer values,
 \item
 the
 \tcode{getloc()}
@@ -3598,7 +3599,7 @@ int sync();
 Synchronizes the controlled sequences with the arrays.
 That is, if
 \tcode{pbase()}
-is non-null the characters between
+is a non-null pointer value, the characters between
 \tcode{pbase()}
 and
 \tcode{pptr()}
@@ -3706,7 +3707,7 @@ The public members of
 \tcode{basic_streambuf}
 call this virtual function only if
 \tcode{gptr()}
-is null or
+is a null pointer value or
 \tcode{gptr() >= egptr()}.
 
 \pnum
@@ -3717,7 +3718,7 @@ where \tcode{c} is the first
 of the
 \term{pending sequence},
 without moving the input sequence position past it.
-If the pending sequence is null then the function returns
+If the pending sequence is a null pointer value, the function returns
 \tcode{traits::eof()}
 to indicate failure.
 
@@ -3726,7 +3727,7 @@ The
 \term{pending sequence}
 of characters is defined as the concatenation of
 \begin{itemize}
-\item the empty sequence if \tcode{gptr()} is null, otherwise the
+\item the empty sequence if \tcode{gptr()} is a null pointer value, otherwise the
 characters in
 \range{gptr()}{egptr()},
 followed by
@@ -3745,7 +3746,7 @@ the next character that would be read from the input sequence.
 \pnum
 The
 \term{backup sequence}
-is the empty sequence if \tcode{eback()} is null, otherwise the
+is the empty sequence if \tcode{eback()} is a null pointer value, otherwise the
 characters in
 \range{eback()}{gptr()}.
 
@@ -3758,12 +3759,12 @@ and
 such that
 if the pending sequence is non-empty, then
 \tcode{egptr()}
-is non-null and
+is a non-null pointer value and
 the characters in \range{gptr()}{egptr()} are
 the characters in the pending sequence,
 otherwise
 either \tcode{gptr()}
-is null or
+is a null pointer value or
 \tcode{gptr() ==  egptr()}.
 
 \pnum
@@ -3771,7 +3772,7 @@ If
 \tcode{eback()}
 and
 \tcode{gptr()}
-are non-null then the function is not constrained as to their contents, but the ``usual backup condition'' is that either
+are non-null pointer values then the function is not constrained as to their contents, but the ``usual backup condition'' is that either
 \begin{itemize}
 \item
 the backup sequence contains at least
@@ -3839,7 +3840,7 @@ The public functions of
 \tcode{basic_streambuf}
 call this virtual function only when
 \tcode{gptr()}
-is null,
+is a null pointer value,
 \tcode{gptr() == eback()},
 or
 \tcode{traits::eq(traits::to_char_type(c), gptr()[-1])}
@@ -3936,7 +3937,7 @@ Consumes some initial subsequence of the characters of the
 The pending sequence is defined as the concatenation of
 \begin{itemize}
 \item
-the empty sequence if \tcode{pbase()} is null, otherwise the
+the empty sequence if \tcode{pbase()} is a null pointer value, otherwise the
 \tcode{pptr() - pbase()}
 characters beginning at
 \tcode{pbase()}, followed by
@@ -3995,7 +3996,7 @@ or
 \tcode{pbase()}
 and
 \tcode{pptr()}
-are both set to the same non-null value.
+are both set to the same non-null pointer value.
 \item
 The function may fail if either
 appending some character to the associated output stream fails or
@@ -4409,7 +4410,7 @@ prepares for formatted or
 unformatted input.
 First, if
 \tcode{is.tie()}
-is not a null pointer, the
+is a non-null pointer value, the
 function calls
 \indexlibraryglobal{flush}%
 \tcode{is.tie()->flush()}
@@ -4800,7 +4801,7 @@ basic_istream<charT, traits>& operator>>(basic_streambuf<charT, traits>* sb);
 \pnum
 \effects
 Behaves as an unformatted input function\iref{istream.unformatted}.
-If \tcode{sb} is null, calls
+If \tcode{sb} is a null pointer value, calls
 \tcode{setstate(fail\-bit)},
 which may throw
 \tcode{ios_base::failure}\iref{iostate.flags}.
@@ -5342,11 +5343,11 @@ which may throw an exception,
 and return.
 If
 \tcode{rdbuf()}
-is not null, calls
+is a non-null pointer value, calls
 \tcode{rdbuf()->sputbackc(c)}.
 If
 \tcode{rdbuf()}
-is null, or if
+is a null pointer value, or if
 \tcode{sputbackc}
 returns
 \tcode{traits::eof()},
@@ -5384,11 +5385,11 @@ which may throw an exception,
 and return.
 If
 \tcode{rdbuf()}
-is not null, calls
+is a non-null pointer value, calls
 \tcode{rdbuf()->sungetc()}.
 If
 \tcode{rdbuf()}
-is null, or if
+is a null pointer value, or if
 \tcode{sungetc}
 returns
 \tcode{traits::eof()},
@@ -5423,7 +5424,7 @@ value returned by subsequent calls to
 After constructing
 a sentry object, if
 \tcode{rdbuf()}
-is a null pointer, returns \tcode{-1}.
+is a null pointer value, returns \tcode{-1}.
 Otherwise, calls
 \tcode{rdbuf()->pubsync()}
 and, if that function returns \tcode{-1}
@@ -5988,7 +5989,7 @@ If
 is nonzero, prepares for formatted or unformatted output.
 If
 \tcode{os.tie()}
-is not a null pointer, calls
+is a non-null pointer value, calls
 \indexlibraryglobal{flush}%
 \tcode{os.tie()->flush()}.\footnote{The call
 \tcode{os.tie()->flush()}
@@ -6362,7 +6363,7 @@ basic_ostream<charT, traits>& operator<<(basic_streambuf<charT, traits>* sb);
 Behaves as an unformatted output function\iref{ostream.unformatted}.
 After the sentry object is
 constructed, if
-\tcode{sb} is null calls
+\tcode{sb} is a null pointer value, calls
 \tcode{setstate(badbit)}
 (which may throw
 \tcode{ios_base::failure}).
@@ -6476,7 +6477,7 @@ template<class traits>
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{s} is not a null pointer.
+\tcode{s} is a non-null pointer value.
 
 \pnum
 \effects
@@ -6615,7 +6616,7 @@ basic_ostream& flush();
 Behaves as an unformatted output function (as described above).
 If
 \tcode{rdbuf()}
-is not a null pointer,
+is a non-null pointer value,
 constructs a sentry object. If this object returns \tcode{true} when converted to a value of type \tcode{bool} the function
 calls
 \tcode{rdbuf()->pubsync()}.
@@ -7497,11 +7498,11 @@ Initializes the base class with
 \tcode{mode}
 with \tcode{which}.
 It is
-\impldef{whether sequence pointers are initialized to null pointers}
+\impldef{whether sequence pointers are initialized to null pointer values}
 whether the sequence pointers
 (\tcode{eback()}, \tcode{gptr()}, \tcode{egptr()},
 \tcode{pbase()}, \tcode{pptr()}, \tcode{epptr()})
-are initialized to null pointers.
+are initialized to null pointer values.
 
 \pnum
 \ensures
@@ -8091,7 +8092,7 @@ If the sequence's next pointer
 \tcode{gptr()}
 or
 \tcode{pptr()})
-is a null pointer and \tcode{newoff} is nonzero,
+is a null pointer value and \tcode{newoff} is nonzero,
 the positioning operation fails.
 
 \begin{libtab2}{\tcode{newoff} values}{stringbuf.seekoff.newoff}
@@ -9451,7 +9452,7 @@ basic_filebuf* open(const filesystem::path::value_type* s,
 \effects
 If
 \tcode{is_open() != false},
-returns a null pointer.
+returns a null pointer value.
 Otherwise,
 initializes the
 \tcode{filebuf}
@@ -9509,12 +9510,12 @@ are declared, in \libheaderref{cstdio}.}
 \pnum
 If the repositioning operation fails, calls
 \tcode{close()}
-and returns a null pointer to indicate failure.
+and returns a null pointer value to indicate failure.
 
 \pnum
 \returns
 \tcode{this}
-if successful, a null pointer otherwise.
+if successful, a null pointer value otherwise.
 \end{itemdescr}
 
 \indexlibrarymember{open}{basic_filebuf}%
@@ -9538,8 +9539,8 @@ basic_filebuf* close();
 \pnum
 \effects
 If
-\tcode{is_open() == false},
-returns a null pointer.
+\tcode{!is_open()},
+returns a null pointer value.
 If a put area exists, calls
 \tcode{overflow(traits::\brk{}eof())}
 to flush characters.
@@ -9559,23 +9560,23 @@ then calls
 characters and calls
 \tcode{overflow(traits::\brk{}eof())}
 again.
-Finally, regardless of whether any of the preceding calls fails or throws an
+Finally, regardless of whether any of the preceding calls fail or throw an
 exception, the function closes the file
-(as if by calling
+(as if by
 \indexlibraryglobal{fclose}%
 \tcode{fclose(file)}).
-If any of the calls made by the function, including \tcode{fclose}, fails,
-\tcode{close} fails by returning a null pointer. If one of these calls throws an
+If any of the calls made by the function fail, including \tcode{fclose},
+fails by returning a null pointer value. If one of these calls throws an
 exception, the exception is caught and rethrown after closing the file.
 
 \pnum
 \returns
 \tcode{this}
-on success, a null pointer otherwise.
+on success, a null pointer value otherwise.
 
 \pnum
 \ensures
-\tcode{is_open() == false}.
+\tcode{!is_open()}.
 \end{itemdescr}
 
 \rSec3[filebuf.virtuals]{Overridden virtual functions}
@@ -9797,7 +9798,7 @@ nonzero arguments}.
 \tcode{pbase()}
 and
 \tcode{pptr()}
-always return null
+always return a null pointer value
 and output to the file should appear as soon as possible.
 \end{itemdescr}
 
@@ -10060,7 +10061,7 @@ and \tcode{sb} with
 \tcode{basic_filebuf<charT, traits>()}\iref{filebuf.cons},
 then calls
 \tcode{rdbuf()->open(s, mode | ios_base::in)}.
-If that function returns a null pointer, calls
+If that function returns a null pointer value, calls
 \tcode{setstate(failbit)}.
 \end{itemdescr}
 
@@ -10156,7 +10157,7 @@ void open(const filesystem::path::value_type* s,
 \effects
 Calls
 \tcode{rdbuf()->open(s, mode | ios_base::in)}.
-If that function does not return a null pointer
+If that function returns a non-null pointer value,
 calls \tcode{clear()},
 otherwise calls
 \tcode{setstate(failbit)}
@@ -10185,9 +10186,9 @@ void close();
 \pnum
 \effects
 Calls
-\tcode{rdbuf()->close()}
-and, if that function returns
-a null pointer,
+\tcode{rdbuf()->close()};
+if that function returns
+a null pointer value,
 calls
 \tcode{setstate(failbit)}
 (which may throw
@@ -10293,7 +10294,7 @@ and \tcode{sb} with
 \tcode{basic_filebuf<charT, traits>()}\iref{filebuf.cons},
 then calls
 \tcode{rdbuf()->open(s, mode | ios_base::out)}.
-If that function returns a null pointer, calls
+If that function returns a null pointer value, calls
 \tcode{setstate(\brk{}fail\-bit)}.
 \end{itemdescr}
 
@@ -10389,7 +10390,7 @@ void open(const filesystem::path::value_type* s,
 \effects
 Calls
 \tcode{rdbuf()->open(s, mode | ios_base::out)}.
-If that function does not return a null pointer
+If that function returns a non-null pointer value,
 calls \tcode{clear()},
 otherwise calls
 \tcode{setstate(\brk{}failbit)}
@@ -10407,7 +10408,7 @@ void close();
 \effects
 Calls
 \tcode{rdbuf()->close()}
-and, if that function fails (returns a null pointer), calls
+and, if that function fails (returns a null pointer value), calls
 \tcode{setstate(\brk{}failbit)}
 (which may throw
 \tcode{ios_base::failure})\iref{iostate.flags}.
@@ -10537,7 +10538,7 @@ and
 \tcode{sb} with \tcode{basic_filebuf<charT, traits>()}.
 Then calls
 \tcode{rdbuf()->open(s, mode)}.
-If that function returns a null pointer, calls
+If that function returns a null pointer value, calls
 \tcode{setstate(failbit)}.
 \end{itemdescr}
 
@@ -10638,7 +10639,7 @@ void open(
 \effects
 Calls
 \tcode{rdbuf()->open(s, mode)}.
-If that function does not return a null pointer calls \tcode{clear()},
+If that function does not return a null pointer value, calls \tcode{clear()},
 otherwise calls
 \tcode{setstate(failbit)}
 (which may throw
@@ -10670,9 +10671,9 @@ void close();
 \pnum
 \effects
 Calls
-\tcode{rdbuf()->close()}
-and, if that function
-returns a null pointer,
+\tcode{rdbuf()->close()};
+if that function
+returns a null pointer value,
 calls
 \tcode{setstate(failbit)}
 (which may throw
@@ -12218,7 +12219,7 @@ for how the value types above and their encodings convert to
 
 \pnum
 Arguments of type \tcode{Source}
-shall not be null pointers.
+shall not be null pointer values.
 
 \rSec3[fs.path.member]{Members}
 

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -6337,7 +6337,7 @@ ostreambuf_iterator(ostream_type& s) noexcept;
 \pnum
 \expects
 \tcode{s.rdbuf()}
-is not a null pointer.
+is not a null pointer value.
 
 \pnum
 \effects
@@ -6354,7 +6354,7 @@ ostreambuf_iterator(streambuf_type* s) noexcept;
 \pnum
 \expects
 \tcode{s}
-is not a null pointer.
+is not a null pointer value.
 
 \pnum
 \effects

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -5558,7 +5558,7 @@ size_t mbrtoc8(char8_t* pc8, const char* s, size_t n, mbstate_t* ps);
 \begin{itemdescr}
 \pnum
 \effects
-If \tcode{s} is a null pointer,
+If \tcode{s} is a null pointer value,
 equivalent to \tcode{mbrtoc8(nullptr, "", 1, ps)}.
 Otherwise, the function inspects at most \tcode{n} bytes
 beginning with the byte pointed to by \tcode{s}
@@ -5567,7 +5567,7 @@ the next multibyte character (including any shift sequences).
 If the function determines
 that the next multibyte character is complete and valid,
 it determines the values of the corresponding UTF-8 code units and then,
-if \tcode{pc8} is not a null pointer,
+if \tcode{pc8} is a non-null pointer value,
 stores the value of the first (or only) such code unit
 in the object pointed to by \tcode{pc8}.
 Subsequent calls will store successive UTF-8 code units
@@ -5610,7 +5610,7 @@ size_t c8rtomb(char* s, char8_t c8, mbstate_t* ps);
 \begin{itemdescr}
 \pnum
 \effects
-If \tcode{s} is a null pointer, equivalent to
+If \tcode{s} is a null pointer value, equivalent to
 \tcode{c8rtomb(buf, u8'$\backslash$0', ps)}
 where \tcode{buf} is an internal buffer.
 Otherwise, if \tcode{c8} completes a sequence of valid UTF-8 code units,
@@ -5633,8 +5633,8 @@ the value of the macro \tcode{EILSEQ} is stored in \tcode{errno},
 
 \pnum
 \remarks
-Calls to \tcode{c8rtomb} with a null pointer argument for \tcode{s}
+Calls to \tcode{c8rtomb} with a null pointer value as an argument for \tcode{s}
 may introduce a data race\iref{res.on.data.races}
 with other calls to \tcode{c8rtomb}
-with a null pointer argument for \tcode{s}.
+with a null pointer value argument for \tcode{s}.
 \end{itemdescr}

--- a/source/support.tex
+++ b/source/support.tex
@@ -2111,7 +2111,7 @@ the first form is called otherwise.
 
 \pnum
 \required
-Return a non-null pointer to suitably aligned storage\iref{basic.stc.dynamic},
+Return a non-null pointer value pointing to suitably aligned storage\iref{basic.stc.dynamic},
 or else throw a
 \tcode{bad_alloc}
 \indexlibraryglobal{bad_alloc}%
@@ -2159,7 +2159,7 @@ function does not return.
 \effects
 Same as above, except that these are called by a placement version of a
 \grammarterm{new-expression}
-when a \Cpp{} program prefers a null pointer result as an error indication,
+when a \Cpp{} program prefers a null pointer value as an error indication,
 instead of a
 \tcode{bad_alloc}
 exception.
@@ -2170,8 +2170,8 @@ exception.
 
 \pnum
 \required
-Return a non-null pointer to suitably aligned storage\iref{basic.stc.dynamic},
-or else return a null pointer.
+Return a non-null pointer value pointing to suitably aligned storage\iref{basic.stc.dynamic},
+or else return a null pointer value.
 Each of these nothrow versions of
 \tcode{operator new}
 returns a pointer obtained as if
@@ -2186,7 +2186,7 @@ or \tcode{operator new(size, alignment)},
 respectively.
 If the call returns normally,
 returns the result of that call.
-Otherwise, returns a null pointer.
+Otherwise, returns a null pointer value.
 
 \pnum
 \begin{example}
@@ -2230,8 +2230,8 @@ replacing both deallocation functions when replacing the allocation function.
 
 \pnum
 \expects
-\tcode{ptr} is a null pointer or
-its value represents the address of
+\tcode{ptr} is a null pointer value or
+it represents the address of
 a block of memory allocated by
 an earlier call to a (possibly replaced)
 \tcode{operator new(std::size_t)}
@@ -2282,7 +2282,7 @@ See the note in the above \replaceable paragraph.
 
 \pnum
 \default
-If \tcode{ptr} is null, does nothing. Otherwise, reclaims the
+If \tcode{ptr} is a null pointer value, does nothing. Otherwise, reclaims the
 storage allocated by the earlier call to \tcode{operator new}.
 
 \pnum
@@ -2323,8 +2323,8 @@ placement version of the \grammarterm{new-expression} throws an exception.
 
 \pnum
 \expects
-\tcode{ptr} is a null pointer or
-its value represents the address of
+\tcode{ptr} is a null pointer value or
+it represents the address of
 a block of memory allocated by
 an earlier call to a (possibly replaced)
 \tcode{operator new(std::size_t)}
@@ -2420,7 +2420,7 @@ respectively.
 \effects
 Same as above, except that these are called by a placement version of a
 \grammarterm{new-expression}
-when a \Cpp{} program prefers a null pointer result as an error indication,
+when a \Cpp{} program prefers a null pointer value as an error indication,
 instead of a
 \tcode{bad_alloc}
 exception.
@@ -2431,8 +2431,8 @@ exception.
 
 \pnum
 \required
-Return a non-null pointer to suitably aligned storage\iref{basic.stc.dynamic},
-or else return a null pointer.
+Return a non-null pointer value pointing to suitably aligned storage\iref{basic.stc.dynamic},
+or else return a null pointer value.
 Each of these nothrow versions of
 \tcode{operator new[]}
 returns a pointer obtained as if
@@ -2447,7 +2447,7 @@ or \tcode{operator new[](size, alignment)},
 respectively.
 If the call returns normally,
 returns the result of that call.
-Otherwise, returns a null pointer.
+Otherwise, returns a null pointer value.
 \end{itemdescr}
 
 \indexlibrarymember{delete}{operator}%
@@ -2483,8 +2483,8 @@ replacing both deallocation functions when replacing the allocation function.
 
 \pnum
 \expects
-\tcode{ptr} is a null pointer or
-its value represents the address of
+\tcode{ptr} is a null pointer value or
+it represents the address of
 a block of memory allocated by
 an earlier call to a (possibly replaced)
 \tcode{operator new[](std::size_t)}
@@ -2556,8 +2556,8 @@ placement version of the array \grammarterm{new-expression} throws an exception.
 
 \pnum
 \expects
-\tcode{ptr} is a null pointer or
-its value represents the address of
+\tcode{ptr} is a null pointer value or
+it represents the address of
 a block of memory allocated by
 an earlier call to a (possibly replaced)
 \tcode{operator new[](std::size_t)}
@@ -2816,7 +2816,7 @@ The previous \tcode{new_handler}.
 
 \pnum
 \remarks
-The initial \tcode{new_handler} is a null pointer.
+The initial \tcode{new_handler} is a null pointer value.
 \end{itemdescr}
 
 \rSec3[get.new.handler]{\tcode{get_new_handler}}
@@ -3121,7 +3121,7 @@ namespace std {
 The class
 \tcode{bad_typeid}
 defines the type of objects
-thrown as exceptions by the implementation to report a null pointer
+thrown as exceptions by the implementation to report a null pointer value
 in a
 \tcode{typeid}
 expression\iref{expr.typeid}.
@@ -3713,7 +3713,7 @@ recursion.
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{p} is not a null pointer.
+\tcode{p} is not the null value.
 
 \pnum
 \throws
@@ -3796,7 +3796,7 @@ The constructor calls \tcode{current_exception()} and stores the returned value.
 \begin{itemdescr}
 \pnum
 \effects
-If \tcode{nested_ptr()} returns a null pointer, the function calls the function \tcode{std::terminate}.
+If \tcode{nested_ptr()} returns a null value, the function calls the function \tcode{std::terminate}.
 Otherwise, it throws the stored exception captured by \tcode{*this}.
 \end{itemdescr}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7386,7 +7386,7 @@ or a null pointer value.
 
 \pnum
 \effects
-If \tcode{p} is not null, the complete object referenced by \tcode{p}
+If \tcode{p} is a non-null pointer value, the complete object referenced by \tcode{p}
 is subsequently declared reachable\iref{basic.stc.dynamic.safety}.
 
 \pnum
@@ -7403,7 +7403,7 @@ template<class T> T* undeclare_reachable(T* p);
 \begin{itemdescr}
 \pnum
 \expects
-If \tcode{p} is not null, the complete object referenced by \tcode{p}
+If \tcode{p} is a non-null pointer value, the complete object referenced by \tcode{p}
 has been previously declared reachable, and is
 live\iref{basic.life} from the time of the call until the last
 \tcode{undeclare_reachable(p)} call on the object.
@@ -7539,7 +7539,7 @@ Otherwise, the function does nothing.
 
 \pnum
 \returns
-A null pointer if the requested aligned buffer
+A null pointer value if the requested aligned buffer
 would not fit into the available space, otherwise the adjusted value
 of \tcode{ptr}.
 
@@ -9920,7 +9920,7 @@ least until the ownership group of \tcode{r} is destroyed.
 \pnum
 \begin{note}
 This constructor allows creation of an empty
-\tcode{shared_ptr} instance with a non-null stored pointer.
+\tcode{shared_ptr} instance with a stored non-null pointer value.
 \end{note}
 \end{itemdescr}
 
@@ -10824,7 +10824,7 @@ The expression \tcode{dynamic_cast<typename shared_ptr<T>::element_type*>(r.get(
 \returns
 \begin{itemize}
 \item When \tcode{dynamic_cast<typename shared_ptr<T>::element_type*>(r.get())}
-  returns a non-null value \tcode{p},
+  returns a non-null pointer value \tcode{p},
   \tcode{shared_ptr<T>(\placeholder{R}, p)},
   where \tcode{\placeholder{R}} is \tcode{r} for the first overload, and
   \tcode{std::move(r)} for the second.
@@ -11674,7 +11674,7 @@ polymorphic_allocator(memory_resource* r);
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{r} is non-null.
+\tcode{r} is a non-null pointer value.
 
 \pnum
 \effects
@@ -11982,7 +11982,7 @@ memory_resource* set_default_resource(memory_resource* r) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-If \tcode{r} is non-null,
+If \tcode{r} is a non-null pointer value,
 sets the value of the default memory resource pointer to \tcode{r},
 otherwise sets the default memory resource pointer to \tcode{new_delete_resource()}.
 
@@ -15149,7 +15149,7 @@ template<class F> function(F f);
 \ensures
 \tcode{!*this} if any of the following hold:
 \begin{itemize}
-\item \tcode{f} is a null function pointer value.
+\item \tcode{f} is of function pointer type and has a null pointer value.
 \item \tcode{f} is a null member pointer value.
 \item \tcode{F} is an instance of the \tcode{function} class template, and
   \tcode{!f}.
@@ -15367,7 +15367,7 @@ template<class T> const T* target() const noexcept;
 \pnum
 \returns
 If \tcode{target_type() == typeid(T)}
-a pointer to the stored function target; otherwise a null pointer.
+a pointer to the stored function target; otherwise a null pointer value.
 \end{itemdescr}
 
 \rSec4[func.wrap.func.nullptr]{Null pointer comparison functions}
@@ -17977,7 +17977,7 @@ template<class S, class M>
 \tcode{true} if and only if
  \tcode{S} is a standard-layout type,
  \tcode{M} is an object type,
- \tcode{m} is not null,
+ \tcode{m} is a non-null member pointer value,
  and each object \tcode{s} of type \tcode{S}
  is pointer-interconvertible\iref{basic.compound}
  with its subobject \tcode{s.*m}.
@@ -17999,7 +17999,7 @@ template<class S1, class S2, class M1, class M2>
 \tcode{true} if and only if
  \tcode{S1} and \tcode{S2} are standard-layout types,
  \tcode{M1} and \tcode{M2} are object types,
- \tcode{m1} and \tcode{m2} are not null,
+ \tcode{m1} and \tcode{m2} are non-null member pointer values,
  and \tcode{m1} and \tcode{m2} point to corresponding members of
  the common initial sequence\iref{class.mem} of \tcode{S1} and \tcode{S2}.
 \end{itemdescr}


### PR DESCRIPTION
Continuing the crusade for consistent conventions, this pull request addresses the inconsistent (and incorrect) usage of constructs such as "null" and "null pointer" when referring to null pointer values. 

A few related changes are included:
- The incorrect use of "null pointer"/"null" in [support.exceptions]; replaced with "the null value" to account for fancy pointers.
- More of a nitpick, but the specifying the "result" of a new-expression sounds more correct than specifying the "value" of the new-expression. While these are synonymous, "result" sounds more correct as a new-expression performs an operation, as opposed to representing some static value. This was applied in http://eel.is/c++draft/expr.new#9.6.1 and http://eel.is/c++draft/expr.new#20.sentence-4

While on the topic, crosslinks linking [conv.ptr] at mentions of "null pointer value" should be changed to [basic.compound[.