### PR TITLE
[expr.post] Only keyword template is optional

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2814,8 +2814,8 @@ Postfix expressions group left-to-right.
     typename-specifier \terminal{(} \opt{expression-list} \terminal{)}\br
     simple-type-specifier braced-init-list\br
     typename-specifier braced-init-list\br
-    postfix-expression \opt{\terminal{.} \terminal{template}} id-expression\br
-    postfix-expression \opt{\terminal{->} \terminal{template}} id-expression\br
+    postfix-expression \terminal{.} \opt{\terminal{template}} id-expression\br
+    postfix-expression \terminal{->} \opt{\terminal{template}} id-expression\br
     postfix-expression \terminal{++}\br
     postfix-expression \terminal{-{-}}\br
     \keyword{dynamic_cast} \terminal{<} type-id \terminal{>} \terminal{(} expression \terminal{)}\br


### PR DESCRIPTION
not the whole `. template` or `-> template`.