### PR TITLE
Reference the normative text for data member order

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -729,7 +729,7 @@ Non-static data members of a (non-union) class
 with the same access control\iref{class.access} and
 non-zero size\iref{intro.object}
 are allocated so that later
-members have higher addresses within a class object.
+members have higher addresses within a class object\iref{expr.rel}.
 \indextext{allocation!unspecified}%
 The order of allocation of non-static data members
 with different access control


### PR DESCRIPTION
[CWG2404](bb641cba40211374d8b2dd3472f42274de662761) demoted this paragraph to a note, but didn't include a reference to _why_ the ordering of non-static data member addresses was still defined.

Credit to [aschepler on StackOverflow](https://stackoverflow.com/a/61590855/166389) for the reference.