### PR TITLE
Add additional example to CWG2303 example to clarify meaning.

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -8049,11 +8049,13 @@ template <> struct X<> {};
 template <typename T, typename... Ts>
   struct X<T, Ts...> : X<Ts...> {};
 struct D : X<int> {};
+struct E : X<>, X<int> {};
 
 template <typename... T>
 int f(const X<T...>&);
 int x = f(D());     // calls \tcode{f<int>}, not \tcode{f<>}
                     // \tcode{B} is \tcode{X<>}, \tcode{C} is \tcode{X<int>}
+int z = f(E());     // calls \tcode{f<int>}, not \tcode{f<>}
 \end{codeblock}
 \end{example}
 \end{itemize}


### PR DESCRIPTION
As discussed on the reflector, CWG2303 causes shadowing of a base class
when attempting deduction in the case where the type is a base of
another successful base class.  This patch adds an example that
clarifies that intent.