### PR TITLE
[diff.mods.to.declarations] Also mention 'byte' and 'to_integer.

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2787,7 +2787,9 @@ Subclause \ref{cwchar.syn} describes the changes.
 
 \pnum
 Header \libheaderref{cstddef}
-declares the name \tcode{nullptr_t} in addition to the names declared in
+declares the names \tcode{nullptr_t}, \tcode{byte}, and \tcode{to_integer},
+and the operators and operator templates in \iref{support.types.byteops},
+in addition to the names declared in
 \libheaderrefx{stddef.h}{depr.c.headers} in the C standard library.
 
 \rSec2[diff.mods.to.behavior]{Modifications to behavior}


### PR DESCRIPTION
These names, as well as operators for std::byte, are part of <cstddef>.

Fixes #4144.