### PR TITLE
[support.types.byteops] remove redundant static_cast to unsigned char

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -370,8 +370,7 @@ template<class IntType>
 \effects
 Equivalent to:
 \begin{codeblock}
-return static_cast<byte>(static_cast<unsigned char>(
-	                   static_cast<unsigned int>(b) << shift));
+return static_cast<byte>(static_cast<unsigned int>(b) << shift);
 \end{codeblock}
 \end{itemdescr}
 
@@ -407,8 +406,7 @@ template<class IntType>
 \effects
 Equivalent to:
 \begin{codeblock}
-return static_cast<byte>(static_cast<unsigned char>(
-	                   static_cast<unsigned int>(b) >> shift));
+return static_cast<byte>(static_cast<unsigned int>(b) >> shift);
 \end{codeblock}
 \end{itemdescr}
 
@@ -433,8 +431,7 @@ constexpr byte operator|(byte l, byte r) noexcept;
 \effects
 Equivalent to:
 \begin{codeblock}
-return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(l) |
-                                                    static_cast<unsigned int>(r)));
+return static_cast<byte>(static_cast<unsigned int>(l) | static_cast<unsigned int>(r));
 \end{codeblock}
 \end{itemdescr}
 
@@ -459,8 +456,7 @@ constexpr byte operator&(byte l, byte r) noexcept;
 \effects
 Equivalent to:
 \begin{codeblock}
-return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(l) &
-                                                    static_cast<unsigned int>(r)));
+return static_cast<byte>(static_cast<unsigned int>(l) & static_cast<unsigned int>(r));
 \end{codeblock}
 \end{itemdescr}
 
@@ -485,8 +481,7 @@ constexpr byte operator^(byte l, byte r) noexcept;
 \effects
 Equivalent to:
 \begin{codeblock}
-return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(l) ^
-                                                    static_cast<unsigned int>(r)));
+return static_cast<byte>(static_cast<unsigned int>(l) ^ static_cast<unsigned int>(r));
 \end{codeblock}
 \end{itemdescr}
 
@@ -500,8 +495,7 @@ constexpr byte operator~(byte b) noexcept;
 \effects
 Equivalent to:
 \begin{codeblock}
-return static_cast<byte>(static_cast<unsigned char>(
-	                   ~static_cast<unsigned int>(b)));
+return static_cast<byte>(~static_cast<unsigned int>(b));
 \end{codeblock}
 \end{itemdescr}
 


### PR DESCRIPTION
These casts are redundant after [CWG2338](https://wg21.link/CWG2338).