### PR TITLE
[intro.refs,time.format] Fix normative references.

### DIFF
--- a/source/back.tex
+++ b/source/back.tex
@@ -26,6 +26,16 @@
 \item
   ISO 4217:2015,
   \doccite{Codes for the representation of currencies}
+\item
+  ISO/IEC/IEEE 60559:2011, \doccite{Information technology ---
+  Microprocessor Systems --- Floating-Point arithmetic}
+\item
+  %%% Format for the following entry is based on that specified at
+  %%% http://www.iec.ch/standardsdev/resources/draftingpublications/directives/principles/referencing.htm
+  The Unicode Consortium. Unicode Standard Annex, UAX \#29,
+  \doccite{Unicode Text Segmentation} [online].
+  Edited by Mark Davis. Revision 35; issued for Unicode 12.0.0. 2019-02-15 [viewed 2020-02-23].
+  Available at \url{http://www.unicode.org/reports/tr29/tr29-35.html}
 \end{itemize}
 
 The arithmetic specification described in ISO/IEC 10967-1:2012 is

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3056,7 +3056,11 @@ The fundamental storage unit in the \Cpp{} memory model is the
 A byte is at least large enough to contain any member of the basic
 \indextext{character set!basic execution}%
 execution character set\iref{lex.charset}
-and the eight-bit code units of the Unicode UTF-8 encoding form
+and the eight-bit code units of the Unicode%
+  \footnote{Unicode\textregistered\ is a registered trademark of Unicode, Inc.
+  This information is given for the convenience of users of this document and
+  does not constitute an endorsement by ISO or IEC of this product.}
+UTF-8 encoding form
 and is composed of a contiguous sequence of
 bits,\footnote{The number of bits in a byte is reported by the macro
 \tcode{CHAR_BIT} in the header \libheaderref{climits}.}

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -54,20 +54,9 @@ does not constitute an endorsement by ISO or IEC of this product.})}
 Universal Coded Character Set (UCS)}
 \item ISO/IEC 10646:2003, \doccite{Information technology ---
 Universal Multiple-Octet Coded Character Set (UCS)}
-\item ISO/IEC/IEEE 60559:2011, \doccite{Information technology ---
-Microprocessor Systems --- Floating-Point arithmetic}
 \item ISO 80000-2:2009, \doccite{Quantities and units ---
 Part 2: Mathematical signs and symbols
 to be used in the natural sciences and technology}
-%%% Format for the following entry is based on that specified at
-%%% http://www.iec.ch/standardsdev/resources/draftingpublications/directives/principles/referencing.htm
-\item The Unicode Consortium. Unicode%
-\footnote{Unicode\textregistered\ is a registered trademark of Unicode, Inc.
-This information is given for the convenience of users of this document and
-does not constitute an endorsement by ISO or IEC of this product.}
-Standard Annex, UAX \#29, \doccite{Unicode Text Segmentation} [online].
-Edited by Mark Davis. Revision 35; issued for Unicode 12.0.0. 2019-02-15 [viewed 2020-02-23].
-Available at \url{http://www.unicode.org/reports/tr29/tr29-35.html}
 \end{itemize}
 
 \pnum

--- a/source/time.tex
+++ b/source/time.tex
@@ -10490,7 +10490,8 @@ are copied unchanged to the output.
 \pnum
 Each conversion specifier \fmtgrammarterm{conversion-spec}
 is replaced by appropriate characters
-as described in \tref{time.format.spec}.
+as described in \tref{time.format.spec};
+the formats specified in ISO 8601:2004 shall be used where so described.
 Some of the conversion specifiers
 depend on the locale that is passed to the formatting function
 if the latter takes one,


### PR DESCRIPTION
ISO/IEC/IEEE 60559:2011 and UAX#29 are not normative
requirements of C++ and thus were moved to the bibliography.
For ISO 8601:2004, highlighted its normative impact on
time formatting.
Move the footnote about the Unicode trademark to the
new first mention of the term in [intro.memory].

Fixes ISO/CS 002 (C++20 DIS)

Fixes cplusplus/nbballot#378