### PR TITLE
[everywhere] Follow ISO rules for the presentation of notes and examples

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -4399,7 +4399,7 @@ do not overlap.
 \begin{note}
 For the overload with an \tcode{ExecutionPolicy},
 there may be a performance cost
-if \tcode{iterator_traits<ForwardIterator1>::value_type}
+if \tcode{iterator_traits<For\-ward\-It\-er\-ator1>::value_type}
 is not \oldconcept{\-Move\-Constructible} (\tref{cpp17.moveconstructible}).
 \end{note}
 
@@ -9736,7 +9736,7 @@ of \tcode{unary_op} and \tcode{binary_op}.
 \pnum
 \begin{note}
 The difference between \tcode{transform_exclusive_scan} and
-\tcode{transform_inclusive_scan} is that \tcode{transform_exclusive_scan}
+\tcode{transform_inclusive_scan} is that \tcode{trans\-form\-_\-exclusive_scan}
 excludes the $i^\text{th}$ input element from the $i^\text{th}$ sum.
 If \tcode{binary_op} is not mathematically associative,
 the behavior of \tcode{transform_exclusive_scan} may be nondeterministic.
@@ -9840,7 +9840,7 @@ of \tcode{unary_op} and \tcode{binary_op}.
 \pnum
 \begin{note}
 The difference between \tcode{transform_exclusive_scan} and
-\tcode{transform_inclusive_scan} is that \tcode{transform_inclusive_scan}
+\tcode{transform_inclusive_scan} is that \tcode{trans\-form\-_\-inclusive_scan}
 includes the $i^\text{th}$ input element in the $i^\text{th}$ sum.
 If \tcode{binary_op} is not mathematically associative,
 the behavior of \tcode{transform_inclusive_scan} may be nondeterministic.

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -336,9 +336,13 @@ during the lifetime of each container object
 or until the allocator is replaced. The allocator may be replaced only via assignment or
 \tcode{swap()}. Allocator replacement is performed by
 copy assignment, move assignment, or swapping of the allocator only if
-\tcode{allocator_traits<allocator_type>::propagate_on_container_copy_assignment::value},
-\tcode{allocator_traits<allocator_type>::propagate_on_container_move_assignment::value},
-or \tcode{alloca\-tor_traits<allocator_type>::propagate_on_container_swap::value} is \tcode{true}
+\begin{itemize}
+\item \tcode{allocator_traits<allocator_type>::propagate_on_container_copy_assignment::value},
+\item \tcode{allocator_traits<allocator_type>::propagate_on_container_move_assignment::value},
+or
+\item \tcode{allocator_traits<allocator_type>::propagate_on_container_swap::value}
+\end{itemize}
+is \tcode{true}
 within the implementation of the corresponding container operation.
 In all container types defined in this Clause, the member \tcode{get_allocator()}
 returns a copy of the allocator used to construct the container or, if that allocator

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4549,7 +4549,7 @@ type\iref{basic.fundamental} is \impldef{\tcode{sizeof} applied to
 fundamental types
 other than \tcode{char}, \tcode{signed char}, and \tcode{unsigned char}}.
 \begin{note}
-In particular, \tcode{sizeof(bool)}, \tcode{sizeof(char16_t)},
+In particular, the values of \tcode{sizeof(bool)}, \tcode{sizeof(char16_t)},
 \tcode{sizeof(char32_t)}, and \tcode{sizeof(wchar_t)} are
 implementation-defined.\footnote{\tcode{sizeof(bool)} is not required to be \tcode{1}.}
 \end{note}

--- a/source/future.tex
+++ b/source/future.tex
@@ -2663,9 +2663,9 @@ For Windows-based operating systems a conversion from UTF-8 to
 \begin{note}
 The example above is representative of
 a historical use of \tcode{filesystem::u8path}.
-Passing a \tcode{std::u8string} to \tcode{path}'s constructor is preferred
-for an indication of UTF-8 encoding more consistent with
-\tcode{path}'s handling of other encodings.
+To indicate a UTF-8 encoding,
+passing a \tcode{std::u8string} to \tcode{path}'s constructor is preferred
+as it is consistent with \tcode{path}'s handling of other encodings.
 \end{note}
 \end{itemdescr}
 

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -913,13 +913,6 @@ implementations.
 published description, and explains in detail the differences between
 \Cpp{} and C\@. Certain features of \Cpp{} exist solely for compatibility
 purposes; \ref{depr} describes those features.
-
-\pnum
-Throughout this document, each example is introduced by
-``\noteintro{Example}'' and terminated by ``\noteoutro{example}''. Each note is
-introduced by ``\noteintro{Note}'' or ``\noteintro{Note $n$ to entry}'' and
-terminated by ``\noteoutro{note}''. Examples
-and notes may be nested.%
 \indextext{standard!structure of|)}
 
 \rSec1[syntax]{Syntax notation}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -14883,8 +14883,9 @@ As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{note}
-To iterate over the current directory, use \tcode{recursive_directory_iterator(".")}
- rather than \tcode{recursive_directory_iterator("")}.
+Use \tcode{recursive_directory_iterator(".")}
+rather than \tcode{recursive_directory_iterator("")}
+to iterate over the current directory.
 \end{note}
 
 \pnum

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1903,18 +1903,12 @@ of type \tcode{X} are swappable\iref{swappable.requirements}, and
 the indicated semantics.
 \end{itemize}
 
-\begin{libreqtab4b}
+\begin{libreqtab4b}[floattable]
 {\oldconcept{Iterator} requirements}
 {iterator}
-\\ \topline
+\topline
 \lhdr{Expression}   &   \chdr{Return type}  &   \chdr{Operational}  &   \rhdr{Assertion/note}       \\
                     &                       &   \chdr{semantics}    &   \rhdr{pre-/post-condition}   \\ \capsep
-\endfirsthead
-\continuedcaption\\
-\hline
-\lhdr{Expression}   &   \chdr{Return type}  &   \chdr{Operational}  &   \rhdr{Assertion/note}       \\
-                    &                       &   \chdr{semantics}    &   \rhdr{pre-/post-condition}   \\ \capsep
-\endhead
 
 \tcode{*r}          &
   unspecified       &
@@ -2045,18 +2039,13 @@ if \tcode{X} meets the \oldconcept{Iterator} requirements\iref{iterator.iterator
 and the expressions in \tref{outputiterator}
 are valid and have the indicated semantics.
 
-\begin{libreqtab4b}
+\begin{libreqtab4b}[floattable]
 {\oldconcept{OutputIterator} requirements (in addition to \oldconcept{Iterator})}
 {outputiterator}
-\\ \topline
+\topline
 \lhdr{Expression}   &   \chdr{Return type}  &   \chdr{Operational}  &   \rhdr{Assertion/note}       \\
                     &                       &   \chdr{semantics}    &   \rhdr{pre-/post-condition}   \\ \capsep
-\endfirsthead
-\continuedcaption\\
-\hline
-\lhdr{Expression}   &   \chdr{Return type}  &   \chdr{Operational}  &   \rhdr{Assertion/note}       \\
-                    &                       &   \chdr{semantics}    &   \rhdr{pre-/post-condition}   \\ \capsep
-\endhead
+
 \tcode{*r = o}      &
  result is not used &
                     &
@@ -2147,18 +2136,13 @@ a mutable iterator
 allows the use of multi-pass one-directional algorithms with forward iterators.
 \end{note}
 
-\begin{libreqtab4b}
+\begin{libreqtab4b}[floattable]
 {\oldconcept{ForwardIterator} requirements (in addition to \oldconcept{InputIterator})}
 {forwarditerator}
-\\ \topline
+\topline
 \lhdr{Expression}   &   \chdr{Return type}  &   \chdr{Operational}  &   \rhdr{Assertion/note}       \\
                     &                       &   \chdr{semantics}    &   \rhdr{pre-/post-condition}   \\ \capsep
-\endfirsthead
-\continuedcaption\\
-\hline
-\lhdr{Expression}   &   \chdr{Return type}  &   \chdr{Operational}  &   \rhdr{Assertion/note}       \\
-                    &                       &   \chdr{semantics}    &   \rhdr{pre-/post-condition}   \\ \capsep
-\endhead
+
 \tcode{r++}         &
  convertible to \tcode{const X\&}   &
  \tcode{\{ X tmp = r;}\br
@@ -2188,18 +2172,13 @@ meets the requirements of a bidirectional iterator if,
 in addition to meeting the \oldconcept{ForwardIterator} requirements,
 the following expressions are valid as shown in \tref{bidirectionaliterator}.
 
-\begin{libreqtab4b}
+\begin{libreqtab4b}[floattable]
 {\oldconcept{BidirectionalIterator} requirements (in addition to \oldconcept{ForwardIterator})}
 {bidirectionaliterator}
-\\ \topline
+\topline
 \lhdr{Expression}   &   \chdr{Return type}  &   \chdr{Operational}  &   \rhdr{Assertion/note}       \\
                     &                       &   \chdr{semantics}    &   \rhdr{pre-/post-condition}   \\ \capsep
-\endfirsthead
-\continuedcaption\\
-\hline
-\lhdr{Expression}   &   \chdr{Return type}  &   \chdr{Operational}  &   \rhdr{Assertion/note}       \\
-                    &                       &   \chdr{semantics}    &   \rhdr{pre-/post-condition}   \\ \capsep
-\endhead
+
 \tcode{\dcr r}      &
  \tcode{X\&}        &
                     &

--- a/source/layout.tex
+++ b/source/layout.tex
@@ -32,14 +32,18 @@
 %%--------------------------------------------------
 %% Paragraph and bullet numbering
 
-\newcounter{Paras}
-\counterwithin{Paras}{chapter}
-\counterwithin{Paras}{section}
-\counterwithin{Paras}{subsection}
-\counterwithin{Paras}{subsubsection}
-\counterwithin{Paras}{paragraph}
-\counterwithin{Paras}{subparagraph}
+% create a new counter that resets for each new subclause
+\newcommand{\newsubclausecounter}[1]{
+\newcounter{#1}
+\counterwithin{#1}{chapter}
+\counterwithin{#1}{section}
+\counterwithin{#1}{subsection}
+\counterwithin{#1}{subsubsection}
+\counterwithin{#1}{paragraph}
+\counterwithin{#1}{subparagraph}
+}
 
+\newsubclausecounter{Paras}
 \newcounter{Bullets1}[Paras]
 \newcounter{Bullets2}[Bullets1]
 \newcounter{Bullets3}[Bullets2]

--- a/source/layout.tex
+++ b/source/layout.tex
@@ -65,8 +65,13 @@
 }}}
 \makeatother
 
-\def\pnum
-{\parabullnum{Paras}{0pt}}
+% Register our intent to number the next paragraph. Don't actually number it
+% yet, because we might have a paragraph break before we see its contents (for
+% example, if the paragraph begins with a note or example).
+\def\pnum{%
+\global\def\maybeaddpnum{\global\def\maybeaddpnum{}\parabullnum{Paras}{0pt}}%
+\everypar=\expandafter{\the\everypar\maybeaddpnum}%
+}
 
 % Leave more room for section numbers in TOC
 \cftsetindents{section}{1.5em}{3.0em}

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1786,7 +1786,7 @@ characters.
 \begin{note}
 Any \grammarterm{universal-character-name}{s} are required to
 correspond to a code point in the range
-$[0, \mathrm{D800})$ or $[\mathrm{E000}, \mathrm{10FFFF}]$ (hexadecimal)\iref{lex.charset}.
+$[0,$ $\mathrm{D800})$ or $[\mathrm{E000},$ $\mathrm{10FFFF}]$ (hexadecimal)\iref{lex.charset}.
 \end{note}
 The size of a narrow string literal is
 the total number of escape sequences and other characters, plus at least

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -228,7 +228,9 @@ except that:
 \begin{itemize}
 \item
 A member operator template
-\tcode{operator()(const basic_string<C, T, A>\&, const basic_string<\brk{}C, T, A>\&)}
+\begin{codeblock}
+operator()(const basic_string<C, T, A>&, const basic_string<C, T, A>&)
+\end{codeblock}
 is provided so that a locale may be used as a predicate argument to
 the standard collections, to collate strings.
 \item

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -91,7 +91,8 @@
       \or\let\s=\paragraph\let\l=\label
       \or\let\s=\subparagraph\let\l=\label
       \fi%
-\s[#3]{#3\hfill[#2]}\l{#2}\addxref{#2}}
+\s[#3]{#3\hfill[#2]}\l{#2}\addxref{#2}%
+\setcounter{note}{0}\setcounter{example}{0}}
 
 % A convenience feature (mostly for the convenience of the Project
 % Editor, to make it easy to move around large blocks of text):
@@ -265,10 +266,16 @@
 \newcommand{\leftshift}[1]{\ensuremath{\mathbin{\mathsf{lshift}_{#1}}}}
 
 %% Notes and examples
+\newcounter{note}
+\newcounter{example}
 \newcommand{\noteintro}[1]{[\textit{#1}:\space}
 \newcommand{\noteoutro}[1]{\textit{\,---\,end #1}\kern.5pt]}
-\newenvironment{note}[1][Note]{\noteintro{#1}}{\noteoutro{note}\space}
-\newenvironment{example}[1][Example]{\noteintro{#1}}{\noteoutro{example}\space}
+\newenvironment{note}[1][Note]
+{\par\small\addtocounter{note}{1}\noteintro{#1 \thenote}}
+{\noteoutro{note}\par}
+\newenvironment{example}[1][Example]
+{\par\small\addtocounter{example}{1}\noteintro{#1 \theexample}}
+{\noteoutro{example}\par}
 
 %% Library function descriptions
 \newcommand{\Fundescx}[1]{\textit{#1}}
@@ -634,4 +641,6 @@
 \let\addcontentsline\oldcontentsline%
 }
 \newcommand{\defncontext}[1]{\textlangle#1\textrangle}
-\newenvironment{defnote}{\addtocounter{termnote}{1}\noteintro{Note \thetermnote{} to entry}}{\noteoutro{note}\space}
+\newenvironment{defnote}
+{\small\addtocounter{termnote}{1}\noteintro{Note \thetermnote{} to entry}}
+{\noteoutro{note}\space}

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -92,7 +92,7 @@
       \or\let\s=\subparagraph\let\l=\label
       \fi%
 \s[#3]{#3\hfill[#2]}\l{#2}\addxref{#2}%
-\setcounter{note}{0}\setcounter{example}{0}}
+}
 
 % A convenience feature (mostly for the convenience of the Project
 % Editor, to make it easy to move around large blocks of text):
@@ -266,16 +266,23 @@
 \newcommand{\leftshift}[1]{\ensuremath{\mathbin{\mathsf{lshift}_{#1}}}}
 
 %% Notes and examples
-\newcounter{note}
-\newcounter{example}
 \newcommand{\noteintro}[1]{[\textit{#1}:\space}
-\newcommand{\noteoutro}[1]{\textit{\,---\,end #1}\kern.5pt]}
-\newenvironment{note}[1][Note]
-{\par\small\addtocounter{note}{1}\noteintro{#1 \thenote}}
-{\noteoutro{note}\par}
-\newenvironment{example}[1][Example]
-{\par\small\addtocounter{example}{1}\noteintro{#1 \theexample}}
-{\noteoutro{example}\par}
+\newcommand{\noteoutro}[1]{\textit{\,---\,#1}\kern.5pt]}
+
+% \newnoteenvironment{ENVIRON}{BEGIN TEXT}{END TEXT}
+% Creates a note-like environment beginning with BEGIN TEXT and
+% ending with END TEXT. A counter with name ENVIRON indicates the
+% number of this kind of note / example that has occurred in this
+% subclause.
+\newcommand{\newnoteenvironment}[3]{
+\newsubclausecounter{#1}
+\newenvironment{#1}
+{\def\noteend{#3}\par\small\stepcounter{#1}\noteintro{#2}}
+{\noteoutro{\noteend}\par}
+}
+
+\newnoteenvironment{note}{Note \arabic{note}}{end note}
+\newnoteenvironment{example}{Example \arabic{example}}{end example}
 
 %% Library function descriptions
 \newcommand{\Fundescx}[1]{\textit{#1}}
@@ -623,11 +630,9 @@
 
 %%--------------------------------------------------
 %% Definitions section for "Terms and definitions"
-\newcounter{termnote}
 \newcommand{\nocontentsline}[3]{}
 \newcommand{\definition}[2]{%
 \addxref{#2}%
-\setcounter{termnote}{0}%
 \let\oldcontentsline\addcontentsline%
 \let\addcontentsline\nocontentsline%
 \ifcase\value{SectionDepth}
@@ -641,6 +646,4 @@
 \let\addcontentsline\oldcontentsline%
 }
 \newcommand{\defncontext}[1]{\textlangle#1\textrangle}
-\newenvironment{defnote}
-{\small\addtocounter{termnote}{1}\noteintro{Note \thetermnote{} to entry}}
-{\noteoutro{note}\space}
+\newnoteenvironment{defnote}{Note \arabic{defnote} to entry}{end note}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -515,7 +515,7 @@ is expression-equivalent to:
 \pnum
 \begin{note}
 Whenever \tcode{ranges::cend(E)} is a valid expression,
-the types \tcode{S} and \tcode{I} of
+the types \tcode{S} and \tcode{I} of the expressions
 \tcode{ranges::cend(E)} and \tcode{ranges::cbegin(E)}
 model \tcode{\libconcept{sentinel_for}<S, I>}.
 \end{note}
@@ -651,7 +651,7 @@ appears in the immediate context of a template instantiation.
 \pnum
 \begin{note}
 Whenever \tcode{ranges::rend(E)} is a valid expression,
-the types \tcode{S} and \tcode{I} of
+the types \tcode{S} and \tcode{I} of the expressions
 \tcode{ranges::rend(E)} and \tcode{ranges::rbegin(E)}
 model \tcode{\libconcept{sentinel_for}<S, I>}.
 \end{note}
@@ -689,7 +689,7 @@ is expression-equivalent to:
 \pnum
 \begin{note}
 Whenever \tcode{ranges::crend(E)} is a valid expression,
-the types \tcode{S} and \tcode{I} of
+the types \tcode{S} and \tcode{I} of the expressions
 \tcode{ranges::crend(E)} and \tcode{ranges::crbegin(E)}
 model \tcode{\libconcept{sentinel_for}<S, I>}.
 \end{note}

--- a/source/tables.tex
+++ b/source/tables.tex
@@ -301,14 +301,15 @@
  \end{LongTable}
 }
 
-\newenvironment{libreqtab4b}[2]
+\newenvironment{libreqtab4b}[3][LongTable]
 {
- \begin{LongTable}
- {#1}{#2}
+ \def\libreqtabenv{#1}
+ \begin{\libreqtabenv}
+ {#2}{#3}
  {x{.13\hsize}x{.15\hsize}x{.29\hsize}x{.27\hsize}}
 }
 {
- \end{LongTable}
+ \end{\libreqtabenv}
 }
 
 \newenvironment{libreqtab4c}[2]

--- a/source/time.tex
+++ b/source/time.tex
@@ -3349,7 +3349,7 @@ Its epoch is unspecified, and
 \begin{note}
 The type that \tcode{file_clock} denotes may be
 in a different namespace than \tcode{std::chrono},
-such as \tcode{std::filesystem}.
+such as \tcode{std::file\-sys\-tem}.
 \end{note}
 
 \rSec3[time.clock.file.members]{Member functions}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -11302,10 +11302,11 @@ Note that
 \begin{itemize}
 \item \tcode{operator()} defines a strict weak ordering as defined in~\ref{alg.sorting};
 
-\item under the equivalence relation defined by \tcode{operator()},
-\tcode{!operator()(a, b) \&\& !operator()(b, a)}, two \tcode{shared_ptr} or
-\tcode{weak_ptr} instances are equivalent if and only if they share ownership or are
-both empty.
+\item
+two \tcode{shared_ptr} or \tcode{weak_ptr} instances are equivalent
+under the equivalence relation defined by \tcode{operator()},
+\tcode{!operator()(a, b) \&\& !operator()(b, a)},
+if and only if they share ownership or are both empty.
 \end{itemize}
 \end{note}
 

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -5,9 +5,9 @@ texfiles=$(ls *.tex | grep -v macros.tex | grep -v layout.tex | grep -v tables.t
 texlibdesc="support.tex concepts.tex diagnostics.tex utilities.tex strings.tex containers.tex iterators.tex ranges.tex algorithms.tex numerics.tex time.tex locales.tex iostreams.tex regex.tex atomics.tex threads.tex"
 texlib="lib-intro.tex $texlibdesc"
 
-# Discover "Overfull \hbox" and "Reference ... undefined" messages from LaTeX.
+# Discover "Overfull \[hv]box" and "Reference ... undefined" messages from LaTeX.
 sed -n '/\.tex/{s/^.*\/\([-a-z0-9]\+\.tex\).*$/\1/;h};
-/Overfull [\\]hbox\|LaTeX Warning..Reference/{x;p;x;p}' std.log |
+/Overfull [\\][hv]box\|LaTeX Warning..Reference/{x;p;x;p}' std.log |
 sed '/^.\+\.tex$/{N;s/\n/:/}' | grep . && exit 1
 
 # Find non-ASCII (Unicode) characters in the source


### PR DESCRIPTION
Number notes and examples, make them one point smaller, and move them to (un-numbered) paragraphs of their own.

Partially addresses ISO/CS 016 (C++20 DIS).

Fixes https://github.com/cplusplus/nbballot/issues/398.