### PR TITLE
[over.literal] Mark use of a reserved identifier with 'error'.

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -4271,9 +4271,11 @@ void operator "" _km(long double);                  // OK
 string operator "" _i18n(const char*, std::size_t); // OK
 template <char...> double operator "" _\u03C0();    // OK: UCN for lowercase pi
 float operator ""_e(const char*);                   // OK
-float operator ""E(const char*);                    // error: reserved literal suffix~(\ref{usrlit.suffix}, \ref{lex.ext})
-double operator""_Bq(long double);                  // OK: does not use the reserved identifier \tcode{_Bq}\iref{lex.name}
-double operator"" _Bq(long double);                 // uses the reserved identifier \tcode{_Bq}\iref{lex.name}
+float operator ""E(const char*);                    // ill-formed, no diagnostic required:
+                                                    // reserved literal suffix~(\ref{usrlit.suffix}, \ref{lex.ext})
+double operator""_Bq(long double);                  // OK: does not use the reserved \grammarterm{identifier} \tcode{_Bq}\iref{lex.name}
+double operator"" _Bq(long double);                 // ill-formed, no diagnostic required:
+                                                    // uses the reserved \grammarterm{identifier} \tcode{_Bq}\iref{lex.name}
 float operator " " B(const char*);                  // error: non-empty \grammarterm{string-literal}
 string operator "" 5X(const char*, std::size_t);    // error: invalid literal suffix identifier
 double operator "" _miles(double);                  // error: invalid \grammarterm{parameter-declaration-clause}


### PR DESCRIPTION
Fixes #4048