### PR TITLE
[class.union.anon] Turn redundant wording into a note

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3317,6 +3317,7 @@ members\iref{class.access}. An anonymous union shall not have
 member functions.
 
 \pnum
+\begin{note}
 A union for which objects, pointers, or references are declared is not an anonymous union.
 \begin{example}
 \begin{codeblock}
@@ -3331,6 +3332,7 @@ The assignment to plain \tcode{aa} is ill-formed since the member name
 is not visible outside the union, and even if it were visible, it is not
 associated with any particular object.
 \end{example}
+\end{note}
 \begin{note}
 Initialization of unions with no user-declared constructors is described
 in~\ref{dcl.init.aggr}.


### PR DESCRIPTION
[[class.union.anon] p1](http://eel.is/c++draft/class.union.anon#1) already specifies that a declaration of a union with declarators isn't an anonymous union, so p3 can be turned into a note. Additionally, objects of pointer type are objects, so "pointers" in p3 can be removed.