### PR TITLE
Non-normative cleanup

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6770,27 +6770,14 @@ except that the return type is replaced with \tcode{bool} and
 the \grammarterm{declarator-id} is replaced with \tcode{operator==}.
 \begin{note}
 Such an implicitly-declared \tcode{==} operator for a class \tcode{X}
-is an inline function and is defined as defaulted
-in the definition of \tcode{X}, and
+is defined as defaulted
+in the definition of \tcode{X} and
 has the same \grammarterm{parameter-declaration-clause} and
 trailing \grammarterm{requires-clause} as
 the respective three-way comparison operator.
-If the three-way comparison operator function
-is declared as a non-static const member,
-the implicitly-declared \tcode{==} operator function
-is a non-static const member.
-If the three-way comparison operator function declaration
-is a friend declaration,
-the implicitly-declared \tcode{==} operator function
-is a friend declaration;
-such a friend function is visible
-to argument-dependent lookup\iref{basic.lookup.argdep}
-only\iref{namespace.memdef}.
-If the three-way comparison operator function
-is declared \tcode{virtual}, \tcode{constexpr}, or \tcode{consteval},
-the implicitly-declared \tcode{==} operator function
-is declared \tcode{virtual}, \tcode{constexpr}, or \tcode{consteval},
-respectively.
+It is declared with \tcode{friend}, \tcode{virtual}, \tcode{constexpr},
+or \tcode{consteval} if
+the three-way comparison operator function is so declared.
 If the three-way comparison operator function
 has no \grammarterm{noexcept-specifier},
 the implicitly-declared \tcode{==} operator function

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -25,7 +25,7 @@ in this International Standard.
 \begin{codeblock}
 class module {};
 module m1;          // was variable declaration; now \grammarterm{module-declaration}
-module *m2;         // OK
+module *m2;         // variable declaration
 
 class import {};
 import j1;          // was variable declaration; now \grammarterm{import-declaration}

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -392,7 +392,7 @@ by preprocessing a \tcode{module} directive\iref{cpp.module}, and
 the \grammarterm{export-keyword} is produced
 by preprocessing either of the previous two directives.
 \begin{note}
-None have any observable spelling.
+None has any observable spelling.
 \end{note}
 
 \pnum

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -893,13 +893,13 @@ are converted into tokens for operators and punctuators:
 \end{bnf}
 
 \begin{bnf}
+%% Ed. note: character protrusion would misalign various operators.
 \microtypesetup{protrusion=false}\obeyspaces
 \nontermdef{preprocessing-operator} \textnormal{one of}\br
     \terminal{\#        \#\#       \%:       \%:\%:}
 \end{bnf}
 
 \begin{bnf}
-%% Ed. note: character protrusion would misalign various operators.
 \microtypesetup{protrusion=false}\obeyspaces
 \nontermdef{operator-or-punctuator} \textnormal{one of}\br
     \terminal{\{        \}        [        ]        (        )}\br

--- a/source/modules.tex
+++ b/source/modules.tex
@@ -821,7 +821,7 @@ whether a declaration is required not to be an exposure\iref{basic.link},
 
 \item
 where definitions for inline functions and templates
-must appear~(\ref{basic.def.odr}, \ref{temp.pre}),
+must appear~(\ref{basic.def.odr}, \ref{dcl.inline}, \ref{temp.pre}),
 
 \item
 the instantiation contexts of templates

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -4008,6 +4008,59 @@ void m() {
 \end{example}
 
 \pnum
+\begin{note}
+Since, in a call context, such type deduction considers only parameters
+for which there are explicit call arguments, some parameters are ignored (namely,
+function parameter packs, parameters with default arguments, and ellipsis
+parameters).
+\begin{example}
+\begin{codeblock}
+template<class T> void f(T);                            // \#1
+template<class T> void f(T*, int=1);                    // \#2
+template<class T> void g(T);                            // \#3
+template<class T> void g(T*, ...);                      // \#4
+
+\end{codeblock}
+\begin{codeblock}
+int main() {
+  int* ip;
+  f(ip);                                                // calls \#2
+  g(ip);                                                // calls \#4
+}
+\end{codeblock}
+\end{example}
+\begin{example}
+\begin{codeblock}
+template<class T, class U> struct A { };
+
+template<class T, class U> void f(U, A<U, T>* p = 0);   // \#1
+template<         class U> void f(U, A<U, U>* p = 0);   // \#2
+template<class T         > void g(T, T = T());          // \#3
+template<class T, class... U> void g(T, U ...);         // \#4
+
+void h() {
+  f<int>(42, (A<int, int>*)0);                          // calls \#2
+  f<int>(42);                                           // error: ambiguous
+  g(42);                                                // error: ambiguous
+}
+\end{codeblock}
+\end{example}
+\begin{example}
+\begin{codeblock}
+template<class T, class... U> void f(T, U...);          // \#1
+template<class T            > void f(T);                // \#2
+template<class T, class... U> void g(T*, U...);         // \#3
+template<class T            > void g(T);                // \#4
+
+void h(int i) {
+  f(&i);                                                // OK: calls \#2
+  g(&i);                                                // OK: calls \#3
+}
+\end{codeblock}
+\end{example}
+\end{note}
+
+\pnum
 If deduction against the other template succeeds for both transformed templates,
 constraints can be considered as follows:
 \begin{itemize}
@@ -4084,59 +4137,6 @@ void h() {
 }
 \end{codeblock}
 \end{example}
-
-\pnum
-\begin{note}
-Since partial ordering in a call context considers only parameters
-for which there are explicit call arguments, some parameters are ignored (namely,
-function parameter packs, parameters with default arguments, and ellipsis
-parameters).
-\begin{example}
-\begin{codeblock}
-template<class T> void f(T);                            // \#1
-template<class T> void f(T*, int=1);                    // \#2
-template<class T> void g(T);                            // \#3
-template<class T> void g(T*, ...);                      // \#4
-
-\end{codeblock}
-\begin{codeblock}
-int main() {
-  int* ip;
-  f(ip);                                                // calls \#2
-  g(ip);                                                // calls \#4
-}
-\end{codeblock}
-\end{example}
-\begin{example}
-\begin{codeblock}
-template<class T, class U> struct A { };
-
-template<class T, class U> void f(U, A<U, T>* p = 0);   // \#1
-template<         class U> void f(U, A<U, U>* p = 0);   // \#2
-template<class T         > void g(T, T = T());          // \#3
-template<class T, class... U> void g(T, U ...);         // \#4
-
-void h() {
-  f<int>(42, (A<int, int>*)0);                          // calls \#2
-  f<int>(42);                                           // error: ambiguous
-  g(42);                                                // error: ambiguous
-}
-\end{codeblock}
-\end{example}
-\begin{example}
-\begin{codeblock}
-template<class T, class... U> void f(T, U...);          // \#1
-template<class T            > void f(T);                // \#2
-template<class T, class... U> void g(T*, U...);         // \#3
-template<class T            > void g(T);                // \#4
-
-void h(int i) {
-  f(&i);                                                // OK: calls \#2
-  g(&i);                                                // OK: calls \#3
-}
-\end{codeblock}
-\end{example}
-\end{note}
 
 \rSec2[temp.alias]{Alias templates}
 

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6492,7 +6492,7 @@ as specified in \ref{temp.constr.decl} and \ref{temp.constr.atomic}
 when determining whether the constraints are satisfied
 or as specified in \ref{temp.constr.decl} when comparing declarations.
 \begin{note}
-The satisfaction of constraints is determined during name lookup or overload
+The satisfaction of constraints is determined during overload
 resolution\iref{over.match}.
 \end{note}
 \begin{example}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6492,8 +6492,9 @@ as specified in \ref{temp.constr.decl} and \ref{temp.constr.atomic}
 when determining whether the constraints are satisfied
 or as specified in \ref{temp.constr.decl} when comparing declarations.
 \begin{note}
-The satisfaction of constraints is determined during overload
-resolution\iref{over.match}.
+The satisfaction of constraints is determined during
+template argument deduction\iref{temp.deduct} and
+overload resolution\iref{over.match}.
 \end{note}
 \begin{example}
 \begin{codeblock}


### PR DESCRIPTION
Changes to notes, examples, and LaTeX comments resulting from DIS review.  Note that just the first line of the big note that moved is also changed.

@zygoloid: please review and/or delegate.