### PR TITLE
[intro.object] Say "member subobject" instead of "data member"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3248,7 +3248,7 @@ of the (unique) object that contains \tcode{x}.
 \end{itemize}
 
 \pnum
-If a complete object, a data member\iref{class.mem}, or an array element is of
+If a complete object, a member subobject, or an array element is of
 class type, its type is considered the \defn{most derived
 class}, to distinguish it from the class type of any base class subobject;
 an object of a most derived class type or of a non-class type is called a


### PR DESCRIPTION
when talking about objects