### PR TITLE
[temp.explicit] Fix unclear reference to elaborated-type-specifier

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -127,13 +127,29 @@ the declaration declares a class template partial specialization\iref{temp.class
 \end{note}
 
 \pnum
-In a
-\grammarterm{template-declaration},
-explicit specialization, or explicit instantiation the
-\grammarterm{init-declarator-list}
-in the declaration shall contain at most one declarator.
-When such a declaration is used to declare a class template,
-no declarator is permitted.
+A \grammarterm{template-declaration} or \grammarterm{explicit-specialization}
+declares a class or a class template if its \grammarterm{declaration} contains no
+\grammarterm{declarator} and it does not declare an alias template\iref{temp.alias} or
+deduction guide\iref{temp.deduct.guide}; the \grammarterm{decl-specifier-seq} of such a
+declaration shall contain a single \grammarterm{defining-type-specifier} that is either
+a \grammarterm{class-specifier}, \grammarterm{enum-specifier}, or an \grammarterm{elaborated-type-specifier}.
+An \grammarterm{explicit-instantiation} that contains no \grammarterm{declarator}
+is an explicit instantiation of a class; such a declaration shall contain an
+\grammarterm{elaborated-type-specifier}, itself containing a \grammarterm{simple-template-id}.
+
+\pnum
+A \grammarterm{template-declaration} or \grammarterm{explicit-specialization}
+shall contain a single \grammarterm{declarator} if it does not declare a class,
+class template, concept\iref{temp.concept}, alias template\iref{temp.alias} or
+deduction guide\iref{temp.deduct.guide}. Similarly, an \grammarterm{explicit-instantiation}
+that does not explicitly instantiate a class shall contain a single \grammarterm{declarator}.
+
+\pnum
+A \grammarterm{template-declaration} or \grammarterm{explicit-specialization} containing
+a \grammarterm{declarator} that does not declare a variable or variable template declares
+a function or function template. Similarly, an \grammarterm{explicit-instantiation} containing
+a \grammarterm{declarator} that does not explicitly instantiate a variable is an explicit
+instantiation of a function.
 
 \pnum
 \indextext{template name!linkage of}%
@@ -6561,7 +6577,8 @@ declaration begins with the \tcode{extern} keyword.
 \pnum
 An explicit instantiation shall not use
 a \grammarterm{storage-class-specifier}\iref{dcl.stc}
-other than \keyword{thread_local}.
+other than \keyword{thread_local}. The \grammarterm{init-declarator}
+of an explicit instantiation (if any) shall not contain an \grammarterm{initializer}.
 An explicit instantiation of a
 function template,
 member function of a class template, or
@@ -6572,13 +6589,6 @@ No \grammarterm{attribute-specifier-seq}\iref{dcl.attr.grammar}
 shall appertain to an explicit instantiation.
 
 \pnum
-If the explicit instantiation is for a class or member class, the
-\grammarterm{elaborated-type-specifier} in the \grammarterm{declaration}
-shall include a \grammarterm{simple-template-id};
-otherwise, the \grammarterm{declaration}
-shall be a \grammarterm{simple-declaration} whose \grammarterm{init-declarator-list}
-comprises a single \grammarterm{init-declarator}
-that does not have an \grammarterm{initializer}.
 If the explicit instantiation is for
 a function or member function,
 the


### PR DESCRIPTION
It is unclear what elaborated-type-specifier we are referring to, and the current wording does not do a good job specifying what form the explicit instantiation should take.