### PR TITLE
[expr.new] Use repeated \indextext for index redirects with multiple targets.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4656,9 +4656,12 @@ unless the \grammarterm{expression} is potentially-throwing\iref{except.spec}.
 
 \pnum
 \indextext{expression!\idxcode{new}}%
-\indextext{free store|seealso{\tcode{new}, \tcode{delete}}}%
-\indextext{memory management|see{\tcode{new}, \tcode{delete}}}%
-\indextext{storage management|see{\tcode{new}, \tcode{delete}}}%
+\indextext{free store|seealso{\tcode{new}}}%
+\indextext{free store|seealso{\tcode{delete}}}%
+\indextext{memory management|see{\tcode{new}}}%
+\indextext{memory management|see{\tcode{delete}}}%
+\indextext{storage management|see{\tcode{new}}}%
+\indextext{storage management|see{\tcode{delete}}}%
 \indextext{\idxcode{new}}%
 The \grammarterm{new-expression} attempts to create an object of the
 \grammarterm{type-id}\iref{dcl.name} or \grammarterm{new-type-id} to which


### PR DESCRIPTION
I overlooked these in https://github.com/cplusplus/draft/pull/1501.