### PR TITLE
[tab:atomic.types.pointer.comp] Fix column captions.

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -2564,12 +2564,12 @@ and computation correspondence is:
 \begin{floattable}
 {Atomic pointer computations}{atomic.types.pointer.comp}{lll|lll}
 \hline
-\tcode{Key}       &
-  Op          &
-  Computation     &
-\tcode{Key}       &
-  Op          &
-  Computation     \\ \hline
+\hdstyle{\tcode{\placeholder{key}}}  &
+  \hdstyle{Op}                       &
+  \hdstyle{Computation}              &
+\hdstyle{\tcode{\placeholder{key}}}  &
+  \hdstyle{Op}                       &
+  \hdstyle{Computation}  \\ \hline
 \tcode{add}       &
   \tcode{+}       &
   addition        &


### PR DESCRIPTION
Same as for [tab:atomic.types.int.comp]: https://github.com/cplusplus/draft/blob/76ce4297dbe18794331174a281f3bf786d77de41/source/atomics.tex#L2210-L2218