### PR TITLE
[temp.class.spec.match] Strengthen wording for matching partial specializations

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3393,11 +3393,13 @@ primary template.
 \end{itemize}
 
 \pnum
-A partial specialization matches a given actual template argument
-list if the template arguments of the partial specialization can be
-deduced from the actual template argument list\iref{temp.deduct},
-and the deduced template arguments satisfy the associated constraints
+A class template partial specialization \defnx{matches}{specialization!matches}
+the template argument list of a class template specialization \tcode{A} if, given the type \tcode{P}
+formed by the \grammarterm{simple-template-id} of the partial specialization,
+template argument deduction\iref{temp.deduct.type} for \tcode{P} from \tcode{A} would succeed
+and the deduced template arguments would satisfy the associated constraints
 of the partial specialization, if any\iref{temp.constr.decl}.
+
 \begin{example}
 \begin{codeblock}
 template<class T1, class T2, int I> class A             { };    // \#1


### PR DESCRIPTION
The current wording for [[temp.class.spec.match] p2](http://eel.is/c++draft/temp.class.spec.match#2) leaves much to be desired in terms of precision:
> A partial specialization matches a given actual template argument list if the template arguments of the partial specialization can be deduced from the actual template argument list, and the deduced template arguments satisfy the associated constraints of the partial specialization, if any.

Template argument deduction uses a concrete type "reference" to deduce the values of template parameters of a "target". Presumably when we say "template arguments of the partial specialization" we mean the *template-argument-list*, however, the "`A` can be deduced from `B`" relation doesn't make the most sense here since it implies that `A` is the resulting argument for a template parameter produced by the deduction, rather than the "target" of the deduction.