### PR TITLE
[stmt.pre, re.grammar, gram] Use a separate bnf environment for each nonterminal.

### DIFF
--- a/source/grammar.tex
+++ b/source/grammar.tex
@@ -33,7 +33,9 @@ typedef-name:\br
 namespace-name:\br
 	identifier\br
 	namespace-alias
+\end{ncbnf}
 
+\begin{ncbnf}
 namespace-alias:\br
 	identifier
 \end{ncbnf}

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -3644,7 +3644,9 @@ The following productions within the ECMAScript grammar are modified as follows:
   ClassAtomExClass\br
   ClassAtomCollatingElement\br
   ClassAtomEquivalence
+\end{ncrebnf}
 
+\begin{ncrebnf}
 \renontermdef{IdentityEscape}\br
   SourceCharacter \textnormal{\textbf{but not}} \terminal{c}
 \end{ncrebnf}
@@ -3655,17 +3657,25 @@ The following new productions are then added:
 \begin{ncrebnf}
 \renontermdef{ClassAtomExClass}\br
   \terminal{[:} ClassName \terminal{:]}
+\end{ncrebnf}
 
+\begin{ncrebnf}
 \renontermdef{ClassAtomCollatingElement}\br
   \terminal{[.} ClassName \terminal{.]}
+\end{ncrebnf}
 
+\begin{ncrebnf}
 \renontermdef{ClassAtomEquivalence}\br
   \terminal{[=} ClassName \terminal{=]}
+\end{ncrebnf}
 
+\begin{ncrebnf}
 \renontermdef{ClassName}\br
   ClassNameCharacter\br
   ClassNameCharacter ClassName
+\end{ncrebnf}
 
+\begin{ncrebnf}
 \renontermdef{ClassNameCharacter}\br
   SourceCharacter \textnormal{\textbf{but not one of}} \terminal{.} \textnormal{\textbf{or}} \terminal{=} \textnormal{\textbf{or}} \terminal{:}
 \end{ncrebnf}

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -21,11 +21,15 @@ Except as indicated, statements are executed in sequence.
     \opt{attribute-specifier-seq} jump-statement\br
     declaration-statement\br
     \opt{attribute-specifier-seq} try-block
+\end{bnf}
 
+\begin{bnf}
 \nontermdef{init-statement}\br
     expression-statement\br
     simple-declaration
+\end{bnf}
 
+\begin{bnf}
 \nontermdef{condition}\br
     expression\br
     \opt{attribute-specifier-seq} decl-specifier-seq declarator brace-or-equal-initializer


### PR DESCRIPTION
This is already done everywhere else in the document as far as I can tell.

No visible difference in the PDF.

(Incidentally, this change makes life easier for cxxdraft-htmlgen.)