### PR TITLE
[lib] Change 'expression inside noexcept' to 'exception specification'

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -7834,7 +7834,7 @@ and \tcode{rhs}.
 
 \pnum
 \remarks
-The expression inside \tcode{noexcept} is equivalent to:\\
+The exception specification is equivalent to:\\
 \tcode{allocator_traits<Allocator>::propagate_on_container_swap::value ||}\\
 \tcode{allocator_traits<Allocator>::is_always_equal::value}.
 \end{itemdescr}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -3606,7 +3606,7 @@ return ranges::iter_move(--tmp);
 
 \pnum
 \remarks
-The expression in \tcode{noexcept} is equivalent to:
+The exception specification is equivalent to:
 \begin{codeblock}
 is_nothrow_copy_constructible_v<Iterator> &&
 noexcept(ranges::iter_move(--declval<Iterator&>()))
@@ -3633,7 +3633,7 @@ ranges::iter_swap(--xtmp, --ytmp);
 
 \pnum
 \remarks
-The expression in \tcode{noexcept} is equivalent to:
+The exception specification is equivalent to:
 \begin{codeblock}
 is_nothrow_copy_constructible_v<Iterator> &&
 is_nothrow_copy_constructible_v<Iterator2> &&

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -3005,7 +3005,7 @@ return s.@\placeholder{G}@(sv, pos);
 
 \pnum
 \remarks
-The expression inside \tcode{noexcept} is equivalent to
+The exception specification is equivalent to
 \tcode{is_nothrow_convertible_v<const T\&, basic_string_view<charT, traits>>}.
 \end{itemdescr}
 
@@ -3059,7 +3059,7 @@ Equivalent to: \tcode{return basic_string_view<charT, traits>(*this).compare(t);
 
 \pnum
 \remarks
-The expression inside \tcode{noexcept} is equivalent to
+The exception specification is equivalent to
 \tcode{is_nothrow_convertible_v<const T\&, basic_string_view<charT, traits>>}.
 \end{itemdescr}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -4182,7 +4182,7 @@ Any exception thrown by move-constructing any $\tcode{T}_i$ for all $i$.
 \pnum
 \remarks
 The exception specification is equivalent to the logical \logop{AND} of
-\tcode{is_nothrow_move_constructible_v<$\tcode{T}_i$>} for all $i$.
+\tcode{is_nothrow_move_con\-structible_v<$\tcode{T}_i$>} for all $i$.
 If \tcode{is_trivially_move_constructible_v<$\tcode{T}_i$>}
 is \tcode{true} for all $i$, this constructor is trivial.
 \end{itemdescr}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -227,7 +227,7 @@ Exchanges values stored in two locations.
 \remarks
 This function
 is a designated customization point\iref{namespace.std}.
-The expression inside \tcode{noexcept} is equivalent to:
+The exception specification is equivalent to:
 
 \begin{codeblock}
 is_nothrow_move_constructible_v<T> && is_nothrow_move_assignable_v<T>
@@ -931,7 +931,7 @@ and to \tcode{second} with\\ \tcode{std::forward<second_type>(p.second)}.
 
 \pnum
 \remarks
-The expression inside \tcode{noexcept} is equivalent to:
+The exception specification is equivalent to:
 \begin{codeblock}
 is_nothrow_move_assignable_v<T1> && is_nothrow_move_assignable_v<T2>
 \end{codeblock}
@@ -979,7 +979,7 @@ Swaps
 
 \pnum
 \remarks
-The expression inside \tcode{noexcept} is equivalent to:
+The exception specification is equivalent to:
 \begin{codeblock}
 is_nothrow_swappable_v<first_type> && is_nothrow_swappable_v<second_type>
 \end{codeblock}
@@ -1719,7 +1719,7 @@ For all $i$, assigns \tcode{std::forward<$\tcode{T}_i$>(get<$i$>(u))} to
 
 \pnum
 \remarks
-The expression inside \tcode{noexcept} is equivalent to the logical \logop{AND} of the
+The exception specification is equivalent to the logical \logop{AND} of the
 following expressions:
 
 \begin{codeblock}
@@ -1849,7 +1849,7 @@ Nothing unless one of the element-wise \tcode{swap} calls throws an exception.
 
 \pnum
 \remarks
-The expression inside \tcode{noexcept} is equivalent to the logical
+The exception specification is equivalent to the logical
 \logop{AND} of the following expressions:
 
 \begin{codeblock}
@@ -2342,7 +2342,7 @@ As if by \tcode{x.swap(y)}.
 
 \pnum
 \remarks
-The expression inside \tcode{noexcept} is equivalent to:
+The exception specification is equivalent to:
 
 \begin{codeblock}
 noexcept(x.swap(y))
@@ -2601,7 +2601,7 @@ Any exception thrown by the selected constructor of \tcode{T}.
 
 \pnum
 \remarks
-The expression inside \tcode{noexcept} is equivalent to
+The exception specification is equivalent to
 \tcode{is_nothrow_move_constructible_v<T>}.
 If \tcode{is_trivially_move_constructible_v<T>} is \tcode{true},
 this constructor is trivial.
@@ -2908,7 +2908,7 @@ no effect \\
 
 \pnum
 \remarks
-The expression inside \tcode{noexcept} is equivalent to:
+The exception specification is equivalent to:
 \begin{codeblock}
 is_nothrow_move_assignable_v<T> && is_nothrow_move_constructible_v<T>
 \end{codeblock}
@@ -3189,7 +3189,7 @@ Any exceptions thrown by the operations in the relevant part of \tref{optional.s
 
 \pnum
 \remarks
-The expression inside \tcode{noexcept} is equivalent to:
+The exception specification is equivalent to:
 \begin{codeblock}
 is_nothrow_move_constructible_v<T> && is_nothrow_swappable_v<T>
 \end{codeblock}
@@ -4126,7 +4126,7 @@ Any exception thrown by the value-initialization of $\tcode{T}_0$.
 This function is \tcode{constexpr} if and only if the
 value-initialization of the alternative type $\tcode{T}_0$ would satisfy the
 requirements for a constexpr function.
-The expression inside \tcode{noexcept} is equivalent to
+The exception specification is equivalent to
 \tcode{is_nothrow_default_constructible_v<$\tcode{T}_0$>}.
 \begin{note}
 See also class \tcode{monostate}.
@@ -4181,7 +4181,7 @@ Any exception thrown by move-constructing any $\tcode{T}_i$ for all $i$.
 
 \pnum
 \remarks
-The expression inside \tcode{noexcept} is equivalent to the logical \logop{AND} of
+The exception specification is equivalent to the logical \logop{AND} of
 \tcode{is_nothrow_move_constructible_v<$\tcode{T}_i$>} for all $i$.
 If \tcode{is_trivially_move_constructible_v<$\tcode{T}_i$>}
 is \tcode{true} for all $i$, this constructor is trivial.
@@ -4250,7 +4250,7 @@ Any exception thrown by the initialization of the selected alternative $\tcode{T
 
 \pnum
 \remarks
-The expression inside \tcode{noexcept} is equivalent to
+The exception specification is equivalent to
 \tcode{is_nothrow_constructible_v<$\tcode{T}_j$, T>}.
 If $\tcode{T}_j$'s selected constructor is a constexpr constructor,
 this constructor is a constexpr constructor.
@@ -4500,7 +4500,7 @@ If \tcode{is_trivially_move_constructible_v<$\tcode{T}_i$> \&\&}
 \tcode{is_trivially_move_assignable_v<$\tcode{T}_i$> \&\&}
 \tcode{is_trivially_destructible_v<$\tcode{T}_i$>}
 is \tcode{true} for all $i$, this assignment operator is trivial.
-The expression inside \tcode{noexcept} is equivalent to
+The exception specification is equivalent to
 \tcode{is_nothrow_move_constructible_v<$\tcode{T}_i$> \&\& is_nothrow_move_assignable_v<$\tcode{T}_i$>} for all $i$.
 \begin{itemize}
 \item If an exception is thrown during the call to $\tcode{T}_j$'s move construction
@@ -4577,7 +4577,7 @@ selected by the imaginary function overload resolution described above.
 
 \pnum
 \remarks
-The expression inside \tcode{noexcept} is equivalent to:
+The exception specification is equivalent to:
 \begin{codeblock}
 is_nothrow_assignable_v<T@$_j$@&, T> && is_nothrow_constructible_v<T@$_j$@, T>
 \end{codeblock}
@@ -4799,7 +4799,7 @@ $\tcode{T}_i$ with $i$ being \tcode{index()}.
 If an exception is thrown during the exchange of the values of \tcode{*this}
 and \tcode{rhs}, the states of the values of \tcode{*this} and of \tcode{rhs}
 are determined by the exception safety guarantee of \tcode{variant}'s move constructor.
-The expression inside \tcode{noexcept} is equivalent to the logical \logop{AND} of
+The exception specification is equivalent to the logical \logop{AND} of
 \tcode{is_nothrow_move_constructible_v<$\tcode{T}_i$> \&\& is_nothrow_swappable_v<$\tcode{T}_i$>} for all $i$.
 \end{itemdescr}
 
@@ -5219,7 +5219,7 @@ Equivalent to \tcode{v.swap(w)}.
 
 \pnum
 \remarks
-The expression inside \tcode{noexcept} is equivalent to \tcode{noexcept(v.swap(w))}.
+The exception specification is equivalent to \tcode{noexcept(v.swap(w))}.
 \end{itemdescr}
 
 \rSec2[variant.bad.access]{Class \tcode{bad_variant_access}}%
@@ -13442,8 +13442,8 @@ that stores a reference to \tcode{r}.
 
 \pnum
 \remarks
-The expression inside \tcode{noexcept}
-is equivalent to \tcode{noexcept(\placeholdernc{FUN}(declval<U>()))}.
+The exception specification is equivalent to
+\tcode{noexcept(\placeholdernc{FUN}(declval<U>()))}.
 \end{itemdescr}
 
 \indexlibraryctor{reference_wrapper}%


### PR DESCRIPTION
https://wg21.link/[stringbuf.assign]#5 doesn't use a code block. Is that OK?