### PR TITLE
[except.uncaught] Remove parentheses when not invoking a function

### DIFF
--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -1096,7 +1096,7 @@ prematurely based on a determination that the unwind process
 will eventually cause a call to the function
 \tcode{std::terminate}.
 
-\rSec2[except.uncaught]{The \tcode{std::uncaught_exceptions()} function}%
+\rSec2[except.uncaught]{The \tcode{std::uncaught_exceptions} function}%
 \indexlibraryglobal{uncaught_exceptions}
 
 \pnum
@@ -1110,6 +1110,6 @@ during any stack unwinding resulting from it being thrown.
 If an exception is rethrown~(\ref{expr.throw}, \ref{propagation}),
 it is considered uncaught from the point of rethrow
 until the rethrown exception is caught.
-The function \tcode{std::uncaught_exceptions()}\iref{uncaught.exceptions}
+The function \tcode{std::uncaught_exceptions}\iref{uncaught.exceptions}
 returns the number of uncaught exceptions in the current thread.%
 \indextext{exception handling|)}


### PR DESCRIPTION
Fixes NB JP 013 (C++20 DIS)

Fixes cplusplus/nbballot#389