### PR TITLE
[expr.ref] clarify access of non-static data members

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3274,8 +3274,8 @@ the named member of the class. The type of \tcode{E1.E2} is \tcode{T}.
 
 \item If \tcode{E2} is a non-static data member and the type of
 \tcode{E1} is ``\cvqual{cq1 vq1} \tcode{X}'', and the type of \tcode{E2}
-is ``\cvqual{cq2 vq2} \tcode{T}'', the expression designates the named
-member of the object designated by the first expression. If \tcode{E1}
+is ``\cvqual{cq2 vq2} \tcode{T}'', the expression designates the associated
+member subobject of the object designated by the first expression. If \tcode{E1}
 is an lvalue, then \tcode{E1.E2} is an lvalue;
 otherwise \tcode{E1.E2} is an xvalue.
 Let the notation \cvqual{vq12} stand for the ``union'' of

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3274,7 +3274,7 @@ the named member of the class. The type of \tcode{E1.E2} is \tcode{T}.
 
 \item If \tcode{E2} is a non-static data member and the type of
 \tcode{E1} is ``\cvqual{cq1 vq1} \tcode{X}'', and the type of \tcode{E2}
-is ``\cvqual{cq2 vq2} \tcode{T}'', the expression designates the associated
+is ``\cvqual{cq2 vq2} \tcode{T}'', the expression designates the corresponding
 member subobject of the object designated by the first expression. If \tcode{E1}
 is an lvalue, then \tcode{E1.E2} is an lvalue;
 otherwise \tcode{E1.E2} is an xvalue.


### PR DESCRIPTION
According to the definitions, objects don't have members, and member subobjects don't have names. The standard is somewhat unclear on how the member subobjects of an object of class type relate to the non-static data members of the class. This change helps clarify that there is a member subobject associated with each non-static data member.