### PR TITLE
[expr.sub] Really deprecate comma in braces

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2861,12 +2861,10 @@ if that operand is an lvalue and an xvalue otherwise.
 The expression \tcode{E1} is sequenced before the expression \tcode{E2}.
 
 \pnum
-\begin{note}
 A comma expression\iref{expr.comma}
 appearing as the \grammarterm{expr-or-braced-init-list}
 of a subscripting expression is deprecated;
 see \ref{depr.comma.subscript}.
-\end{note}
 
 \pnum
 \begin{note}
@@ -6787,12 +6785,10 @@ has three arguments, the second of which has the value
 \end{example}
 
 \pnum
-\begin{note}
 A comma expression
 appearing as the \grammarterm{expr-or-braced-init-list}
 of a subscripting expression\iref{expr.sub} is deprecated;
 see \ref{depr.comma.subscript}.
-\end{note}
 
 \rSec1[expr.const]{Constant expressions}%
 \indextext{expression!constant}


### PR DESCRIPTION
The core convention is to deprecate in core wording, and then
cross-reference from Annex D.  If all references to deprecating
a feature are notes, then there is no normative deprecation.
Resolved by promoting the two notes in core text to straight
normative text proclaiming the deprecation.