### PR TITLE
[dcl.init.ref] Remove "type" from "reference to type T"

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5207,7 +5207,7 @@ explicitly initialized shall be zero-initialized\iref{dcl.init}.
 
 \pnum
 A variable whose declared type is
-``reference to type \tcode{T}''\iref{dcl.ref}
+``reference to \tcode{T}''\iref{dcl.ref}
 shall be initialized.
 \begin{example}
 \begin{codeblock}


### PR DESCRIPTION
This doesn't follow our usual convention