### PR TITLE
[memory.syn] Index the pointer_safety enum class

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6754,7 +6754,11 @@ namespace std {
   template<class Ptr>
     constexpr auto to_address(const Ptr& p) noexcept;
 
-  // \ref{util.dynamic.safety}, pointer safety
+  // \ref{util.dynamic.safety}, pointer safety%
+\indexlibraryglobal{in_place}%
+\indexlibrarymember{relaxed}{pointer_safety}%
+\indexlibrarymember{preferred}{pointer_safety}%
+\indexlibrarymember{strict}{pointer_safety}
   enum class pointer_safety { relaxed, preferred, strict };
   void declare_reachable(void* p);
   template<class T>


### PR DESCRIPTION
As the enum class 'pointer_safety' is defined only in the header synopsis
for <memory>, it had escaped indexing.  This adds the missing entries.