### PR TITLE
[range.access] Introduce 'reified object' to simplify the descriptions.

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -336,6 +336,17 @@ In addition to being available via inclusion of the \libheader{ranges}
 header, the customization point objects in \ref{range.access} are
 available when \libheaderrefx{iterator}{iterator.synopsis} is included.
 
+\pnum
+Within this subclause,
+the \defnadj{reified}{object} of a subexpression \tcode{E} denotes
+\begin{itemize}
+\item
+the same object as \tcode{E} if \tcode{E} is a glvalue, or
+\item
+the result of applying
+the temporary materialization conversion\iref{conv.rval} to \tcode{E} otherwise.
+\end{itemize}
+
 \rSec2[range.access.begin]{\tcode{ranges::begin}}
 \pnum
 The name \tcode{ranges::begin} denotes a customization point
@@ -343,10 +354,7 @@ object\iref{customization.point.object}.
 
 \pnum
 Given a subexpression \tcode{E} with type \tcode{T},
-let \tcode{t} be an lvalue that
-denotes the same object as \tcode{E} if \tcode{E} is a glvalue, and
-otherwise denotes the result of applying
-the temporary materialization conversion\iref{conv.rval} to \tcode{E}.
+let \tcode{t} be an lvalue that denotes the reified object for \tcode{E}.
 Then:
 
 \begin{itemize}
@@ -410,10 +418,7 @@ object\iref{customization.point.object}.
 
 \pnum
 Given a subexpression \tcode{E} with type \tcode{T},
-let \tcode{t} be an lvalue that
-denotes the same object as \tcode{E} if \tcode{E} is a glvalue, and
-otherwise denotes the result of applying
-the temporary materialization conversion\iref{conv.rval} to \tcode{E}.
+let \tcode{t} be an lvalue that denotes the reified object for \tcode{E}.
 Then:
 
 \begin{itemize}
@@ -520,10 +525,7 @@ object\iref{customization.point.object}.
 
 \pnum
 Given a subexpression \tcode{E} with type \tcode{T},
-let \tcode{t} be an lvalue that
-denotes the same object as \tcode{E} if \tcode{E} is a glvalue, and
-otherwise denotes the result of applying
-the temporary materialization conversion\iref{conv.rval} to \tcode{E}.
+let \tcode{t} be an lvalue that denotes the reified object for \tcode{E}.
 Then:
 
 \begin{itemize}
@@ -590,10 +592,7 @@ object\iref{customization.point.object}.
 
 \pnum
 Given a subexpression \tcode{E} with type \tcode{T},
-let \tcode{t} be an lvalue that
-denotes the same object as \tcode{E} if \tcode{E} is a glvalue, and
-otherwise denotes the result of applying
-the temporary materialization conversion\iref{conv.rval} to \tcode{E}.
+let \tcode{t} be an lvalue that denotes the reified object for \tcode{E}.
 Then:
 
 \begin{itemize}
@@ -700,10 +699,7 @@ object\iref{customization.point.object}.
 
 \pnum
 Given a subexpression \tcode{E} with type \tcode{T},
-let \tcode{t} be an lvalue that
-denotes the same object as \tcode{E} if \tcode{E} is a glvalue, and
-otherwise denotes the result of applying
-the temporary materialization conversion\iref{conv.rval} to \tcode{E}.
+let \tcode{t} be an lvalue that denotes the reified object for \tcode{E}.
 Then:
 
 \begin{itemize}
@@ -794,10 +790,7 @@ object\iref{customization.point.object}.
 
 \pnum
 Given a subexpression \tcode{ranges::empty(E)} with type \tcode{T},
-let \tcode{t} be an lvalue that
-denotes the same object as \tcode{E} if \tcode{E} is a glvalue, and
-otherwise denotes the result of applying
-the temporary materialization conversion\iref{conv.rval} to \tcode{E}.
+let \tcode{t} be an lvalue that denotes the reified object for \tcode{E}.
 Then:
 
 \begin{itemize}
@@ -846,10 +839,7 @@ object\iref{customization.point.object}.
 
 \pnum
 Given a subexpression \tcode{E} with type \tcode{T},
-let \tcode{t} be an lvalue that
-denotes the same object as \tcode{E} if \tcode{E} is a glvalue, and
-otherwise denotes the result of applying
-the temporary materialization conversion\iref{conv.rval} to \tcode{E}.
+let \tcode{t} be an lvalue that denotes the reified object for \tcode{E}.
 Then:
 
 \begin{itemize}


### PR DESCRIPTION
Fixes #3802.