### PR TITLE
[dcl.fct.def] Fix incorrect cross-ref referring to "this"

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5945,7 +5945,7 @@ is used only in a constructor; see~\ref{class.ctor} and~\ref{class.init}.
 \pnum
 \begin{note}
 A \grammarterm{cv-qualifier-seq} affects the type of \tcode{this}
-in the body of a member function; see~\ref{dcl.ref}.
+in the body of a member function; see~\ref{expr.prim.this}.
 \end{note}
 
 \pnum


### PR DESCRIPTION
On a somewhat related note, it might be time to just remove [[class.this]](http://eel.is/c++draft/class.this). It only has 3 normative sentences, the first 2 being redundant by [expr.prim.this] and the third by [over.match.funcs].