### PR TITLE
[time.zone.zonedtime.overview] Fix typo

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -9652,7 +9652,7 @@ namespace std::chrono {
     using @\exposid{time-zone-representation}@ =        // \expos
       conditional_t<is_convertible_v<TimeZonePtrOrName, string_view>,
                     const time_zone*,
-                    remove_cv_ref<TimeZonePtrOrName>>;
+                    remove_cvref_t<TimeZonePtrOrName>>;
 
   template<class TimeZonePtrOrName>
     zoned_time(TimeZonePtrOrName&&)


### PR DESCRIPTION
This is a typographical error in the PR of [LWG3294](https://cplusplus.github.io/LWG/issue3294). Clearly<sup>1</sup> `remove_cvref_t` is meant.

cc @HowardHinnant @tomaszkam

<sup>1</sup> For some definition of "clearly".