### PR TITLE
[expr.reinterpret.cast] Fix a note

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3929,11 +3929,13 @@ restriction that a \tcode{reinterpret_cast} cannot cast away constness.}
 When a prvalue \tcode{v} of object pointer type is converted to
 the object pointer type ``pointer to \cv{}~\tcode{T}'', the result is \tcode{static_cast<\cv{} T*>(static_cast<\cv{}~void*>(v))}.
 \begin{note}
-Converting a prvalue of type ``pointer to \tcode{T1}'' to
-the type ``pointer to \tcode{T2}'' (where \tcode{T1} and \tcode{T2} are
-object types and where the alignment requirements of \tcode{T2} are no
-stricter than those of \tcode{T1}) and back to its original type yields
-the original pointer value.
+Converting a pointer of type ``pointer to \tcode{T1}''
+that points to an object of type \tcode{T1}
+to the type ``pointer to \tcode{T2}''
+(where \tcode{T2} is an object type
+and the alignment requirements of \tcode{T2}
+are no stricter than those of \tcode{T1})
+and back to its original type yields the original pointer value.
 \end{note}
 
 \pnum


### PR DESCRIPTION
```c++
struct S { int i; } s;

auto fp = reinterpret_cast<float*>(&s); // the value of `fp` is  "pointer to s"

reinterpret_cast<float*>(reinterpret_cast<int*>(fp));
// converting to `int*` and back to `float*` does NOT yield the original pointer value,
// because the value became "pointer to s.i" when casting to `int*`.
```
@hubert-reinterpretcast 