### PR TITLE
[support.dynamic] Improve cross-referencing for dynamic memory subcla…

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3598,7 +3598,7 @@ c1.f();                         // well-defined; \tcode{c1} refers to a new obje
 If these conditions are not met,
 a pointer to the new object can be obtained from
 a pointer that represents the address of its storage
-by calling \tcode{std::launder}\iref{support.dynamic}.
+by calling \tcode{std::launder}\iref{ptr.launder}.
 \end{note}
 
 \pnum

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2782,7 +2782,7 @@ in the program\iref{definitions}.
 \pnum
 A \Cpp{} program may provide the definition for any of the following
 dynamic memory allocation function signatures declared in header
-\tcode{<new>}~(\ref{basic.stc.dynamic}, \ref{support.dynamic}):
+\tcode{<new>}~(\ref{basic.stc.dynamic}, \ref{new.syn}):
 
 \indextext{\idxcode{new}!\idxcode{operator}!replaceable}%
 \indexlibrarymember{new}{operator}%
@@ -2823,7 +2823,7 @@ operator delete[](void*, std::align_val_t, const std::nothrow_t&)
 
 \pnum
 The program's definitions are used instead of the default versions supplied by
-the implementation\iref{support.dynamic}.
+the implementation\iref{new.delete}.
 Such replacement occurs prior to program startup~(\ref{basic.def.odr}, \ref{basic.start}).
 \indextext{startup!program}%
 The program's declarations shall not be specified as

--- a/source/support.tex
+++ b/source/support.tex
@@ -2003,14 +2003,9 @@ functions that manage the allocation of dynamic storage in a program.
 It also defines components for reporting storage management errors.
 
 \rSec2[new.syn]{Header \tcode{<new>} synopsis}
-
-\indexlibraryglobal{align_val_t}%
-\indexlibraryglobal{destroying_delete_t}%
-\indexlibraryglobal{destroying_delete}%
-\indexlibraryglobal{nothrow_t}%
-\indexlibraryglobal{nothrow}%
 \begin{codeblock}
 namespace std {
+  // \ref{alloc.errors}, memory allocation exceptions
   class bad_alloc;
   class bad_array_new_length;
 
@@ -2019,6 +2014,12 @@ namespace std {
   };
   inline constexpr destroying_delete_t destroying_delete{};
 
+  // global operator new control%
+  \indexlibraryglobal{align_val_t}%
+  \indexlibraryglobal{destroying_delete_t}%
+  \indexlibraryglobal{destroying_delete}%
+  \indexlibraryglobal{nothrow_t}%
+  \indexlibraryglobal{nothrow}
   enum class align_val_t : size_t {};
 
   struct nothrow_t { explicit nothrow_t() = default; };
@@ -2036,6 +2037,7 @@ namespace std {
   inline constexpr size_t hardware_constructive_interference_size = @\impdef{}@;
 }
 
+// \ref{new.delete}, global operator new
 [[nodiscard]] void* operator new(std::size_t size);
 [[nodiscard]] void* operator new(std::size_t size, std::align_val_t alignment);
 [[nodiscard]] void* operator new(std::size_t size, const std::nothrow_t&) noexcept;

--- a/source/support.tex
+++ b/source/support.tex
@@ -2005,7 +2005,7 @@ It also defines components for reporting storage management errors.
 \rSec2[new.syn]{Header \tcode{<new>} synopsis}
 \begin{codeblock}
 namespace std {
-  // \ref{alloc.errors}, storage allocation errors 
+  // \ref{alloc.errors}, storage allocation errors
   class bad_alloc;
   class bad_array_new_length;
 
@@ -2037,7 +2037,7 @@ namespace std {
   inline constexpr size_t hardware_constructive_interference_size = @\impdef{}@;
 }
 
-// \ref{new.delete}, storage allocation and deallocation 
+// \ref{new.delete}, storage allocation and deallocation
 [[nodiscard]] void* operator new(std::size_t size);
 [[nodiscard]] void* operator new(std::size_t size, std::align_val_t alignment);
 [[nodiscard]] void* operator new(std::size_t size, const std::nothrow_t&) noexcept;

--- a/source/support.tex
+++ b/source/support.tex
@@ -2014,7 +2014,7 @@ namespace std {
   };
   inline constexpr destroying_delete_t destroying_delete{};
 
-  // global operator new control%
+  // global \tcode{operator new} control%
   \indexlibraryglobal{align_val_t}%
   \indexlibraryglobal{destroying_delete_t}%
   \indexlibraryglobal{destroying_delete}%

--- a/source/support.tex
+++ b/source/support.tex
@@ -2037,7 +2037,7 @@ namespace std {
   inline constexpr size_t hardware_constructive_interference_size = @\impdef{}@;
 }
 
-// \ref{new.delete}, global operator new
+// \ref{new.delete}, storage allocation and deallocation 
 [[nodiscard]] void* operator new(std::size_t size);
 [[nodiscard]] void* operator new(std::size_t size, std::align_val_t alignment);
 [[nodiscard]] void* operator new(std::size_t size, const std::nothrow_t&) noexcept;

--- a/source/support.tex
+++ b/source/support.tex
@@ -2005,7 +2005,7 @@ It also defines components for reporting storage management errors.
 \rSec2[new.syn]{Header \tcode{<new>} synopsis}
 \begin{codeblock}
 namespace std {
-  // \ref{alloc.errors}, memory allocation exceptions
+  // \ref{alloc.errors}, storage allocation errors 
   class bad_alloc;
   class bad_array_new_length;
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -8336,7 +8336,7 @@ These functions have the semantics specified in the C standard library.
 \pnum
 \remarks
 These functions do not attempt to allocate
-storage by calling \tcode{::operator new()}\iref{support.dynamic}.
+storage by calling \tcode{::operator new()}\iref{new.delete}.
 \indexlibrarymember{new}{operator}%
 
 \pnum


### PR DESCRIPTION
…uses

Update several cross-references to subclause 17.6 with more precise
refernces to subclauses nested one level deeper.  For the synopsis
of the header, added a couple of banner comments with cross-references
too.

In addition, looked into ordering the global namespace declarations
in front of opening namespace std to improve clarity, but that fails
due to use of types declared in namespace std by this header!