### PR TITLE
[atomics] Consistent use of enum class memory_order

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -714,20 +714,20 @@ namespace std {
     atomic_ref(const atomic_ref&) noexcept;
     atomic_ref& operator=(const atomic_ref&) = delete;
 
-    void store(T, memory_order = memory_order_seq_cst) const noexcept;
+    void store(T, memory_order = memory_order::seq_cst) const noexcept;
     T operator=(T) const noexcept;
-    T load(memory_order = memory_order_seq_cst) const noexcept;
+    T load(memory_order = memory_order::seq_cst) const noexcept;
     operator T() const noexcept;
 
-    T exchange(T, memory_order = memory_order_seq_cst) const noexcept;
+    T exchange(T, memory_order = memory_order::seq_cst) const noexcept;
     bool compare_exchange_weak(T&, T,
                                memory_order, memory_order) const noexcept;
     bool compare_exchange_strong(T&, T,
                                  memory_order, memory_order) const noexcept;
     bool compare_exchange_weak(T&, T,
-                               memory_order = memory_order_seq_cst) const noexcept;
+                               memory_order = memory_order::seq_cst) const noexcept;
     bool compare_exchange_strong(T&, T,
-                                 memory_order = memory_order_seq_cst) const noexcept;
+                                 memory_order = memory_order::seq_cst) const noexcept;
 
     void wait(T, memory_order = memory_order::seq_cst) const noexcept;
     void notify_one() const noexcept;
@@ -866,16 +866,16 @@ atomic_ref(const atomic_ref& ref) noexcept;
 \indexlibrarymember{store}{atomic_ref<\placeholder{integral}>}%
 \indexlibrarymember{store}{atomic_ref<\placeholder{floating-point}>}%
 \begin{itemdecl}
-void store(T desired, memory_order order = memory_order_seq_cst) const noexcept;
+void store(T desired, memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \expects
 The \tcode{order} argument is neither
-\tcode{memory_order_consume},
-\tcode{memory_order_acquire}, nor
-\tcode{memory_order_acq_rel}.
+\tcode{memory_order::consume},
+\tcode{memory_order::acquire}, nor
+\tcode{memory_order::acq_rel}.
 
 \pnum
 \effects
@@ -907,14 +907,14 @@ return desired;
 \indexlibrarymember{load}{atomic_ref<\placeholder{integral}>}%
 \indexlibrarymember{load}{atomic_ref<\placeholder{floating-point}>}%
 \begin{itemdecl}
-T load(memory_order order = memory_order_seq_cst) const noexcept;
+T load(memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \expects
 The \tcode{order} argument is neither
-\tcode{memory_order_release} nor \tcode{memory_order_acq_rel}.
+\tcode{memory_order::release} nor \tcode{memory_order::acq_rel}.
 
 \pnum
 \effects
@@ -944,7 +944,7 @@ Equivalent to: \tcode{return load();}
 \indexlibrarymember{exchange}{atomic_ref<\placeholder{integral}>}%
 \indexlibrarymember{exchange}{atomic_ref<\placeholder{floating-point}>}%
 \begin{itemdecl}
-T exchange(T desired, memory_order order = memory_order_seq_cst) const noexcept;
+T exchange(T desired, memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -977,17 +977,17 @@ bool compare_exchange_strong(T& expected, T desired,
                              memory_order success, memory_order failure) const noexcept;
 
 bool compare_exchange_weak(T& expected, T desired,
-                           memory_order order = memory_order_seq_cst) const noexcept;
+                           memory_order order = memory_order::seq_cst) const noexcept;
 
 bool compare_exchange_strong(T& expected, T desired,
-                             memory_order order = memory_order_seq_cst) const noexcept;
+                             memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \expects
 The \tcode{failure} argument is neither
-\tcode{memory_order_release} nor \tcode{memory_order_acq_rel}.
+\tcode{memory_order::release} nor \tcode{memory_order::acq_rel}.
 
 \pnum
 \effects
@@ -1004,10 +1004,10 @@ memory is affected according to the value of \tcode{failure}.
 When only one \tcode{memory_order} argument is supplied,
 the value of \tcode{success} is \tcode{order}, and
 the value of \tcode{failure} is \tcode{order}
-except that a value of \tcode{memory_order_acq_rel} shall be replaced by
-the value \tcode{memory_order_acquire} and
-a value of \tcode{memory_order_release} shall be replaced by
-the value \tcode{memory_order_relaxed}.
+except that a value of \tcode{memory_order::acq_rel} shall be replaced by
+the value \tcode{memory_order::acquire} and
+a value of \tcode{memory_order::release} shall be replaced by
+the value \tcode{memory_order::relaxed}.
 If and only if the comparison is \tcode{false} then,
 after the atomic operation,
 the value in \tcode{expected} is replaced by
@@ -1155,32 +1155,32 @@ namespace std {
     atomic_ref(const atomic_ref&) noexcept;
     atomic_ref& operator=(const atomic_ref&) = delete;
 
-    void store(@\placeholdernc{integral}@, memory_order = memory_order_seq_cst) const noexcept;
+    void store(@\placeholdernc{integral}@, memory_order = memory_order::seq_cst) const noexcept;
     @\placeholdernc{integral}@ operator=(@\placeholder{integral}@) const noexcept;
-    @\placeholdernc{integral}@ load(memory_order = memory_order_seq_cst) const noexcept;
+    @\placeholdernc{integral}@ load(memory_order = memory_order::seq_cst) const noexcept;
     operator @\placeholdernc{integral}@() const noexcept;
 
     @\placeholdernc{integral}@ exchange(@\placeholdernc{integral}@,
-                      memory_order = memory_order_seq_cst) const noexcept;
+                      memory_order = memory_order::seq_cst) const noexcept;
     bool compare_exchange_weak(@\placeholder{integral}@&, @\placeholder{integral}@,
                                memory_order, memory_order) const noexcept;
     bool compare_exchange_strong(@\placeholder{integral}@&, @\placeholder{integral}@,
                                  memory_order, memory_order) const noexcept;
     bool compare_exchange_weak(@\placeholder{integral}@&, @\placeholder{integral}@,
-                               memory_order = memory_order_seq_cst) const noexcept;
+                               memory_order = memory_order::seq_cst) const noexcept;
     bool compare_exchange_strong(@\placeholder{integral}@&, @\placeholder{integral}@,
-                                 memory_order = memory_order_seq_cst) const noexcept;
+                                 memory_order = memory_order::seq_cst) const noexcept;
 
     @\placeholdernc{integral}@ fetch_add(@\placeholdernc{integral}@,
-                       memory_order = memory_order_seq_cst) const noexcept;
+                       memory_order = memory_order::seq_cst) const noexcept;
     @\placeholdernc{integral}@ fetch_sub(@\placeholdernc{integral}@,
-                       memory_order = memory_order_seq_cst) const noexcept;
+                       memory_order = memory_order::seq_cst) const noexcept;
     @\placeholdernc{integral}@ fetch_and(@\placeholdernc{integral}@,
-                       memory_order = memory_order_seq_cst) const noexcept;
+                       memory_order = memory_order::seq_cst) const noexcept;
     @\placeholdernc{integral}@ fetch_or(@\placeholdernc{integral}@,
-                      memory_order = memory_order_seq_cst) const noexcept;
+                      memory_order = memory_order::seq_cst) const noexcept;
     @\placeholdernc{integral}@ fetch_xor(@\placeholdernc{integral}@,
-                       memory_order = memory_order_seq_cst) const noexcept;
+                       memory_order = memory_order::seq_cst) const noexcept;
 
     @\placeholdernc{integral}@ operator++(int) const noexcept;
     @\placeholdernc{integral}@ operator--(int) const noexcept;
@@ -1214,7 +1214,7 @@ in \tref{atomic.types.int.comp}.
 \indexlibrarymember{fetch_sub}{atomic_ref<\placeholder{integral}>}%
 \indexlibrarymember{fetch_xor}{atomic_ref<\placeholder{integral}>}%
 \begin{itemdecl}
-@\placeholdernc{integral}@ fetch_@\placeholdernc{key}@(@\placeholdernc{integral}@ operand, memory_order order = memory_order_seq_cst) const noexcept;
+@\placeholdernc{integral}@ fetch_@\placeholdernc{key}@(@\placeholdernc{integral}@ operand, memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1290,26 +1290,26 @@ namespace std {
     atomic_ref(const atomic_ref&) noexcept;
     atomic_ref& operator=(const atomic_ref&) = delete;
 
-    void store(@\placeholdernc{floating-point}@, memory_order = memory_order_seq_cst) const noexcept;
+    void store(@\placeholdernc{floating-point}@, memory_order = memory_order::seq_cst) const noexcept;
     @\placeholder{floating-point}@ operator=(@\placeholder{floating-point}@) const noexcept;
-    @\placeholder{floating-point}@ load(memory_order = memory_order_seq_cst) const noexcept;
+    @\placeholder{floating-point}@ load(memory_order = memory_order::seq_cst) const noexcept;
     operator @\placeholdernc{floating-point}@() const noexcept;
 
     @\placeholder{floating-point}@ exchange(@\placeholdernc{floating-point}@,
-                            memory_order = memory_order_seq_cst) const noexcept;
+                            memory_order = memory_order::seq_cst) const noexcept;
     bool compare_exchange_weak(@\placeholder{floating-point}@&, @\placeholdernc{floating-point}@,
                                memory_order, memory_order) const noexcept;
     bool compare_exchange_strong(@\placeholder{floating-point}@&, @\placeholdernc{floating-point}@,
                                  memory_order, memory_order) const noexcept;
     bool compare_exchange_weak(@\placeholder{floating-point}@&, @\placeholdernc{floating-point}@,
-                               memory_order = memory_order_seq_cst) const noexcept;
+                               memory_order = memory_order::seq_cst) const noexcept;
     bool compare_exchange_strong(@\placeholder{floating-point}@&, @\placeholdernc{floating-point}@,
-                                 memory_order = memory_order_seq_cst) const noexcept;
+                                 memory_order = memory_order::seq_cst) const noexcept;
 
     @\placeholder{floating-point}@ fetch_add(@\placeholdernc{floating-point}@,
-                             memory_order = memory_order_seq_cst) const noexcept;
+                             memory_order = memory_order::seq_cst) const noexcept;
     @\placeholder{floating-point}@ fetch_sub(@\placeholdernc{floating-point}@,
-                             memory_order = memory_order_seq_cst) const noexcept;
+                             memory_order = memory_order::seq_cst) const noexcept;
 
     @\placeholder{floating-point}@ operator+=(@\placeholder{floating-point}@) const noexcept;
     @\placeholder{floating-point}@ operator-=(@\placeholder{floating-point}@) const noexcept;
@@ -1334,7 +1334,7 @@ in \tref{atomic.types.int.comp}.
 \indexlibrarymember{fetch_sub}{atomic_ref<\placeholder{floating-point}>}%
 \begin{itemdecl}
 @\placeholder{floating-point}@ fetch_@\placeholdernc{key}@(@\placeholder{floating-point}@ operand,
-                          memory_order order = memory_order_seq_cst) const noexcept;
+                          memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1396,23 +1396,23 @@ namespace std {
     atomic_ref(const atomic_ref&) noexcept;
     atomic_ref& operator=(const atomic_ref&) = delete;
 
-    void store(T*, memory_order = memory_order_seq_cst) const noexcept;
+    void store(T*, memory_order = memory_order::seq_cst) const noexcept;
     T* operator=(T*) const noexcept;
-    T* load(memory_order = memory_order_seq_cst) const noexcept;
+    T* load(memory_order = memory_order::seq_cst) const noexcept;
     operator T*() const noexcept;
 
-    T* exchange(T*, memory_order = memory_order_seq_cst) const noexcept;
+    T* exchange(T*, memory_order = memory_order::seq_cst) const noexcept;
     bool compare_exchange_weak(T*&, T*,
                                memory_order, memory_order) const noexcept;
     bool compare_exchange_strong(T*&, T*,
                                  memory_order, memory_order) const noexcept;
     bool compare_exchange_weak(T*&, T*,
-                               memory_order = memory_order_seq_cst) const noexcept;
+                               memory_order = memory_order::seq_cst) const noexcept;
     bool compare_exchange_strong(T*&, T*,
-                                 memory_order = memory_order_seq_cst) const noexcept;
+                                 memory_order = memory_order::seq_cst) const noexcept;
 
-    T* fetch_add(difference_type, memory_order = memory_order_seq_cst) const noexcept;
-    T* fetch_sub(difference_type, memory_order = memory_order_seq_cst) const noexcept;
+    T* fetch_add(difference_type, memory_order = memory_order::seq_cst) const noexcept;
+    T* fetch_sub(difference_type, memory_order = memory_order::seq_cst) const noexcept;
 
     T* operator++(int) const noexcept;
     T* operator--(int) const noexcept;
@@ -1440,7 +1440,7 @@ in \tref{atomic.types.pointer.comp}.
 \indexlibrarymember{fetch_add}{atomic_ref<T*>}%
 \indexlibrarymember{fetch_sub}{atomic_ref<T*>}%
 \begin{itemdecl}
-T* fetch_@\placeholdernc{key}@(difference_type operand, memory_order order = memory_order_seq_cst) const noexcept;
+T* fetch_@\placeholdernc{key}@(difference_type operand, memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2336,19 +2336,19 @@ namespace std {
     atomic& operator=(const atomic&) = delete;
     atomic& operator=(const atomic&) volatile = delete;
 
-    void store(@\placeholdernc{floating-point}@, memory_order = memory_order_seq_cst) volatile noexcept;
-    void store(@\placeholdernc{floating-point}@, memory_order = memory_order_seq_cst) noexcept;
+    void store(@\placeholdernc{floating-point}@, memory_order = memory_order::seq_cst) volatile noexcept;
+    void store(@\placeholdernc{floating-point}@, memory_order = memory_order::seq_cst) noexcept;
     @\placeholdernc{floating-point}@ operator=(@\placeholder{floating-point}@) volatile noexcept;
     @\placeholdernc{floating-point}@ operator=(@\placeholder{floating-point}@) noexcept;
-    @\placeholdernc{floating-point}@ load(memory_order = memory_order_seq_cst) volatile noexcept;
-    @\placeholdernc{floating-point}@ load(memory_order = memory_order_seq_cst) noexcept;
+    @\placeholdernc{floating-point}@ load(memory_order = memory_order::seq_cst) volatile noexcept;
+    @\placeholdernc{floating-point}@ load(memory_order = memory_order::seq_cst) noexcept;
     operator @\placeholdernc{floating-point}@() volatile noexcept;
     operator @\placeholdernc{floating-point}@() noexcept;
 
     @\placeholdernc{floating-point}@ exchange(@\placeholdernc{floating-point}@,
-                            memory_order = memory_order_seq_cst) volatile noexcept;
+                            memory_order = memory_order::seq_cst) volatile noexcept;
     @\placeholdernc{floating-point}@ exchange(@\placeholdernc{floating-point}@,
-                            memory_order = memory_order_seq_cst) noexcept;
+                            memory_order = memory_order::seq_cst) noexcept;
     bool compare_exchange_weak(@\placeholder{floating-point}@&, @\placeholdernc{floating-point}@,
                                memory_order, memory_order) volatile noexcept;
     bool compare_exchange_weak(@\placeholder{floating-point}@&, @\placeholdernc{floating-point}@,
@@ -2358,22 +2358,22 @@ namespace std {
     bool compare_exchange_strong(@\placeholder{floating-point}@&, @\placeholdernc{floating-point}@,
                                  memory_order, memory_order) noexcept;
     bool compare_exchange_weak(@\placeholder{floating-point}@&, @\placeholdernc{floating-point}@,
-                               memory_order = memory_order_seq_cst) volatile noexcept;
+                               memory_order = memory_order::seq_cst) volatile noexcept;
     bool compare_exchange_weak(@\placeholder{floating-point}@&, @\placeholdernc{floating-point}@,
-                               memory_order = memory_order_seq_cst) noexcept;
+                               memory_order = memory_order::seq_cst) noexcept;
     bool compare_exchange_strong(@\placeholder{floating-point}@&, @\placeholdernc{floating-point}@,
-                                 memory_order = memory_order_seq_cst) volatile noexcept;
+                                 memory_order = memory_order::seq_cst) volatile noexcept;
     bool compare_exchange_strong(@\placeholder{floating-point}@&, @\placeholdernc{floating-point}@,
-                                 memory_order = memory_order_seq_cst) noexcept;
+                                 memory_order = memory_order::seq_cst) noexcept;
 
     @\placeholdernc{floating-point}@ fetch_add(@\placeholdernc{floating-point}@,
-                             memory_order = memory_order_seq_cst) volatile noexcept;
+                             memory_order = memory_order::seq_cst) volatile noexcept;
     @\placeholdernc{floating-point}@ fetch_add(@\placeholdernc{floating-point}@,
-                             memory_order = memory_order_seq_cst) noexcept;
+                             memory_order = memory_order::seq_cst) noexcept;
     @\placeholdernc{floating-point}@ fetch_sub(@\placeholdernc{floating-point}@,
-                             memory_order = memory_order_seq_cst) volatile noexcept;
+                             memory_order = memory_order::seq_cst) volatile noexcept;
     @\placeholdernc{floating-point}@ fetch_sub(@\placeholdernc{floating-point}@,
-                             memory_order = memory_order_seq_cst) noexcept;
+                             memory_order = memory_order::seq_cst) noexcept;
 
     @\placeholdernc{floating-point}@ operator+=(@\placeholder{floating-point}@) volatile noexcept;
     @\placeholdernc{floating-point}@ operator+=(@\placeholder{floating-point}@) noexcept;
@@ -2411,8 +2411,8 @@ The key, operator, and computation correspondence are identified in
 \indexlibrarymember{fetch_add}{atomic<\placeholder{floating-point}>}%
 \indexlibrarymember{fetch_sub}{atomic<\placeholder{floating-point}>}%
 \begin{itemdecl}
-T fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order_seq_cst) volatile noexcept;
-T fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order_seq_cst) noexcept;
+T fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order::seq_cst) volatile noexcept;
+T fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/future.tex
+++ b/source/future.tex
@@ -1749,7 +1749,7 @@ template<class T> shared_ptr<T> atomic_load(const shared_ptr<T>* p);
 
 \pnum
 \returns
-\tcode{atomic_load_explicit(p, memory_order::seq_cst)}.
+\tcode{atomic_load_explicit(p, memory_order_seq_cst)}.
 
 \pnum
 \throws
@@ -1766,7 +1766,7 @@ template<class T> shared_ptr<T> atomic_load_explicit(const shared_ptr<T>* p, mem
 \requires \tcode{p} shall not be null.
 
 \pnum
-\requires \tcode{mo} shall not be \tcode{memory_order::release} or \tcode{memory_order::acq_rel}.
+\requires \tcode{mo} shall not be \tcode{memory_order_release} or \tcode{memory_order_acq_rel}.
 
 \pnum
 \returns
@@ -1788,7 +1788,7 @@ template<class T> void atomic_store(shared_ptr<T>* p, shared_ptr<T> r);
 
 \pnum
 \effects
-As if by \tcode{atomic_store_explicit(p, r, memory_order::seq_cst)}.
+As if by \tcode{atomic_store_explicit(p, r, memory_order_seq_cst)}.
 
 \pnum
 \throws
@@ -1805,7 +1805,7 @@ template<class T> void atomic_store_explicit(shared_ptr<T>* p, shared_ptr<T> r, 
 \requires \tcode{p} shall not be null.
 
 \pnum
-\requires \tcode{mo} shall not be \tcode{memory_order::acquire} or \tcode{memory_order::acq_rel}.
+\requires \tcode{mo} shall not be \tcode{memory_order_acquire} or \tcode{memory_order_acq_rel}.
 
 \pnum
 \effects
@@ -1827,7 +1827,7 @@ template<class T> shared_ptr<T> atomic_exchange(shared_ptr<T>* p, shared_ptr<T> 
 
 \pnum
 \returns
-\tcode{atomic_exchange_explicit(p, r, memory_order::seq_cst)}.
+\tcode{atomic_exchange_explicit(p, r, memory_order_seq_cst)}.
 
 \pnum
 \throws
@@ -1870,7 +1870,7 @@ template<class T>
 \pnum
 \returns
 \begin{codeblock}
-atomic_compare_exchange_weak_explicit(p, v, w, memory_order::seq_cst, memory_order::seq_cst)
+atomic_compare_exchange_weak_explicit(p, v, w, memory_order_seq_cst, memory_order_seq_cst)
 \end{codeblock}
 
 \pnum
@@ -1888,7 +1888,7 @@ template<class T>
 \pnum
 \returns
 \begin{codeblock}
-atomic_compare_exchange_strong_explicit(p, v, w, memory_order::seq_cst, memory_order::seq_cst)
+atomic_compare_exchange_strong_explicit(p, v, w, memory_order_seq_cst, memory_order_seq_cst)
 \end{codeblock}
 \end{itemdescr}
 
@@ -1908,8 +1908,8 @@ template<class T>
 \begin{itemdescr}
 \pnum
 \requires \tcode{p} shall not be null and \tcode{v} shall not be null.
-The \tcode{failure} argument shall not be \tcode{memory_order::release} nor
-\tcode{memory_order::acq_rel}.
+The \tcode{failure} argument shall not be \tcode{memory_order_release} nor
+\tcode{memory_order_acq_rel}.
 
 \pnum
 \effects
@@ -2657,7 +2657,7 @@ template<class T>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{atomic_store_explicit(object, desired, memory_order::relaxed);}
+Equivalent to: \tcode{atomic_store_explicit(object, desired, memory_order_relaxed);}
 \end{itemdescr}
 
 \rSec2[depr.atomics.types.operations]{Operations on atomic types}

--- a/source/future.tex
+++ b/source/future.tex
@@ -1749,7 +1749,7 @@ template<class T> shared_ptr<T> atomic_load(const shared_ptr<T>* p);
 
 \pnum
 \returns
-\tcode{atomic_load_explicit(p, memory_order_seq_cst)}.
+\tcode{atomic_load_explicit(p, memory_order::seq_cst)}.
 
 \pnum
 \throws
@@ -1766,7 +1766,7 @@ template<class T> shared_ptr<T> atomic_load_explicit(const shared_ptr<T>* p, mem
 \requires \tcode{p} shall not be null.
 
 \pnum
-\requires \tcode{mo} shall not be \tcode{memory_order_release} or \tcode{memory_order_acq_rel}.
+\requires \tcode{mo} shall not be \tcode{memory_order::release} or \tcode{memory_order::acq_rel}.
 
 \pnum
 \returns
@@ -1788,7 +1788,7 @@ template<class T> void atomic_store(shared_ptr<T>* p, shared_ptr<T> r);
 
 \pnum
 \effects
-As if by \tcode{atomic_store_explicit(p, r, memory_order_seq_cst)}.
+As if by \tcode{atomic_store_explicit(p, r, memory_order::seq_cst)}.
 
 \pnum
 \throws
@@ -1805,7 +1805,7 @@ template<class T> void atomic_store_explicit(shared_ptr<T>* p, shared_ptr<T> r, 
 \requires \tcode{p} shall not be null.
 
 \pnum
-\requires \tcode{mo} shall not be \tcode{memory_order_acquire} or \tcode{memory_order_acq_rel}.
+\requires \tcode{mo} shall not be \tcode{memory_order::acquire} or \tcode{memory_order::acq_rel}.
 
 \pnum
 \effects
@@ -1827,7 +1827,7 @@ template<class T> shared_ptr<T> atomic_exchange(shared_ptr<T>* p, shared_ptr<T> 
 
 \pnum
 \returns
-\tcode{atomic_exchange_explicit(p, r, memory_order_seq_cst)}.
+\tcode{atomic_exchange_explicit(p, r, memory_order::seq_cst)}.
 
 \pnum
 \throws
@@ -1870,7 +1870,7 @@ template<class T>
 \pnum
 \returns
 \begin{codeblock}
-atomic_compare_exchange_weak_explicit(p, v, w, memory_order_seq_cst, memory_order_seq_cst)
+atomic_compare_exchange_weak_explicit(p, v, w, memory_order::seq_cst, memory_order::seq_cst)
 \end{codeblock}
 
 \pnum
@@ -1888,7 +1888,7 @@ template<class T>
 \pnum
 \returns
 \begin{codeblock}
-atomic_compare_exchange_strong_explicit(p, v, w, memory_order_seq_cst, memory_order_seq_cst)
+atomic_compare_exchange_strong_explicit(p, v, w, memory_order::seq_cst, memory_order::seq_cst)
 \end{codeblock}
 \end{itemdescr}
 
@@ -1908,8 +1908,8 @@ template<class T>
 \begin{itemdescr}
 \pnum
 \requires \tcode{p} shall not be null and \tcode{v} shall not be null.
-The \tcode{failure} argument shall not be \tcode{memory_order_release} nor
-\tcode{memory_order_acq_rel}.
+The \tcode{failure} argument shall not be \tcode{memory_order::release} nor
+\tcode{memory_order::acq_rel}.
 
 \pnum
 \effects
@@ -2657,7 +2657,7 @@ template<class T>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{atomic_store_explicit(object, desired, memory_order_relaxed);}
+Equivalent to: \tcode{atomic_store_explicit(object, desired, memory_order::relaxed);}
 \end{itemdescr}
 
 \rSec2[depr.atomics.types.operations]{Operations on atomic types}


### PR DESCRIPTION
Since the application of P0439R0, the library wording has been partially
updated to use the new scoped enumaration values whenever memory order
constants are required, and partially retains use of the inline
constants supplied for back compatibility.

This patch conistently uses the memory_order::enumerators, retaining
the old name only for their declaration, the index, and for Annex C
wording on C++17 compatibility, which /should/ use the old spelling.