### PR TITLE
[allocator.members] Remove stray whitespace.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -8269,7 +8269,7 @@ to the invocation of allocate which returned \tcode{p}.
 
 \pnum
 \effects
-Deallocates the storage referenced by \tcode{p} .
+Deallocates the storage referenced by \tcode{p}.
 
 \pnum
 \remarks


### PR DESCRIPTION
The space is visible in the PDF.