### PR TITLE
[basic.fundamental] Provide more information about which types are integral

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5074,7 +5074,7 @@ Types
 \tcode{bool},
 \tcode{char}, \tcode{wchar_t},
 \tcode{char8_t}, \tcode{char16_t}, \tcode{char32_t},
-and the signed and unsigned integer types are
+and the standard and extended integer types are
 collectively called
 \defnx{integral types}{integral type}.
 A synonym for integral type is \defn{integer type}.


### PR DESCRIPTION
Saying "standard and extended integer types" provides more information to the reader than "signed and unsigned integer types" (integer type implies signed and unsigned) and doesn't alter meaning.