### PR TITLE
[alg.clamp] Add missing calls to invoke

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -8497,15 +8497,15 @@ for the overloads with no parameter \tcode{proj}.
 
 \pnum
 \expects
-\tcode{bool(comp(proj(hi), proj(lo)))} is \tcode{false}.
+\tcode{bool(invoke(comp, invoke(proj, hi), invoke(proj, lo)))} is \tcode{false}.
 For the first form, type \tcode{T}
 meets the \oldconcept{LessThan\-Comparable}
 requirements (\tref{cpp17.lessthancomparable}).
 
 \pnum
 \returns
-\tcode{lo} if \tcode{bool(comp(proj(v), proj(lo)))} is \tcode{true},
-\tcode{hi} if \tcode{bool(comp(proj(hi), proj(v)))} is \tcode{true},
+\tcode{lo} if \tcode{bool(invoke(comp, invoke(proj, v), invoke(proj, lo)))} is \tcode{true},
+\tcode{hi} if \tcode{bool(\brk{}invoke(comp, invoke(proj, hi), invoke(proj, v)))} is \tcode{true},
 otherwise \tcode{v}.
 
 \pnum


### PR DESCRIPTION
...which were accidentally ommitted from 31a1a94d. Note that this doesn't alter the semantics of the overload in `std`: `comp`'s type `Compare` is required to be a function object (and therefore not a pointer-to-member for which `invoke` would be significant) by [alg.sorting]/2.