### PR TITLE
[dcl.fct.def.coroutine] Add missing 'noexcept' for final_suspend.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6404,7 +6404,7 @@ struct generator {
     static auto get_return_object_on_allocation_failure() { return generator{nullptr}; }
     auto get_return_object() { return generator{handle::from_promise(*this)}; }
     auto initial_suspend() { return std::suspend_always{}; }
-    auto final_suspend() { return std::suspend_always{}; }
+    auto final_suspend() noexcept { return std::suspend_always{}; }
     void unhandled_exception() { std::terminate(); }
     void return_void() {}
     auto yield_value(int value) {


### PR DESCRIPTION
The invocation of final_suspend is guaranteed to be non-throwing,
thus final_suspend in the example needs to be declared 'noexcept'.

Fixes #4200