### PR TITLE
[temp.param] Remove definitions in footnote and fix wording referring to non-type template parameters

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -277,17 +277,16 @@ names a template type parameter.
 \tcode{typename}
 followed by a
 \grammarterm{qualified-id}
-denotes the type in a non-type%
+denotes the type in a \grammarterm{parameter-declaration}.%
 \footnote{Since template
 \grammarterm{template-parameter}{s}
 and template
 \grammarterm{template-argument}{s}
 are treated as types for descriptive purposes, the terms
-\term{non-type parameter}
-and
-\term{non-type argument}
-are used to refer to non-type, non-template parameters and arguments.}
-\grammarterm{parameter-declaration}.
+non-type \grammarterm{template-parameter} and
+non-type \grammarterm{template-argument}
+are used to refer to non-type, non-template \grammarterm{template-parameter}{s}
+and \grammarterm{template-argument}{s}.}
 A \grammarterm{template-parameter} of the form
 \tcode{class} \grammarterm{identifier} is a \grammarterm{type-parameter}.
 \begin{example}


### PR DESCRIPTION
Removes some more of those pesky definitions in non-normative text, and has a small drive-by edit to [[temp.param] p2](http://eel.is/c++draft/temp.param#2) (a *parameter-declaration* does not declare a type except for certain cases with *elaborated-type-specifier*s where it kind of does (but not really), but that does not apply in a *template-parameter* either way).

Also, what is stated in the footnote should probably have corresponding normative wording, since we don't currently have any.