### PR TITLE
[over.best.ics] Remove redundant sub-bullet CWG2829

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2272,8 +2272,6 @@ However, if the target is
 \end{itemize}
 and the constructor or user-defined conversion function is a candidate by
 \begin{itemize}
-\item \ref{over.match.ctor}, when the argument is the temporary in the second
-step of a class copy-initialization,
 \item \ref{over.match.copy}, \ref{over.match.conv}, or \ref{over.match.ref}
 (in all cases), or
 \item the second phase of \ref{over.match.list}


### PR DESCRIPTION
The wording in [[over.best.ics] p4 sub 3](http://eel.is/c++draft/over.best.ics#4.3) is not only incorrect, but also redundant:
> However, if the target is [...] the first parameter of a constructor or [...]  and the constructor or user-defined conversion function is a candidate by:
> [over.match.ctor], when the argument is the temporary in the second step of a class copy-initialization, [...]
> user-defined conversion sequences are not considered. 

The "temporary" wording referred to here was removed by [P0135](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0135r1.html) in [[dcl.init]/17.6.3](http://eel.is/c++draft/dcl.init#17.6.3). Additionally, this wording is not even necessary. Consider the following:

```
struct S
{
  S(std::string);
};

S a = "abc"; // ill-formed
```

[[dcl.init]/17.6.3](http://eel.is/c++draft/dcl.init#17.6.3) dictates that the candidate functions here are chosen by [over.match.copy], meaning that [[over.best.ics] p4 sub 4](http://eel.is/c++draft/over.best.ics#4.4) applies from the get-go, thus not allowing the implicit conversion sequence from `const char[4]` to `std::string` to be formed as a user defined conversion  sequence would be required but is not permitted. 

The direct-initialization that is performed as the second step in [[dcl.init]/17.6.3](http://eel.is/c++draft/dcl.init#17.6.3) will always follow the rules of [[dcl.init]/17.6.1](http://eel.is/c++draft/dcl.init#17.6.1) since it is a prvalue of the same type, meaning the constructor selected by [over.match.copy] is the only function that will be called.