### PR TITLE
[iterator.concepts.general] Remove synthesizeable operator!= in example.

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1190,7 +1190,6 @@ struct I {
   I operator--(int);
 
   bool operator==(I) const;
-  bool operator!=(I) const;
 };
 \end{codeblock}
 \tcode{iterator_traits<I>::iterator_category} denotes \tcode{input_iterator_tag},


### PR DESCRIPTION
Fixes #3913.