### PR TITLE
[std] Harmonize phrasing 'terminate is invoked'

### DIFF
--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -334,7 +334,7 @@ it is rethrown.
 If the exception handling mechanism
 handling an uncaught exception\iref{except.uncaught}
 directly invokes a function that exits via an
-exception, the function \tcode{std::terminate} is called\iref{except.terminate}.
+exception, the function \tcode{std::terminate} is invoked\iref{except.terminate}.
 \begin{example}
 \begin{codeblock}
 struct C {
@@ -608,12 +608,10 @@ still active is called the
 
 \pnum
 If no matching handler is found,
-the function
+the function \tcode{std::terminate} is invoked;
+whether or not the stack is unwound before this invocation of
 \tcode{std::terminate}
-is called;
-whether or not the stack is unwound before this call to
-\tcode{std::terminate}
-is \impldef{stack unwinding before call to
+is \impldef{stack unwinding before invocation of
 \tcode{std::terminate}}\iref{except.terminate}.
 
 \pnum
@@ -785,7 +783,7 @@ Whenever an exception is thrown
 and the search for a handler\iref{except.handle}
 encounters the outermost block of a function with a
 non-throwing exception specification,
-the function \tcode{std::terminate} is called\iref{except.terminate}.
+the function \tcode{std::terminate} is invoked\iref{except.terminate}.
 \begin{note}
 An implementation is not permitted to reject an expression merely because, when
 executed, it throws or might
@@ -1066,28 +1064,24 @@ fails to meet a postcondition.
 \pnum
 \indextext{\idxcode{terminate}}%
 In such cases,
-the function \tcode{std::terminate}
-is called\iref{exception.terminate}.
+the function \tcode{std::terminate} is invoked\iref{exception.terminate}.
 In the situation where no matching handler is found, it is
-\impldef{stack unwinding before call to \tcode{std::terminate}} whether or not the
-stack is unwound
-before
-\tcode{std::terminate}
-is called.
+\impldef{stack unwinding before invocation of \tcode{std::terminate}}
+whether or not the stack is unwound
+before \tcode{std::terminate} is invoked.
 In the situation where the search for a handler\iref{except.handle} encounters the
 outermost block of a function
 with a non-throwing exception specification\iref{except.spec}, it is
-\impldef{whether stack is unwound before calling the function \tcode{std::terminate}
-when a \tcode{noexcept} specification
-is violated}
+\impldef{whether stack is unwound before invoking the function \tcode{std::terminate}
+when a \tcode{noexcept} specification is violated}
 whether the stack is unwound, unwound partially, or not unwound at all
-before the function \tcode{std::terminate} is called.
+before the function \tcode{std::terminate} is invoked.
 In all other situations, the stack shall not be unwound before
 the function \tcode{std::terminate}
-is called.
+is invoked.
 An implementation is not permitted to finish stack unwinding
 prematurely based on a determination that the unwind process
-will eventually cause a call to the function
+will eventually cause an invocation of the function
 \tcode{std::terminate}.
 
 \rSec2[except.uncaught]{The \tcode{std::uncaught_exceptions} function}%

--- a/source/support.tex
+++ b/source/support.tex
@@ -1995,8 +1995,8 @@ by throwing an exception that is caught in
 \tcode{main}.
 \end{footnote}
 
-If control leaves a registered function called by \tcode{exit} because the function does
-not provide a handler for a thrown exception, the function \tcode{std::terminate} shall be called\iref{except.terminate}.%
+If a registered function invoked by \tcode{exit} exits via an exception,
+the function \tcode{std::terminate} is invoked\iref{except.terminate}.%
 \indexlibraryglobal{terminate}%
 
 \item
@@ -2076,9 +2076,9 @@ Functions registered by calls to \tcode{at_quick_exit} are called in the
 reverse order of their registration, except that a function shall be called after any
 previously registered functions that had already been called at the time it was
 registered. Objects shall not be destroyed as a result of calling \tcode{quick_exit}.
-If control leaves a registered function called by \tcode{quick_exit} because the
-function does not provide a handler for a thrown exception, the function \tcode{std::terminate} shall
-be called.\indexlibraryglobal{terminate}
+If a registered function invoked by \tcode{quick_exit} exits via an exception,
+the function \tcode{std::terminate} is invoked\iref{except.terminate}.%
+\indexlibraryglobal{terminate}
 \begin{note}
 A function registered via \tcode{at_quick_exit}
 is invoked by the thread that calls \tcode{quick_exit},
@@ -3630,10 +3630,8 @@ using terminate_handler = void (*)();
 
 \begin{itemdescr}
 \pnum
-The type of a
-\term{handler function}
-to be called by
-\tcode{std::terminate()}
+The type of a \term{handler function}
+to be invoked by \tcode{terminate}
 \indexlibraryglobal{terminate}%
 when terminating exception processing.
 

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -796,7 +796,7 @@ If the request was made,
 the callbacks registered by associated \tcode{stop_callback} objects
 are synchronously called.
 If an invocation of a callback exits via an exception
-then \tcode{terminate} is called\iref{except.terminate}.
+then \tcode{terminate} is invoked\iref{except.terminate}.
 \begin{note}
 A stop request includes notifying all condition variables
 of type \tcode{condition_variable_any}
@@ -937,7 +937,7 @@ Any exception thrown by the initialization of \tcode{callback}.
 If evaluating
 \tcode{std::forward<Callback>(callback)()}
 exits via an exception,
-then \tcode{terminate} is called\iref{except.terminate}.
+then \tcode{terminate} is invoked\iref{except.terminate}.
 \end{itemdescr}
 
 \indexlibrarydtor{stop_callback}%
@@ -1224,7 +1224,7 @@ This implies that any exceptions not thrown from the invocation of the copy
 of \tcode{f} will be thrown in the constructing thread, not the new thread.
 \end{note}
 If the invocation of \tcode{invoke} terminates with an uncaught exception,
-\tcode{terminate} is called.
+\tcode{terminate} is invoked\iref{except.terminate}.
 
 \pnum
 \sync
@@ -1270,7 +1270,8 @@ value of \tcode{x.get_id()} prior to the start of construction.
 \begin{itemdescr}
 \pnum
 \effects
-If \tcode{joinable()}, calls \tcode{terminate()}. Otherwise, has no effects.
+If \tcode{joinable()}, invokes \tcode{terminate}\iref{except.terminate}.
+Otherwise, has no effects.
 \begin{note}
 Either implicitly detaching or joining a \tcode{joinable()} thread in its
 destructor could result in difficult to debug correctness (for detach) or performance
@@ -1290,7 +1291,8 @@ thread& operator=(thread&& x) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-If \tcode{joinable()}, calls \tcode{terminate()}. Otherwise, assigns the
+If \tcode{joinable()}, invokes \tcode{terminate}\iref{except.terminate}.
+Otherwise, assigns the
 state of \tcode{x} to \tcode{*this} and sets \tcode{x} to a default constructed state.
 
 \pnum
@@ -4398,7 +4400,7 @@ Nothing.
 \pnum
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
-is called\iref{except.terminate}.
+is invoked\iref{except.terminate}.
 \begin{note}
 This can happen if the re-locking of the mutex throws an exception.
 \end{note}
@@ -4442,7 +4444,7 @@ Any exception thrown by \tcode{pred}.
 \pnum
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
-is called\iref{except.terminate}.
+is invoked\iref{except.terminate}.
 \begin{note}
 This can happen if the re-locking of the mutex throws an exception.
 \end{note}
@@ -4504,7 +4506,7 @@ exceptions\iref{thread.req.timing}.
 \pnum
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
-is called\iref{except.terminate}.
+is invoked\iref{except.terminate}.
 \begin{note}
 This can happen if the re-locking of the mutex throws an exception.
 \end{note}
@@ -4554,8 +4556,8 @@ exceptions\iref{thread.req.timing}.
 
 \pnum
 \remarks
-If the function fails to meet the postcondition, \tcode{terminate()}
-is called\iref{except.terminate}.
+If the function fails to meet the postcondition, \tcode{terminate}
+is invoked\iref{except.terminate}.
 \begin{note}
 This can happen if the re-locking of the mutex throws an exception.
 \end{note}
@@ -4610,7 +4612,7 @@ exceptions\iref{thread.req.timing} or any exception thrown by \tcode{pred}.
 \pnum
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
-is called\iref{except.terminate}.
+is invoked\iref{except.terminate}.
 \begin{note}
 This can happen if the re-locking of the mutex throws an exception.
 \end{note}
@@ -4671,7 +4673,7 @@ exceptions\iref{thread.req.timing} or any exception thrown by \tcode{pred}.
 \pnum
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
-is called\iref{except.terminate}.
+is invoked\iref{except.terminate}.
 \begin{note}
 This can happen if the re-locking of the mutex throws an exception.
 \end{note}
@@ -4831,7 +4833,7 @@ Nothing.
 \pnum
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
-is called\iref{except.terminate}.
+is invoked\iref{except.terminate}.
 \begin{note}
 This can happen if the re-locking of the mutex throws an exception.
 \end{note}
@@ -4898,7 +4900,7 @@ exceptions\iref{thread.req.timing}.
 \pnum
 \remarks
 If the function fails to meet the postcondition, \tcode{terminate()}
-is called\iref{except.terminate}.
+is invoked\iref{except.terminate}.
 \begin{note}
 This can happen if the re-locking of the mutex throws an exception.
 \end{note}
@@ -4935,8 +4937,8 @@ exceptions\iref{thread.req.timing}.
 
 \pnum
 \remarks
-If the function fails to meet the postcondition, \tcode{terminate()}
-is called\iref{except.terminate}.
+If the function fails to meet the postcondition, \tcode{terminate}
+is invoked\iref{except.terminate}.
 \begin{note}
 This can happen if the re-locking of the mutex throws an exception.
 \end{note}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -18648,8 +18648,8 @@ that a parallel algorithm's execution may not be parallelized.
 \pnum
 During the execution of a parallel algorithm with
 the \tcode{execution::sequenced_policy} policy,
-if the invocation of an element access function exits via an uncaught exception,
-\tcode{terminate()} is called.
+if the invocation of an element access function exits via an exception,
+\tcode{terminate} is invoked\iref{except.terminate}.
 \end{itemdescr}
 
 \rSec2[execpol.par]{Parallel execution policy}
@@ -18668,8 +18668,8 @@ a parallel algorithm's execution may be parallelized.
 \pnum
 During the execution of a parallel algorithm with
 the \tcode{execution::parallel_policy} policy,
-if the invocation of an element access function exits via an uncaught exception,
-\tcode{terminate()} is called.
+if the invocation of an element access function exits via an exception,
+\tcode{terminate} is invoked\iref{except.terminate}.
 \end{itemdescr}
 
 \rSec2[execpol.parunseq]{Parallel and unsequenced execution policy}
@@ -18689,8 +18689,8 @@ vectorized.
 \pnum
 During the execution of a parallel algorithm with
 the \tcode{execution::parallel_unsequenced_policy} policy,
-if the invocation of an element access function exits via an uncaught exception,
-\tcode{terminate()} is called.
+if the invocation of an element access function exits via an exception,
+\tcode{terminate} is invoked\iref{except.terminate}.
 \end{itemdescr}
 
 \rSec2[execpol.unseq]{Unsequenced execution policy}
@@ -18710,8 +18710,8 @@ that operate on multiple data items.
 \pnum
 During the execution of a parallel algorithm with
 the \tcode{execution::unsequenced_policy} policy,
-if the invocation of an element access function exits via an uncaught exception,
-\tcode{terminate()} is called.
+if the invocation of an element access function exits via an exception,
+\tcode{terminate} is invoked\iref{except.terminate}.
 
 \rSec2[execpol.objects]{Execution policy objects}
 


### PR DESCRIPTION
instead of saying 'is called'.
Also add cross-references to [except.terminate].
Also use 'exits via an exception' consistently.

Fixes #3079.