### PR TITLE
Disable \requires

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -1,6 +1,8 @@
 %!TEX root = std.tex
 \normannex{depr}{Compatibility features}
 
+\newcommand{\requires}{\Fundesc{Requires}}
+
 \pnum
 This Clause describes features of the \Cpp{} Standard that are specified for compatibility with
 existing implementations.

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -273,7 +273,6 @@
 \newcommand{\Fundesc}[1]{\Fundescx{#1:}\space}
 \newcommand{\recommended}{\Fundesc{Recommended practice}}
 \newcommand{\required}{\Fundesc{Required behavior}}
-\newcommand{\requires}{\Fundesc{Requires}}
 \newcommand{\constraints}{\Fundesc{Constraints}}
 \newcommand{\mandates}{\Fundesc{Mandates}}
 \newcommand{\expects}{\Fundesc{Preconditions}}


### PR DESCRIPTION
Now that Mandating is complete, we can prevent accidentally using `\requires` by relegating the macro itself to Annex D (in a form of meta-deprecation).