### PR TITLE
Remove definition in note

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6068,8 +6068,7 @@ public:
 and
 \tcode{dynamic_cast}s
 during construction for the well-defined cases;
-that is, describes the
-\term{polymorphic behavior}
+that is, describes the polymorphic behavior
 of an object under construction.
 \end{note}
 


### PR DESCRIPTION
[[class.base.init] p17](http://eel.is/c++draft/class.base.init#17) uses `\term` to define *polymorphic behavior* within a note. This definition is not used outside of notes, and terms should not be defined in notes anyways.