### PR TITLE
[basic,support] Correctly use 'startup' and 'start of program'

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -6402,7 +6402,7 @@ other threads in a finite period of time.%
 \indextext{\idxcode{main} function|(}
 
 \pnum
-\indextext{program!start|(}%
+\indextext{program!startup|(}%
 A program shall contain a global function called \tcode{main}
 attached to the global module.
 Executing a program starts a main thread of execution~(\ref{intro.multithread}, \ref{thread.threads})
@@ -6413,8 +6413,8 @@ It is \impldef{defining \tcode{main} in freestanding environment}
 whether a program in a freestanding environment is required to define a \tcode{main}
 function.
 \begin{note}
-In a freestanding environment, start-up and termination is
-\impldef{start-up and termination in freestanding environment}; start-up contains the
+In a freestanding environment, startup and termination is
+\impldef{startup and termination in freestanding environment}; startup contains the
 execution of constructors for objects of namespace scope with static storage duration;
 termination contains the execution of destructors for objects with static storage
 duration.
@@ -6729,7 +6729,7 @@ If the initialization of
 a non-local variable with static or thread storage duration
 exits via an exception,
 the function \tcode{std::terminate} is called\iref{except.terminate}.%
-\indextext{program!start|)}
+\indextext{program!startup|)}
 
 \rSec3[basic.start.term]{Termination}
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -1393,7 +1393,7 @@ static constexpr bool traps;
 \begin{itemdescr}
 \pnum
 \tcode{true}
-if, at program startup, there exists a value of the type that would cause
+if, at the start of the program, there exists a value of the type that would cause
 an arithmetic operation using that value to trap.\footnote{Required by LIA-1.}
 
 \pnum
@@ -1790,7 +1790,7 @@ the C standard library header \libheader{stdint.h}.
 
 \xrefc{7.20}
 
-\rSec1[support.start.term]{Start and termination}
+\rSec1[support.start.term]{Startup and termination}
 
 \pnum
 \begin{note}


### PR DESCRIPTION
Fixes #3530.