### PR TITLE
[concepts.equality] Replace spurious 'this document'

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -53,7 +53,7 @@ being equality-preserving. The \term{domain} of an expression is the set of
 input values for which the expression is required to be well-defined.
 
 \pnum
-Expressions required by this document to be equality-preserving are further
+Expressions required to be equality-preserving are further
 required to be stable: two evaluations of such an expression with the same input
 objects are required to have equal outputs absent any explicit intervening
 modification of those input objects.
@@ -69,7 +69,7 @@ be valid for that object.
 \end{note}
 
 \pnum
-Expressions declared in a \grammarterm{requires-expression} in this document are
+Expressions declared in a \grammarterm{requires-expression} in the library Clauses are
 required to be equality-preserving, except for those annotated with the comment
 ``not required to be equality-preserving.'' An expression so annotated
 may be equality-preserving, but is not required to be so.
@@ -77,7 +77,7 @@ may be equality-preserving, but is not required to be so.
 \pnum
 An expression that may alter the value of one or more of its inputs in a manner
 observable to equality-preserving expressions is said to modify those inputs.
-This document uses a notational convention to specify which expressions declared
+The library Clauses use a notational convention to specify which expressions declared
 in a \grammarterm{requires-expression} modify which inputs: except where
 otherwise specified, an expression operand that is a non-constant lvalue or
 rvalue may be modified. Operands that are constant lvalues or rvalues are

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -69,7 +69,7 @@ be valid for that object.
 \end{note}
 
 \pnum
-Expressions declared in a \grammarterm{requires-expression} in the library Clauses are
+Expressions declared in a \grammarterm{requires-expression} in the library clauses are
 required to be equality-preserving, except for those annotated with the comment
 ``not required to be equality-preserving.'' An expression so annotated
 may be equality-preserving, but is not required to be so.
@@ -77,7 +77,7 @@ may be equality-preserving, but is not required to be so.
 \pnum
 An expression that may alter the value of one or more of its inputs in a manner
 observable to equality-preserving expressions is said to modify those inputs.
-The library Clauses use a notational convention to specify which expressions declared
+The library clauses use a notational convention to specify which expressions declared
 in a \grammarterm{requires-expression} modify which inputs: except where
 otherwise specified, an expression operand that is a non-constant lvalue or
 rvalue may be modified. Operands that are constant lvalues or rvalues are


### PR DESCRIPTION
with 'the library Clauses'.

Fixes #3980.