### PR TITLE
[expr.const] Add cross-reference for 'constant initialization'.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -7302,7 +7302,8 @@ if it is:
 to determine whether it is satisfied\iref{temp.constr.atomic}, or
 \item the initializer of a variable
 that is usable in constant expressions or
-has constant initialization.\footnote{Testing this condition
+has constant initialization\iref{basic.start.static}.%
+\footnote{Testing this condition
 may involve a trial evaluation of its initializer as described above.}
 \begin{example}
 \begin{codeblock}


### PR DESCRIPTION
Fixes #4077