### PR TITLE
[range.utility.helpers] Move template argument out of \libconcept.

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1281,7 +1281,7 @@ template<class R>
 
 template<class I>
   concept @\defexposconcept{has-arrow}@ =                           // \expos
-    @\libconcept{input_iterator<I>}@ && (is_pointer_v<I> || requires(I i) { i.operator->(); });
+    @\libconcept{input_iterator}@<I> && (is_pointer_v<I> || requires(I i) { i.operator->(); });
 
 template<class T, class U>
   concept @\defexposconcept{not-same-as}@ =                         // \expos


### PR DESCRIPTION
Fixes this bad entry:

![image](https://user-images.githubusercontent.com/22357/91376653-dac10580-e81d-11ea-970a-b0a67299d31e.png)
