### PR TITLE
[range.split.outer], [range.split.inner] Fix misuses of current_

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -5590,17 +5590,17 @@ constexpr @\exposid{outer-iterator}@& operator++();
 Equivalent to:
 \begin{codeblock}
 const auto end = ranges::end(@\exposid{parent_}@->@\exposid{base_}@);
-if (@\exposid{current_}@ == end) return *this;
+if (@\placeholder{current}@ == end) return *this;
 const auto [pbegin, pend] = subrange{@\exposid{parent_}@->@\exposid{pattern_}@};
-if (pbegin == pend) ++@\exposid{current_}@;
+if (pbegin == pend) ++@\placeholder{current}@;
 else {
   do {
-    auto [b, p] = ranges::mismatch(std::move(@\exposid{current_}@), end, pbegin, pend);
-    @\exposid{current_}@ = std::move(b);
+    auto [b, p] = ranges::mismatch(std::move(@\placeholder{current}@), end, pbegin, pend);
+    @\placeholder{current}@ = std::move(b);
     if (p == pend) {
       break;            // The pattern matched; skip it
     }
-  } while (++@\exposid{current_}@ != end);
+  } while (++@\placeholder{current}@ != end);
 }
 return *this;
 \end{codeblock}
@@ -5626,7 +5626,7 @@ friend constexpr bool operator==(const @\exposid{outer-iterator}@& x, default_se
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return x.\exposid{current_} == ranges::end(x.\exposid{parent_}->\exposid{base_});}
+Equivalent to: \tcode{return x.\placeholdernc{current} == ranges::end(x.\exposid{parent_}->\exposid{base_});}
 \end{itemdescr}
 
 \rSec3[range.split.outer.value]{Class \tcode{split_view::\exposid{outer-iterator}::value_type}}
@@ -5715,7 +5715,7 @@ namespace std::ranges {
     @\exposid{inner-iterator}@() = default;
     constexpr explicit @\exposid{inner-iterator}@(@\exposid{outer-iterator}@<Const> i);
 
-    constexpr decltype(auto) operator*() const { return *@\exposid{i_}@.@\exposid{current_}@; }
+    constexpr decltype(auto) operator*() const { return *@\exposid{i_}@.@\placeholder{current}@; }
 
     constexpr @\exposid{inner-iterator}@& operator++();
     constexpr decltype(auto) operator++(int) {


### PR DESCRIPTION
This restores references to the 'current' placeholder.

Fixes #3848