### PR TITLE
[class.default.ctor] Fix sloppy wording.

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1304,7 +1304,7 @@ that is defaulted and not defined as deleted
 is
 \defnx{implicitly defined}{constructor!implicitly defined}
 when it is odr-used\iref{term.odr.use}
-to create an object of its class type\iref{intro.object},
+to initialize an object of its class type\iref{intro.object},
 when it is needed for constant evaluation\iref{expr.const}, or
 when it is explicitly defaulted after its first declaration.
 The implicitly-defined default constructor performs the set of
@@ -1329,19 +1329,12 @@ implicit exception specification, see~\ref{dcl.fct.def}.
 \end{note}
 
 \pnum
-\indextext{constructor!implicitly called}%
-Default constructors are called implicitly to create class objects of static, thread,
-or automatic storage duration~(\ref{basic.stc.static}, \ref{basic.stc.thread}, \ref{basic.stc.auto}) defined
-without an initializer\iref{dcl.init},
-are called to create class objects of dynamic storage duration\iref{basic.stc.dynamic} created by a
-\grammarterm{new-expression}
-in which the
-\grammarterm{new-initializer}
-is omitted\iref{expr.new}, or
-are called when the explicit type conversion syntax\iref{expr.type.conv} is
-used.
-A program is ill-formed if the default constructor for an object
-is implicitly used and the constructor is not accessible\iref{class.access}.
+\begin{note}
+\indextext{constructor!implicitly invoked}%
+A default constructor is implicitly invoked to initialize
+a class object when no initializer is specified\iref{dcl.init.general}.
+Such a default constructor is required to be accessible\iref{class.access}.
+\end{note}
 
 \pnum
 \begin{note}


### PR DESCRIPTION
Initialization is fully specified in [dcl.init],
so turn the list of default-initialization cases
into a note and shorten it appropriately.

Fixes #4019