### PR TITLE
[support.types.byteops] Fix misapplication of LWG2950

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -389,7 +389,7 @@ template<class IntType>
 \pnum
 \effects
 Equivalent to:
-\tcode{return b >> shift;}
+\tcode{return b = b >> shift;}
 \end{itemdescr}
 
 \indexlibrarymember{operator>>}{byte}%


### PR DESCRIPTION
[LWG2950](https://wg21.link/LWG2950) has the correct edit but 61babcd dropped the `b =` part.

(Also, now that core has fixed this part of the rules in [CWG2338](https://wg21.link/CWG2338), we can editorially drop the `static_cast<unsigned char>`, but that's separate.)

Fixes #3862.