### PR TITLE
[range.prim.empty] Fix expression specification

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -789,7 +789,7 @@ The name \tcode{ranges::empty} denotes a customization point
 object\iref{customization.point.object}.
 
 \pnum
-Given a subexpression \tcode{ranges::empty(E)} with type \tcode{T},
+Given a subexpression \tcode{E} with type \tcode{T},
 let \tcode{t} be an lvalue that denotes the reified object for \tcode{E}.
 Then:
 


### PR DESCRIPTION
Is `ranges​::​empty(E)` in the text here not `E`?

>Given a subexpression ranges​::​empty(E) with type T, let t be an lvalue that denotes the reified object for E.

- [24.3.11 ranges​::​empty [range.prim.empty] - eel.is](http://eel.is/c++draft/range.access#range.prim.empty-2.sentence-1)