### PR TITLE
[std] Remove superfluous final \rowsep or \hline in tables.

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -2230,7 +2230,7 @@ The following operations perform arithmetic computations. The key, operator, and
   bitwise exclusive or  \\
 \tcode{and}       &
   \tcode{\&}      &
-  bitwise and     &&&\\\hline
+  bitwise and     &&&\\
 \end{floattable}
 
 \indexlibraryglobal{atomic_fetch_add}%
@@ -2575,7 +2575,7 @@ and computation correspondence is:
   addition        &
 \tcode{sub}       &
   \tcode{-}       &
-  subtraction     \\ \hline
+  subtraction     \\
 \end{floattable}
 
 \indexlibraryglobal{atomic_fetch_add}%

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -27,7 +27,7 @@ as summarized in
   \tcode{<unordered_map>}, \tcode{<unordered_set>}    \\ \rowsep
 \ref{container.adaptors}     & Container adaptors               &
   \tcode{<queue>}, \tcode{<stack>}     \\ \rowsep
-\ref{views}                  & Views                            & \tcode{<span>} \\ \rowsep
+\ref{views}                  & Views                            & \tcode{<span>} \\
 \end{libsumtab}
 
 
@@ -411,7 +411,7 @@ iterator type whose value type is \tcode{T}    &
 \tcode{a.crend()}         &
  \tcode{const_reverse_iterator}     &
  \tcode{const_cast<X const\&>(a).rend()} &
- constant                   \\ \rowsep
+ constant                   \\
 \end{libreqtab4a}
 
 \pnum

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -18,7 +18,7 @@ as summarized in \tref{diagnostics.summary}.
 \ref{std.exceptions}  & Exception classes     &   \tcode{<stdexcept>}     \\ \rowsep
 \ref{assertions}      & Assertions            &   \tcode{<cassert>}       \\ \rowsep
 \ref{errno}           & Error numbers         &   \tcode{<cerrno>}        \\ \rowsep
-\ref{syserr}          & System error support  &   \tcode{<system_error>}  \\ \rowsep
+\ref{syserr}          & System error support  &   \tcode{<system_error>}  \\
 \end{libsumtab}
 
 \rSec1[std.exceptions]{Exception classes}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -1715,7 +1715,7 @@ of type \tcode{streamoff} or \tcode{const streamoff}.
 \tcode{p - q}   &
  \tcode{streamoff}      &
  distance       &
- \tcode{p == q + (p - q)}   \\ \rowsep
+ \tcode{p == q + (p - q)}   \\
 \end{libreqtab4c}
 
 \pnum
@@ -13685,7 +13685,7 @@ sequence, with the meanings listed in \tref{fs.enum.path.format}.
   For POSIX-based systems, native and generic formats are equivalent
   and the character sequence should always be interpreted in the same way.
   \end{note}
-\\\rowsep
+\\
 \end{floattable}
 
 \rSec3[fs.enum.file.type]{Enum class \tcode{file_type}}
@@ -13847,7 +13847,7 @@ permissions, with the meanings listed in \tref{fs.enum.perms}.
   \tcode{all | set_uid | set_gid | sticky_bit} \\ \rowsep
 \tcode{unknown} & \tcode{0xFFFF} &  &
   The permissions are not known, such as when a \tcode{file_status} object
-  is created without specifying the permissions \\ \rowsep
+  is created without specifying the permissions \\
 \end{floattable}
 
 \rSec3[fs.enum.perm.opts]{Enum class \tcode{perm_options}}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1498,7 +1498,7 @@ include at least the headers shown in \tref{headers.cpp.fs}.
 \ref{concepts}           & Concepts library          & \tcode{<concepts>}         \\ \rowsep
 \ref{meta}               & Type traits               & \tcode{<type_traits>}      \\ \rowsep
 \ref{bit}                & Bit manipulation          & \tcode{<bit>}              \\ \rowsep
-\ref{atomics}            & Atomics                   & \tcode{<atomic>}           \\ \rowsep
+\ref{atomics}            & Atomics                   & \tcode{<atomic>}           \\
 \end{libsumtab}
 
 \pnum
@@ -1926,7 +1926,7 @@ a value of type (possibly \tcode{const}) \tcode{std::nullptr_t}.
   \tcode{!(a == np)}          \\
 \tcode{np != a}               &
                               &
-                              \\ \rowsep
+                              \\
 \end{oldconcepttable}
 
 \rSec3[hash.requirements]{\oldconcept{Hash} requirements}

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1771,7 +1771,7 @@ the values of these macros with greater values.
 \defnxname{cpp_using_enum}                        & \tcode{201907L} \\ \rowsep
 \defnxname{cpp_variable_templates}                & \tcode{201304L} \\ \rowsep
 \defnxname{cpp_variadic_templates}                & \tcode{200704L} \\ \rowsep
-\defnxname{cpp_variadic_using}                    & \tcode{201611L} \\ \rowsep
+\defnxname{cpp_variadic_using}                    & \tcode{201611L} \\
 \end{LongTable}
 
 \pnum

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -1213,7 +1213,7 @@ the last argument passed to \tcode{imbue}.
 \tcode{"s"}      & \tcode{L"s"}      & \tcode{ctype_base::space}  \\ \rowsep
 \tcode{"upper"}  & \tcode{L"upper"}  & \tcode{ctype_base::upper}  \\ \rowsep
 \tcode{"w"}      & \tcode{L"w"}      & \tcode{ctype_base::alnum}  \\ \rowsep
-\tcode{"xdigit"} & \tcode{L"xdigit"} & \tcode{ctype_base::xdigit} \\ \rowsep
+\tcode{"xdigit"} & \tcode{L"xdigit"} & \tcode{ctype_base::xdigit} \\
 \end{floattable}
 
 \rSec1[re.regex]{Class template \tcode{basic_regex}}

--- a/source/time.tex
+++ b/source/time.tex
@@ -21,7 +21,7 @@ utilities, as summarized in \tref{time.summary}.
 \ref{time.zone}             & Time zones                         & \\
 \ref{time.format}           & Formatting                         & \\
 \ref{time.parse}            & Parsing                            & \\ \rowsep
-\ref{ctime.syn}             & C library time utilities           & \tcode{<ctime>} \\ \rowsep
+\ref{ctime.syn}             & C library time utilities           & \tcode{<ctime>} \\
 \end{libsumtab}
 
 \pnum


### PR DESCRIPTION
- Only a dozen or so tables are affected.
- Effect:
![image](https://user-images.githubusercontent.com/22357/92502749-9f044380-f200-11ea-8b29-d82017b5799c.png)
- The miniscule amount that the content below the affected tables is raised by is too small to cause reflow anywhere.