### PR TITLE
[class.dtor] Remove incorrect uses of virtual as a keyword

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -2228,7 +2228,7 @@ A defaulted destructor for a class
 \pnum
 A destructor is trivial if it is not user-provided and if:
 \begin{itemize}
-\item the destructor is not \tcode{virtual},
+\item the destructor is not virtual,
 
 \item all of the direct base classes of its class have trivial destructors, and
 
@@ -2260,10 +2260,9 @@ implicitly defined.
 \pnum
 \indextext{destructor!virtual}%
 \indextext{destructor!pure virtual}%
-A prospective destructor can be declared
-\tcode{virtual}\iref{class.virtual}
-or pure
-\tcode{virtual}\iref{class.abstract}.
+A prospective destructor can be
+declared \keyword{virtual}\iref{class.virtual}
+and with a \grammarterm{pure-specifier}\iref{class.abstract}.
 If the destructor of a class is virtual and
 any objects of that class or any derived class are created in the program,
 the destructor shall be defined.


### PR DESCRIPTION
These shouldn't be `\tcode`, as these are defined terms (a function can be a _virtual function_ ora  _pure virtual function_)