### PR TITLE
[dcl.stc] Define mutable subobject and make use of keyword consistent

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -483,7 +483,7 @@ The \keyword{mutable} specifier shall appear only in the declaration of
 a non-static data member\iref{class.mem}
 whose type is neither const-qualified nor a reference type.
 A member subobject\iref{intro.object} corresponding to a non-static
-data member declared with the \keyword{mutable} specifier is a \term{mutable subobject}.
+data member declared with the \keyword{mutable} specifier is a \defnadj{mutable}{subobject}.
 \begin{example}
 \begin{codeblock}
 class X {

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -482,6 +482,8 @@ void h() {
 The \tcode{mutable} specifier shall appear only in the declaration of
 a non-static data member\iref{class.mem}
 whose type is neither const-qualified nor a reference type.
+A member subobject\iref{intro.object} corresponding to a non-static
+data member declared with the \tcode{mutable} specifier is a \term{mutable subobject}.
 \begin{example}
 \begin{codeblock}
 class X {
@@ -495,7 +497,7 @@ class X {
 \begin{note}
 The \tcode{mutable} specifier on a class data member nullifies a
 \tcode{const} specifier applied to the containing class object and
-permits modification of the mutable class member even though the rest of
+permits modification of the \tcode{mutable} class member even though the rest of
 the object is const~(\ref{basic.type.qualifier}, \ref{dcl.type.cv}).
 \end{note}
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -479,11 +479,11 @@ void h() {
 \end{example}
 
 \pnum
-The \tcode{mutable} specifier shall appear only in the declaration of
+The \keyword{mutable} specifier shall appear only in the declaration of
 a non-static data member\iref{class.mem}
 whose type is neither const-qualified nor a reference type.
 A member subobject\iref{intro.object} corresponding to a non-static
-data member declared with the \tcode{mutable} specifier is a \term{mutable subobject}.
+data member declared with the \keyword{mutable} specifier is a \term{mutable subobject}.
 \begin{example}
 \begin{codeblock}
 class X {
@@ -495,9 +495,9 @@ class X {
 
 \pnum
 \begin{note}
-The \tcode{mutable} specifier on a class data member nullifies a
+The \keyword{mutable} specifier on a class data member nullifies a
 \tcode{const} specifier applied to the containing class object and
-permits modification of the \tcode{mutable} class member even though the rest of
+permits modification of the \keyword{mutable} class member even though the rest of
 the object is const~(\ref{basic.type.qualifier}, \ref{dcl.type.cv}).
 \end{note}
 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6938,7 +6938,7 @@ an object with an indeterminate value\iref{basic.indet};
 \item
 an invocation of an implicitly-defined copy/move constructor or
 copy/move assignment operator
-for a union whose active member (if any) is mutable,
+for a union whose active member (if any) is \tcode{mutable},
 unless the lifetime of the union object began within the evaluation of $E$;
 
 \item

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6938,7 +6938,7 @@ an object with an indeterminate value\iref{basic.indet};
 \item
 an invocation of an implicitly-defined copy/move constructor or
 copy/move assignment operator
-for a union whose active member (if any) is \tcode{mutable},
+for a union whose active member (if any) is \keyword{mutable},
 unless the lifetime of the union object began within the evaluation of $E$;
 
 \item

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -397,7 +397,7 @@ A \defnadj{structural}{type} is one of the following:
 \item a literal class type with the following properties:
 \begin{itemize}
 \item
-all base classes and non-static data members are public and no members are declared \tcode{mutable}, and
+all base classes and non-static data members are public and no members are declared \keyword{mutable}, and
 \item
 the types of all bases classes and non-static data members are
 structural types or (possibly multi-dimensional) array thereof.

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -397,7 +397,7 @@ A \defnadj{structural}{type} is one of the following:
 \item a literal class type with the following properties:
 \begin{itemize}
 \item
-all base classes and non-static data members are public and non-mutable and
+all base classes and non-static data members are public and no members are declared \tcode{mutable}, and
 \item
 the types of all bases classes and non-static data members are
 structural types or (possibly multi-dimensional) array thereof.


### PR DESCRIPTION
We use the term "mutable subobject" to refer to objects corresponding to members declared `mutable`, but we don't define this anywhere. This defines it in [dcl.stc], and additionally changes adds \tcode to "mutable" when referring to a member declared `mutable`, since it's a keyword in those contexts (this is used for the majority of references to members declared `mutable`). 