### PR TITLE
Fixing customization point references #2

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1218,7 +1218,7 @@ template<class T>
 
 \pnum
 \libconcept{contiguous_range} additionally requires that
-the \tcode{ranges::data} customization point\iref{range.prim.data}
+the \tcode{ranges::data} customization point object\iref{range.prim.data}
 is usable with the range.
 
 \begin{itemdecl}


### PR DESCRIPTION
changed customization point to customization point object when talking about ranges::data