### PR TITLE
[intro.refs] Update from ISO/IEC 10646-1:1993 to ISO/IEC 10646:2003.

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -2144,7 +2144,7 @@ For the facet \tcode{codecvt_utf8_utf16}\indexlibraryglobal{codecvt_utf8_utf16}:
 
 \pnum
 The encoding forms UTF-8, UTF-16, and UTF-32 are specified in ISO/IEC 10646.
-The encoding form UCS-2 is specified in ISO/IEC 10646-1:1993.
+The encoding form UCS-2 is specified in ISO/IEC 10646:2003.
 
 \rSec1[depr.conversions]{Deprecated convenience conversion interfaces}
 

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -53,9 +53,8 @@ This information is given for the convenience of users of this document and
 does not constitute an endorsement by ISO or IEC of this product.})}
 \item ISO/IEC 10646, \doccite{Information technology ---
 Universal Coded Character Set (UCS)}
-\item ISO/IEC 10646-1:1993, \doccite{Information technology ---
-Universal Multiple-Octet Coded Character Set (UCS) --- Part 1:
-Architecture and Basic Multilingual Plane}
+\item ISO/IEC 10646:2003, \doccite{Information technology ---
+Universal Multiple-Octet Coded Character Set (UCS)}
 \item ISO/IEC/IEEE 60559:2011, \doccite{Information technology ---
 Microprocessor Systems --- Floating-Point arithmetic}
 \item ISO 80000-2:2009, \doccite{Quantities and units ---
@@ -91,7 +90,7 @@ hereinafter called \defn{ECMA-262}.
 
 \pnum
 \begin{note}
-References to ISO/IEC 10646-1:1993 are used only
+References to ISO/IEC 10646:2003 are used only
 to support deprecated features\iref{depr.locale.stdcvt}.
 \end{note}
 


### PR DESCRIPTION
This is the most recent version of ISO/IEC 10646 that
specifies the encoding form UCS-2.

Partially addresses ISO/CS 016 (C++20 DIS)

Fixes cplusplus/nbballot#401