### PR TITLE
[span.deduct] Rename template parameter 'End' to 'EndOrSize'

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10711,8 +10711,8 @@ namespace std {
     size_type size_;            // \expos
   };
 
-  template<class It, class End>
-    span(It, End) -> span<remove_reference_t<iter_reference_t<It>>>;
+  template<class It, class EndOrSize>
+    span(It, EndOrSize) -> span<remove_reference_t<iter_reference_t<It>>>;
   template<class T, size_t N>
     span(T (&)[N]) -> span<T, N>;
   template<class T, size_t N>
@@ -10972,8 +10972,8 @@ constexpr span& operator=(const span& other) noexcept = default;
 
 \indexlibrary{\idxcode{span}!deduction guide}%
 \begin{itemdecl}
-template<class It, class End>
-  span(It, End) -> span<remove_reference_t<iter_reference_t<It>>>;
+template<class It, class EndOrSize>
+  span(It, EndOrSize) -> span<remove_reference_t<iter_reference_t<It>>>;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
because it also covers the size_type constructor of span.

Fixes #3778.