### PR TITLE
[thread.condvarany.intwait] remove reference to nonexistent "cv" variable

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -5023,7 +5023,7 @@ during this call and then equivalent to:
 while (!stoken.stop_requested()) {
   if (pred())
     return true;
-  if (cv.wait_until(lock, abs_time) == cv_status::timeout)
+  if (wait_until(lock, abs_time) == cv_status::timeout)
     return pred();
 }
 return pred();


### PR DESCRIPTION
Resolves https://github.com/cplusplus/draft/issues/4114.

Remove reference to nonexistent variable "cv" in the new cv interruptible waits.

Presumably this was copied from a reference implementation that built on top of another cv type wherein "cv" was a member variable.