### PR TITLE
[temp.names] Do not use "template-name" for "name referring to template"

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -722,8 +722,7 @@ and name lookup either finds one or more functions or finds nothing.
 
 \pnum
 \indextext{\idxcode{<}!template and}%
-When a name is considered to be a
-\grammarterm{template-name},
+When a name is considered to refer to a template,
 and it is followed by a \tcode{<},
 the \tcode{<}
 is always taken as the delimiter of a


### PR DESCRIPTION
From core/2020/03/8668.

The structure of [temp.names]/2 – 3 now (following P0846R0, "ADL and Function Templates that are not Visible"):

- Uses _template-name_ basically to handle only the class template cases, and
- introduces the notion that names can be considered to refer to templates.

However, paragraph 3 is prefaced by "[when] a name is **considered to be a _template-name_** [emphasis mine]", which differs from "when a name is **considered to refer to a template**". In particular, it is a stretch to take a name not having the syntactic form of a _template-name_ (such as an _operator-function-id_) as being considered to be a _template-name_ merely because the name is considered to refer to a template.