### PR TITLE
[mem.poly.allocator.mem] Fix syntax for variadic template declaration

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -11826,7 +11826,7 @@ Equivalent to \tcode{deallocate_bytes(p, n*sizeof(T), alignof(T))}.
 
 \indexlibrarymember{new_object}{polymorphic_allocator}%
 \begin{itemdecl}
-template<class T, class CtorArgs...>
+template<class T, class... CtorArgs>
   [[nodiscard]] T* new_object(CtorArgs&&... ctor_args);
 \end{itemdecl}
 


### PR DESCRIPTION
Fixes NB JP 009

Fixes cplusplus/nbballot#385