### PR TITLE
[everywhere] Consistently use 'whitespace'.

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -98,7 +98,7 @@ shall be processed as if an additional new-line character were appended
 to the file.
 
 \item The source file is decomposed into preprocessing
-tokens\iref{lex.pptoken} and sequences of white-space characters
+tokens\iref{lex.pptoken} and sequences of whitespace characters
 (including comments). A source file shall not end in a partial
 preprocessing token or in a partial comment.\footnote{A partial preprocessing
 token would arise from a source file
@@ -109,7 +109,7 @@ or \tcode{>}. A partial comment
 would arise from a source file ending with an unclosed \tcode{/*}
 comment.}
 Each comment is replaced by one space character. New-line characters are
-retained. Whether each nonempty sequence of white-space characters other
+retained. Whether each nonempty sequence of whitespace characters other
 than new-line is retained or replaced by one space character is
 unspecified. The process of dividing a source file's
 characters into preprocessing tokens is context-dependent.
@@ -307,7 +307,7 @@ are locale-specific.%
     string-literal\br
     user-defined-string-literal\br
     preprocessing-op-or-punc\br
-    \textnormal{each non-white-space character that cannot be one of the above}
+    \textnormal{each non-whitespace character that cannot be one of the above}
 \end{bnf}
 
 \pnum
@@ -322,17 +322,17 @@ placeholder tokens produced by preprocessing \tcode{import} and \tcode{module} d
 (\grammarterm{import-keyword}, \grammarterm{module-keyword}, and \grammarterm{export-keyword}),
 identifiers, preprocessing numbers, character literals (including user-defined character
 literals), string literals (including user-defined string literals), preprocessing
-operators and punctuators, and single non-white-space characters that do not lexically
+operators and punctuators, and single non-whitespace characters that do not lexically
 match the other preprocessing token categories. If a \tcode{'} or a \tcode{"} character
 matches the last category, the behavior is undefined. Preprocessing tokens can be
 separated by
-\indextext{space!white}%
-white space;
+\indextext{whitespace}%
+whitespace;
 \indextext{comment}%
-this consists of comments\iref{lex.comment}, or white-space
+this consists of comments\iref{lex.comment}, or whitespace
 characters (space, horizontal tab, new-line, vertical tab, and
 form-feed), or both. As described in \ref{cpp}, in certain
-circumstances during translation phase 4, white space (or the absence
+circumstances during translation phase 4, whitespace (or the absence
 thereof) serves as more than preprocessing token separation. White space
 can appear within a preprocessing token only as part of a header name or
 between the quotation characters in a character literal or
@@ -476,12 +476,12 @@ The set of alternative tokens is defined in
 There are five kinds of tokens: identifiers, keywords, literals,\footnote{Literals include strings and character and numeric literals.
 }
 operators, and other separators.
-\indextext{white space}%
+\indextext{whitespace}%
 Blanks, horizontal and vertical tabs, newlines, formfeeds, and comments
-(collectively, ``white space''), as described below, are ignored except
+(collectively, ``whitespace''), as described below, are ignored except
 as they serve to separate tokens.
 \begin{note}
-Some white space is
+Some whitespace is
 required to separate otherwise adjacent identifiers, keywords, numeric
 literals, and alternative tokens containing alphabetic characters.
 \end{note}
@@ -498,7 +498,7 @@ characters \tcode{*/}. These comments do not nest.
 \indextext{comment!\tcode{//}}%
 The characters \tcode{//} start a comment, which terminates immediately before the
 next new-line character. If there is a form-feed or a vertical-tab
-character in such a comment, only white-space characters shall appear
+character in such a comment, only whitespace characters shall appear
 between it and the new-line that terminates the comment; no diagnostic
 is required.
 \begin{note}

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -4253,8 +4253,8 @@ Where
 or
 \tcode{money_base::none}
 appears as the last element in the format pattern,
-no white space is consumed. Otherwise, where \tcode{money_base::space} appears in any of the
-initial elements of the format pattern, at least one white space character is required. Where
+no whitespace is consumed. Otherwise, where \tcode{money_base::space} appears in any of the
+initial elements of the format pattern, at least one whitespace character is required. Where
 \tcode{money_base::none} appears in any of the initial elements of the format pattern, white
 space is allowed but not required.
 If
@@ -4592,10 +4592,10 @@ Where
 \tcode{none}
 or
 \tcode{space}
-appears, white space is permitted in the format,
+appears, whitespace is permitted in the format,
 except where
 \tcode{none}
-appears at the end, in which case no white space is permitted.
+appears at the end, in which case no whitespace is permitted.
 The value
 \tcode{space}
 indicates that at least one space is required at that position.

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -105,7 +105,7 @@
 
 \begin{bnf}
 \nontermdef{lparen}\br
-    \descr{a \terminal{(} character not immediately preceded by white-space}
+    \descr{a \terminal{(} character not immediately preceded by whitespace}
 \end{bnf}
 
 \begin{bnf}
@@ -137,8 +137,8 @@ At the start of translation phase 4,
 the first token in the sequence,
 referred to as a \defnadj{directive-introducing}{token},
 begins with the first character in the source file
-(optionally after white space containing no new-line characters) or
-follows white space containing at least one new-line character,
+(optionally after whitespace containing no new-line characters) or
+follows whitespace containing at least one new-line character,
 and is
 
 \begin{itemize}
@@ -174,7 +174,7 @@ is immediately followed by whitespace containing a new-line character.%
 \footnote{Thus,
 preprocessing directives are commonly called ``lines''.
 These ``lines'' have no other syntactic significance,
-as all white space is equivalent except in certain situations
+as all whitespace is equivalent except in certain situations
 during preprocessing (see the
 \tcode{\#}
 character string literal creation operator in~\ref{cpp.stringize}, for example).}
@@ -230,14 +230,14 @@ syntax is relaxed to allow any sequence of preprocessing tokens to occur between
 the directive name and the following new-line character.
 
 \pnum
-The only white-space characters that shall appear
+The only whitespace characters that shall appear
 between preprocessing tokens
 within a preprocessing directive
 (from just after the directive-introducing token
 through just before the terminating new-line character)
 are space and horizontal-tab
 (including spaces that have replaced comments
-or possibly other white-space characters
+or possibly other whitespace characters
 in translation phase 3).
 
 \pnum
@@ -933,8 +933,8 @@ int c = Z;      // error: active macro definitions \#3 and \#5 are not valid red
 \indextext{macro!replacement list}%
 Two replacement lists are identical if and only if
 the preprocessing tokens in both have
-the same number, ordering, spelling, and white-space separation,
-where all white-space separations are considered identical.
+the same number, ordering, spelling, and whitespace separation,
+where all whitespace separations are considered identical.
 
 \pnum
 An identifier currently defined as an
@@ -959,16 +959,16 @@ otherwise the program is ill-formed.
 The following sequence is valid:
 \begin{codeblock}
 #define OBJ_LIKE      (1-1)
-#define OBJ_LIKE      @\tcode{/* white space */ (1-1) /* other */}@
+#define OBJ_LIKE      @\tcode{/* whitespace */ (1-1) /* other */}@
 #define FUNC_LIKE(a)   ( a )
-#define FUNC_LIKE( a )(     @\tcode{/* note the white space */ \textbackslash}@
+#define FUNC_LIKE( a )(     @\tcode{/* note the whitespace */ \textbackslash}@
                 a @\tcode{/* other stuff on this line}@
                   @\tcode{*/}@ )
 \end{codeblock}
 But the following redefinitions are invalid:
 \begin{codeblock}
 #define OBJ_LIKE    (0)         // different token sequence
-#define OBJ_LIKE    (1 - 1)     // different white space
+#define OBJ_LIKE    (1 - 1)     // different whitespace
 #define FUNC_LIKE(b) ( a )      // different parameter usage
 #define FUNC_LIKE(b) ( b )      // different parameter spelling
 \end{codeblock}
@@ -976,7 +976,7 @@ But the following redefinitions are invalid:
 
 \pnum
 \indextext{macro!replacement list}%
-There shall be white-space between the identifier and the replacement list
+There shall be whitespace between the identifier and the replacement list
 in the definition of an object-like macro.
 
 \pnum
@@ -1009,7 +1009,7 @@ is called the
 \indextext{name!macro|see{macro, name}}%
 \defnx{macro name}{macro!name}.
 There is one name space for macro names.
-Any white-space characters preceding or following the
+Any whitespace characters preceding or following the
 replacement list of preprocessing tokens are not considered
 part of the replacement list for either form of macro.
 
@@ -1084,7 +1084,7 @@ preprocessing token, skipping intervening matched pairs of left and
 right parenthesis preprocessing tokens.
 Within the sequence of preprocessing tokens making up an invocation
 of a function-like macro,
-new-line is considered a normal white-space character.
+new-line is considered a normal whitespace character.
 
 \pnum
 \indextext{macro!function-like!arguments}%
@@ -1284,7 +1284,7 @@ contains the spelling of the preprocessing token sequence for the
 corresponding argument (excluding placemarker tokens).
 Let the \defn{stringizing argument} be the preprocessing token sequence
 for the corresponding argument with placemarker tokens removed.
-Each occurrence of white space between the stringizing argument's preprocessing
+Each occurrence of whitespace between the stringizing argument's preprocessing
 tokens becomes a single space character in the character string literal.
 White space before the first preprocessing token and after the last
 preprocessing token comprising the stringizing argument is deleted.

--- a/source/time.tex
+++ b/source/time.tex
@@ -11104,8 +11104,8 @@ Some flags can be modified by a width parameter
 given as a positive decimal integer called out as \tcode{\placeholder{N}} below
 which governs how many characters are parsed from the stream in interpreting the flag.
 All characters in the format string that are not represented in~\tref{time.parse.spec},
-except for white space, are parsed unchanged from the stream.
-A white space character matches zero or more white space characters in the input stream.
+except for whitespace, are parsed unchanged from the stream.
+A whitespace character matches zero or more whitespace characters in the input stream.
 
 \pnum
 If the type being parsed cannot represent
@@ -11248,13 +11248,13 @@ The modified command \tcode{\%OM} interprets
 the locale's alternative representation.
 \\ \rowsep
 \tcode{\%n} &
-Matches one white space character.
+Matches one whitespace character.
 \begin{note}
 \tcode{\%n}, \tcode{\%t}, and a space
-can be combined to match a wide range of white-space patterns.
+can be combined to match a wide range of whitespace patterns.
 For example,
-\tcode{"\%n "} matches one or more white space characters, and
-\tcode{"\%n\%t\%t"} matches one to three white space characters.
+\tcode{"\%n "} matches one or more whitespace characters, and
+\tcode{"\%n\%t\%t"} matches one to three whitespace characters.
 \end{note}
 \\ \rowsep
 \tcode{\%p} &
@@ -11281,7 +11281,7 @@ The modified command \tcode{\%OS} interprets
 the locale's alternative representation.
 \\ \rowsep
 \tcode{\%t} &
-Matches zero or one white space characters.
+Matches zero or one whitespace characters.
 \\ \rowsep
 \tcode{\%T} &
 Equivalent to \tcode{\%H:\%M:\%S}.


### PR DESCRIPTION
Do not use 'white space' or 'white-space'.

Fixes #4196