### PR TITLE
[dcl.dcl] Improve note regarding nodeclspec-function-declarations

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -216,8 +216,9 @@ any appropriate initialization\iref{dcl.init} to be done.
 A \grammarterm{nodeclspec-function-declaration} shall declare a
 constructor, destructor, or conversion function.
 \begin{note}
-A \grammarterm{nodeclspec-function-declaration} can only be used in a
-\grammarterm{template-declaration}\iref{temp.pre},
+Because a member function cannot be subject to a non-defining declaration
+outside of a class definition\iref{class.mfct}, a \grammarterm{nodeclspec-function-declaration}
+can only be used in a \grammarterm{template-declaration}\iref{temp.pre},
 \grammarterm{explicit-instantiation}\iref{temp.explicit}, or
 \grammarterm{explicit-specialization}\iref{temp.expl.spec}.
 \end{note}


### PR DESCRIPTION
The [current note](http://eel.is/c++draft/dcl.dcl#dcl.pre-12.note-1) on *nodeclspec-function-declarations* is a little lacking when it comes to providing useful information as to why the outlined restriction exists. This clarifies it.