### PR TITLE
[re.grammar] Don't use monospace for ordinary text.

### DIFF
--- a/source/regex.tex
+++ b/source/regex.tex
@@ -3703,17 +3703,17 @@ names shall be recognized:
 In addition the following expressions shall be equivalent:
 
 \begin{codeblock}
-\d and [[:digit:]]
+\d @\textnormal{and}@ [[:digit:]]
 
-\D and [^[:digit:]]
+\D @\textnormal{and}@ [^[:digit:]]
 
-\s and [[:space:]]
+\s @\textnormal{and}@ [[:space:]]
 
-\S and [^[:space:]]
+\S @\textnormal{and}@ [^[:space:]]
 
-\w and [_[:alnum:]]
+\w @\textnormal{and}@ [_[:alnum:]]
 
-\W and [^_[:alnum:]]
+\W @\textnormal{and}@ [^_[:alnum:]]
 \end{codeblock}
 
 \pnum


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22357/86854047-fe868b80-c0b7-11ea-9e38-88d7e092e864.png)



