### PR TITLE
[expr.const] Change "dynamic cast" to "dynamic_cast" and move throw-expression to its own item

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -7039,8 +7039,10 @@ relational\iref{expr.rel}, or equality\iref{expr.eq}
 operator where the result is unspecified;
 
 \item
-a \grammarterm{throw-expression}\iref{expr.throw} or
-a dynamic cast\iref{expr.dynamic.cast} or \tcode{typeid}\iref{expr.typeid} expression
+a \grammarterm{throw-expression}\iref{expr.throw};
+
+\item
+a \keyword{dynamic_cast}\iref{expr.dynamic.cast} or \keyword{typeid}\iref{expr.typeid} expression
 that would throw an exception;
 
 \item


### PR DESCRIPTION
`dynamic_cast` here would be the correct terminology, we generally adhere to that everywhere else.

Also, I moved *throw-expression* to its own item, since it can either:
- throw an exception
- rethrow an exception
- call `std::terminate`

Thus never being eligible to be evaluated in a constant expression. Putting it in the same item as `dynamic_cast` and `typeid` along with "[...] that would throw an exception" only serves to confuse the reader.