### PR TITLE
[temp.deduct.call] Clear up wording regarding function parameter packs appearing in non-deduced contexts

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -7881,8 +7881,8 @@ as the corresponding function template parameter type.
 Each deduction deduces template arguments for subsequent positions in
 the template parameter packs expanded by the function parameter pack.
 When a function parameter pack appears in a non-deduced
-context\iref{temp.deduct.type}, the type of that pack is
-never deduced.
+context\iref{temp.deduct.type}, the template parameter pack(s)
+expanded by that pack are never deduced, even if they appear in a deduced context elsewhere.
 \begin{example}
 \begin{codeblock}
 template<class ... Types> void f(Types& ...);


### PR DESCRIPTION
[CWG 1388](http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#1388) and [CWG 1399](http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#1399) were both resolved by the [resolution for CWG 1388](http://wiki.edg.com/pub/Wg21kona2012/CoreWorkingGroup/proposed_resolution_core-1388.html), however the wording doesn't account for patterns that don't solely consist of a template parameter pack, or include other template parameters that are otherwise deductible. This PR clears this up, and explicitly specifies that such template parameter pack are never deduced, even if they appear in a deduced context elsewhere.

This is borderline editorial, but I believe the defects and accompanying notes on the wiki sufficiently express the intended meaning here.