### PR TITLE
[macros] Fix PDF links to clauses and annexes

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -70,8 +70,7 @@
 % Set the xref label for a clause to be "Clause n", not just "n".
 \makeatletter
 \newcommand{\customlabel}[2]{%
-\protected@write \@auxout {}{\string \newlabel {#1}{{#2}{\thepage}{#2}{#1}{}} }%
-\hypertarget{#1}{}%
+\@bsphack \begingroup \protected@edef \@currentlabel {\protect \M@TitleReference{#2}{\M@currentTitle}}\MNR@label{#1}\endgroup \@esphack%
 }
 \makeatother
 \newcommand{\clauselabel}[1]{\customlabel{#1}{Clause \thechapter}}


### PR DESCRIPTION
Such links were pointing to immediately after the clause
or annex title, not to immediately before them. The issue
was introduced with commit beb88157cc49f76677fc467db8ec4a523dbc41d0.

Fixes NB JP 014 and JP 015 (C++20 DIS)

Fixes cplusplus/nbballot#390
Fixes cplusplus/nbballot#391