### PR TITLE
[structure.specifications] Integrate [res.on.expects].

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -620,7 +620,8 @@ and also define the function as deleted.
 \item
 \expects
 the conditions
-that the function assumes to hold whenever it is called.
+that the function assumes to hold whenever it is called;
+violation of any preconditions results in undefined behavior.
 
 \item
 \effects
@@ -2975,12 +2976,6 @@ the behavior is undefined unless otherwise specified.
 \begin{note}
 This applies even to objects such as mutexes intended for thread synchronization.
 \end{note}
-
-\rSec3[res.on.expects]{Expects paragraph}
-
-\pnum
-Violation of any preconditions specified in a function's \expects element
-results in undefined behavior.
 
 \rSec3[res.on.requirements]{Semantic requirements}
 

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -23,5 +23,7 @@
 %\movedxrefiii{old.label}{new.label.1}{new.label.2}{new.label.3}
 %\movedxrefs{old.label}{new place (eg \tref{blah})}
 
+\movedxref{res.on.expects}{structure.specifications}
+
 % Deprecated features.
 %\deprxref{old.label}  (if moved to depr.old.label, otherwise use \movedxref)


### PR DESCRIPTION
The latter consisted of a single sentence that is
best integrated into the place where the Preconditions:
element is introduced.

Also fixes LWG3168.