### PR TITLE
[iterator.synopsis] Cleanups

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -361,8 +361,8 @@ namespace std {
     const move_iterator<Iterator1>& x,
     const move_iterator<Iterator2>& y) -> decltype(x.base() - y.base());
   template<class Iterator>
-    constexpr move_iterator<Iterator> operator+(
-      typename move_iterator<Iterator>::difference_type n, const move_iterator<Iterator>& x);
+    constexpr move_iterator<Iterator>
+      operator+(iter_difference_t<Iterator> n, const move_iterator<Iterator>& x);
 
   template<class Iterator>
     constexpr move_iterator<Iterator> make_move_iterator(Iterator i);

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -306,10 +306,9 @@ namespace std {
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y) -> decltype(y.base() - x.base());
   template<class Iterator>
-    constexpr reverse_iterator<Iterator>
-      operator+(
-    typename reverse_iterator<Iterator>::difference_type n,
-    const reverse_iterator<Iterator>& x);
+    constexpr reverse_iterator<Iterator> operator+(
+      iter_difference_t<Iterator> n,
+      const reverse_iterator<Iterator>& x);
 
   template<class Iterator>
     constexpr reverse_iterator<Iterator> make_reverse_iterator(Iterator i);
@@ -3573,7 +3572,7 @@ template<class Iterator1, class Iterator2>
 \begin{itemdecl}
 template<class Iterator>
   constexpr reverse_iterator<Iterator> operator+(
-    typename reverse_iterator<Iterator>::difference_type n,
+    iter_difference_t<Iterator> n,
     const reverse_iterator<Iterator>& x);
 \end{itemdecl}
 

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -358,8 +358,8 @@ namespace std {
 
   template<class Iterator1, class Iterator2>
     constexpr auto operator-(
-    const move_iterator<Iterator1>& x,
-    const move_iterator<Iterator2>& y) -> decltype(x.base() - y.base());
+      const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y)
+        -> decltype(x.base() - y.base());
   template<class Iterator>
     constexpr move_iterator<Iterator>
       operator+(iter_difference_t<Iterator> n, const move_iterator<Iterator>& x);
@@ -4497,9 +4497,9 @@ template<class Iterator1, @\libconcept{three_way_comparable_with}@<Iterator1> It
 \indexlibrarymember{operator-}{move_iterator}%
 \begin{itemdecl}
 template<class Iterator1, class Iterator2>
-  constexpr auto operator-(const move_iterator<Iterator1>& x,
-                           const move_iterator<Iterator2>& y)
-    -> decltype(x.base() - y.base());
+  constexpr auto operator-(
+    const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y)
+      -> decltype(x.base() - y.base());
 template<@\libconcept{sized_sentinel_for}@<Iterator> S>
   friend constexpr iter_difference_t<Iterator>
     operator-(const move_sentinel<S>& x, const move_iterator& y);


### PR DESCRIPTION
Three commits with related changes:
* Change the declaration of `move_iterator`'s non-member `operator+` in [iterator.synopsis] to agree with the redeclaration in [move.iter.nonmember] which was changed by P0896R4.
* Fix the formatting of the declaration of `move_iterator`'s non-member `operator-` in [iterator.synopsis], and harmonize the formatting of the redeclaration in [move.iter.nonmember].
* Use `iter_difference_t` in the declaration of `reverse_iterator`'s non-member `operator+` to harmonize with the style of `move_iterator`.