### PR TITLE
[iterator.concept.random.access] Fix typo

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1791,7 +1791,7 @@ and let \tcode{n} denote a value of type \tcode{D}.
 \tcode{I} models \libconcept{random_access_iterator} only if
 \begin{itemize}
 \item \tcode{(a += n)} is equal to \tcode{b}.
-\item \tcode{addressof(a += n)} is equal to \tcode{addressof(a)}.
+\item \tcode{addressof(a += n)} is equal to \tcode{addressof(b)}.
 \item \tcode{(a + n)} is equal to \tcode{(a += n)}.
 \item For any two positive values
   \tcode{x} and \tcode{y} of type \tcode{D},
@@ -1802,7 +1802,7 @@ and let \tcode{n} denote a value of type \tcode{D}.
   \tcode{(a + n)} is equal to \tcode{[](I c)\{ return ++c; \}(a + D(n - 1))}.
 \item \tcode{(b += D(-n))} is equal to \tcode{a}.
 \item \tcode{(b -= n)} is equal to \tcode{a}.
-\item \tcode{addressof(b -= n)} is equal to \tcode{addressof(b)}.
+\item \tcode{addressof(b -= n)} is equal to \tcode{addressof(a)}.
 \item \tcode{(b - n)} is equal to \tcode{(b -= n)}.
 \item If \tcode{b} is dereferenceable, then
   \tcode{a[n]} is valid and is equal to \tcode{*b}.


### PR DESCRIPTION
- http://eel.is/c++draft/iterators#iterator.concept.random.access-2.2
- http://eel.is/c++draft/iterators#iterator.concept.random.access-2.9

Swapped `addressof(b)` and `addressof(a)`