### PR TITLE
[expr.unary.op] Fix usage of "result"

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4163,13 +4163,12 @@ Expressions with unary operators group right-to-left.
 \pnum
 \indextext{expression!unary operator}%
 \indextext{operator!unary}%
-The unary \tcode{*} operator performs \defn{indirection}:
+The unary \tcode{*} operator performs \defn{indirection}.
 \indextext{dereferencing|see{indirection}}%
-the expression to which it is applied shall be a pointer to an object
-type, or a pointer to a function type and the result is an lvalue
-referring to the object or function to which the expression points. If
-the type of the expression is ``pointer to \tcode{T}'', the type of the
-result is ``\tcode{T}''.
+Its operand shall be a prvalue of type ``pointer to \tcode{T}'',
+where \tcode{T} is an object or function type.
+The operator yields an lvalue of type \tcode{T}
+denoting the object or function to which the operand points.
 \begin{note}
 \indextext{type!incomplete}%
 Indirection through a pointer to an incomplete type (other than
@@ -4179,7 +4178,7 @@ lvalue must not be converted to a prvalue, see~\ref{conv.lval}.
 \end{note}
 
 \pnum
-The result of each of the following unary operators is a prvalue.
+Each of the following unary operators yields a prvalue.
 
 \pnum
 \indextext{name!address of cv-qualified}%


### PR DESCRIPTION
Do paragraphs 7-10 need similar fix or we fine with «the type of the result is `X`» when it means the type of the resulting prvalue?