### PR TITLE
[ranges.syn] Properly capitalize "Clause"

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -318,7 +318,7 @@ namespace std {
 \pnum
 \indextext{to-unsigned-like@\exposid{to-unsigned-like}}%
 \indextext{make-unsigned-like-t@\exposid{make-unsigned-like-t}}%
-Within this clause,
+Within this Clause,
 for an integer-like type \tcode{X}\iref{iterator.concept.winc},
 \tcode{\placeholdernc{make-unsigned-like-t}<X>} denotes
 \tcode{make_unsigned_t<X>} if \tcode{X} is an integer type;


### PR DESCRIPTION
With thanks to @johelegp for catching me exacerbating the problem in https://github.com/cplusplus/LWG/pull/332.