### PR TITLE
[basic.lval] Xvalue don't always denote entities whose resources can be reused

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -143,7 +143,10 @@ Expressions are categorized according to the taxonomy in \fref{basic.lval}.
 or computes the value of an operand of an operator,
 as specified by the context in which it appears,
 or an expression that has type \cv{}~\tcode{void}.
-\item An \defn{xvalue} is a glvalue that denotes an object or bit-field whose resources can be reused (usually because it is near the end of its lifetime).
+\item An \defn{xvalue} is a glvalue that denotes an object or bit-field and is not an lvalue.
+\begin{note}
+Such expressions typically denote entities near the end of their lifetime whose resources can be reused.
+\end{note}
 \item An \defn{lvalue} is a glvalue that is not an xvalue.
 \item An \defn{rvalue} is a prvalue or an xvalue.
 \end{itemize}


### PR DESCRIPTION
Entities denoted by an xvalue can't always have their resources reused (i.e. inaccessible members, cv-qualification, etc.), and such entities generally have no guarantee as to when their lifetime will end. It's best we make this wording non-normative, and instead just say they are glvalue that denote objects/bit-fields and are not lvalues. 

While this definition might sound circular, the value category of an expression is determined from the context in which it appears, not from the definition of what the value categories are.