### PR TITLE
[atomics.types.operations] Fix typo in exposition-only code

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -1907,7 +1907,7 @@ on objects without padding bits\iref{basic.types} is
 if (memcmp(this, &expected, sizeof(*this)) == 0)
   memcpy(this, &desired, sizeof(*this));
 else
-  memcpy(expected, this, sizeof(*this));
+  memcpy(&expected, this, sizeof(*this));
 \end{codeblock}
 \end{note}
 \begin{example}


### PR DESCRIPTION
Fixes cplusplus/nbballot#386

Was fixed on main branch with commit e674373e2515868ca17b24157f30515fad62b8e6 #4001