### PR TITLE
[std] Remove unnecessary bracketing in \tcode and retire \dcr

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -1505,8 +1505,8 @@ value_type operator++(int) const noexcept;
 Equivalent to: \tcode{return fetch_add(1);}
 \end{itemdescr}
 
-\indexlibrarymember{operator\dcr}{atomic_ref<T*>}%
-\indexlibrarymember{operator\dcr}{atomic_ref<\placeholder{integral}>}%
+\indexlibrarymember{operator--}{atomic_ref<T*>}%
+\indexlibrarymember{operator--}{atomic_ref<\placeholder{integral}>}%
 \begin{itemdecl}
 value_type operator--(int) const noexcept;
 \end{itemdecl}
@@ -1529,8 +1529,8 @@ value_type operator++() const noexcept;
 Equivalent to: \tcode{return fetch_add(1) + 1;}
 \end{itemdescr}
 
-\indexlibrarymember{operator\dcr}{atomic_ref<T*>}%
-\indexlibrarymember{operator\dcr}{atomic_ref<\placeholder{integral}>}%
+\indexlibrarymember{operator--}{atomic_ref<T*>}%
+\indexlibrarymember{operator--}{atomic_ref<\placeholder{integral}>}%
 \begin{itemdecl}
 value_type operator--() const noexcept;
 \end{itemdecl}
@@ -2669,8 +2669,8 @@ For the \tcode{volatile} overload of this function,
 Equivalent to: \tcode{return fetch_add(1);}
 \end{itemdescr}
 
-\indexlibrarymember{operator\dcr}{atomic<T*>}%
-\indexlibrarymember{operator\dcr}{atomic<\placeholder{integral}>}%
+\indexlibrarymember{operator--}{atomic<T*>}%
+\indexlibrarymember{operator--}{atomic<\placeholder{integral}>}%
 \begin{itemdecl}
 value_type operator--(int) volatile noexcept;
 value_type operator--(int) noexcept;
@@ -2705,8 +2705,8 @@ For the \tcode{volatile} overload of this function,
 Equivalent to: \tcode{return fetch_add(1) + 1;}
 \end{itemdescr}
 
-\indexlibrarymember{operator\dcr}{atomic<T*>}%
-\indexlibrarymember{operator\dcr}{atomic<\placeholder{integral}>}%
+\indexlibrarymember{operator--}{atomic<T*>}%
+\indexlibrarymember{operator--}{atomic<\placeholder{integral}>}%
 \begin{itemdecl}
 value_type operator--() volatile noexcept;
 value_type operator--() noexcept;

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1088,7 +1088,7 @@ time.
 \tcode{a.back()}        &
  \tcode{reference; const_reference} for constant \tcode{a}    &
  \tcode{\{ auto tmp = a.end();}\br
- \tcode{    \dcr tmp;}\br
+ \tcode{    --tmp;}\br
  \tcode{    return *tmp; \}}    &
  \tcode{basic_string},
  \tcode{array},

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3419,9 +3419,9 @@ and~\ref{expr.ass}.
 \pnum
 \indextext{expression!decrement}%
 \indextext{operator!decrement}%
-\indextext{\idxcode{\dcr}|see{operator, decrement}}%
-\indextext{postfix \tcode{\dcr}}%
-The operand of postfix \tcode{\dcr} is decremented analogously to the
+\indextext{\idxcode{--}|see{operator, decrement}}%
+\indextext{postfix \tcode{--}}%
+The operand of postfix \tcode{--} is decremented analogously to the
 postfix \tcode{++} operator.
 \begin{note}
 For prefix increment and decrement, see~\ref{expr.pre.incr}.
@@ -4378,7 +4378,7 @@ The operand of prefix \tcode{++}
 \indextext{operator!increment}%
 \indextext{prefix \tcode{++}}%
 is modified\iref{defns.access} by adding \tcode{1}.
-\indextext{prefix \tcode{\dcr}}%
+\indextext{prefix \tcode{--}}%
 The operand shall be a modifiable lvalue. The type of the operand shall
 be an arithmetic type other than \cv{}~\tcode{bool},
 or a pointer to a completely-defined object type.
@@ -4396,9 +4396,9 @@ operators\iref{expr.ass} for information on conversions.
 \pnum
 The operand of prefix
 \indextext{operator!decrement}%
-\tcode{\dcr} is modified\iref{defns.access} by subtracting \tcode{1}.
+\tcode{--} is modified\iref{defns.access} by subtracting \tcode{1}.
 The requirements on the operand of prefix
-\tcode{\dcr} and the properties of its result are otherwise the same as
+\tcode{--} and the properties of its result are otherwise the same as
 those of prefix \tcode{++}.
 \begin{note}
 For postfix increment and decrement, see~\ref{expr.post.incr}.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2856,7 +2856,7 @@ Postfix expressions group left-to-right.
     postfix-expression \terminal{.} \opt{\terminal{template}} id-expression\br
     postfix-expression \terminal{->} \opt{\terminal{template}} id-expression\br
     postfix-expression \terminal{++}\br
-    postfix-expression \terminal{-{-}}\br
+    postfix-expression \terminal{--}\br
     \keyword{dynamic_cast} \terminal{<} type-id \terminal{>} \terminal{(} expression \terminal{)}\br
     \keyword{static_cast} \terminal{<} type-id \terminal{>} \terminal{(} expression \terminal{)}\br
     \keyword{reinterpret_cast} \terminal{<} type-id \terminal{>} \terminal{(} expression \terminal{)}\br
@@ -2876,7 +2876,7 @@ The \tcode{>} token following the
 \grammarterm{type-id} in a \tcode{dynamic_cast},
 \tcode{static_cast}, \tcode{reinterpret_cast}, or
 \tcode{const_cast} might be the product of replacing a
-\tcode{>{>}} token by two consecutive \tcode{>}
+\tcode{>>} token by two consecutive \tcode{>}
 tokens\iref{temp.names}.
 \end{note}
 
@@ -4200,7 +4200,7 @@ Expressions with unary operators group right-to-left.
     postfix-expression\br
     unary-operator cast-expression\br
     \terminal{++} cast-expression\br
-    \terminal{-{-}} cast-expression\br
+    \terminal{--} cast-expression\br
     await-expression\br
     \keyword{sizeof} unary-expression\br
     \keyword{sizeof} \terminal{(} type-id \terminal{)}\br

--- a/source/future.tex
+++ b/source/future.tex
@@ -98,8 +98,8 @@ auto cmp = arr1 <=> arr2;       // error
 \rSec1[depr.volatile.type]{Deprecated \tcode{volatile} types}
 
 \pnum
-Postfix \tcode{++} and \tcode{\dcr} expressions\iref{expr.post.incr} and
-prefix \tcode{++} and \tcode{\dcr} expressions\iref{expr.pre.incr}
+Postfix \tcode{++} and \tcode{--} expressions\iref{expr.post.incr} and
+prefix \tcode{++} and \tcode{--} expressions\iref{expr.pre.incr}
 of volatile-qualified arithmetic and pointer types are deprecated.
 
 \begin{example}
@@ -924,7 +924,7 @@ If
 if the input sequence has a putback position available, and if
 \tcode{strmode \& constant} is zero,
 assigns \tcode{c} to
-\tcode{*\dcr{}gnext}.
+\tcode{*--gnext}.
 
 Returns
 \tcode{c}.

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -8098,7 +8098,7 @@ if \tcode{mode}
 \tcode{ios_base::out} is
 nonzero,
 assigns \tcode{c} to
-\tcode{*\dcr gptr()}.
+\tcode{*--gptr()}.
 
 Returns:
 \tcode{c}.

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -620,7 +620,7 @@ the element, if any, pointed to by
 the result of \tcode{n} applications of \tcode{++i}.
 A counted range \countedrange{i}{n} is valid if and only if \tcode{n == 0};
 or \tcode{n} is positive, \tcode{i} is dereferenceable,
-and \countedrange{++i}{-{-}n} is valid.
+and \countedrange{++i}{--n} is valid.
 
 \pnum
 The result of the application of library functions
@@ -1255,7 +1255,7 @@ and let \tcode{o} be a dereferenceable object of type \tcode{Out}.
 \tcode{Out} and \tcode{T} model \tcode{\libconcept{indirectly_writable}<Out, T>} only if
 \begin{itemize}
 \item If \tcode{Out} and \tcode{T} model
-  \tcode{\libconcept{indirectly_readable}<Out> \&\& \libconcept{same_as}<iter_value_t<Out>, decay_t<T>{>}},
+  \tcode{\libconcept{indirectly_readable}<Out> \&\& \libconcept{same_as}<iter_value_t<Out>, decay_t<T>>},
   then \tcode{*o} after any above assignment is equal to
   the value of \tcode{E} before the assignment.
 \end{itemize}
@@ -3017,7 +3017,7 @@ template<@\libconcept{bidirectional_iterator}@ I>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{-{-}x; return x;}
+Equivalent to: \tcode{--x; return x;}
 \end{itemdescr}
 
 \indexlibraryglobal{prev}%
@@ -4566,7 +4566,7 @@ Class template \tcode{move_sentinel} is a sentinel adaptor useful for denoting
 ranges together with \tcode{move_iterator}. When an input iterator type
 \tcode{I} and sentinel type \tcode{S} model \tcode{\libconcept{sentinel_for}<S, I>},
 \tcode{move_sentinel<S>} and \tcode{move_iterator<I>} model
-\tcode{\libconcept{sentinel_for}<move_sentinel<S>, move_iterator<I>{>}} as well.
+\tcode{\libconcept{sentinel_for}<move_sentinel<S>, move_iterator<I>>} as well.
 
 \pnum
 \begin{example}
@@ -5399,7 +5399,7 @@ return tmp;
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{operator{-}-}{counted_iterator}%
+\indexlibrarymember{operator--}{counted_iterator}%
 \begin{itemdecl}
   constexpr counted_iterator& operator--()
     requires @\libconcept{bidirectional_iterator}@<I>;
@@ -5416,7 +5416,7 @@ return *this;
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{operator{-}-}{counted_iterator}%
+\indexlibrarymember{operator--}{counted_iterator}%
 \begin{itemdecl}
   constexpr counted_iterator operator--(int)
     requires @\libconcept{bidirectional_iterator}@<I>;

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2177,22 +2177,22 @@ the following expressions are valid as shown in \tref{bidirectionaliterator}.
 \lhdr{Expression}   &   \chdr{Return type}  &   \chdr{Operational}  &   \rhdr{Assertion/note}       \\
                     &                       &   \chdr{semantics}    &   \rhdr{pre-/post-condition}   \\ \capsep
 
-\tcode{\dcr r}      &
+\tcode{--r}      &
  \tcode{X\&}        &
                     &
  \expects there exists \tcode{s} such that \tcode{r == ++s}.\br
  \ensures \tcode{r} is dereferenceable.\br
- \tcode{\dcr(++r) == r}.\br
- \tcode{\dcr r == \dcr s} implies \tcode{r == s}.\br
- \tcode{addressof(r) == addressof(\dcr r)}.   \\ \hline
+ \tcode{--(++r) == r}.\br
+ \tcode{--r == --s} implies \tcode{r == s}.\br
+ \tcode{addressof(r) == addressof(--r)}.   \\ \hline
 
-\tcode{r\dcr}           &
+\tcode{r--}           &
  convertible to \tcode{const X\&}   &
  \tcode{\{ X tmp = r;}\br
- \tcode{  \dcr r;}\br
+ \tcode{  --r;}\br
  \tcode{  return tmp; \}}&  \\ \rowsep
 
-\tcode{*r\dcr}      &
+\tcode{*r--}      &
  \tcode{reference}   &&  \\
 \end{libreqtab4b}
 
@@ -2226,11 +2226,11 @@ the following expressions are valid as shown in \tref{randomaccessiterator}.
  \tcode{X\&}        &
  \tcode{\{ difference_type m = n;}\br
  \tcode{  if (m >= 0)}\br
- \tcode{    while (m\dcr)}\br
+ \tcode{    while (m--)}\br
  \tcode{      ++r;}\br
  \tcode{  else}\br
  \tcode{    while (m++)}\br
- \tcode{      \dcr r;}\br
+ \tcode{      --r;}\br
  \tcode{  return r; \}}&    \\ \rowsep
 
 \tcode{a + n}\br
@@ -3318,7 +3318,7 @@ constexpr reverse_iterator& operator++();
 \begin{itemdescr}
 \pnum
 \effects
-As if by: \tcode{\dcr current;}
+As if by: \tcode{--current;}
 
 \pnum
 \returns
@@ -3341,7 +3341,7 @@ return tmp;
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{operator\dcr}{reverse_iterator}%
+\indexlibrarymember{operator--}{reverse_iterator}%
 \begin{itemdecl}
 constexpr reverse_iterator& operator--();
 \end{itemdecl}
@@ -3356,7 +3356,7 @@ As if by \tcode{++current}.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\dcr}{reverse_iterator}%
+\indexlibrarymember{operator--}{reverse_iterator}%
 \begin{itemdecl}
 constexpr reverse_iterator operator--(int);
 \end{itemdecl}
@@ -4293,7 +4293,7 @@ return tmp;
 Otherwise, equivalent to \tcode{++current}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\dcr}{move_iterator}%
+\indexlibrarymember{operator--}{move_iterator}%
 \begin{itemdecl}
 constexpr move_iterator& operator--();
 \end{itemdecl}
@@ -4301,14 +4301,14 @@ constexpr move_iterator& operator--();
 \begin{itemdescr}
 \pnum
 \effects
-As if by \tcode{\dcr current}.
+As if by \tcode{--current}.
 
 \pnum
 \returns
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\dcr}{move_iterator}%
+\indexlibrarymember{operator--}{move_iterator}%
 \begin{itemdecl}
 constexpr move_iterator operator--(int);
 \end{itemdecl}

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -248,7 +248,6 @@
 \newcommand{\CppXVII}{\Cpp{} 2017}
 \newcommand{\CppXX}{\Cpp{} 2020}
 \newcommand{\opt}[1]{#1\ensuremath{_\mathit{\color{black}opt}}}
-\newcommand{\dcr}{-{-}}
 \newcommand{\bigoh}[1]{\ensuremath{\mathscr{O}(#1)}}
 
 % Make all tildes a little larger to avoid visual similarity with hyphens.

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3583,7 +3583,7 @@ the expression is interpreted as
 \keyword{operator} \terminal{@} \terminal{(} cast-expression \terminal{)}
 \end{ncsimplebnf}
 \begin{note}
-The operators \tcode{++} and \tcode{\dcr}\iref{expr.pre.incr}
+The operators \tcode{++} and \tcode{--}\iref{expr.pre.incr}
 are described in~\ref{over.inc}.
 \end{note}
 
@@ -3771,8 +3771,8 @@ and the expression is interpreted as
 \rSec2[over.inc]{Increment and decrement}
 \indextext{increment operator!overloaded|see{overloading, increment operator}}%
 \indextext{decrement operator!overloaded|see{overloading, decrement operator}}%
-\indextext{prefix ++ and -{-} overloading@prefix \tcode{++} and \tcode{\dcr}!overloading}%
-\indextext{postfix ++ and -{-} overloading@postfix \tcode{++} and \tcode{\dcr}!overloading}%
+\indextext{prefix ++ and -{-} overloading@prefix \tcode{++} and \tcode{--}!overloading}%
+\indextext{postfix ++ and -{-} overloading@postfix \tcode{++} and \tcode{--}!overloading}%
 
 \pnum
 An \defnadj{increment}{operator function}
@@ -3832,7 +3832,7 @@ void f(X a, Y b) {
 
 \pnum
 A \defnadj{decrement}{operator function}
-is a function named \tcode{\keyword{operator}\dcr}
+is a function named \tcode{\keyword{operator}--}
 and is handled analogously to an increment operator function.
 \indextext{overloading!operator|)}
 

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2448,7 +2448,7 @@ return tmp;
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{operator\dcr}{iota_view::iterator}
+\indexlibrarymember{operator--}{iota_view::iterator}
 \begin{itemdecl}
 constexpr @\exposid{iterator}@& operator--() requires @\exposconcept{decrementable}@<W>;
 \end{itemdecl}
@@ -2463,7 +2463,7 @@ return *this;
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{operator\dcr}{iota_view::iterator}
+\indexlibrarymember{operator--}{iota_view::iterator}
 \begin{itemdecl}
 constexpr @\exposid{iterator}@ operator--(int) requires @\exposconcept{decrementable}@<W>;
 \end{itemdecl}
@@ -3439,7 +3439,7 @@ return tmp;
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{operator\dcr}{filter_view::iterator}%
+\indexlibrarymember{operator--}{filter_view::iterator}%
 \begin{itemdecl}
 constexpr @\exposid{iterator}@& operator--() requires @\libconcept{bidirectional_range}@<V>;
 \end{itemdecl}
@@ -3456,7 +3456,7 @@ return *this;
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{operator\dcr}{filter_view::iterator}%
+\indexlibrarymember{operator--}{filter_view::iterator}%
 \begin{itemdecl}
 constexpr @\exposid{iterator}@ operator--(int) requires @\libconcept{bidirectional_range}@<V>;
 \end{itemdecl}
@@ -3962,7 +3962,7 @@ return tmp;
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{operator\dcr}{transform_view::iterator}%
+\indexlibrarymember{operator--}{transform_view::iterator}%
 \begin{itemdecl}
 constexpr @\exposid{iterator}@& operator--() requires @\libconcept{bidirectional_range}@<@\exposid{Base}@>;
 \end{itemdecl}
@@ -3977,7 +3977,7 @@ return *this;
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{operator\dcr}{transform_view::iterator}%
+\indexlibrarymember{operator--}{transform_view::iterator}%
 \begin{itemdecl}
 constexpr @\exposid{iterator}@ operator--(int) requires @\libconcept{bidirectional_range}@<@\exposid{Base}@>;
 \end{itemdecl}
@@ -5257,7 +5257,7 @@ return tmp;
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{operator\dcr}{join_view::iterator}%
+\indexlibrarymember{operator--}{join_view::iterator}%
 \begin{itemdecl}
 constexpr @\exposid{iterator}@& operator--()
   requires @\exposid{ref-is-glvalue}@ && @\libconcept{bidirectional_range}@<@\exposid{Base}@> &&
@@ -5279,7 +5279,7 @@ return *this;
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{operator\dcr}{join_view::iterator}%
+\indexlibrarymember{operator--}{join_view::iterator}%
 \begin{itemdecl}
 constexpr @\exposid{iterator}@ operator--(int)
   requires @\exposid{ref-is-glvalue}@ && @\libconcept{bidirectional_range}@<@\exposid{Base}@> &&

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -54,7 +54,7 @@ The \tcode{>} token following the
 \grammarterm{template-parameter-list} of a
 \grammarterm{template-declaration}
 can be the product of replacing a
-\tcode{>{>}} token by two consecutive \tcode{>}
+\tcode{>>} token by two consecutive \tcode{>}
 tokens\iref{temp.names}.
 \end{note}
 
@@ -259,7 +259,7 @@ The \tcode{>} token following the
 \grammarterm{template-parameter-list} of a
 \grammarterm{type-parameter}
 can be the product of replacing a
-\tcode{>{>}} token by two consecutive \tcode{>}
+\tcode{>>} token by two consecutive \tcode{>}
 tokens\iref{temp.names}.
 \end{note}
 
@@ -730,7 +730,7 @@ of this description.
 \end{footnote}
 is taken as the ending delimiter
 rather than a greater-than operator.
-Similarly, the first non-nested \tcode{>{>}} is treated as two
+Similarly, the first non-nested \tcode{>>} is treated as two
 consecutive but distinct \tcode{>} tokens, the first of which is taken
 as the end of the \grammarterm{template-argument-list} and completes
 the \grammarterm{template-id}.
@@ -2829,7 +2829,7 @@ template<class ... Args1> struct zip {
 };
 
 typedef zip<short, int>::with<unsigned short, unsigned>::type T1;
-    // \tcode{T1} is \tcode{Tuple<Pair<short, unsigned short>, Pair<int, unsigned>{>}}
+    // \tcode{T1} is \tcode{Tuple<Pair<short, unsigned short>, Pair<int, unsigned>>}
 typedef zip<short>::with<unsigned short, unsigned>::type T2;
     // error: different number of arguments specified for \tcode{Args1} and \tcode{Args2}
 
@@ -4178,7 +4178,7 @@ An alias template name is never deduced.
 \begin{codeblock}
 template<class T> struct Alloc { @\commentellip@ };
 template<class T> using Vec = vector<T, Alloc<T>>;
-Vec<int> v;         // same as \tcode{vector<int, Alloc<int>{>} v;}
+Vec<int> v;         // same as \tcode{vector<int, Alloc<int>> v;}
 
 template<class T>
   void process(Vec<T>& v)

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -7158,7 +7158,7 @@ in this document nor by the implementation, the behavior is undefined.
 \pnum
 \returns
 An object of type
-\tcode{future<invoke_result_t<decay_t<F>, decay_t<Args>...>{>}} that refers
+\tcode{future<invoke_result_t<decay_t<F>, decay_t<Args>...>>} that refers
 to the shared state created by this call to \tcode{async}.
 \begin{note}
 If a future obtained from \tcode{async} is moved outside the local scope,

--- a/source/time.tex
+++ b/source/time.tex
@@ -1403,7 +1403,7 @@ constexpr duration operator++(int);
 Equivalent to: \tcode{return duration(rep_++);}
 \end{itemdescr}
 
-\indexlibrarymember{operator\dcr}{duration}%
+\indexlibrarymember{operator--}{duration}%
 \begin{itemdecl}
 constexpr duration& operator--();
 \end{itemdecl}
@@ -1418,7 +1418,7 @@ Equivalent to: \tcode{--rep_}.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{operator\dcr}{duration}%
+\indexlibrarymember{operator--}{duration}%
 \begin{itemdecl}
 constexpr duration operator--(int);
 \end{itemdecl}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -17351,7 +17351,7 @@ Each of the templates in \ref{meta.trans} shall be a
  struct add_cv;}                    &
  The member typedef \tcode{type} names
  the same type as
- \tcode{add_const_t<add_volatile_t<T>{>}}.                               \\
+ \tcode{add_const_t<add_volatile_t<T>>}.                               \\
 \end{libreqtab2a}
 
 \rSec3[meta.trans.ref]{Reference modifications}
@@ -17872,8 +17872,8 @@ Note D: Notwithstanding the provisions of \ref{meta.type.synop}, and
 pursuant to \ref{namespace.std}, a program may partially specialize
 \tcode{basic_common_reference<T, U, TQual, UQual>}
 for types \tcode{T} and \tcode{U} such that
-\tcode{is_same_v<T, decay_t<T>{>}} and
-\tcode{is_same_v<U, decay_t<U>{>}} are each \tcode{true}.
+\tcode{is_same_v<T, decay_t<T>>} and
+\tcode{is_same_v<U, decay_t<U>>} are each \tcode{true}.
 \begin{note}
 Such specializations
 can be used to influence the result of \tcode{common_reference}, and


### PR DESCRIPTION
Together, these two changes fix #4097.

No visible difference outside of the index.