### PR TITLE
[dcl.fct.def.delete] Make terms cover semantic deletedness

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3933,10 +3933,10 @@ and not
 \end{example}
 
 \pnum
-A function with a deleted definition\iref{dcl.fct.def} shall
-not override a function that does not have a deleted definition. Likewise,
-a function that does not have a deleted definition shall not override a
-function with a deleted definition.%
+A deleted function\iref{dcl.fct.def} shall
+not override a function that is not deleted. Likewise,
+a function that is not deleted shall not override a
+deleted function.%
 \indextext{function!virtual|)}
 
 \pnum

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6217,12 +6217,16 @@ nontrivial1::nontrivial1() = default;   // not first declaration
 \indextext{definition!function!deleted}%
 
 \pnum
-A function definition whose
+A \defnadj{deleted}{definition} of a function is
+a function definition whose
 \grammarterm{function-body}
 is of the form
 \tcode{= delete ;}
-is called a \defnadj{deleted}{definition}. A function with a
-deleted definition is also called a \defnadj{deleted}{function}.
+or an explicitly-defaulted definition of the function where the function is
+defined as deleted.
+A \defnadj{deleted}{function} is
+a function with a
+deleted definition or a function that is implicitly defined as deleted.
 
 \pnum
 A program that refers to a deleted function implicitly or explicitly, other


### PR DESCRIPTION
The definition of "deleted definition" in [dcl.fct.def.delete] is not written in the form of a definition and neither is the definition of "deleted function". Most problematically, these definitions encompass only the syntactic case of explicitly deleting a function but the terms are used where semantic deletedness is meant.

Applying the syntactic interpretation of the definition could lead to the conclusion that the following is ill-formed:
```cpp
struct A { ~A() = delete; };
struct B {
    A a;
      virtual ~B() = default;
};
struct C : B { virtual ~C() = delete; };
```

This patch changes the definitions to cover semantic deletion.

**Drafting notes:**
- It appears that uses of "deleted definition" in the text is usually refer to physical definitions (but not necessarily to explicit deletions).
- The increased verbosity is somewhat necessary to meet the ideal that uses of a term may be replaced with the definition of the term with minimal adjustments.