### PR TITLE
[fs.class.path] Ensure interword spacing inside sentence.

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -11702,7 +11702,7 @@ identifies the location of a file when resolved relative to
 an implied starting location. The elements of a path that determine if it is
 relative are operating system dependent.
 \begin{note}
-Pathnames ``.'' and ``..'' are relative paths.
+Pathnames ``.''\ and ``..''\ are relative paths.
 \end{note}
 
 \pnum


### PR DESCRIPTION
I think LaTeX is interpreting the periods as sentence full stops, causing it to apply sentence-spacing by default. `\ ` forces an interword space.
![image](https://user-images.githubusercontent.com/22357/87561678-4cede880-c6bd-11ea-9cb4-d60cb29c603d.png)
