### PR TITLE
[temp.class.spec] Remove unused hyphenation point

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3243,7 +3243,7 @@ but the partial specialization is more constrained\iref{temp.constr.order}.
 \pnum
 The template parameters are specified in the angle bracket enclosed list
 that immediately follows the keyword
-\tcode{tem\-plate}.
+\tcode{template}.
 For partial specializations, the template argument list is explicitly
 written immediately following the class template name.
 For primary templates, this list is implicitly described by the


### PR DESCRIPTION
Super tiny fix. LaTeX doesn't hyphenate this, so we don't need it.