### PR TITLE
Cleanup of [class.virtual]

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3748,7 +3748,7 @@ by \tcode{X} and \tcode{Y}, as shown in \fref{class.virtnonvirt}.
 
 \pnum
 A non-static member function is a \defnadj{virtual}{function}
-if it is first declared with the keyword \tcode{virtual} or
+if it is declared with the keyword \tcode{virtual} or
 if it overrides a virtual member function declared in a base class
 (see below).\footnote{The use of the \tcode{virtual} specifier in the
 declaration of an overriding function is valid but redundant (has empty
@@ -3765,24 +3765,21 @@ its internal representation might not otherwise require
 any additions for that polymorphic behavior.}
 
 \pnum
-If a virtual member function \tcode{vf} is declared in a class
-\tcode{Base} and in a class \tcode{Derived}, derived directly or
-indirectly from \tcode{Base}, a member function \tcode{vf} with the same
-name, parameter-type-list\iref{dcl.fct}, cv-qualification, and ref-qualifier
-(or absence of same) as \tcode{Base::vf} is declared,
-then \tcode{Derived::vf} \term{overrides}\footnote{A function
+A non-template non-static member function declared in a class \tcode{D}
+\defn{overrides} a virtual member function declared
+in a base class of \tcode{D} if both have the same name,
+parameter-type-list\iref{dcl.fct}, \grammarterm{cv-qualifier-seq},
+and \grammarterm{ref-qualifier} (or absence thereof).
+\footnote{A function
 with the same name but a different parameter list\iref{over}
 as a virtual function is not necessarily virtual and
 does not override. Access control\iref{class.access} is not considered in
 determining overriding.}
-\tcode{Base::vf}. For convenience we say that any virtual function
-overrides itself.
-\indextext{overrider!final}%
-A virtual member function \tcode{C::vf} of a class object \tcode{S} is a \defn{final
-overrider} unless the most derived class\iref{intro.object} of which \tcode{S} is a
-base class subobject (if any) declares or inherits another member function that overrides
-\tcode{vf}. In a derived class, if a virtual member function of a base class subobject
-has more than one final overrider the program is ill-formed.
+The \denfx{final overrider}{overrider!final} of a virtual function \tcode{F} in a class \tcode{C}
+is \tcode{F} if no member of \tcode{C} overrides \tcode{F},
+and otherwise is the member \tcode{G} of \tcode{C} that overrides \tcode{F}
+and itself is not overridden by any other member of \tcode{C};
+there shall be exactly one such \tcode{G}.
 \begin{example}
 \begin{codeblock}
 struct A {
@@ -3838,9 +3835,8 @@ class \tcode{D2}.
 \end{note}
 
 \pnum
-If a virtual function \tcode{f} in some class \tcode{B} is marked with the
-\grammarterm{virt-specifier} \tcode{final} and in a class \tcode{D} derived from \tcode{B}
-a function \tcode{D::f} overrides \tcode{B::f}, the program is ill-formed.
+A virtual function shall not override a function declared
+with the \grammarterm{virt-specifier} \tcode{final}.
 \begin{example}
 \begin{codeblock}
 struct B {
@@ -3854,8 +3850,8 @@ struct D : B {
 \end{example}
 
 \pnum
-If a virtual function is marked with the \grammarterm{virt-specifier} \tcode{override} and
-does not override a member function of a base class, the program is ill-formed.
+A function declared with the \grammarterm{virt-specifier} \tcode{override}
+shall override a virtual function.
 \begin{example}
 \begin{codeblock}
 struct B {

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -2597,6 +2597,7 @@ template <class T> struct AA {
 \end{example}
 
 \pnum
+\begin{note}
 A specialization of
 a member function template does not override a virtual function from a
 base class.
@@ -2612,6 +2613,7 @@ class D : public B {
 };
 \end{codeblock}
 \end{example}
+\end{note}
 
 \pnum
 A specialization of a


### PR DESCRIPTION
This is an attempt to make our definition of "override" and "final overrider" more consistent with its use, and includes some small cleanups along the way.

In [[class.cdtor] p4](http://eel.is/c++draft/class.cdtor#4) we have the following wording:
> [...] the function called is the final overrider in the constructor's or destructor's class [...]

We also have the following wording in [[expr.call] p3](http://eel.is/c++draft/expr.call#3):
> Otherwise, its final overrider in the dynamic type of the object expression is called

In both of these cases, we refer to the final overrider relative to another class. Changing the definition to match the use here seems reasonable. The approach taken here is to define the final overrider of a function relative to a class (as far as I can tell this wording shouldn't change semantics; it accounts for redeclared members not being members of the derived class).

There also was a missing \grammarterms around ref-qualifier, and cv-qualification was changed to be cv-qualifier-seq to match function declarators. Since we no longer need to consider virtual functions to override themselves, it allows us to simplify the wording a bit in other places. 