### PR TITLE
[conv.qual]  Fix example for cv-decomposition

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -721,9 +721,10 @@ the cv-qualifiers $\cv{}_{i+1}$ on the element type are also taken as
 the cv-qualifiers $\cv{}_i$ of the array.
 \begin{example}
 The type denoted by the \grammarterm{type-id} \tcode{const int **}
-has three cv-decompositions,
+has four cv-decompositions,
 taking \tcode{U}
 as ``\tcode{int}'',
+as ``\tcode{const int}'',
 as ``pointer to \tcode{const int}'', and
 as ``pointer to pointer to \tcode{const int}''.
 \end{example}


### PR DESCRIPTION
Nothing in [conv.qual] says that `U` can't have top-level qualifiers.

Discovered by https://stackoverflow.com/users/775806/n-pronouns-m