### PR TITLE
[class.virtual] Fix example with constrained non-templated function

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3873,6 +3873,7 @@ struct D : B {
 A virtual function shall not have a trailing \grammarterm{requires-clause}\iref{dcl.decl}.
 \begin{example}
 \begin{codeblock}
+template<typename T>
 struct A {
   virtual void f() requires true;       // error: virtual function cannot be constrained\iref{temp.constr.decl}
 };


### PR DESCRIPTION
CA378 forbids this.