### PR TITLE
[dcl.fct] Fix incorrectly pluralized grammar terms

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3664,9 +3664,9 @@ template<> void g1<int>(const int*, const double&); // OK, specialization of \tc
 
 \pnum
 An abbreviated function template can have a \grammarterm{template-head}.
-The invented \grammarterm{template-parameters} are
+The invented \grammarterm{template-parameter}{s} are
 appended to the \grammarterm{template-parameter-list} after
-the explicitly declared \grammarterm{template-parameters}.
+the explicitly declared \grammarterm{template-parameter}{s}.
 \begin{example}
 \begin{codeblock}
 template<typename> concept C = /* ... */;


### PR DESCRIPTION
Should be `\grammarterm{template-parameter}{s}`, not `\grammarterm{template-parameters}`