### PR TITLE
[expr.call] [dcl.fct] Move return type requiremens

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3490,10 +3490,7 @@ parameter-type-lists, and \grammarterm{requires-clause}{s}\iref{temp.over.link}.
 \pnum
 \indextext{function return type|see{return type}}%
 \indextext{return type}%
-Functions shall not have a return type of type array or function,
-although they may have a return type of type pointer or reference to such things.
-There shall be no arrays of functions, although there can be arrays of pointers
-to functions.
+The return type shall be a non-array object type, a reference type, or \cv{}~\tcode{void}.
 
 \pnum
 A volatile-qualified return type is deprecated;

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2949,7 +2949,6 @@ type of the function call expression is the return type of the
 statically chosen function (i.e., ignoring the \tcode{virtual} keyword),
 even if the type of the function actually called is different.
 \indextext{type!incomplete}%
-This return type shall be an object type, a reference type or \cv{}~\tcode{void}.
 If the \grammarterm{postfix-expression} names a pseudo-destructor
 (in which case the \grammarterm{postfix-expression}
 is a possibly-parenthesized class member access),


### PR DESCRIPTION
An array element type is constrained by [dcl.array]/4:
> U is called the array element type; this type shall not be a placeholder type ([dcl.spec.auto]), a reference type, a function type, an array of unknown bound, or cv void.