### PR TITLE
[conv.rank] Avoid hinting that 'bool' be a standard integer type.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5316,7 +5316,7 @@ rank of any extended integer type with the same width.
 \item The rank of \keyword{char} equals the rank of \tcode{\keyword{signed} \keyword{char}}
 and \tcode{\keyword{unsigned} \keyword{char}}.
 
-\item The rank of \tcode{bool} is less than the rank of all other
+\item The rank of \tcode{bool} is less than the rank of all
 standard integer types.
 
 \item


### PR DESCRIPTION
Partially addresses #3974