### PR TITLE
Replace "this subclause" with an explicit reference in all formerly-hanging paragraphs

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -6572,7 +6572,7 @@ return ranges::nth_element(ranges::begin(r), nth, ranges::end(r), comp, proj);
 \rSec3[alg.binary.search.general]{General}
 
 \pnum
-All of the algorithms in this subclause are versions of binary search and
+All of the algorithms in \ref{alg.binary.search} are versions of binary search and
 assume that the sequence being searched
 is partitioned with respect to an expression
 formed by binding the search key to an argument of the comparison function.
@@ -7279,7 +7279,7 @@ return ranges::inplace_merge(ranges::begin(r), middle, ranges::end(r), comp, pro
 \rSec3[alg.set.operations.general]{General}
 
 \pnum
-This subclause defines all the basic set operations on sorted structures.
+Subclause \ref{alg.set.operations} defines all the basic set operations on sorted structures.
 They also work with \tcode{multiset}s\iref{multiset}
 containing multiple copies of equivalent elements.
 The semantics of the set operations are generalized to \tcode{multiset}s
@@ -9008,7 +9008,7 @@ namespace std {
 \pnum
 \begin{note}
 The use of closed ranges as well as semi-open ranges
-to specify requirements throughout this subclause is intentional.
+to specify requirements throughout \ref{numeric.ops} is intentional.
 \end{note}
 
 \rSec2[numerics.defns]{Definitions}
@@ -10106,7 +10106,7 @@ where the result of the division is truncated towards zero.
 \rSec2[specialized.algorithms.general]{General}
 
 \pnum
-The contents specified in this subclause~\ref{specialized.algorithms}
+The contents specified in \ref{specialized.algorithms}
 are declared in the header \libheaderref{memory}.
 
 \pnum
@@ -10120,12 +10120,12 @@ before allowing the exception to propagate.
 \begin{note}
 When invoked on ranges of
 potentially-overlapping subobjects\iref{intro.object},
-the algorithms specified in this subclause \ref{specialized.algorithms}
+the algorithms specified in \ref{specialized.algorithms}
 result in undefined behavior.
 \end{note}
 
 \pnum
-Some algorithms specified in this clause make use of the exposition-only function
+Some algorithms specified in \ref{specialized.algorithms} make use of the exposition-only function
 \tcode{\placeholdernc{voidify}}:
 \begin{codeblock}
 template<class T>

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -2729,7 +2729,7 @@ The template parameter \tcode{T} of these partial specializations
 may be an incomplete type.
 
 \pnum
-All changes to an atomic smart pointer in this subclause, and
+All changes to an atomic smart pointer in \ref{util.smartptr.atomic}, and
 all associated \tcode{use_count} increments,
 are guaranteed to be performed atomically.
 Associated \tcode{use_count} decrements

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -7,7 +7,7 @@
 
 \pnum
 \indextext{summary!compatibility with ISO \CppXVII{}}%
-This subclause lists the differences between \Cpp{} and
+Subclause \ref{diff.cpp17} lists the differences between \Cpp{} and
 ISO \CppXVII{} (ISO/IEC 14882:2017, \doccite{Programming Languages --- \Cpp{}}),
 by the chapters of this document.
 
@@ -708,7 +708,7 @@ or on the \tcode{result_of_t} alias template may fail to compile.
 
 \pnum
 \indextext{summary!compatibility with ISO \CppXIV{}}%
-This subclause lists the differences between \Cpp{} and
+Subclause \ref{diff.cpp14} lists the differences between \Cpp{} and
 ISO \CppXIV{} (ISO/IEC 14882:2014, \doccite{Programming Languages --- \Cpp{}}),
 in addition to those listed above,
 by the chapters of this document.
@@ -1067,7 +1067,7 @@ may be ill-formed in this International Standard.
 
 \pnum
 \indextext{summary!compatibility with ISO \CppXI{}}%
-This subclause lists the differences between \Cpp{} and
+Subclause \ref{diff.cpp11} lists the differences between \Cpp{} and
 ISO \CppXI{} (ISO/IEC 14882:2011, \doccite{Programming Languages --- \Cpp{}}),
 in addition to those listed above,
 by the chapters of this document.
@@ -1223,7 +1223,7 @@ in this International Standard.
 
 \pnum
 \indextext{summary!compatibility with ISO \CppIII{}}%
-This subclause lists the differences between \Cpp{} and
+Subclause \ref{diff.cpp03} lists the differences between \Cpp{} and
 ISO \CppIII{} (ISO/IEC 14882:2003, \doccite{Programming Languages --- \Cpp{}}),
 in addition to those listed above,
 by the chapters of this document.
@@ -1765,7 +1765,7 @@ int main() {
 
 \pnum
 \indextext{summary!compatibility with ISO C}%
-This subclause lists the differences between \Cpp{} and ISO C,
+Subclause \ref{diff.iso} lists the differences between \Cpp{} and ISO C,
 in addition to those listed above,
 by the chapters of this document.
 
@@ -2645,7 +2645,7 @@ quite common.
 \indextext{library!C standard}%
 
 \pnum
-This subclause summarizes the explicit changes in headers,
+Subclause \ref{diff.library} summarizes the explicit changes in headers,
 definitions, declarations, or behavior between the C standard library
 in the C standard and the parts of the \Cpp{} standard library that were
 included from the C standard library.

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1208,7 +1208,7 @@ in
 \ref{class},
 and
 \ref{temp.res}, respectively. The remaining
-\grammarterm{type-specifier}{s} are discussed in the rest of this subclause.
+\grammarterm{type-specifier}{s} are discussed in the rest of \ref{dcl.type}.
 \end{note}
 
 \rSec3[dcl.type.cv]{The \fakegrammarterm{cv-qualifier}{s}}%
@@ -1756,7 +1756,7 @@ in a \grammarterm{template-parameter}\iref{temp.param}.
 
 \pnum
 A program that uses a placeholder type in a context not
-explicitly allowed in this subclause is ill-formed.
+explicitly allowed in \ref{dcl.spec.auto} is ill-formed.
 
 \pnum
 If the \grammarterm{init-declarator-list} contains more than one
@@ -4055,7 +4055,7 @@ void m() {
 \indextext{initialization|(}
 
 \pnum
-The process of initialization described in this subclause applies to
+The process of initialization described in \ref{dcl.init} applies to
 all initializations regardless of syntactic context, including the
 initialization of a function parameter\iref{expr.call}, the
 initialization of a return value\iref{stmt.return}, or when an
@@ -4115,7 +4115,7 @@ initializer follows a declarator.
 \end{bnf}
 
 \begin{note}
-The rules in this subclause apply even if the grammar permits only
+The rules in \ref{dcl.init} apply even if the grammar permits only
 the \grammarterm{brace-or-equal-initializer} form
 of \grammarterm{initializer} in a given context.
 \end{note}

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -667,12 +667,12 @@ The meaning of the macros in this header is defined by the POSIX standard.
 \rSec2[syserr.general]{General}
 
 \pnum
-This subclause describes components that the standard library and
+Subclause \ref{syserr} describes components that the standard library and
 \Cpp{} programs may use to report error conditions originating from
 the operating system or other low-level application program interfaces.
 
 \pnum
-Components described in this subclause shall not change the value of
+Components described in \ref{syserr} shall not change the value of
 \tcode{errno}\iref{errno}.
 Implementations should leave the error states provided by other
 libraries unchanged.

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2820,7 +2820,7 @@ the \tcode{++} operator.
 \end{example}
 
 \pnum
-The function templates defined in this subclause are not found by
+The function templates defined in \ref{range.iter.ops} are not found by
 argument-dependent name lookup\iref{basic.lookup.argdep}. When found by
 unqualified\iref{basic.lookup.unqual} name lookup for the
 \grammarterm{postfix-expression} in a function call\iref{expr.call}, they
@@ -2845,7 +2845,7 @@ to have the same type.
 
 \pnum
 The number and order of deducible template parameters for the function templates defined
-in this subclause is unspecified, except where explicitly stated otherwise.
+in \ref{range.iter.ops} is unspecified, except where explicitly stated otherwise.
 
 \rSec3[range.iter.op.advance]{\tcode{ranges::advance}}
 

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -442,7 +442,7 @@ and \tcode{x.front()} can be called only if \tcode{x.empty()} returns
 \rSec2[description.general]{General}
 
 \pnum
-This subclause describes the conventions used to specify the \Cpp{} standard
+Subclause \ref{description} describes the conventions used to specify the \Cpp{} standard
 library. \ref{structure} describes the structure of the normative
 \ref{\firstlibchapter} through \ref{\lastlibchapter} and
 \ref{depr}. \ref{conventions} describes other editorial conventions.
@@ -716,7 +716,7 @@ of other standards\iref{intro.refs}.
 \indextext{conventions}%
 
 \pnum
-This subclause describes several editorial conventions used to describe the contents
+Subclause \ref{conventions} describes several editorial conventions used to describe the contents
 of the \Cpp{} standard library.
 These conventions are for describing
 implementation-defined types\iref{type.descriptions},
@@ -1110,7 +1110,7 @@ An implementation may use any technique that provides equivalent observable beha
 \rSec2[requirements.general]{General}
 
 \pnum
-This subclause specifies requirements that apply to the entire \Cpp{} standard library.
+Subclause \ref{requirements} specifies requirements that apply to the entire \Cpp{} standard library.
 \ref{\firstlibchapter} through \ref{\lastlibchapter} and \ref{depr}
 specify the requirements of individual entities within the library.
 
@@ -1119,7 +1119,7 @@ Requirements specified in terms of interactions between threads do not apply to
 programs having only a single thread of execution.
 
 \pnum
-Within this subclause, \ref{organization} describes the library's contents and
+\ref{organization} describes the library's contents and
 organization, \ref{using} describes how well-formed \Cpp{} programs gain access to library
 entities,
 \ref{utility.requirements} describes constraints on types and functions used with
@@ -2577,7 +2577,7 @@ The \Cpp{} standard library reserves the following kinds of names:
 
 \pnum
 If a program declares or defines a name in a context where it is
-reserved, other than as explicitly allowed by this Clause, its behavior is
+reserved, other than as explicitly allowed by \ref{library}, its behavior is
 undefined.%
 \indextext{undefined}
 

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -1043,8 +1043,8 @@ argument whose value they ignore, but set to
 in case of a parse error.
 
 \pnum
-Within this clause it is unspecified whether one virtual function calls another
-virtual function.
+Within subclause \ref{locale.categories} it is unspecified whether
+one virtual function calls another virtual function.
 
 \rSec2[category.ctype]{The \tcode{ctype} category}
 

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -1665,7 +1665,7 @@ to either \tcode{endian::big} or \tcode{endian::little}.
 \indextext{random number generator|see{uniform random bit generator}}
 
 \pnum
-This subclause defines a facility
+Subclause \ref{rand} defines a facility
 for generating (pseudo-)random numbers.
 
 \pnum
@@ -1693,7 +1693,7 @@ and to templates producing such types when instantiated.
 
 \pnum
 \indextext{\idxcode{result_type}!entity characterization based on}%
-Each of the entities specified via this subclause
+Each of the entities specified in \ref{rand}
 has an associated arithmetic type\iref{basic.fundamental}
 identified as \tcode{result_type}.
 With \tcode{T} as the \tcode{result_type}
@@ -1720,11 +1720,11 @@ according to \tcode{numeric_limits<T>::is_signed}.
 \pnum
 Unless otherwise specified,
 all descriptions of calculations
-in this subclause
+in \ref{rand}
 use mathematical real numbers.
 
 \pnum
-Throughout this subclause,
+Throughout \ref{rand},
 the operators
 \bitand, \bitor, and \xor{}
 denote the respective conventional bitwise operations.
@@ -2907,30 +2907,30 @@ using distribution_type =  D;
 
 \pnum
 Each type instantiated
-from a class template specified in this subclause~\ref{rand.eng}
+from a class template specified in \ref{rand.eng}
 meets the requirements
 of a random number engine\iref{rand.req.eng} type.
 
 \pnum
 Except where specified otherwise,
 the complexity of each function
-specified in this subclause~\ref{rand.eng}
+specified in \ref{rand.eng}
 is constant.
 
 \pnum
 Except where specified otherwise,
-no function described in this subclause~\ref{rand.eng}
+no function described in \ref{rand.eng}
 throws an exception.
 
 \pnum
-Every function described in this subclause~\ref{rand.eng}
+Every function described in \ref{rand.eng}
 that has a function parameter \tcode{q} of type \tcode{Sseq\&}
 for a template type parameter named \tcode{Sseq}
 that is different from type \tcode{seed_seq}
 throws what and when the invocation of \tcode{q.generate} throws.
 
 \pnum
-Descriptions are provided in this subclause~\ref{rand.eng}
+Descriptions are provided in \ref{rand.eng}
 only for engine operations
 that are not described in \ref{rand.req.eng}
 or for operations where there is additional semantic information.
@@ -2942,7 +2942,7 @@ and for equality and inequality operators
 are not shown in the synopses.
 
 \pnum
-Each template specified in this subclause~\ref{rand.eng}
+Each template specified in \ref{rand.eng}
 requires one or more relationships,
 involving the value(s) of its non-type template parameter(s), to hold.
 A program instantiating any of these templates
@@ -2951,7 +2951,7 @@ if any such required relationship fails to hold.
 
 \pnum
 For every random number engine and for every random number engine adaptor \tcode{X}
-defined in this subclause\iref{rand.eng} and in subclause~\ref{rand.adapt}:
+defined in \ref{rand.eng} and in \ref{rand.adapt}:
 \begin{itemize}
 \item
 if the constructor
@@ -9870,7 +9870,7 @@ ISO C 7.12.3, 7.12.4
 \pnum
 \indextext{NaN}\indextext{domain error}%
 If any argument value
-to any of the functions specified in this subclause
+to any of the functions specified in \ref{sf.cmath}
 is a NaN (Not a Number),
 the function shall return a NaN
 but it shall not report a domain error.

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3466,13 +3466,13 @@ The allocation and deallocation functions,
 \keyword{operator} \tcode{\keyword{delete}[]},
 are described completely in~\ref{basic.stc.dynamic}.
 The attributes and restrictions
-found in the rest of this subclause do not apply to them unless explicitly
+found in the rest of \ref{over.oper} do not apply to them unless explicitly
 stated in~\ref{basic.stc.dynamic}.
 
 \pnum
 The \tcode{co_await} operator is described completely in~\ref{expr.await}.
 The attributes and restrictions
-found in the rest of this subclause do not apply to it unless explicitly
+found in the rest of \ref{over.oper} do not apply to it unless explicitly
 stated in~\ref{expr.await}.
 
 \pnum
@@ -3519,7 +3519,7 @@ except where explicitly stated below.
 Operator
 functions cannot have more or fewer parameters than the
 number required for the corresponding operator, as
-described in the rest of this subclause.
+described in the rest of \ref{over.oper}.
 
 \pnum
 Operators not mentioned explicitly in subclauses~\ref{over.ass} through~\ref{over.inc}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -339,7 +339,7 @@ header, the customization point objects in \ref{range.access} are
 available when \libheaderrefx{iterator}{iterator.synopsis} is included.
 
 \pnum
-Within this subclause,
+Within \ref{range.access},
 the \defnadj{reified}{object} of a subexpression \tcode{E} denotes
 \begin{itemize}
 \item
@@ -1267,7 +1267,7 @@ template<class T>
 \rSec2[range.utility.general]{General}
 
 \pnum
-The components in this subclause are general utilities for representing and
+The components in \ref{range.utility} are general utilities for representing and
 manipulating ranges.
 
 \rSec2[range.utility.helpers]{Helper concepts}
@@ -1831,7 +1831,7 @@ model \libconcept{borrowed_range}.
 \rSec2[range.factories.general]{General}
 
 \pnum
-This subclause defines \term{range factories},
+Subclause \ref{range.factories} defines \term{range factories},
 which are utilities to create a \libconcept{view}.
 
 \pnum
@@ -2914,7 +2914,7 @@ Equivalent to: \tcode{return x.\exposid{parent_} == nullptr || !*x.\exposid{pare
 \rSec2[range.adaptors.general]{General}
 
 \pnum
-This subclause defines \term{range adaptors}, which are utilities that transform a
+Subclause \ref{range.adaptors} defines \term{range adaptors}, which are utilities that transform a
 \libconcept{range} into a \libconcept{view} with custom behaviors. These
 adaptors can be chained to create pipelines of range transformations that
 evaluate lazily as the resulting view is iterated.

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -1245,7 +1245,7 @@ this.
 
 \pnum
 \indexlibraryglobal{regex_error}%
-The functions described in this Clause report errors by throwing
+The functions described in \ref{re.regex} report errors by throwing
 exceptions of type \tcode{regex_error}.
 
 \indexlibraryglobal{basic_regex}%

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -31,7 +31,7 @@ as summarized in \tref{strings.summary}.
 \rSec2[char.traits.general]{General}
 
 \pnum
-This subclause defines requirements on classes representing
+Subclause \ref{char.traits} defines requirements on classes representing
 \term{character traits},
 and defines a class template
 \tcode{char_traits<charT>},
@@ -49,8 +49,8 @@ Most classes specified in \ref{string.classes}, \ref{string.view},
 and \ref{input.output} need a set of related types and functions to complete
 the definition of their semantics.  These types and functions are provided as a
 set of member \grammarterm{typedef-name}{s} and functions in the template
-parameter \tcode{traits} used by each such template.  This subclause defines the
-semantics of these members.
+parameter \tcode{traits} used by each such template.
+Subclause \ref{char.traits} defines the semantics of these members.
 
 \pnum
 To specialize those templates to generate a string, string view, or
@@ -752,7 +752,7 @@ arbitrary char-like objects with the first element of the sequence at position z
 Such a sequence is also called a ``string'' if the type of the
 char-like objects that it holds
 is clear from context.
-In the rest of this Clause,
+In the rest of \ref{basic.string},
 the type of the char-like objects held in a \tcode{basic_string} object
 is designated by \tcode{charT}.
 
@@ -3942,7 +3942,7 @@ The same suffix \tcode{s} is used for \tcode{chrono::duration} literals denoting
 
 \pnum
 The class template \tcode{basic_string_view} describes an object that can refer to a constant contiguous sequence of char-like\iref{strings.general} objects with the first element of the sequence at position zero.
-In the rest of this subclause, the type of the char-like objects held in a \tcode{basic_string_view} object is designated by \tcode{charT}.
+In the rest of \ref{string.view}, the type of the char-like objects held in a \tcode{basic_string_view} object is designated by \tcode{charT}.
 
 \pnum
 \begin{note}

--- a/source/support.tex
+++ b/source/support.tex
@@ -3868,7 +3868,7 @@ if (auto p = dynamic_cast<const nested_exception*>(addressof(e)))
 The header \libheaderdef{initializer_list} defines a class template and several
 support functions related to list-initialization~(see \ref{dcl.init.list}).
 \indextext{signal-safe!\idxcode{initializer_list} functions}%
-All functions specified in this subclause are signal-safe\iref{support.signal}.
+All functions specified in \ref{support.initlist} are signal-safe\iref{support.signal}.
 
 \rSec2[initializer.list.syn]{Header \tcode{<initializer_list>} synopsis}
 \indexlibraryglobal{initializer_list}%
@@ -4932,7 +4932,7 @@ namespace std {
 \rSec3[coroutine.traits.general]{General}
 
 \pnum
-This subclause defines requirements on classes representing
+Subclause \ref{coroutine.traits} defines requirements on classes representing
 \term{coroutine traits},
 and defines the class template
 \tcode{coroutine_traits}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1468,7 +1468,7 @@ then \tcode{P} is not at least as specialized as \tcode{A}.
 
 \pnum
 \begin{note}
-This subclause defines the meaning of constraints on template arguments.
+Subclause \ref{temp.constr} defines the meaning of constraints on template arguments.
 The abstract syntax and satisfaction rules are defined
 in \ref{temp.constr.constr}.
 Constraints are associated with declarations in \ref{temp.constr.decl}.
@@ -4920,7 +4920,7 @@ An expression may be
 \defnx{value-dependent}{expression!value-dependent}
 (that is, its value when evaluated as a constant expression\iref{expr.const}
 may depend on a template parameter)
-as described in this subclause.
+as described below.
 
 \pnum
 In an expression of the form:

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -308,7 +308,7 @@ for the current execution agent.
 \rSec2[thread.stoptoken.intro]{Introduction}
 
 \pnum
-This clause describes components that can be used
+Subclause \ref{thread.stoptoken} describes components that can be used
 to asynchonously request that an operation stops execution in a timely manner,
 typically because the result is no longer required.
 Such a request is called a \defn{stop request}.
@@ -1917,7 +1917,7 @@ Timeout-related exceptions\iref{thread.req.timing}.
 \rSec2[thread.mutex.general]{General}
 
 \pnum
-This subclause provides mechanisms for mutual exclusion: mutexes, locks, and call
+Subclause \ref{thread.mutex} provides mechanisms for mutual exclusion: mutexes, locks, and call
 once. These mechanisms ease the production of race-free
 programs\iref{intro.multithread}.
 
@@ -1989,8 +1989,8 @@ recursive and non-recursive mutexes are supplied.
 The \defn{mutex types} are the standard library types \tcode{mutex},
 \tcode{recursive_mutex}, \tcode{timed_mutex}, \tcode{recursive_timed_mutex},
 \tcode{shared_mutex}, and \tcode{shared_timed_mutex}.
-They meet the requirements set out in this subclause. In this description, \tcode{m}
-denotes an object of a mutex type.
+They meet the requirements set out in \ref{thread.mutex.requirements.mutex}.
+In this description, \tcode{m} denotes an object of a mutex type.
 
 \pnum
 The mutex types meet the \oldconcept{Lockable} requirements\iref{thread.req.lockable.req}.
@@ -5346,7 +5346,7 @@ allowed for mutex types\iref{thread.mutex.requirements.mutex}.
 \rSec2[thread.coord.general]{General}
 
 \pnum
-This subclause describes various concepts related to thread coordination, and
+Subclause \ref{thread.coord} describes various concepts related to thread coordination, and
 defines the coordination types \tcode{latch} and \tcode{barrier}.
 These types facilitate concurrent computation performed by a number of threads.
 

--- a/source/time.tex
+++ b/source/time.tex
@@ -2598,7 +2598,7 @@ template<class ToDuration, class Clock, class Duration>
 \rSec2[time.clock.general]{General}
 
 \pnum
-The types defined in this subclause meet the
+The types defined in \ref{time.clock} meet the
 \oldconcept{TrivialClock}
 requirements\iref{time.clock.req}
 unless otherwise specified.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -5270,7 +5270,7 @@ The specialization is enabled\iref{unord.hash}.
 \rSec2[any.general]{General}
 
 \pnum
-This subclause describes components that \Cpp{} programs may use to perform operations on objects of a discriminated type.
+Subclause \ref{any} describes components that \Cpp{} programs may use to perform operations on objects of a discriminated type.
 
 \pnum
 \begin{note}
@@ -6035,7 +6035,7 @@ The integral value corresponding to two
 or more bits is the sum of their bit values.
 
 \pnum
-The functions described in this subclause can report three kinds of
+The functions described in \ref{template.bitset} can report three kinds of
 errors, each associated with a distinct exception:
 \begin{itemize}
 \item
@@ -8433,7 +8433,7 @@ deleter before such replacement is considered completed.
 
 \pnum
 Each object of a type \tcode{U} instantiated from the \tcode{unique_ptr} template
-specified in this subclause has the strict ownership semantics, specified above,
+specified in \ref{unique.ptr} has the strict ownership semantics, specified above,
 of a unique pointer. In partial satisfaction of these semantics, each such \tcode{U}
 is \oldconcept{MoveConstructible} and \oldconcept{MoveAssignable}, but is not
 \oldconcept{CopyConstructible} nor \oldconcept{CopyAssignable}.
@@ -14770,7 +14770,7 @@ the initialization of the state entities of \tcode{g}\iref{func.def}.
 \indextext{function object!binders|(}
 
 \pnum
-This subclause describes a uniform mechanism for binding
+Subclause \ref{func.bind} describes a uniform mechanism for binding
 arguments of callable objects.
 
 \rSec3[func.bind.isbind]{Class template \tcode{is_bind_expression}}
@@ -15001,7 +15001,7 @@ used in a function call expression\iref{expr.call} of \tcode{pm}.
 \indextext{function object!wrapper|(}
 
 \pnum
-This subclause describes a polymorphic wrapper class that
+Subclause \ref{func.wrap} describes a polymorphic wrapper class that
 encapsulates arbitrary callable objects.
 
 \rSec3[func.wrap.badcall]{Class \tcode{bad_function_call}}%
@@ -15467,7 +15467,7 @@ As if by: \tcode{f1.swap(f2);}
 \rSec3[func.search.general]{General}
 
 \pnum
-This subclause provides function object types\iref{function.objects} for
+Subclause \ref{func.search} provides function object types\iref{function.objects} for
 operations that search for a sequence \range{pat\textunderscore\nobreak first}{pat_last} in another
 sequence \range{first}{last} that is provided to the object's function call
 operator.  The first sequence (the pattern to be searched for) is provided to
@@ -15475,7 +15475,7 @@ the object's constructor, and the second (the sequence to be searched) is
 provided to the function call operator.
 
 \pnum
-Each specialization of a class template specified in this subclause \ref{func.search}
+Each specialization of a class template specified in \ref{func.search}
 shall meet the \oldconcept{CopyConst\-ruct\-ible} and \oldconcept{CopyAssignable} requirements.
 Template parameters named
 \begin{itemize}
@@ -15487,7 +15487,7 @@ Template parameters named
 \item \tcode{RandomAccessIterator2}, and
 \item \tcode{BinaryPredicate}
 \end{itemize}
-of templates specified in this subclause
+of templates specified in
 \ref{func.search} shall meet the same requirements and semantics as
 specified in \ref{algorithms.general}.
 Template parameters named \tcode{Hash} shall meet the \oldconcept{Hash}
@@ -15820,7 +15820,7 @@ program-defined specialization that depends on at least one program-defined type
 \rSec2[meta.general]{General}
 
 \pnum
-This subclause describes components used by \Cpp{} programs, particularly in
+Subclause \ref{meta} describes components used by \Cpp{} programs, particularly in
 templates, to support the widest possible range of types, optimise
 template code usage, detect type related user errors, and perform
 type inference and transformation at compile time. It includes type
@@ -15833,7 +15833,7 @@ type transformations allow certain properties of types to be manipulated.
 
 \pnum
 \indextext{signal-safe!type traits}%
-All functions specified in this subclause are signal-safe\iref{support.signal}.
+All functions specified in \ref{meta} are signal-safe\iref{support.signal}.
 
 \rSec2[meta.rqmts]{Requirements}
 
@@ -15879,16 +15879,16 @@ named \tcode{type}, which shall be a synonym for the modified type.
 \pnum
 Unless otherwise specified,
 the behavior of a program that adds specializations
-for any of the templates specified in this subclause~\ref{meta}
+for any of the templates specified in \ref{meta}
 is undefined.
 
 \pnum
 Unless otherwise specified, an incomplete type may be used
-to instantiate a template specified in this subclause.
+to instantiate a template specified in \ref{meta}.
 The behavior of a program is undefined if:
 \begin{itemize}
 \item
-  an instantiation of a template specified in subclause~\ref{meta}
+  an instantiation of a template specified in \ref{meta}
   directly or indirectly depends on
   an incompletely-defined object type \tcode{T}, and
 \item
@@ -16357,7 +16357,7 @@ the interface for various type traits.
 \rSec3[meta.unary.general]{General}
 
 \pnum
-This subclause contains templates that may be used to query the
+Subclause \ref{meta.unary} contains templates that may be used to query the
 properties of a type at compile time.
 
 \pnum
@@ -17265,11 +17265,11 @@ being ill-formed.
 
 \rSec3[meta.trans.general]{General}
 \pnum
-This subclause contains templates that may be used to transform one
+Subclause \ref{meta.trans} contains templates that may be used to transform one
 type to another following some predefined rule.
 
 \pnum
-Each of the templates in this subclause shall be a
+Each of the templates in \ref{meta.trans} shall be a
 \oldconcept{TransformationTrait}\iref{meta.rqmts}.
 
 \rSec3[meta.trans.cv]{Const-volatile modifications}


### PR DESCRIPTION
These typically mean the parent subclause now. Mechanically:

"this subclause" became "\ref{parent}".

"This subclause" became "Subclause \ref{parent}", because it doesn't
look great to start a sentennce with a subclause number.

... with some manual fixups for cases where that didn't work out well.