### PR TITLE
Allow 'listings' package v1.8d

### DIFF
--- a/source/styles.tex
+++ b/source/styles.tex
@@ -142,13 +142,13 @@
 %% (copied verbatim from listings.sty version 1.6 except where commented)
 \makeatletter
 
-\lst@CheckVersion{1.8c}{\lst@CheckVersion{1.8b}{\lst@CheckVersion{1.7}{\lst@CheckVersion{1.6}{\lst@CheckVersion{1.5b}{
+\lst@CheckVersion{1.8d}{\lst@CheckVersion{1.8c}{\lst@CheckVersion{1.8b}{\lst@CheckVersion{1.7}{\lst@CheckVersion{1.6}{\lst@CheckVersion{1.5b}{
  \typeout{^^J%
  ***^^J%
  *** This file requires listings.sty version 1.6.^^J%
  *** You have version \lst@version; exiting ...^^J%
  ***^^J}%
- \batchmode \@@end}}}}}
+ \batchmode \@@end}}}}}}
 
 \def\lst@Init#1{%
     \begingroup


### PR DESCRIPTION
texlive 2020 uses version 1.8d