### PR TITLE
[class.temporary] space-separate trivially copyable

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4092,7 +4092,7 @@ Temporary objects are created
 \item
 when a prvalue is converted to an xvalue\iref{conv.rval},
 \item
-when needed by the implementation to pass or return an object of trivially-copyable type (see below),
+when needed by the implementation to pass or return an object of trivially copyable type (see below),
 and
 \item
 when throwing an exception\iref{except.throw}.


### PR DESCRIPTION
"trivially-copyable" is space-separated in the rest of the standard
(this occurrence originated in  611f4c675e2160463cb1fbf71ab87bd67c9102eb and is the only such spelling in the entire commit history)
