### PR TITLE
[istream.syn][ostream.syn] update synopses according to LWG1203

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4052,8 +4052,8 @@ namespace std {
   template<class charT, class traits>
     basic_istream<charT, traits>& ws(basic_istream<charT, traits>& is);
 
-  template<class charT, class traits, class T>
-    basic_istream<charT, traits>& operator>>(basic_istream<charT, traits>&& is, T&& x);
+  template<class Istream, class T>
+    Istream&& operator>>(Istream&& is, T&& x);
 }
 \end{codeblock}
 
@@ -4087,8 +4087,8 @@ namespace std {
   template<class charT, class traits>
     basic_ostream<charT, traits>& flush_emit(basic_ostream<charT, traits>& os);
 
-  template<class charT, class traits, class T>
-    basic_ostream<charT, traits>& operator<<(basic_ostream<charT, traits>&& os, const T& x);
+  template<class Ostream, class T>
+    Ostream&& operator<<(Ostream&& os, const T& x);
 }
 \end{codeblock}
 


### PR DESCRIPTION
Missing editorial changes in [this commit](https://github.com/cplusplus/draft/pull/3749/commits/ffb23d0521af5a8795fc051d2915858d00518d41).