### PR TITLE
[everywhere] Reduce width of space after Note: and Example:.

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -266,7 +266,7 @@
 \newcommand{\leftshift}[1]{\ensuremath{\mathbin{\mathsf{lshift}_{#1}}}}
 
 %% Notes and examples
-\newcommand{\noteintro}[1]{[\textit{#1}:\space}
+\newcommand{\noteintro}[1]{[\textit{#1}:}
 \newcommand{\noteoutro}[1]{\textit{\,---\,#1}\kern.5pt]}
 
 % \newnoteenvironment{ENVIRON}{BEGIN TEXT}{END TEXT}
@@ -286,7 +286,7 @@
 
 %% Library function descriptions
 \newcommand{\Fundescx}[1]{\textit{#1}}
-\newcommand{\Fundesc}[1]{\Fundescx{#1:}\space}
+\newcommand{\Fundesc}[1]{\Fundescx{#1}:\space}
 \newcommand{\recommended}{\Fundesc{Recommended practice}}
 \newcommand{\required}{\Fundesc{Required behavior}}
 \newcommand{\constraints}{\Fundesc{Constraints}}


### PR DESCRIPTION
Use upright font for : in Preconditions: and friends.