### PR TITLE
[allocator.requirements] Fix punctuation in tables.

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2024,17 +2024,17 @@ and \tcode{std::forward}, respectively.
 \tcode{p}       &   a value of type \tcode{XX::pointer}, obtained
 by calling \tcode{a1.allocate}, where \tcode{a1 == a}   \\ \rowsep
 \tcode{q}       &   a value of type \tcode{XX::const_pointer}
-obtained by conversion from a value \tcode{p}.          \\ \rowsep
+obtained by conversion from a value \tcode{p}           \\ \rowsep
 \tcode{r}       &   a value of type \tcode{T\&}
-obtained by the expression \tcode{*p}.                  \\ \rowsep
+obtained by the expression \tcode{*p}                   \\ \rowsep
 \tcode{w}       &   a value of type \tcode{XX::void_pointer} obtained by
   conversion from a value \tcode{p}  \\ \rowsep
 \tcode{x}       &   a value of type \tcode{XX::const_void_pointer} obtained by
   conversion from a value \tcode{q} or a value \tcode{w}  \\ \rowsep
 \tcode{y}       &   a value of type \tcode{XX::const_void_pointer} obtained by
 conversion from a result value of \tcode{YY::allocate}, or else a value of
-type (possibly \tcode{const}) \tcode{std::nullptr_t}. \\ \rowsep
-\tcode{n}       &   a value of type \tcode{XX::size_type}.   \\ \rowsep
+type (possibly \tcode{const}) \tcode{std::nullptr_t}  \\ \rowsep
+\tcode{n}       &   a value of type \tcode{XX::size_type}    \\ \rowsep
 \tcode{Args}    &   a template parameter pack               \\ \rowsep
 \tcode{args}    &   a function parameter pack with the pattern \tcode{Args\&\&} \\
 \end{libreqtab2}
@@ -2075,13 +2075,13 @@ type (possibly \tcode{const}) \tcode{std::nullptr_t}. \\ \rowsep
 
 \tcode{X::size_type}        &
   unsigned integer type     &
-  a type that can represent the size of the largest object in the allocation model. &
+  a type that can represent the size of the largest object in the allocation model &
   \tcode{make_unsigned_t<X::\brk{}difference_type>} \\ \rowsep
 
 \tcode{X::difference_type}  &
   signed integer type       &
   a type that can represent the difference between any two pointers
-    in the allocation model.&
+    in the allocation model &
   \tcode{pointer_traits<X::\brk{}pointer>::\brk{}difference_type} \\ \rowsep
 
 \tcode{typename X::template rebind<U>::other}   &
@@ -2095,15 +2095,17 @@ type (possibly \tcode{const}) \tcode{std::nullptr_t}. \\ \rowsep
 
 \tcode{*q}                  &
   \tcode{const T\&}         &
-  \tcode{*q} refers to the same object as \tcode{*p}& \\ \rowsep
+  \tcode{*q} refers to the same object as \tcode{*p}. & \\ \rowsep
 
 \tcode{p->m}                &
   type of \tcode{T::m}      &
-  \expects \tcode{(*p).m} is well-defined. equivalent to \tcode{(*p).m}  & \\ \rowsep
+  \expects \tcode{(*p).m} is well-defined.\br
+  equivalent to \tcode{(*p).m}  & \\ \rowsep
 
 \tcode{q->m}                &
   type of \tcode{T::m}      &
-  \expects \tcode{(*q).m} is well-defined. equivalent to \tcode{(*q).m}  & \\ \rowsep
+  \expects \tcode{(*q).m} is well-defined.\br
+  equivalent to \tcode{(*q).m}  & \\ \rowsep
 
 \tcode{static_cast<\brk{}X::pointer\brk{}>(w)}  &
   \tcode{X::pointer}                &
@@ -2158,7 +2160,7 @@ If \tcode{n == 0}, the return value is unspecified.
 
 \tcode{a1 == a2}            &
   \tcode{bool}              &
-  returns \tcode{true} only if storage allocated from each can
+  Returns \tcode{true} only if storage allocated from each can
     be deallocated via the other. \tcode{operator==} shall be reflexive, symmetric,
     and transitive, and shall not exit via an exception. &  \\ \rowsep
 
@@ -2199,7 +2201,7 @@ If \tcode{n == 0}, the return value is unspecified.
 \tcode{a.construct(c, args)}&
   (not used)                &
   \effects Constructs an object of type \tcode{C} at
-    \tcode{c}               &
+    \tcode{c}.              &
   \tcode{construct_at(c,~std::\brk{}forward<Args>\brk{}(args)...)}  \\ \rowsep
 
 \tcode{a.destroy(c)}        &
@@ -2209,7 +2211,7 @@ If \tcode{n == 0}, the return value is unspecified.
 
 \tcode{a.select_on_container_copy_construction()} &
   \tcode{X}                 &
-  Typically returns either \tcode{a} or \tcode{X()} &
+  Typically returns either \tcode{a} or \tcode{X()}. &
   \tcode{return a;}         \\ \rowsep
 
 \tcode{X::propagate_on_container_copy_assignment} &


### PR DESCRIPTION
Fixes #3202. 

The requirement tables need a wholesale overhaul, so this is just shaving off the tip of the iceberg.