### PR TITLE
[dcl.init, dcl.stc] Move specification as to where extern is allowed into [dcl.stc]

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -406,7 +406,8 @@ see~\ref{basic.link}.
 \indextext{restriction!\idxcode{extern}}%
 The \tcode{extern} specifier shall be applied only to the declaration of a variable
 or function. The \tcode{extern} specifier shall not be used in the
-declaration of a class member or function parameter.
+declaration of a class member, function parameter, or block-scope variable with
+an \grammarterm{initializer}.
 \indextext{\idxcode{extern}!linkage of}%
 \indextext{consistency!linkage}%
 For the linkage of a name declared with an \tcode{extern} specifier,
@@ -4134,10 +4135,6 @@ Default arguments are more restricted; see~\ref{dcl.fct.default}.
 The order of initialization of variables with static storage duration is described in~\ref{basic.start}
 and~\ref{stmt.dcl}.
 \end{note}
-
-\pnum
-A declaration of a block-scope variable with external or internal
-linkage that has an \grammarterm{initializer} is ill-formed.
 
 \pnum
 \indextext{initialization!default}%


### PR DESCRIPTION
The current specification lives in [dcl.init], but it fits better in the specification of `extern`, since the only way a local variable can acquire external or internal linkage is through the use of `extern`, and it's better to specify such broad restrictions in one place.