### PR TITLE
[class.mem] Deduction guides do not declare new members

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -513,6 +513,8 @@ A \grammarterm{member-declaration} does not declare new members of the class
 if it is
 \begin{itemize}
 \item a friend declaration\iref{class.friend},
+\item a \grammarterm{deduction-guide}\iref{temp.deduct.guide},
+\item a \grammarterm{template-declaration} whose \grammarterm{declaration} is one of the above,
 \item a \grammarterm{static_assert-declaration},
 \item a \grammarterm{using-declaration}\iref{namespace.udecl}, or
 \item an \grammarterm{empty-declaration}.


### PR DESCRIPTION
The intent in [P0091R3](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0091r3.html) is pretty clear (emphasis mine):
> Deduction guides must name a class template and must be introduced within the same semantic scope of the class template, but **they do not becomes members of that scope (i.e if that scope is a class)**.