### PR TITLE
[dcl.array] Clarify that arrays do not have extra padding.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3084,7 +3084,7 @@ has cv-qualified type; see~\ref{basic.type.qualifier}.
 \end{note}
 
 \pnum
-An object of type ``array of \tcode{N} \tcode{U}'' contains
+An object of type ``array of \tcode{N} \tcode{U}'' consists of
 a contiguously allocated non-empty set
 of \tcode{N} subobjects of type \tcode{U},
 known as the \defnx{elements}{array!element} of the array,


### PR DESCRIPTION
Fixes #3791 