### PR TITLE
[expr.const] Disambiguate 'it' by introducing the name V.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6850,12 +6850,12 @@ it is constexpr or
 it has reference or const-qualified integral or enumeration type.
 
 \pnum
-A constant-initialized potentially-constant variable is
+A constant-initialized potentially-constant variable $V$ is
 \defn{usable in constant expressions} at a point $P$ if
-its initializing declaration $D$ is reachable from $P$ and
+$V$'s initializing declaration $D$ is reachable from $P$ and
 \begin{itemize}
-\item it is constexpr,
-\item it is not initialized to a TU-local value, or
+\item $V$ is constexpr,
+\item $V$ is not initialized to a TU-local value, or
 \item $P$ is in the same translation unit as $D$.
 \end{itemize}
 An object or reference is \defn{usable in constant expressions} if it is


### PR DESCRIPTION
Fixes #4072 