### PR TITLE
[expr.prim.lambda.capture] Use the term "local entity".

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1970,8 +1970,7 @@ named in a friend declaration\iref{class.friend}.
 \end{bnf}
 
 \pnum
-The body of a \grammarterm{lambda-expression} may refer to variables
-with automatic storage duration and the \tcode{*this} object (if any)
+The body of a \grammarterm{lambda-expression} may refer to local entities
 of enclosing block scopes by capturing those entities, as described
 below.
 


### PR DESCRIPTION
The term "local entity" can be used here now that structured bindings
can be captured (after P1091R3 and P1381R1).