### PR TITLE
[lib] Canonicalize order of library descriptive elements.

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -3265,15 +3265,12 @@ to an integral type~(\ref{conv.integral}, \ref{class.conv}).
 
 \pnum
 \expects
+\tcode{n >= 0} is \tcode{true}.
 \tcode{Function} meets the \oldconcept{MoveConstructible} requirements.
 \begin{note}
 \tcode{Function} need not meet
 the requirements of \oldconcept{CopyConstructible}.
 \end{note}
-
-\pnum
-\expects
-\tcode{n >= 0} is \tcode{true}.
 
 \pnum
 \effects
@@ -3308,11 +3305,8 @@ to an integral type~(\ref{conv.integral}, \ref{class.conv}).
 
 \pnum
 \expects
-\tcode{Function} meets the \oldconcept{CopyConstructible} requirements.
-
-\pnum
-\expects
 \tcode{n >= 0} is \tcode{true}.
+\tcode{Function} meets the \oldconcept{CopyConstructible} requirements.
 
 \pnum
 \effects
@@ -5203,13 +5197,13 @@ Let $j$ be the end of the resulting range. Returns:
 \end{itemize}
 
 \pnum
-\remarks
-Stable\iref{algorithm.stable}.
-
-\pnum
 \complexity
 Exactly \tcode{last - first} applications
 of the corresponding predicate and any projection.
+
+\pnum
+\remarks
+Stable\iref{algorithm.stable}.
 
 \pnum
 \begin{note}
@@ -6319,7 +6313,6 @@ the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
 \oldconcept{\-Move\-Assignable} (\tref{cpp17.moveassignable}) requirements.
 
 \pnum
-\expects
 For iterators \tcode{a1} and \tcode{b1} in \range{first}{last}, and
 iterators \tcode{x2} and \tcode{y2} in \range{result_first}{result_last},
 after evaluating the assignment \tcode{*y2 = *b1}, let $E$ be the value of
@@ -8111,17 +8104,17 @@ For the first form, \tcode{T} meets the
 \pnum
 \returns
 The smaller value.
-
-\pnum
-\remarks
 Returns the first argument when the arguments are equivalent.
-An invocation may explicitly specify
-an argument for the template parameter \tcode{T}
-of the overloads in namespace \tcode{std}.
 
 \pnum
 \complexity
 Exactly one comparison and two applications of the projection, if any.
+
+\pnum
+\remarks
+An invocation may explicitly specify
+an argument for the template parameter \tcode{T}
+of the overloads in namespace \tcode{std}.
 \end{itemdescr}
 
 \indexlibraryglobal{min}%
@@ -8153,19 +8146,19 @@ requirements (\tref{cpp17.lessthancomparable}).
 \pnum
 \returns
 The smallest value in the input range.
-
-\pnum
-\remarks
 Returns a copy of the leftmost element
 when several elements are equivalent to the smallest.
-An invocation may explicitly specify
-an argument for the template parameter \tcode{T}
-of the overloads in namespace \tcode{std}.
 
 \pnum
 \complexity
 Exactly \tcode{ranges::distance(r) - 1} comparisons
 and twice as many applications of the projection, if any.
+
+\pnum
+\remarks
+An invocation may explicitly specify
+an argument for the template parameter \tcode{T}
+of the overloads in namespace \tcode{std}.
 \end{itemdescr}
 
 \indexlibraryglobal{max}%
@@ -8189,17 +8182,17 @@ For the first form, \tcode{T} meets the
 \pnum
 \returns
 The larger value.
-
-\pnum
-\remarks
 Returns the first argument when the arguments are equivalent.
-An invocation may explicitly specify
-an argument for the template parameter \tcode{T}
-of the overloads in namespace \tcode{std}.
 
 \pnum
 \complexity
 Exactly one comparison and two applications of the projection, if any.
+
+\pnum
+\remarks
+An invocation may explicitly specify
+an argument for the template parameter \tcode{T}
+of the overloads in namespace \tcode{std}.
 \end{itemdescr}
 
 \indexlibraryglobal{max}%
@@ -8231,19 +8224,19 @@ requirements (\tref{cpp17.lessthancomparable}).
 \pnum
 \returns
 The largest value in the input range.
-
-\pnum
-\remarks
 Returns a copy of the leftmost element
 when several elements are equivalent to the largest.
-An invocation may explicitly specify
-an argument for the template parameter \tcode{T}
-of the overloads in namespace \tcode{std}.
 
 \pnum
 \complexity
 Exactly \tcode{ranges::distance(r) - 1} comparisons
 and twice as many applications of the projection, if any.
+
+\pnum
+\remarks
+An invocation may explicitly specify
+an argument for the template parameter \tcode{T}
+of the overloads in namespace \tcode{std}.
 \end{itemdescr}
 
 \indexlibraryglobal{minmax}%
@@ -8272,14 +8265,14 @@ For the first form, \tcode{T} meets the
 \tcode{\{a, b\}} otherwise.
 
 \pnum
+\complexity
+Exactly one comparison and two applications of the projection, if any.
+
+\pnum
 \remarks
 An invocation may explicitly specify
 an argument for the template parameter \tcode{T}
 of the overloads in namespace \tcode{std}.
-
-\pnum
-\complexity
-Exactly one comparison and two applications of the projection, if any.
 \end{itemdescr}
 
 \indexlibraryglobal{minmax}%
@@ -8318,16 +8311,16 @@ where \tcode{x} is a copy of the leftmost element with the smallest value and
 in the input range.
 
 \pnum
-\remarks
-An invocation may explicitly specify
-an argument for the template parameter \tcode{T}
-of the overloads in namespace \tcode{std}.
-
-\pnum
 \complexity
 At most $(3/2)\tcode{ranges::distance(r)}$ applications
 of the corresponding predicate
 and twice as many applications of the projection, if any.
+
+\pnum
+\remarks
+An invocation may explicitly specify
+an argument for the template parameter \tcode{T}
+of the overloads in namespace \tcode{std}.
 \end{itemdescr}
 
 \indexlibraryglobal{min_element}%
@@ -10816,12 +10809,12 @@ void qsort(void* base, size_t nmemb, size_t size, @\placeholder{compare-pred}@* 
 
 \begin{itemdescr}
 \pnum
-\effects
-These functions have the semantics specified in the C standard library.
-
-\pnum
 \expects
 The objects in the array pointed to by \tcode{base} are of trivial type.
+
+\pnum
+\effects
+These functions have the semantics specified in the C standard library.
 
 \pnum
 \throws

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -1708,14 +1708,14 @@ void store(T desired, memory_order order = memory_order::seq_cst) noexcept;
 
 \begin{itemdescr}
 \pnum
-\expects
-The \tcode{order} argument is neither \tcode{memory_order::consume},
-\tcode{memory_order::acquire}, nor \tcode{memory_order::acq_rel}.
-
-\pnum
 \constraints
 For the \tcode{volatile} overload of this function,
 \tcode{is_always_lock_free} is \tcode{true}.
+
+\pnum
+\expects
+The \tcode{order} argument is neither \tcode{memory_order::consume},
+\tcode{memory_order::acquire}, nor \tcode{memory_order::acq_rel}.
 
 \pnum
 \effects
@@ -1761,13 +1761,13 @@ T load(memory_order order = memory_order::seq_cst) const noexcept;
 
 \begin{itemdescr}
 \pnum
-\expects
-The \tcode{order} argument is neither \tcode{memory_order::release} nor \tcode{memory_order::acq_rel}.
-
-\pnum
 \constraints
 For the \tcode{volatile} overload of this function,
 \tcode{is_always_lock_free} is \tcode{true}.
+
+\pnum
+\expects
+The \tcode{order} argument is neither \tcode{memory_order::release} nor \tcode{memory_order::acq_rel}.
 
 \pnum
 \effects
@@ -1861,14 +1861,14 @@ bool compare_exchange_strong(T& expected, T desired,
 
 \begin{itemdescr}
 \pnum
-\expects
-The \tcode{failure} argument is neither \tcode{memory_order::release} nor
-\tcode{memory_order::acq_rel}.
-
-\pnum
 \constraints
 For the \tcode{volatile} overload of this function,
 \tcode{is_always_lock_free} is \tcode{true}.
+
+\pnum
+\expects
+The \tcode{failure} argument is neither \tcode{memory_order::release} nor
+\tcode{memory_order::acq_rel}.
 
 \pnum
 \effects

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -3787,13 +3787,13 @@ explicit deque(size_type n, const Allocator& = Allocator());
 
 \begin{itemdescr}
 \pnum
+\expects
+\tcode{T} is \oldconcept{DefaultInsertable} into \tcode{*this}.
+
+\pnum
 \effects
 Constructs a \tcode{deque} with
 \tcode{n} default-inserted elements using the specified allocator.
-
-\pnum
-\expects
-\tcode{T} is \oldconcept{DefaultInsertable} into \tcode{*this}.
 
 \pnum
 \complexity
@@ -3807,15 +3807,15 @@ deque(size_type n, const T& value, const Allocator& = Allocator());
 
 \begin{itemdescr}
 \pnum
+\expects
+\tcode{T} is \oldconcept{CopyInsertable} into \tcode{*this}.
+
+\pnum
 \effects
 Constructs a
 \tcode{deque}
 with \tcode{n} copies of \tcode{value},
 using the specified allocator.
-
-\pnum
-\expects
-\tcode{T} is \oldconcept{CopyInsertable} into \tcode{*this}.
 
 \pnum
 \complexity
@@ -3949,6 +3949,14 @@ deque invalidates all the iterators to the deque, but has no effect on
 the validity of references to elements of the deque.
 
 \pnum
+\complexity
+The complexity is linear in the number of elements inserted plus the lesser
+of the distances to the beginning and end of the deque.
+Inserting a single element at either the beginning or end of a deque always takes constant time
+and causes a single call to a constructor of
+\tcode{T}.
+
+\pnum
 \remarks
 If an exception is thrown other than by the
 copy constructor, move constructor,
@@ -3960,14 +3968,6 @@ there are no effects.
 Otherwise, if an exception is thrown by the move constructor of a
 non-\oldconcept{CopyInsertable}
 \tcode{T}, the effects are unspecified.
-
-\pnum
-\complexity
-The complexity is linear in the number of elements inserted plus the lesser
-of the distances to the beginning and end of the deque.
-Inserting a single element at either the beginning or end of a deque always takes constant time
-and causes a single call to a constructor of
-\tcode{T}.
 \end{itemdescr}
 
 \indexlibrarymember{erase}{deque}%
@@ -3992,15 +3992,15 @@ iterator and all iterators and references to all the elements of the deque.
 \end{note}
 
 \pnum
+\throws
+Nothing unless an exception is thrown by the assignment operator of
+\tcode{T}.
+
+\pnum
 \complexity
 The number of calls to the destructor of \tcode{T} is the same as the
 number of elements erased, but the number of calls to the assignment operator of \tcode{T} is
 no more than the lesser of the number of elements before the erased elements and the number of elements after the erased elements.
-
-\pnum
-\throws
-Nothing unless an exception is thrown by the assignment operator of
-\tcode{T}.
 \end{itemdescr}
 
 \rSec3[deque.erasure]{Erasure}
@@ -4291,14 +4291,14 @@ const_iterator cbefore_begin() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns
-A non-dereferenceable iterator that, when incremented, is equal to the iterator
-returned by \tcode{begin()}.
-
-\pnum
 \effects
 \tcode{cbefore_begin()} is equivalent to
 \tcode{const_cast<forward_list const\&>(*this).before_begin()}.
+
+\pnum
+\returns
+A non-dereferenceable iterator that, when incremented, is equal to the iterator
+returned by \tcode{begin()}.
 
 \pnum
 \remarks
@@ -4691,13 +4691,13 @@ Nothing unless an exception is thrown by the equality comparison or the
 predicate.
 
 \pnum
-\remarks
-Stable\iref{algorithm.stable}.
-
-\pnum
 \complexity
 Exactly \tcode{distance(begin(), end())} applications of the corresponding
 predicate.
+
+\pnum
+\remarks
+Stable\iref{algorithm.stable}.
 \end{itemdescr}
 
 \indexlibrarymember{unique}{forward_list}%
@@ -4755,13 +4755,13 @@ refer to their elements, but they now behave as iterators into \tcode{*this}, no
 \tcode{x}.
 
 \pnum
-\remarks
-Stable\iref{algorithm.stable}.
-
-\pnum
 \complexity
 At most \tcode{distance(begin(),
 end()) + distance(x.begin(), x.end()) - 1} comparisons.
+
+\pnum
+\remarks
+Stable\iref{algorithm.stable}.
 \end{itemdescr}
 
 \indexlibrarymember{sort}{forward_list}%
@@ -4778,12 +4778,12 @@ If an exception is thrown, the order of the elements in \tcode{*this} is unspeci
 Does not affect the validity of iterators and references.
 
 \pnum
-\remarks
-Stable\iref{algorithm.stable}.
-
-\pnum
 \complexity
 Approximately $N \log N$ comparisons, where $N$ is \tcode{distance(begin(), end())}.
+
+\pnum
+\remarks
+Stable\iref{algorithm.stable}.
 \end{itemdescr}
 
 \indexlibrarymember{reverse}{forward_list}%
@@ -5161,11 +5161,6 @@ void push_back(T&& x);
 
 \begin{itemdescr}
 \pnum
-\remarks
-Does not affect the validity of iterators and references.
-If an exception is thrown there are no effects.
-
-\pnum
 \complexity
 Insertion of a single element into a list takes constant time and
 exactly one call to a constructor of
@@ -5173,6 +5168,11 @@ exactly one call to a constructor of
 number of elements inserted, and the number of calls to the copy
 constructor or move constructor of \tcode{T} is exactly equal
 to the number of elements inserted.
+
+\pnum
+\remarks
+Does not affect the validity of iterators and references.
+If an exception is thrown there are no effects.
 \end{itemdescr}
 
 \indexlibrarymember{erase}{list}%
@@ -5376,14 +5376,14 @@ or
 \tcode{pred(*i) != false}.
 
 \pnum
-\remarks
-Stable\iref{algorithm.stable}.
-
-\pnum
 \complexity
 Exactly
 \tcode{size()}
 applications of the corresponding predicate.
+
+\pnum
+\remarks
+Stable\iref{algorithm.stable}.
 \end{itemdescr}
 
 \indexlibrarymember{unique}{list}%
@@ -5453,12 +5453,6 @@ refer to their elements, but they now behave as iterators into \tcode{*this}, no
 \tcode{x}.
 
 \pnum
-\remarks
-Stable\iref{algorithm.stable}. If \tcode{addressof(x) != this}, the range \tcode{[x.begin(), x.end())}
-is empty after the merge.
-No elements are copied by this operation.
-
-\pnum
 \complexity
 At most
 \tcode{size() + x.size() - 1}
@@ -5466,6 +5460,12 @@ applications of \tcode{comp} if
 \tcode{addressof(x) != this};
 otherwise, no applications of \tcode{comp} are performed.
 If an exception is thrown other than by a comparison there are no effects.
+
+\pnum
+\remarks
+Stable\iref{algorithm.stable}. If \tcode{addressof(x) != this}, the range \tcode{[x.begin(), x.end())}
+is empty after the merge.
+No elements are copied by this operation.
 \end{itemdescr}
 
 \indexlibrarymember{reverse}{list}%
@@ -5499,15 +5499,15 @@ the order of the elements in \tcode{*this} is unspecified.
 Does not affect the validity of iterators and references.
 
 \pnum
-\remarks
-Stable\iref{algorithm.stable}.
-
-\pnum
 \complexity
 Approximately
 $N \log N$
 comparisons, where
 \tcode{N == size()}.
+
+\pnum
+\remarks
+Stable\iref{algorithm.stable}.
 \end{itemdescr}
 
 \rSec3[list.erasure]{Erasure}
@@ -5836,15 +5836,15 @@ other than by the move constructor of a non-\oldconcept{CopyInsertable} type,
 there are no effects.
 
 \pnum
-\complexity
-It does not change the size of the sequence and takes at most linear
-time in the size of the sequence.
-
-\pnum
 \throws
 \tcode{length_error} if \tcode{n >
 max_size()}.\footnote{\tcode{reserve()} uses \tcode{Allocator::allocate()} which
 may throw an appropriate exception.}
+
+\pnum
+\complexity
+It does not change the size of the sequence and takes at most linear
+time in the size of the sequence.
 
 \pnum
 \remarks
@@ -6000,6 +6000,14 @@ constexpr void push_back(T&& x);
 
 \begin{itemdescr}
 \pnum
+\complexity
+If reallocation happens,
+linear in the number of elements of the resulting vector;
+otherwise,
+linear in the number of elements inserted plus the distance
+to the end of the vector.
+
+\pnum
 \remarks
 Causes reallocation if the new size is greater than the old capacity.
 Reallocation invalidates all the references, pointers, and iterators
@@ -6020,14 +6028,6 @@ If an exception is thrown while inserting a single element at the end and
 is \tcode{true}, there are no effects.
 Otherwise, if an exception is thrown by the move constructor of a non-\oldconcept{CopyInsertable}
 \tcode{T}, the effects are unspecified.
-
-\pnum
-\complexity
-If reallocation happens,
-linear in the number of elements of the resulting vector;
-otherwise,
-linear in the number of elements inserted plus the distance
-to the end of the vector.
 \end{itemdescr}
 
 \indexlibrarymember{erase}{vector}%
@@ -6043,17 +6043,17 @@ constexpr void pop_back();
 Invalidates iterators and references at or after the point of the erase.
 
 \pnum
+\throws
+Nothing unless an exception is thrown by the
+assignment operator or move assignment operator of
+\tcode{T}.
+
+\pnum
 \complexity
 The destructor of \tcode{T} is called the number of times equal to the
 number of the elements erased, but the assignment operator
 of \tcode{T} is called the number of times equal to the number of
 elements in the vector after the erased elements.
-
-\pnum
-\throws
-Nothing unless an exception is thrown by the
-assignment operator or move assignment operator of
-\tcode{T}.
 \end{itemdescr}
 
 \rSec3[vector.erasure]{Erasure}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -1325,6 +1325,15 @@ static bool sync_with_stdio(bool sync = true);
 
 \begin{itemdescr}
 \pnum
+\effects
+If any input or output operation has occurred using the standard streams prior to the
+call, the effect is
+\impldef{effect of calling \tcode{ios_base::sync_with_stdio} after
+any input or output operation on standard streams}.
+Otherwise, called with a \tcode{false} argument, it allows the standard streams to
+operate independently of the standard C streams.
+
+\pnum
 \returns
 \tcode{true}
 if the previous state of the standard iostream objects\iref{iostream.objects}
@@ -1335,15 +1344,7 @@ the function returns
 \tcode{true}.
 
 \pnum
-\effects
-If any input or output operation has occurred using the standard streams prior to the
-call, the effect is
-\impldef{effect of calling \tcode{ios_base::sync_with_stdio} after
-any input or output operation on standard streams}.
-Otherwise, called with a \tcode{false} argument, it allows the standard streams to
-operate independently of the standard C streams.
-
-\pnum
+\remarks
 When a standard iostream object \tcode{str} is
 \textit{synchronized}
 with a standard stdio stream \tcode{f}, the effect of inserting a character \tcode{c} by
@@ -2197,15 +2198,6 @@ void clear(iostate state = goodbit);
 
 \begin{itemdescr}
 \pnum
-\ensures
-If
-\tcode{rdbuf() != 0}
-then
-\tcode{state == rdstate()};
-otherwise
-\tcode{rdstate() == (state | ios_base::badbit)}.
-
-\pnum
 \effects
 If \tcode{((state | (rdbuf() ? goodbit : badbit)) \& exceptions()) == 0},
 returns.
@@ -2214,6 +2206,15 @@ Otherwise, the function throws an object of class
 constructed with
 \impldef{argument values to construct \tcode{ios_base::failure}}
 argument values.%
+
+\pnum
+\ensures
+If
+\tcode{rdbuf() != 0}
+then
+\tcode{state == rdstate()};
+otherwise
+\tcode{rdstate() == (state | ios_base::badbit)}.
 \end{itemdescr}
 
 \indexlibrarymember{setstate}{basic_ios}%
@@ -2312,13 +2313,13 @@ void exceptions(iostate except);
 
 \begin{itemdescr}
 \pnum
-\ensures
-\tcode{except == exceptions()}.
-
-\pnum
 \effects
 Calls
 \tcode{clear(rdstate())}.
+
+\pnum
+\ensures
+\tcode{except == exceptions()}.
 \end{itemdescr}
 
 \rSec2[std.ios.manip]{\tcode{ios_base} manipulators}
@@ -3701,15 +3702,6 @@ int_type underflow();
 
 \begin{itemdescr}
 \pnum
-\remarks
-The public members of
-\tcode{basic_streambuf}
-call this virtual function only if
-\tcode{gptr()}
-is null or
-\tcode{gptr() >= egptr()}.
-
-\pnum
 \returns
 \tcode{traits::to_int_type(c)},
 where \tcode{c} is the first
@@ -3720,6 +3712,15 @@ without moving the input sequence position past it.
 If the pending sequence is null then the function returns
 \tcode{traits::eof()}
 to indicate failure.
+
+\pnum
+\remarks
+The public members of
+\tcode{basic_streambuf}
+call this virtual function only if
+\tcode{gptr()}
+is null or
+\tcode{gptr() >= egptr()}.
 
 \pnum
 The
@@ -3867,16 +3868,6 @@ Whether the input sequence is backed up or modified in any other way is unspecif
 \end{itemize}
 
 \pnum
-\ensures
-On return, the constraints of
-\tcode{gptr()},
-\tcode{eback()},
-and
-\tcode{pptr()}
-are the same as for
-\tcode{underflow()}.
-
-\pnum
 \returns
 \tcode{traits::eof()}
 to indicate failure.
@@ -3889,6 +3880,16 @@ is called only when put back has really failed.
 Returns some value other than
 \tcode{traits::eof()}
 to indicate success.
+
+\pnum
+\ensures
+On return, the constraints of
+\tcode{gptr()},
+\tcode{eback()},
+and
+\tcode{pptr()}
+are the same as for
+\tcode{underflow()}.
 
 \pnum
 \default
@@ -5207,11 +5208,10 @@ which may throw
 for the next available input character \tcode{c}
 (in which case \tcode{c} is extracted).
 \end{itemize}
-
-\pnum
-\remarks
+\begin{note}
 The last condition will never occur if
 \tcode{traits::eq_int_type(delim, traits::eof())}.
+\end{note}
 
 \pnum
 \returns
@@ -7806,20 +7806,20 @@ basic_string<charT, traits, Allocator> str() &&;
 
 \begin{itemdescr}
 \pnum
-\returns
-A \tcode{basic_string<charT, traits, Allocator>} object
-move constructed from
-the \tcode{basic_stringbuf}'s underlying character sequence in \tcode{buf}.
-This can be achieved by first adjusting \tcode{buf} to have
-the same content as \tcode{view()}.
-
-\pnum
 \ensures
 The underlying character sequence \tcode{buf} is empty and
 \tcode{pbase()}, \tcode{pptr()}, \tcode{epptr()}, \tcode{eback()},
 \tcode{gptr()}, and \tcode{egptr()}
 are initialized as if by calling \tcode{init_buf_ptrs()}
 with an empty \tcode{buf}.
+
+\pnum
+\returns
+A \tcode{basic_string<charT, traits, Allocator>} object
+move constructed from
+the \tcode{basic_stringbuf}'s underlying character sequence in \tcode{buf}.
+This can be achieved by first adjusting \tcode{buf} to have
+the same content as \tcode{view()}.
 \end{itemdescr}
 
 \indexlibrarymember{view}{basic_stringbuf}%
@@ -8030,15 +8030,15 @@ Signals success by returning a value other than
 \end{itemize}
 
 \pnum
-\remarks
-The function can alter the number of write positions available as a
-result of any call.
-
-\pnum
 \returns
 As specified above, or
 \tcode{traits::eof()}
 to indicate failure.
+
+\pnum
+\remarks
+The function can alter the number of write positions available as a
+result of any call.
 
 \pnum
 The function can make a write position available only if
@@ -9570,13 +9570,13 @@ If any of the calls made by the function, including \tcode{fclose}, fails,
 exception, the exception is caught and rethrown after closing the file.
 
 \pnum
+\ensures
+\tcode{is_open() == false}.
+
+\pnum
 \returns
 \tcode{this}
 on success, a null pointer otherwise.
-
-\pnum
-\ensures
-\tcode{is_open() == false}.
 \end{itemdescr}
 
 \rSec3[filebuf.virtuals]{Overridden virtual functions}
@@ -9835,6 +9835,17 @@ otherwise call
 \tcode{fseek(file, 0, whence)}.
 
 \pnum
+\returns
+A newly constructed
+\tcode{pos_type}
+object that stores the resultant
+stream position, if possible.
+If the positioning operation fails, or
+if the object cannot represent the resultant stream position,
+returns
+\tcode{pos_type(off_type(-1))}.
+
+\pnum
 \remarks
 ``The last operation was output'' means either
 the last virtual operation was overflow or
@@ -9856,17 +9867,6 @@ as indicated in \tref{filebuf.seekoff}.
 \tcode{basic_ios::cur}  & \tcode{SEEK_CUR}  \\
 \tcode{basic_ios::end}  & \tcode{SEEK_END}  \\
 \end{libtab2}
-
-\pnum
-\returns
-A newly constructed
-\tcode{pos_type}
-object that stores the resultant
-stream position, if possible.
-If the positioning operation fails, or
-if the object cannot represent the resultant stream position,
-returns
-\tcode{pos_type(off_type(-1))}.
 \end{itemdescr}
 
 \indexlibrarymember{seekpos}{basic_filebuf}%
@@ -10790,10 +10790,9 @@ basic_syncbuf(streambuf_type* obuf, const Allocator& allocator);
 Sets \tcode{wrapped} to \tcode{obuf}.
 
 \pnum
-\remarks
-A copy of \tcode{allocator} is used
-to allocate memory for internal buffers
-holding the associated output.
+\ensures
+\tcode{get_wrapped() == obuf} and
+\tcode{get_allocator() == allocator} are \tcode{true}.
 
 \pnum
 \throws
@@ -10802,9 +10801,10 @@ by the construction of a mutex or
 by memory allocation.
 
 \pnum
-\ensures
-\tcode{get_wrapped() == obuf} and
-\tcode{get_allocator() == allocator} are \tcode{true}.
+\remarks
+A copy of \tcode{allocator} is used
+to allocate memory for internal buffers
+holding the associated output.
 \end{itemdescr}
 
 \indexlibraryctor{basic_syncbuf}%
@@ -10867,10 +10867,6 @@ has the observable state it would have had if
 it had been move constructed from \tcode{rhs}\iref{syncstream.syncbuf.cons}.
 
 \pnum
-\returns
-\tcode{*this}.
-
-\pnum
 \ensures
 \begin{itemize}
 \item
@@ -10882,6 +10878,10 @@ allocator_traits<Allocator>::propagate_on_container_move_assignment::value
 \end{codeblock}
 is \tcode{true}; otherwise, the allocator is unchanged.
 \end{itemize}
+
+\pnum
+\returns
+\tcode{*this}.
 
 \pnum
 \remarks
@@ -10929,6 +10929,10 @@ if and only if a call was made to \tcode{sync()}
 since the most recent call to \tcode{emit()}, if any.
 
 \pnum
+\ensures
+On success, the associated output is empty.
+
+\pnum
 \returns
 \tcode{true} if all of the following conditions hold;
 otherwise \tcode{false}:
@@ -10937,10 +10941,6 @@ otherwise \tcode{false}:
 \item All of the characters in the associated output were successfully transferred.
 \item The call to \tcode{wrapped->pubsync()} (if any) succeeded.
 \end{itemize}
-
-\pnum
-\ensures
-On success, the associated output is empty.
 
 \pnum
 \sync
@@ -13249,12 +13249,6 @@ path lexically_relative(const path& base) const;
 
 \begin{itemdescr}
 \pnum
-\returns
-\tcode{*this} made relative to \tcode{base}.
-Does not resolve\iref{fs.class.path} symlinks.
-Does not first normalize\iref{fs.path.generic} \tcode{*this} or \tcode{base}.
-
-\pnum
 \effects
 If:
 \begin{itemize}
@@ -13299,6 +13293,12 @@ If \tcode{n<0,} returns \tcode{path()}; otherwise
   for each element in \range{a}{end()}.
 \end{itemize}
 \end{itemize}
+
+\pnum
+\returns
+\tcode{*this} made relative to \tcode{base}.
+Does not resolve\iref{fs.class.path} symlinks.
+Does not first normalize\iref{fs.path.generic} \tcode{*this} or \tcode{base}.
 
 \pnum
 \begin{example}
@@ -15749,12 +15749,6 @@ bool equivalent(const path& p1, const path& p2, error_code& ec) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns
-\tcode{true}, if \tcode{p1} and \tcode{p2} resolve to the same file
-  system entity, otherwise \tcode{false}. The signature with argument \tcode{ec}
-  returns \tcode{false} if an error occurs.
-
-\pnum
 Two paths are considered to resolve to the same file system entity if two
   candidate entities reside on the same device at the same location.
   \begin{note}
@@ -15765,12 +15759,18 @@ Two paths are considered to resolve to the same file system entity if two
   \end{note}
 
 \pnum
-\remarks
-\tcode{!exists(p1) || !exists(p2)} is an error.
+\returns
+\tcode{true}, if \tcode{p1} and \tcode{p2} resolve to the same file
+  system entity, otherwise \tcode{false}. The signature with argument \tcode{ec}
+  returns \tcode{false} if an error occurs.
 
 \pnum
 \throws
 As specified in~\ref{fs.err.report}.
+
+\pnum
+\remarks
+\tcode{!exists(p1) || !exists(p2)} is an error.
 \end{itemdescr}
 
 
@@ -16243,11 +16243,6 @@ Exactly one of the \tcode{perm_options} constants
 \tcode{replace}, \tcode{add}, or \tcode{remove} is present in \tcode{opts}.
 
 \pnum
-\remarks
-The second signature behaves as if it had an additional parameter
-\tcode{perm_options} \tcode{opts} with an argument of \tcode{perm_options::replace}.
-
-\pnum
 \effects
 Applies the action specified by \tcode{opts}
 to the file \tcode{p} resolves to,
@@ -16264,6 +16259,11 @@ implementation may use some other mechanism.
 \pnum
 \throws
 As specified in~\ref{fs.err.report}.
+
+\pnum
+\remarks
+The second signature behaves as if it had an additional parameter
+\tcode{perm_options} \tcode{opts} with an argument of \tcode{perm_options::replace}.
 \end{itemdescr}
 
 \rSec3[fs.op.proximate]{Proximate}
@@ -16696,12 +16696,12 @@ Same as \tcode{status()}, above, except
       \tcode{file_status(file_type::none)} if an error occurs.
 
 \pnum
-\remarks
-Pathname resolution terminates if \tcode{p} names a symbolic link.
-
-\pnum
 \throws
 As specified in~\ref{fs.err.report}.
+
+\pnum
+\remarks
+Pathname resolution terminates if \tcode{p} names a symbolic link.
 \end{itemdescr}
 
 
@@ -16754,11 +16754,6 @@ path weakly_canonical(const path& p, error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\returns
-\tcode{p} with symlinks resolved and
-  the result normalized\iref{fs.path.generic}.
-
-\pnum
 \effects
 Using \tcode{status(p)} or \tcode{status(p, ec)}, respectively,
   to determine existence,
@@ -16779,14 +16774,19 @@ Using \tcode{status(p)} or \tcode{status(p, ec)}, respectively,
 The returned path is in normal form\iref{fs.path.generic}.
 
 \pnum
-\remarks
-Implementations should
-  avoid unnecessary normalization such as
-  when \tcode{canonical} has already been called on the entirety of \tcode{p}.
+\returns
+\tcode{p} with symlinks resolved and
+  the result normalized\iref{fs.path.generic}.
 
 \pnum
 \throws
 As specified in~\ref{fs.err.report}.
+
+\pnum
+\remarks
+Implementations should
+  avoid unnecessary normalization such as
+  when \tcode{canonical} has already been called on the entirety of \tcode{p}.
 \end{itemdescr}
 
 \rSec1[c.files]{C library files}

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -792,18 +792,18 @@ Compares two strings according to the
 facet.
 
 \pnum
-\remarks
-This member operator template (and therefore
-\tcode{locale}
-itself) meets the requirements for a comparator predicate template argument\iref{algorithms}
-applied to strings.
-
-\pnum
 \returns
 \begin{codeblock}
 use_facet<collate<charT>>(*this).compare(s1.data(), s1.data() + s1.size(),
                                          s2.data(), s2.data() + s2.size()) < 0
 \end{codeblock}
+
+\pnum
+\remarks
+This member operator template (and therefore
+\tcode{locale}
+itself) meets the requirements for a comparator predicate template argument\iref{algorithms}
+applied to strings.
 
 \pnum
 \begin{example}
@@ -841,6 +841,11 @@ otherwise, the effect on the C locale, if any, is \impldef{effect on C locale of
 \tcode{locale::global}}.
 
 \pnum
+\returns
+The previous value of
+\tcode{locale()}.
+
+\pnum
 \remarks
 No library function other than
 \tcode{locale::global()}
@@ -850,11 +855,6 @@ affects the value returned by
 See~\ref{c.locales} for data race considerations when
 \tcode{setlocale} is invoked.
 \end{note}
-
-\pnum
-\returns
-The previous value of
-\tcode{locale()}.
 \end{itemdescr}
 
 \indexlibrarymember{locale}{classic}%
@@ -3883,18 +3883,18 @@ In such cases the values of those \tcode{struct tm} members are unspecified
 and may be outside their valid range.
 
 \pnum
+\returns
+An iterator pointing immediately beyond the last character
+recognized as possibly part of a valid input sequence for the given
+\tcode{format} and \tcode{modifier}.
+
+\pnum
 \remarks
 It is unspecified whether multiple calls to
 \tcode{do_get()} with the
 address of the same \tcode{struct tm} object will update the current contents of
 the object or simply overwrite its members. Portable programs should zero
 out the object before invoking the function.
-
-\pnum
-\returns
-An iterator pointing immediately beyond the last character
-recognized as possibly part of a valid input sequence for the given
-\tcode{format} and \tcode{modifier}.
 \end{itemdescr}
 
 \rSec3[locale.time.get.byname]{Class template \tcode{time_get_byname}}
@@ -4429,6 +4429,10 @@ Calls
 \tcode{str.width(0)}.
 
 \pnum
+\returns
+An iterator pointing immediately after the last character produced.
+
+\pnum
 \remarks
 % issues 22-021, 22-030, 22-034 from 97-0058/N1096, 97-0036/N1074
 The currency symbol is generated if and only if
@@ -4459,10 +4463,6 @@ It is possible, with some combinations of format patterns and flag values,
 to produce output that cannot be parsed using
 \tcode{num_get<>::get}.
 \end{note}
-
-\pnum
-\returns
-An iterator pointing immediately after the last character produced.
 \end{itemdescr}
 
 \rSec3[locale.moneypunct]{Class template \tcode{moneypunct}}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -4098,6 +4098,12 @@ explicit random_device(const string& token);
 
 \begin{itemdescr}
 \pnum
+\throws
+A value of an \impldef{exception type when \tcode{random_device} constructor fails} type
+ derived from \tcode{exception}
+ if the \tcode{random_device} could not be initialized.
+
+\pnum
 \remarks
  The semantics of the \tcode{token} parameter
  and the token value used by the default constructor are
@@ -4105,12 +4111,6 @@ explicit random_device(const string& token);
 \footnote{The parameter is intended
    to allow an implementation to differentiate
    between different sources of randomness.}
-
-\pnum
-\throws
-A value of an \impldef{exception type when \tcode{random_device} constructor fails} type
- derived from \tcode{exception}
- if the \tcode{random_device} could not be initialized.
 \end{itemdescr}
 
 \indexlibrarymember{entropy}{random_device}%

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -3089,6 +3089,11 @@ constexpr ref_view(T&& t);
 
 \begin{itemdescr}
 \pnum
+\effects
+Initializes \exposid{r_} with
+\tcode{addressof(static_cast<R\&>(std::forward<T>(t)))}.
+
+\pnum
 \remarks
 Let \tcode{\placeholder{FUN}} denote the exposition-only functions
 \begin{codeblock}
@@ -3099,11 +3104,6 @@ The expression in the \grammarterm{requires-clause} is equivalent to
 \begin{codeblock}
 @\libconcept{convertible_to}@<T, R&> && requires { @\placeholder{FUN}@(declval<T>()); }
 \end{codeblock}
-
-\pnum
-\effects
-Initializes \exposid{r_} with
-\tcode{addressof(static_cast<R\&>(std::forward<T>(t)))}.
 \end{itemdescr}
 
 

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -1172,14 +1172,14 @@ data held by \tcode{*this}.
 \end{note}
 
 \pnum
+\ensures
+\tcode{getloc() == loc}.
+
+\pnum
 \returns
 If no locale has been previously imbued then a copy of the
 global locale in effect at the time of construction of \tcode{*this},
 otherwise a copy of the last argument passed to \tcode{imbue}.
-
-\pnum
-\ensures
-\tcode{getloc() == loc}.
 \end{itemdescr}
 
 \indexlibraryglobal{locale}%

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -1724,14 +1724,14 @@ constexpr reference       at(size_type pos);
 
 \begin{itemdescr}
 \pnum
+\returns
+\tcode{operator[](pos)}.
+
+\pnum
 \throws
 \tcode{out_of_range}
 if
 \tcode{pos >= size()}.
-
-\pnum
-\returns
-\tcode{operator[](pos)}.
 \end{itemdescr}
 
 \indexlibrarymember{front}{basic_string}%
@@ -2274,14 +2274,6 @@ constexpr basic_string& insert(size_type pos, const charT* s, size_type n);
 \range{s}{s + n} is a valid range.
 
 \pnum
-\throws
-\begin{itemize}
-\item \tcode{out_of_range} if \tcode{pos > size()},
-\item \tcode{length_error} if \tcode{n > max_size() - size()}, or
-\item any exceptions thrown by \tcode{allocator_traits<Allocator>::allocate}.
-\end{itemize}
-
-\pnum
 \effects
 Inserts a copy of the range \range{s}{s + n}
 immediately before the character at position \tcode{pos} if \tcode{pos < size()},
@@ -2290,6 +2282,14 @@ or otherwise at the end of the string.
 \pnum
 \returns
 \tcode{*this}.
+
+\pnum
+\throws
+\begin{itemize}
+\item \tcode{out_of_range} if \tcode{pos > size()},
+\item \tcode{length_error} if \tcode{n > max_size() - size()}, or
+\item any exceptions thrown by \tcode{allocator_traits<Allocator>::allocate}.
+\end{itemize}
 \end{itemdescr}
 
 \indexlibrarymember{insert}{basic_string}%
@@ -2417,12 +2417,6 @@ constexpr basic_string& erase(size_type pos = 0, size_type n = npos);
 
 \begin{itemdescr}
 \pnum
-\throws
-\tcode{out_of_range}
-if \tcode{pos}
-\tcode{> size()}.
-
-\pnum
 \effects
 Determines the effective length \tcode{xlen}
 of the string to be removed as the smaller of \tcode{n} and
@@ -2432,6 +2426,12 @@ Removes the characters in the range \range{begin() + pos}{begin() + pos + xlen}.
 \pnum
 \returns
 \tcode{*this}.
+
+\pnum
+\throws
+\tcode{out_of_range}
+if \tcode{pos}
+\tcode{> size()}.
 \end{itemdescr}
 
 \indexlibrarymember{erase}{basic_string}%
@@ -2445,10 +2445,6 @@ constexpr iterator erase(const_iterator p);
 \tcode{p} is a valid dereferenceable iterator on \tcode{*this}.
 
 \pnum
-\throws
-Nothing.
-
-\pnum
 \effects
 Removes the character referred to by \tcode{p}.
 
@@ -2459,6 +2455,10 @@ the element being erased.
 If no such element exists,
 \tcode{end()}
 is returned.
+
+\pnum
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{erase}{basic_string}%
@@ -2473,10 +2473,6 @@ constexpr iterator erase(const_iterator first, const_iterator last);
 \tcode{*this}. \range{first}{last} is a valid range.
 
 \pnum
-\throws
-Nothing.
-
-\pnum
 \effects
 Removes the characters in the range
 \tcode{[first, last)}.
@@ -2488,6 +2484,10 @@ the other elements being erased.
 If no such element exists,
 \tcode{end()}
 is returned.
+
+\pnum
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{pop_back}{basic_string}%
@@ -2501,12 +2501,12 @@ constexpr void pop_back();
 \tcode{!empty()}.
 
 \pnum
-\throws
-Nothing.
-
-\pnum
 \effects
 Equivalent to \tcode{erase(end() - 1)}.
+
+\pnum
+\throws
+Nothing.
 \end{itemdescr}
 
 \rSec4[string.replace]{\tcode{basic_string::replace}}
@@ -2603,15 +2603,6 @@ constexpr basic_string& replace(size_type pos1, size_type n1, const charT* s, si
 \range{s}{s + n2} is a valid range.
 
 \pnum
-\throws
-\begin{itemize}
-\item \tcode{out_of_range} if \tcode{pos1 > size()},
-\item \tcode{length_error} if the length of the resulting string
-would exceed \tcode{max_size()} (see below), or
-\item any exceptions thrown by \tcode{allocator_traits<Allocator>::allocate}.
-\end{itemize}
-
-\pnum
 \effects
 Determines the effective length \tcode{xlen} of the string to be
 removed as the smaller of \tcode{n1} and \tcode{size() - pos1}. If
@@ -2623,6 +2614,15 @@ with a copy of the range \range{s}{s + n2}.
 \pnum
 \returns
 \tcode{*this}.
+
+\pnum
+\throws
+\begin{itemize}
+\item \tcode{out_of_range} if \tcode{pos1 > size()},
+\item \tcode{length_error} if the length of the resulting string
+would exceed \tcode{max_size()}, or
+\item any exceptions thrown by \tcode{allocator_traits<Allocator>::allocate}.
+\end{itemize}
 \end{itemdescr}
 
 \indexlibrarymember{replace}{basic_string}%
@@ -2643,15 +2643,6 @@ constexpr basic_string& replace(size_type pos1, size_type n1, size_type n2, char
 
 \begin{itemdescr}
 \pnum
-\throws
-\begin{itemize}
-\item \tcode{out_of_range} if \tcode{pos1 > size()},
-\item \tcode{length_error} if the length of the resulting string
-would exceed \tcode{max_size()} (see below), or
-\item any exceptions thrown by \tcode{allocator_traits<Allocator>::allocate.}
-\end{itemize}
-
-\pnum
 \effects
 Determines the effective length \tcode{xlen} of the string to be
 removed as the smaller of \tcode{n1} and \tcode{size() - pos1}. If
@@ -2663,6 +2654,15 @@ with \tcode{n2} copies of \tcode{c}.
 \pnum
 \returns
 \tcode{*this}.
+
+\pnum
+\throws
+\begin{itemize}
+\item \tcode{out_of_range} if \tcode{pos1 > size()},
+\item \tcode{length_error} if the length of the resulting string
+would exceed\tcode{max_size()}, or
+\item any exceptions thrown by \tcode{allocator_traits<Allocator>::allocate.}
+\end{itemize}
 \end{itemdescr}
 
 \indexlibrarymember{replace}{basic_string}%
@@ -3001,12 +3001,6 @@ constexpr basic_string substr(size_type pos = 0, size_type n = npos) const;
 
 \begin{itemdescr}
 \pnum
-\throws
-\tcode{out_of_range}
-if
-\tcode{pos > size()}.
-
-\pnum
 \effects
 Determines the effective length \tcode{rlen} of the string to copy as the smaller of \tcode{n} and
 \tcode{size() - pos}.
@@ -3014,6 +3008,12 @@ Determines the effective length \tcode{rlen} of the string to copy as the smalle
 \pnum
 \returns
 \tcode{basic_string(data()+pos, rlen)}.
+
+\pnum
+\throws
+\tcode{out_of_range}
+if
+\tcode{pos > size()}.
 \end{itemdescr}
 
 \rSec4[string.compare]{\tcode{basic_string::compare}}
@@ -4381,12 +4381,12 @@ constexpr const_reference at(size_type pos) const;
 
 \begin{itemdescr}
 \pnum
-\throws
-\tcode{out_of_range} if \tcode{pos >= size()}.
-
-\pnum
 \returns
 \tcode{data_[pos]}.
+
+\pnum
+\throws
+\tcode{out_of_range} if \tcode{pos >= size()}.
 \end{itemdescr}
 
 \indexlibrarymember{front}{basic_string_view}%
@@ -4500,10 +4500,6 @@ constexpr size_type copy(charT* s, size_type n, size_type pos = 0) const;
 Let \tcode{rlen} be the smaller of \tcode{n} and \tcode{size() - pos}.
 
 \pnum
-\throws
-\tcode{out_of_range} if \tcode{pos > size()}.
-
-\pnum
 \expects
 \range{s}{s + rlen} is a valid range.
 
@@ -4514,6 +4510,10 @@ Equivalent to \tcode{traits::copy(s, data() + pos, rlen)}.
 \pnum
 \returns
 \tcode{rlen}.
+
+\pnum
+\throws
+\tcode{out_of_range} if \tcode{pos > size()}.
 
 \pnum
 \complexity
@@ -4530,16 +4530,16 @@ constexpr basic_string_view substr(size_type pos = 0, size_type n = npos) const;
 Let \tcode{rlen} be the smaller of \tcode{n} and \tcode{size() - pos}.
 
 \pnum
-\throws
-\tcode{out_of_range} if \tcode{pos > size()}.
-
-\pnum
 \effects
 Determines \tcode{rlen}, the effective length of the string to reference.
 
 \pnum
 \returns
 \tcode{basic_string_view(data() + pos, rlen)}.
+
+\pnum
+\throws
+\tcode{out_of_range} if \tcode{pos > size()}.
 \end{itemdescr}
 
 \indexlibrarymember{compare}{basic_string_view}%
@@ -4557,10 +4557,6 @@ Determines \tcode{rlen}, the effective length of the strings to compare.
 The function then compares the two strings by calling \tcode{traits::compare(data(), str.data(), rlen)}.
 
 \pnum
-\complexity
-\bigoh{\tcode{rlen}}.
-
-\pnum
 \returns
 The nonzero result if the result of the comparison is nonzero.
 Otherwise, returns a value as indicated in \tref{string.view.compare}.
@@ -4569,6 +4565,10 @@ Otherwise, returns a value as indicated in \tref{string.view.compare}.
 \tcode{size() == str.size()} & \tcode{ \ 0}\\
 \tcode{size() >  str.size()} & \tcode{> 0}\\
 \end{libtab2}
+
+\pnum
+\complexity
+\bigoh{\tcode{rlen}}.
 \end{itemdescr}
 
 \indexlibrarymember{compare}{basic_string_view}%

--- a/source/support.tex
+++ b/source/support.tex
@@ -2203,6 +2203,33 @@ void operator delete(void* ptr, std::size_t size, std::align_val_t alignment) no
 
 \begin{itemdescr}
 \pnum
+\expects
+\tcode{ptr} is a null pointer or
+its value represents the address of
+a block of memory allocated by
+an earlier call to a (possibly replaced)
+\tcode{operator new(std::size_t)}
+or
+\tcode{operator new(std::size_t, std::align_val_t)}
+which has not been invalidated by an intervening call to
+\tcode{operator delete}.
+
+\pnum
+If an implementation has strict pointer safety\iref{basic.stc.dynamic.safety}
+then \tcode{ptr} is a safely-derived pointer.
+
+\pnum
+If the \tcode{alignment} parameter is not present,
+\tcode{ptr} was returned by an allocation function
+without an \tcode{alignment} parameter.
+If present, the \tcode{alignment} argument
+is equal to the \tcode{alignment} argument
+passed to the allocation function that returned \tcode{ptr}.
+If present, the \tcode{size} argument
+is equal to the \tcode{size} argument
+passed to the allocation function that returned \tcode{ptr}.
+
+\pnum
 \effects
 The
 deallocation functions\iref{basic.stc.dynamic.deallocation}
@@ -2223,35 +2250,6 @@ the corresponding version without the \tcode{size} parameter.
 The default behavior below may change in the future, which will require
 replacing both deallocation functions when replacing the allocation function.
 \end{note}
-
-\pnum
-\expects
-\tcode{ptr} is a null pointer or
-its value represents the address of
-a block of memory allocated by
-an earlier call to a (possibly replaced)
-\tcode{operator new(std::size_t)}
-or
-\tcode{operator new(std::size_t, std::align_val_t)}
-which has not been invalidated by an intervening call to
-\tcode{operator delete}.
-
-\pnum
-\expects
-If an implementation has strict pointer safety\iref{basic.stc.dynamic.safety}
-then \tcode{ptr} is a safely-derived pointer.
-
-\pnum
-\expects
-If the \tcode{alignment} parameter is not present,
-\tcode{ptr} was returned by an allocation function
-without an \tcode{alignment} parameter.
-If present, the \tcode{alignment} argument
-is equal to the \tcode{alignment} argument
-passed to the allocation function that returned \tcode{ptr}.
-If present, the \tcode{size} argument
-is equal to the \tcode{size} argument
-passed to the allocation function that returned \tcode{ptr}.
 
 \pnum
 \required
@@ -2305,19 +2303,6 @@ void operator delete(void* ptr, std::align_val_t alignment, const std::nothrow_t
 
 \begin{itemdescr}
 \pnum
-\effects
-The
-deallocation functions\iref{basic.stc.dynamic.deallocation}
-called by the implementation
-to render the value of \tcode{ptr} invalid
-when the constructor invoked from a nothrow
-placement version of the \grammarterm{new-expression} throws an exception.
-
-\pnum
-\replaceable
-\replaceabledesc{either}
-
-\pnum
 \expects
 \tcode{ptr} is a null pointer or
 its value represents the address of
@@ -2330,18 +2315,29 @@ which has not been invalidated by an intervening call to
 \tcode{operator delete}.
 
 \pnum
-\expects
 If an implementation has strict pointer safety\iref{basic.stc.dynamic.safety}
 then \tcode{ptr} is a safely-derived pointer.
 
 \pnum
-\expects
 If the \tcode{alignment} parameter is not present,
 \tcode{ptr} was returned by an allocation function
 without an \tcode{alignment} parameter.
 If present, the \tcode{alignment} argument
 is equal to the \tcode{alignment} argument
 passed to the allocation function that returned \tcode{ptr}.
+
+\pnum
+\effects
+The
+deallocation functions\iref{basic.stc.dynamic.deallocation}
+called by the implementation
+to render the value of \tcode{ptr} invalid
+when the constructor invoked from a nothrow
+placement version of the \grammarterm{new-expression} throws an exception.
+
+\pnum
+\replaceable
+\replaceabledesc{either}
 
 \pnum
 \default
@@ -2456,6 +2452,33 @@ void operator delete[](void* ptr, std::size_t size, std::align_val_t alignment) 
 
 \begin{itemdescr}
 \pnum
+\expects
+\tcode{ptr} is a null pointer or
+its value represents the address of
+a block of memory allocated by
+an earlier call to a (possibly replaced)
+\tcode{operator new[](std::size_t)}
+or
+\tcode{operator new[](std::size_t, std::align_val_t)}
+which has not been invalidated by an intervening call to
+\tcode{operator delete[]}.
+
+\pnum
+If an implementation has strict pointer safety\iref{basic.stc.dynamic.safety}
+then \tcode{ptr} is a safely-derived pointer.
+
+\pnum
+If the \tcode{alignment} parameter is not present,
+\tcode{ptr} was returned by an allocation function
+without an \tcode{alignment} parameter.
+If present, the \tcode{alignment} argument
+is equal to the \tcode{alignment} argument
+passed to the allocation function that returned \tcode{ptr}.
+If present, the \tcode{size} argument
+is equal to the \tcode{size} argument
+passed to the allocation function that returned \tcode{ptr}.
+
+\pnum
 \effects
 The
 deallocation functions\iref{basic.stc.dynamic.deallocation}
@@ -2476,35 +2499,6 @@ the corresponding version without the \tcode{size} parameter.
 The default behavior below may change in the future, which will require
 replacing both deallocation functions when replacing the allocation function.
 \end{note}
-
-\pnum
-\expects
-\tcode{ptr} is a null pointer or
-its value represents the address of
-a block of memory allocated by
-an earlier call to a (possibly replaced)
-\tcode{operator new[](std::size_t)}
-or
-\tcode{operator new[](std::size_t, std::align_val_t)}
-which has not been invalidated by an intervening call to
-\tcode{operator delete[]}.
-
-\pnum
-\expects
-If an implementation has strict pointer safety\iref{basic.stc.dynamic.safety}
-then \tcode{ptr} is a safely-derived pointer.
-
-\pnum
-\expects
-If the \tcode{alignment} parameter is not present,
-\tcode{ptr} was returned by an allocation function
-without an \tcode{alignment} parameter.
-If present, the \tcode{alignment} argument
-is equal to the \tcode{alignment} argument
-passed to the allocation function that returned \tcode{ptr}.
-If present, the \tcode{size} argument
-is equal to the \tcode{size} argument
-passed to the allocation function that returned \tcode{ptr}.
 
 \pnum
 \required
@@ -2538,19 +2532,6 @@ void operator delete[](void* ptr, std::align_val_t alignment, const std::nothrow
 
 \begin{itemdescr}
 \pnum
-\effects
-The
-deallocation functions\iref{basic.stc.dynamic.deallocation}
-called by the implementation
-to render the value of \tcode{ptr} invalid
-when the constructor invoked from a nothrow
-placement version of the array \grammarterm{new-expression} throws an exception.
-
-\pnum
-\replaceable
-\replaceabledesc{either}
-
-\pnum
 \expects
 \tcode{ptr} is a null pointer or
 its value represents the address of
@@ -2563,18 +2544,29 @@ which has not been invalidated by an intervening call to
 \tcode{operator delete[]}.
 
 \pnum
-\expects
 If an implementation has strict pointer safety\iref{basic.stc.dynamic.safety}
 then \tcode{ptr} is a safely-derived pointer.
 
 \pnum
-\expects
 If the \tcode{alignment} parameter is not present,
 \tcode{ptr} was returned by an allocation function
 without an \tcode{alignment} parameter.
 If present, the \tcode{alignment} argument
 is equal to the \tcode{alignment} argument
 passed to the allocation function that returned \tcode{ptr}.
+
+\pnum
+\effects
+The
+deallocation functions\iref{basic.stc.dynamic.deallocation}
+called by the implementation
+to render the value of \tcode{ptr} invalid
+when the constructor invoked from a nothrow
+placement version of the array \grammarterm{new-expression} throws an exception.
+
+\pnum
+\replaceable
+\replaceabledesc{either}
 
 \pnum
 \default
@@ -2638,13 +2630,13 @@ void operator delete(void* ptr, void*) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects
-Intentionally performs no action.
-
-\pnum
 \expects
 If an implementation has strict pointer safety\iref{basic.stc.dynamic.safety}
 then \tcode{ptr} is a safely-derived pointer.
+
+\pnum
+\effects
+Intentionally performs no action.
 
 \pnum
 \remarks
@@ -2661,13 +2653,13 @@ void operator delete[](void* ptr, void*) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects
-Intentionally performs no action.
-
-\pnum
 \expects
 If an implementation has strict pointer safety\iref{basic.stc.dynamic.safety}
 then \tcode{ptr} is a safely-derived pointer.
+
+\pnum
+\effects
+Intentionally performs no action.
 
 \pnum
 \remarks
@@ -3550,13 +3542,13 @@ Establishes the function designated by \tcode{f} as the current
 handler function for terminating exception processing.
 
 \pnum
+\returns
+The previous \tcode{terminate_handler}.
+
+\pnum
 \remarks
 It is unspecified whether a null pointer value designates the default
 \tcode{terminate_handler}.
-
-\pnum
-\returns
-The previous \tcode{terminate_handler}.
 \end{itemdescr}
 
 \rSec3[get.terminate]{\tcode{get_terminate}}
@@ -3584,12 +3576,6 @@ This may be a null pointer value.
 
 \begin{itemdescr}
 \pnum
-\remarks
-Called by the implementation when exception
-handling must be abandoned for any of several reasons\iref{except.terminate}.
-May also be called directly by the program.
-
-\pnum
 \effects
 Calls a \tcode{terminate_handler} function. It is unspecified which
 \tcode{terminate_handler} function will be called if an exception is active
@@ -3600,6 +3586,12 @@ A
 default \tcode{terminate_handler} is always considered a callable handler in
 this context.
 \end{note}
+
+\pnum
+\remarks
+Called by the implementation when exception
+handling must be abandoned for any of several reasons\iref{except.terminate}.
+May also be called directly by the program.
 \end{itemdescr}
 
 \rSec2[uncaught.exceptions]{\tcode{uncaught_exceptions}}
@@ -5024,12 +5016,12 @@ static coroutine_handle from_promise(Promise& p);
 \tcode{p} is a reference to a promise object of a coroutine.
 
 \pnum
-\returns
-A coroutine handle \tcode{h} referring to the coroutine.
-
-\pnum
 \ensures
 \tcode{addressof(h.promise()) == addressof(p)}.
+
+\pnum
+\returns
+A coroutine handle \tcode{h} referring to the coroutine.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{coroutine_handle}%

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -920,15 +920,15 @@ is evaluated by the first call to \tcode{request_stop()}
 on an associated \tcode{stop_source}.
 
 \pnum
+\throws
+Any exception thrown by the initialization of \tcode{callback}.
+
+\pnum
 \remarks
 If evaluating
 \tcode{std::forward<Callback>(callback)()}
 exits via an exception,
 then \tcode{terminate} is called\iref{except.terminate}.
-
-\pnum
-\throws
-Any exception thrown by the initialization of \tcode{callback}.
 \end{itemdescr}
 
 \indexlibrarydtor{stop_callback}%
@@ -3281,13 +3281,13 @@ requirements\iref{thread.req.lockable.req}.
 As if by \tcode{pm->try_lock()}.
 
 \pnum
-\returns
-The value returned by the call to \tcode{try_lock()}.
-
-\pnum
 \ensures
 \tcode{owns == res}, where \tcode{res} is the value returned by
 the call to \tcode{try_lock()}.
+
+\pnum
+\returns
+The value returned by the call to \tcode{try_lock()}.
 
 \pnum
 \throws
@@ -3320,13 +3320,13 @@ requirements\iref{thread.req.lockable.timed}.
 As if by \tcode{pm->try_lock_until(abs_time)}.
 
 \pnum
-\returns
-The value returned by the call to \tcode{try_lock_until(abs_time)}.
-
-\pnum
 \ensures
 \tcode{owns == res}, where \tcode{res} is the value returned by
 the call to \tcode{try_lock_until(abs_time)}.
+
+\pnum
+\returns
+The value returned by the call to \tcode{try_lock_until(abs_time)}.
 
 \pnum
 \throws
@@ -3358,12 +3358,12 @@ The supplied \tcode{Mutex} type meets the \oldconcept{TimedLockable} requirement
 As if by \tcode{pm->try_lock_for(rel_time)}.
 
 \pnum
-\returns
-The value returned by the call to \tcode{try_lock_for(rel_time)}.
-
-\pnum
 \ensures
 \tcode{owns == res}, where \tcode{res} is the value returned by the call to \tcode{try_lock_for(rel_time)}.
+
+\pnum
+\returns
+The value returned by the call to \tcode{try_lock_for(rel_time)}.
 
 \pnum
 \throws
@@ -3425,12 +3425,12 @@ mutex_type* release() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns
-The previous value of \tcode{pm}.
-
-\pnum
 \ensures
 \tcode{pm == 0} and \tcode{owns == false}.
+
+\pnum
+\returns
+The previous value of \tcode{pm}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{unique_lock}%
@@ -3761,13 +3761,13 @@ bool try_lock();
 As if by \tcode{pm->try_lock_shared()}.
 
 \pnum
-\returns
-The value returned by the call to \tcode{pm->try_lock_shared()}.
-
-\pnum
 \ensures
 \tcode{owns == res}, where \tcode{res} is the value returned by
 the call to \tcode{pm->try_lock_shared()}.
+
+\pnum
+\returns
+The value returned by the call to \tcode{pm->try_lock_shared()}.
 
 \pnum
 \throws
@@ -3795,14 +3795,14 @@ template<class Clock, class Duration>
 As if by \tcode{pm->try_lock_shared_until(abs_time)}.
 
 \pnum
-\returns
-The value returned by the call to
-\tcode{pm->try_lock_shared_until(abs_time)}.
-
-\pnum
 \ensures
 \tcode{owns == res}, where \tcode{res} is the value returned by
 the call to \tcode{pm->try_lock_shared_until(abs_time)}.
+
+\pnum
+\returns
+The value returned by the call to
+\tcode{pm->try_lock_shared_until(abs_time)}.
 
 \pnum
 \throws
@@ -3830,12 +3830,12 @@ template<class Rep, class Period>
 As if by \tcode{pm->try_lock_shared_for(rel_time)}.
 
 \pnum
-\returns
-The value returned by the call to \tcode{pm->try_lock_shared_for(rel_time)}.
-
-\pnum
 \ensures
 \tcode{owns == res}, where \tcode{res} is the value returned by the call to \tcode{pm->try_lock_shared_for(rel_time)}.
+
+\pnum
+\returns
+The value returned by the call to \tcode{pm->try_lock_shared_for(rel_time)}.
 
 \pnum
 \throws
@@ -3896,12 +3896,12 @@ mutex_type* release() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns
-The previous value of \tcode{pm}.
-
-\pnum
 \ensures
 \tcode{pm == nullptr} and \tcode{owns == false}.
+
+\pnum
+\returns
+The previous value of \tcode{pm}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{shared_lock}%
@@ -4358,14 +4358,6 @@ or a call to \tcode{notify_all()}, or spuriously.
 \end{itemize}
 
 \pnum
-\remarks
-If the function fails to meet the postcondition, \tcode{terminate()}
-is called\iref{except.terminate}.
-\begin{note}
-This can happen if the re-locking of the mutex throws an exception.
-\end{note}
-
-\pnum
 \ensures
 \tcode{lock.owns_lock()} is \tcode{true} and \tcode{lock.mutex()}
 is locked by the calling thread.
@@ -4373,6 +4365,14 @@ is locked by the calling thread.
 \pnum
 \throws
 Nothing.
+
+\pnum
+\remarks
+If the function fails to meet the postcondition, \tcode{terminate()}
+is called\iref{except.terminate}.
+\begin{note}
+This can happen if the re-locking of the mutex throws an exception.
+\end{note}
 \end{itemdescr}
 
 \indexlibrarymember{wait}{condition_variable}%
@@ -4402,14 +4402,6 @@ while (!pred())
 \end{codeblock}
 
 \pnum
-\remarks
-If the function fails to meet the postcondition, \tcode{terminate()}
-is called\iref{except.terminate}.
-\begin{note}
-This can happen if the re-locking of the mutex throws an exception.
-\end{note}
-
-\pnum
 \ensures
 \tcode{lock.owns_lock()} is \tcode{true} and \tcode{lock.mutex()}
 is locked by the calling thread.
@@ -4417,6 +4409,14 @@ is locked by the calling thread.
 \pnum
 \throws
 Any exception thrown by \tcode{pred}.
+
+\pnum
+\remarks
+If the function fails to meet the postcondition, \tcode{terminate()}
+is called\iref{except.terminate}.
+\begin{note}
+This can happen if the re-locking of the mutex throws an exception.
+\end{note}
 \end{itemdescr}
 
 \indexlibrarymember{wait_until}{condition_variable}%
@@ -4457,14 +4457,6 @@ If the function exits via an exception, \tcode{lock.lock()} is called prior to e
 \end{itemize}
 
 \pnum
-\remarks
-If the function fails to meet the postcondition, \tcode{terminate()}
-is called\iref{except.terminate}.
-\begin{note}
-This can happen if the re-locking of the mutex throws an exception.
-\end{note}
-
-\pnum
 \ensures
 \tcode{lock.owns_lock()} is \tcode{true} and \tcode{lock.mutex()}
 is locked by the calling thread.
@@ -4479,6 +4471,14 @@ otherwise \tcode{cv_status::no_timeout}.
 \throws
 Timeout-related
 exceptions\iref{thread.req.timing}.
+
+\pnum
+\remarks
+If the function fails to meet the postcondition, \tcode{terminate()}
+is called\iref{except.terminate}.
+\begin{note}
+This can happen if the re-locking of the mutex throws an exception.
+\end{note}
 \end{itemdescr}
 
 \indexlibrarymember{wait_for}{condition_variable}%
@@ -4508,10 +4508,20 @@ return wait_until(lock, chrono::steady_clock::now() + rel_time);
 \end{codeblock}
 
 \pnum
+\ensures
+\tcode{lock.owns_lock()} is \tcode{true} and \tcode{lock.mutex()}
+is locked by the calling thread.
+
+\pnum
 \returns
 \tcode{cv_status::timeout} if
 the relative timeout\iref{thread.req.timing} specified by \tcode{rel_time} expired,
 otherwise \tcode{cv_status::no_timeout}.
+
+\pnum
+\throws
+Timeout-related
+exceptions\iref{thread.req.timing}.
 
 \pnum
 \remarks
@@ -4520,16 +4530,6 @@ is called\iref{except.terminate}.
 \begin{note}
 This can happen if the re-locking of the mutex throws an exception.
 \end{note}
-
-\pnum
-\ensures
-\tcode{lock.owns_lock()} is \tcode{true} and \tcode{lock.mutex()}
-is locked by the calling thread.
-
-\pnum
-\throws
-Timeout-related
-exceptions\iref{thread.req.timing}.
 \end{itemdescr}
 
 \indexlibrarymember{wait_until}{condition_variable}%
@@ -4563,14 +4563,6 @@ return true;
 \end{codeblock}
 
 \pnum
-\remarks
-If the function fails to meet the postcondition, \tcode{terminate()}
-is called\iref{except.terminate}.
-\begin{note}
-This can happen if the re-locking of the mutex throws an exception.
-\end{note}
-
-\pnum
 \ensures
 \tcode{lock.owns_lock()} is \tcode{true} and \tcode{lock.mutex()}
 is locked by the calling thread.
@@ -4585,6 +4577,14 @@ The returned value indicates whether the predicate evaluated to
 \throws
 Timeout-related
 exceptions\iref{thread.req.timing} or any exception thrown by \tcode{pred}.
+
+\pnum
+\remarks
+If the function fails to meet the postcondition, \tcode{terminate()}
+is called\iref{except.terminate}.
+\begin{note}
+This can happen if the re-locking of the mutex throws an exception.
+\end{note}
 \end{itemdescr}
 
 \indexlibrarymember{wait_for}{condition_variable}%
@@ -4624,14 +4624,6 @@ timeout has already expired.
 \end{note}
 
 \pnum
-\remarks
-If the function fails to meet the postcondition, \tcode{terminate()}
-is called\iref{except.terminate}.
-\begin{note}
-This can happen if the re-locking of the mutex throws an exception.
-\end{note}
-
-\pnum
 \ensures
 \tcode{lock.owns_lock()} is \tcode{true} and \tcode{lock.mutex()}
 is locked by the calling thread.
@@ -4646,6 +4638,14 @@ regardless of whether the timeout was triggered.
 \throws
 Timeout-related
 exceptions\iref{thread.req.timing} or any exception thrown by \tcode{pred}.
+
+\pnum
+\remarks
+If the function fails to meet the postcondition, \tcode{terminate()}
+is called\iref{except.terminate}.
+\begin{note}
+This can happen if the re-locking of the mutex throws an exception.
+\end{note}
 \end{itemdescr}
 
 \rSec2[thread.condition.condvarany]{Class \tcode{condition_variable_any}}
@@ -4790,20 +4790,20 @@ a call to \tcode{notify_all()}, or spuriously.
 \end{itemize}
 
 \pnum
-\remarks
-If the function fails to meet the postcondition, \tcode{terminate()}
-is called\iref{except.terminate}.
-\begin{note}
-This can happen if the re-locking of the mutex throws an exception.
-\end{note}
-
-\pnum
 \ensures
 \tcode{lock} is locked by the calling thread.
 
 \pnum
 \throws
 Nothing.
+
+\pnum
+\remarks
+If the function fails to meet the postcondition, \tcode{terminate()}
+is called\iref{except.terminate}.
+\begin{note}
+This can happen if the re-locking of the mutex throws an exception.
+\end{note}
 \end{itemdescr}
 
 \indexlibrarymember{wait}{condition_variable_any}%
@@ -4850,14 +4850,6 @@ If the function exits via an exception, \tcode{lock.lock()} is called prior to e
 \end{itemize}
 
 \pnum
-\remarks
-If the function fails to meet the postcondition, \tcode{terminate()}
-is called\iref{except.terminate}.
-\begin{note}
-This can happen if the re-locking of the mutex throws an exception.
-\end{note}
-
-\pnum
 \ensures
 \tcode{lock} is locked by the calling thread.
 
@@ -4871,6 +4863,14 @@ otherwise \tcode{cv_status::no_timeout}.
 \throws
 Timeout-related
 exceptions\iref{thread.req.timing}.
+
+\pnum
+\remarks
+If the function fails to meet the postcondition, \tcode{terminate()}
+is called\iref{except.terminate}.
+\begin{note}
+This can happen if the re-locking of the mutex throws an exception.
+\end{note}
 \end{itemdescr}
 
 \indexlibrarymember{wait_for}{condition_variable_any}%
@@ -4888,10 +4888,19 @@ return wait_until(lock, chrono::steady_clock::now() + rel_time);
 \end{codeblock}
 
 \pnum
+\ensures
+\tcode{lock} is locked by the calling thread.
+
+\pnum
 \returns
 \tcode{cv_status::timeout} if
 the relative timeout\iref{thread.req.timing} specified by \tcode{rel_time} expired,
 otherwise \tcode{cv_status::no_timeout}.
+
+\pnum
+\throws
+Timeout-related
+exceptions\iref{thread.req.timing}.
 
 \pnum
 \remarks
@@ -4900,15 +4909,6 @@ is called\iref{except.terminate}.
 \begin{note}
 This can happen if the re-locking of the mutex throws an exception.
 \end{note}
-
-\pnum
-\ensures
-\tcode{lock} is locked by the calling thread.
-
-\pnum
-\throws
-Timeout-related
-exceptions\iref{thread.req.timing}.
 \end{itemdescr}
 
 \indexlibrarymember{wait_until}{condition_variable_any}%
@@ -4995,16 +4995,16 @@ The returned value indicates whether the predicate evaluated to
 \tcode{lock} is locked by the calling thread.
 
 \pnum
+\throws
+Any exception thrown by \tcode{pred}.
+
+\pnum
 \remarks
 If the function fails to meet the postcondition,
 \tcode{terminate} is called\iref{except.terminate}.
 \begin{note}
 This can happen if the re-locking of the mutex throws an exception.
 \end{note}
-
-\pnum
-\throws
-Any exception thrown by \tcode{pred}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -5047,17 +5047,17 @@ regardless of whether the timeout was triggered or a stop request was made.
 \tcode{lock} is locked by the calling thread.
 
 \pnum
+\throws
+Timeout-related exceptions \iref{thread.req.timing},
+or any exception thrown by \tcode{pred}.
+
+\pnum
 \remarks
 If the function fails to meet the postcondition,
 \tcode{terminate} is called\iref{except.terminate}.
 \begin{note}
 This can happen if the re-locking of the mutex throws an exception.
 \end{note}
-
-\pnum
-\throws
-Timeout-related exceptions \iref{thread.req.timing},
-or any exception thrown by \tcode{pred}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -6534,12 +6534,12 @@ shared_future<R> share() noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns
-\tcode{shared_future<R>(std::move(*this))}.
-
-\pnum
 \ensures
 \tcode{valid() == false}.
+
+\pnum
+\returns
+\tcode{shared_future<R>(std::move(*this))}.
 \end{itemdescr}
 
 \indexlibrarymember{get}{future}%
@@ -6565,6 +6565,10 @@ value stored in the shared state;
 \end{itemize}
 
 \pnum
+\ensures
+\tcode{valid() == false}.
+
+\pnum
 \returns
 \begin{itemize}
 \item
@@ -6581,10 +6585,6 @@ value stored in the shared state;
 \pnum
 \throws
 The stored exception, if an exception was stored in the shared state.
-
-\pnum
-\ensures
-\tcode{valid() == false}.
 \end{itemdescr}
 
 \indexlibrarymember{valid}{future}%

--- a/source/time.tex
+++ b/source/time.tex
@@ -8854,11 +8854,6 @@ The iterator following \tcode{p} is dereferenceable.
 Erases the \tcode{tzdb} referred to by the iterator following \tcode{p}.
 
 \pnum
-\returns
-An iterator pointing to the element following the one that was erased,
-or \tcode{end()} if no such element exists.
-
-\pnum
 \ensures
 No pointers, references, or iterators are invalidated
 except those referring to the erased \tcode{tzdb}.
@@ -8866,6 +8861,11 @@ except those referring to the erased \tcode{tzdb}.
 It is not possible to erase the \tcode{tzdb}
 referred to by \tcode{begin()}.
 \end{note}
+
+\pnum
+\returns
+An iterator pointing to the element following the one that was erased,
+or \tcode{end()} if no such element exists.
 
 \pnum
 \throws
@@ -9807,10 +9807,6 @@ zoned_time(TimeZonePtr z, const local_time<Duration>& tp);
 
 \begin{itemdescr}
 \pnum
-\expects
-\tcode{z} refers to a time zone.
-
-\pnum
 \constraints
 \begin{codeblock}
 is_convertible_v<
@@ -9818,6 +9814,10 @@ is_convertible_v<
   sys_time<duration>>
 \end{codeblock}
 is \tcode{true}.
+
+\pnum
+\expects
+\tcode{z} refers to a time zone.
 
 \pnum
 \effects
@@ -9844,10 +9844,6 @@ zoned_time(TimeZonePtr z, const local_time<Duration>& tp, choose c);
 
 \begin{itemdescr}
 \pnum
-\expects
-\tcode{z} refers to a time zone.
-
-\pnum
 \constraints
 \begin{codeblock}
 is_convertible_v<
@@ -9855,6 +9851,10 @@ is_convertible_v<
   sys_time<duration>>
 \end{codeblock}
 is \tcode{true}.
+
+\pnum
+\expects
+\tcode{z} refers to a time zone.
 
 \pnum
 \effects

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -875,14 +875,14 @@ constexpr pair& operator=(const pair& p);
 Assigns \tcode{p.first} to \tcode{first} and \tcode{p.second} to \tcode{second}.
 
 \pnum
+\returns
+\tcode{*this}.
+
+\pnum
 \remarks
 This operator is defined as deleted unless
 \tcode{is_copy_assignable_v<first_type>} is \tcode{true} and
 \tcode{is_copy_assignable_v<second_type>} is \tcode{true}.
-
-\pnum
-\returns
-\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{pair}%
@@ -1684,13 +1684,13 @@ Assigns each element of \tcode{u} to the corresponding
 element of \tcode{*this}.
 
 \pnum
+\returns
+\tcode{*this}.
+
+\pnum
 \remarks
 This operator is defined as deleted unless
 \tcode{is_copy_assignable_v<$\tcode{T}_i$>} is \tcode{true} for all $i$.
-
-\pnum
-\returns
-\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{tuple}%
@@ -1709,6 +1709,10 @@ For all $i$, assigns \tcode{std::forward<$\tcode{T}_i$>(get<$i$>(u))} to
 \tcode{get<$i$>(*this)}.
 
 \pnum
+\returns
+\tcode{*this}.
+
+\pnum
 \remarks
 The expression inside \tcode{noexcept} is equivalent to the logical \textsc{and} of the
 following expressions:
@@ -1717,10 +1721,6 @@ following expressions:
 is_nothrow_move_assignable_v<@$\mathtt{T}_i$@>
 \end{codeblock}
 where $\mathtt{T}_i$ is the $i^\text{th}$ type in \tcode{Types}.
-
-\pnum
-\returns
-\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{tuple}%
@@ -1839,6 +1839,10 @@ Calls \tcode{swap} for each element in \tcode{*this} and its
 corresponding element in \tcode{rhs}.
 
 \pnum
+\throws
+Nothing unless one of the element-wise \tcode{swap} calls throws an exception.
+
+\pnum
 \remarks
 The expression inside \tcode{noexcept} is equivalent to the logical
 \textsc{and} of the following expressions:
@@ -1847,10 +1851,6 @@ The expression inside \tcode{noexcept} is equivalent to the logical
 is_nothrow_swappable_v<@$\mathtt{T}_i$@>
 \end{codeblock}
 where $\mathtt{T}_i$ is the $i^\text{th}$ type in \tcode{Types}.
-
-\pnum
-\throws
-Nothing unless one of the element-wise \tcode{swap} calls throws an exception.
 \end{itemdescr}
 
 \rSec2[tuple.creation]{Tuple creation functions}
@@ -2256,7 +2256,7 @@ returning a type that is convertible to \tcode{bool}.
 For any two zero-length tuples \tcode{e} and \tcode{f}, \tcode{e == f} returns \tcode{true}.
 
 \pnum
-\effects
+\remarks
 The elementary comparisons are performed in order from the
 zeroth index upwards.  No comparisons or element accesses are
 performed after the first equality comparison that evaluates to
@@ -2332,16 +2332,16 @@ template<class... Types>
 for every type \tcode{T} in \tcode{Types}.
 
 \pnum
+\effects
+As if by \tcode{x.swap(y)}.
+
+\pnum
 \remarks
 The expression inside \tcode{noexcept} is equivalent to:
 
 \begin{codeblock}
 noexcept(x.swap(y))
 \end{codeblock}
-
-\pnum
-\effects
-As if by \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec1[optional]{Optional objects}
@@ -4430,12 +4430,12 @@ Otherwise, equivalent to \tcode{operator=(variant(rhs))}.
 \end{itemize}
 
 \pnum
-\returns
-\tcode{*this}.
-
-\pnum
 \ensures
 \tcode{index() == rhs.index()}.
+
+\pnum
+\returns
+\tcode{*this}.
 
 \pnum
 \remarks
@@ -5578,12 +5578,12 @@ any& operator=(any&& rhs) noexcept;
 As if by \tcode{any(std::move(rhs)).swap(*this)}.
 
 \pnum
-\returns
-\tcode{*this}.
-
-\pnum
 \ensures
 The state of \tcode{*this} is equivalent to the original state of \tcode{rhs}.
+
+\pnum
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{any}%
@@ -8240,6 +8240,12 @@ deallocation call shall happen before the next allocation (if any) in this order
 A pointer to the initial element of an array of \tcode{n} \tcode{T}.
 
 \pnum
+\throws
+\tcode{bad_array_new_length} if
+\tcode{numeric_limits<size_t>::max() / sizeof(T) < n}, or
+\tcode{bad_alloc} if the storage cannot be obtained.
+
+\pnum
 \remarks
 The storage for the array
 is obtained by calling \tcode{::operator new}\iref{new.delete},
@@ -8247,12 +8253,6 @@ but it is unspecified when or how often this
 function is called.
 This function starts the lifetime of the array object,
 but not that of any of the array elements.
-
-\pnum
-\throws
-\tcode{bad_array_new_length} if
-\tcode{numeric_limits<size_t>::max() / sizeof(T) < n}, or
-\tcode{bad_alloc} if the storage cannot be obtained.
 \end{itemdescr}
 
 \indexlibrarymember{deallocate}{allocator}%
@@ -8519,12 +8519,12 @@ template<class U> void operator()(U* ptr) const;
 
 \begin{itemdescr}
 \pnum
-\mandates
-\tcode{U} is a complete type.
-
-\pnum
 \constraints
 \tcode{U(*)[]} is convertible to \tcode{T(*)[]}.
+
+\pnum
+\mandates
+\tcode{U} is a complete type.
 
 \pnum
 \effects
@@ -8623,14 +8623,14 @@ constexpr unique_ptr(nullptr_t) noexcept;
 
 \begin{itemdescr}
 \pnum
-\expects
-\tcode{D} meets the \oldconcept{DefaultConstructible} requirements (\tref{cpp17.defaultconstructible}),
-and that construction does not throw an exception.
-
-\pnum
 \constraints
 \tcode{is_pointer_v<deleter_type>} is \tcode{false} and
 \tcode{is_default_constructible_v<deleter_type>} is \tcode{true}.
+
+\pnum
+\expects
+\tcode{D} meets the \oldconcept{DefaultConstructible} requirements (\tref{cpp17.defaultconstructible}),
+and that construction does not throw an exception.
 
 \pnum
 \effects
@@ -8867,12 +8867,12 @@ Calls \tcode{reset(u.release())} followed by
 \tcode{get_deleter() = std::forward<D>(u.get_dele\-ter())}.
 
 \pnum
-\returns
-\tcode{*this}.
-
-\pnum
 \ensures
 \tcode{u.get() == nullptr}.
+
+\pnum
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{unique_ptr}%
@@ -8904,12 +8904,12 @@ Calls \tcode{reset(u.release())} followed by
 \tcode{get_deleter() = std::forward<E>(u.get_dele\-ter())}.
 
 \pnum
-\returns
-\tcode{*this}.
-
-\pnum
 \ensures
 \tcode{u.get() == nullptr}.
+
+\pnum
+\returns
+\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{unique_ptr}%
@@ -10258,16 +10258,16 @@ If \tcode{T} is \tcode{U[N]}, \tcode{i < N}.
 \tcode{get()[i]}.
 
 \pnum
+\throws
+Nothing.
+
+\pnum
 \remarks
 When \tcode{T} is not an array type,
 it is unspecified whether this member function is declared.
 If it is declared, it is unspecified what its return type is,
 except that the declaration (although not necessarily the definition)
 of the function shall be well-formed.
-
-\pnum
-\throws
-Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{use_count}{shared_ptr}%
@@ -10380,14 +10380,14 @@ use a copy of \tcode{a}
 If an exception is thrown, the functions have no effect.
 
 \pnum
-\returns
-A \tcode{shared_ptr} instance that stores and owns the address of
-the newly constructed object.
-
-\pnum
 \ensures
 \tcode{r.get() != 0 \&\& r.use_count() == 1},
 where \tcode{r} is the return value.
+
+\pnum
+\returns
+A \tcode{shared_ptr} instance that stores and owns the address of
+the newly constructed object.
 
 \pnum
 \throws
@@ -11111,13 +11111,13 @@ template<class Y> weak_ptr& operator=(const shared_ptr<Y>& r) noexcept;
 Equivalent to \tcode{weak_ptr(r).swap(*this)}.
 
 \pnum
+\returns
+\tcode{*this}.
+
+\pnum
 \remarks
 The implementation may meet the effects (and the
 implied guarantees) via different means, without creating a temporary object.
-
-\pnum
-\returns
-\tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{weak_ptr}%
@@ -12288,19 +12288,19 @@ void* do_allocate(size_t bytes, size_t alignment) override;
 
 \begin{itemdescr}
 \pnum
-\returns
-A pointer to allocated storage\iref{basic.stc.dynamic.allocation}
-with a size of at least \tcode{bytes}.
-The size and alignment of the allocated memory shall meet the requirements
-for a class derived from \tcode{memory_resource}\iref{mem.res.class}.
-
-\pnum
 \effects
 If the pool selected for a block of size \tcode{bytes}
 is unable to satisfy the memory request from its own internal data structures,
 it will call \tcode{upstream_resource()->allocate()} to obtain more memory.
 If \tcode{bytes} is larger than that which the largest pool can handle,
 then memory will be allocated using \tcode{upstream_resource()->allocate()}.
+
+\pnum
+\returns
+A pointer to allocated storage\iref{basic.stc.dynamic.allocation}
+with a size of at least \tcode{bytes}.
+The size and alignment of the allocated memory shall meet the requirements
+for a class derived from \tcode{memory_resource}\iref{mem.res.class}.
 
 \pnum
 \throws
@@ -12501,13 +12501,6 @@ void* do_allocate(size_t bytes, size_t alignment) override;
 
 \begin{itemdescr}
 \pnum
-\returns
-A pointer to allocated storage\iref{basic.stc.dynamic.allocation}
-with a size of at least \tcode{bytes}.
-The size and alignment of the allocated memory shall meet the requirements
-for a class derived from \tcode{memory_resource}\iref{mem.res.class}.
-
-\pnum
 \effects
 If the unused space in \tcode{current_buffer}
 can fit a block with the specified \tcode{bytes} and \tcode{alignment},
@@ -12518,6 +12511,13 @@ where \tcode{n} is not less than \tcode{max(bytes, next_buffer_size)} and
 and increase \tcode{next_buffer_size}
 by an \impldef{growth factor for \tcode{monotonic_buffer_resource}} growth factor (which need not be integral),
 then allocate the return block from the newly-allocated \tcode{current_buffer}.
+
+\pnum
+\returns
+A pointer to allocated storage\iref{basic.stc.dynamic.allocation}
+with a size of at least \tcode{bytes}.
+The size and alignment of the allocated memory shall meet the requirements
+for a class derived from \tcode{memory_resource}\iref{mem.res.class}.
 
 \pnum
 \throws
@@ -15549,7 +15549,6 @@ the \oldconcept{CopyConstructible} requirements, and
 the \oldconcept{CopyAssignable} requirements.
 
 \pnum
-\expects
 Let \tcode{V} be \tcode{iterator_traits<RandomAccessIterator1>::val\-ue_type}.
 For any two values \tcode{A} and \tcode{B} of type \tcode{V},
 if \tcode{pred(A, B) == true}, then \tcode{hf(A) == hf(B)} is \tcode{true}.
@@ -15647,7 +15646,6 @@ The value type of \tcode{RandomAccessIterator1} meets the \oldconcept{DefaultCon
 \oldconcept{Copy\-Constructible}, and \oldconcept{CopyAssignable} requirements.
 
 \pnum
-\expects
 Let \tcode{V} be \tcode{iterator_traits<RandomAccessIterator1>::val\-ue_type}.
 For any two values \tcode{A} and \tcode{B} of type \tcode{V},
 if \tcode{pred(A, B) == true}, then \tcode{hf(A) == hf(B)} is \tcode{true}.


### PR DESCRIPTION
Partially addresses #3677

(There are 6 remaining mis-orderings that need more attention.)