### PR TITLE
[expr.comma] Remove mid-sentence example

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6771,14 +6771,11 @@ value category as its right operand, and is a bit-field if its
 right operand is a bit-field.
 
 \pnum
-In contexts where comma is given a special meaning,
-\begin{example}
-in
-lists of arguments to functions\iref{expr.call} and lists of
-initializers\iref{dcl.init}
-\end{example}
-the comma operator as
-described in this subclause can appear only in parentheses.
+\begin{note}
+In contexts where the comma token is given special meaning
+(e.g. function calls\iref{expr.call}, lists of initializers\iref{dcl.init},
+or \grammarterm{template-argument-list}{s}\iref{temp.names}),
+the comma operator as described in this subclause can appear only in parentheses.
 \begin{example}
 \begin{codeblock}
 f(a, (t=3, t+2), c);
@@ -6786,6 +6783,7 @@ f(a, (t=3, t+2), c);
 has three arguments, the second of which has the value
 \tcode{5}.
 \end{example}
+\end{note}
 
 \pnum
 \begin{note}


### PR DESCRIPTION
Having an example after a comma mid-sentence is _horrible_ (I had to read this several times to realize that it wasn't a sentence fragment).