### PR TITLE
\defnc and \defna

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -833,7 +833,7 @@ namespace; these restrictions apply to both regions.
 \pnum
 For a given declarative region \placeholder{R}
 and a point \placeholder{P} outside \placeholder{R},
-the set of \defnx{intervening}{region!declarative!intervening} declarative regions
+the set of \defna{intervening}{region!declarative} declarative regions
 between \placeholder{P} and \placeholder{R}
 comprises all declarative regions
 that are or enclose \placeholder{R} and do not enclose \placeholder{P}.
@@ -4246,8 +4246,8 @@ set of values, which may be empty.
 Every alignment value shall be a non-negative integral power of two.
 
 \pnum
-Alignments have an order from \defnx{weaker}{alignment!weaker} to
-\defnx{stronger}{alignment!stronger} or \defnx{stricter}{alignment!stricter} alignments. Stricter
+Alignments have an order from \defna{weaker}{alignment} to
+\defna{stronger}{alignment} or \defna{stricter}{alignment} alignments. Stricter
 alignments have larger alignment values. An address that satisfies an alignment
 requirement also satisfies any weaker valid alignment requirement.
 
@@ -5107,7 +5107,7 @@ This document imposes no requirements on the accuracy of
 floating-point operations; see also~\ref{support.limits}.
 \end{note}
 Integral and floating-point types are collectively
-called \defnx{arithmetic}{type!arithmetic} types.
+called \defna{arithmetic}{type} types.
 \indextext{\idxcode{numeric_limits}!specializations for arithmetic types}%
 Specializations of the standard library template
 \tcode{std::numeric_limits}\iref{support.limits} shall specify the

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2863,7 +2863,7 @@ int k();            // error: matches \#4
 \end{example}
 As a consequence of these rules,
 all declarations of an entity are attached to the same module;
-the entity is said to be \defnx{attached}{attached!entity} to that module.
+the entity is said to be \defnc{attached}{entity} to that module.
 
 \pnum
 \indextext{consistency!type declaration}%
@@ -2934,7 +2934,7 @@ explicit specializations of it might be usable in other translation units.
 \end{note}
 
 \pnum
-An entity is \defnx{TU-local}{TU-local!entity} if it is
+An entity is \defnc{TU-local}{entity} if it is
 \begin{itemize}
 \item
 a type, function, variable, or template that
@@ -2966,7 +2966,7 @@ The specialization might have been implicitly or explicitly instantiated.
 \end{itemize}
 
 \pnum
-A value or object is \defnx{TU-local}{TU-local!value or object} if either
+A value or object is \defnc{TU-local}{value or object} if either
 \begin{itemize}
 \item
 it is, or is a pointer to,

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1393,7 +1393,7 @@ constructor.
 
 \pnum
 A default constructor is
-\defnx{trivial}{constructor!default!trivial}
+\defna{trivial}{constructor!default}
 if it is not user-provided and if:
 \begin{itemize}
 \item
@@ -1412,13 +1412,13 @@ type (or array thereof), each such class has a trivial default constructor.
 \end{itemize}
 
 Otherwise, the default constructor is
-\defnx{non-trivial}{constructor!default!non-trivial}.
+\defna{non-trivial}{constructor!default}.
 
 \pnum
 A default constructor
 that is defaulted and not defined as deleted
 is
-\defnx{implicitly defined}{constructor!implicitly defined}
+\defna{implicitly defined}{constructor}
 when it is odr-used\iref{basic.def.odr}
 to create an object of its class type\iref{intro.object},
 when it is needed for constant evaluation\iref{expr.const}, or
@@ -2017,7 +2017,7 @@ the assignment operator selected to copy/move that member is trivial;
 \end{itemize}
 \indextext{assignment operator!move!non-trivial}%
 otherwise the copy/move assignment operator is
-\defnx{non-trivial}{assignment operator!copy!non-trivial}.
+\defna{non-trivial}{assignment operator!copy}.
 
 \pnum
 \indextext{assignment operator!copy!implicitly defined}%
@@ -2237,7 +2237,7 @@ type (or array thereof), each such class has a trivial destructor.
 \end{itemize}
 
 Otherwise, the destructor is
-\defnx{non-trivial}{destructor!non-trivial}.
+\defna{non-trivial}{destructor}.
 
 \pnum
 A defaulted destructor is a constexpr destructor
@@ -2247,7 +2247,7 @@ if it satisfies the requirements for a constexpr destructor\iref{dcl.constexpr}.
 A destructor
 that is defaulted and not defined as deleted
 is
-\defnx{implicitly defined}{destructor!implicitly defined}
+\defna{implicitly defined}{destructor}
 when it is odr-used\iref{basic.def.odr}
 or when it is explicitly defaulted after its first declaration.
 
@@ -3886,7 +3886,7 @@ see~\ref{class.dtor} and~\ref{class.free}.
 
 \pnum
 The return type of an overriding function shall be either identical to
-the return type of the overridden function or \defnx{covariant}{return type!covariant} with
+the return type of the overridden function or \defna{covariant}{return type} with
 the classes of the functions. If a function \tcode{D::f} overrides a
 function \tcode{B::f}, the return types of the functions are covariant
 if they satisfy the following criteria:
@@ -6693,7 +6693,7 @@ two parameters of type \tcode{C}.
 A comparison operator function for class \tcode{C} that
 is defaulted on its first declaration and
 is not defined as deleted is
-\defnx{implicitly defined}{operator!comparison!implicitly defined}
+\defna{implicitly defined}{operator!comparison}
 when it is odr-used or needed for constant evaluation.
 Name lookups in the defaulted definition
 of a comparison operator function

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1222,7 +1222,7 @@ classes are called its \term{potentially constructed subobjects}.
 \pnum
 A defaulted special member function is
 \indextext{member function!constexpr-compatible}%
-\defnx{constexpr-compatible}{constexpr-compatible!defaulted special member function}
+\defnc{constexpr-compatible}{defaulted special member function}
 if the corresponding implicitly-declared special member function
 would be a constexpr function.
 
@@ -3112,7 +3112,7 @@ A \defn{union} is a class defined with the \grammarterm{class-key}
 
 \pnum
 In a union,
-a non-static data member is \defnx{active}{active!union member}
+a non-static data member is \defnc{active}{union member}
 if its name refers to an object
 whose lifetime has begun and has not ended\iref{basic.life}.
 At most one of the non-static data members of an object of union type
@@ -6713,7 +6713,7 @@ any non-static data member of \tcode{C} is of reference type or
 
 \pnum
 A binary operator expression \tcode{a @ b} is
-\defnx{usable}{usable!binary operator expression}
+\defnc{usable}{binary operator expression}
 if either
 
 \begin{itemize}
@@ -6730,7 +6730,7 @@ neither \tcode{a} nor \tcode{b} is of class or enumeration type and
 \pnum
 A defaulted comparison function is
 \indextext{operator!comparison!constexpr-compatible}%
-\defnx{constexpr-compatible}{constexpr-compatible!defaulted comparison operator}
+\defnc{constexpr-compatible}{defaulted comparison operator}
 if it
 satisfies the requirements for a constexpr function\iref{dcl.constexpr} and
 no overload resolution

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -25,7 +25,7 @@ concepts, object concepts, and callable concepts as summarized in
 \rSec1[concepts.equality]{Equality preservation}
 
 \pnum
-An expression is \defnx{equality-preserving}{expression!equality-preserving} if,
+An expression is \defna{equality-preserving}{expression} if,
 given equal inputs, the expression results in equal outputs. The inputs to an
 expression are the set of the expression's operands. The output of an expression
 is the expression's result and all operands modified by the expression.

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4638,7 +4638,7 @@ When an aggregate is initialized by an initializer list
 as specified in~\ref{dcl.init.list},
 the elements of the initializer list are taken as initializers
 for the elements of the aggregate.
-The \defnx{explicitly initialized elements}{explicitly initialized elements!aggregate}
+The \defnc{explicitly initialized elements}{aggregate}
 of the aggregate are determined as follows:
 \begin{itemize}
 \item

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4623,7 +4623,7 @@ protected and private base class' members or constructors.
 \end{note}
 
 \pnum
-The \defnx{elements}{aggregate!elements} of an aggregate are:
+The \defna{elements}{aggregate} of an aggregate are:
 \begin{itemize}
 \item
 for an array, the array elements in increasing subscript order, or
@@ -5996,7 +5996,7 @@ A function definition whose
 \grammarterm{function-body}
 is of the form
 \tcode{= default ;}
-is called an \defnx{explicitly-defaulted}{definition!function!explicitly-defaulted} definition.
+is called an \defna{explicitly-defaulted}{definition!function} definition.
 A function that is explicitly defaulted shall
 \begin{itemize}
 \item be a special member function or
@@ -6241,7 +6241,7 @@ task<void> g3(int a, ...) {     // error: variable parameter list not allowed
 
 \pnum
 \indextext{promise type|see{coroutine, promise type}}%
-The \defnx{promise type}{coroutine!promise type} of a coroutine is
+The \defna{promise type}{coroutine} of a coroutine is
 \tcode{std::coroutine_traits<R, P$_1$, $\dotsc$, P$_n$>::promise_type},
 where
 \tcode{R} is the return type of the function, and
@@ -6338,7 +6338,7 @@ a resumption member function\iref{coroutine.handle.resumption}
 of a coroutine handle\iref{coroutine.handle}
 that refers to the coroutine.
 The function that invoked a resumption member function is
-called the \defnx{resumer}{coroutine!resumer}.
+called the \defna{resumer}{coroutine}.
 Invoking a resumption member function for a coroutine
 that is not suspended results in undefined behavior.
 
@@ -6776,7 +6776,7 @@ Each enumeration also has an \defnx{underlying type}{type!underlying!enumeration
 The underlying type can be explicitly specified using an \grammarterm{enum-base}.
 For a scoped enumeration type, the underlying type is \tcode{int} if it is not
 explicitly specified. In both of these cases, the underlying type is said to be
-\defnx{fixed}{type!underlying!fixed}.
+\defna{fixed}{type!underlying}.
 Following the closing brace of an \grammarterm{enum-specifier}, each
 enumerator has the type of its enumeration.
 If the underlying type is fixed, the type of each enumerator

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -818,7 +818,7 @@ might throw an exception.
 
 \pnum
 An expression $E$ is
-\defnx{potentially-throwing}{potentially-throwing!expression} if
+\defnc{potentially-throwing}{expression} if
 \begin{itemize}
 \item
 $E$ is a function call\iref{expr.call}
@@ -948,7 +948,7 @@ if the base class function has a non-throwing exception specification.
 \end{example}
 
 \pnum
-An exception specification is considered to be \defnx{needed}{needed!exception specification} when:
+An exception specification is considered to be \defnc{needed}{exception specification} when:
 \begin{itemize}
 \item in an expression, the function is the unique lookup result or the selected
 member of a set of overloaded functions~(\ref{basic.lookup}, \ref{over.match}, \ref{over.over});

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -259,7 +259,7 @@ keyword was most recently entered by the thread of control and not yet exited.
 Throwing an exception
 copy-initializes~(\ref{dcl.init}, \ref{class.copy.ctor}) a temporary object,
 called the
-\defnx{exception object}{exception handling!exception object}.
+\defna{exception object}{exception handling}.
 An lvalue denoting the temporary is used to initialize the
 variable declared in the matching
 \grammarterm{handler}\iref{except.handle}.
@@ -599,7 +599,7 @@ handler continues in a dynamically surrounding try block
 of the same thread.
 
 \pnum
-A handler is considered \defnx{active}{exception handling!handler!active} when
+A handler is considered \defna{active}{exception handling!handler} when
 initialization is complete for the parameter (if any) of the catch clause.
 \begin{note}
 The stack will have been unwound at that point.
@@ -613,7 +613,7 @@ catch clause exits.
 \indextext{currently handled exception|see{exception handling, currently handled exception}}%
 The exception with the most recently activated handler that is
 still active is called the
-\defnx{currently handled exception}{exception handling!currently handled exception}.
+\defna{currently handled exception}{exception handling}.
 
 \pnum
 If no matching handler is found,

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -215,8 +215,8 @@ are xvalues. The expression \tcode{ar} is an lvalue.
 \end{example}
 
 \pnum
-The \defnx{result}{result!glvalue} of a glvalue is the entity denoted by the expression.
-The \defnx{result}{result!prvalue} of a prvalue
+The \defnc{result}{glvalue} of a glvalue is the entity denoted by the expression.
+The \defnc{result}{prvalue} of a prvalue
 is the value that the expression stores into its context;
 a prvalue that has type \cv{}~\tcode{void} has no result.
 A prvalue whose result is the value \placeholder{V}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2923,7 +2923,7 @@ function is non-virtual, or if the \grammarterm{id-expression} in the class
 member access expression is a \grammarterm{qualified-id}, that function is
 called. Otherwise, its final overrider\iref{class.virtual} in the dynamic type
 of the object expression is called; such a call is referred to as a
-\defnx{virtual function call}{function!virtual function call}.
+\defna{virtual function call}{function}.
 \begin{note}
 The dynamic type is the type of the object referred to by the
 current value of the object expression. \ref{class.cdtor}~describes the

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -14084,7 +14084,7 @@ Implementations should store such additional file attributes
 during directory iteration if their values are available
 and storing the values would allow the implementation to eliminate file system accesses
 by \tcode{directory_entry} observer functions\iref{fs.op.funcs}.
-Such stored file attribute values are said to be \defnx{cached}{file attributes!cached}.
+Such stored file attribute values are said to be \defna{cached}{file attributes}.
 
 \pnum
 \begin{note}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -11947,7 +11947,7 @@ any operating system dependent \grammarterm{root-name}{s}}}
 
 \pnum
 A \defn{filename} is
-the name of a file. The \defnx{dot}{dot!filename} and \defnx{dot-dot}{dot-dot!filename} filenames,
+the name of a file. The \defnc{dot}{filename} and \defnc{dot-dot}{filename} filenames,
 consisting solely of one and two period characters respectively,
 have special meaning.
 The following characteristics of filenames are operating system dependent:
@@ -12030,7 +12030,7 @@ These dot-dot filenames attempt to refer to nonexistent parent directories.
 \item If the path is empty, add a dot.
 \end{enumerate}
 
-The result of normalization is a path in \defnx{normal form}{normal form!path},
+The result of normalization is a path in \defnc{normal form}{path},
 which is said to be \term{normalized}.
 \indextext{path!normalization|)}%
 

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -565,7 +565,7 @@ corresponding sequence.
 Such a value is called a \defnx{past-the-end value}{iterator!past-the-end}.
 Values of an iterator \tcode{i}
 for which the expression \tcode{*i} is defined
-are called \defnx{dereferenceable}{iterator!dereferenceable}.
+are called \defna{dereferenceable}{iterator}.
 The library never assumes that past-the-end values are dereferenceable.
 Iterators can also have singular values that are not associated with any
 sequence.

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2992,7 +2992,7 @@ results in undefined behavior.
 \pnum
 A sequence \tcode{Args} of template arguments is said to
 \indextext{concept!model}%
-\defnx{model}{model!concept} a concept \tcode{C}
+\defnc{model}{concept} a concept \tcode{C}
 if \tcode{Args}
 satisfies \tcode{C}\iref{temp.constr.decl} and
 meets all semantic requirements (if any)

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -896,15 +896,15 @@ The following terms apply to objects and values of
 bitmask types:
 \begin{itemize}
 \item
-To \defnx{set}{bitmask!value!set}
+To \defna{set}{bitmask!value}
 a value \textit{Y} in an object \textit{X}
 is to evaluate the expression \textit{X} \tcode{|=} \textit{Y}.
 \item
-To \defnx{clear}{bitmask!value!clear}
+To \defna{clear}{bitmask!value}
 a value \textit{Y} in an object
 \textit{X} is to evaluate the expression \textit{X} \tcode{\&= \~}\textit{Y}.
 \item
-The value \textit{Y} \defnx{is set}{bitmask!value!is set} in the object
+The value \textit{Y} \defna{is set}{bitmask!value} in the object
 \textit{X} if the expression \textit{X} \tcode{\&} \textit{Y} is nonzero.
 \end{itemize}
 
@@ -1467,9 +1467,9 @@ These names are also subject to the restrictions of~\ref{macro.names}.
 
 \pnum
 Two kinds of implementations are defined:
-\defnx{hosted}{implementation!hosted}
+\defna{hosted}{implementation}
 and
-\defnx{freestanding}{implementation!freestanding}\iref{intro.compliance};
+\defna{freestanding}{implementation}\iref{intro.compliance};
 the kind of the implementation is
 \impldef{whether the implementation is hosted or freestanding}.
 For a hosted implementation, this document

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -225,6 +225,8 @@
 \newcommand{\defn}[1]{\defnx{#1}{#1}}
 % Contextual defined term.
 \newcommand{\defnc}[2]{\defnx{#1}{#1!#2}}
+% Adjectival defined term.
+\newcommand{\defna}[2]{\defnx{#1}{#2!#1}}
 % Defined term with different index entry.
 \newcommand{\defnx}[2]{\indexdefn{#2}\textit{#1}}
 % Compound defined term with 'see' for primary term.

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -223,6 +223,8 @@
 
 % Non-compound defined term.
 \newcommand{\defn}[1]{\defnx{#1}{#1}}
+% Contextual defined term.
+\newcommand{\defnc}[2]{\defnx{#1}{#1!#2}}
 % Defined term with different index entry.
 \newcommand{\defnx}[2]{\indexdefn{#2}\textit{#1}}
 % Compound defined term with 'see' for primary term.

--- a/source/modules.tex
+++ b/source/modules.tex
@@ -119,7 +119,7 @@ A \defnadj{module unit}{purview} is
 the sequence of \grammarterm{token}{s}
 starting at the \grammarterm{module-declaration}
 and extending to the end of the translation unit.
-The \defnx{purview}{purview!named module}
+The \defnc{purview}{named module}
 of a named module \tcode{M} is the set of module unit purviews
 of \tcode{M}'s module units.
 
@@ -128,7 +128,7 @@ The \defnadj{global}{module} is the collection of all
 \grammarterm{global-module-fragment}{s}
 and all translation units that are not module units.
 Declarations appearing in such a context
-are said to be in the \defnx{purview}{purview!global module} of the global module.
+are said to be in the \defnc{purview}{global module} of the global module.
 \begin{note}
 The global module has no name, no module interface unit, and is not
 introduced by any \grammarterm{module-declaration}.
@@ -136,7 +136,7 @@ introduced by any \grammarterm{module-declaration}.
 
 \pnum
 A \defn{module} is either a named module or the global module.
-A declaration is \defnx{attached}{attached!declaration} to a module as follows:
+A declaration is \defnc{attached}{declaration} to a module as follows:
 \begin{itemize}
 \item If the declaration
 \begin{itemize}
@@ -699,7 +699,7 @@ prior to this determination.
 
 \pnum
 A declaration \tcode{D} in a global module fragment of a module unit
-is \defnx{discarded}{discarded!declaration} if \tcode{D}
+is \defnc{discarded}{declaration} if \tcode{D}
 is not decl-reachable from any \grammarterm{declaration}
 in the \grammarterm{declaration-seq}
 of the \grammarterm{translation-unit}.
@@ -981,7 +981,7 @@ to name lookup\iref{basic.scope.namespace}.
 
 \pnum
 All translation units that are necessarily reachable are
-\defnx{reachable}{reachable!translation unit}.
+\defnc{reachable}{translation unit}.
 It is unspecified whether additional translation units on which the
 point within the program has an interface dependency are considered reachable,
 and under what circumstances.%
@@ -996,7 +996,7 @@ in programs intending to be portable.
 
 \pnum
 A declaration $D$ is
-\defnx{reachable}{reachable!declaration} if,
+\defnc{reachable}{declaration} if,
 for any point $P$ in the
 instantiation context\iref{module.context},
 \begin{itemize}

--- a/source/modules.tex
+++ b/source/modules.tex
@@ -213,7 +213,7 @@ shall not contain an \grammarterm{export-declaration} or
 \grammarterm{module-import-declaration}.
 
 \pnum
-A declaration is \defnx{exported}{declaration!exported} if it is
+A declaration is \defna{exported}{declaration} if it is
 \begin{itemize}
 \item a namespace-scope declaration declared within an
       \grammarterm{export-declaration}, or
@@ -320,7 +320,7 @@ export struct S;                // error: exported declaration follows non-expor
 \end{example}
 
 \pnum
-A name is \defnx{exported}{name!exported} by a module
+A name is \defna{exported}{name} by a module
 if it is introduced or redeclared
 by an exported declaration in the purview of that module.
 \begin{note}
@@ -517,7 +517,7 @@ a translation unit $T$, it also imports
 all translation units imported by
 exported \grammarterm{module-import-declaration}{s}
 in $T$; such translation units are
-said to be \defnx{exported}{module!exported} by $T$.
+said to be \defna{exported}{module} by $T$.
 Additionally, when a \grammarterm{module-import-declaration}
 in a module unit of some module $M$ imports another module unit $U$ of $M$,
 it also imports all translation units imported by

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -863,7 +863,7 @@ each translation unit and at most one point of undefinition, as follows:
 \begin{itemize}
 \item
 \indextext{point of!macro definition|see{macro, point of definition}}%
-The \defnx{point of definition}{macro!point of definition}
+The \defna{point of definition}{macro}
 of a macro definition within a translation unit
 is the point at which its \tcode{\#define} directive occurs (in the translation
 unit containing the \tcode{\#define} directive), or,
@@ -875,7 +875,7 @@ macro definition, if any (in any other translation unit).
 
 \item
 \indextext{point of!macro undefinition|see{macro, point of undefinition}}%
-The \defnx{point of undefinition}{macro!point of undefinition}
+The \defna{point of undefinition}{macro}
 of a macro definition within a translation unit
 is the first point at which a \tcode{\#undef} directive naming the macro occurs
 after its point of definition, or the first point
@@ -885,7 +885,7 @@ macro definition, whichever (if any) occurs first.
 
 \pnum
 \indextext{active macro directive|see{macro, active}}%
-A macro directive is \defnx{active}{macro!active} at a source location
+A macro directive is \defna{active}{macro} at a source location
 if it has a point of definition in that translation unit preceding the location,
 and does not have a point of undefinition in that translation unit preceding
 the location.

--- a/source/support.tex
+++ b/source/support.tex
@@ -5568,7 +5568,7 @@ for every pointer-to-atomic argument \tcode{A} passed to \tcode{f},
 
 \pnum
 \indextext{signal-safe!evaluation|see{evaluation, signal-safe}}%
-An evaluation is \defnx{signal-safe}{evaluation!signal-safe} unless it includes one of the following:
+An evaluation is \defna{signal-safe}{evaluation} unless it includes one of the following:
 \begin{itemize}
 \item
 a call to any standard library function,

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1845,7 +1845,7 @@ so it does match \#2.
 \indextext{constraint!normalization|(}%
 
 \pnum
-The \defnx{normal form}{normal form!constraint} of an \grammarterm{expression} \tcode{E} is
+The \defnc{normal form}{constraint} of an \grammarterm{expression} \tcode{E} is
 a constraint\iref{temp.constr.constr} that is defined as follows:
 %
 \begin{itemize}
@@ -1901,7 +1901,7 @@ whose parameter mapping is the identity mapping.
 The process of obtaining the normal form of a
 \grammarterm{constraint-expression}
 is called
-\defnx{normalization}{normalization!constraint|see{constraint, normalization}}.
+\defnc{normalization}{constraint|see{constraint, normalization}}.
 \begin{note}
 Normalization of \grammarterm{constraint-expression}{s}
 is performed
@@ -3722,7 +3722,7 @@ For example, a template type parameter can be used in the
 \pnum
 \indextext{expression!equivalent|see{equivalent, expressions}}%
 Two expressions involving template parameters are considered
-\defnx{equivalent}{equivalent!expressions}
+\defnc{equivalent}{expressions}
 if two function definitions containing the expressions would satisfy
 the one-definition rule\iref{basic.def.odr}, except that the tokens used
 to name the template parameters may differ as long as a token used to
@@ -3772,7 +3772,7 @@ template <class T> void spam(decltype([]{}) (*s)[sizeof(T)]);
 \end{example}
 \indextext{expression!functionally equivalent|see{functionally equivalent, expressions}}%
 Two potentially-evaluated expressions involving template parameters that are not equivalent are
-\defnx{functionally equivalent}{functionally equivalent!expressions}
+\defnc{functionally equivalent}{expressions}
 if, for any given set of template arguments, the evaluation of the
 expression results in the same value.
 Two unevaluated operands that are not equivalent
@@ -3785,7 +3785,7 @@ For instance, one could have redundant parentheses.
 
 \pnum
 Two \grammarterm{template-head}{s} are
-\defnx{equivalent}{equivalent!\idxgram{template-head}{s}} if
+\defnc{equivalent}{\idxgram{template-head}{s}} if
 their \grammarterm{template-parameter-list}{s} have the same length,
 corresponding \grammarterm{template-parameter}{s} are equivalent
 and such that if either \grammarterm{template-parameter}
@@ -3796,7 +3796,7 @@ they both have
 \grammarterm{requires-clause}{s} and the corresponding
 \grammarterm{constraint-expression}{s} are equivalent.
 Two \grammarterm{template-parameter}{s} are
-\defnx{equivalent}{equivalent!\idxgram{template-parameter}{s}}
+\defnc{equivalent}{\idxgram{template-parameter}{s}}
 under the following conditions:
 \begin{itemize}
 \item they declare template parameters of the same kind,
@@ -3811,14 +3811,14 @@ When determining whether types or \grammarterm{type-constraint}{s}
 are equivalent, the rules above are used to compare expressions
 involving template parameters.
 Two \grammarterm{template-head}{s} are
-\defnx{functionally equivalent}{functionally equivalent!\idxgram{template-head}{s}}
+\defnc{functionally equivalent}{\idxgram{template-head}{s}}
 if they accept and are satisfied by\iref{temp.constr.constr}
 the same set of template argument lists.
 
 \pnum
 \indextext{template!function!equivalent|see{equivalent, function template}}%
 Two function templates are
-\defnx{equivalent}{equivalent!function templates}
+\defnc{equivalent}{function templates}
 if they
 are declared in the same scope,
 have the same name,
@@ -3832,7 +3832,7 @@ template parameters.
 \indextext{equivalent!functionally|see{functionally equivalent}}%
 \indextext{template!function!functionally equivalent|see{functionally equivalent, function template}}%
 Two function templates are
-\defnx{functionally equivalent}{functionally equivalent!function templates}
+\defnc{functionally equivalent}{function templates}
 if they
 are declared in the same scope,
 have the same name,
@@ -4281,7 +4281,7 @@ is an unevaluated operand\iref{expr.context}.
 
 \pnum
 The first declared template parameter of a concept definition is its
-\defnx{prototype parameter}{prototype parameter!concept}.
+\defnc{prototype parameter}{concept}.
 \indextext{type concept|see{concept, type}}%
 A \defnx{type concept}{concept!type}
 is a concept whose prototype parameter

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -848,7 +848,7 @@ D<B<int> > db;
 \end{example}
 
 \pnum
-A \grammarterm{template-id} is \defnx{valid}{\idxgram{template-id}!valid} if
+A \grammarterm{template-id} is \defna{valid}{\idxgram{template-id}} if
 \begin{itemize}
 \item
   there are at most as many arguments as there are parameters
@@ -1619,7 +1619,7 @@ nor a logical \logop{OR} expression\iref{expr.log.or}.
 \pnum
 Two atomic constraints, $e_1$ and $e_2$, are
 \indextext{identical!atomic constraints|see{atomic constraint, identical}}%
-\defnx{identical}{atomic constraint!identical}
+\defna{identical}{atomic constraint}
 if they are formed from the same appearance of the same
 \grammarterm{expression}
 and if, given a hypothetical template $A$
@@ -2729,7 +2729,7 @@ is the number of elements in the pack expansion of its \grammarterm{initializer}
 \pnum
 \indextext{pattern|see{pack expansion, pattern}}%
 A \defn{pack expansion}
-consists of a \defnx{pattern}{pack expansion!pattern} and an ellipsis, the instantiation of which
+consists of a \defna{pattern}{pack expansion} and an ellipsis, the instantiation of which
 produces zero or more instantiations of the pattern in a list (described below).
 The form of the pattern
 depends on the context in which the expansion occurs. Pack
@@ -4897,9 +4897,9 @@ value of
 template parameters (as determined by the template arguments) and this determines
 the context for name lookup for certain names.
 An expression may be
-\defnx{type-dependent}{expression!type-dependent}
+\defna{type-dependent}{expression}
 (that is, its type may depend on a template parameter) or
-\defnx{value-dependent}{expression!value-dependent}
+\defna{value-dependent}{expression}
 (that is, its value when evaluated as a constant expression\iref{expr.const}
 may depend on a template parameter)
 as described in this subclause.

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -5559,7 +5559,7 @@ Each \defn{barrier phase} consists of the following steps:
 \indextext{phase synchronization point|see{barrier, phase synchronization point }}%
 \pnum
 \indextext{block (execution)}%
-Each phase defines a \defnx{phase synchronization point}{barrier!phase synchronization point}.
+Each phase defines a \defna{phase synchronization point}{barrier}.
 Threads that arrive at the barrier during the phase
 can block on the phase synchronization point by calling \tcode{wait}, and
 will remain blocked until the phase completion step is run.
@@ -5952,7 +5952,7 @@ An \ntbs{} incorporating \tcode{code().message()}.
 \pnum
 Many of the classes introduced in subclause~\ref{futures} use some state to communicate results. This
 \indextext{shared state|see{future, shared state}}
-\defnx{shared state}{future!shared state} consists of some state information and some (possibly not
+\defna{shared state}{future} consists of some state information and some (possibly not
 yet evaluated) \term{result}, which can be a (possibly void) value or an exception.
 \begin{note}
 Futures, promises, and tasks defined in this clause reference such shared state.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2505,8 +2505,8 @@ namespace std {
 
 \pnum
 Any instance of \tcode{optional<T>} at any given time either contains a value or does not contain a value.
-When an instance of \tcode{optional<T>} \defnx{contains a value}{contains a value!\idxcode{optional}},
-it means that an object of type \tcode{T}, referred to as the optional object's \defnx{contained value}{contained value!\idxcode{optional}},
+When an instance of \tcode{optional<T>} \defnc{contains a value}{\idxcode{optional}},
+it means that an object of type \tcode{T}, referred to as the optional object's \defnc{contained value}{\idxcode{optional}},
 is allocated within the storage of the optional object.
 Implementations are not permitted to use additional storage, such as dynamic memory, to allocate its contained value.
 The contained value shall be allocated in a region of the \tcode{optional<T>} storage suitably aligned for the type \tcode{T}.
@@ -4067,7 +4067,7 @@ Any instance of \tcode{variant} at any given time either holds a value
 of one of its alternative types or holds no value.
 When an instance of \tcode{variant} holds a value of alternative type \tcode{T},
 it means that a value of type \tcode{T}, referred to as the \tcode{variant}
-object's \defnx{contained value}{contained value!\idxcode{variant}}, is allocated within the storage of the
+object's \defnc{contained value}{\idxcode{variant}}, is allocated within the storage of the
 \tcode{variant} object.
 Implementations are not permitted to use additional storage, such as dynamic
 memory, to allocate the contained value.
@@ -5379,7 +5379,7 @@ namespace std {
 \pnum
 An object of class \tcode{any} stores an instance of any type that meets the constructor requirements or it has no value,
 and this is referred to as the \defn{state} of the class \tcode{any} object.
-The stored instance is called the \defnx{contained value}{contained value!\idxcode{any}}.
+The stored instance is called the \defnc{contained value}{\idxcode{any}}.
 Two states are equivalent if either they both have no value, or they both have a value and the contained values are equivalent.
 
 \pnum
@@ -9766,7 +9766,7 @@ reflect modifications that can introduce data races.
 \pnum
 For the purposes of subclause \ref{smartptr},
 a pointer type \tcode{Y*} is said to be
-\defnx{compatible with}{compatible with!\idxcode{shared_ptr}}
+\defnc{compatible with}{\idxcode{shared_ptr}}
 a pointer type \tcode{T*} when either
 \tcode{Y*} is convertible to \tcode{T*} or
 \tcode{Y} is \tcode{U[N]} and \tcode{T} is \cv{}~\tcode{U[]}.
@@ -19469,7 +19469,7 @@ string s3 = format("{0:},{0:+},{0:-},{0: }", nan);      // value of \tcode{s3} i
 \pnum
 The \tcode{\#} option causes the
 % FIXME: This is not a definition.
-\defnx{alternate form}{alternate form!format string}
+\defnc{alternate form}{format string}
 to be used for the conversion.
 This option is valid for arithmetic types other than
 \tcode{charT} and \tcode{bool}
@@ -19593,7 +19593,7 @@ whose estimated width is no greater than the precision.
 
 \pnum
 When the \tcode{L} option is used, the form used for the conversion is called
-the \defnx{locale-specific form}{locale-specific form!format string}.
+the \defnc{locale-specific form}{format string}.
 The \tcode{L} option is only valid for arithmetic types, and
 its effect depends upon the type.
 \begin{itemize}


### PR DESCRIPTION
New macros to handle the common case where the displayed defined term is a child or parent of another in the index.  Each has about the same number of uses; I found them to make the actual prose in the source more readable (since the other `{foo}` can be read as a kind of gloss), but it's up to edit@ to decide whether it's worth having more macro names.