### PR TITLE
Adjust Foreword based on comments from ISO/CS

### DIFF
--- a/source/preface.tex
+++ b/source/preface.tex
@@ -12,7 +12,7 @@ non-governmental, in liaison with ISO and IEC, also take part in the work.
 
 The procedures used to develop this document and those intended for its further
 maintenance are described in the ISO/IEC Directives, Part 1. In particular the
-different approval criteria needed for the different types of documents should
+different approval criteria needed for the different types of document should
 be noted. This document was drafted in accordance with the editorial rules of
 the ISO/IEC Directives, Part 2
 (see \href{http://www.iso.org/directives}{\tcode{www.iso.org/directives}}).
@@ -34,7 +34,7 @@ the voluntary nature of standards,
 the meaning of ISO specific terms and expressions related
 to conformity assessment, as well as information about ISO's adherence
 to the World Trade Organization (WTO) principles
-in the Technical Barriers to Trade (TBT) see the following URL:
+in the Technical Barriers to Trade (TBT), see
 \href{http://www.iso.org/iso/foreword.html}{\tcode{www.iso.org/iso/foreword.html}}.
 
 This document was prepared by
@@ -43,21 +43,21 @@ Subcommittee SC 22, \textit{Programming languages, their environments and system
 
 This sixth edition cancels and replaces the fifth edition
 (ISO/IEC 14882:2017), which has been technically revised.
-It also incorporates the Technical Specifications
+
+The main changes compared to the previous edition are as follows:
+
+\begin{itemize}
+\item incorporation of the Technical Specifications
 \begin{itemize}
 \item ISO/IEC TS 19217:2015 \textit{Programming Languages --- \Cpp{} Extensions for concepts},
 \item ISO/IEC TS 21425:2017 \textit{Programming Languages --- \Cpp{} Extensions for ranges},
 \item ISO/IEC TS 22277:2017 \textit{Programming Languages --- \Cpp{} Extensions for Coroutines},
 \item ISO/IEC TS 21544:2018 \textit{Programming Languages --- Extensions to \Cpp{} for Modules},
 \item portions of ISO/IEC TS 19571:2016 \textit{Programming Languages --- Technical specification for \Cpp{} extensions for concurrency}, and % latch and barrier
-\item portions of ISO/IEC TS 19568:2017 \textit{Programming Languages --- \Cpp{} Extensions for Library Fundamentals}.
+\item portions of ISO/IEC TS 19568:2017 \textit{Programming Languages --- \Cpp{} Extensions for Library Fundamentals},
 \end{itemize}
-
-The main changes compared to the previous edition are as follows:
-
-\begin{itemize}
 % language changes
-\item addition of concepts, \grammarterm{requires-clause}s, and \grammarterm{requires-expression}s and
+\item addition of concepts, \grammarterm{requires-clause}s, \grammarterm{requires-expression}s, and
 \libheaderref{concepts} header
 \item addition of coroutines, including
 \keyword{co_yield}, \keyword{co_await}, and \keyword{co_return} keywords and
@@ -71,111 +71,43 @@ rewriting of comparison operator expressions, and \libheaderref{compare} header
 \item support for optional reason string in \tcode{[[nodiscard]]} attribute
 \item ability to require constant initialization with \keyword{constinit} keyword
 \item ability to require constant evaluation with \keyword{consteval} keyword
-\item extension of constant evaluation support to cover
-\begin{itemize}
-  \item memory allocation and deallocation
-  \item virtual function calls
-  \item \keyword{dynamic_cast} and \keyword{typeid}
-  \item changing the active member of a union
-  \item uninitialized variables
-\end{itemize}
-\item support for constexpr functions to contain
-\keyword{catch} handlers and \grammarterm{asm-declaration}s
-that are not reached during constant evaluation
+\item extensions to constant evaluation
 \item support for controlling destruction in a class-specific operator delete function
 \item addition of \keyword{using} \keyword{enum} declaration
 \item addition of \keyword{char8_t} type
-\item guarantee that \keyword{char16_t} and \keyword{char32_t} literals
-are encoded as UTF-16 and UTF-32 respectively
 \item support for an initializer statement in range-based for loops
 \item support for default member initializers for bit-fields
 \item support for parenthesized aggregate initialization
-\item extended support for lambda expressions, including
-\begin{itemize}
-  \item explicit \grammarterm{template-head}s in generic lambdas
-  \item default construction and assignment of stateless closure types
-  \item lambda expressions in unevaluated operands
-  \item pack expansion of lambda \grammarterm{init-capture}s
-\end{itemize}
-\item generalized support for structured bindings
+\item extensions to lambda expressions
+\item extensions to structured bindings
 \item support for inline namespaces in nested namespace definitions
 \item support for conditionally-explicit member functions
-\item extended support for class template argument deduction to cover
-aggregate initialization and alias templates
+\item extensions to class template argument deduction
 \item reduced cases in which \keyword{typename} is required
 \item support for calling an undeclared \grammarterm{template-id}
 via argument-dependent name lookup
-\item relaxed access checking rules in template specialization declarations
 \item revised memory model
-\item expanded cases in which returned or thrown variables are implicitly moved
 \item extended support for variadic macros with \mname{VA_OPT}
 % library changes
 \item feature test macros and \libheaderref{version} header
-\item restricted valid uses of standard library functions and function templates
 \item addition of ranges and \libheaderref{ranges} header
 \item addition of calendar and time zone support
 \item addition of text formatting library and \libheaderref{format} header
-\item addition of synchronization facilities for
-waiting, notifications, semaphores, latches, and barriers, and
-\libheaderref{barrier}, \libheaderref{latch} and \libheaderref{semaphore} headers
+\item addition of \libheaderref{barrier}, \libheaderref{latch}, and \libheaderref{semaphore} headers
 \item addition of mathematical constants library and \libheaderref{numbers} header
 \item support for representing source locations and \libheaderrefx{source_location}{source.location.syn} header
 \item addition of \tcode{span} view and \libheaderref{span} header
 \item addition of joining thread class and \libheaderrefx{stop_token}{thread.stoptoken.syn} header
-\item extensions to atomic types and operations, including
-\begin{itemize}
-  \item new class template \tcode{atomic_ref}
-  \item new atomic floating-point operations
-  \item new atomic smart pointer types
-  \item support for compare-and-exchange operations on types with padding
-  \item conversion of \tcode{memory_order} to a scoped enumeration
-\end{itemize}
+\item extensions to atomic types and operations
 \item addition of \tcode{unsequenced} execution policy
-\item new utility functions, types, and templates in the standard library, including
-\begin{itemize}
-  \item \raggedright new type traits
-    \tcode{is_bounded_array},
-    \tcode{is_corresponding_member},
-    \tcode{is_layout_compatible},
-    \tcode{is_nothrow_convertible},
-    \tcode{is_pointer_interconvertible_base_of},
-    \tcode{is_pointer_interconvertible_with_class}, and
-    \tcode{is_unbounded_array}
-  \item new transformation traits
-    \tcode{remove_cvref},
-    \tcode{type_identity},
-    \tcode{unwrap_ref_decay}, and
-    \tcode{unwrap_reference}
-  \item new standard library primitive functions \tcode{assume_aligned} and
-    \tcode{is_constant_evaluated}
-  \item new free functions \tcode{erase} and \tcode{erase_if} for containers
-  \item utilities for uses-allocator construction
-  \item function template \tcode{to_address}
-  \item function template \tcode{bind_front}
-  \item function template \tcode{to_array}
-\end{itemize}
-\item \tcode{make_shared} support for array types
-\item support for allocating objects owned by \tcode{shared_ptr} and \tcode{unique_ptr}
-with default initialization
+\item new utility functions, types, and templates in the standard library
 \item addition of bit manipulation library and \libheaderref{bit} header
 \item addition of a synchronized buffered output stream and \libheaderref{syncstream} header
-\item addition of \tcode{shift} algorithms
-\item addition of \tcode{midpoint} and \tcode{lerp} math functions
-\item use of \tcode{[[nodiscard]]} attribute in the standard library
 \item support for heterogeneous lookup for unordered containers
 \item support for element existence detection in associative containers
-\item change to return removed element count
-from \tcode{remove}, \tcode{remove_if}, and \tcode{unique}
-member functions on \tcode{list} and \tcode{forward_list}
-\item addition of \tcode{starts_with} and \tcode{ends_with}
-to \tcode{basic_string} and \tcode{basic_string_view}
 \item support for move semantics in \libheaderrefx{numeric}{numeric.ops.overview} algorithms
 \item support for efficient access to the buffer of a \tcode{basic_stringbuf}
 \item extended constant expression evaluation support in the standard library
-to cover more algorithms, utilities, and types, including
-\tcode{pair}, \tcode{tuple}, \tcode{vector}, and \tcode{string}
-% annexes
-\item removal of deprecated features
 \end{itemize}
 
 Any feedback or questions on this document


### PR DESCRIPTION
Fix some minor discrepancies between our Foreword and the text provided by ISO/CS, and reduce the list of changes a bit.

Fixes cplusplus/nbballot#388.