### PR TITLE
[class] [over] Redundant specification of ignoring move special members

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1682,10 +1682,10 @@ A defaulted copy/\brk{}move constructor for a class
 \item for the copy constructor, a non-static data member of rvalue reference type.
 \end{itemize}
 
+\begin{note}
 A defaulted move constructor that is defined as deleted is ignored by overload
 resolution~(\ref{over.match}, \ref{over.over}).
-\begin{note}
-A deleted move constructor would otherwise interfere with initialization from
+Such a constructor would otherwise interfere with initialization from
 an rvalue which can use the copy constructor instead.
 \end{note}
 
@@ -1968,8 +1968,10 @@ class \tcode{X} is defined as deleted if \tcode{X} has:
   defaulted assignment operator.
 \end{itemize}
 
+\begin{note}
 A defaulted move assignment operator that is defined as deleted is ignored by
 overload resolution~(\ref{over.match}, \ref{over.over}).
+\end{note}
 
 \pnum
 \indextext{assignment operator!copy!hidden}%

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -663,7 +663,7 @@ with the set of non-template candidate functions.
 
 \pnum
 A
-defaulted move special function~(\ref{class.copy.ctor}, \ref{class.copy.assign})
+defaulted move special member function~(\ref{class.copy.ctor}, \ref{class.copy.assign})
 that is defined as deleted
 is excluded from the set of candidate functions in all contexts.
 A constructor inherited from class type \tcode{C}\iref{class.inhctor.init}


### PR DESCRIPTION
[[class.copy.ctor] p10](http://eel.is/c++draft/class.copy.ctor#10) and [[class.copy.assign] p7](http://eel.is/c++draft/class.copy.assign#7) both redundantly specify that defaulted move special member functions that are defined as deleted are ignored by overload resolution. This is already specified in [[over.match.funcs] p8](http://eel.is/c++draft/over.match.funcs#8), so turning the others into notes would be good. Also, [[over.match.funcs] p8](http://eel.is/c++draft/over.match.funcs#8) refers to "special functions", this is incorrect terminology and has been changed to "special member functions"