### PR TITLE
[temp.over] Fix example

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -9267,9 +9267,8 @@ is well-formed even if the template
 \tcode{f}
 is only declared and not defined at the point of the call.
 The program will be ill-formed unless a specialization for
-\tcode{f<const char*>},
-either implicitly or explicitly generated,
-is present in some translation unit.
+\tcode{f<const char*>}
+is explicitly instantiated in some translation unit\iref{temp.pre}.
 \end{example}
 
 \indextext{template|)}


### PR DESCRIPTION
[[temp.pre]/10](http://eel.is/c++draft/temp.pre#10):
"""
A definition of a function template ... shall be reachable from the end of every definition domain ([basic.def.odr]) in which it is implicitly instantiated ([temp.inst]) unless the corresponding specialization is **explicitly instantiated** ([temp.explicit]) in some translation unit; no diagnostic is required.
"""

So, implicit instantiation (or explicit specialization) won't make the example well-formed.