### PR TITLE
[res.on.requires] Move description of 'Requires' element to Annex D

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -343,6 +343,20 @@ much as in the C Standard. It may also provide these names within
 the namespace \tcode{std}.
 \end{example}
 
+\rSec1[depr.res.on.required]{Requires paragraph}
+
+\pnum
+In addition to the elements specified in \ref{structure.specifications},
+descriptions of function semantics may also contain a \requires element
+to denote the preconditions for calling a function.
+
+\pnum
+\indextext{restriction}%
+Violation of any preconditions specified in a function's \requires element
+results in undefined behavior
+unless the function's \throws element
+specifies throwing an exception when the precondition is violated.
+
 \indexlibraryglobal{rel_ops}%
 \rSec1[depr.relops]{Relational operators}
 

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -592,9 +592,6 @@ preconditions, there will be no \expects element.}
 
 \begin{itemize}
 \item
-\requires the preconditions for calling the function.
-
-\item
 \constraints
 the conditions for the function's participation
 in overload resolution\iref{over.match}.
@@ -2981,14 +2978,7 @@ the behavior is undefined unless otherwise specified.
 This applies even to objects such as mutexes intended for thread synchronization.
 \end{note}
 
-\rSec3[res.on.required]{Requires paragraph}
-
-\pnum
-\indextext{restriction}%
-Violation of any preconditions specified in a function's \requires element
-results in undefined behavior
-unless the function's \throws element
-specifies throwing an exception when the precondition is violated.
+\rSec3[res.on.expects]{Expects paragraph}
 
 \pnum
 Violation of any preconditions specified in a function's \expects element

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -289,3 +289,6 @@
 
 % Deprecated free-function atomic access to shared pointers
 \deprxref{util.smartptr.shared.atomic}
+
+% Deprecated "requires" element
+\deprxref{res.on.required}


### PR DESCRIPTION
Fixes #3664 