### PR TITLE
[conv.integral, conv.double] Fix promotion conversions

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -928,8 +928,7 @@ a prvalue of an integer type.
 
 \pnum
 \indextext{conversion!bool@\tcode{bool}}%
-If the destination type is \keyword{bool}, see~\ref{conv.bool}. If the
-source type is \keyword{bool}, the value \keyword{false} is converted to
+If the source type is \keyword{bool}, the value \keyword{false} is converted to
 zero and the value \keyword{true} is converted to one.
 
 \pnum
@@ -940,8 +939,8 @@ that is congruent to the source integer modulo $2^N$,
 where $N$ is the width of the destination type.
 
 \pnum
-The conversions allowed as integral promotions are excluded from the set
-of integral conversions.
+The conversions performed by integral promotions and boolean conversions are
+excluded from the set of integral conversions.
 
 \rSec2[conv.double]{Floating-point conversions}
 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -939,7 +939,7 @@ that is congruent to the source integer modulo $2^N$,
 where $N$ is the width of the destination type.
 
 \pnum
-The conversions performed by integral promotions and boolean conversions are
+The conversions allowed as integral promotions and boolean conversions are
 excluded from the set of integral conversions.
 
 \rSec2[conv.double]{Floating-point conversions}
@@ -961,7 +961,7 @@ destination values, the result of the conversion is an
 Otherwise, the behavior is undefined.
 
 \pnum
-The conversions allowed as floating-point promotions are excluded from
+Floating-point promotion is excluded from
 the set of floating-point conversions.
 
 \rSec2[conv.fpint]{Floating-integral conversions}


### PR DESCRIPTION
- Instead of delegating integral conversions to `bool` to [conv.bool], we can just exclude them from the set of integral conversions (no normative effects as it delegates). 
- [conv.integral] p2 & p3 can be merged as the work better as a single paragraph (due to "Otherwise [...]").
- There is only one floating-point promotion conversion (from `float` to `double`); we need not say "conversions".