### PR TITLE
[over.ics.ref] Remove erroneous capitalization of Conversion

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2515,7 +2515,7 @@ When a parameter of reference type binds directly\iref{dcl.init.ref} to an
 argument expression, the implicit conversion sequence is the identity conversion,
 unless the argument expression has a type that is a derived class of the parameter
 type, in which case the implicit conversion sequence is a derived-to-base
-Conversion\iref{over.best.ics}.
+conversion\iref{over.best.ics}.
 \begin{example}
 \begin{codeblock}
 struct A {};


### PR DESCRIPTION
We don't capitalize it anywhere else when used in the context