### PR TITLE
[lex.ext] Simplify use of \placeholder.

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1915,7 +1915,7 @@ or a numeric literal operator template\iref{over.literal} but not both.
 If \placeholder{S} contains a raw literal operator,
 the literal \placeholder{L} is treated as a call of the form
 \begin{codeblock}
-operator "" @\placeholder{X}@(@"\placeholder{n}{"}@)
+operator "" @\placeholder{X}@("@\placeholder{n}@")
 \end{codeblock}
 Otherwise (\placeholder{S} contains a numeric literal operator template),
 \placeholder{L} is treated as a call of the form
@@ -1941,7 +1941,7 @@ or a numeric literal operator template\iref{over.literal} but not both.
 If \placeholder{S} contains a raw literal operator,
 the \grammarterm{literal} \placeholder{L} is treated as a call of the form
 \begin{codeblock}
-operator "" @\placeholder{X}@(@"\placeholder{f}{"}@)
+operator "" @\placeholder{X}@("@\placeholder{f}@")
 \end{codeblock}
 Otherwise (\placeholder{S} contains a numeric literal operator template),
 \placeholder{L} is treated as a call of the form


### PR DESCRIPTION
This change has no visible effect on the PDF, but:

- it makes the LaTeX source a little bit simpler
- it makes the use of `\placeholder` inside a string literal consistent with e.g.

https://github.com/cplusplus/draft/blob/de443df351fdecd010633fbadde0d793d0005616/source/declarations.tex#L5972

- it makes things easier for cxxdraft-htmlgen (I admit this is my main motivation).
