### PR TITLE
[basic], [expr] Fix incorrect cross-references to [conv.ptr] for null pointer values

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3954,7 +3954,7 @@ to an allocation function are unspecified.
 Even if the size of the space
 requested is zero, the request can fail. If the request succeeds, the
 value returned by a replaceable allocation function
-is a non-null pointer value\iref{conv.ptr}
+is a non-null pointer value\iref{basic.compound}
 \tcode{p0} different from any previously returned value \tcode{p1},
 unless that value \tcode{p1} was subsequently passed to a
 replaceable deallocation function.
@@ -4087,7 +4087,7 @@ supplied in the standard library, the call has no effect.
 
 \pnum
 If the argument given to a deallocation function in the standard library
-is a pointer that is not the null pointer value\iref{conv.ptr}, the
+is a pointer that is not the null pointer value\iref{basic.compound}, the
 deallocation function shall deallocate the storage referenced by the
 pointer, ending the duration of the region of storage.
 
@@ -5240,7 +5240,7 @@ a \defn{pointer to} an object or function (the pointer is said to \defn{point} t
 a \defn{pointer past the end of} an object\iref{expr.add}, or
 \item
 \indextext{null pointer value|see{value, null pointer}}
-the \defnx{null pointer value}{value!null pointer}\iref{conv.ptr} for that type, or
+the \defnx{null pointer value}{value!null pointer} for that type, or
 \item
 \indextext{invalid pointer value|see{value, invalid pointer}}
 an \defnx{invalid pointer value}{value!invalid pointer}.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3531,7 +3531,7 @@ unary \tcode{*} operator to a pointer\footnote{If \tcode{p} is an expression of
 pointer type, then \tcode{*p},
 \tcode{(*p)}, \tcode{*(p)}, \tcode{((*p))}, \tcode{*((p))}, and so on
 all meet this requirement.}
-and the pointer is a null pointer value\iref{conv.ptr}, the
+and the pointer is a null pointer value\iref{basic.compound}, the
 \tcode{typeid} expression throws an exception\iref{except.throw} of
 a type that would match a handler of type
 \indextext{\idxcode{bad_typeid}}%
@@ -3773,7 +3773,7 @@ If \tcode{B} is a virtual base class of \tcode{D} or
 a base class of a virtual base class of \tcode{D}, or
 if no valid standard conversion from ``pointer to \tcode{D}''
 to ``pointer to \tcode{B}'' exists\iref{conv.ptr}, the program is ill-formed.
-The null pointer value\iref{conv.ptr} is converted
+The null pointer value\iref{basic.compound} is converted
 to the null pointer value of the destination type. If the prvalue of type
 ``pointer to \cvqual{cv1} \tcode{B}'' points to a \tcode{B} that is
 actually a subobject of an object of type \tcode{D}, the resulting
@@ -3944,7 +3944,7 @@ type and back, possibly with different cv-qualification, shall yield the origina
 pointer value.
 
 \pnum
-The null pointer value\iref{conv.ptr} is converted to the null pointer value
+The null pointer value\iref{basic.compound} is converted to the null pointer value
 of the destination type.
 \begin{note}
 A null pointer constant of type \tcode{std::nullptr_t} cannot be converted to a
@@ -4057,7 +4057,7 @@ to the original object if the operand is a glvalue and
 to the result of applying the temporary materialization conversion\iref{conv.rval} otherwise.
 
 \pnum
-A null pointer value\iref{conv.ptr} is converted to the null pointer
+A null pointer value\iref{basic.compound} is converted to the null pointer
 value of the destination type. The null member pointer
 value\iref{conv.mem} is converted to the null member pointer value of
 the destination type.


### PR DESCRIPTION
The definition of *null pointer value" was moved to [basic.compound], however, multiple cross-references still refer to [conv.ptr].