### PR TITLE
[vector.cons] Fix subclause heading.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -5702,7 +5702,7 @@ allocator completeness requirements\iref{allocator.requirements.completeness}.
 \tcode{T} shall be complete before any member of the resulting specialization
 of \tcode{vector} is referenced.
 
-\rSec3[vector.cons]{Constructors, copy, and assignment}
+\rSec3[vector.cons]{Constructors}
 
 \indexlibraryctor{vector}
 \begin{itemdecl}


### PR DESCRIPTION
Remove mention of "assignment", which is not specified here.

Fixes #4193 