### PR TITLE
[expr.prim.paren] Replace "value" with "result"

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1235,7 +1235,7 @@ class Outer {
 \pnum
 \indextext{expression!parenthesized}%
 A parenthesized expression \tcode{($E$)}
-is a primary expression whose type, value, and value category are identical to those of $E$.
+is a primary expression whose type, result, and value category are identical to those of $E$.
 The parenthesized expression can be used in exactly the same contexts as
 those where $E$ can be used, and with the same
 meaning, except as otherwise indicated.


### PR DESCRIPTION
E can be a glvalue