### PR TITLE
[time.cal.year.nonmembers] Avoid narrowing conversion

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -4771,7 +4771,7 @@ constexpr year operator+(const year& x, const years& y) noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{year\{int\{x\} + y.count()\}}.
+\tcode{year\{int\{x\} + static_cast<int>(y.count())\}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{year}%


### PR DESCRIPTION
The years::rep type could be a signed integer wider than int.