### PR TITLE
[memory.syn,specialized.algorithms] Append "-for" to exposition-only concept "no-throw-sentinel"

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -10143,12 +10143,12 @@ operations to throw exceptions.
 
 \begin{itemdecl}
 template<class S, class I>
-concept @\defexposconcept{no-throw-sentinel}@ = sentinel_for<S, I>; // \expos
+concept @\defexposconcept{no-throw-sentinel-for}@ = sentinel_for<S, I>; // \expos
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-Types \tcode{S} and \tcode{I} model \tcode{\placeholder{no-throw-sentinel}}
+Types \tcode{S} and \tcode{I} model \tcode{\placeholder{no-throw-sentinel-for}}
 only if no exceptions are thrown from copy construction, move construction,
 copy assignment, move assignment, or comparisons between
 valid values of type \tcode{I} and \tcode{S}.
@@ -10165,7 +10165,7 @@ template<class R>
 concept @\defexposconcept{no-throw-input-range}@ = // \expos
   range<R> &&
   @\placeholder{no-throw-input-iterator}@<iterator_t<R>> &&
-  @\placeholdernc{no-throw-sentinel}@<sentinel_t<R>, iterator_t<R>>;
+  @\placeholder{no-throw-sentinel-for}@<sentinel_t<R>, iterator_t<R>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10180,7 +10180,7 @@ template<class I>
 concept @\defexposconcept{no-throw-forward-iterator}@ = // \expos
   @\placeholder{no-throw-input-iterator}@<I> &&
   forward_iterator<I> &&
-  @\placeholdernc{no-throw-sentinel}@<I, I>;
+  @\placeholder{no-throw-sentinel-for}@<I, I>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10220,7 +10220,7 @@ for (; first != last; ++first)
 \indexlibraryglobal{uninitialized_default_construct}%
 \begin{itemdecl}
 namespace ranges {
-  template<@\placeholdernc{no-throw-forward-iterator}@ I, @\placeholdernc{no-throw-sentinel}@<I> S>
+  template<@\placeholdernc{no-throw-forward-iterator}@ I, @\placeholder{no-throw-sentinel-for}@<I> S>
       requires default_initializable<iter_value_t<I>>
     I uninitialized_default_construct(I first, S last);
   template<@\placeholdernc{no-throw-forward-range}@ R>
@@ -10299,7 +10299,7 @@ for (; first != last; ++first)
 \indexlibraryglobal{uninitialized_value_construct}%
 \begin{itemdecl}
 namespace ranges {
-  template<@\placeholdernc{no-throw-forward-iterator}@ I, @\placeholdernc{no-throw-sentinel}@<I> S>
+  template<@\placeholdernc{no-throw-forward-iterator}@ I, @\placeholder{no-throw-sentinel-for}@<I> S>
       requires default_initializable<iter_value_t<I>>
     I uninitialized_value_construct(I first, S last);
   template<@\placeholdernc{no-throw-forward-range}@ R>
@@ -10388,7 +10388,7 @@ for (; first != last; ++result, (void) ++first)
 \begin{itemdecl}
 namespace ranges {
   template<input_iterator I, sentinel_for<I> S1,
-           @\placeholdernc{no-throw-forward-iterator}@ O, @\placeholdernc{no-throw-sentinel}@<O> S2>
+           @\placeholdernc{no-throw-forward-iterator}@ O, @\placeholder{no-throw-sentinel-for}@<O> S2>
       requires constructible_from<iter_value_t<O>, iter_reference_t<I>>
     uninitialized_copy_result<I, O>
       uninitialized_copy(I ifirst, S1 ilast, O ofirst, S2 olast);
@@ -10445,7 +10445,7 @@ for ( ; n > 0; ++result, (void) ++first, --n) {
 \indexlibraryglobal{uninitialized_copy_n}%
 \begin{itemdecl}
 namespace ranges {
-  template<input_iterator I, @\placeholdernc{no-throw-forward-iterator}@ O, @\placeholdernc{no-throw-sentinel}@<O> S>
+  template<input_iterator I, @\placeholdernc{no-throw-forward-iterator}@ O, @\placeholder{no-throw-sentinel-for}@<O> S>
       requires constructible_from<iter_value_t<O>, iter_reference_t<I>>
     uninitialized_copy_n_result<I, O>
       uninitialized_copy_n(I ifirst, iter_difference_t<I> n, O ofirst, S olast);
@@ -10497,7 +10497,7 @@ return result;
 \begin{itemdecl}
 namespace ranges {
   template<input_iterator I, sentinel_for<I> S1,
-           @\placeholdernc{no-throw-forward-iterator}@ O, @\placeholdernc{no-throw-sentinel}@<O> S2>
+           @\placeholdernc{no-throw-forward-iterator}@ O, @\placeholder{no-throw-sentinel-for}@<O> S2>
       requires constructible_from<iter_value_t<O>, iter_rvalue_reference_t<I>>
     uninitialized_move_result<I, O>
       uninitialized_move(I ifirst, S1 ilast, O ofirst, S2 olast);
@@ -10557,7 +10557,7 @@ return {first, result};
 \indexlibraryglobal{uninitialized_move_n}%
 \begin{itemdecl}
 namespace ranges {
-  template<input_iterator I, @\placeholdernc{no-throw-forward-iterator}@ O, @\placeholdernc{no-throw-sentinel}@<O> S>
+  template<input_iterator I, @\placeholdernc{no-throw-forward-iterator}@ O, @\placeholder{no-throw-sentinel-for}@<O> S>
       requires constructible_from<iter_value_t<O>, iter_rvalue_reference_t<I>>
     uninitialized_move_n_result<I, O>
       uninitialized_move_n(I ifirst, iter_difference_t<I> n, O ofirst, S olast);
@@ -10608,7 +10608,7 @@ for (; first != last; ++first)
 \indexlibraryglobal{uninitialized_fill}%
 \begin{itemdecl}
 namespace ranges {
-  template<@\placeholdernc{no-throw-forward-iterator}@ I, @\placeholdernc{no-throw-sentinel}@<I> S, class T>
+  template<@\placeholdernc{no-throw-forward-iterator}@ I, @\placeholder{no-throw-sentinel-for}@<I> S, class T>
       requires constructible_from<iter_value_t<I>, const T&>
     I uninitialized_fill(I first, S last, const T& x);
   template<@\placeholdernc{no-throw-forward-range}@ R, class T>
@@ -10733,7 +10733,7 @@ for (; first != last; ++first)
 \indexlibraryglobal{destroy}%
 \begin{itemdecl}
 namespace ranges {
-  template<@\placeholdernc{no-throw-input-iterator}@ I, @\placeholdernc{no-throw-sentinel}@<I> S>
+  template<@\placeholdernc{no-throw-input-iterator}@ I, @\placeholder{no-throw-sentinel-for}@<I> S>
       requires destructible<iter_value_t<I>>
     constexpr I destroy(I first, S last) noexcept;
   template<@\placeholdernc{no-throw-input-range}@ R>

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6837,7 +6837,7 @@ namespace std {
   template<class I>
     concept @\exposconcept{no-throw-forward-iterator}@ = @\seebelow@;  // \expos
   template<class S, class I>
-    concept @\exposconcept{no-throw-sentinel}@ = @\seebelow@;          // \expos
+    concept @\exposconcept{no-throw-sentinel-for}@ = @\seebelow@;      // \expos
   template<class R>
     concept @\exposconcept{no-throw-input-range}@ = @\seebelow@;       // \expos
   template<class R>
@@ -6859,7 +6859,7 @@ namespace std {
                                         NoThrowForwardIterator first, Size n);
 
   namespace ranges {
-    template<@\exposconcept{no-throw-forward-iterator}@ I, @\exposconcept{no-throw-sentinel}@<I> S>
+    template<@\exposconcept{no-throw-forward-iterator}@ I, @\exposconcept{no-throw-sentinel-for}@<I> S>
       requires default_initializable<iter_value_t<I>>
         I uninitialized_default_construct(I first, S last);
     template<@\exposconcept{no-throw-forward-range}@ R>
@@ -6887,7 +6887,7 @@ namespace std {
                                       NoThrowForwardIterator first, Size n);
 
   namespace ranges {
-    template<@\exposconcept{no-throw-forward-iterator}@ I, @\exposconcept{no-throw-sentinel}@<I> S>
+    template<@\exposconcept{no-throw-forward-iterator}@ I, @\exposconcept{no-throw-sentinel-for}@<I> S>
       requires default_initializable<iter_value_t<I>>
         I uninitialized_value_construct(I first, S last);
     template<@\exposconcept{no-throw-forward-range}@ R>
@@ -6918,7 +6918,7 @@ namespace std {
     template<class I, class O>
       using uninitialized_copy_result = in_out_result<I, O>;
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S1,
-             @\exposconcept{no-throw-forward-iterator}@ O, @\exposconcept{no-throw-sentinel}@<O> S2>
+             @\exposconcept{no-throw-forward-iterator}@ O, @\exposconcept{no-throw-sentinel-for}@<O> S2>
       requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_reference_t<I>>
         uninitialized_copy_result<I, O>
           uninitialized_copy(I ifirst, S1 ilast, O ofirst, S2 olast);
@@ -6929,7 +6929,7 @@ namespace std {
 
     template<class I, class O>
       using uninitialized_copy_n_result = in_out_result<I, O>;
-    template<@\libconcept{input_iterator}@ I, @\exposconcept{no-throw-forward-iterator}@ O, @\exposconcept{no-throw-sentinel}@<O> S>
+    template<@\libconcept{input_iterator}@ I, @\exposconcept{no-throw-forward-iterator}@ O, @\exposconcept{no-throw-sentinel-for}@<O> S>
       requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_reference_t<I>>
         uninitialized_copy_n_result<I, O>
           uninitialized_copy_n(I ifirst, iter_difference_t<I> n, O ofirst, S olast);
@@ -6954,7 +6954,7 @@ namespace std {
     template<class I, class O>
       using uninitialized_move_result = in_out_result<I, O>;
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S1,
-             @\exposconcept{no-throw-forward-iterator}@ O, @\exposconcept{no-throw-sentinel}@<O> S2>
+             @\exposconcept{no-throw-forward-iterator}@ O, @\exposconcept{no-throw-sentinel-for}@<O> S2>
       requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_rvalue_reference_t<I>>
         uninitialized_move_result<I, O>
           uninitialized_move(I ifirst, S1 ilast, O ofirst, S2 olast);
@@ -6966,7 +6966,7 @@ namespace std {
     template<class I, class O>
       using uninitialized_move_n_result = in_out_result<I, O>;
     template<@\libconcept{input_iterator}@ I,
-             @\exposconcept{no-throw-forward-iterator}@ O, @\exposconcept{no-throw-sentinel}@<O> S>
+             @\exposconcept{no-throw-forward-iterator}@ O, @\exposconcept{no-throw-sentinel-for}@<O> S>
       requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_rvalue_reference_t<I>>
         uninitialized_move_n_result<I, O>
           uninitialized_move_n(I ifirst, iter_difference_t<I> n, O ofirst, S olast);
@@ -6988,7 +6988,7 @@ namespace std {
                            NoThrowForwardIterator first, Size n, const T& x);
 
   namespace ranges {
-    template<@\exposconcept{no-throw-forward-iterator}@ I, @\exposconcept{no-throw-sentinel}@<I> S, class T>
+    template<@\exposconcept{no-throw-forward-iterator}@ I, @\exposconcept{no-throw-sentinel-for}@<I> S, class T>
       requires @\libconcept{constructible_from}@<iter_value_t<I>, const T&>
         I uninitialized_fill(I first, S last, const T& x);
     template<@\exposconcept{no-throw-forward-range}@ R, class T>
@@ -7027,7 +7027,7 @@ namespace std {
     template<@\libconcept{destructible}@ T>
       constexpr void destroy_at(T* location) noexcept;
 
-    template<@\exposconcept{no-throw-input-iterator}@ I, @\exposconcept{no-throw-sentinel}@<I> S>
+    template<@\exposconcept{no-throw-input-iterator}@ I, @\exposconcept{no-throw-sentinel-for}@<I> S>
       requires @\libconcept{destructible}@<iter_value_t<I>>
         constexpr I destroy(I first, S last) noexcept;
     template<@\exposconcept{no-throw-input-range}@ R>


### PR DESCRIPTION
... for consistency with the renaming of the concept `sentinel` to `sentinel_for` from P1754R1.

Fixes #4050.