### PR TITLE
Strike surviving mentions of "storage class" (outside of stable names and grammar)

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3257,11 +3257,12 @@ variables, but since they are union members they have the same address.
 \pnum
 \indextext{\idxcode{union}!global anonymous}%
 \indextext{scope!anonymous \tcode{union} at namespace}%
-Anonymous unions declared in the scope of a namespace with external linkage
-shall be declared \keyword{static}. Anonymous unions declared at
-block scope shall be declared with any storage class allowed for a
-block variable, or with no storage class. A storage class is not
-allowed in a declaration of an anonymous union in a class scope.
+An anonymous union declared in the scope of a namespace with external linkage
+shall use the \grammarterm{storage-class-specifier} \keyword{static}.
+Anonymous unions declared at block scope shall not use a \grammarterm{storage-class-specifier}
+that is not permitted in the declaration of a block variable.
+An anonymous union declaration at class scope shall not have
+a \grammarterm{storage-class-specifier}.
 
 \pnum
 \begin{note}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2162,7 +2162,7 @@ in place of a \grammarterm{declarator}\iref{dcl.fct,except.pre},
 it is as if a unique identifier were included in
 the appropriate place\iref{dcl.name}.
 The preceding specifiers indicate
-the type, storage class or other properties
+the type, storage duration, linkage, or other properties
 of the entity or entities being declared.
 Each declarator specifies one entity and
 (optionally) names it and/or
@@ -8483,7 +8483,7 @@ is treated as if it contains the
 \keyword{extern}
 specifier\iref{dcl.stc} for the purpose of determining the linkage of the
 declared name and whether it is a definition. Such a declaration shall
-not specify a storage class.
+not have a \grammarterm{storage-class-specifier}.
 \begin{example}
 \begin{codeblock}
 extern "C" double f();

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2001,7 +2001,7 @@ cv-qualification, and value category of the argument and how these
 are converted to match the corresponding properties of the
 parameter.
 \begin{note}
-Other properties, such as the lifetime, storage class,
+Other properties, such as the lifetime, storage duration, linkage,
 alignment, accessibility of the argument, whether the argument is a bit-field,
 and whether a function is deleted\iref{dcl.fct.def.delete}, are ignored.
 So, although an implicit

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -306,9 +306,8 @@ Here, the template \tcode{f} has a \grammarterm{type-parameter}
 called \tcode{T}, rather than an unnamed non-type
 \grammarterm{template-parameter} of class \tcode{T}.
 \end{example}
-A storage class shall not be specified in a
-\grammarterm{template-parameter}
-declaration.
+A \grammarterm{template-parameter} declaration shall not
+have a \grammarterm{storage-class-specifier}.
 Types shall not be defined in a \grammarterm{template-parameter}
 declaration.
 


### PR DESCRIPTION
Outside of the grammar term and first paragraph of [dcl.stc], "storage class" has no meaning in C++, and has no need to be defined. This replaces mentions of "storage class" with *storage-class-specifier*, "storage duration" and "linkage" where appropriate. 