### PR TITLE
Fix incorrect references to past the end pointers

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -10070,7 +10070,7 @@ elements $i$ and $j$ of the same array object \tcode{x}.
 As specified in \ref{basic.compound},
 an object that is not an array element
 is considered to belong to a single-element array for this purpose and
-a pointer past the last element of an array of $n$ elements
+a pointer past the end of the last element of an array of $n$ elements
 is considered to be equivalent to a pointer
 to a hypothetical array element $n$ for this purpose.
 \end{note}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5764,8 +5764,8 @@ the result has the type of \tcode{P}.
 of an array object \tcode{x} with $n$ elements\iref{dcl.array},%
 \footnote{As specified in \ref{basic.compound},
 an object that is not an array element
-is considered to belong to a single-element array for this purpose and
-a pointer past the last element of an array of $n$ elements
+is considered to belong to a single-element array for this purpose, and
+a pointer past the end of the last element of an array of $n$ elements
 is considered to be equivalent to a pointer to a hypothetical array element
 $n$ for this purpose.}
 the expressions \tcode{P + J} and \tcode{J + P}
@@ -6039,7 +6039,7 @@ The result of comparing unequal pointers to objects%
 an object that is not an array element
 is considered to belong to a
 single-element array for this purpose and
-a pointer past the last element of an array of $n$ elements
+a pointer past the end of the last element of an array of $n$ elements
 is considered to be equivalent to a pointer to a hypothetical array element
 $n$ for this purpose.}
 is defined in terms of a partial order consistent with the following rules:
@@ -6118,7 +6118,7 @@ Comparing pointers is defined as follows:
 \begin{itemize}
 \item
 If one pointer represents the address of a complete object, and another
-pointer represents the address one past the last element of a different
+pointer represents the address past the end\iref{basic.compound} of a different
 complete object,%
 \footnote{As specified in \ref{basic.compound},
 an object that is not an array element is

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -559,7 +559,7 @@ an \tcode{iterator_traits} specialization must provide them.
 \pnum
 \indextext{past-the-end iterator|see{iterator, past-the-end}}%
 \indextext{dereferenceable iterator|see{iterator, dereferenceable}}%
-Just as a regular pointer to an array guarantees that there is a pointer value pointing past the last element
+Just as a regular pointer to an array guarantees that there is a pointer value pointing past the end of the last element
 of the array, so for any iterator type there is an iterator value that points past the last element of a
 corresponding sequence.
 Such a value is called a \defnx{past-the-end value}{iterator!past-the-end}.

--- a/source/support.tex
+++ b/source/support.tex
@@ -3881,7 +3881,7 @@ namespace std {
 
     constexpr size_t size() const noexcept;     // number of elements
     constexpr const E* begin() const noexcept;  // first element
-    constexpr const E* end() const noexcept;    // one past the last element
+    constexpr const E* end() const noexcept;    // past the end of the last element
   };
 
   // \ref{support.initlist.range}, initializer list range access


### PR DESCRIPTION
The proper terminology is used and defined in [[basic.compound] p3](http://eel.is/c++draft/basic.compound#3):
> [...] a pointer past the end of the last element of an array `x` of `n` elements [...]