### PR TITLE
[lex.ccon] Remove redundant nested \tcode.

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1352,8 +1352,8 @@ form feed       &   FF              &   \tcode{\textbackslash f}                
 alert           &   BEL             &   \tcode{\textbackslash a}                \\
 backslash       &   \textbackslash  &   \tcode{\textbackslash\textbackslash}    \\
 question mark   &   ?               &   \tcode{\textbackslash ?}                \\
-single quote    &   \tcode{'}       &   \tcode{\textbackslash\tcode{'}}         \\
-double quote    &   \tcode{"}       &   \tcode{\textbackslash\tcode{"}}         \\
+single quote    &   \tcode{'}       &   \tcode{\textbackslash '}                \\
+double quote    &   \tcode{"}       &   \tcode{\textbackslash "}                \\
 octal number    &   \numconst{ooo}  &   \tcode{\textbackslash\numconst{ooo}}    \\
 hex number      &   \numconst{hhh}  &   \tcode{\textbackslash x\numconst{hhh}}  \\
 \end{floattable}


### PR DESCRIPTION
No visible difference in the PDF.