### PR TITLE
[expr.throw] Make wording for throw-expressions more consistent with [expr] CWG2699

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6584,19 +6584,21 @@ int main() {
 A \grammarterm{throw-expression} is of type \tcode{void}.
 
 \pnum
-Evaluating a \grammarterm{throw-expression} with an operand throws an
-exception\iref{except.throw}; the type of the exception object is determined by removing
-any top-level \grammarterm{cv-qualifier}{s} from the static type of the
-operand and adjusting the type
-from ``array of \tcode{T}'' or function type \tcode{T}
-to ``pointer to \tcode{T}''.
+A \grammarterm{throw-expression} with an operand throws an exception\iref{except.throw}.
+The array-to-pointer\iref{conv.array} and function-to-pointer\iref{conv.func}
+standard conversions are performed on the operand.
+The type of the exception object\iref{except.throw} is determined by
+removing any top-level cv-qualifiers from the type of the (possibly-converted) operand.
 
 \pnum
 \indextext{exception handling!rethrow}%
-A
-\grammarterm{throw-expression}
+\indextext{exception handling!terminate called@\tcode{terminate} called}%
+\indextext{\idxcode{terminate}!called}%
+A \grammarterm{throw-expression}
 with no operand rethrows the currently handled exception\iref{except.handle}.
-The exception is reactivated with the existing exception object;
+If no exception is currently being handled,
+the function \tcode{std::terminate} is called\iref{except.terminate}.
+Otherwise, the exception is reactivated with the existing exception object;
 no new exception object is created.
 The exception is no longer considered to be caught.
 \begin{example}
@@ -6611,16 +6613,6 @@ try {
 }
 \end{codeblock}
 \end{example}
-
-\pnum
-\indextext{exception handling!rethrow}%
-\indextext{exception handling!terminate called@\tcode{terminate} called}%
-\indextext{\idxcode{terminate}!called}%
-If no exception is presently being handled,
-evaluating a
-\grammarterm{throw-expression}
-with no operand calls
-\tcode{std::\brk{}terminate()}\iref{except.terminate}.
 
 \rSec2[expr.ass]{Assignment and compound assignment operators}%
 \indextext{expression!assignment and compound assignment}


### PR DESCRIPTION
The array/function-to-pointer standard conversions are always applied when initializing pointer types. Thus, we have no need to specify this adjustment manually, outside of stripping top-level cv. Lvalue-to-rvalue conversions are not specified here as to avoid confusion regarding implicit move. Makes it much more consistent with the rest of our wording :)

Additionally, p4 is merged into p3, as the information is pertinent there, and reduces the amount of repetition. `std::terminate()` is also changed to `std::terminate` to be consistent with how we reference calls to library functions throughout the document,

Also fixes #3959.