### PR TITLE
[over.oper] Make statement about non-overloadable operators a note.

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3420,6 +3420,7 @@ Both the unary and binary forms of
 can be overloaded.
 
 \pnum
+\begin{note}
 \indextext{restriction!operator overloading}%
 The following operators cannot be overloaded:
 \begin{ncsimplebnf}\obeyspaces
@@ -3429,6 +3430,7 @@ nor can the preprocessing symbols
 \tcode{\#}\iref{cpp.stringize}
 and
 \tcode{\#\#}\iref{cpp.concat}.
+\end{note}
 
 \pnum
 \indextext{call!operator function}%


### PR DESCRIPTION
Fixes #3674.