### PR TITLE
[check] Detect subclauses without siblings.

### DIFF
--- a/tools/check.sh
+++ b/tools/check.sh
@@ -93,6 +93,24 @@ for f in $texfiles; do
     awk -F: 'BEGIN { prevlevel = 0 } $3 ~ /^\\rSec./ { match($3, "[0-9]"); level=substr($3, RSTART, 1); if (text && level > prevlevel) { print prevsec " <-- Hanging paragraph follows" } prevlevel = level; prevsec = $3; text = 0 } $3 == "x" { text = 1 }'
 done | grep . && exit 1
 
+# Subclauses without siblings
+for f in $texfiles; do
+    sed -n '/^\\rSec/{=;p}' $f |
+    # prefix output with filename and line
+    sed '/^[0-9]\+$/{N;s/\n/:/}' | sed "s/.*/$f:&/" |
+    awk -F: 'BEGIN { prevlevel = 0 }
+      {
+	match($3, "[0-9]");
+	level = substr($3, RSTART, 1);
+	if (level < prevlevel && secs[prevlevel] == 1) { print title[prevlevel] " <-- Subclause without siblings" }
+	++secs[level];
+	title[level] = $0;
+	secs[level + 1] = 0;
+	prevlevel = level;
+      }'
+done | grep . && exit 1
+
+
 # Library descriptive macros not immediately preceded by \pnum.
 for f in $texlibdesc; do
     sed -n '/^\\pnum/{h;:x;n;/^\\index/b x;/^\\\(constraints\|mandates\|expects\|effects\|sync\|ensures\|returns\|throws\|complexity\|remarks\|errors\)/{x;/\n/{x;=;p};d};/^\\pnum/D;H;b x}' $f |


### PR DESCRIPTION
According to the ISO Directives, Part 2, each subclause
is required to have at least one sibling.

Partially addresses #3525 and cplusplus/nbballot#394