### PR TITLE
modify customization point to customization point object #1

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -677,7 +677,7 @@ template<class T, class U>
 \pnum
 \begin{note}
 The semantics of the \libconcept{swappable} and \libconcept{swappable_with}
-concepts are fully defined by the \tcode{ranges::swap} customization point.
+concepts are fully defined by the \tcode{ranges::swap} customization point object.
 \end{note}
 
 \pnum


### PR DESCRIPTION
modify customization point to customization point object when referring to ranges::swap