### PR TITLE
[ranges.syn] Fix declaration of transform_view

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -202,7 +202,8 @@ namespace std::ranges {
   // \ref{range.transform}, transform view
   template<@\libconcept{input_range}@ V, @\libconcept{copy_constructible}@ F>
     requires view<V> && is_object_v<F> &&
-             regular_invocable<F&, range_reference_t<V>>
+             regular_invocable<F&, range_reference_t<V>> &&
+             @\exposconcept{can-reference}@<invoke_result_t<F&, range_reference_t<V>>>
   class transform_view;
 
   namespace views { inline constexpr @\unspec@ transform = @\unspec@; }


### PR DESCRIPTION
... to agree with the declaration in [range.transform.view] as modified by [LWG-3325](https://cplusplus.github.io/LWG/issue3325). The resolution of this LWG issue failed to direct the Editor to also change the declaration in [ranges.syn].