### PR TITLE
[variant.helper] Use 'struct' for variant_size and variant_alternative

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -4807,7 +4807,7 @@ with a base characteristic of \tcode{integral_constant<size_t, N>} for some \tco
 
 \indexlibraryglobal{variant_size}%
 \begin{itemdecl}
-template<class T> class variant_size<const T>;
+template<class T> struct variant_size<const T>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4827,7 +4827,7 @@ template<class... Types>
 
 \indexlibraryglobal{variant_alternative}%
 \begin{itemdecl}
-template<size_t I, class T> class variant_alternative<I, const T>;
+template<size_t I, class T> struct variant_alternative<I, const T>;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Fixes NB JP 005 and JP 006 (C++20 DIS)

Fixes cplusplus/nbballot#381
Fixes cplusplus/nbballot#382