### PR TITLE
[class.abstract] Clean up redundant wording

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -4114,25 +4114,17 @@ provide a variety of implementations.
 \end{note}
 
 \pnum
-A virtual function is specified as
-a \defnx{pure virtual function}{function!virtual!pure} by using a
-\grammarterm{pure-specifier}\iref{class.mem} in the function declaration
-in the class definition.
+A virtual function is a \defnx{pure virtual function}{function!virtual!pure}
+if its \grammarterm{member-declarator} has a \grammarterm{pure-specifier}\iref{class.mem}.
 \begin{note}
 Such a function might be inherited: see below.
 \end{note}
-A class is an \defnadj{abstract}{class}
-if it has at least one pure virtual function.
-\begin{note}
-An abstract class can be used only as a base class of some other class;
-no objects of an abstract class can be created
-except as subobjects of a class
-derived from it~(\ref{basic.def}, \ref{class.mem}).
-\end{note}
 \indextext{definition!pure virtual function}%
+\begin{note}
 A pure virtual function need be defined only if called with, or as if
 with\iref{class.dtor}, the \grammarterm{qualified-id}
-syntax\iref{expr.prim.id.qual}.
+syntax\iref{expr.prim.id.qual}; see~\ref{basic.def.odr}.
+\end{note}
 \begin{example}
 \begin{codeblock}
 class point { @\commentellip@ };
@@ -4159,30 +4151,16 @@ struct C {
 \end{example}
 
 \pnum
-\begin{note}
-An abstract class type cannot be used
-as a parameter or return type of
-a function being defined\iref{dcl.fct} or called\iref{expr.call},
-except as specified in \ref{dcl.type.simple}.
-Further, an abstract class type cannot be used as
-the type of an explicit type conversion~(\ref{expr.static.cast},
-\ref{expr.reinterpret.cast}, \ref{expr.const.cast}),
-because the resulting prvalue would be of abstract class type\iref{basic.lval}.
-However, pointers and references to abstract class types
-can appear in such contexts.
-\end{note}
-
-\pnum
 \indextext{function!virtual!pure}%
-A class is abstract if it contains or inherits at least one pure virtual
-function for which the final overrider is pure virtual.
+A class is an \defnadj{abstract}{class}
+if it has at least one member that is a pure virtual function.
 \begin{example}
 \begin{codeblock}
 class ab_circle : public shape {
   int radius;
 public:
   void rotate(int) { }
-  // \tcode{ab_circle::draw()} is a pure virtual
+  // \tcode{ab_circle::draw()} is a pure virtual function
 };
 \end{codeblock}
 
@@ -4203,6 +4181,27 @@ would make class \tcode{circle} non-abstract and a definition of
 
 \pnum
 \begin{note}
+An abstract class type can only be used
+\begin{itemize}
+\item
+as the referred to type in a reference,
+\item
+as the pointed to type in a pointer,
+\item
+in an explicit type conversion
+to the above types~(\ref{expr.static.cast}, \ref{expr.reinterpret.cast},
+\ref{expr.const.cast}, \ref{expr.dynamic.cast}), or
+\item
+as a base class\iref{class.derived}.
+\end{itemize}
+\end{note}
+\begin{note}
+Except for base class subobjects, an object cannot
+have abstract class type~(\ref{basic.def}, \ref{class.mem}, \ref{expr.new}).
+\end{note}
+
+\pnum
+\begin{note}
 An abstract class can be derived from a class that is not abstract, and
 a pure virtual function may override a virtual function which is not
 pure.
@@ -4210,12 +4209,14 @@ pure.
 
 \pnum
 \indextext{class!constructor and abstract}%
+\begin{note}
 Member functions can be called from a constructor (or destructor) of an
 abstract class;
 \indextext{virtual function call!undefined pure}%
 the effect of making a virtual call\iref{class.virtual} to a pure
 virtual function directly or indirectly for the object being created (or
-destroyed) from such a constructor (or destructor) is undefined.%
+destroyed) from such a constructor (or destructor) is undefined; see~\ref{class.cdtor}.%
+\end{note}
 \indextext{derived class|)}
 
 \rSec1[class.member.lookup]{Member name lookup}%
@@ -6336,6 +6337,8 @@ destruction,
 the function called is the
 final overrider in the constructor's or destructor's class and not one
 overriding it in a more-derived class.
+If that final overrider is a pure virtual function\iref{class.abstract},
+the behavior is undefined.
 If the virtual function call uses an explicit class member access\iref{expr.ref}
 and the object expression refers to
 the complete object of \tcode{x} or one of that object's base class subobjects


### PR DESCRIPTION
[class.abstract] p2 sentence 3 is entirely redundant by [class.abstract] p4, [class.abstract] sentence 5 is redundant by [basic.def.odr] p3.1, the normative specification for [class.abstract] p6 makes more sense in [class.cdtor] p4, [class.abstract] p2 note 2 and [class.abstract] p3 can be merged into a single note, and the definition of abstract class in [class.abstract] p4 doesn't need to care about final overriders, since members of a base class that aren't redeclared are members of the derived class.

The definition of _pure virtual function_ should probably use `\defnadj`, but please let me know what makes the most sense :)