### PR TITLE
[class.derived] Remove second definition of base class subobject

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3528,8 +3528,8 @@ class\iref{dcl.init.ref}.
 \end{note}
 
 \pnum
-The \grammarterm{base-specifier-list} specifies the type of the
-\term{base class subobjects} contained in an
+The \grammarterm{base-specifier-list} specifies the types of the
+base class subobjects\iref{intro.object} contained in an
 object of the derived class type.
 \begin{example}
 \begin{codeblock}


### PR DESCRIPTION
This is already defined in [intro.object].