### PR TITLE
Fix solitary subclauses

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -1659,9 +1659,7 @@ with a member typedef \tcode{type} that names the following type:
 \end{itemize}
 \end{itemdescr}
 
-\rSec1[depr.iterator.primitives]{Deprecated iterator primitives}
-
-\rSec2[depr.iterator.basic]{Basic iterator}
+\rSec1[depr.iterator]{Deprecated \tcode{iterator} class template}
 
 \pnum
 The header \libheaderrefx{iterator}{iterator.synopsis} has the following addition:

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -393,7 +393,7 @@ namespace std {
   template<@\libconcept{input_iterator}@ I>
     struct iterator_traits<counted_iterator<I>>;
 
-  // \ref{unreachable.sentinels}, unreachable sentinels
+  // \ref{unreachable.sentinel}, unreachable sentinel
   struct unreachable_sentinel_t;
   inline constexpr unreachable_sentinel_t unreachable_sentinel{};
 
@@ -5664,9 +5664,7 @@ template<@\libconcept{indirectly_swappable}@<I> I2>
 Equivalent to \tcode{ranges::iter_swap(x.current, y.current)}.
 \end{itemdescr}
 
-\rSec2[unreachable.sentinels]{Unreachable sentinel}
-
-\rSec3[unreachable.sentinel]{Class \tcode{unreachable_sentinel_t}}
+\rSec2[unreachable.sentinel]{Unreachable sentinel}
 
 \indexlibraryglobal{unreachable_sentinel_t}%
 \pnum

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -969,9 +969,7 @@ used in a loop, it is faster to cache the
 facet and use it directly, or use the vector form of
 \tcode{ctype<>::is}.}
 
-\rSec3[conversions]{Conversions}
-
-\rSec4[conversions.character]{Character conversions}
+\rSec3[conversions.character]{Character conversions}
 
 \indexlibraryglobal{toupper}%
 \begin{itemdecl}
@@ -5051,6 +5049,8 @@ namespace std {
 \pnum
 The contents and meaning of the header \libheaderdef{clocale}
 are the same as the C standard library header \libheader{locale.h}.
+
+\rSec2[clocale.data.races]{Data races}
 
 \pnum
 Calls to the function \tcode{setlocale} may introduce a data

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -159,6 +159,10 @@ this document does not specify the effect on
 floating-point evaluation in constant expressions.
 \end{note}
 
+\xrefc{7.6}
+
+\rSec2[cfenv.thread]{Threads}
+
 \pnum
 The floating-point environment has thread storage
 duration\iref{basic.stc.thread}. The initial state for a thread's floating-point
@@ -175,8 +179,6 @@ state of the parent thread at the time of the child's creation.
 \pnum
 A separate floating-point environment is maintained for each thread. Each function
 accesses the environment corresponding to its calling thread.
-
-\xrefc{7.6}
 
 \rSec1[complex.numbers]{Complex numbers}
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -1694,6 +1694,14 @@ the C standard library header \libheader{float.h}.
 
 \rSec1[cstdint]{Integer types}
 
+\rSec2[cstdint.general]{General}
+
+\pnum
+The header
+\libheaderref{cstdint}
+supplies integer types having specified widths, and
+macros that specify limits of integer types.
+
 \rSec2[cstdint.syn]{Header \tcode{<cstdint>} synopsis}
 
 \indexheader{cstdint}%

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -287,3 +287,9 @@
 \deprxref{res.on.required}
 \deprxref{fs.path.factory}
 \movedxref{operators}{depr.relops}
+
+% Collapsed subclauses with no siblings.
+\movedxref{depr.iterator.primitives}{depr.iterator}
+\movedxref{depr.iterator.basic}{depr.iterator}
+\movedxref{unreachable.sentinels}{unreachable.sentinel}
+\movedxref{conversions}{conversions.character}


### PR DESCRIPTION
[ISO/CS comment 018 on the C++20 DIS](https://github.com/cplusplus/nbballot/issues/394) requests that we avoid subclauses with no siblings.

Merging this to master will address #3525.

Fixes cplusplus/nbballot#394