### PR TITLE
[class.static.mfct] Strike redundant normative wording

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -2797,12 +2797,12 @@ functions.
 \begin{note}
 A static member function does not have a \tcode{this}
 pointer\iref{class.this}.
+A static member function cannot be declared \tcode{virtual}\iref{dcl.fct.spec}.
+There cannot be a static and a non-static member function with
+the same name, parameter-type-list, and trailing \grammarterm{requires-clause}\iref{over.load}.
+A static member function cannot not be declared \tcode{const},
+\tcode{volatile}, or \tcode{const volatile}\iref{dcl.fct}.
 \end{note}
-A static member function shall not be \tcode{virtual}. There
-shall not be a static and a non-static member function with the
-same name and the same parameter types\iref{over.load}. A
-static member function shall not be declared \tcode{const},
-\tcode{volatile}, or \tcode{const volatile}.
 
 \rSec3[class.static.data]{Static data members}
 \indextext{member data!static}%


### PR DESCRIPTION
All of the normative wording here is redundant: the overloading rule is specified in [over.load], the _cv-qualifier-seq_ rule in [dcl.fct], and the virtual rule in [dcl.fct.spec]. 

I added the trailing _requires-clause_ rule for overloading, and also changed "shall" to "cannot" since it shouldn't be used within informative wording.

It seems that we ran out of normative wording in this sub clause with this change, so perhaps more drastic measures should be taken (eventually).