### PR TITLE
[intro.defs] Remove cross-references to main part

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -110,12 +110,13 @@ defined.
 \indexdefn{access}%
 \definition{access}{defns.access}
 \defncontext{execution-time action}
-read\iref{conv.lval} or
-modify (\ref{expr.ass}, \ref{expr.post.incr}, \ref{expr.pre.incr})
-the value of an object
+read or modify the value of an object
 
 \begin{defnote}
 Only objects of scalar type can be accessed.
+Reads of scalar objects are described in \ref{conv.lval} and
+modifications of scalar objects are describred in
+\ref{expr.ass}, \ref{expr.post.incr}, and \ref{expr.pre.incr}.
 Attempts to read or modify an object of class type
 typically invoke a constructor\iref{class.ctor}
 or assignment operator\iref{class.copy.assign};
@@ -126,29 +127,29 @@ although they may involve accesses of scalar subobjects.
 \definition{arbitrary-positional stream}{defns.arbitrary.stream}
 \defncontext{library}
 \indexdefn{stream!arbitrary-positional}%
-stream (described in \ref{input.output}) that can seek to any integral position within
+stream that can seek to any integral position within
 the length of the stream
 
 \begin{defnote}
-Every arbitrary-positional stream is also a repositional stream.
+Every arbitrary-positional stream is also a repositional stream\iref{defns.repositional.stream}.
 \end{defnote}
 
 \indexdefn{argument}%
 \indexdefn{argument!function call expression}
 \definition{argument}{defns.argument}
 \defncontext{function call expression} expression in the
-comma-separated list bounded by the parentheses\iref{expr.call}
+comma-separated list bounded by the parentheses
 
 \indexdefn{argument}%
 \indexdefn{argument!function-like macro}%
 \definition{argument}{defns.argument.macro}
 \defncontext{function-like macro} sequence of preprocessing tokens in the
-comma-separated list bounded by the parentheses\iref{cpp.replace}
+comma-separated list bounded by the parentheses
 
 \indexdefn{argument}%
 \indexdefn{argument!throw expression}%
 \definition{argument}{defns.argument.throw}
-\defncontext{throw expression} operand of \tcode{throw}\iref{expr.throw}
+\defncontext{throw expression} operand of \keyword{throw}
 
 \indexdefn{argument}%
 \indexdefn{argument!template instantiation}%
@@ -157,7 +158,7 @@ comma-separated list bounded by the parentheses\iref{cpp.replace}
 \grammarterm{constant-expression},
 \grammarterm{type-id}, or
 \grammarterm{id-expression} in the comma-separated
-list bounded by the angle brackets\iref{temp.arg}
+list bounded by the angle brackets
 
 \indexdefn{block (execution)}%
 \definition{block}{defns.block}
@@ -169,7 +170,7 @@ continuing execution past the blocking operation
 \indexdefn{block (statement)}%
 \definition{block}{defns.block.stmt}
 \defncontext{statement}
-compound statement\iref{stmt.block}
+compound statement
 
 \definition{character}{defns.character}
 \indexdefn{character}%
@@ -186,7 +187,7 @@ The term does not mean only
 \tcode{char32_t},
 and
 \tcode{wchar_t}
-objects,
+objects\iref{basic.fundamental},
 but any value that can be represented by a type
 that provides the definitions specified in
 \ref{strings}, \ref{localization}, \ref{input.output}, or~\ref{re}.
@@ -232,8 +233,8 @@ constructs that it does not support.
 \indexdefn{constant subexpression}%
 expression whose evaluation as subexpression of a
 \grammarterm{conditional-expression}
-\tcode{CE}\iref{expr.cond} would not prevent \tcode{CE}
-from being a core constant expression\iref{expr.const}
+\tcode{CE} would not prevent \tcode{CE}
+from being a core constant expression
 
 \definition{deadlock}{defns.deadlock}
 \defncontext{library}
@@ -255,12 +256,12 @@ implementation's output messages
 
 \definition{direct-non-list-initialization}{defns.direct-non-list-init}
 \indexdefn{direct-non-list-initialization}%
-direct-initialization\iref{dcl.init}
-that is not list-initialization\iref{dcl.init.list}
+direct-initialization
+that is not list-initialization
 
 \indexdefn{type!dynamic}%
 \definition{dynamic type}{defns.dynamic.type}
-\defncontext{glvalue} type of the most derived object\iref{intro.object} to which the
+\defncontext{glvalue} type of the most derived object to which the
 glvalue refers
 
 \begin{example}
@@ -280,7 +281,7 @@ treated similarly.
 \indexdefn{expression-equivalent}%
 expressions that all have the same effects,
 either
-are all potentially-throwing\iref{except.spec} or
+are all potentially-throwing or
 are all not potentially-throwing,
 and
 either
@@ -334,8 +335,8 @@ restrictions imposed upon programs by the implementation
 
 \definition{iostream class templates}{defns.iostream.templates}
 \defncontext{library}
-templates, defined in \ref{input.output},
-that take two template arguments
+templates that are declared in header \libheader{iosfwd} and
+take two template arguments
 
 \begin{defnote}
 The arguments are named \tcode{charT} and \tcode{traits}.
@@ -354,7 +355,7 @@ language that each implementation documents
 \definition{modifier function}{defns.modifier}
 \defncontext{library}
 \indexdefn{function!modifier}%
-class member function\iref{class.mfct} other than a constructor,
+class member function other than a constructor,
 assignment operator, or destructor
 that alters the state of an object of the class
 
@@ -391,7 +392,7 @@ value
 \definition{observer function}{defns.observer}
 \defncontext{library}
 \indexdefn{function!observer}%
-class member function\iref{class.mfct} that accesses the state of an object of the class
+class member function that accesses the state of an object of the class
 but does not alter that state
 
 \begin{defnote}
@@ -484,8 +485,7 @@ definitions of all translation units\iref{basic.link}.
 \definition{repositional stream}{defns.repositional.stream}
 \defncontext{library}
 \indexdefn{stream!repositional}%
-stream (described in \ref{input.output}) that can seek to a position that was
-previously encountered
+stream that can seek to a position that was previously encountered
 
 \definition{required behavior}{defns.required.behavior}
 \defncontext{library}
@@ -515,7 +515,7 @@ If a \Cpp{} program provides a definition for any reserved function, the results
 \definition{signature}{defns.signature}
 \defncontext{function}
 name,
-parameter-type-list\iref{dcl.fct},
+parameter-type-list,
 and enclosing namespace (if any)
 
 \begin{defnote}
@@ -527,32 +527,32 @@ name mangling and linking.
 \definition{signature}{defns.signature.friend}
 \defncontext{non-template friend function with trailing \grammarterm{requires-clause}}
 name,
-parameter-type-list\iref{dcl.fct},
+parameter-type-list,
 enclosing class,
 and
-trailing \grammarterm{requires-clause}\iref{dcl.decl}
+trailing \grammarterm{requires-clause}
 
 \indexdefn{signature}%
 \definition{signature}{defns.signature.templ}
 \defncontext{function template}
 name,
-parameter-type-list\iref{dcl.fct},
+parameter-type-list,
 enclosing namespace (if any),
 return type,
 \grammarterm{template-head},
 and
-trailing \grammarterm{requires-clause}\iref{dcl.decl} (if any)
+trailing \grammarterm{requires-clause} (if any)
 
 \indexdefn{signature}%
 \definition{signature}{defns.signature.templ.friend}
 \defncontext{friend function template with constraint involving enclosing template parameters}
 name,
-parameter-type-list\iref{dcl.fct},
+parameter-type-list,
 return type,
 enclosing class,
 \grammarterm{template-head},
 and
-trailing \grammarterm{requires-clause}\iref{dcl.decl} (if any)
+trailing \grammarterm{requires-clause} (if any)
 
 \indexdefn{signature}%
 \definition{signature}{defns.signature.spec}
@@ -563,25 +563,25 @@ and its template arguments (whether explicitly specified or deduced)
 \definition{signature}{defns.signature.member}
 \defncontext{class member function}
 name,
-parameter-type-list\iref{dcl.fct},
+parameter-type-list,
 class of which the function is a member,
 \cv-qualifiers (if any),
 \grammarterm{ref-qualifier} (if any),
 and
-trailing \grammarterm{requires-clause}\iref{dcl.decl} (if any)
+trailing \grammarterm{requires-clause} (if any)
 
 \indexdefn{signature}%
 \definition{signature}{defns.signature.member.templ}
 \defncontext{class member function template}
 name,
-parameter-type-list\iref{dcl.fct},
+parameter-type-list,
 class of which the function is a member,
 \cv-qualifiers (if any),
 \grammarterm{ref-qualifier} (if any),
 return type (if any),
 \grammarterm{template-head},
 and
-trailing \grammarterm{requires-clause}\iref{dcl.decl} (if any)
+trailing \grammarterm{requires-clause} (if any)
 
 \indexdefn{signature}%
 \definition{signature}{defns.signature.member.spec}
@@ -601,7 +601,7 @@ Requirements for stable algorithms are given in \ref{algorithm.stable}.
 
 \indexdefn{type!static}%
 \definition{static type}{defns.static.type}
-type of an expression\iref{basic.types} resulting from
+type of an expression resulting from
 analysis of the program without considering execution semantics
 
 \begin{defnote}
@@ -667,7 +667,7 @@ and \tcode{x.front()} can be called only if \tcode{x.empty()} returns
 \indexdefn{program!well-formed}%
 \definition{well-formed program}{defns.well.formed}
 \Cpp{}  program constructed according to the syntax rules, diagnosable
-semantic rules, and the one-definition rule\iref{basic.def.odr}%
+semantic rules, and the one-definition rule%
 \indextext{definitions|)}
 
 \rSec0[intro]{General principles}


### PR DESCRIPTION
Partially addresses ISO/CS 016 (C++20 DIS)

Fixes cplusplus/nbballot#397