### PR TITLE
[container.requirements.general] Don't use 'f()' to refer to non-nullary function.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -276,7 +276,7 @@ Those entries marked ``(Note A)'' or ``(Note B)''
 have linear complexity for \tcode{array} and have constant complexity
 for all other standard containers.
 \begin{note}
-The algorithm \tcode{equal()} is defined in \ref{algorithms}.
+The algorithm \tcode{equal} is defined in \ref{algorithms}.
 \end{note}
 
 \pnum


### PR DESCRIPTION
Per [Specification-Style-Guidelines/describing-function-calls](https://github.com/cplusplus/draft/wiki/Specification-Style-Guidelines#describing-function-calls).