### PR TITLE
[mask.array.assign] Replace "it" with its antecedent

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -8710,7 +8710,7 @@ const mask_array& operator=(const mask_array&) const;
 These assignment operators have reference semantics, assigning the values
 of the argument array elements to selected elements of the
 \tcode{valarray<T>}
-object to which it refers.
+object to which the \tcode{mask_array} object refers.
 \end{itemdescr}
 
 \rSec3[mask.array.comp.assign]{Compound assignment}


### PR DESCRIPTION
Many nouns appear in this sentence before "it", _none_ of which is the proper antecedent.