### PR TITLE
[alg.clamp] Reword for clarity

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -8486,16 +8486,22 @@ template<class T, class Proj = identity,
 
 \begin{itemdescr}
 \pnum
+Let \tcode{comp} be \tcode{less\{\}}
+for the overloads with no parameter \tcode{comp},
+and let \tcode{proj} be \tcode{identity\{\}}
+for the overloads with no parameter \tcode{proj}.
+
+\pnum
 \expects
-The value of \tcode{lo} is no greater than \tcode{hi}.
+\tcode{bool(comp(proj(hi), proj(lo)))} is \tcode{false}.
 For the first form, type \tcode{T}
 meets the \oldconcept{LessThan\-Comparable}
 requirements (\tref{cpp17.lessthancomparable}).
 
 \pnum
 \returns
-\tcode{lo} if \tcode{v} is less than \tcode{lo},
-\tcode{hi} if \tcode{hi} is less than \tcode{v},
+\tcode{lo} if \tcode{bool(comp(proj(v), proj(lo)))} is \tcode{true},
+\tcode{hi} if \tcode{bool(comp(proj(hi), proj(v)))} is \tcode{true},
 otherwise \tcode{v}.
 
 \pnum
@@ -8505,7 +8511,7 @@ If NaN is avoided, \tcode{T} can be a floating-point type.
 
 \pnum
 \complexity
-At most two comparisons and three applications of any projection.
+At most two comparisons and three applications of the projection.
 \end{itemdescr}
 
 \rSec2[alg.lex.comparison]{Lexicographical comparison}


### PR DESCRIPTION
Define `comp` and `proj` for the overloads with no such parameters and spell out the meaning of the handwavy "is no greater than" and "is less than".