### PR TITLE
[intro.refs] Fix clause reference to ISO/IEC 9899.

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -73,7 +73,7 @@ Available at \url{http://www.unicode.org/reports/tr29/tr29-35.html}
 \end{itemize}
 
 \pnum
-The library described in Clause 7 of ISO/IEC 9899:2018
+The library described in ISO/IEC 9899:2018, Clause 7,
 is hereinafter called the
 \defnx{C standard library}{C!standard library}.%
 \footnote{With the qualifications noted in \ref{\firstlibchapter}


### PR DESCRIPTION
Fixes cplusplus/nbballot#402