### PR TITLE
More cv-qualification fixes

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3337,9 +3337,8 @@ A parameter list consisting of a single unnamed parameter of
 non-dependent type \tcode{void} is equivalent to an empty parameter
 list.
 \indextext{parameter!\idxcode{void}}%
-Except for this special case, a parameter shall not have type \term{cv}
-\tcode{void}.
-A parameter with \tcode{volatile}-qualified type is deprecated;
+Except for this special case, a parameter shall not have type \cv{}~\tcode{void}.
+A parameter with volatile-qualified type is deprecated;
 see~\ref{depr.volatile.type}.
 If the
 \grammarterm{parameter-declaration-clause}
@@ -3497,7 +3496,7 @@ There shall be no arrays of functions, although there can be arrays of pointers
 to functions.
 
 \pnum
-A \tcode{volatile}-qualified return type is deprecated;
+A volatile-qualified return type is deprecated;
 see~\ref{depr.volatile.type}.
 
 \pnum

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3343,7 +3343,7 @@ The value obtained is a copy of the original value.
 The operand shall be a modifiable lvalue. The type of the operand shall
 be an arithmetic type other than \cv{}~\tcode{bool},
 or a pointer to a complete object type.
-An operand with \tcode{volatile}-qualified type is deprecated;
+An operand with volatile-qualified type is deprecated;
 see~\ref{depr.volatile.type}.
 The value of the operand object is modified\iref{defns.access}
 by adding \tcode{1} to it.
@@ -4308,7 +4308,7 @@ is modified\iref{defns.access} by adding \tcode{1}.
 The operand shall be a modifiable lvalue. The type of the operand shall
 be an arithmetic type other than \cv{}~\tcode{bool},
 or a pointer to a completely-defined object type.
-An operand with \tcode{volatile}-qualified type is deprecated;
+An operand with volatile-qualified type is deprecated;
 see~\ref{depr.volatile.type}.
 The result is the updated operand; it is an lvalue, and it is a
 bit-field if the operand is a bit-field.
@@ -6692,7 +6692,7 @@ resulting value of the bit-field is
 
 \pnum
 A simple assignment whose left operand is of
-a \tcode{volatile}-qualified type is deprecated\iref{depr.volatile.type}
+a volatile-qualified type is deprecated\iref{depr.volatile.type}
 unless the (possibly parenthesized) assignment is a discarded-value expression or
 an unevaluated operand.
 
@@ -6701,7 +6701,7 @@ The behavior of an expression of the form \tcode{E1 \placeholder{op}= E2}
 is equivalent to \tcode{E1 = E1 \placeholder{op} E2} except
 that \tcode{E1} is evaluated only once.
 Such expressions are deprecated
-if \tcode{E1} has \tcode{volatile}-qualified type; see~\ref{depr.volatile.type}.
+if \tcode{E1} has volatile-qualified type; see~\ref{depr.volatile.type}.
 For \tcode{+=} and \tcode{-=},
 \tcode{E1} shall either have arithmetic type or be a pointer to a
 possibly cv-qualified completely-defined object type. In all other

--- a/source/future.tex
+++ b/source/future.tex
@@ -98,7 +98,7 @@ auto cmp = arr1 <=> arr2;       // error
 \pnum
 Postfix \tcode{++} and \tcode{\dcr} expressions\iref{expr.post.incr} and
 prefix \tcode{++} and \tcode{\dcr} expressions\iref{expr.pre.incr}
-of \tcode{volatile}-qualified arithmetic and pointer types are deprecated.
+of volatile-qualified arithmetic and pointer types are deprecated.
 
 \begin{example}
 \begin{codeblock}
@@ -110,7 +110,7 @@ volatile int velociraptor;
 
 \pnum
 Certain assignments
-where the left operand is a \tcode{volatile}-qualified non-class type
+where the left operand is a volatile-qualified non-class type
 are deprecated; see~\ref{expr.ass}.
 
 \begin{example}
@@ -128,8 +128,8 @@ brachiosaur = brachiosaur + neck;   // OK
 
 \pnum
 A function type\iref{dcl.fct}
-with a parameter with \tcode{volatile}-qualified type or
-with a \tcode{volatile}-qualified return type is deprecated.
+with a parameter with volatile-qualified type or
+with a volatile-qualified return type is deprecated.
 
 \begin{example}
 \begin{codeblock}
@@ -141,7 +141,7 @@ void fly(volatile struct pterosaur* pteranodon);                // OK
 
 
 \pnum
-A structured binding\iref{dcl.struct.bind} of a \tcode{volatile}-qualified type
+A structured binding\iref{dcl.struct.bind} of a volatile-qualified type
 is deprecated.
 
 \begin{example}


### PR DESCRIPTION
[dcl.fct] uses `\term{cv}` for a placeholder cv-qualifier as opposed to the usual `\cv{}`, this fixes that.

Additionally, the wording for "Deprecating volatile" uses `\tcode{volatile}`-qualified, as opposed to the defined term _volatile-qualified_ from [basic.type.qualifier]. This is also addressed.