### PR TITLE
[string.conversions] Replaced comparisons of a pointer against 0 with comparision against nullptr

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -3658,7 +3658,7 @@ and the last three functions call \tcode{strtoul(str.c_str(), ptr, base)},
 base)}, respectively. Each function returns the converted result, if any. The
 argument \tcode{ptr} designates a pointer to an object internal to the function
 that is used to determine what to store at \tcode{*idx}. If the function does
-not throw an exception and \tcode{idx != 0}, the function stores in \tcode{*idx}
+not throw an exception and \tcode{idx != nullptr}, the function stores in \tcode{*idx}
 the index of the first unconverted element of \tcode{str}.
 
 \pnum
@@ -3692,7 +3692,7 @@ These functions call
 \tcode{strtold(\brk{}str.c_str(), ptr)}, respectively. Each function returns
 the converted result, if any. The argument \tcode{ptr} designates a pointer to
 an object internal to the function that is used to determine what to store at
-\tcode{*idx}. If the function does not throw an exception and \tcode{idx != 0},
+\tcode{*idx}. If the function does not throw an exception and \tcode{idx != nullptr},
 the function stores in \tcode{*idx} the index of the first unconverted element
 of \tcode{str}.
 
@@ -3762,7 +3762,7 @@ and the last three functions call \tcode{wcstoul(str.c_str(), ptr, base)},
 base)}, respectively. Each function returns the converted result, if any. The
 argument \tcode{ptr} designates a pointer to an object internal to the function
 that is used to determine what to store at \tcode{*idx}. If the function does
-not throw an exception and \tcode{idx != 0}, the function stores in \tcode{*idx}
+not throw an exception and \tcode{idx != nullptr}, the function stores in \tcode{*idx}
 the index of the first unconverted element of \tcode{str}.
 
 \pnum
@@ -3794,7 +3794,7 @@ These functions call \tcode{wcstof(str.c_str(), ptr)},
 respectively. Each function returns the converted
 result, if any. The argument \tcode{ptr} designates a pointer to an object internal to
 the function that is used to determine what to store at \tcode{*idx}. If the function
-does not throw an exception and \tcode{idx != 0}, the function stores in \tcode{*idx}
+does not throw an exception and \tcode{idx != nullptr}, the function stores in \tcode{*idx}
 the index of the first unconverted element of \tcode{str}.
 
 \pnum


### PR DESCRIPTION
While technically correct, comparing pointers against nullptr is usually preferred to comparing them against the null pointer costant 0. Moreover, it seems more consistent to compare against nullptr, since the default value of the pointer idx is actually declared as nullptr in the synopsis.