### PR TITLE
[res.on.expects] Replace obsolete term 'expects' in the title.

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2976,7 +2976,7 @@ the behavior is undefined unless otherwise specified.
 This applies even to objects such as mutexes intended for thread synchronization.
 \end{note}
 
-\rSec3[res.on.expects]{Expects paragraph}
+\rSec3[res.on.preconditions]{Preconditions paragraph}
 
 \pnum
 Violation of any preconditions specified in a function's \expects element


### PR DESCRIPTION
Fixes #4016 