### PR TITLE
[everywhere] Stop talking about C++ International Standards.

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -22,7 +22,7 @@ Required for new features.
 Logical lines beginning with
 \tcode{module} or \tcode{import} may
 be interpreted differently
-in this International Standard.
+in this revision of \Cpp{}.
 \begin{example}
 \begin{codeblock}
 class module {};
@@ -86,7 +86,7 @@ Valid \CppXVII{} code using
 \tcode{constinit},
 \tcode{co_await}, \tcode{co_yield}, \tcode{co_return},
 or \tcode{requires}
-as an identifier is not valid in this International Standard.
+as an identifier is not valid in this revision of \Cpp{}.
 
 \diffref{lex.operators}
 \change
@@ -96,7 +96,7 @@ Necessary for new functionality.
 \effect
 Valid \CppXVII{} code that contains a \tcode{<=} token
 immediately followed by a \tcode{>} token
-may be ill-formed or have different semantics in this International Standard:
+may be ill-formed or have different semantics in this revision of \Cpp{}:
 \begin{codeblock}
 namespace N {
   struct X {};
@@ -117,7 +117,7 @@ type deduction to distinguish ordinary and UTF-8 string and character literals.
 Valid \CppXVII{} code that depends on
 UTF-8 string literals having type ``array of \tcode{const char}'' and
 UTF-8 character literals having type ``\tcode{char}''
-is not valid in this International Standard.
+is not valid in this revision of \Cpp{}.
 \begin{codeblock}
 const auto *u8s = u8"text";     // \tcode{u8s} previously deduced as \tcode{const char*}; now deduced as \tcode{const char8_t*}
 const char *ps = u8s;           // ill-formed; previously well-formed
@@ -147,7 +147,7 @@ the object to which it is applied.
 Increase consistency of the language model.
 \effect
 Valid ISO \CppXVII{} code may be ill-formed or
-have undefined behavior in this International Standard.
+have undefined behavior in this revision of \Cpp{}.
 \begin{example}
 \begin{codeblock}
 int f() {
@@ -195,7 +195,7 @@ can contain only C-compatible constructs.
 \rationale
 Necessary for implementability.
 \effect
-Valid \CppXVII{} code may be ill-formed in this International Standard.
+Valid \CppXVII{} code may be ill-formed in this revision of \Cpp{}.
 \begin{codeblock}
 typedef struct {
   void f() {}           // ill-formed; previously well-formed
@@ -209,7 +209,7 @@ in different translation units.
 \rationale
 Required for modules support.
 \effect
-Valid \CppXVII{} code may be ill-formed in this International Standard,
+Valid \CppXVII{} code may be ill-formed in this revision of \Cpp{},
 with no diagnostic required.
 \begin{codeblock}
 // Translation unit 1
@@ -232,7 +232,7 @@ which may apply notwithstanding the declared constructors of a class.
 Valid \CppXVII{} code that aggregate-initializes
 a type with a user-declared constructor
 may be ill-formed or have different semantics
-in this International Standard.
+in this revision of \Cpp{}.
 \begin{codeblock}
 struct A {              // not an aggregate; previously an aggregate
   A() = delete;
@@ -274,7 +274,7 @@ is now a narrowing conversion.
 Catches bugs.
 \effect
 Valid \CppXVII{} code may fail to compile
-in this International Standard. For example:
+in this revision of \Cpp{}. For example:
 \begin{codeblock}
 bool y[] = { "bc" };    // ill-formed; previously well-formed
 \end{codeblock}
@@ -293,7 +293,7 @@ in a conversion function declaration.
 Necessary for new functionality.
 \effect
 Valid \CppXVII{} code may fail to compile
-in this International Standard. For example:
+in this revision of \Cpp{}. For example:
 \begin{codeblock}
 struct S {
   explicit (S)(const S&);       // ill-formed; previously well-formed
@@ -310,7 +310,7 @@ is no longer valid as the \grammarterm{declarator-id} of a constructor or destru
 Remove potentially error-prone option for redundancy.
 \effect
 Valid \CppXVII{} code may fail to compile
-in this International Standard. For example:
+in this revision of \Cpp{}. For example:
 \begin{codeblock}
 template<class T>
 struct A {
@@ -331,7 +331,7 @@ Side effect of making it easier to write
 more efficient code that takes advantage of moves.
 \effect
 Valid \CppXVII{} code may fail to compile or have different semantics
-in this International Standard.
+in this revision of \Cpp{}.
 For example:
 \begin{codeblock}
 struct base {
@@ -438,11 +438,11 @@ Removal of obsolete feature that has been replaced by \tcode{noexcept}.
 A valid \CppXVII{} function declaration, member function declaration, function
 pointer declaration, or function reference declaration that uses \tcode{throw()}
 for its exception specification will be rejected as ill-formed in this
-International Standard. It should simply be replaced with \tcode{noexcept} for no
+revision of \Cpp{}. It should simply be replaced with \tcode{noexcept} for no
 change of meaning since \CppXVII{}.
 \begin{note}
 There is no way to write a function declaration
-that is non-throwing in this International Standard
+that is non-throwing in this revision of \Cpp{}
 and is also non-throwing in \CppIII{}
 except by using the preprocessor to generate
 a different token sequence in each case.
@@ -474,7 +474,7 @@ The following \Cpp{} headers are new:
 \libheaderref{syncstream}, and
 \libheaderrefx{version}{support.limits.general}.
 Valid \CppXVII{} code that \tcode{\#include}{s} headers with these names may be
-invalid in this International Standard.
+invalid in this revision of \Cpp{}.
 
 \diffref{headers}
 \change
@@ -515,7 +515,7 @@ changed from \tcode{void} to \tcode{container::size_type}.
 \rationale
 Improve efficiency and convenience of finding number of removed elements.
 \effect
-Code that depends on the return types might have different semantics in this International Standard.
+Code that depends on the return types might have different semantics in this revision of \Cpp{}.
 Translation units compiled against this version of \Cpp{} may be incompatible with
 translation units compiled against \CppXVII{}, either failing to link or having undefined behavior.
 
@@ -554,7 +554,7 @@ Character array extraction only takes array types.
 \rationale
 Increase safety via preventing buffer overflow at compile time.
 \effect
-Valid \CppXVII{} code may fail to compile in this International Standard:
+Valid \CppXVII{} code may fail to compile in this revision of \Cpp{}:
 \begin{codeblock}
 auto p = new char[100];
 char q[100];
@@ -605,7 +605,7 @@ Required for new features.
 \effect
 Valid \CppXVII{} code that depends on the \tcode{u8string()} and
 \tcode{generic_u8string()} member functions of \tcode{std::filesystem::path}
-returning \tcode{std::string} is not valid in this International Standard.
+returning \tcode{std::string} is not valid in this revision of \Cpp{}.
 \begin{codeblock}
 std::filesystem::path p;
 std::string s1 = p.u8string();          // ill-formed; previously well-formed
@@ -723,7 +723,7 @@ Removal of trigraph support as a required feature.
 Prevents accidental uses of trigraphs in non-raw string literals and comments.
 \effect
 Valid \CppXIV{} code that uses trigraphs may not be valid or may have different
-semantics in this International Standard. Implementations may choose to
+semantics in this revision of \Cpp{}. Implementations may choose to
 translate trigraphs as specified in \CppXIV{} if they appear outside of a raw
 string literal, as part of the \impldef{mapping from physical source file characters
 to basic source character set} mapping from physical source file characters to
@@ -737,9 +737,9 @@ the basic source character set.
 Necessary to enable \grammarterm{hexadecimal-floating-point-literal}s.
 \effect
 Valid \CppXIV{} code may fail to compile or produce different results in
-this International Standard. Specifically, character sequences like \tcode{0p+0}
+this revision of \Cpp{}. Specifically, character sequences like \tcode{0p+0}
 and \tcode{0e1_p+0} are three separate tokens each in \CppXIV{}, but one single token
-in this International Standard.
+in this revision of \Cpp{}.
 For example:
 \begin{codeblock}
 #define F(a) b ## a
@@ -755,7 +755,7 @@ Remove increment operator with \tcode{bool} operand.
 Obsolete feature with occasionally surprising semantics.
 \effect
 A valid \CppXIV{} expression utilizing the increment operator on
-a \tcode{bool} lvalue is ill-formed in this International Standard.
+a \tcode{bool} lvalue is ill-formed in this revision of \Cpp{}.
 Note that this might occur when the lvalue has a type given by a template
 parameter.
 
@@ -770,7 +770,7 @@ to allocate an object with an over-aligned class type,
 where that class has no allocation functions of its own,
 \tcode{::operator new(std::size_t)}
 is used to allocate the memory.
-In this International Standard,
+In this revision of \Cpp{},
 \tcode{::operator new(std::size_t, std::align_val_t)}
 is used instead.
 
@@ -781,10 +781,10 @@ is used instead.
 \change
 Removal of \tcode{register} \grammarterm{storage-class-specifier}.
 \rationale
-Enable repurposing of deprecated keyword in future revisions of this International Standard.
+Enable repurposing of deprecated keyword in future revisions of \Cpp{}.
 \effect
 A valid \CppXIV{} declaration utilizing the \tcode{register}
-\grammarterm{storage-class-specifier} is ill-formed in this International Standard.
+\grammarterm{storage-class-specifier} is ill-formed in this revision of \Cpp{}.
 The specifier can simply be removed to retain the original meaning.
 
 \diffref{dcl.spec.auto}
@@ -794,7 +794,7 @@ The specifier can simply be removed to retain the original meaning.
 More intuitive deduction behavior.
 \effect
 Valid \CppXIV{} code may fail to compile or may change meaning
-in this International Standard. For example:
+in this revision of \Cpp{}. For example:
 \begin{codeblock}
 auto x1{1};         // was \tcode{std::initializer_list<int>}, now \tcode{int}
 auto x2{1, 2};      // was \tcode{std::initializer_list<int>}, now ill-formed
@@ -807,7 +807,7 @@ Make exception specifications be part of the type system.
 Improve type-safety.
 \effect
 Valid \CppXIV{} code may fail to compile or change meaning in this
-International Standard.
+revision of \Cpp{}.
 For example:
 \begin{codeblock}
 void g1() noexcept;
@@ -824,7 +824,7 @@ to apply to user-defined types with base classes.
 To increase convenience of aggregate initialization.
 \effect
 Valid \CppXIV{} code may fail to compile or produce different results in this
-International Standard; initialization from an empty initializer list will
+revision of \Cpp{}; initialization from an empty initializer list will
 perform aggregate initialization instead of invoking a default constructor
 for the affected types.
 For example:
@@ -880,7 +880,7 @@ allows partial specializations to decompose
 from the type deduced for the non-type template argument.
 \effect
 Valid \CppXIV{} code may fail to compile
-or produce different results in this International Standard.
+or produce different results in this revision of \Cpp{}.
 For example:
 \begin{codeblock}
 template <int N> struct A;
@@ -900,7 +900,7 @@ Remove dynamic exception specifications.
 Dynamic exception specifications were a deprecated feature
 that was complex and brittle in use.
 They interacted badly with the type system,
-which became a more significant issue in this International Standard
+which became a more significant issue in this revision of \Cpp{}
 where (non-dynamic) exception specifications are part of the function type.
 \effect
 A valid \CppXIV{} function declaration,
@@ -908,9 +908,9 @@ member function declaration,
 function pointer declaration,
 or function reference declaration,
 if it has a potentially throwing dynamic exception specification,
-will be rejected as ill-formed in this International Standard.
+is rejected as ill-formed in this revision of \Cpp{}.
 Violating a non-throwing dynamic exception specification
-will call \tcode{terminate}
+calls \tcode{terminate}
 rather than \tcode{unexpected}
 and might not perform stack unwinding prior to such a call.
 
@@ -933,7 +933,7 @@ The following \Cpp{} headers are new:
 and
 \libheaderref{variant}.
 Valid \CppXIV{} code that \tcode{\#include}{s} headers with these names may be
-invalid in this International Standard.
+invalid in this revision of \Cpp{}.
 
 \diffref{namespace.future}
 \change
@@ -946,7 +946,7 @@ The global namespaces \tcode{std}
 followed by an arbitrary sequence of \grammarterm{digit}{s}\iref{lex.name}
 are reserved for future standardization.
 Valid \CppXIV{} code that uses such a top-level namespace,
-e.g., \tcode{std2}, may be invalid in this International Standard.
+e.g., \tcode{std2}, may be invalid in this revision of \Cpp{}.
 
 \rSec2[diff.cpp14.utilities]{\ref{utilities}: general utilities library}
 
@@ -957,9 +957,9 @@ Constructors taking allocators removed.
 No implementation consensus.
 \effect
 Valid \CppXIV{} code may fail to compile or may change meaning in this
-International Standard. Specifically, constructing a \tcode{std::function} with
+revision of \Cpp{}. Specifically, constructing a \tcode{std::function} with
 an allocator is ill-formed and uses-allocator construction will not pass an
-allocator to \tcode{std::function} constructors in this International Standard.
+allocator to \tcode{std::function} constructors in this revision of \Cpp{}.
 
 \diffref{util.smartptr.shared}
 \change
@@ -969,7 +969,7 @@ Adding array support to \tcode{shared_ptr},
 via the syntax \tcode{shared_ptr<T[]>} and \tcode{shared_ptr<T[N]>}.
 \effect
 Valid \CppXIV{} code may fail to compile or may change meaning in this
-International Standard.
+revision of \Cpp{}.
 For example:
 \begin{codeblock}
 #include <memory>
@@ -985,13 +985,13 @@ Non-const \tcode{.data()} member added.
 \rationale
 The lack of a non-const \tcode{.data()}
 differed from the similar member of \tcode{std::vector}.
-This change regularizes behavior for this International Standard.
+This change regularizes behavior.
 \effect
 Overloaded functions which have differing code paths
 for \tcode{char*} and \tcode{const char*} arguments
 will execute differently
 when called with a non-const string's \tcode{.data()} member
-in this International Standard.
+in this revision of \Cpp{}.
 
 \begin{codeblock}
 int f(char *) = delete;
@@ -1010,7 +1010,7 @@ Increase portability, clarification of associative container requirements.
 \effect
 Valid \CppXIV{} code that attempts to use associative containers
 having a comparison object with non-const function call operator
-may fail to compile in this International Standard:
+may fail to compile in this revision of \Cpp{}:
 \begin{codeblock}
 #include <set>
 
@@ -1049,7 +1049,7 @@ are not defined.
 Superseded by new features.
 \effect
 Valid \CppXIV{} code that uses these class templates
-and function templates may fail to compile in this International Standard.
+and function templates may fail to compile in this revision of \Cpp{}.
 
 \nodiffref
 \change
@@ -1059,7 +1059,7 @@ Redundant feature for compatibility with pre-standard code
 has served its time.
 \effect
 A valid \CppXIV{} program using these identifiers
-may be ill-formed in this International Standard.
+may be ill-formed in this revision of \Cpp{}.
 
 \rSec1[diff.cpp11]{\Cpp{} and ISO \CppXI{}}
 
@@ -1081,16 +1081,16 @@ by the chapters of this document.
 Necessary to enable single quotes as digit separators.
 \effect
 Valid \CppXI{} code may fail to compile or may change meaning in this
-International Standard. For example, the following code is valid both in \CppXI{} and in
-this International Standard, but the macro invocation produces different outcomes
+revision of \Cpp{}. For example, the following code is valid both in \CppXI{} and in
+this revision of \Cpp{}, but the macro invocation produces different outcomes
 because the single quotes delimit a \grammarterm{character-literal} in \CppXI{}, whereas they are digit
-separators in this International Standard:
+separators in this revision of \Cpp{}:
 
 \begin{codeblock}
 #define M(x, ...) __VA_ARGS__
 int x[2] = { M(1'2,3'4, 5) };
 // \tcode{int x[2] = \{ 5 \};\ \ \ \ \ } --- \CppXI{}
-// \tcode{int x[2] = \{ 3'4, 5 \};} --- this International Standard
+// \tcode{int x[2] = \{ 3'4, 5 \};} --- this revision of \Cpp{}
 \end{codeblock}
 
 \rSec2[diff.cpp11.basic]{\ref{basic}: basics}
@@ -1108,7 +1108,7 @@ void* operator new(std::size_t, std::size_t);
 void operator delete(void*, std::size_t) noexcept;
 \end{codeblock}
 
-In this International Standard, however, the declaration of \tcode{operator delete}
+In this revision of \Cpp{}, however, the declaration of \tcode{operator delete}
 might match a predefined usual (non-placement)
 \tcode{operator delete}\iref{basic.stc.dynamic}. If so, the
 program is ill-formed, as it was for class member allocation functions and
@@ -1127,7 +1127,7 @@ standard conversions), especially the creation of the temporary due to
 lvalue-to-rvalue conversion, were considered gratuitous and surprising.
 \effect
 Valid \CppXI{} code that relies on the conversions may behave differently
-in this International Standard:
+in this revision of \Cpp{}:
 
 \begin{codeblock}
 struct S {
@@ -1141,7 +1141,7 @@ int f(bool cond) {
 }
 \end{codeblock}
 
-In \CppXI{}, \tcode{f(true)} returns \tcode{1}. In this International Standard,
+In \CppXI{}, \tcode{f(true)} returns \tcode{1}. In this revision of \Cpp{},
 it returns \tcode{2}.
 
 \begin{codeblock}
@@ -1149,7 +1149,7 @@ sizeof(true ? "" : throw 0)
 \end{codeblock}
 
 In \CppXI{}, the expression yields \tcode{sizeof(const char*)}. In this
-International Standard, it yields \tcode{sizeof(const char[1])}.
+revision of \Cpp{}, it yields \tcode{sizeof(const char[1])}.
 
 \rSec2[diff.cpp11.dcl.dcl]{\ref{dcl.dcl}: declarations}
 
@@ -1161,9 +1161,9 @@ International Standard, it yields \tcode{sizeof(const char[1])}.
 Necessary to allow \tcode{constexpr} member functions to mutate
 the object.
 \effect
-Valid \CppXI{} code may fail to compile in this International Standard.
+Valid \CppXI{} code may fail to compile in this revision of \Cpp{}.
 For example, the following code is valid in \CppXI{}
-but invalid in this International Standard because it declares the same member
+but invalid in this revision of \Cpp{} because it declares the same member
 function twice with different return types:
 \begin{codeblock}
 struct S {
@@ -1179,7 +1179,7 @@ Classes with default member initializers can be aggregates.
 Necessary to allow default member initializers to be used
 by aggregate initialization.
 \effect
-Valid \CppXI{} code may fail to compile or may change meaning in this International Standard.
+Valid \CppXI{} code may fail to compile or may change meaning in this revision of \Cpp{}.
 For example:
 \begin{codeblock}
 struct S {          // Aggregate in \CppXIV{} onwards.
@@ -1191,7 +1191,7 @@ struct X {
 };
 X a{};
 S b{a};             // uses copy constructor in \CppXI{},
-                    // performs aggregate initialization in this International Standard
+                    // performs aggregate initialization in this revision of \Cpp{}
 \end{codeblock}
 
 \rSec2[diff.cpp11.library]{\ref{library}: library introduction}
@@ -1204,7 +1204,7 @@ New functionality.
 \effect
 The \Cpp{} header \libheaderrefx{shared_mutex}{shared.mutex.syn} is new.
 Valid \CppXI{} code that \tcode{\#include}{s} a header with that name may be
-invalid in this International Standard.
+invalid in this revision of \Cpp{}.
 
 \rSec2[diff.cpp11.input.output]{\ref{input.output}: input/output library}
 
@@ -1215,7 +1215,7 @@ invalid in this International Standard.
 Use of \tcode{gets} is considered dangerous.
 \effect
 Valid \CppXI{} code that uses the \tcode{gets} function may fail to compile
-in this International Standard.
+in this revision of \Cpp{}.
 
 \rSec1[diff.cpp03]{\Cpp{} and ISO \CppIII{}}
 
@@ -1237,7 +1237,7 @@ New kinds of \grammarterm{string-literal}s.
 Required for new features.
 \effect
 Valid \CppIII{} code may fail to compile or produce different results in
-this International Standard. Specifically, macros named \tcode{R}, \tcode{u8},
+this revision of \Cpp{}. Specifically, macros named \tcode{R}, \tcode{u8},
 \tcode{u8R}, \tcode{u}, \tcode{uR}, \tcode{U}, \tcode{UR}, or \tcode{LR} will
 not be expanded when adjacent to a \grammarterm{string-literal} but will be interpreted as
 part of the \grammarterm{string-literal}. For example:
@@ -1253,7 +1253,7 @@ User-defined literal string support.
 Required for new features.
 \effect
 Valid \CppIII{} code may fail to compile or produce different results in
-this International Standard.
+this revision of \Cpp{}.
 For example:
 \begin{codeblock}
 #define _x "there"
@@ -1261,7 +1261,7 @@ For example:
 \end{codeblock}
 
 Previously, \#1 would have consisted of two separate preprocessing tokens and
-the macro \tcode{_x} would have been expanded. In this International Standard,
+the macro \tcode{_x} would have been expanded. In this revision of \Cpp{},
 \#1 consists of a single preprocessing token, so the macro is not expanded.
 
 \diffref{lex.key}
@@ -1282,8 +1282,7 @@ Added to \tref{lex.key}, the following identifiers are new keywords:
 \tcode{static_assert},
 and
 \tcode{thread_local}.
-Valid \CppIII{} code using these identifiers is invalid in this International
-Standard.
+Valid \CppIII{} code using these identifiers is invalid in this revision of \Cpp{}.
 
 \diffref{lex.icon}
 \change
@@ -1304,7 +1303,7 @@ Removing surprising interactions with templates and constant
 expressions.
 \effect
 Valid \CppIII{} code may fail to compile or produce different results in
-this International Standard.
+this revision of \Cpp{}.
 For example:
 \begin{codeblock}
 void f(void *);     // \#1
@@ -1321,7 +1320,7 @@ Specify rounding for results of integer \tcode{/} and \tcode{\%}.
 Increase portability, C99 compatibility.
 \effect
 Valid \CppIII{} code that uses integer division rounds the result toward 0 or
-toward negative infinity, whereas this International Standard always rounds
+toward negative infinity, whereas this revision of \Cpp{} always rounds
 the result toward 0.
 
 \diffref{expr.log.and}
@@ -1331,7 +1330,7 @@ the result toward 0.
 Required for new features.
 \effect
 Valid \CppIII{} code may fail to compile or produce different results in
-this International Standard.
+this revision of \Cpp{}.
 For example:
 \begin{codeblock}
 bool b1 = new int && false;             // previously \tcode{false}, now ill-formed
@@ -1348,8 +1347,10 @@ Remove \tcode{auto} as a storage class specifier.
 New feature.
 \effect
 Valid \CppIII{} code that uses the keyword \tcode{auto} as a storage class
-specifier may be invalid in this International Standard. In this International
-Standard, \tcode{auto} indicates that the type of a variable is to be deduced
+specifier
+may be invalid in this revision of \Cpp{}.
+In this revision of \Cpp{},
+\tcode{auto} indicates that the type of a variable is to be deduced
 from its initializer expression.
 
 \diffref{dcl.init.list}
@@ -1358,9 +1359,9 @@ Narrowing restrictions in aggregate initializers.
 \rationale
 Catches bugs.
 \effect
-Valid \CppIII{} code may fail to compile in this International Standard. For
+Valid \CppIII{} code may fail to compile in this revision of \Cpp{}. For
 example, the following code is valid in \CppIII{} but invalid in this
-International Standard because \tcode{double} to \tcode{int} is a narrowing
+revision of \Cpp{} because \tcode{double} to \tcode{int} is a narrowing
 conversion:
 \begin{codeblock}
 int x[] = { 2.0 };
@@ -1385,7 +1386,7 @@ User-declared destructors have an implicit exception specification.
 \rationale
 Clarification of destructor requirements.
 \effect
-Valid \CppIII{} code may execute differently in this International Standard. In
+Valid \CppIII{} code may execute differently in this revision of \Cpp{}. In
 particular, destructors that throw exceptions will call \tcode{std::terminate}
 (without calling \tcode{std::unexpected}) if their exception specification is
 non-throwing.
@@ -1399,7 +1400,7 @@ Remove \tcode{export}.
 No implementation consensus.
 \effect
 A valid \CppIII{} declaration containing \tcode{export} is ill-formed in this
-International Standard.
+revision of \Cpp{}.
 
 \diffref{temp.arg}
 \change
@@ -1413,7 +1414,7 @@ Change to semantics of well-defined expression. A valid \CppIII{} expression
 containing a right angle bracket (``\tcode{>}'') followed immediately by
 another right angle bracket may now be treated as closing two templates.
 For example, the following code is valid in \CppIII{} because ``\tcode{>>}''
-is a right-shift operator, but invalid in this International Standard because
+is a right-shift operator, but invalid in this revision of \Cpp{} because
 ``\tcode{>>}'' closes two templates.
 
 \begin{codeblock}
@@ -1428,8 +1429,8 @@ Allow dependent calls of functions with internal linkage.
 \rationale
 Overly constrained, simplify overload resolution rules.
 \effect
-A valid \CppIII{} program could get a different result than this
-International Standard.
+A valid \CppIII{} program could get a different result than in this
+revision of \Cpp{}.
 
 \rSec2[diff.cpp03.library]{\ref{library}: library introduction}
 
@@ -1441,10 +1442,10 @@ New reserved identifiers.
 Required by new features.
 \effect
 Valid \CppIII{} code that uses any identifiers added to the \Cpp{} standard
-library by this International Standard may fail to compile or produce different
-results in this International Standard. A comprehensive list of identifiers used
+library by later revisions of \Cpp{} may fail to compile or produce different
+results in this revision of \Cpp{}. A comprehensive list of identifiers used
 by the \Cpp{} standard library can be found in the Index of Library Names in this
-International Standard.
+document.
 
 \diffref{headers}
 \change
@@ -1481,7 +1482,7 @@ In addition the following C compatibility headers are new:
 and
 \libheaderref{cuchar}.
 Valid \CppIII{} code that \tcode{\#include}{s} headers with these names may be
-invalid in this International Standard.
+invalid in this revision of \Cpp{}.
 
 \diffref{swappable.requirements}
 \effect
@@ -1500,7 +1501,7 @@ New functionality.
 \effect
 The global namespace \tcode{posix} is now reserved for standardization. Valid
 \CppIII{} code that uses a top-level namespace \tcode{posix} may be invalid in
-this International Standard.
+this revision of \Cpp{}.
 
 \diffref{res.on.macro.definitions}
 \change
@@ -1511,7 +1512,7 @@ Avoid hard to diagnose or non-portable constructs.
 Names of attribute identifiers may not be used as macro names. Valid \CppIII{}
 code that defines \tcode{override}, \tcode{final},
 \tcode{carries_dependency}, or \tcode{noreturn} as macros is invalid in this
-International Standard.
+revision of \Cpp{}.
 
 \rSec2[diff.cpp03.language.support]{\ref{support}:
 language support library}
@@ -1524,10 +1525,9 @@ language support library}
 Consistent application of \tcode{noexcept}.
 \effect
 Valid \CppIII{} code that assumes that global \tcode{operator new} only
-throws \tcode{std::bad_alloc} may execute differently in this International
-Standard.
+throws \tcode{std::bad_alloc} may execute differently in this revision of \Cpp{}.
 Valid \CppIII{} code that replaces the global replaceable \tcode{operator new}
-is ill-formed in this International Standard,
+is ill-formed in this revision of \Cpp{},
 because the exception specification of \tcode{throw(std::bad_alloc)}
 was removed.
 
@@ -1541,7 +1541,7 @@ Support for new thread facilities.
 \effect
 Valid but implementation-specific \CppIII{} code that relies on
 \tcode{errno} being the same across threads may change behavior in this
-International Standard.
+revision of \Cpp{}.
 
 \rSec2[diff.cpp03.utilities]{\ref{utilities}: general utilities library}
 
@@ -1565,7 +1565,7 @@ Superseded by new feature; \tcode{unary_function} and
 \effect
 Valid \CppIII{} code that depends on function object types being derived from
 \tcode{unary_function} or \tcode{binary_function} may fail to compile
-in this International Standard.
+in this revision of \Cpp{}.
 
 \rSec2[diff.cpp03.strings]{\ref{strings}: strings library}
 
@@ -1575,9 +1575,9 @@ in this International Standard.
 strings.
 \rationale
 Invalidation is subtly different with reference-counted strings.
-This change regularizes behavior for this International Standard.
+This change regularizes behavior.
 \effect
-Valid \CppIII{} code may execute differently in this International Standard.
+Valid \CppIII{} code may execute differently in this revision of \Cpp{}.
 
 \diffref{string.require}
 \change
@@ -1585,7 +1585,7 @@ Loosen \tcode{basic_string} invalidation rules.
 \rationale
 Allow small-string optimization.
 \effect
-Valid \CppIII{} code may execute differently in this International Standard.
+Valid \CppIII{} code may execute differently in this revision of \Cpp{}.
 Some \tcode{const} member functions, such as \tcode{data} and \tcode{c_str},
 no longer invalidate iterators.
 
@@ -1599,7 +1599,7 @@ Lack of specification of complexity of \tcode{size()} resulted in
 divergent implementations with inconsistent performance characteristics.
 \effect
 Some container implementations that conform to \CppIII{} may not conform to the
-specified \tcode{size()} requirements in this International Standard. Adjusting
+specified \tcode{size()} requirements in this revision of \Cpp{}. Adjusting
 containers such as \tcode{std::list} to the stricter requirements may require
 incompatible changes.
 
@@ -1645,7 +1645,7 @@ The following member functions have changed:
 
 Valid \CppIII{} code that relies on these functions returning \tcode{void}
 (e.g., code that creates a pointer to member function that points to one
-of these functions) will fail to compile with this International Standard.
+of these functions) will fail to compile with this revision of \Cpp{}.
 
 \diffref{sequence.reqmts,associative.reqmts}
 \change
@@ -1668,7 +1668,7 @@ The signatures of the following member functions changed from taking an
 \end{itemize}
 
 Valid \CppIII{} code that uses these functions may fail to compile with this
-International Standard.
+revision of \Cpp{}.
 
 \diffref{sequence.reqmts,associative.reqmts}
 \change
@@ -1679,8 +1679,7 @@ Performance, compatibility with move semantics.
 For \tcode{vector}, \tcode{deque}, and \tcode{list}
 the fill value passed to \tcode{resize} is now passed by reference instead of
 by value, and an additional overload of \tcode{resize} has been added. Valid
-\CppIII{} code that uses this function may fail to compile with this International
-Standard.
+\CppIII{} code that uses this function may fail to compile with this revision of \Cpp{}.
 
 \rSec2[diff.cpp03.algorithms]{\ref{algorithms}: algorithms library}
 
@@ -1692,7 +1691,7 @@ Required by new feature.
 \effect
 A valid \CppIII{} program may detect that an object with a valid but
 unspecified state has a different valid but unspecified state with this
-International Standard. For example, \tcode{std::remove} and
+revision of \Cpp{}. For example, \tcode{std::remove} and
 \tcode{std::remove_if} may leave the tail of the input sequence with a
 different set of values than previously.
 
@@ -1706,7 +1705,7 @@ Compatibility with C99.
 \effect
 Valid \CppIII{} code that uses implementation-specific knowledge about the
 binary representation of the required template specializations of
-\tcode{std::complex} may not be compatible with this International Standard.
+\tcode{std::complex} may not be compatible with this revision of \Cpp{}.
 
 \rSec2[diff.cpp03.input.output]{\ref{input.output}: input/output library}
 
@@ -1717,7 +1716,7 @@ Specify use of \tcode{explicit} in existing boolean conversion functions.
 Clarify intentions, avoid workarounds.
 \effect
 Valid \CppIII{} code that relies on implicit boolean conversions will fail to
-compile with this International Standard. Such conversions occur in the
+compile with this revision of \Cpp{}. Such conversions occur in the
 following conditions:
 
 \begin{itemize}
@@ -1738,7 +1737,7 @@ More detailed error messages.
 \tcode{std::exception}, but is now derived from \tcode{std::system_error},
 which in turn is derived from \tcode{std::runtime_error}. Valid \CppIII{} code
 that assumes that \tcode{std::ios_base::failure} is derived directly from
-\tcode{std::exception} may execute differently in this International Standard.
+\tcode{std::exception} may execute differently in this revision of \Cpp{}.
 
 \diffref{ios.base}
 \change
@@ -1749,7 +1748,7 @@ Required for new features.
 \effect
 Valid \CppIII{} code that relies on \tcode{std::ios_base} flag types being
 represented as \tcode{std::bitset} or as an integer type may fail to compile
-with this International Standard. For example:
+with this revision of \Cpp{}. For example:
 \begin{codeblock}
 #include <iostream>
 
@@ -2026,7 +2025,7 @@ Feature with surprising semantics.
 A valid ISO C expression utilizing the decrement operator on
 a \tcode{bool} lvalue
 (for instance, via the C typedef in \libdeprheaderref{stdbool.h})
-is ill-formed in this International Standard.
+is ill-formed in \Cpp{}.
 
 \diffref{expr.sizeof,expr.cast}
 \change
@@ -2678,7 +2677,7 @@ standard library.
 The types \tcode{char16_t} and \tcode{char32_t}
 are distinct types rather than typedefs to existing integral types.
 The tokens \tcode{char16_t} and \tcode{char32_t}
-are keywords in this International Standard\iref{lex.key}.
+are keywords in \Cpp{}\iref{lex.key}.
 They do not appear as macro or type names defined in
 \libheaderref{cuchar}.
 
@@ -2688,7 +2687,7 @@ They do not appear as macro or type names defined in
 The type \tcode{wchar_t} is a distinct type rather than a typedef to an
 existing integral type.
 The token \tcode{wchar_t}
-is a keyword in this International Standard\iref{lex.key}.
+is a keyword in \Cpp{}\iref{lex.key}.
 It does not appear as a macro or type name defined in any of
 \libheaderref{cstddef},
 \libheaderref{cstdlib},
@@ -2698,8 +2697,8 @@ or \libheaderref{cwchar}.
 \indexhdr{assert.h}%
 
 \pnum
-The token \tcode{static_assert} is a keyword in this International
-Standard\iref{lex.key}. It does not appear as a macro name defined
+The token \tcode{static_assert} is a keyword in \Cpp{}.
+It does not appear as a macro name defined
 in \libheaderref{cassert}.
 
 \rSec3[diff.header.iso646.h]{Header \tcode{<iso646.h>}}
@@ -2718,8 +2717,7 @@ The tokens
 \tcode{xor},
 and
 \tcode{xor_eq}
-are keywords in this International
-Standard\iref{lex.key},
+are keywords in \Cpp{}\iref{lex.key},
 and are not introduced as macros
 by \libdeprheaderref{iso646.h}.
 
@@ -2727,8 +2725,7 @@ by \libdeprheaderref{iso646.h}.
 \indexhdr{stdalign.h}%
 
 \pnum
-The token \tcode{alignas} is a keyword in this International
-Standard\iref{lex.key},
+The token \tcode{alignas} is a keyword in \Cpp{}\iref{lex.key},
 and is not introduced as a macro
 by \libdeprheaderref{stdalign.h}.
 
@@ -2737,7 +2734,7 @@ by \libdeprheaderref{stdalign.h}.
 
 \pnum
 The tokens \tcode{bool}, \tcode{true}, and \tcode{false}
-are keywords in this International Standard\iref{lex.key},
+are keywords in \Cpp{}\iref{lex.key},
 and are not introduced as macros
 by \libdeprheaderref{stdbool.h}.
 
@@ -2754,8 +2751,8 @@ defined in any of
 \libheaderref{cstring},
 \libheaderref{ctime},
 or \libheaderref{cwchar},
-is an \impldef{definition of \tcode{NULL}} \Cpp{} null pointer constant in
-this International Standard\iref{support.types}.
+is an \impldef{definition of \tcode{NULL}} null pointer constant in
+\Cpp{}\iref{support.types}.
 
 \rSec2[diff.mods.to.declarations]{Modifications to declarations}
 
@@ -2823,7 +2820,7 @@ Subclause \ref{csetjmp.syn} describes the changes.
 \pnum
 The macro \tcode{offsetof}, defined in
 \libheaderref{cstddef},
-accepts a restricted set of \tcode{\placeholder{type}} arguments in this International Standard.
+accepts a restricted set of \tcode{\placeholder{type}} arguments in \Cpp{}.
 Subclause \ref{support.types.layout} describes the change.
 
 \rSec3[diff.malloc]{Memory allocation functions}
@@ -2835,5 +2832,5 @@ The functions
 \indexlibraryglobal{malloc}\tcode{malloc},
 and
 \indexlibraryglobal{realloc}\tcode{realloc}
-are restricted in this International Standard.
+are restricted in \Cpp{}.
 Subclause \ref{c.malloc} describes the changes.

--- a/source/future.tex
+++ b/source/future.tex
@@ -13,7 +13,7 @@ existing implementations.
 These are deprecated features, where
 \term{deprecated}
 is defined as:
-Normative for the current edition of this International Standard,
+Normative for the current revision of \Cpp{},
 but having been identified as a candidate for removal from future revisions.
 An implementation may declare library names and entities described in this Clause with the
 \tcode{deprecated} attribute\iref{dcl.attr.deprecated}.
@@ -42,7 +42,7 @@ auto cmp = e <=> f;             // error
 \rSec1[depr.capture.this]{Implicit capture of \tcode{*this} by reference}
 
 \pnum
-For compatibility with prior \Cpp{} International Standards,
+For compatibility with prior revisions of \Cpp{},
 a \grammarterm{lambda-expression} with \grammarterm{capture-default}
 \tcode{=}\iref{expr.prim.lambda.capture} may implicitly capture
 \tcode{*this} by reference.
@@ -160,7 +160,7 @@ void park(linhenykus alvarezsauroid) {
 \rSec1[depr.static.constexpr]{Redeclaration of \tcode{static constexpr} data members}
 
 \pnum
-For compatibility with prior \Cpp{} International Standards, a \tcode{constexpr}
+For compatibility with prior revisions of \Cpp{}, a \tcode{constexpr}
 static data member may be redundantly redeclared outside the class with no initializer.
 This usage is deprecated.
 \begin{example}
@@ -204,7 +204,7 @@ The implicit definition of a copy assignment operator\iref{class.copy.assign}
 as defaulted is deprecated if the class has
 a user-declared copy constructor or
 a user-declared destructor.
-In a future revision of this International Standard, these implicit definitions
+In a future revision of \Cpp{}, these implicit definitions
 could become deleted\iref{dcl.fct.def.delete}.
 
 \rSec1[depr.c.headers]{C headers}
@@ -286,7 +286,7 @@ The \Cpp{} header \libheader{iso646.h} is empty.
 \tcode{or_eq},
 \tcode{xor}, and
 \tcode{xor_eq}
-are keywords in this International Standard\iref{lex.key}.
+are keywords in \Cpp{}\iref{lex.key}.
 \end{note}
 
 \rSec2[depr.stdalign.h.syn]{Header \tcode{<stdalign.h>} synopsis}

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1634,7 +1634,7 @@ The following macro names shall be defined by the implementation:
 The integer literal \tcode{\cppver}.
 \begin{note}
 It is intended that future
-versions of this International Standard will
+revisions of \Cpp{} will
 replace the value of this macro with a greater value.
 \end{note}
 
@@ -1703,7 +1703,7 @@ an \impldef{text of \mname{TIME} when time of translation is not available} vali
 The macros defined in \tref{cpp.predefined.ft} shall be defined to
 the corresponding integer literal.
 \begin{note}
-Future versions of this International Standard might replace
+Future revisions of \Cpp{} might replace
 the values of these macros with greater values.
 \end{note}
 \end{description}

--- a/source/support.tex
+++ b/source/support.tex
@@ -542,7 +542,7 @@ Each of the macros defined in \libheader{version} is also defined
 after inclusion of any member of the set of library headers
 indicated in the corresponding comment in this synopsis.
 \begin{note}
-Future versions of this International Standard might replace
+Future revisions of \Cpp{} might replace
 the values of these macros with greater values.
 \end{note}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15119,7 +15119,7 @@ is \tcode{R(ArgTypes...)}.
 \pnum
 \begin{note}
 The types deduced by the deduction guides for \tcode{function}
-may change in future versions of this International Standard.
+might change in future revisions of \Cpp{}.
 \end{note}
 
 \rSec4[func.wrap.func.con]{Constructors and destructor}


### PR DESCRIPTION
As far as ISO is concerned, there is only one International Standard for
C++, and in any case, we don't mean the document here, we mean the
language in the abstract and don't care whether that's an ISO standard
or not. Refer to "revisions of C++" instead of revisions of particular
ISO documents.

Partially addresses ISO/CS 016 (C++20 DIS).