### PR TITLE
fixing customization point references #3

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -64,7 +64,7 @@ namespace std {
     using iter_reference_t = decltype(*declval<T&>());
 
   namespace ranges {
-    // \ref{iterator.cust}, customization points
+    // \ref{iterator.cust}, customization point objects
     inline namespace @\unspec@ {
       // \ref{iterator.cust.move}, \tcode{ranges::iter_move}
       inline constexpr @\unspec@ iter_move = @\unspec@;
@@ -1043,7 +1043,7 @@ void reverse(BI first, BI last) {
 \end{codeblock}
 \end{example}
 
-\rSec2[iterator.cust]{Customization points}
+\rSec2[iterator.cust]{Customization point objects}
 
 \rSec3[iterator.cust.move]{\tcode{ranges::iter_move}}
 


### PR DESCRIPTION
Modified the title of [iterator.cust] to 'customizatin point objects' since it talks about customization point objects. Modified the reference to it in [iterator.synopsis] too.