### PR TITLE
[module.reach] Clarify that only TUs with an interface dependency may be incidentally reachable

### DIFF
--- a/source/modules.tex
+++ b/source/modules.tex
@@ -982,9 +982,9 @@ to name lookup\iref{basic.scope.namespace}.
 \pnum
 All translation units that are necessarily reachable are
 \defnx{reachable}{reachable!translation unit}.
-It is unspecified whether additional translation units on which the
-point within the program has an interface dependency are considered reachable,
-and under what circumstances.%
+Additional translation units on which the
+point within the program has an interface dependency may be considered reachable,
+but it is unspecified which are and under what circumstances.%
 \footnote{Implementations are therefore not required to prevent the semantic
 effects of additional translation units involved in the compilation from being
 observed.}


### PR DESCRIPTION
I think this is the intent of that sentence. Another possible reading, and the one my rewording attempts to prevent, is that because it doesn't say that no other TUs may be reachable, any TU may be, and it is just giving an example of a specific likely case of incidental reachability. But if that is the intent, then we probably shouldn't have it in normative text.

There is an existing issue in the wording (#3502) in that http://eel.is/c++draft/module#import-10 defines "has an interface dependency" as a relationship between two TUs, but this uses it as a relationship between "point with the program" and a TU. This makes it ambiguous about whether TU imported later in a file may be reachable at an earlier point. I am not trying to resolve that ambiguity with this change.