### PR TITLE
C++20 [thread.syn] Do not mandate including <initializer_list> when including <thread>

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -966,7 +966,6 @@ These threads are intended to map one-to-one with operating system threads.
 \indexheader{thread}%
 \begin{codeblock}
 #include <compare>              // see \ref{compare.syn}
-#include <initializer_list>     // see \ref{initializer.list.syn}
 
 namespace std {
   class thread;


### PR DESCRIPTION
This was accidentally introduced while applying
LWG3330 Include <compare> from most library headers.

Clone of #3991 for C++20 DIS.
Fixes #3988 