### PR TITLE
[dcl.spec.auto] Denoise wording for when placeholders can deduce from an initializer

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1717,12 +1717,8 @@ shall be followed by one or more
 each of which shall
 be followed by a non-empty
 \grammarterm{initializer}.
-In an \grammarterm{initializer} of the form
-\begin{codeblock}
-( @\textrm{\grammarterm{expression-list}}@ )
-\end{codeblock}
-the \grammarterm{expression-list} shall be a single
-\grammarterm{assignment-expression}.
+If the \grammarterm{initializer} is a parenthesized \grammarterm{expression-list},
+the \grammarterm{expression-list} shall be a single \grammarterm{assignment-expression}.
 \begin{example}
 \begin{codeblock}
 auto x = 5;                     // OK: \tcode{x} has type \tcode{int}


### PR DESCRIPTION
We usually say "parenthesized *expression-list*", there is no need to use a code block to specify this.