### PR TITLE
[depr.atomics] Fix <atomic> header name.

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -2658,7 +2658,7 @@ for an indication of UTF-8 encoding more consistent with
 \rSec1[depr.atomics]{Deprecated atomic operations}
 
 \pnum
-The header \libheaderref{atomics} has the following additions.
+The header \libheaderrefx{atomic}{atomics.syn} has the following additions.
 
 \begin{codeblock}
 namespace std {


### PR DESCRIPTION
The typo was introduced in commit bbb46260d5dd0bb8b561cc74f929ac9a982629a9
while applying P0883R2 Fixing Atomic Initialization.

Fixes #3947.