### PR TITLE
[expr.unary.op] Use 'negative', not 'negation'.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4276,7 +4276,7 @@ operands. The type of the result is the type of the promoted operand.
 \pnum
 \indextext{operator!unary minus}%
 The operand of the unary \tcode{-} operator shall have arithmetic or unscoped
-enumeration type and the result is the negation of its operand. Integral
+enumeration type and the result is the negative of its operand. Integral
 promotion is performed on integral or enumeration operands. The negative
 of an unsigned quantity is computed by subtracting its value from $2^n$,
 where $n$ is the number of bits in the promoted operand. The type of the


### PR DESCRIPTION
Fixes #4131