### PR TITLE
[stmt.return] Fix the operand's conversions description

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4347,7 +4347,7 @@ parenthesized initializer shall be a single expression.
 The initialization that occurs in the \tcode{=} form of a
 \grammarterm{brace-or-equal-initializer} or
 \grammarterm{condition}\iref{stmt.select},
-as well as in argument passing, function return,
+as well as in argument passing,
 throwing an exception\iref{except.throw},
 handling an exception\iref{except.handle},
 and aggregate member initialization\iref{dcl.init.aggr},

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -826,11 +826,15 @@ destructor\iref{class.dtor}.
 A \tcode{return} statement with an operand of type \tcode{void} shall be used only
 in a function whose return type is \cv{}~\tcode{void}.
 A \tcode{return} statement with any other operand shall be used only
-in a function whose return type is not \cv{}~\tcode{void};
+in a function whose return type is not \cv{}~\tcode{void}.
+
+\pnum
 \indextext{conversion!return type}%
-the \tcode{return} statement initializes the
-glvalue result or prvalue result object of the (explicit or implicit) function call
-by copy-initialization\iref{dcl.init} from the operand.
+The sequence of conversions applied to the operand of the \tcode{return} statement
+is the same sequence which would be applied to the parenthesized operand,
+if the parenthesized operand was used to copy-initialize\iref{dcl.init}
+a hypothetical variable having the same type as the return type of the function
+containing the \tcode{return} statement.
 \begin{note}
 A \tcode{return} statement can involve
 an invocation of a constructor to perform a copy or move of the operand


### PR DESCRIPTION
This is a follow up on  #3124/#3587 @sdkrystian @jensmaurer .

This is by no means complete, lotsa wording after the changes and till the end of the subclause seems very broken, namely:
```latex
The destructor for the returned object
is potentially invoked~(\ref{class.dtor}, \ref{except.ctor}).
\begin{example}
\begin{codeblock}
class A {
  ~A() {}
};
A f() { return A(); }   // error: destructor of \tcode{A} is private (even though it is never invoked)
\end{codeblock}
\end{example}
```
There is no "returned object" in `A f() { return A(); }`. The normative part and the Example should be reworded.

```latex
\pnum
The copy-initialization of the result of the call is sequenced before the...
```
We don't have a copy-initialization of the result, so this should also be reworded.