### PR TITLE
[special] Remove index entry for 'X(X&)'.

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1134,7 +1134,6 @@ see~\ref{class.ctor} and~\ref{class.dtor}.
 
 \rSec2[special]{Special member functions}
 
-\indextext{\idxcode{X(X\&)}|see{constructor, copy}}%
 \indextext{~@\tcode{\~}|see{destructor}}%
 \indextext{assignment!copy|see{assignment operator, copy}}%
 \indextext{assignment!move|see{assignment operator, move}}%


### PR DESCRIPTION
This index entry seems useless because how would one even know to look for "X(X&)" in the index, given that the name X is arbitrary? :)