### PR TITLE
[class.dtor] Change redundant wording into note

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -2098,9 +2098,10 @@ implicitly defined.
 A prospective destructor can be
 declared \keyword{virtual}\iref{class.virtual}
 and with a \grammarterm{pure-specifier}\iref{class.abstract}.
-If the destructor of a class is virtual and
-any objects of that class or any derived class are created in the program,
-the destructor shall be defined.
+\begin{note}
+Since a pure virtual destructor will be invoked by the destructor of
+a derived class, it must still be defined in most cases; see~\ref{basic.def.odr}.
+\end{note}
 
 \pnum
 \begin{note}


### PR DESCRIPTION
First sentence was recommended by @jensmaurer (non-pure virtual functions are always odr-used), the second is redundant because destructors are non-static data members and inheritance doesn't play into whether a virtual function is overridden (i.e. this is covered by [class.virtual] p1 & p2).