### PR TITLE
[index] Use LaTeX package 'imakeidx' to allow for more indices.

### DIFF
--- a/source/back.tex
+++ b/source/back.tex
@@ -77,11 +77,9 @@ are present in this document, with the exceptions described below.\\}
 }
 
 \clearpage
-\renewcommand{\indexname}{Index of grammar productions}
 \renewcommand{\preindexhook}{The first bold page number for each entry is the page in the
 general text where the grammar production is defined. The second bold page number is the
 corresponding page in the Grammar summary\iref{gram}. Other page numbers refer to pages where the grammar production is mentioned in the general text.\\}
-\renewcommand{\leftmark}{\indexname}
 {
 \raggedright
 \printindex[grammarindex]
@@ -90,8 +88,6 @@ corresponding page in the Grammar summary\iref{gram}. Other page numbers refer t
 \clearpage
 \renewcommand{\preindexhook}{The bold page number for each entry refers to
 the page where the synopsis of the header is shown.\\}
-\renewcommand{\indexname}{Index of library headers}
-\renewcommand{\leftmark}{\indexname}
 {
 \raggedright
 \printindex[headerindex]
@@ -99,8 +95,6 @@ the page where the synopsis of the header is shown.\\}
 
 \clearpage
 \renewcommand{\preindexhook}{}
-\renewcommand{\indexname}{Index of library names}
-\renewcommand{\leftmark}{\indexname}
 {
 \raggedright
 \printindex[libraryindex]
@@ -110,8 +104,6 @@ the page where the synopsis of the header is shown.\\}
 \renewcommand{\preindexhook}{The bold page number for each entry is the page
 where the concept is defined.
 Other page numbers refer to pages where the concept is mentioned in the general text.\\}
-\renewcommand{\indexname}{Index of library concepts}
-\renewcommand{\leftmark}{\indexname}
 {
 \raggedright
 \printindex[conceptindex]
@@ -120,7 +112,6 @@ Other page numbers refer to pages where the concept is mentioned in the general 
 \clearpage
 \renewcommand{\preindexhook}{The entries in this index are rough descriptions; exact
 specifications are at the indicated page in the general text.\\}
-\renewcommand{\indexname}{Index of implementation-defined behavior}
 \renewcommand{\leftmark}{Index of impl.-def. behavior}
 {
 \raggedright

--- a/source/latexmkrc
+++ b/source/latexmkrc
@@ -3,4 +3,4 @@ sub makeglo2gls {
     system("makeindex -s basic.gst -o '$_[0]'.gls '$_[0]'.glo");
 }
 
-$makeindex = 'stem=`basename %S .idx`; makeindex %O `test -f ${stem}.ist && echo "-s ${stem}.ist"` -o %D %S';
+$pdflatex = "pdflatex -shell-escape %O %S"

--- a/source/std.tex
+++ b/source/std.tex
@@ -24,6 +24,7 @@
 \usepackage{amsmath}      % additional math symbols
 \usepackage{mathrsfs}     % mathscr font
 \usepackage[final]{microtype}
+\usepackage[splitindex,original]{imakeidx}
 \usepackage{multicol}
 \usepackage{lmodern}
 \usepackage{xcolor}
@@ -59,12 +60,12 @@
 \input{macros}
 \input{tables}
 
-\makeindex[generalindex]
-\makeindex[grammarindex]
-\makeindex[headerindex]
-\makeindex[libraryindex]
-\makeindex[conceptindex]
-\makeindex[impldefindex]
+\makeindex[name=generalindex,options=-s generalindex.ist,title=Index]
+\makeindex[name=grammarindex,title=Index of grammar productions]
+\makeindex[name=headerindex,title=Index of library headers]
+\makeindex[name=libraryindex,options=-s libraryindex.ist,title=Index of library names]
+\makeindex[name=conceptindex,title=Index of library concepts]
+\makeindex[name=impldefindex,title=Index of implementation-defined behavior]
 \makeglossary[xrefindex]
 \makeglossary[xrefdelta]
 


### PR DESCRIPTION
This doesn't consume a \write stream per index.
The disadvantage is that it needs the `-shell-escape` option for pdflatex to split up the single index file.

We can now easily add a separate index of exposition-only library names.

"diffpdf" says the before/after PDFs are the same.