### PR TITLE
[basic.fundamental] Use canonical types in Table 12

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4944,10 +4944,10 @@ the largest value of the corresponding unsigned type.
 \lhdr{Type} & \rhdr{Minimum width $N$} \\
 \capsep
 \tcode{signed char} & 8 \\
-\tcode{short} & 16 \\
+\tcode{short int} & 16 \\
 \tcode{int} & 16 \\
-\tcode{long} & 32 \\
-\tcode{long long} & 64 \\
+\tcode{long int} & 32 \\
+\tcode{long long int} & 64 \\
 \end{floattable}
 
 \pnum


### PR DESCRIPTION
In all other places in this sub-clause we use the canonical forms of type names as described in [dcl.type.simple]. We should do so here as well.