### PR TITLE
C++20 [range.single.view] Add missing requires-clause to \itemdecl

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1940,6 +1940,7 @@ Initializes \exposid{value_} with \tcode{std::move(t)}.
 \indexlibraryctor{single_view}%
 \begin{itemdecl}
 template<class... Args>
+  requires @\libconcept{constructible_from}@<T, Args...>
 constexpr single_view(in_place_t, Args&&... args);
 \end{itemdecl}
 


### PR DESCRIPTION
This is a clone of #4009 to apply to the C++20 DIS.