### PR TITLE
[meta.trans.other] "C++ object type" is overprecise

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -17476,7 +17476,7 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  struct aligned_storage;}
  &
  The value of \textit{default-alignment} shall be the most
- stringent alignment requirement for any \Cpp{} object type whose size
+ stringent alignment requirement for any object type whose size
  is no greater than \tcode{Len}\iref{basic.types}.
  The member typedef \tcode{type} shall be a trivial standard-layout type
  suitable for use as uninitialized storage for any object whose size


### PR DESCRIPTION
...suggesting that elsewhere where we say only "object type" we intend to admit non-C++ object types.