### PR TITLE
[dcl.init] Remove redundant paragraph about initialization with () initializer

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4292,11 +4292,6 @@ In some cases, additional initialization is done later.
 \end{note}
 
 \pnum
-An object whose initializer is an empty set of parentheses, i.e.,
-\tcode{()},
-shall be
-value-initialized.
-
 \indextext{ambiguity!function declaration}%
 \begin{note}
 Since


### PR DESCRIPTION
I've left the Note, because I don't know where to move it.

Fixes #4047