### PR TITLE
[dcl.init] Remove redundant specification of when value-initialization occurs

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4293,31 +4293,6 @@ In some cases, additional initialization is done later.
 \end{note}
 
 \pnum
-An object whose initializer is an empty set of parentheses, i.e.,
-\tcode{()},
-shall be
-value-initialized.
-
-\indextext{ambiguity!function declaration}%
-\begin{note}
-Since
-\tcode{()}
-is not permitted by the syntax for
-\grammarterm{initializer},
-\begin{codeblock}
-X a();
-\end{codeblock}
-is not the declaration of an object of class
-\tcode{X},
-but the declaration of a function taking no argument and returning an
-\tcode{X}.
-The form
-\tcode{()}
-is permitted in certain other initialization contexts~(\ref{expr.new},
-\ref{expr.type.conv}, \ref{class.base.init}).
-\end{note}
-
-\pnum
 If no initializer is specified for an object, the object is default-initialized.
 
 \pnum
@@ -4397,6 +4372,25 @@ or an array of
 \tcode{wchar_t},
 and the initializer is a \grammarterm{string-literal}, see~\ref{dcl.init.string}.
 \item If the initializer is \tcode{()}, the object is value-initialized.
+\indextext{ambiguity!function declaration}%
+\begin{note}
+Since
+\tcode{()}
+is not permitted by the syntax for
+\grammarterm{initializer},
+\begin{codeblock}
+X a();
+\end{codeblock}
+is not the declaration of an object of class
+\tcode{X},
+but the declaration of a function taking no argument and returning an
+\tcode{X}.
+The form
+\tcode{()}
+is permitted in certain other initialization contexts~(\ref{expr.new},
+\ref{expr.type.conv}, \ref{class.base.init}).
+\end{note}
+
 \item
 Otherwise, if the destination type is an array,
 the object is initialized as follows.


### PR DESCRIPTION
[[dcl.init] p17.4](http://eel.is/c++draft/dcl.init#17.4) and [[dcl.init] p11](http://eel.is/c++draft/dcl.init#11) both specify when value-initialization is performed. This can just be specified in p17.4, since it describes the semantics of initializers. The note in p11 is also moved to p17.4.

While on the topic, both of the aforementioned paragraphs only specify initialization of an object with `()`, but not a reference, and [dcl.init.ref] does not handle this case either. 

One way to resolve this would be:
- Strike p9 (or turn it into a note)
- Add an item to the definitions of value/default-initialization saying "If `T` is a reference type, the program is ill-formed"
- Change p17.4 to "If the initializer is `()`, value-initialization is performed", and move it above p17.2

In addition to this, there definitely is room for improvement in the rest of the subclause. Currently, p17 specifies "the semantics of initializers", however if we change this to specify the process of initialization, we can make *initialization* a defined term (something like "*Initialization* determines the initial value of an object or the entity to which a reference is bound from an initializer. [...] Initialization of an object or reference is performed using the following procedure: [...]:"), and move some of the floating sentences into p17, such as p12. Floating sentence p14 and p19 both refer to the same form of initialization, so they can be merged. However, these are definitely out of the scope of this PR, so let me know if this is worth pursuing,