### PR TITLE
[format.syn] Avoid forward references

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -19052,6 +19052,19 @@ Nothing.
 \indexlibrarymember{size}{format_to_n_result}%
 \begin{codeblock}
 namespace std {
+  // \ref{format.context}, class template \tcode{basic_format_context}
+  template<class Out, class charT> class basic_format_context;
+  using format_context = basic_format_context<@\unspec@, char>;
+  using wformat_context = basic_format_context<@\unspec@, wchar_t>;
+
+  // \ref{format.args}, class template \tcode{basic_format_args}
+  template<class Context> class basic_format_args;
+  using format_args = basic_format_args<format_context>;
+  using wformat_args = basic_format_args<wformat_context>;
+
+  template<class Out, class charT>
+    using @\libglobal{format_args_t}@ = basic_format_args<basic_format_context<Out, charT>>;
+
   // \ref{format.functions}, formatting functions
   template<class... Args>
     string format(string_view fmt, const Args&... args);
@@ -19125,11 +19138,6 @@ namespace std {
   using format_parse_context = basic_format_parse_context<char>;
   using wformat_parse_context = basic_format_parse_context<wchar_t>;
 
-  // \ref{format.context}, class template \tcode{basic_format_context}
-  template<class Out, class charT> class basic_format_context;
-  using format_context = basic_format_context<@\unspec@, char>;
-  using wformat_context = basic_format_context<@\unspec@, wchar_t>;
-
   // \ref{format.arguments}, arguments
   // \ref{format.arg}, class template \tcode{basic_format_arg}
   template<class Context> class basic_format_arg;
@@ -19146,14 +19154,6 @@ namespace std {
   template<class... Args>
     @\placeholder{format-arg-store}@<wformat_context, Args...>
       make_wformat_args(const Args&... args);
-
-  // \ref{format.args}, class template \tcode{basic_format_args}
-  template<class Context> class basic_format_args;
-  using format_args = basic_format_args<format_context>;
-  using wformat_args = basic_format_args<wformat_context>;
-
-  template<class Out, class charT>
-    using @\libglobal{format_args_t}@ = basic_format_args<basic_format_context<Out, charT>>;
 
   // \ref{format.error}, class \tcode{format_error}
   class format_error;


### PR DESCRIPTION
by moving the declarations of w/format_context and
w/format_args to the front.