### PR TITLE
[stmt.return] Improve CWG2426 wording

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -845,7 +845,7 @@ std::pair<std::string,int> f(const char* p, int x) {
 }
 \end{codeblock}
 \end{example}
-The destructor for the returned object
+The destructor for the result object
 is potentially invoked~(\ref{class.dtor}, \ref{except.ctor}).
 \begin{example}
 \begin{codeblock}


### PR DESCRIPTION
The Example immediately after the wording makes me strongly suspect that the wording should've looked like this.
https://timsong-cpp.github.io/cppwp/n4659/basic.lval#def:result_object