### PR TITLE
[thread.syn] Don't mandate including <initializer_list> when including <thread>

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -966,7 +966,6 @@ These threads are intended to map one-to-one with operating system threads.
 \indexheader{thread}%
 \begin{codeblock}
 #include <compare>              // see \ref{compare.syn}
-#include <initializer_list>     // see \ref{initializer.list.syn}
 
 namespace std {
   class thread;


### PR DESCRIPTION
Fix #3988 