### PR TITLE
[dcl.fct.def.general] Non-templated functions cannot have a requires-clause CWG2831

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5906,6 +5906,8 @@ definition shall not be
 a (possibly cv-qualified) class type that is
 incomplete or abstract within the function body
 unless the function is deleted\iref{dcl.fct.def.delete}.
+The optional \grammarterm{requires-clause} shall only be present
+in the definition of a templated function.
 
 \pnum
 \begin{example}


### PR DESCRIPTION
[CA378](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1971r0.html) intended to prohibited constraining non-templated functions. As a result, the following wording was changed in [[dcl.decl] p4](http://eel.is/c++draft/dcl.decl#4):
> The optional *requires-clause* in an *init-declarator* or *member-declarator* shall be present only if the declarator declares a templated function.

Consider a *function-definition*. It has neither an *init-declarator* nor a *member-declarator*, and the "a function definition must be a valid declaration" rule doesn't account for the *requires-clause*. 

I think the cleanest way to fix this is to add a sentence to [dcl.fct.def.general] p3 explicitly prohibiting this rather than dancing around the "definition must be a valid declaration" rule as context would have to be accounted for.