### PR TITLE
[fs.norm.ref] Dissolve subclause.

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -11319,7 +11319,7 @@ implementable, so the conformance subclauses take that into account.
 
 \rSec3[fs.conform.9945]{POSIX conformance}
 \pnum
-Some behavior is specified by reference to POSIX\iref{fs.norm.ref}. How such behavior is actually implemented is unspecified.
+Some behavior is specified by reference to POSIX. How such behavior is actually implemented is unspecified.
 \begin{note}
 This constitutes an ``as if'' rule allowing implementations
 to call native
@@ -11383,18 +11383,6 @@ program to test for a precondition before calling a function described herein,
 As a design practice, preconditions are not specified when it
 is unreasonable for a program to detect them prior to calling the function.
 \end{note}
-
-\rSec2[fs.norm.ref]{Normative references}
-
-\pnum
-Subclause~\ref{filesystems} mentions commercially
-available operating systems for purposes of exposition.\footnote{
-POSIX\textregistered\ is a registered trademark of The IEEE\@.
-Windows\textregistered\ is a registered trademark of Microsoft Corporation.
-This information is given for the convenience of users of this document and
-does not constitute an endorsement by ISO or IEC of these
-products.
-}
 
 \rSec2[fs.req]{Requirements}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -19584,7 +19584,12 @@ a locale-independent, implementation-defined encoding.
 Implementations should use a Unicode encoding
 on platforms capable of displaying Unicode text in a terminal.
 \begin{note}
-This is the case for Windows-based and many POSIX-based operating systems.
+This is the case for Windows%
+\footnote{
+Windows\textregistered\ is a registered trademark of Microsoft Corporation.
+This information is given for the convenience of users of this document and
+does not constitute an endorsement by ISO or IEC of this product.}-based and
+many POSIX-based operating systems.
 \end{note}
 
 \pnum

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -21,6 +21,9 @@
 % [facets.examples] was removed.
 \removedxref{facets.examples}
 
+% Local normative references for filesystems were removed.
+\removedxref{fs.norm.ref}
+
 % Renamed sections.
 %\movedxref{old.label}{new.label}
 %\movedxrefii{old.label}{new.label.1}{new.label.2}


### PR DESCRIPTION
There should only be one subclause called "normative
references".

Fixes #4176