### PR TITLE
In the index, properly sort terms starting with two underscores

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -996,8 +996,8 @@ shall exist a
 preprocessing token that terminates the invocation.
 
 \pnum
-\indextext{__VA_ARGS__@\mname{VA_ARGS}}%
-\indextext{__VA_OPT__@\mname{VA_OPT}}%
+\indextext{__va_args__@\mname{VA_ARGS}}%
+\indextext{__va_opt__@\mname{VA_OPT}}%
 The identifiers \mname{VA_ARGS} and \mname{VA_OPT}
 shall occur only in the \grammarterm{replacement-list}
 of a function-like macro that uses the ellipsis notation in the parameters.
@@ -1139,7 +1139,7 @@ one more than the number of parameters in the macro definition (excluding the
 \indextext{macro!argument substitution}%
 \indextext{argument substitution|see{macro, argument substitution}}%
 
-\indextext{__VA_OPT__@\mname{VA_OPT}}%
+\indextext{__va_opt__@\mname{VA_OPT}}%
 \begin{bnf}
 \nontermdef{va-opt-replacement}\br
     \terminal{\mname{VA_OPT} (} \opt{pp-tokens} \terminal{)}
@@ -1176,7 +1176,7 @@ int x = F(LPAREN(), 0, <:-);    // replaced by \tcode{int x = 42;}
 \end{example}
 
 \pnum
-\indextext{__VA_ARGS__@\mname{VA_ARGS}}%
+\indextext{__va_args__@\mname{VA_ARGS}}%
 An identifier \mname{VA_ARGS} that occurs in the replacement list
 shall be treated as if it were a parameter, and the variable arguments shall form
 the preprocessing tokens used to replace it.
@@ -1202,7 +1202,7 @@ puts("The first, second, and third items.");
 \end{example}
 
 \pnum
-\indextext{__VA_OPT__@\mname{VA_OPT}}%
+\indextext{__va_opt__@\mname{VA_OPT}}%
 The identifier \mname{VA_OPT}
 shall always occur as part of the preprocessing token sequence
 \grammarterm{va-opt-replacement};
@@ -1633,7 +1633,7 @@ The following macro names shall be defined by the implementation:
 \begin{description}
 
 \item
-\indextext{__CPLUSPLUS@\xname{cplusplus}}%
+\indextext{\idxxname{cplusplus}}%
 \xname{cplusplus}\\
 The integer literal \tcode{\cppver}.
 \begin{note}
@@ -1643,7 +1643,7 @@ replace the value of this macro with a greater value.
 \end{note}
 
 \item
-\indextext{__DATE__@\mname{DATE}}%
+\indextext{__date__@\mname{DATE}}%
 \mname{DATE}\\
 The date of translation of the source file:
 a character string literal of the form
@@ -1660,27 +1660,27 @@ an \impldef{text of \mname{DATE} when date of translation is not available} vali
 shall be supplied.
 
 \item
-\indextext{__FILE__@\mname{FILE}}%
+\indextext{__file__@\mname{FILE}}%
 \mname{FILE}\\
 The presumed name of the current source file (a character string
 literal).%
 \footnote{The presumed source file name can be changed by the \tcode{\#line} directive.}
 
 \item
-\indextext{__LINE__@\mname{LINE}}%
+\indextext{__line__@\mname{LINE}}%
 \mname{LINE}\\
 The presumed line number (within the current source file) of the current source line
 (an integer literal).%
 \footnote{The presumed line number can be changed by the \tcode{\#line} directive.}
 
 \item
-\indextext{__STDC_HOSTED__@\mname{STDC_HOSTED}}%
+\indextext{__stdc_hosted__@\mname{STDC_HOSTED}}%
 \mname{STDC_HOSTED}\\
 The integer literal \tcode{1} if the implementation is a hosted
 implementation or the integer literal \tcode{0} if it is not.
 
 \item
-\indextext{__STDCPP_DEFAULT_NEW_ALIGNMENT__@\mname{STDCPP_DEFAULT_NEW_ALIGNMENT}}%
+\indextext{__stdcpp_default_new_alignment__@\mname{STDCPP_DEFAULT_NEW_ALIGNMENT}}%
 \mname{STDCPP_DEFAULT_NEW_ALIGNMENT}\\
 An integer literal of type \tcode{std::size_t}
 whose value is the alignment guaranteed
@@ -1692,7 +1692,7 @@ Larger alignments will be passed to
 \end{note}
 
 \item
-\indextext{__TIME__@\mname{TIME}}%
+\indextext{__time__@\mname{TIME}}%
 \mname{TIME}\\
 The time of translation of the source file:
 a character string literal of the form
@@ -1785,26 +1785,26 @@ The following macro names are conditionally defined by the implementation:
 
 \begin{description}
 \item
-\indextext{__STDC__@\mname{STDC}}%
+\indextext{__stdc__@\mname{STDC}}%
 \mname{STDC}\\
 Whether \mname{STDC} is predefined and if so, what its value is,
 are \impldef{definition and meaning of \mname{STDC}}.
 
 \item
-\indextext{__STDC_MB_MIGHT_NEQ_WC__@\mname{STDC_MB_MIGHT_NEQ_WC}}%
+\indextext{__stdc_mb_might_neq_wc__@\mname{STDC_MB_MIGHT_NEQ_WC}}%
 \mname{STDC_MB_MIGHT_NEQ_WC}\\
 The integer literal \tcode{1}, intended to indicate that, in the encoding for
 \tcode{wchar_t}, a member of the basic character set need not have a code value equal to
 its value when used as the lone character in an ordinary character literal.
 
 \item
-\indextext{__STDC_VERSION__@\mname{STDC_VERSION}}%
+\indextext{__stdc_version__@\mname{STDC_VERSION}}%
 \mname{STDC_VERSION}\\
 Whether \mname{STDC_VERSION} is predefined and if so, what its value is,
 are \impldef{definition and meaning of \mname{STDC_VERSION}}.
 
 \item
-\indextext{__STDC_ISO_10646__@\mname{STDC_ISO_10646}}%
+\indextext{__stdc_iso_10646__@\mname{STDC_ISO_10646}}%
 \mname{STDC_ISO_10646}\\
 An integer literal of the form \tcode{yyyymmL} (for example,
 \tcode{199712L}).
@@ -1815,13 +1815,13 @@ the characters that are defined by ISO/IEC 10646, along with
 all amendments and technical corrigenda as of the specified year and month.
 
 \item
-\indextext{__STDCPP_STRICT_POINTER_SAFETY__@\mname{STDCPP_STRICT_POINTER_SAFETY}}%
+\indextext{__stdcpp_strict_pointer_safety__@\mname{STDCPP_STRICT_POINTER_SAFETY}}%
 \mname{STDCPP_STRICT_POINTER_SAFETY}\\
 Defined, and has the value integer literal 1, if and only if the implementation
 has strict pointer safety\iref{basic.stc.dynamic.safety}.
 
 \item
-\indextext{__STDCPP_THREADS__@\mname{STDCPP_THREADS}}%
+\indextext{__stdcpp_threads__@\mname{STDCPP_THREADS}}%
 \mname{STDCPP_THREADS}\\
 Defined, and has the value integer literal 1, if and only if a program
 can have more than one thread of execution\iref{intro.multithread}.


### PR DESCRIPTION
Lowercase `__cplusplus` had properly been sorted relative to uppercase `__DATE__`,
..., `__VA_OPT__`, but the other lowercase terms `__cpp_`* and `__has_`* had wrongly
been sorted after all the uppercase ones.

Instead of special-casing `__cplusplus`, special-case the uppercase terms.