### PR TITLE
renaming [common.iter.cust]

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -5056,7 +5056,7 @@ are each \tcode{false}.
 $i$ is \tcode{x.v_.index()} and $j$ is \tcode{y.v_.index()}.
 \end{itemdescr}
 
-\rSec3[common.iter.cust]{Customization}
+\rSec3[common.iter.cust]{Customizations}
 
 \indexlibrarymember{iter_move}{common_iterator}%
 \begin{itemdecl}


### PR DESCRIPTION
renaming [common.iter.cust] to match [counted.iter.cust] for consistency reasons