### PR TITLE
[support] Renamed from [language.support].

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1170,7 +1170,7 @@ code that defines \tcode{override}, \tcode{final},
 \tcode{carries_dependency}, or \tcode{noreturn} as macros is invalid in this
 International Standard.
 
-\rSec2[diff.cpp03.language.support]{\ref{language.support}:
+\rSec2[diff.cpp03.language.support]{\ref{support}:
 language support library}
 
 \diffref{new.delete.single}

--- a/source/config.tex
+++ b/source/config.tex
@@ -9,5 +9,5 @@
 \newcommand{\reldate}{\today}
 
 %% Library chapters
-\newcommand{\firstlibchapter}{language.support}
+\newcommand{\firstlibchapter}{support}
 \newcommand{\lastlibchapter}{thread}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -26,7 +26,7 @@ Detailed specifications for each of the components in the library are in
 {ll}
 \topline
 \hdstyle{Clause}        & \hdstyle{Category}          \\ \capsep
-\ref{language.support}  & Language support library    \\
+\ref{support}           & Language support library    \\
 \ref{concepts}          & Concepts library            \\
 \ref{diagnostics}       & Diagnostics library         \\
 \ref{utilities}         & General utilities library   \\
@@ -45,7 +45,7 @@ Detailed specifications for each of the components in the library are in
 \end{floattable}
 
 \pnum
-The language support library\iref{language.support} provides components that are
+The language support library\iref{support} provides components that are
 required by certain parts of the \Cpp{} language, such as memory allocation~(\ref{expr.new},
 \ref{expr.delete}) and exception processing\iref{except}.
 
@@ -260,7 +260,7 @@ non-reserved function whose definition may be provided by a \Cpp{} program
 \begin{defnote}
 A \Cpp{} program may designate a handler function at various points in its execution by
 supplying a pointer to the function when calling any of the library functions that install
-handler functions\iref{language.support}.
+handler functions\iref{support}.
 \end{defnote}
 
 \definition{implementation-defined strict total order over pointers}
@@ -680,7 +680,7 @@ then that supersedes any occurrences of that element in the code sequence.
 
 \pnum
 For non-reserved replacement and handler functions,
-\ref{language.support} specifies two behaviors for the functions in question:
+\ref{support} specifies two behaviors for the functions in question:
 their required and default behavior.
 The \defnx{default behavior}{behavior!default}
 describes a function definition provided by the implementation.
@@ -2834,7 +2834,7 @@ No diagnostic is required.
 
 \pnum
 The \Cpp{} standard library provides a default version of the following handler
-function\iref{language.support}:
+function\iref{support}:
 
 \begin{itemize}
 \item

--- a/source/support.tex
+++ b/source/support.tex
@@ -1,5 +1,5 @@
 %!TEX root = std.tex
-\rSec0[language.support]{Language support library}
+\rSec0[support]{Language support library}
 
 \rSec1[support.general]{General}
 

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -284,6 +284,9 @@
 % Dissolved subclause.
 \movedxref{func.wrap.badcall.const}{func.wrap.badcall}
 
+% Shortened label
+\movedxref{language.support}{support}
+
 % Deprecated features.
 %\deprxref{old.label}  (if moved to depr.old.label, otherwise use \movedxref)
 


### PR DESCRIPTION
Fixes #3520.