### PR TITLE
Clean up of discarded-value expressions

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -456,15 +456,15 @@ following:
 Using an overloaded operator causes a function call; the
 above covers only operators with built-in meaning.
 \end{note}
-If the (possibly converted) expression is a prvalue,
-the temporary materialization conversion\iref{conv.rval} is applied.
+The temporary materialization conversion\iref{conv.rval} is applied
+if the (possibly converted) expression is a prvalue of object type.
+The expression is evaluated and its result (if any) is discarded.
 \begin{note}
 If the expression is an lvalue of
 class type, it must have a volatile copy constructor to initialize the
 temporary object that is the result object of the lvalue-to-rvalue
 conversion.
 \end{note}
-The glvalue expression is evaluated and its value is discarded.
 
 \rSec1[conv]{Standard conversions}
 
@@ -3650,7 +3650,7 @@ reference-compatible with ``\cvqual{cv1}
 the result refers to the object or the specified base class subobject
 thereof; otherwise, the lvalue-to-rvalue conversion\iref{conv.lval}
 is applied to the bit-field and the resulting prvalue is used as the
-\grammarterm{expression} of the \tcode{static_cast} for the remainder of this subclause.
+operand of the \tcode{static_cast} for the remainder of this subclause.
 If \tcode{T2} is an inaccessible\iref{class.access} or
 ambiguous\iref{class.member.lookup} base class of \tcode{T1},
 a program that necessitates such a cast is ill-formed.
@@ -3690,8 +3690,10 @@ listed below. No other conversion shall be performed explicitly using a
 
 \pnum
 Any expression can be explicitly converted to type \cv{}~\tcode{void},
-in which case it becomes a discarded-value
-expression\iref{expr.prop}.
+in which case the operand is a discarded-value expression\iref{expr.prop}.
+\begin{note}
+Such a \tcode{static_cast} has no result as it is a prvalue of type \tcode{void}, see~\ref{basic.lval}.
+\end{note}
 \begin{note}
 However, if the value is in a temporary
 object\iref{class.temporary}, the destructor for that


### PR DESCRIPTION
This fixes a few issues with discarded-value expressions:

1. The current wording in [expr.prop] states that the temporary materialization conversion is applied to prvalues of `void` type, which makes discarded-value expressions of `void` type ill-formed (temporary materialization conversion requires a complete type). This fixes that, and ensures that all discarded-value expressions are evaluated (with the exception of unevaluated operands, of course)

2. In [expr.static.cast], grammatical term *expression* is used where "operand" is much clearer, and more consistent with the rest of the wording. Additionally, specifying that the operand of the cast becomes a discarded-value expression is much clearer than saying "the expression", since it could be interpreted as saying that the whole expression is a discarded value expression (it shouldn't, since the operand itself needs to be temporarily materialized and evaluated). A note is also added to clarify that the conversion will be an expression of type `void` with no result.

3. A `return` statement can sometimes have an operand of type `void`, in which case it *should* be a discarded-value expression, but this is not specified. 

As for the editorial nature of this, the intent here is pretty clear :)

Will rename commit after edits :)