### PR TITLE
[basic.types] Change redundant normative wording into note

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4740,8 +4740,9 @@ bound or of incomplete element type, is an
 object type is unknown.}
 Incompletely-defined object types and \cv{}~\tcode{void} are
 \defnx{incomplete types}{type!incomplete}\iref{basic.fundamental}.
-Objects shall not be defined to have an
-incomplete type.
+\begin{note}
+Objects cannot be defined to have an incomplete type\iref{basic.def}.
+\end{note}
 
 \pnum
 A class type (such as ``\tcode{class X}'') might be incomplete at one


### PR DESCRIPTION
[[basic.types] p5 sentence 3](http://eel.is/c++draft/basic.types#5.sentence-3) is made redundant by [[basic.def] p5](http://eel.is/c++draft/basic.def#5). This changes the former into a note and adds a cross-ref to [basic.def].