### PR TITLE
[alg.is.permutation] Rephrase to simplify

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -3968,7 +3968,7 @@ template<class ForwardIterator1, class ForwardIterator2,
 \pnum
 Let \tcode{last2} be \tcode{first2 + (last1 - first1)}
 for the overloads with no parameter named \tcode{last2},
-and let \tcode{pred} be \tcode{equal<>\{\}}
+and let \tcode{pred} be \tcode{equal_to\{\}}
 for the overloads with no parameter \tcode{pred}.
 
 \pnum

--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -3965,6 +3965,11 @@ template<class ForwardIterator1, class ForwardIterator2,
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+Let \tcode{last2} be \tcode{first2 + (last1 - first1)}
+for the overloads with no parameter named \tcode{last2},
+and let \tcode{pred} be \tcode{equal<>\{\}}
+for the overloads with no parameter \tcode{pred}.
 
 \pnum
 \mandates
@@ -3975,19 +3980,13 @@ template<class ForwardIterator1, class ForwardIterator2,
 The comparison function is an equivalence relation.
 
 \pnum
-\remarks
-If \tcode{last2} was not given in the argument list,
-it denotes \tcode{first2 + (last1 - first1)} below.
-
-\pnum
 \returns
 If \tcode{last1 - first1 != last2 - first2}, return \tcode{false}.
 Otherwise return \tcode{true}
 if there exists a permutation of the elements
-in the range \range{first2}{first2 + (last1 - first1)},
+in the range \range{first2}{last2},
 beginning with \tcode{ForwardIterator2 begin},
-such that \tcode{equal(first1, last1, begin)} returns \tcode{true} or
-\tcode{equal(first1, last1, begin, pred)} returns \tcode{true};
+such that \tcode{equal(first1, last1, begin, pred)} returns \tcode{true};
 otherwise, returns \tcode{false}.
 
 \pnum
@@ -3998,10 +3997,7 @@ meet the requirements of random access iterators and
 \tcode{last1 - first1 != last2 - first2}.
 Otherwise, exactly \tcode{last1 - first1} applications
 of the corresponding predicate
-if \tcode{equal(\brk{}first1, last1, first2, last2)} would return \tcode{true}
-if \tcode{pred} was not given in the argument list or
-\tcode{equal(first1, last1, first2, last2, pred)} would return \tcode{true}
-if \tcode{pred} was given in the argument list;
+if \tcode{equal(first1, last1, first2, last2, pred)} would return \tcode{true};
 otherwise, at worst \bigoh{N^2}, where $N$ has the value \tcode{last1 - first1}.
 \end{itemdescr}
 


### PR DESCRIPTION
Defines `last2` and `pred` for the overloads in `std` with no parameters by those names so the remainder of the specification need not exhaustively describe each case.