### PR TITLE
[intro.ack] Dissolve subclause.

### DIFF
--- a/source/back.tex
+++ b/source/back.tex
@@ -2,10 +2,20 @@
 
 \chapter{Bibliography}
 
-The following documents are cited informatively in this document.
-
 \begin{itemize}
 \renewcommand{\labelitemi}{---}
+\item
+  Bjarne Stroustrup,
+  \doccite{The \Cpp{} Programming Language, second edition}, Chapter R.
+  Addison-Wesley Publishing Company, ISBN 0-201-53992-6, copyright \copyright 1991 AT\&T
+\item
+  Brian W. Kernighan and Dennis M. Ritchie,
+  \doccite{The C Programming Language}, Appendix A.
+  Prentice-Hall, 1978, ISBN 0-13-110163-3, copyright \copyright 1978 AT\&T
+\item
+  P.J. Plauger,
+  \doccite{The Draft Standard \Cpp{} Library}.
+  Prentice-Hall, ISBN 0-13-117003-1, copyright \copyright 1995 P.J. Plauger)
 \item
   IANA Time Zone Database,
   available at \url{https://www.iana.org/time-zones}

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -33,7 +33,12 @@ of this document. For dated references, only the edition cited applies.
 For undated references, the latest edition of the referenced document
 (including any amendments) applies.
 \begin{itemize}
-\item Ecma International, \doccite{ECMAScript Language Specification},
+\item Ecma International, \doccite{ECMAScript%
+\footnote{ECMAScript\textregistered\ is a registered trademark of Ecma
+International.
+This information is given for the convenience of users of this document and
+does not constitute an endorsement by ISO or IEC of this product.}
+Language Specification},
 Standard Ecma-262, third edition, 1999.
 \item ISO/IEC 2382 (all parts), \doccite{Information technology ---
 Vocabulary}
@@ -41,7 +46,11 @@ Vocabulary}
 Information interchange --- Representation of dates and times}
 \item ISO/IEC 9899:2018, \doccite{Programming languages --- C}
 \item ISO/IEC 9945:2003, \doccite{Information Technology --- Portable
-Operating System Interface (POSIX)}
+Operating System Interface (POSIX%
+\footnote{POSIX\textregistered\ is a registered trademark of
+the Institute of Electrical and Electronic Engineers, Inc.
+This information is given for the convenience of users of this document and
+does not constitute an endorsement by ISO or IEC of this product.})}
 \item ISO/IEC 10646, \doccite{Information technology ---
 Universal Coded Character Set (UCS)}
 \item ISO/IEC 10646-1:1993, \doccite{Information technology ---
@@ -54,7 +63,11 @@ Part 2: Mathematical signs and symbols
 to be used in the natural sciences and technology}
 %%% Format for the following entry is based on that specified at
 %%% http://www.iec.ch/standardsdev/resources/draftingpublications/directives/principles/referencing.htm
-\item The Unicode Consortium. Unicode Standard Annex, UAX \#29, \doccite{Unicode Text Segmentation} [online].
+\item The Unicode Consortium. Unicode%
+\footnote{Unicode\textregistered\ is a registered trademark of Unicode, Inc.
+This information is given for the convenience of users of this document and
+does not constitute an endorsement by ISO or IEC of this product.}
+Standard Annex, UAX \#29, \doccite{Unicode Text Segmentation} [online].
 Edited by Mark Davis. Revision 35; issued for Unicode 12.0.0. 2019-02-15 [viewed 2020-02-23].
 Available at \url{http://www.unicode.org/reports/tr29/tr29-35.html}
 \end{itemize}
@@ -658,34 +671,3 @@ intervening commas (e.g., \grammarterm{identifier-list} is a sequence of
 identifiers separated by commas).
 \end{itemize}%
 \indextext{notation!syntax|)}
-
-\rSec1[intro.ack]{Acknowledgments}
-
-\pnum
-The \Cpp{}  programming language as described in this document
-is based on the language as described in Chapter R (Reference
-Manual) of Stroustrup: \doccite{The \Cpp{}  Programming Language} (second
-edition, Addison-Wesley Publishing Company, ISBN 0-201-53992-6,
-copyright \copyright 1991 AT\&T). That, in turn, is based on the C
-programming language as described in Appendix A of Kernighan and
-Ritchie: \doccite{The C Programming Language} (Prentice-Hall, 1978, ISBN
-0-13-110163-3, copyright \copyright 1978 AT\&T).
-
-\pnum
-Portions of the library Clauses of this document are based
-on work by P.J. Plauger, which was published as \doccite{The Draft
-Standard \Cpp{}  Library} (Prentice-Hall, ISBN 0-13-117003-1, copyright
-\copyright 1995 P.J. Plauger).
-
-\pnum
-POSIX\textregistered\ is a registered trademark of the Institute of Electrical and
-Electronic Engineers, Inc.
-
-\pnum
-ECMAScript\textregistered\ is a registered trademark of Ecma International.
-
-\pnum
-Unicode\textregistered\ is a registered trademark of Unicode, Inc.
-
-\pnum
-All rights in these originals are reserved.

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -282,6 +282,9 @@
 % Shortened label
 \movedxref{language.support}{support}
 
+% Dissolved subclause
+\movedxref{intro.ack}{intro.refs}
+
 % Deprecated features.
 \deprxref{util.smartptr.shared.atomic}
 \deprxref{res.on.required}


### PR DESCRIPTION
Integrate trademark acknowledgements into [intro.refs].
Add base works to the bibliography.

Partially addresses ISO/CS 016 (C++20 DIS)

Fixes cplusplus/nbballot#399