### PR TITLE
[class.mfct] consteval member functions are also inline.

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -854,30 +854,29 @@ in which case it is an inline\iref{dcl.inline} member function
 if it is attached to the global module, or
 it may be defined outside of its class
 definition if it has already been declared but not defined in its class
-definition. A member function definition that appears outside of the
+definition.
+\begin{note}
+A member function is also inline if it is declared
+\tcode{inline}, \tcode{constexpr}, or \tcode{consteval}.
+\end{note}
+
+\pnum
+A member function definition that appears outside of the
 class definition shall appear in a namespace scope enclosing the class
 definition. Except for member function definitions that appear outside
 of a class definition, and except for explicit specializations of member
 functions of class templates and member function
 templates\iref{temp.spec} appearing outside of the class definition, a
 member function shall not be redeclared.
-
-\pnum
-An inline member function (whether static or non-static) may
-also be defined outside of its class definition provided either its
-declaration in the class definition or its definition outside of the
-class definition declares the function as \tcode{inline} or \tcode{constexpr}.
-\begin{note}
-Member functions of a class have the linkage of the name of the class.
-See~\ref{basic.link}.
-\end{note}
-
-\pnum
 \begin{note}
 There can be at most one definition of a non-inline member function in
 a program. There may be more than one
 inline member function definition in a program.
 See~\ref{basic.def.odr} and~\ref{dcl.inline}.
+\end{note}
+\begin{note}
+Member functions of a class have the linkage of the name of the class.
+See~\ref{basic.link}.
 \end{note}
 
 \pnum


### PR DESCRIPTION
Fixes #3663.