### PR TITLE
[lex.ccon,lex.string] Remove redundant repetition of the grammar.

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -98,7 +98,7 @@ void f(char*) {
 
 \howwide
 Programs that have a legitimate reason to treat string literal objects
-as pointers to potentially modifiable memory are probably rare.
+as potentially modifiable memory are probably rare.
 
 \rSec2[diff.basic]{\ref{basic}: basics}
 

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -32,7 +32,7 @@ Common.
 
 \diffref{lex.ccon}
 \change
-Type of character literal is changed from \tcode{int} to \tcode{char}.
+Type of \grammarterm{character-literal} is changed from \tcode{int} to \tcode{char}.
 \rationale
 This is needed for improved overloaded function argument type
 matching.
@@ -64,7 +64,7 @@ Programs which depend upon \tcode{sizeof('x')} are probably rare.
 \diffref{lex.string}
 \change
 String literals made const.\\
-The type of a string literal is changed
+The type of a \grammarterm{string-literal} is changed
 from ``array of \tcode{char}''
 to ``array of \tcode{const char}''.
 The type of a UTF-8 string literal is changed
@@ -97,7 +97,7 @@ void f(char*) {
 \end{codeblock}
 
 \howwide
-Programs that have a legitimate reason to treat string literals
+Programs that have a legitimate reason to treat string literal objects
 as pointers to potentially modifiable memory are probably rare.
 
 \rSec2[diff.basic]{\ref{basic}: basics}
@@ -889,15 +889,15 @@ by the chapters of this document.
 
 \diffref{lex.pptoken}
 \change
-New kinds of string literals.
+New kinds of \grammarterm{string-literal}s.
 \rationale
 Required for new features.
 \effect
 Valid \CppIII{} code may fail to compile or produce different results in
 this International Standard. Specifically, macros named \tcode{R}, \tcode{u8},
 \tcode{u8R}, \tcode{u}, \tcode{uR}, \tcode{U}, \tcode{UR}, or \tcode{LR} will
-not be expanded when adjacent to a string literal but will be interpreted as
-part of the string literal. For example:
+not be expanded when adjacent to a \grammarterm{string-literal} but will be interpreted as
+part of the \grammarterm{string-literal}. For example:
 \begin{codeblock}
 #define u8 "abc"
 const char* s = u8"def";        // Previously \tcode{"abcdef"}, now \tcode{"def"}
@@ -1435,7 +1435,7 @@ Necessary to enable single quotes as digit separators.
 Valid \CppXI{} code may fail to compile or may change meaning in this
 International Standard. For example, the following code is valid both in \CppXI{} and in
 this International Standard, but the macro invocation produces different outcomes
-because the single quotes delimit a character literal in \CppXI{}, whereas they are digit
+because the single quotes delimit a \grammarterm{character-literal} in \CppXI{}, whereas they are digit
 separators in this International Standard:
 
 \begin{codeblock}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4395,7 +4395,7 @@ an array of \tcode{char16_t},
 an array of \tcode{char32_t},
 or an array of
 \tcode{wchar_t},
-and the initializer is a string literal, see~\ref{dcl.init.string}.
+and the initializer is a \grammarterm{string-literal}, see~\ref{dcl.init.string}.
 \item If the initializer is \tcode{()}, the object is value-initialized.
 \item
 Otherwise, if the destination type is an array,
@@ -5164,12 +5164,12 @@ UTF-8 string literal,
 UTF-16 string literal,
 UTF-32 string literal, or
 wide string literal,
-respectively, or by an appropriately-typed string literal enclosed in
+respectively, or by an appropriately-typed \grammarterm{string-literal} enclosed in
 braces\iref{lex.string}.
 \indextext{initialization!character array}%
 Successive
 characters of the
-value of the string literal
+value of the \grammarterm{string-literal}
 initialize the elements of the array.
 \begin{example}
 \begin{codeblock}
@@ -5546,7 +5546,7 @@ copy-list-initialization, or by direct-initialization for
 direct-list-initialization).
 
 \item Otherwise, if \tcode{T} is a character array and the initializer list has a
-single element that is an appropriately-typed string literal\iref{dcl.init.string},
+single element that is an appropriately-typed \grammarterm{string-literal}\iref{dcl.init.string},
 initialization is performed as described in that subclause.
 
 \item Otherwise, if \tcode{T} is an aggregate, aggregate initialization is

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1152,13 +1152,15 @@ this behavior is deprecated\iref{depr.arith.conv.enum}.
 \rSec2[expr.prim.literal]{Literals}
 
 \pnum
-A
 \indextext{literal}%
 \indextext{constant}%
-\grammarterm{literal}
-is a primary expression.
-Its type depends on its form\iref{lex.literal}.
-A string literal is an lvalue; all other literals are prvalues.
+A \grammarterm{literal} is a primary expression,
+whose type is determined based on its form as specified in \ref{lex.literal}.
+A \grammarterm{string-literal} is an lvalue,
+a \grammarterm{user-defined-literal}
+has the same value category
+as the corresponding operator call expression described in \ref{lex.ext},
+and any other \grammarterm{literal} is a prvalue.
 
 \rSec2[expr.prim.this]{This}
 
@@ -4850,7 +4852,7 @@ its value is such that the size of the allocated object would exceed the
 \item
 the \grammarterm{new-initializer} is a \grammarterm{braced-init-list} and the
 number of array elements for which initializers are provided (including the
-terminating \tcode{'\textbackslash 0'} in a string literal\iref{lex.string}) exceeds the
+terminating \tcode{'\textbackslash 0'} in a \grammarterm{string-literal}\iref{lex.string}) exceeds the
 number of elements to initialize.
 \end{itemize}
 

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -127,9 +127,9 @@ concatenation\iref{cpp.concat}, the behavior is undefined. A
 source file to be processed from phase 1 through phase 4, recursively.
 All preprocessing directives are then deleted.
 
-\item Each basic source character set member in a character literal or a string
-literal, as well as each escape sequence and \grammarterm{universal-character-name} in a
-character literal or a non-raw string literal, is converted to the corresponding
+\item Each basic source character set member in a \grammarterm{character-literal} or a
+\grammarterm{string-literal}, as well as each escape sequence and \grammarterm{universal-character-name} in a
+\grammarterm{character-literal} or a non-raw string literal, is converted to the corresponding
 member of the execution character set~(\ref{lex.ccon}, \ref{lex.string}); if
 there is no corresponding member, it is converted to an \impldef{converting
 characters from source character set to execution character set} member other
@@ -256,8 +256,9 @@ any ISO/IEC 10646 character.
 If a \grammarterm{universal-character-name} outside
 the \grammarterm{c-char-sequence}, \grammarterm{s-char-sequence}, or
 \grammarterm{r-char-sequence} of
-a character or
-string literal corresponds to a control character or
+a \grammarterm{character-literal} or \grammarterm{string-literal}
+(in either case, including within a \grammarterm{user-defined-literal})
+corresponds to a control character or
 to a character in the basic
 source character set, the program is ill-formed.\footnote{A sequence of characters resembling a \grammarterm{universal-character-name} in an
 \grammarterm{r-char-sequence}\iref{lex.string} does not form a
@@ -334,8 +335,8 @@ form-feed), or both. As described in \ref{cpp}, in certain
 circumstances during translation phase 4, white space (or the absence
 thereof) serves as more than preprocessing token separation. White space
 can appear within a preprocessing token only as part of a header name or
-between the quotation characters in a character literal or string
-literal.
+between the quotation characters in a character literal or
+string literal.
 
 \pnum
 If the input stream has been parsed into preprocessing tokens up to a
@@ -1224,20 +1225,11 @@ that cannot be represented by any of the allowed types.
 
 \pnum
 \indextext{literal!character}%
-\indextext{literal!narrow-character}%
 \indextext{literal!\idxcode{char16_t}}%
 \indextext{literal!\idxcode{char32_t}}%
-A character literal is one or more characters enclosed in single quotes,
-as in \tcode{'x'}, optionally preceded by
-\tcode{u8}, \tcode{u}, \tcode{U}, or \tcode{L},
-as in
-\tcode{u8'w'}, \tcode{u'x'}, \tcode{U'y'}, or \tcode{L'z'},
-respectively.
-
-\pnum
 \indextext{literal!type of character}%
 \indextext{literal!character!ordinary}%
-A character literal that does not begin with
+A \grammarterm{character-literal} that does not begin with
 \tcode{u8}, \tcode{u}, \tcode{U}, or \tcode{L}
 is an \defn{ordinary character literal}.
 An ordinary character literal that contains a
@@ -1256,10 +1248,10 @@ and has an \impldef{value of multicharacter literal} value.
 
 \pnum
 \indextext{literal!character!UTF-8}%
-A character literal that
+A \grammarterm{character-literal} that
 begins with \tcode{u8}, such as \tcode{u8'w'},
 \indextext{prefix!\idxcode{u8}}%
-is a character literal of type \tcode{char8_t},
+is a \grammarterm{character-literal} of type \tcode{char8_t},
 known as a \defn{UTF-8 character literal}.
 The value of a UTF-8 character literal
 is equal to its ISO/IEC 10646 code point value,
@@ -1275,10 +1267,10 @@ A UTF-8 character literal containing multiple \grammarterm{c-char}{s} is ill-for
 \pnum
 \indextext{literal!character!UTF-16}%
 \indextext{type!\idxcode{char16_t}}%
-A character literal that
+A \grammarterm{character-literal} that
 begins with the letter \tcode{u}, such as \tcode{u'x'},
 \indextext{prefix!\idxcode{u}}%
-is a character literal of type \tcode{char16_t},
+is a \grammarterm{character-literal} of type \tcode{char16_t},
 known as a \defn{UTF-16 character literal}.
 The value of a UTF-16 character literal
 is equal to its ISO/IEC 10646 code point value,
@@ -1295,10 +1287,10 @@ containing multiple \grammarterm{c-char}{s} is ill-formed.
 \pnum
 \indextext{literal!character!UTF-32}%
 \indextext{type!\idxcode{char32_t}}%
-A character literal that
+A \grammarterm{character-literal} that
 begins with the letter \tcode{U}, such as \tcode{U'y'},
 \indextext{prefix!\idxcode{U}}%
-is a character literal of type \tcode{char32_t},
+is a \grammarterm{character-literal} of type \tcode{char32_t},
 known as a \defn{UTF-32 character literal}.
 The value of a
 UTF-32 character literal containing a single \grammarterm{c-char} is equal
@@ -1311,7 +1303,7 @@ multiple \grammarterm{c-char}{s} is ill-formed.
 \indextext{wide-character}%
 \indexhdr{stddef.h}%
 \indextext{type!\idxcode{wchar_t}}%
-A character literal that
+A \grammarterm{character-literal} that
 begins with the letter \tcode{L}, such as \tcode{L'z'},
 \indextext{prefix!\idxcode{L}}%
 is a \defn{wide-character literal}. A wide-character literal has type
@@ -1386,12 +1378,12 @@ sequence. A sequence of octal or hexadecimal digits is terminated by the
 first character that is not an octal digit or a hexadecimal digit,
 respectively.
 \indextext{literal!implementation-defined value of char@implementation-defined value of \tcode{char}}%
-The value of a character literal is \impldef{value of character literal outside range of
-corresponding type} if it falls outside of the \impldef{range defined for character literals}
-range defined for \tcode{char} (for character literals with no prefix) or
-\tcode{wchar_t} (for character literals prefixed by \tcode{L}).
+The value of a \grammarterm{character-literal} is \impldef{value of \grammarterm{character-literal} outside range of
+corresponding type} if it falls outside of the \impldef{range defined for \grammarterm{character-literal}s}
+range defined for \tcode{char} (for \grammarterm{character-literal}s with no prefix) or
+\tcode{wchar_t} (for \grammarterm{character-literal}s prefixed by \tcode{L}).
 \begin{note}
-If the value of a character literal prefixed by
+If the value of a \grammarterm{character-literal} prefixed by
 \tcode{u}, \tcode{u8}, or \tcode{U}
 is outside the range defined for its type,
 the program is ill-formed.
@@ -1589,37 +1581,6 @@ chosen in an \impldef{choice of larger or smaller value of
 \end{bnf}
 
 \pnum
-\indextext{literal!string}%
-\indextext{literal!string!narrow}%
-\indextext{literal!string!wide}%
-\indextext{literal!string!\idxcode{char16_t}}%
-\indextext{literal!string!\idxcode{char32_t}}%
-\indextext{character string}%
-A \grammarterm{string-literal} is a sequence of characters (as defined
-in~\ref{lex.ccon}) surrounded by double quotes, optionally prefixed by
-\tcode{R},
-\tcode{u8},
-\tcode{u8R},
-\tcode{u},
-\tcode{uR},
-\tcode{U},
-\tcode{UR},
-\tcode{L},
-or \tcode{LR},
-as in
-\tcode{"..."},
-\tcode{R"(...)"},
-\tcode{u8"..."},
-\tcode{u8R"**(...)**"},
-\tcode{u"..."},
-\tcode{uR"*\~{}(...)*\~{}"},
-\tcode{U"..."},
-\tcode{UR"zzz(...)zzz"},
-\tcode{L"..."},
-or \tcode{LR"(...)"},
-respectively.
-
-\pnum
 \indextext{literal!string!raw}%
 A \grammarterm{string-literal} that has an \tcode{R}
 \indextext{prefix!\idxcode{R}}%
@@ -1666,6 +1627,8 @@ is equivalent to \tcode{"x = \textbackslash "\textbackslash\textbackslash\textba
 \end{example}
 
 \pnum
+\indextext{literal!string}%
+\indextext{character string}%
 \indextext{string!type of}%
 \indextext{literal!string!narrow}%
 After translation phase 6, a \grammarterm{string-literal}
@@ -1689,11 +1652,13 @@ each successive element of the object representation\iref{basic.types} has
 the value of the corresponding code unit of the UTF-8 encoding of the string.
 
 \pnum
+\indextext{literal!narrow-character}%
 Ordinary string literals and UTF-8 string literals are
 also referred to as narrow string literals.
 
 \pnum
 \indextext{literal!string!UTF-16}%
+\indextext{literal!string!\idxcode{char16_t}}%
 \indextext{type!\idxcode{char16_t}}%
 A \grammarterm{string-literal} that begins with \tcode{u},
 \indextext{prefix!\idxcode{u}}%
@@ -1715,6 +1680,7 @@ as a sequence of two 16-bit code units.
 
 \pnum
 \indextext{literal!string!UTF-32}%
+\indextext{literal!string!\idxcode{char32_t}}%
 \indextext{type!\idxcode{char32_t}}%
 A \grammarterm{string-literal} that begins with \tcode{U},
 \indextext{prefix!\idxcode{U}}%
@@ -1743,17 +1709,17 @@ is initialized with the given characters.
 \pnum
 \indextext{concatenation!string}%
 In translation phase 6\iref{lex.phases}, adjacent \grammarterm{string-literal}{s} are concatenated. If
-both \grammarterm{string-literal}{s} have the same \grammarterm{encoding-prefix}, the resulting concatenated string literal has
+both \grammarterm{string-literal}{s} have the same \grammarterm{encoding-prefix}, the resulting concatenated \grammarterm{string-literal} has
 that \grammarterm{encoding-prefix}. If one \grammarterm{string-literal} has no \grammarterm{encoding-prefix}, it is treated as a \grammarterm{string-literal} of
 the same \grammarterm{encoding-prefix} as the other operand. If a UTF-8 string literal token is adjacent to a
 wide string literal token, the program is ill-formed. Any other concatenations are
-conditionally-supported with \impldef{concatenation of some types of string literals}
+conditionally-supported with \impldef{concatenation of some types of \grammarterm{string-literal}s}
 behavior.
 \begin{note}
 This
 concatenation is an interpretation, not a conversion.
 Because the interpretation happens in translation phase 6 (after each character from a
-string literal has been translated into a value from the appropriate character set), a
+\grammarterm{string-literal} has been translated into a value from the appropriate character set), a
 \grammarterm{string-literal}'s initial rawness has no effect on the interpretation or
 well-formedness of the concatenation.
 \end{note}
@@ -1796,11 +1762,11 @@ after concatenation (and not the single hexadecimal character
 \indextext{\idxcode{0}!null character|see {character, null}}%
 After any necessary concatenation, in translation phase
 7\iref{lex.phases}, \tcode{'\textbackslash 0'} is appended to every
-string literal so that programs that scan a string can find its end.
+\grammarterm{string-literal} so that programs that scan a string can find its end.
 
 \pnum
 Escape sequences and \grammarterm{universal-character-name}{s} in non-raw string literals
-have the same meaning as in character literals\iref{lex.ccon}, except that
+have the same meaning as in \grammarterm{character-literal}s\iref{lex.ccon}, except that
 the single quote \tcode{'} is representable either by itself or by the escape sequence
 \tcode{\textbackslash'}, and the double quote \tcode{"} shall be preceded by a
 \tcode{\textbackslash},
@@ -1837,13 +1803,13 @@ Evaluating a \grammarterm{string-literal} results in a string literal object
 with static storage duration, initialized from the given characters as
 specified above.
 \indextext{string!distinct}%
-Whether all string literals are distinct (that is, are stored in
+Whether all \grammarterm{string-literal}s are distinct (that is, are stored in
 nonoverlapping objects) and whether successive evaluations of a
 \grammarterm{string-literal} yield the same or a different object is
 unspecified.
 \begin{note}
 \indextext{literal!string!undefined change to}%
-The effect of attempting to modify a string literal is undefined.
+The effect of attempting to modify a \grammarterm{string-literal} is undefined.
 \end{note}
 
 \rSec2[lex.bool]{Boolean literals}
@@ -2037,11 +2003,11 @@ int main() {
 \end{example}
 
 \pnum
-In translation phase 6\iref{lex.phases}, adjacent string literals are concatenated and
-\grammarterm{user-defined-string-literal}{s} are considered string literals for that
+In translation phase 6\iref{lex.phases}, adjacent \grammarterm{string-literal}s are concatenated and
+\grammarterm{user-defined-string-literal}{s} are considered \grammarterm{string-literal}s for that
 purpose. During concatenation, \grammarterm{ud-suffix}{es} are removed and ignored and
 the concatenation process occurs as described in~\ref{lex.string}. At the end of phase
-6, if a string literal is the result of a concatenation involving at least one
+6, if a \grammarterm{string-literal} is the result of a concatenation involving at least one
 \grammarterm{user-defined-string-literal}, all the participating
 \grammarterm{user-defined-string-literal}{s} shall have the same \grammarterm{ud-suffix}
 and that suffix is applied to the result of the concatenation.

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -997,7 +997,7 @@ elements up to and including the terminating null character.
 \pnum
 A \defnx{static \ntbs{}}{NTBS@\ntbs{}!static}
 is an \ntbs{} with
-static storage duration.\footnote{A string literal, such as
+static storage duration.\footnote{A \grammarterm{string-literal}, such as
 \tcode{"abc"},
 is a static \ntbs{}.}
 

--- a/source/limits.tex
+++ b/source/limits.tex
@@ -59,7 +59,7 @@ Arguments in one macro invocation\iref{cpp.replace} [256].
 \item%
 Characters in one logical source line\iref{lex.phases} [65\,536].
 \item%
-Characters in a string literal\iref{lex.string}
+Characters in a \grammarterm{string-literal}\iref{lex.string}
 (after concatenation\iref{lex.phases}) [65\,536].
 \item%
 Size of an object\iref{intro.object} [262\,144].

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -1373,7 +1373,7 @@ values to the corresponding
 \tcode{charT}
 value or values.\footnote{The char argument of
 \tcode{do_widen}
-is intended to accept values derived from character literals for conversion
+is intended to accept values derived from \grammarterm{character-literal}s for conversion
 to the locale's encoding.}
 The only characters for which unique transformations are required
 are those in the basic source character set\iref{lex.charset}.

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1583,7 +1583,7 @@ where
 \begin{itemize}
 \item
 if $e_i$ is of array type and
-$x_i$ is a \grammarterm{braced-init-list} or string literal,
+$x_i$ is a \grammarterm{braced-init-list} or \grammarterm{string-literal},
 $\tcode{T}_i$ is an rvalue reference to the declared type of $e_i$, and
 \item
 otherwise, $\tcode{T}_i$ is the declared type of $e_i$,
@@ -2631,7 +2631,7 @@ Otherwise, if the parameter type is a character array%
 \footnote{Since there are no parameters of array type,
 this will only occur as the referenced type of a reference parameter.}
 and the initializer list has a single element that is an appropriately-typed
-string literal\iref{dcl.init.string}, the implicit conversion
+\grammarterm{string-literal}\iref{dcl.init.string}, the implicit conversion
 sequence is the identity conversion.
 
 \pnum

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -475,17 +475,17 @@ the integer literal \tcode{0x8000} is signed and positive within a \tcode{\#if}
 expression even though it is unsigned in translation phase
 7\iref{lex.phases}.
 \end{note}
-This includes interpreting character literals, which may involve
+This includes interpreting \grammarterm{character-literal}s, which may involve
 converting escape sequences into execution character set members.
-Whether the numeric value for these character literals
-matches the value obtained when an identical character literal
+Whether the numeric value for these \grammarterm{character-literal}s
+matches the value obtained when an identical \grammarterm{character-literal}
 occurs in an expression
 (other than within a
 \tcode{\#if}
 or
 \tcode{\#elif}
 directive)
-is \impldef{numeric values of character literals in \tcode{\#if}
+is \impldef{numeric values of \grammarterm{character-literal}s in \tcode{\#if}
 directives}.
 \begin{note}
 Thus, the constant expression in the following
@@ -499,8 +499,8 @@ contexts:
 if ('z' - 'a' == 25)
 \end{codeblock}
 \end{note}
-Also, whether a single-character character literal may have a negative
-value is \impldef{negative value of character literal in preprocessor}.
+Also, whether a single-character \grammarterm{character-literal} may have a negative
+value is \impldef{negative value of \grammarterm{character-literal} in preprocessor}.
 Each subexpression with type
 \tcode{bool}
 is subjected to integral promotion before processing continues.
@@ -665,10 +665,10 @@ in the directive are processed just as in normal text
 replacement list of preprocessing tokens).
 If the directive resulting after all replacements does not match
 one of the two previous forms, the behavior is
-undefined.\footnote{Note that adjacent string literals are not concatenated into
-a single string literal
+undefined.\footnote{Note that adjacent \grammarterm{string-literal}s are not concatenated into
+a single \grammarterm{string-literal}
 (see the translation phases in~\ref{lex.phases});
-thus, an expansion that results in two string literals is an
+thus, an expansion that results in two \grammarterm{string-literal}s is an
 invalid directive.}
 The method by which a sequence of preprocessing tokens between a
 \tcode{<}
@@ -1036,7 +1036,7 @@ A preprocessing directive of the form
 defines an
 \defnadj{object-like}{macro} that
 causes each subsequent instance of the macro name\footnote{Since, by macro-replacement time,
-all character literals and string literals are preprocessing tokens,
+all \grammarterm{character-literal}s and \grammarterm{string-literal}s are preprocessing tokens,
 not sequences possibly containing identifier-like subsequences
 (see \ref{lex.phases}, translation phases),
 they are never scanned for macro names or parameters.}
@@ -1295,14 +1295,14 @@ preprocessing token comprising the stringizing argument is deleted.
 Otherwise, the original spelling of each preprocessing token in the
 stringizing argument is retained in the character string literal,
 except for special handling for producing the spelling of
-string literals and character literals:
+\grammarterm{string-literal}s and \grammarterm{character-literal}s:
 a
 \tcode{\textbackslash}
 character is inserted before each
 \tcode{"}
 and
 \tcode{\textbackslash}
-character of a character literal or string literal
+character of a \grammarterm{character-literal} or \grammarterm{string-literal}
 (including the delimiting
 \tcode{"}
 characters).
@@ -1534,7 +1534,7 @@ a macro name.
 \indextext{\idxcode{\#line}|see{preprocessing directives, line control}}
 
 \pnum
-The string literal of a
+The \grammarterm{string-literal} of a
 \tcode{\#line}
 directive, if present,
 shall be a character string literal.
@@ -1859,7 +1859,7 @@ A unary operator expression of the form:
 \begin{ncbnf}
 \terminal{_Pragma} \terminal{(} string-literal \terminal{)}
 \end{ncbnf}
-is processed as follows: The string literal is \defnx{destringized}{destringization}
+is processed as follows: The \grammarterm{string-literal} is \defnx{destringized}{destringization}
 by deleting the \tcode{L} prefix, if present, deleting the leading and trailing
 double-quotes, replacing each escape sequence \tcode{\textbackslash"} by a double-quote, and
 replacing each escape sequence \tcode{\textbackslash\textbackslash} by a single

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -4437,7 +4437,7 @@ constexpr const_pointer data() const noexcept;
 
 \pnum
 \begin{note}
-Unlike \tcode{basic_string::data()} and string literals,
+Unlike \tcode{basic_string::data()} and \grammarterm{string-literal}s,
 \tcode{data()} may return a pointer to a buffer that is not null-terminated.
 Therefore it is typically a mistake to pass \tcode{data()} to a function that takes just a \tcode{const charT*} and expects a null-terminated string.
 \end{note}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1221,7 +1221,7 @@ the reference or pointer value shall not refer to
 or be the address of (respectively):
 \begin{itemize}
 \item a temporary object\iref{class.temporary},
-\item a string literal\iref{lex.string},
+\item a string literal object\iref{lex.string},
 \item the result of a \tcode{typeid} expression\iref{expr.typeid},
 \item a predefined \mname{func} variable\iref{dcl.fct.def.general}, or
 \item a subobject\iref{intro.object} of one of the above.
@@ -1260,7 +1260,7 @@ B<void(0)> b4;                  // error: template parameter type cannot be \tco
 
 \pnum
 \begin{note}
-A string literal\iref{lex.string} is
+A \grammarterm{string-literal}\iref{lex.string} is
 not an acceptable \grammarterm{template-argument}
 for a \grammarterm{template-parameter} of non-class type.
 \begin{example}
@@ -1269,8 +1269,8 @@ template<class T, T p> class X {
   @\commentellip@
 };
 
-X<const char*, "Studebaker"> x; // error: string literal as \grammarterm{template-argument}
-X<const char*, "Knope" + 1> x2; // error: subobject of string literal as \grammarterm{template-argument}
+X<const char*, "Studebaker"> x; // error: string literal object as \grammarterm{template-argument}
+X<const char*, "Knope" + 1> x2; // error: subobject of string literal object as \grammarterm{template-argument}
 
 const char p[] = "Vivisectionist";
 X<const char*, p> y;            // OK
@@ -1279,7 +1279,7 @@ struct A {
   constexpr A(const char*) {}
 };
 
-X<A, "Pyrophoricity"> z;        // OK, string literal is a constructor argument to \tcode{A}
+X<A, "Pyrophoricity"> z;        // OK, \grammarterm{string-literal} is a constructor argument to \tcode{A}
 \end{codeblock}
 \end{example}
 \end{note}


### PR DESCRIPTION
Also use the grammar non-terminals character-literal and
string-literal throughout the standard.

Fixes #3636.