### PR TITLE
[basic.lval] Dynamic type is not a property of objects

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -289,15 +289,15 @@ is ill-formed~(\ref{expr.ass}, \ref{expr.post.incr}, \ref{expr.pre.incr}).
 \pnum
 If a program attempts to access\iref{defns.access}
 the stored value of an object through a glvalue
-whose type is not similar\iref{conv.qual} to
+whose static type is not similar\iref{conv.qual} to
 one of the following types the behavior is
 undefined:\footnote{The intent of this list is to specify those circumstances in which an
 object may or may not be aliased.}
 \begin{itemize}
-\item the dynamic type of the object,
+\item the type of the object,
 
 \item a type that is the signed or unsigned type corresponding to the
-dynamic type of the object, or
+type of the object, or
 
 \item a \tcode{char}, \tcode{unsigned char}, or \tcode{std::byte} type.
 \end{itemize}


### PR DESCRIPTION
This is not the only place where such wording exists, but fixing other occurrences would require more substantial rewrites.