### PR TITLE
[temp.mem] Change "virtual" to "declared virtual"

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -2608,7 +2608,7 @@ class B {
 
 class D : public B {
   template <class T> void f(T); // does not override \tcode{B::f(int)}
-  void f(int i) { f<>(i); }     // overriding function that calls the template instantiation
+  void f(int i) { f<>(i); }     // overriding function that calls the function template specialization
 };
 \end{codeblock}
 \end{example}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -2586,7 +2586,7 @@ int main() {
 \end{example}
 
 \pnum
-A member function template shall not be virtual.
+A member function template shall not be declared \keyword{virtual}.
 \begin{example}
 \begin{codeblock}
 template <class T> struct AA {


### PR DESCRIPTION
Non-template functions are never virtual by inheritance. 

This also includes a small drive-by fix to an example.