### PR TITLE
[basic, class, expr] Replace enumerated type with enumeration type

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5181,9 +5181,8 @@ on the access to these entities\iref{class.access};
 different types at different times, \ref{class.union};
 
 \item
-\defnx{enumerations}{\idxcode{enum}}, which comprise a set of named constant values.
-Each distinct enumeration constitutes a different
-\defnadj{enumerated}{type}, \ref{dcl.enum};
+\defnx{enumerations}{\idxcode{enum}},
+which comprise a set of named constant values, \ref{dcl.enum};
 
 \item
 \indextext{member pointer to|see{pointer to member}}%

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -758,7 +758,7 @@ names\iref{class.ctor}
 \item every member template of class \tcode{T};
 
 \item every enumerator of every member of class \tcode{T} that is an
-unscoped enumerated type; and
+unscoped enumeration type; and
 
 \item every member of every anonymous union that is a member of class
 \tcode{T}.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -852,7 +852,7 @@ to a prvalue of type \tcode{int} if \tcode{int} can represent all the
 values of the bit-field; otherwise, it can be converted to
 \tcode{unsigned int} if \tcode{unsigned int} can represent all the
 values of the bit-field. If the bit-field is larger yet, no integral
-promotion applies to it. If the bit-field has an enumerated type, it is
+promotion applies to it. If the bit-field has enumeration type, it is
 treated as any other value of that type for promotion purposes.
 
 \pnum
@@ -1098,7 +1098,7 @@ converted to \tcode{float}.
 
 \item Otherwise, the integral promotions\iref{conv.prom} shall be
 performed on both operands.\footnote{As a consequence, operands of type \tcode{bool}, \tcode{char8_t}, \tcode{char16_t},
-\tcode{char32_t}, \tcode{wchar_t}, or an enumerated type are converted
+\tcode{char32_t}, \tcode{wchar_t}, or of enumeration type are converted
 to some integral type.}
 Then the following rules shall be applied to the promoted operands:
 


### PR DESCRIPTION
We already define _enumerated type_ in [enumerated.types], and we only use it a handful of times in core. We should strike it to prevent any confusion and to improve consistency.