### PR TITLE
[class.virtual] index semantics of final and override

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3839,7 +3839,7 @@ class \tcode{D2}.
 
 \pnum
 If a virtual function \tcode{f} in some class \tcode{B} is marked with the
-\grammarterm{virt-specifier} \tcode{final} and in a class \tcode{D} derived from \tcode{B}
+\grammarterm{virt-specifier} \keyword{final} and in a class \tcode{D} derived from \tcode{B}
 a function \tcode{D::f} overrides \tcode{B::f}, the program is ill-formed.
 \begin{example}
 \begin{codeblock}
@@ -3854,7 +3854,7 @@ struct D : B {
 \end{example}
 
 \pnum
-If a virtual function is marked with the \grammarterm{virt-specifier} \tcode{override} and
+If a virtual function is marked with the \grammarterm{virt-specifier} \keyword{override} and
 does not override a member function of a base class, the program is ill-formed.
 \begin{example}
 \begin{codeblock}


### PR DESCRIPTION
Index the two paragraphs that actually specify the rules for 'final'
and 'override' virt-specifiers applied to functions.

I chose to index these specifiers using the 'keyword' macro rather
than try to set up a separate indextext entry to ensure:
1) the index points to the right page if ever the paragraph splits
across pages
2) the form is consistent with every othert index entry for these
two contextual keywords, which are all created by 'keyword'
Visually confirmed that the text renders in the same monospace
font as the previous 'tcode' entry.