### PR TITLE
Use consistent terminology when referring to what a pointer to member points to

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4469,7 +4469,7 @@ was obtained through one of the following:
 \item
   a pointer-to-member operation\iref{expr.mptr.oper} using the \tcode{.*} operator
   where the left operand is one of these expressions and
-  the right operand is a pointer to data member of non-reference type,
+  the right operand is of pointer to data member type,
 \item
   a
   \begin{itemize}
@@ -5196,7 +5196,7 @@ Each distinct enumeration constitutes a different
 \defnx{pointers to non-static class members}{pointer to member},%
 \footnote{Static class members are objects or functions, and pointers to them are
 ordinary pointers to objects or functions.}
-which identify members of a given
+which \defn{designate} members of a given
 type within objects of a given class, \ref{dcl.mptr}.
 Pointers to data members and pointers to member functions are collectively
 called \term{pointer-to-member} types.

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3417,7 +3417,7 @@ shall appear only as:
 \begin{itemize}
 \item the function type for a non-static member function,
 
-\item the function type to which a pointer to member refers,
+\item the function type to which a pointer to member points,
 
 \item the top-level function type of a function typedef declaration
 or \grammarterm{alias-declaration},

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2921,8 +2921,9 @@ is ``\placeholder{derived-declarator-type-list}
 then the type of the identifier of
 \tcode{D}
 is ``\placeholder{derived-declarator-type-list} \grammarterm{cv-qualifier-seq} pointer to member of class
-\grammarterm{nested-name-specifier} of type
-\tcode{T}''.
+\grammarterm{nested-name-specifier} of type \tcode{T}''.
+\tcode{T} is known as the \defn{member type};
+it shall not be a reference type or ``\cv{}~\tcode{void}''.
 The optional \grammarterm{attribute-specifier-seq}\iref{dcl.attr.grammar} appertains to the
 pointer-to-member.
 
@@ -2987,11 +2988,8 @@ obj.*pmi = 7;       // assign \tcode{7} to an integer member of \tcode{obj}
 \end{example}
 
 \pnum
-A pointer to member shall not point to a static member
-of a class\iref{class.static},
-a member with reference type,
-or
-``\cv{}~\tcode{void}''.
+A pointer to member shall not designate a static member
+of a class\iref{class.static}.
 
 \pnum
 \begin{note}
@@ -3417,7 +3415,7 @@ shall appear only as:
 \begin{itemize}
 \item the function type for a non-static member function,
 
-\item the function type to which a pointer to member points,
+\item the member type\iref{dcl.mptr} of a pointer to member type,
 
 \item the top-level function type of a function typedef declaration
 or \grammarterm{alias-declaration},

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1020,9 +1020,9 @@ inaccessible\iref{class.access},
 ambiguous\iref{class.member.lookup}, or virtual\iref{class.mi} base
 class of \tcode{D}, or a base class of a virtual base class of
 \tcode{D}, a program that necessitates this conversion is ill-formed.
-The result of the conversion refers to the same member as the pointer to
-member before the conversion took place, but it refers to the base class
-member as if it were a member of the derived class. The result refers to
+The result of the conversion points to the same member as the pointer to
+member before the conversion took place, but it points to the base class
+member as if it were a member of the derived class. The result points to
 the member in \tcode{D}'s instance of \tcode{B}. Since the result has
 type ``pointer to member of \tcode{D} of type \cv{} \tcode{T}'',
 indirection through it with a \tcode{D} object is valid. The result is the same
@@ -2906,7 +2906,7 @@ the postfix expression shall be an
 implicit~(\ref{class.mfct.non-static}, \ref{class.static}) or explicit
 class member access\iref{expr.ref} whose \grammarterm{id-expression} is a
 function member name, or a pointer-to-member
-expression\iref{expr.mptr.oper} selecting a function member; the call is as a member of
+expression\iref{expr.mptr.oper} pointing to a function member; the call is as a member of
 the class object referred to by the
 object expression. In the case of an implicit class
 member access, the implied object is the one pointed to by \tcode{this}.
@@ -4186,7 +4186,7 @@ The result of the unary \tcode{\&} operator is a pointer to its operand.
 \item
 If the operand is a \grammarterm{qualified-id} naming a non-static or variant member \tcode{m}
 of some class \tcode{C} with type \tcode{T}, the result has type ``pointer to member
-of class \tcode{C} of type \tcode{T}'' and is a prvalue designating \tcode{C::m}.
+of class \tcode{C} of type \tcode{T}'' and is a prvalue pointing to \tcode{C::m}.
 \item
 Otherwise, if the operand is an lvalue of type \tcode{T},
 the resulting expression is a prvalue of type ``pointer to \tcode{T}''
@@ -5587,8 +5587,7 @@ of type ``pointer to member of \tcode{T}'' to its first operand, which shall be
 a glvalue
 of
 class \tcode{T} or of a class of which \tcode{T} is an unambiguous and
-accessible base class. The result is an object or a function of the type
-specified by the second operand.
+accessible base class. The result the object or a function to which the second operand points.
 
 \pnum
 The binary operator \tcode{->*} binds its second operand, which shall be
@@ -5605,7 +5604,7 @@ Abbreviating \grammarterm{pm-expression}\tcode{.*}\grammarterm{cast-expression} 
 is called the \defn{object expression}.
 If the dynamic type of \tcode{E1} does not
 contain the member to which
-\tcode{E2} refers, the behavior is undefined.
+\tcode{E2} points, the behavior is undefined.
 Otherwise, the expression \tcode{E1} is sequenced before the expression \tcode{E2}.
 
 \pnum
@@ -5614,7 +5613,7 @@ the cv-qualifiers of the operands are combined to produce the
 cv-qualifiers of the result, are the same as the rules for
 \tcode{E1.E2} given in~\ref{expr.ref}.
 \begin{note}
-It is not possible to use a pointer to member that refers to a
+It is not possible to use a pointer to member that points to a
 \tcode{mutable} member to modify a const class object. For
 example,
 \begin{codeblock}
@@ -5625,7 +5624,7 @@ struct S {
 void f()
 {
 const S cs;
-int S::* pm = &S::i;            // \tcode{pm} refers to \tcode{mutable} member \tcode{S::i}
+int S::* pm = &S::i;            // \tcode{pm} points to \tcode{mutable} member \tcode{S::i}
 cs.*pm = 88;                    // error: \tcode{cs} is a const object
 }
 \end{codeblock}
@@ -6155,7 +6154,7 @@ compare unequal.
 If either is a pointer to a virtual member function, the result is unspecified.
 
 \item
-If one refers to a member of class \tcode{C1} and the other refers to a member
+If one points to a member of class \tcode{C1} and the other points to a member
 of a different class \tcode{C2}, where neither is a base class of the other,
 the result is unspecified.
 \begin{example}
@@ -6172,11 +6171,11 @@ bool b1 = (bx == cx);   // unspecified
 \end{example}
 
 \item
-If both refer to (possibly different) members of the same union\iref{class.union},
+If both point to (possibly different) members of the same union\iref{class.union},
 they compare equal.
 
 \item
-Otherwise, two pointers to members compare equal if they would refer to the same member of
+Otherwise, two pointers to members compare equal if they would point to the same member of
 the same most derived object\iref{intro.object} or the same subobject if
 indirection with a hypothetical object of the associated
 class type were performed, otherwise they compare unequal.
@@ -7228,7 +7227,7 @@ satisfies the following constraints:
 
   \item
   if the value is of pointer-to-member-function type,
-  it does not designate an immediate function, and
+  it does not point to an immediate function, and
 
   \item
   if the value is an object of class or array type,

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1020,9 +1020,9 @@ inaccessible\iref{class.access},
 ambiguous\iref{class.member.lookup}, or virtual\iref{class.mi} base
 class of \tcode{D}, or a base class of a virtual base class of
 \tcode{D}, a program that necessitates this conversion is ill-formed.
-The result of the conversion points to the same member as the pointer to
-member before the conversion took place, but it points to the base class
-member as if it were a member of the derived class. The result points to
+The result of the conversion designates the same member as the pointer to
+member before the conversion took place, but it designates the base class
+member as if it were a member of the derived class. The result designates
 the member in \tcode{D}'s instance of \tcode{B}. Since the result has
 type ``pointer to member of \tcode{D} of type \cv{} \tcode{T}'',
 indirection through it with a \tcode{D} object is valid. The result is the same
@@ -2906,7 +2906,7 @@ the postfix expression shall be an
 implicit~(\ref{class.mfct.non-static}, \ref{class.static}) or explicit
 class member access\iref{expr.ref} whose \grammarterm{id-expression} is a
 function member name, or a pointer-to-member
-expression\iref{expr.mptr.oper} pointing to a function member; the call is as a member of
+expression\iref{expr.mptr.oper} of function type; the call is as a member of
 the class object referred to by the
 object expression. In the case of an implicit class
 member access, the implied object is the one pointed to by \tcode{this}.
@@ -3800,8 +3800,8 @@ exists\iref{conv.mem}, the program is ill-formed.
 The null member pointer value\iref{conv.mem} is converted to the null
 member pointer value of the destination type. If class \tcode{B}
 contains the original member, or is a base or derived class of the class
-containing the original member, the resulting pointer to member points
-to the original member. Otherwise, the behavior is undefined.
+containing the original member, the resulting pointer to member designates
+the original member. Otherwise, the behavior is undefined.
 \begin{note}
 Although class \tcode{B} need not contain the original member, the
 dynamic type of the object with which indirection through the pointer
@@ -4186,7 +4186,7 @@ The result of the unary \tcode{\&} operator is a pointer to its operand.
 \item
 If the operand is a \grammarterm{qualified-id} naming a non-static or variant member \tcode{m}
 of some class \tcode{C} with type \tcode{T}, the result has type ``pointer to member
-of class \tcode{C} of type \tcode{T}'' and is a prvalue pointing to \tcode{C::m}.
+of class \tcode{C} of type \tcode{T}'' and is a prvalue designating \tcode{C::m}.
 \item
 Otherwise, if the operand is an lvalue of type \tcode{T},
 the resulting expression is a prvalue of type ``pointer to \tcode{T}''
@@ -5582,38 +5582,35 @@ left-to-right.
 \end{bnf}
 
 \pnum
-The binary operator \tcode{.*} binds its second operand, which shall be
-of type ``pointer to member of \tcode{T}'' to its first operand, which shall be
-a glvalue
-of
-class \tcode{T} or of a class of which \tcode{T} is an unambiguous and
-accessible base class. The result the object or a function to which the second operand points.
+In a pointer-to-member expression of the form \tcode{E1->*E2}, \tcode{E2} shall
+be of type ``pointer to member of \tcode{T}'' and \tcode{E1} shall be of type
+``pointer to \cv{}~\tcode{U}'' where \tcode{U} is \tcode{T} or a type of which
+\tcode{T} is an accessible and unambiguous base class. The expression is converted
+to the equivalent form \tcode{(*(E1)).*E2}; the remainder of this subclause will
+address only the operator \tcode{.*}.
 
 \pnum
-The binary operator \tcode{->*} binds its second operand, which shall be
-of type ``pointer to member of \tcode{T}'' to its first operand, which shall be of
-type ``pointer to \tcode{U}''
-where \tcode{U} is either \tcode{T} or
-a class of which \tcode{T}
-is an unambiguous and accessible base class.
-The expression \tcode{E1->*E2} is converted into the equivalent form
-\tcode{(*(E1)).*E2}.
+Abbreviating \grammarterm{pm-expression}\tcode{.*}\grammarterm{cast-expression} as \tcode{E1.*E2},
+\tcode{E2} shall be of type ``pointer to member of \tcode{T}'', and \tcode{E1} shall be a glvalue
+of type \tcode{T} or a type of which \tcode{T} is an accessible and unambiguous base class
+(ignoring cv-qualification). The expression \tcode{E1} is known as the \defn{object expression}.
+If \tcode{E2} is the null-member-pointer value, or the member \tcode{E2} designates is not a
+member of the the dynamic type of the object expression, the behavior is undefined.
+The result is the member subobject or function designated
+by \tcode{E2} corresponding to the object denoted by the object expression;
+the expression is a prvalue if the result is a function, and otherwise has
+the same value category as the (possibly-converted) object expression.
+The expression \tcode{E1} is sequenced before the expression \tcode{E2}.
 
 \pnum
-Abbreviating \grammarterm{pm-expression}\tcode{.*}\grammarterm{cast-expression} as \tcode{E1.*E2}, \tcode{E1}
-is called the \defn{object expression}.
-If the dynamic type of \tcode{E1} does not
-contain the member to which
-\tcode{E2} points, the behavior is undefined.
-Otherwise, the expression \tcode{E1} is sequenced before the expression \tcode{E2}.
+The manner in which the cv-qualifiers of the operands are combined
+to produce the cv-qualifiers of the result are the same as those
+specified in~\ref{expr.ref} for the expression \tcode{E1.M}, where
+the invented \grammarterm{id-expression} \tcode{M} denotes the same
+member \tcode{E2} designates.
 
-\pnum
-The restrictions on cv-qualification, and the manner in which
-the cv-qualifiers of the operands are combined to produce the
-cv-qualifiers of the result, are the same as the rules for
-\tcode{E1.E2} given in~\ref{expr.ref}.
 \begin{note}
-It is not possible to use a pointer to member that points to a
+It is not possible to use a pointer to member designating a
 \tcode{mutable} member to modify a const class object. For
 example,
 \begin{codeblock}
@@ -5624,7 +5621,7 @@ struct S {
 void f()
 {
 const S cs;
-int S::* pm = &S::i;            // \tcode{pm} points to \tcode{mutable} member \tcode{S::i}
+int S::* pm = &S::i;            // \tcode{pm} designates the \tcode{mutable} member \tcode{S::i}
 cs.*pm = 88;                    // error: \tcode{cs} is a const object
 }
 \end{codeblock}
@@ -5632,31 +5629,23 @@ cs.*pm = 88;                    // error: \tcode{cs} is a const object
 
 \pnum
 \indextext{function!pointer to member}%
-If the result of \tcode{.*} or \tcode{->*} is a function, then that
-result can be used only as the operand for the function call operator
-\tcode{()}.
+If the result of a pointer-to-member expression is a function, the
+result can be used only as the left-hand operand of a member function call.
 \begin{example}
 \begin{codeblock}
 (ptr_to_obj->*ptr_to_mfct)(10);
 \end{codeblock}
-calls the member function denoted by \tcode{ptr_to_mfct} for the object
+calls the member function designated by \tcode{ptr_to_mfct} for the object
 pointed to by \tcode{ptr_to_obj}.
 \end{example}
-In a \tcode{.*} expression whose object expression is an rvalue, the program is
-ill-formed if the second operand is a pointer to member function
-whose \grammarterm{ref-qualifier} is \tcode{\&},
-unless its \grammarterm{cv-qualifier-seq} is \tcode{const}.
-In a \tcode{.*}
-expression whose object expression is an lvalue, the program is ill-formed if the second
-operand is
-a pointer to member function
-whose \grammarterm{ref-qualifier} is \tcode{\&\&}.
-The result of a \tcode{.*} expression
-whose second operand is a pointer to a data member is an lvalue if the first
-operand is an lvalue and an xvalue otherwise. The result of a \tcode{.*} expression whose
-second operand is a pointer to a member function is a prvalue.
-If the second operand is the null
-member pointer value\iref{conv.mem}, the behavior is undefined.
+
+\pnum
+In a pointer-to-member expression whose object expression is an xvalue,
+if the second operand is of pointer-to-member-function type, the member type\iref{dcl.mptr}
+shall not have the \grammarterm{ref-qualifier} \tcode{\&} unless its \grammarterm{cv-qualifier-seq}
+is \tcode{const}. Similarly, in a pointer-to-member expression whose object expression is an lvalue,
+if the second operand is of pointer-to-member-function type, the member type\iref{dcl.mptr}
+shall not have the \grammarterm{ref-qualifier} \tcode{\&\&}.
 
 \rSec2[expr.mul]{Multiplicative operators}%
 \indextext{expression!multiplicative operators}%
@@ -6154,7 +6143,7 @@ compare unequal.
 If either is a pointer to a virtual member function, the result is unspecified.
 
 \item
-If one points to a member of class \tcode{C1} and the other points to a member
+If one designates a member of class \tcode{C1} and the other designates a member
 of a different class \tcode{C2}, where neither is a base class of the other,
 the result is unspecified.
 \begin{example}
@@ -6171,11 +6160,11 @@ bool b1 = (bx == cx);   // unspecified
 \end{example}
 
 \item
-If both point to (possibly different) members of the same union\iref{class.union},
+If both designate (possibly different) members of the same union\iref{class.union},
 they compare equal.
 
 \item
-Otherwise, two pointers to members compare equal if they would point to the same member of
+Otherwise, two pointers to members compare equal if they would designate the same member of
 the same most derived object\iref{intro.object} or the same subobject if
 indirection with a hypothetical object of the associated
 class type were performed, otherwise they compare unequal.
@@ -7227,7 +7216,7 @@ satisfies the following constraints:
 
   \item
   if the value is of pointer-to-member-function type,
-  it does not point to an immediate function, and
+  it does not designate an immediate function, and
 
   \item
   if the value is an object of class or array type,

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2477,7 +2477,7 @@ the behavior of a \Cpp{} program is unspecified (possibly ill-formed)
 if it attempts to form a reference
 to \tcode{\placeholder{F}}
 or
-if it attempts to form a pointer-to-member designating
+if it attempts to form a pointer-to-member to
 either a standard library non-static member function\iref{member.functions}
 or an instantiation of a standard library member function template.
 

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2477,7 +2477,7 @@ the behavior of a \Cpp{} program is unspecified (possibly ill-formed)
 if it attempts to form a reference
 to \tcode{\placeholder{F}}
 or
-if it attempts to form a pointer-to-member to
+if it attempts to form a pointer-to-member designating
 either a standard library non-static member function\iref{member.functions}
 or an instantiation of a standard library member function template.
 

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -2084,7 +2084,7 @@ they are of enumeration type and their values are the same,%
 they are of pointer type and they have the same pointer value, or
 
 \item
-they are of pointer-to-member type and they point to the same class member
+they are of pointer-to-member type and they designate the same class member
 or are both the null member pointer value, or
 
 \item
@@ -8531,7 +8531,7 @@ A function type includes the types of each of the function parameters
 and the return type.
 \item
 A pointer-to-member type includes the type of the class object pointed to
-and the type of the member pointed to.
+and the member type\iref{dcl.mptr}.
 \item
 A type that is a specialization of a class template (e.g.,
 \tcode{A<int>})

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -2084,7 +2084,7 @@ they are of enumeration type and their values are the same,%
 they are of pointer type and they have the same pointer value, or
 
 \item
-they are of pointer-to-member type and they refer to the same class member
+they are of pointer-to-member type and they point to the same class member
 or are both the null member pointer value, or
 
 \item


### PR DESCRIPTION
Currently, a mixture of "points", "refers", "selects", "designates", and "denotes" is used when referring to what a pointer to member points to. While pointer to members aren't the same as *pointers*, they certainly are "pointers" in the sense that an object or function can be obtained through them via indirection, hence the replacement with "points to" in this PR. Additionally, we already use "refers to", "designates", and "denotes" for glvalue expressions, so this clears up any ambiguity.