### PR TITLE
[mask.array.comp.assign] Clarify "mask object"

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -8744,7 +8744,7 @@ These compound assignments have reference semantics, applying the
 indicated operation to the elements of the argument array and selected elements
 of the
 \tcode{valarray<T>}
-object to which the mask object refers.
+object to which the \tcode{mask_array} object refers.
 \end{itemdescr}
 
 \rSec3[mask.array.fill]{Fill function}


### PR DESCRIPTION
We don't refer to an instance of a specialization of `mask_array` as a "mask object" elsewhere, but we do use the phrase "`mask_array` object" which is consistent with library-wide style.