### PR TITLE
footnote environment

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -129,14 +129,16 @@ for which mutability requirements are expressed explicitly.
 \end{note}
 
 \pnum
-Both in-place and copying versions are provided for certain algorithms.%
-\footnote{The decision whether to include a copying version was
+Both in-place and copying versions are provided for certain algorithms.
+\begin{footnote}
+The decision whether to include a copying version was
 usually based on complexity considerations.
 When the cost of doing the operation dominates the cost of copy,
 the copying version is not included.
 For example, \tcode{sort_copy} is not included
 because the cost of sorting is much more significant,
-and users might as well do \tcode{copy} followed by \tcode{sort}.}
+and users might as well do \tcode{copy} followed by \tcode{sort}.
+\end{footnote}
 When such a version is provided for \textit{algorithm} it is called
 \textit{algorithm\tcode{_copy}}.
 Algorithms that take predicates end with the suffix \tcode{_if}
@@ -4445,9 +4447,11 @@ Let $N$ be \tcode{last - first}.
 \effects
 Copies elements in the range \range{first}{last}
 into the range \range{result - $N$}{result}
-starting from \tcode{last - 1} and proceeding to \tcode{first}.%
-\footnote{\tcode{copy_backward} can be used instead of copy
-when \tcode{last} is in the range \range{result - $N$}{result}.}
+starting from \tcode{last - 1} and proceeding to \tcode{first}.
+\begin{footnote}
+\tcode{copy_backward} can be used instead of copy
+when \tcode{last} is in the range \range{result - $N$}{result}.
+\end{footnote}
 For each positive integer $n \le N$,
 performs \tcode{*(result - $n$) = *(last - $n$)}.
 
@@ -4596,9 +4600,11 @@ Let $N$ be \tcode{last - first}.
 \effects
 Moves elements in the range \range{first}{last}
 into the range \range{result - $N$}{result}
-starting from \tcode{last - 1} and proceeding to \tcode{first}.%
-\footnote{\tcode{move_backward} can be used instead of move
-when \tcode{last} is in the range \range{result - $N$}{result}.}
+starting from \tcode{last - 1} and proceeding to \tcode{first}.
+\begin{footnote}
+\tcode{move_backward} can be used instead of move
+when \tcode{last} is in the range \range{result - $N$}{result}.
+\end{footnote}
 For each positive integer $n \le N$,
 performs \tcode{*(result - $n$) = $E$}.
 
@@ -4799,8 +4805,10 @@ modify elements in the ranges
 \begin{itemize}
 \item \crange{first1}{first1 + $N$},
 \item \crange{first2}{first2 + $N$}, and
-\item \crange{result}{result + $N$}.%
-\footnote{The use of fully closed ranges is intentional.}
+\item \crange{result}{result + $N$}.
+\begin{footnote}
+The use of fully closed ranges is intentional.
+\end{footnote}
 \end{itemize}
 
 \pnum
@@ -8451,8 +8459,11 @@ template<@\libconcept{forward_range}@ R, class Proj = identity,
 \tcode{\{first, first\}} if \range{first}{last} is empty, otherwise
 \tcode{\{m, M\}}, where \tcode{m} is
 the first iterator in \range{first}{last} such that no iterator in the range refers
-to a smaller element, and where \tcode{M} is the last iterator\footnote{This behavior
-intentionally differs from \tcode{max_element}.}
+to a smaller element, and where \tcode{M} is the last iterator
+\begin{footnote}
+This behavior
+intentionally differs from \tcode{max_element}.
+\end{footnote}
 in \range{first}{last} such that no iterator in the range refers to a larger element.
 
 \pnum
@@ -9033,8 +9044,10 @@ the \oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible})
 and \oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}) requirements.
 In the range \crange{first}{last},
 \tcode{binary_op} neither modifies elements
-nor invalidates iterators or subranges.%
-\footnote{The use of fully closed ranges is intentional.}
+nor invalidates iterators or subranges.
+\begin{footnote}
+The use of fully closed ranges is intentional.
+\end{footnote}
 
 \pnum
 \effects
@@ -9043,11 +9056,13 @@ initializing the accumulator \tcode{acc} with the initial value \tcode{init}
 and then modifies it with
 \tcode{acc = std::move(acc) + *i} or
 \tcode{acc = binary_op(std::move(acc), *i)}
-for every iterator \tcode{i} in the range \range{first}{last} in order.%
-\footnote{\tcode{accumulate} is similar
+for every iterator \tcode{i} in the range \range{first}{last} in order.
+\begin{footnote}
+\tcode{accumulate} is similar
 to the APL reduction operator and Common Lisp reduce function,
 but it avoids the difficulty of defining the result of reduction
-on an empty sequence by always requiring an initial value.}
+on an empty sequence by always requiring an initial value.
+\end{footnote}
 \end{itemdescr}
 
 \rSec2[reduce]{Reduce}
@@ -9197,8 +9212,10 @@ and \oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}) requirements.
 In the ranges \crange{first1}{last1} and
 \crange{first2}{first2 + (last1 - first1)}
 \tcode{binary_op1} and \tcode{binary_op2}
-neither modifies elements nor invalidates iterators or subranges.%
-\footnote{The use of fully closed ranges is intentional.}
+neither modifies elements nor invalidates iterators or subranges.
+\begin{footnote}
+The use of fully closed ranges is intentional.
+\end{footnote}
 
 \pnum
 \effects
@@ -9387,8 +9404,10 @@ is implicitly convertible to \tcode{InputIt\-er\-a\-tor}'s value type.
 \expects
 In the ranges \crange{first}{last} and \crange{result}{result + (last - first)}
 \tcode{binary_op} neither modifies elements
-nor invalidates iterators or subranges.%
-\footnote{The use of fully closed ranges is intentional.}
+nor invalidates iterators or subranges.
+\begin{footnote}
+The use of fully closed ranges is intentional.
+\end{footnote}
 
 \pnum
 \effects
@@ -9889,8 +9908,10 @@ that denotes an object of type \tcode{minus<>}.
   For all overloads, in the ranges \crange{first}{last}
   and \crange{result}{result + (last - first)},
   \tcode{binary_op} neither modifies elements
-  nor invalidate iterators or subranges.%
-  \footnote{The use of fully closed ranges is intentional.}
+  nor invalidate iterators or subranges.
+\begin{footnote}
+The use of fully closed ranges is intentional.
+\end{footnote}
 \end{itemize}
 
 

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -637,11 +637,12 @@ block\iref{intro.progress}.
 
 \pnum
 \recommended
-Operations that are lock-free should also be address-free%
-\footnote{
+Operations that are lock-free should also be address-free
+\begin{footnote}
 That is,
 atomic operations on the same memory location via two different addresses will
-communicate atomically.}.
+communicate atomically.
+\end{footnote}.
 The implementation of these operations should not depend on any per-process state.
 \begin{note}
 This restriction enables communication by memory that is

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -129,9 +129,13 @@ it contains
 the
 \indextext{declaration!\idxcode{extern}}%
 \tcode{extern} specifier\iref{dcl.stc} or a
-\grammarterm{linkage-specification}\footnote{Appearing inside the brace-enclosed
+\grammarterm{linkage-specification}
+\begin{footnote}
+Appearing inside the brace-enclosed
 \grammarterm{declaration-seq} in a \grammarterm{linkage-specification} does
-not affect whether a declaration is a definition.}\iref{dcl.link}
+not affect whether a declaration is a definition.
+\end{footnote}%
+\iref{dcl.link}
 and neither an \grammarterm{initializer} nor a
 \grammarterm{function-body},
 \item
@@ -423,10 +427,13 @@ function for a class is odr-used by the definition of a constructor of that
 class. A non-placement deallocation function for a class is odr-used by the
 definition of the destructor of that class, or by being selected by the
 lookup at the point of definition of a virtual
-destructor\iref{class.dtor}.\footnote{An implementation is not required
+destructor\iref{class.dtor}.
+\begin{footnote}
+An implementation is not required
 to call allocation and
 deallocation functions from constructors or destructors; however, this
-is a permissible implementation technique.}
+is a permissible implementation technique.
+\end{footnote}
 
 \pnum
 An assignment operator function in a class is odr-used by an
@@ -1500,10 +1507,13 @@ or before its use in a namespace enclosing its namespace.
 \pnum
 In the definition of a function that is a member of namespace \tcode{N},
 a name used after the function's
-\grammarterm{declarator-id}\footnote{This refers to unqualified names
+\grammarterm{declarator-id}
+\begin{footnote}
+This refers to unqualified names
 that occur, for instance, in
 a type or default argument in the
-\grammarterm{parameter-declaration-clause} or used in the function body.}
+\grammarterm{parameter-declaration-clause} or used in the function body.
+\end{footnote}
 shall be
 declared before its use in the block in which it is used or in one of
 its enclosing blocks\iref{stmt.block} or shall be declared before its
@@ -1528,11 +1538,13 @@ void A::N::f() {
 \end{example}
 
 \pnum
-A name used in the definition of a class \tcode{X}%
-\footnote{This
+A name used in the definition of a class \tcode{X}
+\begin{footnote}
+This
 refers to unqualified names following the class name;
 such a name might be used in a \grammarterm{base-specifier} or
-in the \grammarterm{member-specification} of the class definition.}
+in the \grammarterm{member-specification} of the class definition.
+\end{footnote}
 outside of a complete-class context\iref{class.mem} of \tcode{X}
 shall be declared in one of the following ways:
 \begin{itemize}
@@ -1542,11 +1554,14 @@ of \tcode{X}\iref{class.member.lookup}, or
 \tcode{Y}\iref{class.nest}, before the definition of \tcode{X} in
 \tcode{Y}, or shall be a member of a base class of \tcode{Y} (this
 lookup applies in turn to \tcode{Y}'s enclosing classes, starting with
-the innermost enclosing class),\footnote{This lookup applies whether the
+the innermost enclosing class),
+\begin{footnote}
+This lookup applies whether the
 definition of \tcode{X} is
 nested within \tcode{Y}'s definition or whether \tcode{X}'s definition
 appears in a namespace scope enclosing \tcode{Y}'s
-definition\iref{class.nest}.}
+definition\iref{class.nest}.
+\end{footnote}
 or
 \item if \tcode{X} is a local class\iref{class.local} or is a nested
 class of a local class, before the definition of class \tcode{X} in a
@@ -1601,11 +1616,15 @@ For the members of a class \tcode{X}, a name used
 in a complete-class context\iref{class.mem} of \tcode{X} or
 in the definition of a class member outside of the definition of \tcode{X},
 following the member's
-\grammarterm{declarator-id}\footnote{That is, an unqualified name that occurs,
+\grammarterm{declarator-id}
+\begin{footnote}
+That is, an unqualified name that occurs,
 for instance, in a
 type in the
 \grammarterm{parameter-declaration-clause} or in the
-\grammarterm{noexcept-specifier}.}, shall be declared in one of the
+\grammarterm{noexcept-specifier}.
+\end{footnote}%
+, shall be declared in one of the
 following ways:
 \begin{itemize}
 \item before its use in the block in which it is used or in an enclosing
@@ -1618,10 +1637,13 @@ class of \tcode{X}\iref{class.member.lookup}, or
 is a nested class of class \tcode{Y}\iref{class.nest}, shall be a
 member of \tcode{Y}, or shall be a member of a base class of \tcode{Y}
 (this lookup applies in turn to \tcode{Y}'s enclosing classes, starting
-with the innermost enclosing class),\footnote{This lookup applies whether
+with the innermost enclosing class),
+\begin{footnote}
+This lookup applies whether
 the member function is defined
 within the definition of class \tcode{X} or whether the member function
-is defined in a namespace scope enclosing \tcode{X}'s definition.}
+is defined in a namespace scope enclosing \tcode{X}'s definition.
+\end{footnote}
 or
 
 \item if \tcode{X} is a local class\iref{class.local} or is a nested
@@ -2142,10 +2164,13 @@ scope\iref{basic.scope.hiding}.
 \end{itemize}
 
 \pnum
-In a lookup in which function names are not ignored\footnote{Lookups in which
+In a lookup in which function names are not ignored
+\begin{footnote}
+Lookups in which
 function names are ignored include names appearing in a
 \grammarterm{nested-name-specifier}, an
-\grammarterm{elaborated-type-specifier}, or a \grammarterm{base-specifier}.}
+\grammarterm{elaborated-type-specifier}, or a \grammarterm{base-specifier}.
+\end{footnote}
 and the \grammarterm{nested-name-specifier} nominates a class \tcode{C}:
 \begin{itemize}
 \item if the name specified after the \grammarterm{nested-name-specifier},
@@ -3053,14 +3078,19 @@ The fundamental storage unit in the \Cpp{} memory model is the
 A byte is at least large enough to contain any member of the basic
 \indextext{character set!basic execution}%
 execution character set\iref{lex.charset}
-and the eight-bit code units of the Unicode%
-  \footnote{Unicode\textregistered\ is a registered trademark of Unicode, Inc.
-  This information is given for the convenience of users of this document and
-  does not constitute an endorsement by ISO or IEC of this product.}
+and the eight-bit code units of the Unicode
+\begin{footnote}
+Unicode\textregistered\ is a registered trademark of Unicode, Inc.
+This information is given for the convenience of users of this document and
+does not constitute an endorsement by ISO or IEC of this product.
+\end{footnote}
 UTF-8 encoding form
 and is composed of a contiguous sequence of
-bits,\footnote{The number of bits in a byte is reported by the macro
-\tcode{CHAR_BIT} in the header \libheaderref{climits}.}
+bits,
+\begin{footnote}
+The number of bits in a byte is reported by the macro
+\tcode{CHAR_BIT} in the header \libheaderref{climits}.
+\end{footnote}
 the number of which is \impldef{bits in a byte}. The least
 significant bit is called the \defn{low-order bit}; the most
 significant bit is called the \defn{high-order bit}. The memory
@@ -3308,10 +3338,13 @@ or
 if at least one is a subobject of zero size
 and they are of different types;
 otherwise, they have distinct addresses
-and occupy disjoint bytes of storage.\footnote{Under the ``as-if'' rule an
+and occupy disjoint bytes of storage.
+\begin{footnote}
+Under the ``as-if'' rule an
 implementation is allowed to store two objects at the same machine address or
 not store an object at all if the program cannot observe the
-difference\iref{intro.execution}.}
+difference\iref{intro.execution}.
+\end{footnote}
 \begin{example}
 \begin{codeblock}
 static const char test1 = 'x';
@@ -3459,9 +3492,12 @@ produced by the destructor has undefined behavior.
 
 \pnum
 Before the lifetime of an object has started but after the storage which
-the object will occupy has been allocated\footnote{For example, before the
+the object will occupy has been allocated
+\begin{footnote}
+For example, before the
 construction of a global object
-that is initialized via a user-provided constructor\iref{class.cdtor}.}
+that is initialized via a user-provided constructor\iref{class.cdtor}.
+\end{footnote}
 or, after the lifetime of an object has ended and before the storage
 which the object occupied is reused or released, any pointer that represents the address of
 the storage location where the object will be or was located may be
@@ -3609,12 +3645,15 @@ by calling \tcode{std::launder}\iref{ptr.launder}.
 If a program ends the lifetime of an object of type \tcode{T} with
 static\iref{basic.stc.static}, thread\iref{basic.stc.thread},
 or automatic\iref{basic.stc.auto}
-storage duration and if \tcode{T} has a non-trivial destructor,\footnote{That
+storage duration and if \tcode{T} has a non-trivial destructor,
+\begin{footnote}
+That
 is, an object for which a destructor will be called
 implicitly---upon exit from the block for an object with
 automatic storage duration, upon exit from the thread for an object with
 thread storage duration, or upon exit from the program for an object
-with static storage duration.}
+with static storage duration.
+\end{footnote}
 and another object of the original type does not occupy
 that same storage location when the implicit destructor call takes
 place, the behavior of the program is undefined. This is true
@@ -3775,9 +3814,12 @@ passing an invalid pointer value to a deallocation function
 have undefined behavior.
 Any other use of an invalid pointer value has
 \impldef{any use of an invalid pointer other than to perform indirection or deallocate}
-behavior.\footnote{Some implementations might define that
+behavior.
+\begin{footnote}
+Some implementations might define that
 copying an invalid pointer value
-causes a system-generated runtime fault.}
+causes a system-generated runtime fault.
+\end{footnote}
 
 \rSec3[basic.stc.static]{Static storage duration}
 
@@ -3965,11 +4007,14 @@ in~\ref{new.delete.single} and~\ref{new.delete.array},
 \tcode{p0} represents the address of a block of storage disjoint from the storage
 for any other object accessible to the caller.
 The effect of indirecting through a pointer
-returned from a request for zero size is undefined.\footnote{The intent is
+returned from a request for zero size is undefined.
+\begin{footnote}
+The intent is
 to have \tcode{operator new()} implementable by
 calling \tcode{std::malloc()} or \tcode{std::calloc()}, so the rules are
 substantially the same. \Cpp{} differs from C in requiring a zero request
-to return a non-null pointer.}
+to return a non-null pointer.
+\end{footnote}
 
 \pnum
 For an allocation function other than
@@ -4064,11 +4109,14 @@ whose parameters after the first are
 \item
 optionally, a parameter of type \tcode{std::destroying_delete_t}, then
 \item
-optionally, a parameter of type \tcode{std::size_t}%
-\footnote{The global \tcode{operator delete(void*, std::size_t)}
+optionally, a parameter of type \tcode{std::size_t}
+\begin{footnote}
+The global \tcode{operator delete(void*, std::size_t)}
 precludes use of an
 allocation function \tcode{void operator new(std::size_t, std::size_t)} as a placement
-allocation function~(\ref{diff.cpp11.basic}).}, then
+allocation function~(\ref{diff.cpp11.basic}).
+\end{footnote}%
+, then
 \item
 optionally, a parameter of type \tcode{std::align_val_t}.
 \end{itemize}
@@ -4117,11 +4165,14 @@ and is one of the following:
 \item the value returned by a call to the \Cpp{} standard library implementation of
 \tcode{::operator new(std::\brk{}size_t)} or
 \tcode{::operator new(std::size_t, std::align_val_t)}%
-;\footnote{This subclause does not impose restrictions
+;%
+\begin{footnote}
+This subclause does not impose restrictions
 on indirection through pointers to memory not allocated by \tcode{::operator new}. This
 maintains the ability of many \Cpp{} implementations to use binary libraries and
 components written in other languages. In particular, this applies to C binaries,
-because indirection through pointers to memory allocated by \tcode{std::malloc} is not restricted.}
+because indirection through pointers to memory allocated by \tcode{std::malloc} is not restricted.
+\end{footnote}
 
 \item the result of taking the address of an object (or one of its
   subobjects) designated by an lvalue resulting from indirection
@@ -4443,9 +4494,12 @@ sequenced before the construction of the next array element, if any.
 
 \pnum
 The third context is when a reference is bound to a
-temporary object.\footnote{The same rules apply to initialization of an
+temporary object.
+\begin{footnote}
+The same rules apply to initialization of an
   \tcode{initializer_list} object\iref{dcl.init.list} with its
-  underlying temporary array.}
+  underlying temporary array.
+\end{footnote}
 The temporary object to which the reference is bound or the temporary object
 that is the complete object of a subobject to which the reference is bound
 persists for the lifetime of the reference if the glvalue
@@ -4681,9 +4735,11 @@ For any object (other than a potentially-overlapping subobject) of trivially cop
 object can be copied into an array of
 \tcode{char},
 \tcode{unsigned char}, or
-\tcode{std::byte}\iref{cstddef.syn}.%
-\footnote{By using, for example, the library
-functions\iref{headers} \tcode{std::memcpy} or \tcode{std::memmove}.}
+\tcode{std::byte}\iref{cstddef.syn}.
+\begin{footnote}
+By using, for example, the library
+functions\iref{headers} \tcode{std::memcpy} or \tcode{std::memmove}.
+\end{footnote}
 If the content of that array
 is copied back into the object, the object shall
 subsequently hold its original value.
@@ -4702,8 +4758,11 @@ For any trivially copyable type \tcode{T}, if two pointers to \tcode{T} point to
 distinct \tcode{T} objects \tcode{obj1} and \tcode{obj2}, where neither
 \tcode{obj1} nor \tcode{obj2} is a potentially-overlapping subobject, if the underlying
 bytes\iref{intro.memory} making up
-\tcode{obj1} are copied into \tcode{obj2},\footnote{By using, for example,
-the library functions\iref{headers} \tcode{std::memcpy} or \tcode{std::memmove}.}
+\tcode{obj1} are copied into \tcode{obj2},
+\begin{footnote}
+By using, for example,
+the library functions\iref{headers} \tcode{std::memcpy} or \tcode{std::memmove}.
+\end{footnote}
  \tcode{obj2} shall subsequently hold the same value as
 \tcode{obj1}.
 \begin{example}
@@ -4732,18 +4791,23 @@ are \defn{padding bits}.
 For trivially copyable types, the value representation is
 a set of bits in the object representation that determines a
 \defn{value}, which is one discrete element of an
-\impldef{values of a trivially copyable type} set of values.\footnote{The
+\impldef{values of a trivially copyable type} set of values.
+\begin{footnote}
+The
 intent is that the memory model of \Cpp{} is compatible
-with that of ISO/IEC 9899 Programming Language C.}
+with that of ISO/IEC 9899 Programming Language C.
+\end{footnote}
 
 \pnum
 \indextext{type!incompletely-defined object}%
 A class that has been declared but not defined, an enumeration type in certain
 contexts\iref{dcl.enum}, or an array of unknown
 bound or of incomplete element type, is an
-\defnadj{incompletely-defined}{object type}.%
-\footnote{The size and layout of an instance of an incompletely-defined
-object type is unknown.}
+\defnadj{incompletely-defined}{object type}.
+\begin{footnote}
+The size and layout of an instance of an incompletely-defined
+object type is unknown.
+\end{footnote}
 Incompletely-defined object types and \cv{}~\tcode{void} are
 \defnx{incomplete types}{type!incomplete}\iref{basic.fundamental}.
 Objects shall not be defined to have an
@@ -4938,8 +5002,11 @@ as the corresponding signed integer type.
 For each value $x$ of a signed integer type,
 the value of the corresponding unsigned integer type
 congruent to $x$ modulo $2^N$ has the same value
-of corresponding bits in its value representation.\footnote{This
-is also known as two's complement representation.}
+of corresponding bits in its value representation.
+\begin{footnote}
+This
+is also known as two's complement representation.
+\end{footnote}
 \begin{example}
 The value $-1$ of a signed integer type has the same representation as
 the largest value of the corresponding unsigned type.
@@ -5193,8 +5260,10 @@ Each distinct enumeration constitutes a different
 \item
 \indextext{member pointer to|see{pointer to member}}%
 \defnx{pointers to non-static class members}{pointer to member},%
-\footnote{Static class members are objects or functions, and pointers to them are
-ordinary pointers to objects or functions.}
+\begin{footnote}
+Static class members are objects or functions, and pointers to them are
+ordinary pointers to objects or functions.
+\end{footnote}
 which identify members of a given
 type within objects of a given class, \ref{dcl.mptr}.
 Pointers to data members and pointers to member functions are collectively
@@ -5248,9 +5317,11 @@ A value of a
 pointer type
 that is a pointer to or past the end of an object
 \defn{represents the address} of
-the first byte in memory\iref{intro.memory} occupied by the object%
-\footnote{For an object that is not within its lifetime,
-this is the first byte in memory that it will occupy or used to occupy.}
+the first byte in memory\iref{intro.memory} occupied by the object
+\begin{footnote}
+For an object that is not within its lifetime,
+this is the first byte in memory that it will occupy or used to occupy.
+\end{footnote}
 or the first byte in memory
 after the end of the storage occupied by the object,
 respectively.
@@ -5354,10 +5425,13 @@ specified in the \grammarterm{decl-specifier-seq}\iref{dcl.spec},
 The cv-qualified or
 cv-unqualified versions of a type
 are distinct types; however, they shall have the same representation and
-alignment requirements\iref{basic.align}.\footnote{The same representation
+alignment requirements\iref{basic.align}.
+\begin{footnote}
+The same representation
 and alignment requirements are meant to imply
 interchangeability as arguments to functions, return values from
-functions, and non-static data members of unions.}
+functions, and non-static data members of unions.
+\end{footnote}
 
 \pnum
 Except for array types, a compound type\iref{basic.compound} is not cv-qualified by the
@@ -5674,10 +5748,13 @@ value computation and
 \indextext{side effects}%
 side effect associated with a full-expression is
 sequenced before every value computation and side effect associated with the
-next full-expression to be evaluated.\footnote{As specified
+next full-expression to be evaluated.
+\begin{footnote}
+As specified
 in~\ref{class.temporary}, after a full-expression is evaluated, a sequence of
 zero or more invocations of destructor functions for temporary objects takes
-place, usually in reverse order of the construction of each temporary object.}
+place, usually in reverse order of the construction of each temporary object.
+\end{footnote}
 
 \pnum
 \indextext{evaluation!unspecified order of}%
@@ -5729,8 +5806,11 @@ for every evaluation \placeholder{A} that occurs within \placeholder{F} and
 every evaluation \placeholder{B} that does not occur within \placeholder{F} but
 is evaluated on the same thread and as part of the same signal handler (if any),
 either \placeholder{A} is sequenced before \placeholder{B} or
-\placeholder{B} is sequenced before \placeholder{A}.\footnote{In other words,
-function executions do not interleave with each other.}
+\placeholder{B} is sequenced before \placeholder{A}.
+\begin{footnote}
+In other words,
+function executions do not interleave with each other.
+\end{footnote}
 \begin{note}
 If \placeholder{A} and \placeholder{B} would not otherwise be sequenced then they are
 indeterminately sequenced.
@@ -5778,10 +5858,14 @@ the initial call to the top-level function of the new thread is executed by the
 new thread, not by the creating thread.
 \end{note}
 Every thread in a program can
-potentially access every object and function in a program.\footnote{An object
+potentially access every object and function in a program.
+\begin{footnote}
+An object
 with automatic or thread storage duration\iref{basic.stc} is associated with
 one specific thread, and can be accessed by a different thread only indirectly
-through a pointer or reference\iref{basic.compound}.} Under a hosted
+through a pointer or reference\iref{basic.compound}.
+\end{footnote}
+Under a hosted
 implementation, a \Cpp{} program can have more than one thread running
 concurrently. The execution of each thread proceeds as defined by the remainder
 of this document. The execution of the entire program consists of an execution
@@ -6656,11 +6740,13 @@ is sequenced before the first statement of \tcode{main} or is deferred.
 If it is deferred, it strongly happens before
 any non-initialization odr-use
 of any non-inline function or non-inline variable
-defined in the same translation unit as the variable to be initialized.%
-\footnote{A non-local variable with static storage duration
+defined in the same translation unit as the variable to be initialized.
+\begin{footnote}
+A non-local variable with static storage duration
 having initialization
 with side effects is initialized in this case,
-even if it is not itself odr-used~(\ref{basic.def.odr}, \ref{basic.stc.static}).}
+even if it is not itself odr-used~(\ref{basic.def.odr}, \ref{basic.stc.static}).
+\end{footnote}
 It is \impldef{threads and program points at which deferred dynamic initialization is performed}
 in which threads and at which points in the program such deferred dynamic initialization occurs.
 

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -190,10 +190,13 @@ its base classes first declared in the same class, and
 
 \item has no element of the set $M(\mathtt{S})$ of types
 as a base class,
-where for any type \tcode{X}, $M(\mathtt{X})$ is defined as follows.\footnote{
+where for any type \tcode{X}, $M(\mathtt{X})$ is defined as follows.
+\begin{footnote}
+
 This ensures that two subobjects that have the same class type and that
 belong to the same most derived object are not allocated at the same
-address\iref{expr.eq}.}
+address\iref{expr.eq}.
+\end{footnote}
 \begin{note}
 $M(\mathtt{X})$ is the set of the types of all non-base-class subobjects
 that can be at a zero offset in \tcode{X}.
@@ -1019,7 +1022,10 @@ call \tcode{n1.set("abc",\&n2,0)}, \tcode{tword} refers to
 \tcode{n1.tword}, and in the call \tcode{n2.set("def",0,0)}, it refers
 to \tcode{n2.tword}. The functions \tcode{strlen}, \tcode{perror}, and
 \tcode{strcpy} are not members of the class \tcode{tnode} and should be
-declared elsewhere.\footnote{See, for example, \libheaderref{cstring}.}
+declared elsewhere.
+\begin{footnote}
+See, for example, \libheaderref{cstring}.
+\end{footnote}
 \end{example}
 
 \pnum
@@ -1617,11 +1623,14 @@ has a copy constructor whose first parameter is of type
 or
 \tcode{const}
 \tcode{volatile}
-\tcode{M\&}.\footnote{This implies that the reference parameter of the
+\tcode{M\&}.
+\begin{footnote}
+This implies that the reference parameter of the
 implicitly-declared copy constructor
 cannot bind to a
 \tcode{volatile}
-lvalue; see~\ref{diff.class}.}
+lvalue; see~\ref{diff.class}.
+\end{footnote}
 Otherwise, the implicitly-declared copy constructor will have the form
 \begin{codeblock}
 X::X(X&)
@@ -1801,13 +1810,16 @@ and the lifetime of $o$ begins before the copy is performed.
 A user-declared \term{copy} assignment operator \tcode{X::operator=} is a
 non-static non-template member function of class \tcode{X} with exactly one
 parameter of type \tcode{X}, \tcode{X\&}, \tcode{const X\&},
-\tcode{volatile X\&}, or \tcode{const volatile X\&}.\footnote{Because
+\tcode{volatile X\&}, or \tcode{const volatile X\&}.
+\begin{footnote}
+Because
 a template assignment operator or an assignment operator
 taking an rvalue reference parameter is never a copy assignment operator,
 the presence of such an assignment operator does not suppress the
 implicit declaration of a copy assignment operator. Such assignment operators
 participate in overload resolution with other assignment operators, including
-copy assignment operators, and, if selected, will be used to assign an object.}
+copy assignment operators, and, if selected, will be used to assign an object.
+\end{footnote}
 \begin{note}
 An overloaded assignment operator must be declared to have only one parameter;
 see~\ref{over.ass}.
@@ -1865,9 +1877,12 @@ for all the non-static data members of \tcode{X}
 that are of a class type \tcode{M} (or array thereof),
 each such class type has a copy assignment operator whose parameter is of type
 \tcode{const M\&}, \tcode{const volatile M\&},
-or \tcode{M}.\footnote{This implies that the reference parameter of the
+or \tcode{M}.
+\begin{footnote}
+This implies that the reference parameter of the
 implicitly-declared copy assignment operator cannot bind to a
-\tcode{volatile} lvalue; see~\ref{diff.class}.}
+\tcode{volatile} lvalue; see~\ref{diff.class}.
+\end{footnote}
 \end{itemize}
 
 Otherwise, the implicitly-declared copy assignment operator
@@ -2636,11 +2651,14 @@ The type of the conversion function\iref{dcl.fct} is
 A conversion function is never used to convert a (possibly cv-qualified) object
 to the (possibly cv-qualified) same object type (or a reference to it),
 to a (possibly cv-qualified) base class of that type (or a reference to it),
-or to \cv{}~\tcode{void}.\footnote{These conversions are considered
+or to \cv{}~\tcode{void}.
+\begin{footnote}
+These conversions are considered
 as standard conversions for the purposes of overload resolution~(\ref{over.best.ics}, \ref{over.ics.ref}) and therefore initialization\iref{dcl.init} and explicit casts\iref{expr.static.cast}. A conversion to \tcode{void} does not invoke any conversion function\iref{expr.static.cast}.
 Even though never directly called to perform a conversion,
 such conversion functions can be declared and can potentially
-be reached through a call to a virtual conversion function in a base class.}
+be reached through a call to a virtual conversion function in a base class.
+\end{footnote}
 \begin{example}
 \begin{codeblock}
 struct X {
@@ -3760,19 +3778,25 @@ by \tcode{X} and \tcode{Y}, as shown in \fref{class.virtnonvirt}.
 A non-static member function is a \defnadj{virtual}{function}
 if it is first declared with the keyword \tcode{virtual} or
 if it overrides a virtual member function declared in a base class
-(see below).\footnote{The use of the \tcode{virtual} specifier in the
+(see below).
+\begin{footnote}
+The use of the \tcode{virtual} specifier in the
 declaration of an overriding function is valid but redundant (has empty
-semantics).}
+semantics).
+\end{footnote}
 \begin{note}
 Virtual functions support dynamic binding and object-oriented
 programming.
 \end{note}
 A class that declares or inherits a virtual function is
-called a \defnadj{polymorphic}{class}.\footnote{If
+called a \defnadj{polymorphic}{class}.
+\begin{footnote}
+If
 all virtual functions are immediate functions,
 the class is still polymorphic even though
 its internal representation might not otherwise require
-any additions for that polymorphic behavior.}
+any additions for that polymorphic behavior.
+\end{footnote}
 
 \pnum
 If a virtual member function \tcode{vf} is declared in a class
@@ -3780,11 +3804,14 @@ If a virtual member function \tcode{vf} is declared in a class
 indirectly from \tcode{Base}, a member function \tcode{vf} with the same
 name, parameter-type-list\iref{dcl.fct}, cv-qualification, and ref-qualifier
 (or absence of same) as \tcode{Base::vf} is declared,
-then \tcode{Derived::vf} \term{overrides}\footnote{A function
+then \tcode{Derived::vf} \term{overrides}
+\begin{footnote}
+A function
 with the same name but a different parameter list\iref{over}
 as a virtual function is not necessarily virtual and
 does not override. Access control\iref{class.access} is not considered in
-determining overriding.}
+determining overriding.
+\end{footnote}
 \tcode{Base::vf}. For convenience we say that any virtual function
 overrides itself.
 \indextext{overrider!final}%
@@ -3903,9 +3930,11 @@ function \tcode{B::f}, the return types of the functions are covariant
 if they satisfy the following criteria:
 \begin{itemize}
 \item both are pointers to classes, both are lvalue references to
-classes, or both are rvalue references to classes\footnote{Multi-level pointers to classes or references to multi-level pointers to
+classes, or both are rvalue references to classes
+\begin{footnote}
+Multi-level pointers to classes or references to multi-level pointers to
 classes are not allowed.%
-}
+\end{footnote}
 
 \item the class in the return type of \tcode{B::f} is the same class as
 the class in the return type of \tcode{D::f}, or is an unambiguous and
@@ -4520,9 +4549,12 @@ that is, its name can be used anywhere without access restriction.
 \pnum
 A member of a class can also access all the names to which the class has access.
 A local class of a member function may access
-the same names that the member function itself may access.\footnote{Access
+the same names that the member function itself may access.
+\begin{footnote}
+Access
 permissions are thus transitive and cumulative to nested
-and local classes.}
+and local classes.
+\end{footnote}
 
 \pnum
 \indextext{access control!member name}%
@@ -4789,10 +4821,13 @@ If a class is declared to be a base class for another class using the
 access specifier, the
 public and protected
 members of the base class are accessible as private
-members of the derived class.\footnote{As specified previously in \ref{class.access},
+members of the derived class.
+\begin{footnote}
+As specified previously in \ref{class.access},
 private members of a base class remain inaccessible even to derived classes
 unless friend
-declarations within the base class definition are used to grant access explicitly.}
+declarations within the base class definition are used to grant access explicitly.
+\end{footnote}
 
 \pnum
 In the absence of an
@@ -5322,9 +5357,12 @@ void f() {
 \pnum
 An additional access check beyond those described earlier in \ref{class.access}
 is applied when a non-static data member or non-static member function is a
-protected member of its naming class\iref{class.access.base}.\footnote{This
+protected member of its naming class\iref{class.access.base}.
+\begin{footnote}
+This
 additional check does not apply to other members,
-e.g., static data members or enumerator member constants.}
+e.g., static data members or enumerator member constants.
+\end{footnote}
 As described earlier, access to a protected member is granted because the
 reference occurs in a friend or member of some class \tcode{C}. If the access is
 to form a pointer to member\iref{expr.unary.op}, the
@@ -6487,9 +6525,12 @@ selected constructor is an rvalue reference to the object's type,
 the destruction of that object occurs when the target would have been destroyed;
 otherwise, the destruction occurs at the later of the times when the
 two objects would have been destroyed without the
-optimization.\footnote{Because only one object is destroyed instead of two,
+optimization.
+\begin{footnote}
+Because only one object is destroyed instead of two,
 and one copy/move constructor
-is not executed, there is still one object destroyed for each one constructed.}
+is not executed, there is still one object destroyed for each one constructed.
+\end{footnote}
 This elision of copy/move operations, called
 \indexdefn{copy elision|see{constructor, copy, elision}}%
 \indexdefn{elision!copy|see{constructor, copy, elision}}%
@@ -7088,11 +7129,13 @@ If the \grammarterm{delete-expression}
 is used to deallocate a class object whose static type has a virtual
 destructor, the deallocation function is the one selected at the point
 of definition of the dynamic type's virtual
-destructor\iref{class.dtor}.\footnote{A similar provision is not needed for
+destructor\iref{class.dtor}.
+\begin{footnote}
+A similar provision is not needed for
 the array version of \tcode{operator} \tcode{delete} because~\ref{expr.delete}
 requires that in this situation, the static type of the object to be deleted be
 the same as its dynamic type.
-}
+\end{footnote}
 Otherwise, if the
 \grammarterm{delete-expression}
 is used to deallocate an object of class

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -598,8 +598,12 @@ and \tcode{E2} is expression-equivalent to an expression
 
 \begin{itemize}
 \item
-  \tcode{S} is \tcode{(void)swap(E1, E2)}\footnote{The name \tcode{swap} is used
-  here unqualified.} if \tcode{E1} or \tcode{E2}
+  \tcode{S} is \tcode{(void)swap(E1, E2)}
+\begin{footnote}
+The name \tcode{swap} is used
+  here unqualified.
+\end{footnote}
+if \tcode{E1} or \tcode{E2}
   has class or enumeration type\iref{basic.compound} and that expression is valid, with
   overload resolution performed in a context that includes the declaration
 \begin{codeblock}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -3002,9 +3002,12 @@ a pathologically bad hash function). The behavior of a program that uses
 \tcode{operator==} or \tcode{operator!=} on unordered containers is undefined
 unless the \tcode{Pred} function object has
 the same behavior for both containers and the equality comparison function
-for \tcode{Key} is a refinement\footnote{Equality comparison is a refinement
+for \tcode{Key} is a refinement
+\begin{footnote}
+Equality comparison is a refinement
 of partitioning if no two objects that
-compare equal fall into different partitions.}
+compare equal fall into different partitions.
+\end{footnote}
 of the partition into equivalent-key groups produced by \tcode{Pred}.
 
 \pnum
@@ -4865,10 +4868,12 @@ The exceptions are the
 \tcode{operator[]}
 and
 \tcode{at}
-member functions, which are not provided.\footnote{These member functions
+member functions, which are not provided.
+\begin{footnote}
+These member functions
 are only provided by containers whose iterators
 are random access iterators.
-}
+\end{footnote}
 Descriptions are provided here only for operations on
 \tcode{list}
 that are not described in one of these tables
@@ -5217,9 +5222,12 @@ is exactly equal to the size of the range.
 
 \pnum
 Since lists allow fast insertion and erasing from the middle of a list, certain
-operations are provided specifically for them.\footnote{As specified
+operations are provided specifically for them.
+\begin{footnote}
+As specified
 in~\ref{allocator.requirements}, the requirements in this Clause apply only to
-lists whose allocators compare equal.}
+lists whose allocators compare equal.
+\end{footnote}
 In this subclause,
 arguments for a template parameter
 named \tcode{Predicate} or \tcode{BinaryPredicate}
@@ -5847,8 +5855,11 @@ there are no effects.
 \pnum
 \throws
 \tcode{length_error} if \tcode{n >
-max_size()}.\footnote{\tcode{reserve()} uses \tcode{Allocator::allocate()} which
-can throw an appropriate exception.}
+max_size()}.
+\begin{footnote}
+\tcode{reserve()} uses \tcode{Allocator::allocate()} which
+can throw an appropriate exception.
+\end{footnote}
 
 \pnum
 \complexity

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1192,11 +1192,14 @@ Except in a declaration of a constructor, destructor, or conversion
 function, at least one \grammarterm{defining-type-specifier} that is not a
 \grammarterm{cv-qualifier} shall appear in a complete
 \grammarterm{type-specifier-seq} or a complete
-\grammarterm{decl-specifier-seq}.\footnote{There is no special
+\grammarterm{decl-specifier-seq}.
+\begin{footnote}
+There is no special
 provision for a \grammarterm{decl-specifier-seq} that
 lacks a \grammarterm{type-specifier} or that has a
 \grammarterm{type-specifier} that only specifies \grammarterm{cv-qualifier}{s}.
-The ``implicit int'' rule of C is no longer supported.}
+The ``implicit int'' rule of C is no longer supported.
+\end{footnote}
 
 \pnum
 \begin{note}
@@ -3305,7 +3308,10 @@ appertains to the function type.
 
 \pnum
 \indextext{type!function}%
-A type of either form is a \term{function type}.\footnote{As indicated by syntax, cv-qualifiers are a significant component in function return types.}
+A type of either form is a \term{function type}.%
+\begin{footnote}
+As indicated by syntax, cv-qualifiers are a significant component in function return types.
+\end{footnote}
 
 \indextext{declaration!function}%
 \begin{bnf}
@@ -3736,11 +3742,14 @@ comma. In this case, the ellipsis is parsed as part of the
 \grammarterm{abstract-declarator} if the type of the parameter either names
 a template parameter pack that has not been expanded or contains \tcode{auto};
 otherwise, it is
-parsed as part of the \grammarterm{parameter-declaration-clause}.\footnote{One can explicitly disambiguate the parse either by
+parsed as part of the \grammarterm{parameter-declaration-clause}.
+\begin{footnote}
+One can explicitly disambiguate the parse either by
 introducing a comma (so the ellipsis will be parsed as part of the
 \grammarterm{parameter-declaration-clause}) or by introducing a name for the
 parameter (so the ellipsis will be parsed as part of the
-\grammarterm{declarator-id}).}%
+\grammarterm{declarator-id}).
+\end{footnote}
 \indextext{declarator!function|)}
 
 \rSec3[dcl.fct.default]{Default arguments}%
@@ -3796,13 +3805,15 @@ it shall not occur within a
 or
 \grammarterm{abstract-declarator}
 of a
-\grammarterm{parameter-declaration}.\footnote{This means that default
+\grammarterm{parameter-declaration}.
+\begin{footnote}
+This means that default
 arguments cannot appear,
 for example, in declarations of pointers to functions,
 references to functions, or
 \tcode{typedef}
 declarations.
-}
+\end{footnote}
 
 \pnum
 For non-template functions, default arguments can be added in later
@@ -4171,11 +4182,13 @@ is a scalar type\iref{basic.types}, the
 object
 is initialized to the value obtained by converting the integer literal \tcode{0}
 (zero) to
-\tcode{T};\footnote{As specified in~\ref{conv.ptr}, converting an integer
+\tcode{T};
+\begin{footnote}
+As specified in~\ref{conv.ptr}, converting an integer
 literal whose value is
 \tcode{0}
 to a pointer type results in a null pointer value.
-}
+\end{footnote}
 
 \item
 if
@@ -4860,9 +4873,11 @@ as a one-dimensional array that has three elements
 since no size was specified and there are three initializers.
 \end{example}
 An array of unknown bound shall not be initialized with
-an empty \grammarterm{braced-init-list} \tcode{\{\}}.%
-\footnote{The syntax provides for empty \grammarterm{braced-init-list}{s},
-but nonetheless \Cpp{} does not have zero length arrays.}
+an empty \grammarterm{braced-init-list} \tcode{\{\}}.
+\begin{footnote}
+The syntax provides for empty \grammarterm{braced-init-list}{s},
+but nonetheless \Cpp{} does not have zero length arrays.
+\end{footnote}
 \begin{note}
 A default member initializer does not determine the bound for a member
 array of unknown bound.  Since the default member initializer is
@@ -5304,8 +5319,11 @@ has a class type (i.e.,
 is a class type), where \tcode{T1} is not reference-related to \tcode{T2}, and can be converted
 to an lvalue of type ``\cvqual{cv3} \tcode{T3}'', where
 ``\cvqual{cv1} \tcode{T1}'' is reference-compatible with
-``\cvqual{cv3} \tcode{T3}''\footnote{This requires a conversion
-function\iref{class.conv.fct} returning a reference type.}
+``\cvqual{cv3} \tcode{T3}''
+\begin{footnote}
+This requires a conversion
+function\iref{class.conv.fct} returning a reference type.
+\end{footnote}
 (this conversion is selected by enumerating the applicable conversion
 functions\iref{over.match.ref} and choosing the best one through overload
 resolution\iref{over.match}),
@@ -5988,10 +6006,13 @@ static const char __func__[] = "@\placeholder{function-name}@";
 had been provided, where \tcode{\placeholder{function-name}} is an \impldef{string resulting
 from \mname{func}} string.
 It is unspecified whether such a variable has an address
-distinct from that of any other object in the program.\footnote{Implementations are
+distinct from that of any other object in the program.
+\begin{footnote}
+Implementations are
 permitted to provide additional predefined variables with names that are reserved to the
 implementation\iref{lex.name}. If a predefined variable is not
-odr-used\iref{basic.def.odr}, its string value need not be present in the program image.}
+odr-used\iref{basic.def.odr}, its string value need not be present in the program image.
+\end{footnote}
 \begin{example}
 \begin{codeblock}
 struct S {
@@ -6856,10 +6877,13 @@ enumeration type is $M$.
 It is possible to define an enumeration that has values not defined by
 any of its enumerators. If the \grammarterm{enumerator-list} is empty, the
 values of the enumeration are as if the enumeration had a single enumerator with
-value 0.\footnote{This set of values is used to define promotion and
+value 0.
+\begin{footnote}
+This set of values is used to define promotion and
 conversion semantics for the enumeration type. It does not preclude an
 expression of enumeration type from having a value that falls outside
-this range.}
+this range.
+\end{footnote}
 
 \pnum
 Two enumeration types are \defnx{layout-compatible enumerations}{layout-compatible!enumeration}
@@ -7321,7 +7345,10 @@ namespace R {
 
 \pnum
 If a friend declaration in a non-local class first declares a
-class, function, class template or function template\footnote{this implies that the name of the class or function is unqualified.}
+class, function, class template or function template
+\begin{footnote}
+this implies that the name of the class or function is unqualified.
+\end{footnote}
 the friend is a member of the innermost enclosing
 namespace. The friend declaration does not by itself make the name
 visible to unqualified lookup\iref{basic.lookup.unqual} or qualified
@@ -7599,12 +7626,15 @@ of the declarations found by the search.
 \end{note}
 An ambiguity exists if the best match finds two functions with the same
 signature, even if one is in a namespace reachable through
-\grammarterm{using-directive}{s} in the namespace of the other.\footnote{During
+\grammarterm{using-directive}{s} in the namespace of the other.
+\begin{footnote}
+During
 name lookup in a class hierarchy, some ambiguities can be
 resolved by considering whether one member hides the other along some
 paths\iref{class.member.lookup}. There is no such disambiguation when
 considering the set of names found as a result of following
-\grammarterm{using-directive}{s}.}
+\grammarterm{using-directive}{s}.
+\end{footnote}
 \begin{example}
 \begin{codeblock}
 namespace D {
@@ -7660,11 +7690,13 @@ void f() {
 \end{bnf}
 
 \pnum
-Each \grammarterm{using-declarator} in a \grammarterm{using-declaration}%
-\footnote{A \grammarterm{using-declaration} with more than one
+Each \grammarterm{using-declarator} in a \grammarterm{using-declaration}
+\begin{footnote}
+A \grammarterm{using-declaration} with more than one
 \grammarterm{using-declarator} is equivalent to a corresponding sequence
 of \grammarterm{using-declaration}{s} with
-one \grammarterm{using-declarator} each.}
+one \grammarterm{using-declarator} each.
+\end{footnote}
 introduces a set of declarations into the declarative region in
 which the \grammarterm{using-declaration} appears.
 The set of declarations introduced by the \grammarterm{using-declarator} is found by

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -19,8 +19,11 @@
 \indextext{expression|(}%
 \begin{note}
 \ref{expr} defines the syntax, order of evaluation, and meaning
-of expressions.\footnote{The precedence of operators is not directly specified, but it can be
-derived from the syntax.}
+of expressions.
+\begin{footnote}
+The precedence of operators is not directly specified, but it can be
+derived from the syntax.
+\end{footnote}
 An expression is a sequence of operators and operands that specifies a
 computation. An expression can result in a value and can cause side
 effects.
@@ -75,8 +78,11 @@ adjustable by a library function.
 \begin{note}
 The implementation can regroup operators according to
 the usual mathematical rules only
-where the operators really are associative or commutative.\footnote{Overloaded
-operators are never assumed to be associative or commutative.}
+where the operators really are associative or commutative.
+\begin{footnote}
+Overloaded
+operators are never assumed to be associative or commutative.
+\end{footnote}
 For example, in the following fragment
 \begin{codeblock}
 int a, b;
@@ -121,9 +127,12 @@ The values of the floating-point operands and
 the results of floating-point expressions
 may be represented in greater precision and range than that
 required by the type; the types are not changed\
-thereby.\footnote{The cast and assignment operators must still perform their specific
+thereby.
+\begin{footnote}
+The cast and assignment operators must still perform their specific
 conversions as described in~\ref{expr.type.conv}, \ref{expr.cast},
-\ref{expr.static.cast} and~\ref{expr.ass}.}
+\ref{expr.static.cast} and~\ref{expr.ass}.
+\end{footnote}
 
 \rSec1[expr.prop]{Properties of expressions}
 
@@ -291,8 +300,11 @@ If a program attempts to access\iref{defns.access}
 the stored value of an object through a glvalue
 whose type is not similar\iref{conv.qual} to
 one of the following types the behavior is
-undefined:\footnote{The intent of this list is to specify those circumstances in which an
-object can or cannot be aliased.}
+undefined:
+\begin{footnote}
+The intent of this list is to specify those circumstances in which an
+object can or cannot be aliased.
+\end{footnote}
 \begin{itemize}
 \item the dynamic type of the object,
 
@@ -589,17 +601,22 @@ descriptions of those operators and contexts.
 \indextext{type!incomplete}%
 A glvalue\iref{basic.lval} of a non-function, non-array type \tcode{T}
 can be converted to
-a prvalue.\footnote{For historical reasons, this conversion is called the ``lvalue-to-rvalue''
+a prvalue.
+\begin{footnote}
+For historical reasons, this conversion is called the ``lvalue-to-rvalue''
 conversion, even though that name does not accurately reflect the taxonomy
-of expressions described in~\ref{basic.lval}.}
+of expressions described in~\ref{basic.lval}.
+\end{footnote}
 If \tcode{T} is an incomplete type, a
 program that necessitates this conversion is ill-formed. If \tcode{T}
 is a non-class type, the type of the prvalue is
 the cv-unqualified version of \tcode{T}. Otherwise, the type of the
-prvalue is \tcode{T}.%
-\footnote{In \Cpp{} class and array prvalues can have cv-qualified types.
+prvalue is \tcode{T}.
+\begin{footnote}
+In \Cpp{} class and array prvalues can have cv-qualified types.
 This differs from ISO C, in which non-lvalues never have
-cv-qualified types.}
+cv-qualified types.
+\end{footnote}
 
 \pnum
 When an lvalue-to-rvalue conversion
@@ -676,8 +693,11 @@ The result is a pointer to the first element of the array.
 \indextext{conversion!function-to-pointer}%
 An lvalue of function type \tcode{T} can be converted to a prvalue of
 type ``pointer to \tcode{T}''. The result is a pointer to the
-function.\footnote{This conversion never applies to non-static member functions because an
-lvalue that refers to a non-static member function cannot be obtained.}
+function.
+\begin{footnote}
+This conversion never applies to non-static member functions because an
+lvalue that refers to a non-static member function cannot be obtained.
+\end{footnote}
 
 \rSec2[conv.rval]{Temporary materialization conversion}
 \indextext{conversion!temporary materialization}%
@@ -1031,7 +1051,9 @@ indirection through it with a \tcode{D} object is valid. The result is the same
 as if indirecting through the pointer to member of \tcode{B} with the
 \tcode{B} subobject of \tcode{D}. The null member pointer value is
 converted to the null member pointer value of the destination
-type.\footnote{The rule for conversion of pointers to members (from pointer to member
+type.
+\begin{footnote}
+The rule for conversion of pointers to members (from pointer to member
 of base to pointer to member of derived) appears inverted compared to
 the rule for pointers to objects (from pointer to derived to pointer to
 base)~(\ref{conv.ptr}, \ref{class.derived}). This inversion is
@@ -1041,7 +1063,8 @@ and the rules for conversions
 of such pointers do not apply to pointers to members.
 \indextext{conversion!pointer-to-member!\idxcode{void*}}%
 In particular, a pointer to member cannot be converted to a
-\tcode{void*}.}
+\tcode{void*}.
+\end{footnote}
 
 \rSec2[conv.fctptr]{Function pointer conversions}
 
@@ -1099,9 +1122,12 @@ converted to \tcode{double}.
 converted to \tcode{float}.
 
 \item Otherwise, the integral promotions\iref{conv.prom} shall be
-performed on both operands.\footnote{As a consequence, operands of type \tcode{bool}, \tcode{char8_t}, \tcode{char16_t},
+performed on both operands.
+\begin{footnote}
+As a consequence, operands of type \tcode{bool}, \tcode{char8_t}, \tcode{char16_t},
 \tcode{char32_t}, \tcode{wchar_t}, or an enumerated type are converted
-to some integral type.}
+to some integral type.
+\end{footnote}
 Then the following rules shall be applied to the promoted operands:
 
 \begin{itemize}
@@ -1266,8 +1292,12 @@ non-static member function of a class can only be used:
 \begin{itemize}
 \item as part of a class member access\iref{expr.ref} in which the
 object expression
-refers to the member's class\footnote{This also applies when the object expression
-is an implicit \tcode{(*this)}~(\ref{class.mfct.non-static}).} or a class derived from
+refers to the member's class
+\begin{footnote}
+This also applies when the object expression
+is an implicit \tcode{(*this)}~(\ref{class.mfct.non-static}).
+\end{footnote}
+or a class derived from
 that class, or
 
 \item to form a pointer to member\iref{expr.unary.op}, or
@@ -2861,9 +2891,12 @@ postfix expression. One of the expressions shall be a glvalue of type ``array of
 to \tcode{T}'' and the other shall be a prvalue of unscoped enumeration or integral type.
 The result is of type ``\tcode{T}''.
 \indextext{type!incomplete}%
-The type ``\tcode{T}'' shall be a completely-defined object type.\footnote{This
+The type ``\tcode{T}'' shall be a completely-defined object type.%
+\begin{footnote}
+This
 is true even if the subscript operator is used in the following common idiom:
-\tcode{\&x[0]}.}
+\tcode{\&x[0]}.
+\end{footnote}
 The expression \tcode{E1[E2]} is identical (by definition) to
 \tcode{*((E1)+(E2))},
 except that in the case of an array operand, the result is an lvalue
@@ -3212,11 +3245,14 @@ A postfix expression followed by a dot \tcode{.} or an arrow \tcode{->},
 optionally followed by the keyword
 \keyword{template}\iref{temp.names}, and then followed by an
 \grammarterm{id-expression}, is a postfix expression. The postfix
-expression before the dot or arrow is evaluated;\footnote{If the class member
+expression before the dot or arrow is evaluated;
+\begin{footnote}
+If the class member
 access expression is evaluated, the subexpression evaluation happens even if the
 result is unnecessary to determine
 the value of the entire postfix expression, for example if the
-\grammarterm{id-expression} denotes a static member.}
+\grammarterm{id-expression} denotes a static member.
+\end{footnote}
 the result of that evaluation, together with the
 \grammarterm{id-expression}, determines the result of the entire postfix
 expression.
@@ -3228,8 +3264,11 @@ For the second option (arrow) the first expression
 shall be a prvalue having pointer type.
 The expression \tcode{E1->E2} is
 converted to the equivalent form \tcode{(*(E1)).E2}; the remainder of
-\ref{expr.ref}~will address only the first option (dot).\footnote{Note that
-\tcode{(*(E1))} is an lvalue.}
+\ref{expr.ref}~will address only the first option (dot).
+\begin{footnote}
+Note that
+\tcode{(*(E1))} is an lvalue.
+\end{footnote}
 
 \pnum
 Abbreviating
@@ -3424,10 +3463,13 @@ Similarly, if
 \tcode{T} is ``reference to \cvqual{cv1} \tcode{B}'' and \tcode{v} has
 type \cvqual{cv2} \tcode{D} such that \tcode{B} is a base class of
 \tcode{D}, the result is the unique \tcode{B} subobject of the \tcode{D}
-object referred to by \tcode{v}.\footnote{The most derived
+object referred to by \tcode{v}.
+\begin{footnote}
+The most derived
 object\iref{intro.object} pointed or referred to by
 \tcode{v} can contain other \tcode{B} objects as base classes, but these
-are ignored.}
+are ignored.
+\end{footnote}
 In both the pointer and
 reference cases, the program is ill-formed if \tcode{B} is an inaccessible or
 ambiguous base class of \tcode{D}.
@@ -3527,8 +3569,11 @@ The result of a \tcode{typeid} expression is an lvalue of static type
 \tcode{std::type_info} or \tcode{const} \term{name} where \term{name} is an
 \impldef{derived type for \tcode{typeid}} class publicly derived from
 \tcode{std::type_info} which preserves the behavior described
-in~\ref{type.info}.\footnote{The recommended name for such a class is
-\tcode{extended_type_info}.}
+in~\ref{type.info}.
+\begin{footnote}
+The recommended name for such a class is
+\tcode{extended_type_info}.
+\end{footnote}
 The lifetime of the object referred to by the lvalue extends to the end
 of the program. Whether or not the destructor is called for the
 \tcode{std::type_info} object at the end of the program is unspecified.
@@ -3539,10 +3584,13 @@ polymorphic class type\iref{class.virtual}, the result refers to a
 \tcode{std::type_info} object representing the type of the most derived
 object\iref{intro.object} (that is, the dynamic type) to which the
 glvalue refers. If the glvalue is obtained by applying the
-unary \tcode{*} operator to a pointer\footnote{If \tcode{p} is an expression of
+unary \tcode{*} operator to a pointer
+\begin{footnote}
+If \tcode{p} is an expression of
 pointer type, then \tcode{*p},
 \tcode{(*p)}, \tcode{*(p)}, \tcode{((*p))}, \tcode{*((p))}, and so on
-all meet this requirement.}
+all meet this requirement.
+\end{footnote}
 and the pointer is a null pointer value\iref{basic.compound}, the
 \tcode{typeid} expression throws an exception\iref{except.throw} of
 a type that would match a handler of type
@@ -3931,10 +3979,13 @@ See also~\ref{conv.ptr} for more details of pointer conversions.
 
 \pnum
 An object pointer
-can be explicitly converted to an object pointer of a different type.\footnote{The
+can be explicitly converted to an object pointer of a different type.
+\begin{footnote}
+The
 types can have different \cv-qualifiers, subject to
 the overall
-restriction that a \tcode{reinterpret_cast} cannot cast away constness.}
+restriction that a \tcode{reinterpret_cast} cannot cast away constness.
+\end{footnote}
 When a prvalue \tcode{v} of object pointer type is converted to
 the object pointer type ``pointer to \cv{}~\tcode{T}'', the result is \tcode{static_cast<\cv{} T*>(static_cast<\cv{}~void*>(v))}.
 \begin{note}
@@ -3972,10 +4023,14 @@ converted to a null pointer value.
 A prvalue of type ``pointer to member of \tcode{X} of type \tcode{T1}''
 can be explicitly converted to a prvalue of a different type ``pointer to member of
 \tcode{Y} of type \tcode{T2}'' if \tcode{T1} and \tcode{T2} are both
-function types or both object types.\footnote{\tcode{T1} and \tcode{T2} can have
+function types or both object types.
+\begin{footnote}
+\tcode{T1} and \tcode{T2} can have
 different \cv-qualifiers, subject to
 the overall restriction that a \tcode{reinterpret_cast} cannot cast away
-constness.} The null member pointer value\iref{conv.mem} is converted to the
+constness.
+\end{footnote}
+The null member pointer value\iref{conv.mem} is converted to the
 null member pointer value of the destination type. The result of this
 conversion is unspecified, except in the following cases:
 
@@ -4006,9 +4061,11 @@ where \tcode{p} is a pointer to \placeholder{x}
 of type ``pointer to \tcode{T1}''.
 No temporary is created, no copy is made, and
 no constructors\iref{class.ctor} or conversion
-functions\iref{class.conv} are called.%
-\footnote{This is sometimes referred to as a type pun
-when the result refers to the same object as the source glvalue.}
+functions\iref{class.conv} are called.
+\begin{footnote}
+This is sometimes referred to as a type pun
+when the result refers to the same object as the source glvalue.
+\end{footnote}
 
 \rSec3[expr.const.cast]{Const cast}
 
@@ -4081,9 +4138,12 @@ the destination type.
 \begin{note}
 Depending on the type of the object, a write operation through the
 pointer, lvalue or pointer to data member resulting from a
-\tcode{const_cast} that casts away a const-qualifier\footnote{\tcode{const_cast}
+\tcode{const_cast} that casts away a const-qualifier
+\begin{footnote}
+\tcode{const_cast}
 is not limited to conversions that cast away a
-const-qualifier.}
+const-qualifier.
+\end{footnote}
 might produce undefined behavior\iref{dcl.type.cv}.
 \end{note}
 
@@ -4553,7 +4613,10 @@ other than \tcode{char}, \tcode{signed char}, and \tcode{unsigned char}}.
 \begin{note}
 In particular, the values of \tcode{sizeof(bool)}, \tcode{sizeof(char16_t)},
 \tcode{sizeof(char32_t)}, and \tcode{sizeof(wchar_t)} are
-implementation-defined.\footnote{\tcode{sizeof(bool)} is not required to be \tcode{1}.}
+implementation-defined.
+\begin{footnote}
+\tcode{sizeof(bool)} is not required to be \tcode{1}.
+\end{footnote}
 \end{note}
 \begin{note}
 See~\ref{intro.memory} for the definition of byte
@@ -4570,11 +4633,13 @@ of that class including any padding required for placing objects of that
 type in an array.
 The result of applying \tcode{sizeof} to a
 potentially-overlapping subobject is
-the size of the type, not the size of the subobject.%
-\footnote{The actual size of a potentially-overlapping subobject
+the size of the type, not the size of the subobject.
+\begin{footnote}
+The actual size of a potentially-overlapping subobject
 can be less than the result of
 applying \tcode{sizeof} to the subobject, due to virtual base classes
-and less strict padding requirements on potentially-overlapping subobjects.}
+and less strict padding requirements on potentially-overlapping subobjects.
+\end{footnote}
 \indextext{array!\idxcode{sizeof}}%
 When applied to an array, the result is the total number of bytes in the
 array. This implies that the size of an array of $n$ elements is
@@ -4858,10 +4923,14 @@ the expression is of non-class type and its value before converting to
 
 \item
 the expression is of class type and its value before application of the second
-standard conversion\iref{over.ics.user}\footnote{If the conversion function
+standard conversion\iref{over.ics.user}
+\begin{footnote}
+If the conversion function
 returns a signed integer type, the second standard conversion converts to the
 unsigned type \tcode{std::size_t} and thus thwarts any attempt to detect a
-negative value afterwards.} is less than zero;
+negative value afterwards.
+\end{footnote}
+is less than zero;
 
 \item
 its value is such that the size of the allocated object would exceed the
@@ -5176,9 +5245,12 @@ invoked\iref{class.dtor}.
 
 \pnum
 \indextext{\idxcode{new}!exception and}%
-If any part of the object initialization described above\footnote{This might
+If any part of the object initialization described above%
+\begin{footnote}
+This might
 include evaluating a \grammarterm{new-initializer} and/or calling
-a constructor.}
+a constructor.
+\end{footnote}
 terminates by throwing an exception and a suitable deallocation function
 can be found, the deallocation function is called to free the memory in
 which the object was being constructed, after which the exception
@@ -5263,16 +5335,22 @@ The first alternative is a
 \defnx{single-object delete expression}{delete!single-object}, and the
 second is an \defnx{array delete expression}{delete!array}.
 Whenever the \tcode{delete} keyword is immediately followed by empty square
-brackets, it shall be interpreted as the second alternative.\footnote{A
+brackets, it shall be interpreted as the second alternative.
+\begin{footnote}
+A
 \grammarterm{lambda-expression} with a \grammarterm{lambda-introducer}
 that consists of empty square brackets can follow the \tcode{delete} keyword
-if the \grammarterm{lambda-expression} is enclosed in parentheses.}
+if the \grammarterm{lambda-expression} is enclosed in parentheses.
+\end{footnote}
 The operand shall be of pointer to object type or of class type. If of
 class type, the operand is contextually implicitly converted\iref{conv}
 to a pointer to object
-type.\footnote{This implies that an object
+type.
+\begin{footnote}
+This implies that an object
 cannot be deleted using a pointer of type
-\tcode{void*} because \tcode{void} is not an object type.}
+\tcode{void*} because \tcode{void} is not an object type.
+\end{footnote}
 The \grammarterm{delete-expression}'s result has type
 \tcode{void}.
 
@@ -5291,10 +5369,13 @@ object\iref{class.derived}. If not, the behavior is undefined.
 \indextext{array!\idxcode{delete}}%
 In an array delete expression, the value of the operand of \tcode{delete}
 may be a null pointer value or a pointer value that resulted from
-a previous array \grammarterm{new-expression}.\footnote{For nonzero-length
+a previous array \grammarterm{new-expression}.
+\begin{footnote}
+For nonzero-length
 arrays, this is the same as a pointer to the first
 element of the array created by that \grammarterm{new-expression}.
-Zero-length arrays do not have a first element.}
+Zero-length arrays do not have a first element.
+\end{footnote}
 If not, the behavior is undefined.
 \begin{note}
 This means that the syntax of the \grammarterm{delete-expression} must
@@ -5720,8 +5801,11 @@ expression by the second.
 If the second operand of \tcode{/} or \tcode{\%} is zero the behavior is
 undefined.
 For integral operands the \tcode{/} operator yields the algebraic quotient with
-any fractional part discarded;\footnote{This is often called truncation towards
-zero.} if the quotient \tcode{a/b} is representable in the type of the result,
+any fractional part discarded;
+\begin{footnote}
+This is often called truncation towards zero.
+\end{footnote}
+if the quotient \tcode{a/b} is representable in the type of the result,
 \tcode{(a/b)*b + a\%b} is equal to \tcode{a}; otherwise, the behavior
 of both \tcode{a/b} and \tcode{a\%b} is undefined.
 
@@ -5781,13 +5865,15 @@ the result has the type of \tcode{P}.
 \item If \tcode{P} evaluates to a null pointer value and
 \tcode{J} evaluates to 0, the result is a null pointer value.
 \item Otherwise, if \tcode{P} points to an array element $i$
-of an array object \tcode{x} with $n$ elements\iref{dcl.array},%
-\footnote{As specified in \ref{basic.compound},
+of an array object \tcode{x} with $n$ elements\iref{dcl.array},
+\begin{footnote}
+As specified in \ref{basic.compound},
 an object that is not an array element
 is considered to belong to a single-element array for this purpose and
 a pointer past the last element of an array of $n$ elements
 is considered to be equivalent to a pointer to a hypothetical array element
-$n$ for this purpose.}
+$n$ for this purpose.
+\end{footnote}
 the expressions \tcode{P + J} and \tcode{J + P}
 (where \tcode{J} has the value $j$)
 point to the (possibly-hypothetical) array element
@@ -6054,14 +6140,16 @@ them to their composite pointer type\iref{expr.type}.
 After conversions, the operands shall have the same type.
 
 \pnum
-The result of comparing unequal pointers to objects%
-\footnote{As specified in \ref{basic.compound},
+The result of comparing unequal pointers to objects
+\begin{footnote}
+As specified in \ref{basic.compound},
 an object that is not an array element
 is considered to belong to a
 single-element array for this purpose and
 a pointer past the last element of an array of $n$ elements
 is considered to be equivalent to a pointer to a hypothetical array element
-$n$ for this purpose.}
+$n$ for this purpose.
+\end{footnote}
 is defined in terms of a partial order consistent with the following rules:
 
 \begin{itemize}
@@ -6139,10 +6227,12 @@ Comparing pointers is defined as follows:
 \item
 If one pointer represents the address of a complete object, and another
 pointer represents the address one past the last element of a different
-complete object,%
-\footnote{As specified in \ref{basic.compound},
+complete object,
+\begin{footnote}
+As specified in \ref{basic.compound},
 an object that is not an array element is
-considered to belong to a single-element array for this purpose.}
+considered to belong to a single-element array for this purpose.
+\end{footnote}
 the result of the comparison is unspecified.
 \item
 Otherwise, if the pointers are both null, both point to the same
@@ -6892,9 +6982,11 @@ function\iref{dcl.constexpr} that is being evaluated as part
 of $E$;
 
 \item
-an invocation of a non-constexpr function%
-\footnote{Overload resolution\iref{over.match}
-is applied as usual.};
+an invocation of a non-constexpr function
+\begin{footnote}
+Overload resolution\iref{over.match}
+is applied as usual.
+\end{footnote};
 
 \item
 an invocation of an undefined constexpr function;
@@ -6918,11 +7010,13 @@ limits (see \ref{implimits});
 
 \item
 an operation that would have undefined behavior
-as specified in \ref{intro} through \ref{cpp}%
-\footnote{This includes,
+as specified in \ref{intro} through \ref{cpp}
+\begin{footnote}
+This includes,
 for example, signed integer overflow\iref{expr.prop}, certain
 pointer arithmetic\iref{expr.add}, division by
-zero\iref{expr.mul}, or certain shift operations\iref{expr.shift}.};
+zero\iref{expr.mul}, or certain shift operations\iref{expr.shift}.
+\end{footnote};
 
 \item
 an lvalue-to-rvalue conversion\iref{conv.lval} unless
@@ -7311,9 +7405,11 @@ if it is:
 to determine whether it is satisfied\iref{temp.constr.atomic}, or
 \item the initializer of a variable
 that is usable in constant expressions or
-has constant initialization\iref{basic.start.static}.%
-\footnote{Testing this condition
-might involve a trial evaluation of its initializer as described above.}
+has constant initialization\iref{basic.start.static}.
+\begin{footnote}
+Testing this condition
+might involve a trial evaluation of its initializer as described above.
+\end{footnote}
 \begin{example}
 \begin{codeblock}
 template<bool> struct X {};
@@ -7353,13 +7449,17 @@ a manifestly constant-evaluated expression,
 a potentially-evaluated expression\iref{basic.def.odr},
 
 \item
-an immediate subexpression of a \grammarterm{braced-init-list},%
-\footnote{Constant evaluation might be necessary to determine whether a narrowing conversion is performed\iref{dcl.init.list}.}
+an immediate subexpression of a \grammarterm{braced-init-list},
+\begin{footnote}
+Constant evaluation might be necessary to determine whether a narrowing conversion is performed\iref{dcl.init.list}.
+\end{footnote}
 
 \item
 an expression of the form \tcode{\&} \grammarterm{cast-expression}
-that occurs within a templated entity,%
-\footnote{Constant evaluation might be necessary to determine whether such an expression is value-dependent\iref{temp.dep.constexpr}.}
+that occurs within a templated entity,
+\begin{footnote}
+Constant evaluation might be necessary to determine whether such an expression is value-dependent\iref{temp.dep.constexpr}.
+\end{footnote}
 or
 
 \item

--- a/source/future.tex
+++ b/source/future.tex
@@ -704,11 +704,14 @@ If
 If
 \tcode{n < 0},
 \tcode{N} is
-\tcode{INT_MAX}.\footnote{The function signature
+\tcode{INT_MAX}.
+\begin{footnote}
+The function signature
 \indexlibraryglobal{strlen}%
 \tcode{strlen(const char*)}
 is declared in \libheaderref{cstring}.
-The macro \tcode{INT_MAX} is defined in \libheaderref{climits}.}
+The macro \tcode{INT_MAX} is defined in \libheaderref{climits}.
+\end{footnote}
 \end{itemize}
 
 \pnum
@@ -1294,10 +1297,13 @@ then \tcode{s} shall designate the first element of an array of \tcode{n} elemen
 contains an \ntbs{} whose first element is designated by \tcode{s}.
 \indextext{NTBS@\ntbs{}}%
 The constructor is
-\tcode{strstreambuf(s, n, s + std::strlen(s))}.\footnote{The function signature
+\tcode{strstreambuf(s, n, s + std::strlen(s))}.
+\begin{footnote}
+The function signature
 \indexlibraryglobal{strlen}%
 \tcode{strlen(const char*)}
-is declared in \libheaderref{cstring}.}
+is declared in \libheaderref{cstring}.
+\end{footnote}
 \end{itemize}
 \end{itemdescr}
 
@@ -2146,8 +2152,10 @@ For the facet \tcode{codecvt_utf8_utf16}\indexlibraryglobal{codecvt_utf8_utf16}:
 
 \pnum
 The encoding forms UTF-8, UTF-16, and UTF-32 are specified in ISO/IEC 10646.
-The encoding form UCS-2 is specified in ISO/IEC 10646:2003.%
-\footnote{Cancelled and replaced by ISO/IEC 10646:2017.}
+The encoding form UCS-2 is specified in ISO/IEC 10646:2003.
+\begin{footnote}
+Cancelled and replaced by ISO/IEC 10646:2017.
+\end{footnote}
 
 \rSec1[depr.conversions]{Deprecated convenience conversion interfaces}
 

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -38,25 +38,32 @@ For undated references, the latest edition of the referenced document
 Information interchange --- Representation of dates and times}
 \item ISO/IEC 9899:2018, \doccite{Programming languages --- C}
 \item ISO/IEC 9945:2003, \doccite{Information Technology --- Portable
-Operating System Interface (POSIX%
-\footnote{POSIX\textregistered\ is a registered trademark of
+Operating System Interface (POSIX
+\begin{footnote}
+POSIX\textregistered\ is a registered trademark of
 the Institute of Electrical and Electronic Engineers, Inc.
 This information is given for the convenience of users of this document and
-does not constitute an endorsement by ISO or IEC of this product.})}
+does not constitute an endorsement by ISO or IEC of this product.
+\end{footnote}%
+)}
 \item ISO/IEC 10646, \doccite{Information technology ---
 Universal Coded Character Set (UCS)}
-\item ISO/IEC 10646:2003,%
-\footnote{Cancelled and replaced by ISO/IEC 10646:2017.}
+\item ISO/IEC 10646:2003,
+\begin{footnote}
+Cancelled and replaced by ISO/IEC 10646:2017.
+\end{footnote}
 \doccite{Information technology ---
 Universal Multiple-Octet Coded Character Set (UCS)}
 \item ISO 80000-2:2009, \doccite{Quantities and units ---
 Part 2: Mathematical signs and symbols
 to be used in the natural sciences and technology}
-\item Ecma International, \doccite{ECMAScript%
-\footnote{ECMAScript\textregistered\ is a registered trademark of Ecma
+\item Ecma International, \doccite{ECMAScript
+\begin{footnote}
+ECMAScript\textregistered\ is a registered trademark of Ecma
 International.
 This information is given for the convenience of users of this document and
-does not constitute an endorsement by ISO or IEC of this product.}
+does not constitute an endorsement by ISO or IEC of this product.
+\end{footnote}
 Language Specification},
 Standard Ecma-262, third edition, 1999.
 \end{itemize}
@@ -64,10 +71,12 @@ Standard Ecma-262, third edition, 1999.
 \pnum
 The library described in ISO/IEC 9899:2018, Clause 7,
 is hereinafter called the
-\defnx{C standard library}{C!standard library}.%
-\footnote{With the qualifications noted in \ref{\firstlibchapter}
+\defnx{C standard library}{C!standard library}.
+\begin{footnote}
+With the qualifications noted in \ref{\firstlibchapter}
 through \ref{\lastlibchapter} and in \ref{diff.library}, the C standard
-library is a subset of the \Cpp{} standard library.}
+library is a subset of the \Cpp{} standard library.
+\end{footnote}
 
 \pnum
 The operating system interface described in ISO/IEC 9945:2003 is
@@ -764,8 +773,11 @@ If a program contains no violations of the rules in
 \ref{lex} through \ref{\lastlibchapter} and \ref{depr},
 a conforming implementation shall,
 within its resource limits as described in \ref{implimits},
-accept and correctly execute\footnote{``Correct execution'' can include undefined behavior, depending on
-the data being processed; see \ref{intro.defs} and~\ref{intro.execution}.}
+accept and correctly execute
+\begin{footnote}
+``Correct execution'' can include undefined behavior, depending on
+the data being processed; see \ref{intro.defs} and~\ref{intro.execution}.
+\end{footnote}
 that program.
 \item
 \indextext{message!diagnostic}%
@@ -834,8 +846,11 @@ Having done so, however, they can compile and execute such programs.
 \pnum
 Each implementation shall include documentation that identifies all
 conditionally-supported constructs\indextext{behavior!conditionally-supported}
-that it does not support and defines all locale-specific characteristics.\footnote{This documentation also defines implementation-defined behavior;
-see~\ref{intro.abstract}.}%
+that it does not support and defines all locale-specific characteristics.
+\begin{footnote}
+This documentation also defines implementation-defined behavior;
+see~\ref{intro.abstract}.
+\end{footnote}
 \indextext{conformance requirements!general|)}%
 \indextext{conformance requirements|)}%
 
@@ -852,7 +867,9 @@ structure of the abstract machine.
 \indextext{as-if rule}%
 \indextext{behavior!observable}%
 Rather, conforming implementations are required to emulate (only) the observable
-behavior of the abstract machine as explained below.\footnote{This provision is
+behavior of the abstract machine as explained below.
+\begin{footnote}
+This provision is
 sometimes called the ``as-if'' rule, because an implementation is free to
 disregard any requirement of this document as long as the result
 is \emph{as if} the requirement had been obeyed, as far as can be determined
@@ -861,7 +878,8 @@ implementation need not evaluate part of an expression if it can deduce that its
 value is not used and that no
 \indextext{side effects}%
 side effects affecting the
-observable behavior of the program are produced.}
+observable behavior of the program are produced.
+\end{footnote}
 
 \pnum
 \indextext{behavior!implementation-defined}%
@@ -869,9 +887,13 @@ Certain aspects and operations of the abstract machine are described in this
 document as implementation-defined (for example,
 \tcode{sizeof(int)}). These constitute the parameters of the abstract machine.
 Each implementation shall include documentation describing its characteristics
-and behavior in these respects.\footnote{This documentation also includes
+and behavior in these respects.
+\begin{footnote}
+This documentation also includes
 conditionally-supported constructs and locale-specific behavior.
-See~\ref{intro.compliance}.} Such documentation shall define the instance of the
+See~\ref{intro.compliance}.
+\end{footnote}
+Such documentation shall define the instance of the
 abstract machine that corresponds to that implementation (referred to as the
 ``corresponding instance'' below).
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -280,11 +280,14 @@ Default template arguments are described as appearing both in
 and in the synopsis of other headers
 but it is well-formed to include both
 \libheader{iosfwd}
-and one or more of the other headers.\footnote{It is the implementation's
+and one or more of the other headers.
+\begin{footnote}
+It is the implementation's
 responsibility to implement headers so
 that including \libheader{iosfwd}
 and other headers does not violate the rules about
-multiple occurrences of default arguments.}
+multiple occurrences of default arguments.
+\end{footnote}
 
 \rSec2[iostream.forward.overview]{Overview}
 
@@ -431,7 +434,9 @@ The objects are constructed and the associations are established at some
 time prior to or during the first time an object of class
 \tcode{ios_base::Init} is constructed, and in any case before the body
 of \tcode{main}\iref{basic.start.main} begins execution.
-The objects are not destroyed during program execution.\footnote{Constructors and destructors for objects with
+The objects are not destroyed during program execution.
+\begin{footnote}
+Constructors and destructors for objects with
 static storage duration can
 access these objects to read input from
 \tcode{stdin}
@@ -439,7 +444,7 @@ or write output to
 \tcode{stdout}
 or
 \tcode{stderr}.
-}
+\end{footnote}
 
 \pnum
 \recommended
@@ -688,7 +693,10 @@ using streamoff = @\impdef@;
 \begin{itemdescr}
 \pnum
 The type \tcode{streamoff} is a synonym for one of the signed basic integral types of
-sufficient size to represent the maximum possible file size for the operating system.\footnote{Typically \tcode{long long}.}
+sufficient size to represent the maximum possible file size for the operating system.
+\begin{footnote}
+Typically \tcode{long long}.
+\end{footnote}
 \end{itemdescr}
 
 \indexlibraryglobal{streamsize}%
@@ -703,8 +711,11 @@ The type
 is a synonym for one of the signed basic
 integral types.
 It is used to represent the number of characters transferred in an I/O
-operation, or the size of I/O buffers.\footnote{\tcode{streamsize}
-is used in most places where ISO C would use \tcode{size_t}.}
+operation, or the size of I/O buffers.
+\begin{footnote}
+\tcode{streamsize}
+is used in most places where ISO C would use \tcode{size_t}.
+\end{footnote}
 \end{itemdescr}
 
 \rSec2[ios.base]{Class \tcode{ios_base}}
@@ -1380,11 +1391,13 @@ is the same as the effect of
 \begin{codeblock}
 str.rdbuf()->sputbackc(c);
 \end{codeblock}
-for any sequence of characters.\footnote{This implies that operations on a standard iostream object can be mixed arbitrarily
+for any sequence of characters.
+\begin{footnote}
+This implies that operations on a standard iostream object can be mixed arbitrarily
 with operations on the corresponding stdio stream. In practical terms, synchronization
 usually means that a standard iostream object and a standard stdio object share a
 buffer.
-}
+\end{footnote}
 \end{itemdescr}
 
 \rSec3[ios.base.storage]{Storage functions}
@@ -1427,17 +1440,23 @@ The function then extends the array pointed at by
 \tcode{iarray[idx]}.
 Each newly allocated element of the array is initialized to zero.
 The reference returned is invalid after any other operations on the
-object.\footnote{An implementation is free to implement both the integer
+object.
+\begin{footnote}
+An implementation is free to implement both the integer
 array pointed at by \tcode{iarray} and the pointer array pointed at by
 \tcode{parray} as sparse data structures, possibly with a one-element
-cache for each.}
+cache for each.
+\end{footnote}
 However, the value of the storage referred to is retained, so
 that until the next call to
 \tcode{copyfmt},
 calling
 \tcode{iword}
 with the same index yields another reference to the same value.
-If the function fails\footnote{For example, because it cannot allocate space.}
+If the function fails
+\begin{footnote}
+For example, because it cannot allocate space.
+\end{footnote}
 and
 \tcode{*this}
 is a base class subobject of a
@@ -1485,7 +1504,10 @@ that until the next call to
 calling
 \tcode{pword}
 with the same index yields another reference to the same value.
-If the function fails\footnote{For example, because it cannot allocate space.}
+If the function fails
+\begin{footnote}
+For example, because it cannot allocate space.
+\end{footnote}
 and
 \tcode{*this}
 is a base class subobject of a
@@ -2055,8 +2077,11 @@ the corresponding member objects of \tcode{rhs} as follows:
 \item \tcode{rdstate()}, \tcode{rdbuf()}, and \tcode{exceptions()} are left unchanged;
 
 \item the contents of arrays pointed at by \tcode{pword} and \tcode{iword} are copied,
-not the pointers themselves;\footnote{ This suggests an infinite amount of copying, but the implementation can keep
-track of the maximum element of the arrays that is nonzero.}
+not the pointers themselves;
+\begin{footnote}
+ This suggests an infinite amount of copying, but the implementation can keep
+track of the maximum element of the arrays that is nonzero.
+\end{footnote}
 and
 
 \item if any newly stored pointer values in \tcode{*this} point at objects stored outside
@@ -2280,11 +2305,14 @@ if
 or
 \tcode{badbit}
 is set in
-\tcode{rdstate()}.\footnote{Checking
+\tcode{rdstate()}.
+\begin{footnote}
+Checking
 \tcode{badbit}
 also for
 \tcode{fail()}
-is historical practice.}
+is historical practice.
+\end{footnote}
 \end{itemdescr}
 
 \indexlibrarymember{bad}{basic_ios}%
@@ -2636,7 +2664,9 @@ Calls
 
 \pnum
 \returns
-\tcode{str}\footnote{The function signature
+\tcode{str}
+\begin{footnote}
+The function signature
 \tcode{dec(ios_base\&)}
 can be called by
 the function signature
@@ -2644,7 +2674,9 @@ the function signature
 to permit expressions of the form
 \tcode{cout << dec}
 to change the format flags stored in
-\tcode{cout}.}.
+\tcode{cout}.
+\end{footnote}%
+.
 \end{itemdescr}
 
 \indexlibraryglobal{hex}%
@@ -3045,10 +3077,13 @@ basic_streambuf();
 \begin{itemdescr}
 \pnum
 \effects
-Initializes:\footnote{The default constructor is protected for class
+Initializes:
+\begin{footnote}
+The default constructor is protected for class
 \tcode{basic_streambuf}
 to assure that only objects for classes
-derived from this class can be constructed.}
+derived from this class can be constructed.
+\end{footnote}
 \begin{itemize}
 \item
 all pointer member objects to null pointers,
@@ -3631,8 +3666,11 @@ Returns zero.
 
 \indexlibrarymember{showmanyc}{basic_streambuf}%
 \begin{itemdecl}
-streamsize showmanyc();@\footnote{\textrm{The morphemes of \tcode{showmanyc}\
-are ``es-how-many-see'', not ``show-manic''.}}@
+streamsize showmanyc();@
+\begin{footnote}
+\textrm{The morphemes of \tcode{showmanyc}\
+are ``es-how-many-see'', not ``show-manic''.}
+\end{footnote}@
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3653,13 +3691,16 @@ returns -1, then calls to
 \tcode{underflow()}
 or
 \tcode{uflow()}
-will fail.\footnote{\tcode{underflow}
+will fail.
+\begin{footnote}
+\tcode{underflow}
 or
 \tcode{uflow}
 might fail by throwing an exception prematurely.
 The intention is not only that the calls will not return
 \tcode{eof()}
-but that they will return ``immediately''.}
+but that they will return ``immediately''.
+\end{footnote}
 
 \pnum
 \default
@@ -3692,13 +3733,16 @@ would return
 
 \pnum
 \returns
-The number of characters assigned.\footnote{Classes derived from
+The number of characters assigned.
+\begin{footnote}
+Classes derived from
 \tcode{basic_streambuf}
 can provide more efficient ways to implement
 \tcode{xsgetn()}
 and
 \tcode{xsputn()}
-by overriding these definitions from the base class.}
+by overriding these definitions from the base class.
+\end{footnote}
 
 \pnum
 \remarks
@@ -3977,12 +4021,15 @@ obeys the following constraints:
 \begin{itemize}
 \item
 The effect of consuming a character on the associated output sequence is
-specified.\footnote{That is, for each class derived from an instance of
+specified.
+\begin{footnote}
+That is, for each class derived from an instance of
 \tcode{basic_streambuf}
 in this Clause~(\ref{stringbuf},
 \ref{filebuf}),
 a specification of how consuming a character effects the associated output sequence is given.
-There is no requirement on a program-defined class.}
+There is no requirement on a program-defined class.
+\end{footnote}
 \item
 Let
 \tcode{r}
@@ -4027,14 +4074,17 @@ if the function fails.
 Otherwise,
 returns some value other than
 \tcode{traits::eof()}
-to indicate success.\footnote{Typically,
+to indicate success.
+\begin{footnote}
+Typically,
 \tcode{overflow}
 returns \tcode{c} to indicate success, except when
 \tcode{traits::eq_int_type(c, traits::eof())}
 returns
 \tcode{true},
 in which case it returns
-\tcode{traits::not_eof(c)}.}
+\tcode{traits::not_eof(c)}.
+\end{footnote}
 
 \pnum
 \default
@@ -4443,9 +4493,12 @@ If no such call occurs before the
 \tcode{sentry}
 object is destroyed, the call to
 \tcode{flush}
-may be eliminated entirely.\footnote{This will be possible only in functions
+may be eliminated entirely.
+\begin{footnote}
+This will be possible only in functions
 that are part of the library.
-The semantics of the constructor used in user code is as specified.}
+The semantics of the constructor used in user code is as specified.
+\end{footnote}
 If \tcode{noskipws} is zero and
 \tcode{is.flags() \& ios_base::skipws}
 is nonzero, the function extracts and discards each character as long as
@@ -4491,12 +4544,15 @@ otherwise,
 During preparation, the constructor may call
 \tcode{setstate(failbit)}
 (which may throw
-\tcode{ios_base::\brk{}failure}\iref{iostate.flags}).\footnote{The
+\tcode{ios_base::\brk{}failure}\iref{iostate.flags}).
+\begin{footnote}
+The
 \tcode{sentry}
 constructor and destructor
 can also perform additional
 \indextext{implementation-dependent}%
-implementation-dependent operations.}
+implementation-dependent operations.
+\end{footnote}
 \end{itemdescr}
 
 \indexlibrarydtor{sentry}%
@@ -4543,9 +4599,12 @@ the function endeavors
 to obtain the requested input.
 If an exception is thrown during input then
 \tcode{ios_base::badbit}
-is turned on\footnote{This is done without causing an
+is turned on
+\begin{footnote}
+This is done without causing an
 \tcode{ios_base::failure}
-to be thrown.}
+to be thrown.
+\end{footnote}
 in
 \tcode{*this}'s
 error state.
@@ -4678,9 +4737,12 @@ This extractor does not behave as a formatted input function
 
 \pnum
 \returns
-\tcode{pf(*this)}.\footnote{See, for example, the function signature
-\tcode{ws(basic_istream\&)}\iref{istream.manip}.%
-\indexlibraryglobal{ws}}%
+\tcode{pf(*this)}.%
+\indexlibraryglobal{ws}%
+\begin{footnote}
+See, for example, the function signature
+\tcode{ws(basic_istream\&)}\iref{istream.manip}.
+\end{footnote}
 \end{itemdescr}
 
 \indexlibrarymember{operator>>}{basic_istream}%
@@ -4711,8 +4773,11 @@ basic_istream<charT, traits>& operator>>(ios_base& (*pf)(ios_base&));
 \pnum
 \effects
 Calls
-\tcode{pf(*this)}.\footnote{See, for example, the function signature
-\tcode{dec(ios_base\&)}\iref{basefield.manip}.}
+\tcode{pf(*this)}.
+\begin{footnote}
+See, for example, the function signature
+\tcode{dec(ios_base\&)}\iref{basefield.manip}.
+\end{footnote}
 This extractor does not behave as a formatted input function
 (as described in~\ref{istream.formatted.reqmts}).
 
@@ -4881,9 +4946,12 @@ an argument shall also store a null character (using
 in the first location of the array.
 If an exception is thrown during input then
 \tcode{ios_base::badbit}
-is turned on\footnote{This is done without causing an
+is turned on
+\begin{footnote}
+This is done without causing an
 \tcode{ios_base::failure}
-to be thrown.}
+to be thrown.
+\end{footnote}
 in
 \tcode{*this}'s
 error state.
@@ -4955,11 +5023,14 @@ basic_istream<charT, traits>& get(char_type& c);
 Behaves as an unformatted input function
 (as described above).
 After constructing a sentry object, extracts
-a character, if one is available, and assigns it to \tcode{c}.\footnote{Note
+a character, if one is available, and assigns it to \tcode{c}.
+\begin{footnote}
+Note
 that this function is not overloaded on types
 \tcode{signed char}
 and
-\tcode{unsigned char}.}
+\tcode{unsigned char}.
+\end{footnote}
 Otherwise, the function calls
 \tcode{setstate(failbit)}
 (which may throw
@@ -4983,10 +5054,13 @@ Behaves as an unformatted input function
 After constructing a sentry object, extracts
 characters and stores them
 into successive locations of an array whose first element is designated by
-\tcode{s}.\footnote{Note that this function is not overloaded on types
+\tcode{s}.
+\begin{footnote}
+Note that this function is not overloaded on types
 \tcode{signed char}
 and
-\tcode{unsigned char}.}
+\tcode{unsigned char}.
+\end{footnote}
 Characters are extracted and stored until any of the following occurs:
 \begin{itemize}
 \item
@@ -5102,10 +5176,13 @@ Behaves as an unformatted input function
 After constructing a sentry object, extracts
 characters and stores them
 into successive locations of an array whose first element is designated by
-\tcode{s}.\footnote{Note that this function is not overloaded on types
+\tcode{s}.
+\begin{footnote}
+Note that this function is not overloaded on types
 \tcode{signed char}
 and
-\tcode{unsigned char}.}
+\tcode{unsigned char}.
+\end{footnote}
 Characters are extracted and stored until one of the following occurs:
 \begin{enumerate}
 \item
@@ -5116,11 +5193,14 @@ end-of-file occurs on the input sequence
 \tcode{traits::eq(c, delim)}
 for the next available input
 character \tcode{c}
-(in which case the input character is extracted but not stored);\footnote{Since
+(in which case the input character is extracted but not stored);
+\begin{footnote}
+Since
 the final input character is ``extracted'',
 it is counted in the
 \tcode{gcount()},
-even though it is not stored.}
+even though it is not stored.
+\end{footnote}
 \item
 \tcode{n} is less than one or \tcode{n - 1}
 characters are stored
@@ -5129,19 +5209,25 @@ characters are stored
 \end{enumerate}
 
 \pnum
-These conditions are tested in the order shown.\footnote{This allows an input
+These conditions are tested in the order shown.
+\begin{footnote}
+This allows an input
 line which exactly fills the buffer, without setting
 \tcode{failbit}.
-This is different behavior than the historical AT\&T implementation.}
+This is different behavior than the historical AT\&T implementation.
+\end{footnote}
 
 \pnum
 If the function extracts no characters, it calls
 \tcode{setstate(failbit)}
 (which may throw
-\tcode{ios_base::\brk{}failure}\iref{iostate.flags}).\footnote{This implies an
+\tcode{ios_base::\brk{}failure}\iref{iostate.flags}).
+\begin{footnote}
+This implies an
 empty input line will not cause
 \tcode{failbit}
-to be set.}
+to be set.
+\end{footnote}
 
 \pnum
 In any case, if \tcode{n} is greater than zero, it then stores a null character
@@ -5274,10 +5360,13 @@ which may throw an exception,
 and return.
 Otherwise extracts characters and stores them
 into successive locations of an array whose first element is designated by
-\tcode{s}.\footnote{Note that this function is not overloaded on types
+\tcode{s}.
+\begin{footnote}
+Note that this function is not overloaded on types
 \tcode{signed char}
 and
-\tcode{unsigned char}.}
+\tcode{unsigned char}.
+\end{footnote}
 Characters are extracted and stored until either of the following occurs:
 \begin{itemize}
 \item
@@ -6011,10 +6100,13 @@ If
 \tcode{os.tie()}
 is not a null pointer, calls
 \indexlibraryglobal{flush}%
-\tcode{os.tie()->flush()}.\footnote{The call
+\tcode{os.tie()->flush()}.%
+\begin{footnote}
+The call
 \tcode{os.tie()->flush()}
 does not necessarily occur if the function can determine that no
-synchronization is necessary.}
+synchronization is necessary.
+\end{footnote}
 
 \pnum
 If, after any preparation is completed,
@@ -6027,12 +6119,15 @@ otherwise,
 During preparation, the constructor may call
 \tcode{setstate(failbit)}
 (which may throw
-\tcode{ios_base::\brk{}failure}\iref{iostate.flags}).\footnote{The
+\tcode{ios_base::\brk{}failure}\iref{iostate.flags}).
+\begin{footnote}
+The
 \tcode{sentry}
 constructor and destructor
 can also perform additional
 \indextext{implementation-dependent}%
-implementation-dependent operations.}
+implementation-dependent operations.
+\end{footnote}
 \end{itemdescr}
 
 \indexlibrarydtor{basic_ostream::sentry}%
@@ -6147,9 +6242,12 @@ If the generation fails, then the formatted output function does
 which can throw an exception.
 If an exception is thrown during output, then
 \tcode{ios_base::badbit}
-is turned on\footnote{This is done without causing an
+is turned on
+\begin{footnote}
+This is done without causing an
 \tcode{ios_base::failure}
-to be thrown.}
+to be thrown.
+\end{footnote}
 in
 \tcode{*this}'s
 error state.
@@ -6328,9 +6426,12 @@ in~\ref{ostream.formatted.reqmts}).
 
 \pnum
 \returns
-\tcode{pf(*this)}.\footnote{See, for example, the function signature
+\tcode{pf(*this)}.
+\begin{footnote}
+See, for example, the function signature
 \indexlibraryglobal{endl}%
-\tcode{endl(basic_ostream\&)}\iref{ostream.manip}.}
+\tcode{endl(basic_ostream\&)}\iref{ostream.manip}.
+\end{footnote}
 \end{itemdescr}
 
 \indexlibrarymember{operator<<}{basic_ostream}%
@@ -6349,9 +6450,12 @@ behave as a formatted output function (as described in~\ref{ostream.formatted.re
 
 \pnum
 \returns
-\tcode{*this}.\footnote{See, for example, the function signature
+\tcode{*this}.
+\begin{footnote}
+See, for example, the function signature
 \indexlibraryglobal{dec}%
-\tcode{dec(ios_base\&)}\iref{basefield.manip}.}
+\tcode{dec(ios_base\&)}\iref{basefield.manip}.
+\end{footnote}
 \end{itemdescr}
 
 \indexlibrarymember{operator<<}{basic_ostream}%
@@ -6551,9 +6655,12 @@ the function endeavors
 to generate the requested output.
 If an exception is thrown during output, then
 \tcode{ios_base::badbit}
-is turned on\footnote{This is done without causing an
+is turned on
+\begin{footnote}
+This is done without causing an
 \tcode{ios_base::failure}
-to be thrown.}
+to be thrown.
+\end{footnote}
 in
 \tcode{*this}'s
 error state.
@@ -6575,10 +6682,13 @@ basic_ostream<charT, traits>& put(char_type c);
 Behaves as an unformatted output function (as described above).
 After constructing a sentry
 object, inserts
-the character \tcode{c}, if possible.\footnote{Note that this function is not overloaded on types
+the character \tcode{c}, if possible.
+\begin{footnote}
+Note that this function is not overloaded on types
 \tcode{signed char}
 and
-\tcode{unsigned char}.}
+\tcode{unsigned char}.
+\end{footnote}
 
 \pnum
 Otherwise, calls
@@ -6603,10 +6713,13 @@ Behaves as an unformatted output function (as described above).  After construct
 object, obtains
 characters to insert from
 successive locations of an array whose first element is designated by
-\tcode{s}.\footnote{Note that this function is not overloaded on types
+\tcode{s}.
+\begin{footnote}
+Note that this function is not overloaded on types
 \tcode{signed char}
 and
-\tcode{unsigned char}.}
+\tcode{unsigned char}.
+\end{footnote}
 Characters are inserted until either of the following occurs:
 \begin{itemize}
 \item
@@ -6826,13 +6939,16 @@ unspecified type such that if \tcode{out} is an object of type
 \tcode{basic_istream<charT, traits>} then the expression
 \tcode{in >> resetiosflags(\brk{}mask)} behaves as if it called
 \tcode{f(in, mask)}, where the function \tcode{f}
-is defined as:\footnote{ The expression \tcode{cin >> resetiosflags(ios_base::skipws)}
+is defined as:
+\begin{footnote}
+ The expression \tcode{cin >> resetiosflags(ios_base::skipws)}
 clears \tcode{ios_base::skipws} in the format flags stored in the
 \tcode{basic_istream<charT, traits>} object \tcode{cin} (the same as
 \tcode{cin >> noskipws}), and the expression
 \tcode{cout << resetiosflags(ios_base::showbase)} clears \tcode{ios_base::showbase} in the
 format flags stored in the \tcode{basic_ostream<charT, traits>} object
-\tcode{cout} (the same as \tcode{cout << noshowbase}). }
+\tcode{cout} (the same as \tcode{cout << noshowbase}).
+\end{footnote}
 
 \begin{codeblock}
 void f(ios_base& str, ios_base::fmtflags mask) {
@@ -9526,15 +9642,17 @@ If the open operation succeeds and
 \tcode{ios_base::ate} is set in \tcode{mode},
 positions the file to the end
 (as if by calling \tcode{fseek(file, 0, SEEK_END)}, where
-\tcode{file} is the pointer returned by calling \tcode{fopen}).%
-\footnote{The macro \tcode{SEEK_END}
+\tcode{file} is the pointer returned by calling \tcode{fopen}).
+\begin{footnote}
+The macro \tcode{SEEK_END}
 is defined, and the function signatures
 \indexlibraryglobal{fopen}%
 \tcode{fopen(const char*, const char*)}
 and
 \tcode{fseek(FILE*, long, int)}
 \indexlibraryglobal{fseek}%
-are declared, in \libheaderref{cstdio}.}
+are declared, in \libheaderref{cstdio}.
+\end{footnote}
 
 \pnum
 If the repositioning operation fails, calls

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -587,9 +587,12 @@ Most of the library's algorithmic templates that operate on data structures have
 interfaces that use ranges. A \defn{range} is an iterator and a \defn{sentinel}
 that designate the beginning and end of the computation, or an iterator and a
 count that designate the beginning and the number of elements to which the
-computation is to be applied.\footnote{The sentinel denoting the end of a range
+computation is to be applied.
+\begin{footnote}
+The sentinel denoting the end of a range
 can have the same type as the iterator denoting the beginning of the range, or a
-different type.}
+different type.
+\end{footnote}
 
 \pnum
 An iterator and a sentinel denoting a range are comparable.
@@ -635,10 +638,12 @@ previously obtained from that iterator.
 
 \pnum
 An \defnadj{invalid}{iterator}
-is an iterator that may be singular.\footnote{This definition applies to pointers, since pointers are iterators.
+is an iterator that may be singular.
+\begin{footnote}
+This definition applies to pointers, since pointers are iterators.
 The effect of dereferencing an iterator that has been invalidated
 is undefined.
-}
+\end{footnote}
 
 \pnum
 \indextext{iterator!constexpr}%

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -57,8 +57,11 @@ program\iref{basic.link}.
 \pnum
 \indextext{translation!phases|(}%
 The precedence among the syntax rules of translation is specified by the
-following phases.\footnote{Implementations behave as if these separate phases
-occur, although in practice different phases can be folded together.}
+following phases.
+\begin{footnote}
+Implementations behave as if these separate phases
+occur, although in practice different phases can be folded together.
+\end{footnote}
 
 \begin{enumerate}
 \item
@@ -100,14 +103,17 @@ to the file.
 \item The source file is decomposed into preprocessing
 tokens\iref{lex.pptoken} and sequences of white-space characters
 (including comments). A source file shall not end in a partial
-preprocessing token or in a partial comment.\footnote{A partial preprocessing
+preprocessing token or in a partial comment.
+\begin{footnote}
+A partial preprocessing
 token would arise from a source file
 ending in the first portion of a multi-character token that requires a
 terminating sequence of characters, such as a \grammarterm{header-name}
 that is missing the closing \tcode{"}
 or \tcode{>}. A partial comment
 would arise from a source file ending with an unclosed \tcode{/*}
-comment.}
+comment.
+\end{footnote}
 Each comment is replaced by one space character. New-line characters are
 retained. Whether each nonempty sequence of white-space characters other
 than new-line is retained or replaced by one space character is
@@ -133,8 +139,11 @@ All preprocessing directives are then deleted.
 member of the execution character set~(\ref{lex.ccon}, \ref{lex.string}); if
 there is no corresponding member, it is converted to an \impldef{converting
 characters from source character set to execution character set} member other
-than the null (wide) character.\footnote{An implementation need not convert all
-non-corresponding source characters to the same execution character.}
+than the null (wide) character.
+\begin{footnote}
+An implementation need not convert all
+non-corresponding source characters to the same execution character.
+\end{footnote}
 
 \item Adjacent string literal tokens are concatenated.
 
@@ -213,14 +222,17 @@ needed for execution in its execution environment.%
 \indextext{character set|(}%
 The \defnx{basic source character set}{character set!basic source} consists of 96 characters: the space character,
 the control characters representing horizontal tab, vertical tab, form feed, and
-new-line, plus the following 91 graphical characters:\footnote{The glyphs for
+new-line, plus the following 91 graphical characters:
+\begin{footnote}
+The glyphs for
 the members of the basic source character set are intended to
 identify characters from the subset of ISO/IEC 10646 which corresponds to the ASCII
 character set. However, the mapping from source file characters to the source
 character set (described in translation phase 1) is specified as
 \impldef{mapping from physical source file characters to basic source character set},
 and therefore implementations must document how the basic source characters are
-represented in source files.}
+represented in source files.
+\end{footnote}
 \begin{codeblock}
 a b c d e f g h i j k l m n o p q r s t u v w x y z
 A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
@@ -260,9 +272,12 @@ a \grammarterm{character-literal} or \grammarterm{string-literal}
 (in either case, including within a \grammarterm{user-defined-literal})
 corresponds to a control character or
 to a character in the basic
-source character set, the program is ill-formed.\footnote{A sequence of characters resembling a \grammarterm{universal-character-name} in an
+source character set, the program is ill-formed.
+\begin{footnote}
+A sequence of characters resembling a \grammarterm{universal-character-name} in an
 \grammarterm{r-char-sequence}\iref{lex.string} does not form a
-\grammarterm{universal-character-name}.}
+\grammarterm{universal-character-name}.
+\end{footnote}
 \begin{note}
 ISO/IEC 10646 code points are integers in the range $[0, \mathrm{10FFFF}]$ (hexadecimal).
 A surrogate code point is a value in the range $[\mathrm{D800}, \mathrm{DFFF}]$ (hexadecimal).
@@ -422,19 +437,25 @@ violates a constraint on increment operators, even though the parse
 \pnum
 \indextext{token!alternative|(}%
 Alternative token representations are provided for some operators and
-punctuators.\footnote{\indextext{digraph}%
+punctuators.
+\begin{footnote}
+\indextext{digraph}%
 These include ``digraphs'' and additional reserved words. The term
 ``digraph'' (token consisting of two characters) is not perfectly
 descriptive, since one of the alternative \grammarterm{preprocessing-token}s is
 \tcode{\%:\%:} and of course several primary tokens contain two
 characters. Nonetheless, those alternative tokens that aren't lexical
-keywords are colloquially known as ``digraphs''. }
+keywords are colloquially known as ``digraphs''.
+\end{footnote}
 
 \pnum
 In all respects of the language, each alternative token behaves the
-same, respectively, as its primary token, except for its spelling.\footnote{Thus the ``stringized'' values\iref{cpp.stringize} of
+same, respectively, as its primary token, except for its spelling.
+\begin{footnote}
+Thus the ``stringized'' values\iref{cpp.stringize} of
 \tcode{[} and \tcode{<:} will be different, maintaining the source
-spelling, but the tokens can otherwise be freely interchanged. }
+spelling, but the tokens can otherwise be freely interchanged.
+\end{footnote}
 The set of alternative tokens is defined in
 \tref{lex.digraph}.
 
@@ -473,8 +494,10 @@ The set of alternative tokens is defined in
 
 \pnum
 \indextext{\idxgram{token}}%
-There are five kinds of tokens: identifiers, keywords, literals,\footnote{Literals include strings and character and numeric literals.
-}
+There are five kinds of tokens: identifiers, keywords, literals,%
+\begin{footnote}
+Literals include strings and character and numeric literals.
+\end{footnote}
 operators, and other separators.
 \indextext{white space}%
 Blanks, horizontal and vertical tabs, newlines, formfeeds, and comments
@@ -560,10 +583,13 @@ either of the character sequences \tcode{/*} or \tcode{//} in a
 is conditionally-supported with \impldef{meaning of \tcode{'}, \tcode{\textbackslash},
 \tcode{/*}, or \tcode{//} in a \grammarterm{q-char-sequence} or an
 \grammarterm{h-char-sequence}} semantics, as is the appearance of the character
-\tcode{"} in an \grammarterm{h-char-sequence}.\footnote{Thus, a sequence of characters
+\tcode{"} in an \grammarterm{h-char-sequence}.
+\begin{footnote}
+Thus, a sequence of characters
 that resembles an escape sequence might result in an error, be interpreted as the
 character corresponding to the escape sequence, or have a completely different meaning,
-depending on the implementation.}%
+depending on the implementation.
+\end{footnote}
 \indextext{header!name|)}
 
 \rSec1[lex.ppnumber]{Preprocessing numbers}
@@ -636,7 +662,9 @@ The initial element shall not be a \grammarterm{universal-character-name}
 designating a character whose encoding falls into one of the ranges
 specified in \tref{lex.name.disallowed}.
 Upper- and lower-case letters are
-different. All characters are significant.\footnote{On systems in which linkers cannot accept extended
+different. All characters are significant.
+\begin{footnote}
+On systems in which linkers cannot accept extended
 characters, an encoding of the \grammarterm{universal-character-name} can be used in
 forming valid external identifiers. For example, some otherwise unused
 character or sequence of characters can be used to encode the
@@ -644,7 +672,8 @@ character or sequence of characters can be used to encode the
 characters can produce a long external identifier, but \Cpp{} does not
 place a translation limit on significant characters for external
 identifiers. In \Cpp{}, upper- and lower-case letters are considered
-different for all identifiers, including external identifiers. }
+different for all identifiers, including external identifiers.
+\end{footnote}
 
 \begin{floattable}{Ranges of characters allowed}{lex.name.allowed}
 {lllll}
@@ -926,9 +955,12 @@ in translation phase 7\iref{lex.phases}.%
 \pnum
 \indextext{constant}%
 \indextext{literal!constant}%
-There are several kinds of literals.\footnote{The term ``literal'' generally designates, in this
+There are several kinds of literals.
+\begin{footnote}
+The term ``literal'' generally designates, in this
 document, those tokens that are called ``constants'' in
-ISO C. }
+ISO C.
+\end{footnote}
 
 \begin{bnf}
 \nontermdef{literal}\br
@@ -1302,8 +1334,11 @@ A \grammarterm{character-literal} that
 begins with the letter \tcode{L}, such as \tcode{L'z'},
 \indextext{prefix!\idxcode{L}}%
 is a \defn{wide-character literal}. A wide-character literal has type
-\tcode{wchar_t}.\footnote{They are intended for character sets where a character does
-not fit into a single byte. }
+\tcode{wchar_t}.
+\begin{footnote}
+They are intended for character sets where a character does
+not fit into a single byte.
+\end{footnote}
 The value of a wide-character literal containing a single
 \grammarterm{c-char} has value equal to the numerical value of the encoding
 of the \grammarterm{c-char} in the execution wide-character set, unless the
@@ -1320,8 +1355,11 @@ of a wide-character literal containing multiple \grammarterm{c-char}{s} is
 
 \pnum
 Certain non-graphic characters, the single quote \tcode{'}, the double quote \tcode{"},
-the question mark \tcode{?},\footnote{Using an escape sequence for a question mark
-is supported for compatibility with ISO \CppXIV{} and ISO C.}
+the question mark \tcode{?},
+\begin{footnote}
+Using an escape sequence for a question mark
+is supported for compatibility with ISO \CppXIV{} and ISO C.
+\end{footnote}
 and the backslash
 \indextext{backslash character}%
 \indextext{\idxcode{\textbackslash}|see{backslash character}}%

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -147,10 +147,13 @@ library. \ref{structure} describes the structure of
 \rSec3[structure.elements]{Elements}
 
 \pnum
-Each library clause contains the following elements, as applicable:\footnote{To
+Each library clause contains the following elements, as applicable:
+\begin{footnote}
+To
 save space, items that do not apply to a Clause are omitted.
 For example, if a Clause does not specify any requirements,
-there will be no ``Requirements'' subclause.}
+there will be no ``Requirements'' subclause.
+\end{footnote}
 
 \begin{itemize}
 \item Summary
@@ -233,8 +236,11 @@ In some cases the semantic requirements are presented as \Cpp{} code.
 Such code is intended as a
 specification of equivalence of a construct to another construct, not
 necessarily as the way the construct
-must be implemented.\footnote{Although in some cases the code given is
-unambiguously the optimum implementation.}
+must be implemented.
+\begin{footnote}
+Although in some cases the code given is
+unambiguously the optimum implementation.
+\end{footnote}
 
 \pnum
 Required operations of any concept defined in this document need not be
@@ -268,9 +274,12 @@ The detailed specifications each contain the following elements:%
 
 \pnum
 Descriptions of class member functions follow the order (as
-appropriate):\footnote{To save space, items that do not apply to a class are omitted.
+appropriate):
+\begin{footnote}
+To save space, items that do not apply to a class are omitted.
 For example, if a class does not specify any comparison operator functions, there
-will be no ``Comparison operator functions'' subclause.}
+will be no ``Comparison operator functions'' subclause.
+\end{footnote}
 
 \begin{itemize}
 \item constructor(s) and destructor
@@ -283,9 +292,12 @@ will be no ``Comparison operator functions'' subclause.}
 
 \pnum
 Descriptions of function semantics contain the following elements (as
-appropriate):\footnote{To save space, elements that do not apply to a function are omitted.
+appropriate):
+\begin{footnote}
+To save space, elements that do not apply to a function are omitted.
 For example, if a function specifies no
-preconditions, there will be no \expects element.}
+preconditions, there will be no \expects element.
+\end{footnote}
 
 \begin{itemize}
 \item
@@ -387,8 +399,11 @@ behavior described is the required behavior.
 
 \pnum
 If the formulation of a complexity requirement calls for a negative number of
-operations, the actual requirement is zero operations.\footnote{This simplifies
-the presentation of complexity requirements in some cases.}
+operations, the actual requirement is zero operations.
+\begin{footnote}
+This simplifies
+the presentation of complexity requirements in some cases.
+\end{footnote}
 
 \pnum
 Complexity requirements specified in the library clauses are upper bounds,
@@ -461,14 +476,17 @@ using @\placeholdernc{synth-three-way-result}@ = decltype(@\placeholdernc{synth-
 
 \pnum
 The Requirements subclauses may describe names that are used to specify
-constraints on template arguments.\footnote{Examples
+constraints on template arguments.
+\begin{footnote}
+Examples
 from~\ref{utility.requirements} include:
 \oldconcept{EqualityComparable},
 \oldconcept{LessThanComparable},
 \oldconcept{CopyConstructible}.
 Examples from~\ref{iterator.requirements} include:
 \oldconcept{InputIterator},
-\oldconcept{ForwardIterator}.}
+\oldconcept{ForwardIterator}.
+\end{footnote}
 These names are used in library Clauses
 to describe the types that
 may be supplied as arguments by a \Cpp{} program when instantiating template components from
@@ -501,8 +519,11 @@ that takes a callback parameter with C language linkage.
 Several types defined in \ref{input.output} are
 \defnx{enumerated types}{type!enumerated}.
 Each enumerated type may be implemented as an enumeration or as a synonym for
-an enumeration.\footnote{Such as an integer type, with constant integer
-values\iref{basic.fundamental}.}
+an enumeration.
+\begin{footnote}
+Such as an integer type, with constant integer
+values\iref{basic.fundamental}.
+\end{footnote}
 
 \pnum
 The enumerated type \tcode{\placeholder{enumerated}} can be written:
@@ -640,10 +661,12 @@ which is
 also its value in the \tcode{"C"}
 locale, but may change during program
 execution by a call to
-\tcode{setlocale(int, const char*)},\footnote{declared in
+\tcode{setlocale(int, const char*)},
+\begin{footnote}
+declared in
 \libheaderref{clocale}.
 \indexlibraryglobal{setlocale}%
-}
+\end{footnote}
 or by a change to a
 \tcode{locale}
 object, as described in \ref{locales} and \ref{input.output}.
@@ -677,12 +700,14 @@ or \ntbs{},
 is a character sequence whose highest-addressed element
 with defined content has the value zero
 (the \defnx{terminating null character}{character!terminating null});
-no other element in the sequence has the value zero.%
-\footnote{Many of the objects manipulated by
+no other element in the sequence has the value zero.
+\begin{footnote}
+Many of the objects manipulated by
 function signatures declared in
 \libheaderref{cstring} are character sequences or \ntbs{}s.
 The size of some of these character sequences is limited by
-a length value, maintained separately from the character sequence.}
+a length value, maintained separately from the character sequence.
+\end{footnote}
 
 \pnum
 The \defnx{length of an \ntbs{}}{NTBS@\ntbs{}!length}
@@ -699,9 +724,12 @@ elements up to and including the terminating null character.
 \pnum
 A \defnx{static \ntbs{}}{NTBS@\ntbs{}!static}
 is an \ntbs{} with
-static storage duration.\footnote{A \grammarterm{string-literal}, such as
+static storage duration.
+\begin{footnote}
+A \grammarterm{string-literal}, such as
 \tcode{"abc"},
-is a static \ntbs{}.}
+is a static \ntbs{}.
+\end{footnote}
 
 \rSec5[multibyte.strings]{Multibyte strings}
 
@@ -711,10 +739,13 @@ A \defnx{null-terminated multibyte string}{NTMBS@\ntmbs{}},
 or \ntmbs{},
 is an \ntbs{} that constitutes a
 sequence of valid multibyte characters, beginning and ending in the initial
-shift state.\footnote{An \ntbs{} that contains characters only from the
+shift state.
+\begin{footnote}
+An \ntbs{} that contains characters only from the
 basic execution character set is also an \ntmbs{}.
 Each multibyte character then
-consists of a single byte.}
+consists of a single byte.
+\end{footnote}
 
 \pnum
 A \defnx{static \ntmbs{}}{NTMBS@\ntmbs{}!static}
@@ -849,14 +880,20 @@ and
 are defined within the namespace
 \tcode{std}
 or namespaces nested within namespace
-\tcode{std}.\footnote{The C standard library headers\iref{depr.c.headers} also define
+\tcode{std}.
+\begin{footnote}
+The C standard library headers\iref{depr.c.headers} also define
 names within the global namespace, while the \Cpp{} headers for C library
-facilities\iref{headers} can also define names within the global namespace.}%
+facilities\iref{headers} can also define names within the global namespace.
+\end{footnote}
 \indextext{namespace}
 It is unspecified whether names declared in a specific namespace are declared
 directly in that namespace or in an inline namespace inside that
-namespace.\footnote{This gives implementers freedom to use inline namespaces to
-support multiple configurations of the library.}
+namespace.
+\begin{footnote}
+This gives implementers freedom to use inline namespaces to
+support multiple configurations of the library.
+\end{footnote}
 
 \pnum
 Whenever a name \tcode{x} defined in the standard library is mentioned,
@@ -872,9 +909,12 @@ is meant.
 
 \pnum
 Each element of the \Cpp{} standard library is declared or defined (as appropriate) in a
-\defn{header}.\footnote{A header is not necessarily a source file, nor are the
+\defn{header}.
+\begin{footnote}
+A header is not necessarily a source file, nor are the
 sequences delimited by \tcode{<} and \tcode{>} in header names necessarily valid source
-file names\iref{cpp.include}.}
+file names\iref{cpp.include}.
+\end{footnote}
 
 \pnum
 The \Cpp{} standard library provides the
@@ -969,11 +1009,13 @@ shown in \tref{headers.cpp}.
 The facilities of the C standard library are provided in the
 \indextext{library!C standard}%
 additional headers shown in \tref{headers.cpp.c}.%
-\footnote{It is intentional that there is no \Cpp{} header
+\begin{footnote}
+It is intentional that there is no \Cpp{} header
 for any of these C headers:
 \libnoheader{stdatomic.h},
 \libnoheader{stdnoreturn.h},
-\libnoheader{threads.h}.}
+\libnoheader{threads.h}.
+\end{footnote}
 
 \begin{multicolfloattable}{\Cpp{} headers for C library facilities}{headers.cpp.c}
 {lllllll}
@@ -1048,23 +1090,32 @@ The names defined as macros in C include the following:
 
 \pnum
 Names that are defined as functions in C shall be defined as functions in the
-\Cpp{} standard library.\footnote{This disallows the practice, allowed in C, of
+\Cpp{} standard library.
+\begin{footnote}
+This disallows the practice, allowed in C, of
 providing a masking macro in addition to the function prototype. The only way to
 achieve equivalent inline behavior in \Cpp{} is to provide a definition as an
-extern inline function.}
+extern inline function.
+\end{footnote}
 
 \pnum
 Identifiers that are keywords or operators in \Cpp{} shall not be defined as
-macros in \Cpp{} standard library headers.\footnote{In particular, including the
-standard header \libheader{iso646.h} has no effect.}
+macros in \Cpp{} standard library headers.
+\begin{footnote}
+In particular, including the
+standard header \libheader{iso646.h} has no effect.
+\end{footnote}
 
 \pnum
 \ref{depr.c.headers}, C standard library headers, describes the effects of using
-the \tcode{\placeholder{name}.h} (C header) form in a \Cpp{} program.\footnote{ The
+the \tcode{\placeholder{name}.h} (C header) form in a \Cpp{} program.
+\begin{footnote}
+ The
 \tcode{".h"} headers dump all their names into the global namespace, whereas the
 newer forms keep their names in namespace \tcode{std}. Therefore, the newer
 forms are the preferred forms for all uses except for \Cpp{} programs which are
-intended to be strictly compatible with C. }
+intended to be strictly compatible with C.
+\end{footnote}
 
 \pnum
 Annex K of the C standard describes a large number of functions,
@@ -1268,7 +1319,10 @@ being included exactly once, except that the effect of including either
 depends each time on the lexically current definition of
 \indextext{\idxcode{NDEBUG}}%
 \indexlibraryglobal{NDEBUG}%
-\tcode{NDEBUG}.\footnote{This is the same as the C standard library.}
+\tcode{NDEBUG}.
+\begin{footnote}
+This is the same as the C standard library.
+\end{footnote}
 
 \pnum
 A translation unit shall include a header only outside of any
@@ -1302,10 +1356,13 @@ or
 linkage is \impldef{linkage of names from C standard library}. It is recommended that an
 implementation use
 \tcode{extern "C++"}
-linkage for this purpose.\footnote{The only reliable way to declare an object or
+linkage for this purpose.
+\begin{footnote}
+The only reliable way to declare an object or
 function signature from the C standard library is by including the header that
 declares it, notwithstanding the latitude granted in 7.1.4 of the C
-Standard.}
+Standard.
+\end{footnote}
 
 \pnum
 Objects and functions
@@ -1834,11 +1891,13 @@ When reusing storage denoted by some pointer value \tcode{p},
 can be used to implicitly create a suitable array object
 and obtain a pointer to it.
 \end{example}
-\tcode{allocate} may throw an appropriate exception.%
-\footnote{It is intended that \tcode{a.allocate} be an efficient means
+\tcode{allocate} may throw an appropriate exception.
+\begin{footnote}
+It is intended that \tcode{a.allocate} be an efficient means
 of allocating a single object of type \tcode{T}, even when \tcode{sizeof(T)}
 is small. That is, there is no need for a container to maintain its own
-free list.}
+free list.
+\end{footnote}
 \begin{tailnote}
 If \tcode{n == 0}, the return value is unspecified.
 \end{tailnote}
@@ -2123,10 +2182,13 @@ to namespace
 depends on at least one program-defined type
 and
 (b) the specialization meets the standard library requirements
-for the original template.\footnote{Any
+for the original template.
+\begin{footnote}
+Any
 library code that instantiates other library templates
 must be prepared to work adequately with any user-supplied specialization
-that meets the minimum requirements of this document.}
+that meets the minimum requirements of this document.
+\end{footnote}
 
 \pnum
 The behavior of a \Cpp{} program is undefined
@@ -2200,8 +2262,8 @@ on at least one user-defined type
 and
 (b)
 the overload meets the standard library requirements
-for the customization point.%
-\footnote{
+for the customization point.
+\begin{footnote}
 Any library customization point
 must be prepared
 to work adequately
@@ -2223,7 +2285,8 @@ and the function parameters
 and return type
 of the object's \tcode{operator()}
 must match those
-of the corresponding customization point's specification.}
+of the corresponding customization point's specification.
+\end{footnote}
 \begin{note}
 This permits
 a (qualified or unqualified) call
@@ -2380,8 +2443,11 @@ Each name declared as an object with external linkage
 \indextext{linkage!external}%
 in a header is reserved to the implementation to designate that library
 object with external linkage,%
-\indextext{linkage!external}\footnote{The list of such reserved names includes
-\tcode{errno}, declared or defined in \libheaderref{cerrno}.}
+\indextext{linkage!external}%
+\begin{footnote}
+The list of such reserved names includes
+\tcode{errno}, declared or defined in \libheaderref{cerrno}.
+\end{footnote}
 both in namespace \tcode{std} and in the global namespace.
 
 \pnum
@@ -2392,7 +2458,9 @@ global function signature declared with
 external linkage in a header is reserved to the
 implementation to designate that function signature with
 \indextext{linkage!external}%
-external linkage.\footnote{The list of such reserved function
+external linkage.%
+\begin{footnote}
+The list of such reserved function
 signatures with external linkage includes
 \indexlibraryglobal{setjmp}%
 \tcode{setjmp(jmp_buf)},
@@ -2402,7 +2470,8 @@ and
 \indexlibraryglobal{va_list}%
 \tcode{va_end(va_list)},
 declared or defined in
-\libheaderref{cstdarg}.}
+\libheaderref{cstdarg}.
+\end{footnote}
 
 \pnum
 Each name from the C standard library declared with external linkage
@@ -2425,14 +2494,17 @@ a function signature with both
 and
 \indextext{\idxcode{extern ""C++""}}%
 \tcode{extern "C++"}
-linkage,\footnote{The function signatures declared in
+linkage,
+\begin{footnote}
+The function signatures declared in
 \indextext{Amendment 1}%
 \libheaderref{cuchar},
 \libheaderref{cwchar},
 and
 \libheaderref{cwctype}
 are always reserved, notwithstanding the restrictions imposed in subclause
-4.5.1 of Amendment 1 to the C Standard for these headers.}
+4.5.1 of Amendment 1 to the C Standard for these headers.
+\end{footnote}
 or as a name of namespace scope in the global namespace.
 
 \rSec4[extern.types]{Types}
@@ -2774,10 +2846,13 @@ inline\iref{dcl.inline}.
 A call to a non-member function signature
 described in \ref{\firstlibchapter} through \ref{\lastlibchapter} and
 \ref{depr} shall behave as if the implementation declared no additional
-non-member function signatures.\footnote{A valid \Cpp{} program always
+non-member function signatures.
+\begin{footnote}
+A valid \Cpp{} program always
 calls the expected library non-member function. An implementation can
 also define additional non-member functions that would otherwise not
-be called by a valid \Cpp{} program.}
+be called by a valid \Cpp{} program.
+\end{footnote}
 
 \pnum
 An implementation shall not declare a non-member function signature
@@ -2978,10 +3053,13 @@ Every base class not specified as
 \tcode{virtual} shall not be virtual;
 \item
 Unless explicitly stated otherwise, types with distinct names shall be distinct
-types.\footnote{There is an implicit exception to this rule for types that are
+types.
+\begin{footnote}
+There is an implicit exception to this rule for types that are
 described as synonyms for basic integral types, such as
 \tcode{size_t}\iref{support.types} and
-\tcode{streamoff}\iref{stream.types}.}
+\tcode{streamoff}\iref{stream.types}.
+\end{footnote}
 \end{itemize}
 
 \pnum
@@ -3002,16 +3080,22 @@ that would be caught by an exception handler for the base type.
 
 \pnum
 Functions from the C standard library shall not throw exceptions%
-\indextext{specifications!C standard library exception}\footnote{That is, the C
+\indextext{specifications!C standard library exception}%
+\begin{footnote}
+That is, the C
 library functions can all be treated as if they
 are marked \tcode{noexcept}.
 This allows implementations to make performance optimizations
-based on the absence of exceptions at runtime.}
+based on the absence of exceptions at runtime.
+\end{footnote}
 except when such a function calls a program-supplied function that throws an
-exception.\footnote{The functions
+exception.
+\begin{footnote}
+The functions
 \tcode{qsort()}
 and
-\tcode{bsearch()}\iref{alg.c.library} meet this condition.}
+\tcode{bsearch()}\iref{alg.c.library} meet this condition.
+\end{footnote}
 
 \pnum
 Destructor operations defined in the \Cpp{} standard library
@@ -3026,12 +3110,14 @@ Functions defined in the
 that do not have a \throws paragraph
 but do have a potentially-throwing exception specification
 may throw \impldef{exceptions thrown by standard library functions that have a
-potentially-throwing exception specification} exceptions.%
-\footnote{In particular, they
+potentially-throwing exception specification} exceptions.
+\begin{footnote}
+In particular, they
 can report a failure to allocate storage by throwing an exception of type
 \tcode{bad_alloc},
 or a class derived from
-\tcode{bad_alloc}\iref{bad.alloc}.}
+\tcode{bad_alloc}\iref{bad.alloc}.
+\end{footnote}
 Implementations should
 report errors by throwing exceptions of or derived
 from the standard exception classes~(\ref{bad.alloc},

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -103,9 +103,12 @@ namespace std {
 \pnum
 The header \libheader{locale}
 defines classes and declares functions that encapsulate and manipulate
-the information peculiar to a locale.\footnote{In this subclause, the type name
+the information peculiar to a locale.
+\begin{footnote}
+In this subclause, the type name
 \tcode{struct tm}
-is an incomplete type that is defined in \libheaderref{ctime}.}
+is an incomplete type that is defined in \libheaderref{ctime}.
+\end{footnote}
 
 \rSec1[locales]{Locales}
 
@@ -176,10 +179,12 @@ and
 
 \pnum
 \begin{example}
-An iostream \tcode{operator<<} might be implemented as:%
-\footnote{Note that in the call to \tcode{put},
+An iostream \tcode{operator<<} might be implemented as:
+\begin{footnote}
+Note that in the call to \tcode{put},
 the stream is implicitly converted
-to an \tcode{ostreambuf_iterator<charT, traits>}.}
+to an \tcode{ostreambuf_iterator<charT, traits>}.
+\end{footnote}
 
 \begin{codeblock}
 template<class charT, class traits>
@@ -470,10 +475,12 @@ Class \tcode{facet} is the base class for locale feature sets.
 A class is a \defn{facet}
 if it is publicly derived from another facet, or
 if it is a class derived from \tcode{locale::facet} and
-contains a publicly accessible declaration as follows:%
-\footnote{This is a complete list of requirements; there are no other requirements.
+contains a publicly accessible declaration as follows:
+\begin{footnote}
+This is a complete list of requirements; there are no other requirements.
 Thus, a facet class need not have a public
-copy constructor, assignment, default constructor, destructor, etc.}
+copy constructor, assignment, default constructor, destructor, etc.
+\end{footnote}
 \begin{codeblock}
 static ::std::locale::id id;
 \end{codeblock}
@@ -965,11 +972,14 @@ use_facet<ctype<charT>>(loc).is(ctype_base::@\placeholder{F}@, c)
 \end{codeblock}
 where \tcode{\placeholder{F}} is the
 \tcode{ctype_base::mask}
-value corresponding to that function\iref{category.ctype}.\footnote{When
+value corresponding to that function\iref{category.ctype}.
+\begin{footnote}
+When
 used in a loop, it is faster to cache the
 \tcode{ctype<>}
 facet and use it directly, or use the vector form of
-\tcode{ctype<>::is}.}
+\tcode{ctype<>::is}.
+\end{footnote}
 
 \rSec3[conversions.character]{Character conversions}
 
@@ -1379,10 +1389,13 @@ value or sequence of
 \tcode{char}
 values to the corresponding
 \tcode{charT}
-value or values.\footnote{The char argument of
+value or values.
+\begin{footnote}
+The char argument of
 \tcode{do_widen}
 is intended to accept values derived from \grammarterm{character-literal}s for conversion
-to the locale's encoding.}
+to the locale's encoding.
+\end{footnote}
 The only characters for which unique transformations are required
 are those in the basic source character set\iref{lex.charset}.
 
@@ -1395,8 +1408,11 @@ facet \tcode{ctc} and valid
 value \tcode{M},
 \tcode{(ctc.\brk{}is(M, c) || !is(M, do_widen(c)) )}
 is
-\tcode{true}.\footnote{In other words, the transformed character is not a member
-of any character classification that \tcode{c} is not also a member of.}
+\tcode{true}.
+\begin{footnote}
+In other words, the transformed character is not a member
+of any character classification that \tcode{c} is not also a member of.
+\end{footnote}
 
 The second form transforms each character
 \tcode{*p}
@@ -1544,7 +1560,9 @@ A specialization
 is provided so that the member functions on type
 \tcode{char}
 can be implemented
-inline.\footnote{Only the
+inline.
+\begin{footnote}
+Only the
 \tcode{char}
 (not
 \tcode{unsigned char}
@@ -1553,7 +1571,8 @@ and
 form is provided.
 The specialization is specified in the standard, and not left as an
 implementation detail, because it affects the derivation interface for
-\tcode{ctype<char>}.}
+\tcode{ctype<char>}.
+\end{footnote}
 The \impldef{value of \tcode{ctype<char>::table_size}} value of member
 \tcode{table_size}
 is at least 256.
@@ -2051,7 +2070,9 @@ then
 do_in(state, from, from_end, from_next, to, to + 1, to_next)
 \end{codeblock}
 shall also return
-\tcode{ok}.\footnote{Informally, this means that
+\tcode{ok}.
+\begin{footnote}
+Informally, this means that
 \tcode{basic_filebuf}
 assumes that the mappings from internal to external characters is
 1 to N: that a
@@ -2059,7 +2080,7 @@ assumes that the mappings from internal to external characters is
 facet that is used by
 \tcode{basic_filebuf}
 can translate characters one internal character at a time.
-}
+\end{footnote}
 \begin{note}
 As a result of operations on \tcode{state}, it can return \tcode{ok} or \tcode{partial} and set \tcode{from_next == from} and \tcode{to_next != to}.
 \end{note}
@@ -2118,8 +2139,11 @@ sequence.
 Places characters starting at \tcode{to} that should be appended
 to terminate a sequence when the current
 \tcode{stateT}
-is given by \tcode{state}.\footnote{Typically these will be characters to return the state to
-\tcode{stateT()}.}
+is given by \tcode{state}.
+\begin{footnote}
+Typically these will be characters to return the state to
+\tcode{stateT()}.
+\end{footnote}
 Stores no more than
 \tcode{(to_end - to)}
 destination elements, and leaves the \tcode{to_next} pointer
@@ -2152,11 +2176,14 @@ int do_encoding() const noexcept;
 \returns
 \tcode{-1} if the encoding of the \tcode{externT} sequence is state-dependent; else the
 constant number of \tcode{externT} characters needed to produce an internal
-character; or \tcode{0} if this number is not a constant.\footnote{If \tcode{encoding()}
+character; or \tcode{0} if this number is not a constant.
+\begin{footnote}
+If \tcode{encoding()}
 yields \tcode{-1}, then more than \tcode{max_length()} \tcode{externT} elements
 can be consumed when producing a single \tcode{internT} character, and additional
 \tcode{externT} elements can appear at the end of a sequence after those that
-yield the final \tcode{internT} character.}
+yield the final \tcode{internT} character.
+\end{footnote}
 \end{itemdescr}
 
 \indexlibrarymember{codecvt}{do_always_noconv}%
@@ -2269,12 +2296,15 @@ and
 handle numeric formatting and parsing.
 Virtual functions are provided for several numeric types.
 Implementations may (but are not required to) delegate extraction
-of smaller types to extractors for larger types.\footnote{Parsing
+of smaller types to extractors for larger types.
+\begin{footnote}
+Parsing
 \tcode{"-1"} correctly into, e.g., an
 \tcode{unsigned short}
 requires that the corresponding member
 \tcode{get()}
-at least extract the sign before delegating.}
+at least extract the sign before delegating.
+\end{footnote}
 
 \pnum
 All specifications of member functions for
@@ -2971,13 +3001,17 @@ A local variable is initialized as
 fmtflags adjustfield = (flags & (ios_base::adjustfield));
 \end{codeblock}
 
-The location of any padding\footnote{The conversion specification
+The location of any padding
+\begin{footnote}
+The conversion specification
 \tcode{\#o}
 generates a leading
 \tcode{0}
 which is
 \textit{not}
-a padding character.} is determined according to \tref{facet.num.put.fill}.
+a padding character.
+\end{footnote}
+is determined according to \tref{facet.num.put.fill}.
 
 \begin{floattable}{Fill padding}{facet.num.put.fill}
 {p{3in}l}
@@ -3243,10 +3277,13 @@ string do_grouping() const;
 A \tcode{string} \tcode{vec} used as a vector of integer values,
 in which each element
 \tcode{vec[i]}
-represents the number of digits\footnote{Thus, the string
+represents the number of digits
+\begin{footnote}
+Thus, the string
 \tcode{"\textbackslash003"} specifies groups of 3 digits each, and
 \tcode{"3"} probably indicates groups of 51 (!) digits each,
-because 51 is the ASCII value of \tcode{"3"}.}
+because 51 is the ASCII value of \tcode{"3"}.
+\end{footnote}
 in the group at position \tcode{i}, starting with position 0 as the
 rightmost group.
 If
@@ -3432,8 +3469,11 @@ value that, compared lexicographically with the result of calling
 \tcode{transform()}
 on another string, yields the same result as calling
 \tcode{do_compare()}
-on the same two strings.\footnote{This function is useful when one string is
-being compared to many other strings.}
+on the same two strings.
+\begin{footnote}
+This function is useful when one string is
+being compared to many other strings.
+\end{footnote}
 \end{itemdescr}
 
 \indexlibrarymember{collate}{do_hash}%
@@ -3575,12 +3615,15 @@ If the sequence being parsed matches the correct format, the corresponding
 members of the
 \tcode{struct tm}
 argument are set to the values used to produce the sequence; otherwise
-either an error is reported or unspecified values are assigned.\footnote{In
+either an error is reported or unspecified values are assigned.
+\begin{footnote}
+In
 other words, user confirmation is required for reliable parsing of
 user-entered dates and times, but machine-generated formats can be
 parsed reliably.
 This allows parsers to be aggressive about
-interpreting user variations on standard formats.}
+interpreting user variations on standard formats.
+\end{footnote}
 
 \pnum
 If the end iterator is reached during parsing by any of the
@@ -3748,11 +3791,14 @@ dateorder do_date_order() const;
 \pnum
 \returns
 An enumeration value indicating the preferred order of components for
-those date formats that are composed of day, month, and year.\footnote{This
+those date formats that are composed of day, month, and year.
+\begin{footnote}
+This
 function is intended as a convenience only, for common
 formats, and can return
 \tcode{no_order}
-in valid locales.}
+in valid locales.
+\end{footnote}
 Returns
 \tcode{no_order}
 if the date format specified by
@@ -4014,8 +4060,12 @@ obtained from
 The first character of each sequence is equal to
 \tcode{'\%'},
 followed by an optional modifier character
-\tcode{mod}\footnote{Although the C programming language defines no modifiers,
-most vendors do.} and a format specifier character
+\tcode{mod}
+\begin{footnote}
+Although the C programming language defines no modifiers,
+most vendors do.
+\end{footnote}
+and a format specifier character
 \tcode{spec}
 as defined for the function
 \tcode{strftime}.
@@ -4326,8 +4376,11 @@ in the order in which they appear,
 preceded by a minus sign if and only if the result is negative.
 The value
 \tcode{units}
-is produced as if by\footnote{The semantics here are different from
-\tcode{ct.narrow}.}
+is produced as if by
+\begin{footnote}
+The semantics here are different from
+\tcode{ct.narrow}.
+\end{footnote}
 \begin{codeblock}
 for (int i = 0; i < n; ++i)
   buf2[i] = src[find(atoms, atoms+sizeof(src), buf1[i]) - atoms];
@@ -4569,13 +4622,16 @@ value
 \tcode{static_cast<part>(p.field[i])}
 determines the
 $\tcode{i}^\text{th}$
-component of the format\footnote{An array of
+component of the format
+\begin{footnote}
+An array of
 \tcode{char},
 rather than an array of
 \tcode{part},
 is specified for
 \tcode{pattern::field}
-purely for efficiency.}
+purely for efficiency.
+\end{footnote}
 In the
 \tcode{field}
 member of a
@@ -4720,8 +4776,11 @@ charT do_decimal_point() const;
 \returns
 The radix separator to use in case
 \tcode{do_frac_digits()}
-is greater than zero.\footnote{In common U.S. locales this is
-\tcode{'.'}.}
+is greater than zero.
+\begin{footnote}
+In common U.S. locales this is
+\tcode{'.'}.
+\end{footnote}
 \end{itemdescr}
 
 \indexlibrarymember{moneypunct}{do_thousands_sep}%
@@ -4734,8 +4793,11 @@ charT do_thousands_sep() const;
 \returns
 The digit group separator to use in case
 \tcode{do_grouping()}
-specifies a digit grouping pattern.\footnote{In common U.S. locales this is
-\tcode{','}.}
+specifies a digit grouping pattern.
+\begin{footnote}
+In common U.S. locales this is
+\tcode{','}.
+\end{footnote}
 \end{itemdescr}
 
 \indexlibrarymember{moneypunct}{do_grouping}%
@@ -4747,10 +4809,13 @@ string do_grouping() const;
 \pnum
 \returns
 A pattern defined identically as, but not necessarily equal to, the result of
-\tcode{numpunct<charT>::\brk{}do_grouping()}.\footnote{To specify grouping by 3s,
+\tcode{numpunct<charT>::\brk{}do_grouping()}.
+\begin{footnote}
+To specify grouping by 3s,
 the value is \tcode{"\textbackslash003"}
 \textit{not}
-\tcode{"3"}.}
+\tcode{"3"}.
+\end{footnote}
 \end{itemdescr}
 
 \indexlibrarymember{moneypunct}{do_curr_symbol}%
@@ -4781,7 +4846,10 @@ string_type do_negative_sign() const;
 \returns
 \tcode{do_positive_sign()}
 returns the string to use to indicate a
-positive monetary value;\footnote{This is usually the empty string.}
+positive monetary value;
+\begin{footnote}
+This is usually the empty string.
+\end{footnote}
 \tcode{do_negative_sign()}
 returns the string to use to indicate a negative value.
 \end{itemdescr}
@@ -4794,8 +4862,11 @@ int do_frac_digits() const;
 \begin{itemdescr}
 \pnum
 \returns
-The number of digits after the decimal radix separator, if any.\footnote{In
-common U.S.\ locales, this is 2.}
+The number of digits after the decimal radix separator, if any.
+\begin{footnote}
+In
+common U.S.\ locales, this is 2.
+\end{footnote}
 \end{itemdescr}
 
 \indexlibrarymember{moneypunct}{do_pos_format}%
@@ -4819,11 +4890,14 @@ and
 return an object of type
 \tcode{pattern}
 initialized to
-\tcode{\{ symbol, sign, none, value \}}.\footnote{Note that the international
+\tcode{\{ symbol, sign, none, value \}}.
+\begin{footnote}
+Note that the international
 symbol returned by
 \tcode{do_curr_symbol()}
 usually contains a space, itself;
-for example, \tcode{"USD "}.}
+for example, \tcode{"USD "}.
+\end{footnote}
 \end{itemdescr}
 
 \rSec3[locale.moneypunct.byname]{Class template \tcode{moneypunct_byname}}

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -289,6 +289,22 @@
 \newnoteenvironment{note}{Note \arabic{note}}{end note}
 \newnoteenvironment{example}{Example \arabic{example}}{end example}
 
+\makeatletter
+\let\footnote\@undefined
+\global\newsavebox{\@tempfootboxa}   % must be global, to escape tables/figures
+\newsavebox{\@templfootbox}
+\newenvironment{footnote}{%
+  \unskip\footnotemark%    no space before the mark
+  \normalfont%
+  \footnotesize%           text size for rendering the footnote text
+  \begin{lrbox}{\@templfootbox}%       temporarily save to local box
+}{%
+  \end{lrbox}%
+  \global\setbox\@tempfootboxa\hbox{\unhbox\@templfootbox}%  copy to global box
+  \footnotetext{\unhbox\@tempfootboxa}%
+}
+\makeatother
+
 %% Library function descriptions
 \newcommand{\Fundescx}[1]{\textit{#1}}
 \newcommand{\Fundesc}[1]{\Fundescx{#1}:\space}

--- a/source/modules.tex
+++ b/source/modules.tex
@@ -524,8 +524,11 @@ Additionally, when a \grammarterm{module-import-declaration}
 in a module unit of some module $M$ imports another module unit $U$ of $M$,
 it also imports all translation units imported by
 non-exported \grammarterm{module-import-declaration}{s}
-in the module unit purview of $U$.\footnote{This is consistent
-with the rules for visibility of imported names\iref{basic.scope.namespace}.}
+in the module unit purview of $U$.
+\begin{footnote}
+This is consistent
+with the rules for visibility of imported names\iref{basic.scope.namespace}.
+\end{footnote}
 These rules can in turn lead to the importation of yet more
 translation units.
 
@@ -656,9 +659,12 @@ and the other declares a member or friend of $C$, or
 one of $D$ and $M$ declares an enumeration $E$
 and the other declares an enumerator of $E$, or
 \item
-$D$ declares a function or variable and $M$ is declared in $D$,%
-\footnote{A declaration can appear within a \grammarterm{lambda-expression}
-in the initializer of a variable.} or
+$D$ declares a function or variable and $M$ is declared in $D$,
+\begin{footnote}
+A declaration can appear within a \grammarterm{lambda-expression}
+in the initializer of a variable.
+\end{footnote}
+or
 \item
 one of $M$ and $D$ declares a template and the other declares
 a partial or explicit specialization or
@@ -986,10 +992,12 @@ All translation units that are necessarily reachable are
 \defnx{reachable}{reachable!translation unit}.
 Additional translation units on which the
 point within the program has an interface dependency may be considered reachable,
-but it is unspecified which are and under what circumstances.%
-\footnote{Implementations are therefore not required to prevent the semantic
+but it is unspecified which are and under what circumstances.
+\begin{footnote}
+Implementations are therefore not required to prevent the semantic
 effects of additional translation units involved in the compilation from being
-observed.}
+observed.
+\end{footnote}
 \begin{note}
 It is advisable to avoid
 depending on the reachability of any additional translation units

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -44,14 +44,16 @@ that meets the
 \oldconcept{CopyConstructible},
 \oldconcept{CopyAssignable}, and
 \oldconcept{Destructible}
-requirements\iref{utility.arg.requirements}.%
-\footnote{In other words, value types.
+requirements\iref{utility.arg.requirements}.
+\begin{footnote}
+In other words, value types.
 These include arithmetic types,
 pointers, the library class
 \tcode{complex},
 and instantiations of
 \tcode{valarray}
-for value types.}
+for value types.
+\end{footnote}
 
 \pnum
 If any operation on \tcode{T}
@@ -2314,12 +2316,14 @@ according to \ref{strings} and \ref{input.output}.
   & \bigoh{$\text{size of state}$}
   \\ \rowsep
 \tcode{E(q)}%
-\indextext{constructor!random number engine requirement}\footnote{  This constructor
+\indextext{constructor!random number engine requirement}%
+\begin{footnote}
+  This constructor
   (as well as the subsequent corresponding \tcode{seed()} function)
   can be particularly useful
   to applications requiring
   a large number of independent random sequences.
-  }
+\end{footnote}
   &
   & Creates an engine
     with an initial state
@@ -2362,14 +2366,15 @@ according to \ref{strings} and \ref{input.output}.
   \\ \rowsep
 \tcode{e.discard(z)}%
 \indextext{\idxcode{discard}!random number engine requirement}
-\footnote{  This operation is common
+\begin{footnote}
+  This operation is common
   in user code,
   and can often be implemented
   in an engine-specific manner
   so as to provide significant performance improvements
   over an equivalent naive loop
   that makes \tcode{z} consecutive calls \tcode{e()}.
-}
+\end{footnote}
   & \tcode{void}
   & Advances \tcode{e}'s state \state{e}{i}
       to $\tcode{e}_{i+\tcode{z}}$
@@ -3103,9 +3108,12 @@ template<class Sseq> explicit linear_congruential_engine(Sseq& q);
 
 \pnum
 A \tcode{mersenne_twister_engine} random number
-engine\footnote{The name of this engine refers, in part, to a property of its period:
+engine
+\begin{footnote}
+The name of this engine refers, in part, to a property of its period:
  For properly-selected values of the parameters,
- the period is closely related to a large Mersenne prime number.}
+ the period is closely related to a large Mersenne prime number.
+\end{footnote}
 produces unsigned integer random numbers
 in the closed interval $[0,2^w-1]$.
 The
@@ -4116,10 +4124,12 @@ A value of an \impldef{exception type when \tcode{random_device} constructor fai
 \remarks
  The semantics of the \tcode{token} parameter
  and the token value used by the default constructor are
- \impldef{semantics of \tcode{token} parameter and default token value used by \tcode{random_device} constructors}.%
-\footnote{The parameter is intended
+ \impldef{semantics of \tcode{token} parameter and default token value used by \tcode{random_device} constructors}.
+\begin{footnote}
+The parameter is intended
    to allow an implementation to differentiate
-   between different sources of randomness.}
+   between different sources of randomness.
+\end{footnote}
 \end{itemdescr}
 
 \indexlibrarymember{entropy}{random_device}%
@@ -4132,11 +4142,14 @@ double entropy() const noexcept;
 \returns
 If the implementation employs a random number engine,
  returns $0.0$.
- Otherwise, returns an entropy estimate\footnote{If a device has $n$ states
+ Otherwise, returns an entropy estimate
+\begin{footnote}
+If a device has $n$ states
    whose respective probabilities are
    $P_0, \dotsc, P_{n-1}$,
    the device entropy $S$ is defined as\\
-   $S = - \sum_{i=0}^{n-1} P_i \cdot \log P_i$.}
+   $S = - \sum_{i=0}^{n-1} P_i \cdot \log P_i$.
+\end{footnote}
  for the random numbers returned by \tcode{operator()},
  in the range
    \tcode{min()}
@@ -4440,10 +4453,13 @@ Exactly
  $k = \max(1, \left\lceil b / \log_2 R \right\rceil)$
  invocations
  of \tcode{g},
- where $b$\footnote{$b$ is introduced
+ where $b$
+\begin{footnote}
+$b$ is introduced
    to avoid any attempt
    to produce more bits of randomness
-   than can be held in \tcode{RealType}.}
+   than can be held in \tcode{RealType}.
+\end{footnote}
    is the lesser of \tcode{numeric_limits<RealType>::digits}
                 and \tcode{bits},
  and
@@ -5440,14 +5456,17 @@ The value of the \tcode{b} parameter
 An \tcode{extreme_value_distribution} random number distribution
 produces random numbers $x$
 distributed according to
-the probability density function\footnote{The distribution corresponding to
+the probability density function
+\begin{footnote}
+The distribution corresponding to
  this probability density function
  is also known
  (with a possible change of variable)
  as the Gumbel Type I,
  the log-Weibull,
  or the Fisher-Tippett Type I
- distribution.}%
+ distribution.
+\end{footnote}
 \indextext{probability density function!\idxcode{extreme_value_distribution}}%
 \indextext{\idxcode{extreme_value_distribution}!probability density function}
 \[ p(x\,|\,a,b) = \frac{1}{b}
@@ -6948,11 +6967,14 @@ const member functions of
 are also applicable to this type.
 This return type shall not add
 more than two levels of template nesting over the most deeply nested
-argument type.\footnote{\ref{implimits} recommends a minimum number
+argument type.
+\begin{footnote}
+\ref{implimits} recommends a minimum number
 of recursively nested template
 instantiations.
 This requirement thus indirectly suggests a minimum
-allowable complexity for valarray expressions.}
+allowable complexity for valarray expressions.
+\end{footnote}
 
 \pnum
 Implementations introducing such replacement types shall provide
@@ -7101,7 +7123,9 @@ to as an ``array'' throughout the remainder of~\ref{numarray}.
 The illusion of higher dimensionality
 may be produced by the familiar idiom of computed indices, together
 with the powerful subsetting capabilities provided
-by the generalized subscript operators.\footnote{The intent is to specify
+by the generalized subscript operators.
+\begin{footnote}
+The intent is to specify
 an array template that has the minimum functionality
 necessary to address aliasing ambiguities and the proliferation of
 temporary objects.
@@ -7109,7 +7133,8 @@ Thus, the
 \tcode{valarray}
 template is neither a
 matrix class nor a field class.
-However, it is a very useful building block for designing such classes.}
+However, it is a very useful building block for designing such classes.
+\end{footnote}
 
 \rSec3[valarray.cons]{Constructors}
 
@@ -7122,13 +7147,16 @@ valarray();
 \pnum
 \effects
 Constructs a \tcode{valarray}
-that has zero length.\footnote{This default constructor is essential,
+that has zero length.
+\begin{footnote}
+This default constructor is essential,
 since arrays of
 \tcode{valarray}
 can be useful.
 After initialization, the length of an empty array can be increased with the
 \tcode{resize}
-member function.}
+member function.
+\end{footnote}
 \end{itemdescr}
 
 \indexlibraryctor{valarray}%
@@ -7171,10 +7199,13 @@ Constructs a \tcode{valarray} that has length \tcode{n}.
 The values of the elements of the array are initialized with the
 first
 \tcode{n}
-values pointed to by the first argument.\footnote{This constructor is the
+values pointed to by the first argument.
+\begin{footnote}
+This constructor is the
 preferred method for converting a C array to a
 \tcode{valarray}
-object.}
+object.
+\end{footnote}
 \end{itemdescr}
 
 \indexlibraryctor{valarray}%
@@ -7187,11 +7218,14 @@ valarray(const valarray& v);
 \effects
 Constructs a \tcode{valarray} that has the same length as \tcode{v}.
 The elements are initialized with the values of the corresponding
-elements of \tcode{v}.\footnote{This copy constructor creates
+elements of \tcode{v}.
+\begin{footnote}
+This copy constructor creates
 a distinct array rather than an alias.
 Implementations in which arrays share storage are permitted, but they
 would need to implement a copy-on-reference mechanism to ensure that arrays are
-conceptually distinct.}
+conceptually distinct.
+\end{footnote}
 \end{itemdescr}
 
 \indexlibraryctor{valarray}%
@@ -8174,8 +8208,10 @@ namespace std {
 The \tcode{slice}
 class represents a BLAS-like slice from an array.
 Such a slice is specified by a starting index, a length, and a
-stride.\footnote{BLAS stands for
-\textit{Basic Linear Algebra Subprograms.}
+stride.
+\begin{footnote}
+BLAS stands for
+\textit{Basic Linear Algebra Subprograms}.
 \Cpp{} programs can instantiate this class.
 See, for example,
 Dongarra, Du Croz, Duff, and Hammerling:
@@ -8183,7 +8219,8 @@ Dongarra, Du Croz, Duff, and Hammerling:
 Technical Report MCS-P1-0888,
 Argonne National Laboratory (USA),
 Mathematics and Computer Science Division,
-August, 1988.}
+August, 1988.
+\end{footnote}
 
 \rSec3[cons.slice]{Constructors}
 
@@ -9896,7 +9933,8 @@ for which:
 
   \item
   the corresponding mathematical function
-  is not mathematically defined.\footnote{%
+  is not mathematically defined.
+\begin{footnote}
     A mathematical function
     is mathematically defined
     for a given set of argument values
@@ -9907,7 +9945,8 @@ for which:
     (b)
       if its limiting value exists
       and does not depend
-      on the direction of approach.}
+      on the direction of approach.
+\end{footnote}
 \end{itemize}
 
 \pnum

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -265,13 +265,16 @@ and
 \tcode{volatile}
 type-specifiers buried within a parameter type specification are significant
 and can be used to distinguish overloaded function
-declarations.\footnote{When a parameter type includes a function type,
+declarations.
+\begin{footnote}
+When a parameter type includes a function type,
 such as in the case of a parameter type that is a pointer to function, the
 \tcode{const}
 and
 \tcode{volatile}
 type-specifiers at the outermost level of the parameter type
-specifications for the inner function type are also ignored.}
+specifications for the inner function type are also ignored.
+\end{footnote}
 In particular, for any type
 \tcode{T},
 ``pointer to
@@ -647,7 +650,9 @@ if the context requires a candidate that
 is not explicit and the generated specialization is explicit\iref{dcl.fct.spec},
 it will be removed from the candidate set.
 Those candidates are then handled as candidate
-functions in the usual way.\footnote{The process of argument deduction fully
+functions in the usual way.
+\begin{footnote}
+The process of argument deduction fully
 determines the parameter types of
 the
 function template specializations,
@@ -658,7 +663,8 @@ no template parameter types.
 Therefore, except where specified otherwise,
 function template specializations
 and non-template functions\iref{dcl.fct} are treated equivalently
-for the remainder of overload resolution.}
+for the remainder of overload resolution.
+\end{footnote}
 A given name can refer to one or more function templates and also
 to a set of non-template functions.
 In such a case, the
@@ -776,10 +782,13 @@ operator
 has type ``\cv{}~\tcode{T}''
 where
 \tcode{T}
-denotes a class.\footnote{Note that cv-qualifiers on the type of objects are
+denotes a class.
+\begin{footnote}
+Note that cv-qualifiers on the type of objects are
 significant in overload
 resolution for
-both glvalue and class prvalue objects.}
+both glvalue and class prvalue objects.
+\end{footnote}
 Under this
 assumption, the
 \grammarterm{id-expression}
@@ -838,7 +847,9 @@ scope or refers to another class, then
 a contrived object of type
 \tcode{T}
 becomes the implied object
-argument.\footnote{An implied object argument is contrived to
+argument.
+\begin{footnote}
+An implied object argument is contrived to
 correspond to the implicit object
 parameter attributed to member functions during overload resolution.
 It is not
@@ -848,7 +859,8 @@ Since the member functions all have the
 same implicit
 object parameter, the contrived object will not be the cause to select or
 reject a
-function.}
+function.
+\end{footnote}
 If the argument list is augmented by a contrived object and overload
 resolution selects one of the non-static member functions of
 \tcode{T},
@@ -899,7 +911,9 @@ each non-explicit conversion function declared in a base class of
 provided the function is not hidden within
 \tcode{T}
 by another
-intervening declaration.\footnote{Note that this construction can yield
+intervening declaration.
+\begin{footnote}
+Note that this construction can yield
 candidate call functions that cannot be
 differentiated one from the other by overload resolution because they have
 identical
@@ -907,7 +921,8 @@ declarations or differ only in their return type.
 The call will be ambiguous
 if overload
 resolution cannot select a match to the call that is uniquely better than such
-undifferentiable functions.}
+undifferentiable functions.
+\end{footnote}
 
 \pnum
 The argument list submitted to overload resolution consists of
@@ -1146,8 +1161,11 @@ The argument list contains all of the
 operands of the operator.
 The best function from the set of candidate functions is selected
 according to~\ref{over.match.viable}
-and~\ref{over.match.best}.\footnote{If the set of candidate functions is empty,
-overload resolution is unsuccessful.}
+and~\ref{over.match.best}.
+\begin{footnote}
+If the set of candidate functions is empty,
+overload resolution is unsuccessful.
+\end{footnote}
 \begin{example}
 \begin{codeblock}
 struct A {
@@ -1231,14 +1249,17 @@ When
 returns, the operator
 \tcode{->}
 is applied to the value returned, with the original second
-operand.\footnote{If the value returned by the
+operand.
+\begin{footnote}
+If the value returned by the
 \tcode{\keyword{operator}->}
 function has class type, this can result in selecting and calling another
 \tcode{\keyword{operator}->}
 function.
 The process repeats until an
 \tcode{\keyword{operator}->}
-function returns a value of non-class type.}
+function returns a value of non-class type.
+\end{footnote}
 
 \pnum
 If the operator is the operator
@@ -1941,10 +1962,13 @@ ICS\textit{1}(\tcode{F}) is neither better nor worse than ICS\textit{1}(\tcode{G
 for any function
 \tcode{G},
 and, symmetrically, ICS\textit{1}(\tcode{G}) is neither better nor worse than
-ICS\textit{1}(\tcode{F});\footnote{If a function is a static member function, this
+ICS\textit{1}(\tcode{F});
+\begin{footnote}
+If a function is a static member function, this
 definition means that the first argument, the implied object argument,
 has no effect in the determination of whether the function is better
-or worse than any other function.}
+or worse than any other function.
+\end{footnote}
 otherwise,
 \item
 let ICS\textit{i}(\tcode{F}) denote the implicit conversion sequence that converts
@@ -2147,7 +2171,9 @@ A b2 = a;           // uses \#7 to deduce \tcode{A<A<int>>} and \#1 to initializ
 \pnum
 If there is exactly one viable function that is a better function
 than all other viable functions, then it is the one selected by
-overload resolution; otherwise the call is ill-formed.\footnote{The algorithm
+overload resolution; otherwise the call is ill-formed.
+\begin{footnote}
+The algorithm
 for selecting the best viable function is linear in the number
 of viable
 functions.
@@ -2180,7 +2206,8 @@ So, make a second pass over
 the viable
 functions to verify that
 \tcode{W}
-is better than all other functions.}
+is better than all other functions.
+\end{footnote}
 \begin{example}
 \begin{codeblock}
 void Fcn(const int*,  short);
@@ -2637,9 +2664,11 @@ or a class derived from \tcode{X}, the implicit conversion sequence is the one
 required to convert the element to the parameter type.
 
 \pnum
-Otherwise, if the parameter type is a character array%
-\footnote{Since there are no parameters of array type,
-this will only occur as the referenced type of a reference parameter.}
+Otherwise, if the parameter type is a character array
+\begin{footnote}
+Since there are no parameters of array type,
+this will only occur as the referenced type of a reference parameter.
+\end{footnote}
 and the initializer list has a single element that is an appropriately-typed
 \grammarterm{string-literal}\iref{dcl.init.string}, the implicit conversion
 sequence is the identity conversion.
@@ -3764,7 +3793,9 @@ When the postfix increment is called as a result of using the
 \tcode{++}
 operator, the
 \tcode{int}
-argument will have value zero.\footnote{Calling
+argument will have value zero.
+\begin{footnote}
+Calling
 \tcode{\keyword{operator}++}
 explicitly, as in expressions like
 \tcode{a.\keyword{operator}++(2)},
@@ -3772,7 +3803,8 @@ has no special properties:
 The argument to
 \tcode{\keyword{operator}++}
 is
-\tcode{2}.}
+\tcode{2}.
+\end{footnote}
 \begin{example}
 \begin{codeblock}
 struct X {

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -170,14 +170,16 @@ one of the two preceding forms.
 \end{itemize}
 
 The last token in the sequence is the first token within the sequence that
-is immediately followed by whitespace containing a new-line character.%
-\footnote{Thus,
+is immediately followed by whitespace containing a new-line character.
+\begin{footnote}
+Thus,
 preprocessing directives are commonly called ``lines''.
 These ``lines'' have no other syntactic significance,
 as all white space is equivalent except in certain situations
 during preprocessing (see the
 \tcode{\#}
-character string literal creation operator in~\ref{cpp.stringize}, for example).}
+character string literal creation operator in~\ref{cpp.stringize}, for example).
+\end{footnote}
 \begin{note}
 A new-line character ends the preprocessing directive even if it occurs
 within what would otherwise be an invocation of a function-like macro.
@@ -313,10 +315,13 @@ The expression that controls conditional inclusion
 shall be an integral constant expression except that
 identifiers
 (including those lexically identical to keywords)
-are interpreted as described below\footnote{Because the controlling constant expression is evaluated
+are interpreted as described below
+\begin{footnote}
+Because the controlling constant expression is evaluated
 during translation phase 4,
 all identifiers either are or are not macro names ---
-there simply are no keywords, enumeration constants, etc.}
+there simply are no keywords, enumeration constants, etc.
+\end{footnote}
 and it may contain zero or more \grammarterm{defined-macro-expression}{s} and/or
 \grammarterm{has-include-expression}{s} and/or
 \grammarterm{has-attribute-expression}{s} as unary operator expressions.
@@ -547,7 +552,9 @@ is processed; lacking a
 directive, all the groups until the
 \tcode{\#endif}
 \indextext{\idxcode{\#endif}}%
-are skipped.\footnote{As indicated by the syntax,
+are skipped.%
+\begin{footnote}
+As indicated by the syntax,
 a preprocessing token cannot follow a
 \tcode{\#else}
 or
@@ -555,7 +562,8 @@ or
 directive before the terminating new-line character.
 However,
 comments can appear anywhere in a source file,
-including within a preprocessing directive.}
+including within a preprocessing directive.
+\end{footnote}
 
 \pnum
 \begin{example}
@@ -663,11 +671,14 @@ in the directive are processed just as in normal text
 replacement list of preprocessing tokens).
 If the directive resulting after all replacements does not match
 one of the two previous forms, the behavior is
-undefined.\footnote{Note that adjacent \grammarterm{string-literal}s are not concatenated into
+undefined.
+\begin{footnote}
+Note that adjacent \grammarterm{string-literal}s are not concatenated into
 a single \grammarterm{string-literal}
 (see the translation phases in~\ref{lex.phases});
 thus, an expansion that results in two \grammarterm{string-literal}s is an
-invalid directive.}
+invalid directive.
+\end{footnote}
 The method by which a sequence of preprocessing tokens between a
 \tcode{<}
 and a
@@ -1032,16 +1043,22 @@ A preprocessing directive of the form
 \end{ncsimplebnf}
 defines an
 \defnadj{object-like}{macro} that
-causes each subsequent instance of the macro name\footnote{Since, by macro-replacement time,
+causes each subsequent instance of the macro name
+\begin{footnote}
+Since, by macro-replacement time,
 all \grammarterm{character-literal}s and \grammarterm{string-literal}s are preprocessing tokens,
 not sequences possibly containing identifier-like subsequences
 (see \ref{lex.phases}, translation phases),
-they are never scanned for macro names or parameters.}
+they are never scanned for macro names or parameters.
+\end{footnote}
 to be replaced by the replacement list of preprocessing tokens
-that constitute the remainder of the directive.\footnote{An alternative token\iref{lex.digraph} is not an identifier,
+that constitute the remainder of the directive.
+\begin{footnote}
+An alternative token\iref{lex.digraph} is not an identifier,
 even when its spelling consists entirely of letters and underscores.
 Therefore it is not possible to define a macro
-whose name is the same as that of an alternative token.}
+whose name is the same as that of an alternative token.
+\end{footnote}
 The replacement list is then rescanned for more macro names as
 specified below.
 
@@ -1097,7 +1114,10 @@ are separated by comma preprocessing tokens,
 but comma preprocessing tokens between matching
 inner parentheses do not separate arguments.
 If there are sequences of preprocessing tokens within the list of
-arguments that would otherwise act as preprocessing directives,\footnote{A \grammarterm{conditionally-supported-directive} is a preprocessing directive regardless of whether the implementation supports it.}
+arguments that would otherwise act as preprocessing directives,
+\begin{footnote}
+A \grammarterm{conditionally-supported-directive} is a preprocessing directive regardless of whether the implementation supports it.
+\end{footnote}
 the behavior is undefined.
 
 \pnum
@@ -1329,8 +1349,11 @@ immediately preceded or followed by a
 \tcode{\#\#}
 preprocessing token, the parameter is replaced by the
 corresponding argument's preprocessing token sequence; however, if an argument consists of no preprocessing tokens, the parameter is
-replaced by a placemarker preprocessing token instead.\footnote{Placemarker preprocessing tokens do not appear in the syntax
-because they are temporary entities that exist only within translation phase 4.}
+replaced by a placemarker preprocessing token instead.
+\begin{footnote}
+Placemarker preprocessing tokens do not appear in the syntax
+because they are temporary entities that exist only within translation phase 4.
+\end{footnote}
 
 \pnum
 For both object-like and function-like macro invocations, before the
@@ -1667,15 +1690,19 @@ shall be supplied.
 \indextext{__file__@\mname{FILE}}%
 \mname{FILE}\\
 The presumed name of the current source file (a character string
-literal).%
-\footnote{The presumed source file name can be changed by the \tcode{\#line} directive.}
+literal).
+\begin{footnote}
+The presumed source file name can be changed by the \tcode{\#line} directive.
+\end{footnote}
 
 \item
 \indextext{__line__@\mname{LINE}}%
 \mname{LINE}\\
 The presumed line number (within the current source file) of the current source line
-(an integer literal).%
-\footnote{The presumed line number can be changed by the \tcode{\#line} directive.}
+(an integer literal).
+\begin{footnote}
+The presumed line number can be changed by the \tcode{\#line} directive.
+\end{footnote}
 
 \item
 \indextext{__stdc_hosted__@\mname{STDC_HOSTED}}%

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -1017,8 +1017,11 @@ designated by the iterator range \range{first}{last}.
 If the parameter \tcode{icase} is \tcode{true} then the returned mask identifies the
 character classification without regard to the case of the characters being
 matched, otherwise it does honor the case of the characters being
-matched.\footnote{For example, if the parameter \tcode{icase} is \tcode{true} then
-\tcode{[[:lower:]]} is the same as \tcode{[[:alpha:]]}.}
+matched.
+\begin{footnote}
+For example, if the parameter \tcode{icase} is \tcode{true} then
+\tcode{[[:lower:]]} is the same as \tcode{[[:alpha:]]}.
+\end{footnote}
 The value
 returned shall be independent of the case of the characters in
 the character sequence. If the name

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -276,8 +276,11 @@ label, the condition is not evaluated and the second substatement is
 not executed. In the second form of \tcode{if} statement
 (the one including \tcode{else}), if the first substatement is also an
 \tcode{if} statement then that inner \tcode{if} statement shall contain
-an \tcode{else} part.\footnote{In other words, the \tcode{else} is associated with the nearest un-elsed
-\tcode{if}.}
+an \tcode{else} part.
+\begin{footnote}
+In other words, the \tcode{else} is associated with the nearest un-elsed
+\tcode{if}.
+\end{footnote}
 
 \pnum
 If the \tcode{if} statement is of the form \tcode{if constexpr}, the value
@@ -967,8 +970,11 @@ destroyed on exit from the block\iref{stmt.jump}.
 It is possible to transfer into a block, but not in a way that bypasses
 declarations with initialization (including ones in \grammarterm{condition}s
 and \grammarterm{init-statement}s).
-A program that jumps\footnote{The transfer from the condition of a \tcode{switch} statement to a
-\tcode{case} label is considered a jump in this respect.}
+A program that jumps
+\begin{footnote}
+The transfer from the condition of a \tcode{switch} statement to a
+\tcode{case} label is considered a jump in this respect.
+\end{footnote}
 from a point where a variable with automatic storage duration is
 not in scope to a point where it is in scope is ill-formed unless
 the variable has vacuous initialization\iref{basic.life}.

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -218,12 +218,14 @@ shall be able to represent all of the
 valid characters converted from the corresponding
 \tcode{char_type}
 values, as well as an end-of-file value,
-\tcode{eof()}.%
-\footnote{If
+\tcode{eof()}.
+\begin{footnote}
+If
 \tcode{eof()}
 can be held in
 \tcode{char_type}
-then some iostreams operations can give surprising results.}
+then some iostreams operations can give surprising results.
+\end{footnote}
 \end{itemdescr}
 
 \indexlibrarymember{state_type}{char_traits}%
@@ -1109,10 +1111,13 @@ invalidated by the following uses of that \tcode{basic_string} object:
 
 \begin{itemize}
 \item Passing as an argument to any standard library function taking a reference to non-const
-\tcode{basic_string} as an argument.\footnote{For example, as an argument to non-member
+\tcode{basic_string} as an argument.
+\begin{footnote}
+For example, as an argument to non-member
 functions \tcode{swap()}\iref{string.special},
 \tcode{operator>{}>()}\iref{string.io}, and \tcode{getline()}\iref{string.io}, or as
-an argument to \tcode{basic_string::swap()}.}
+an argument to \tcode{basic_string::swap()}.
+\end{footnote}
 
 \item Calling non-const member functions, except
 \tcode{operator[]},
@@ -4044,7 +4049,11 @@ namespace std {
     using reference              = value_type&;
     using const_reference        = const value_type&;
     using const_iterator         = @\impdefx{type of \tcode{basic_string_view::const_iterator}}@; // see \ref{string.view.iterators}
-    using iterator               = const_iterator;@\footnote{Because \tcode{basic_string_view} refers to a constant sequence, \tcode{iterator} and \tcode{const_iterator} are the same type.}@
+    using iterator               = const_iterator;@
+\begin{footnote}
+Because \tcode{basic_string_view} refers to a constant sequence, \tcode{iterator} and \tcode{const_iterator} are the same type.
+\end{footnote}%
+@
     using const_reverse_iterator = reverse_iterator<const_iterator>;
     using reverse_iterator       = const_reverse_iterator;
     using size_type              = size_t;

--- a/source/support.tex
+++ b/source/support.tex
@@ -274,13 +274,15 @@ Although \tcode{nullptr}'s address cannot be taken, the address of another
 The macro
 \indexlibraryglobal{NULL}%
 \tcode{NULL}
-is an \impldef{definition of \tcode{NULL}} null pointer constant.%
-\footnote{Possible definitions include
+is an \impldef{definition of \tcode{NULL}} null pointer constant.
+\begin{footnote}
+Possible definitions include
 \tcode{0}
 and
 \tcode{0L},
 but not
-\tcode{(void*)0}.}
+\tcode{(void*)0}.
+\end{footnote}
 
 \xrefc{7.19}
 
@@ -296,10 +298,13 @@ accepts a restricted set of \tcode{\placeholder{type}}
 arguments in this document.
 Use of the \tcode{offsetof} macro with a \tcode{\placeholder{type}}
 other than a standard-layout class\iref{class.prop}
-is conditionally-supported.\footnote{Note that \tcode{offsetof}
+is conditionally-supported.
+\begin{footnote}
+Note that \tcode{offsetof}
 is required to work as specified even if unary
 \tcode{operator\&}
-is overloaded for any of the types involved.}
+is overloaded for any of the types involved.
+\end{footnote}\space
 The expression \tcode{offsetof(\placeholder{type}, \placeholder{member-designator})}
 is never type-dependent\iref{temp.dep.expr} and it is
 value-dependent\iref{temp.dep.constexpr} if and only if \tcode{\placeholder{type}} is
@@ -921,8 +926,11 @@ static constexpr T min() noexcept;
 
 \begin{itemdescr}
 \pnum
-Minimum finite value.\footnote{Equivalent to \tcode{CHAR_MIN}, \tcode{SHRT_MIN},
-\tcode{FLT_MIN}, \tcode{DBL_MIN}, etc.}
+Minimum finite value.
+\begin{footnote}
+Equivalent to \tcode{CHAR_MIN}, \tcode{SHRT_MIN},
+\tcode{FLT_MIN}, \tcode{DBL_MIN}, etc.
+\end{footnote}
 
 \indextext{number!subnormal}%
 \pnum
@@ -943,8 +951,11 @@ static constexpr T max() noexcept;
 
 \begin{itemdescr}
 \pnum
-Maximum finite value.\footnote{Equivalent to \tcode{CHAR_MAX}, \tcode{SHRT_MAX},
-\tcode{FLT_MAX}, \tcode{DBL_MAX}, etc.}
+Maximum finite value.
+\begin{footnote}
+Equivalent to \tcode{CHAR_MAX}, \tcode{SHRT_MAX},
+\tcode{FLT_MAX}, \tcode{DBL_MAX}, etc.
+\end{footnote}
 
 \pnum
 Meaningful for all specializations in which
@@ -959,9 +970,12 @@ static constexpr T lowest() noexcept;
 \begin{itemdescr}
 \pnum
 A finite value \tcode{x} such that there is no other finite
-value \tcode{y} where \tcode{y < x}.\footnote{\tcode{lowest()} is necessary because not all
+value \tcode{y} where \tcode{y < x}.
+\begin{footnote}
+\tcode{lowest()} is necessary because not all
 floating-point representations have a smallest (most negative) value that is
-the negative of the largest (most positive) finite value.}
+the negative of the largest (most positive) finite value.
+\end{footnote}
 
 \pnum
 Meaningful for all specializations in which \tcode{is_bounded != false}.
@@ -983,8 +997,12 @@ For integer types, the number of non-sign bits in the representation.
 
 \pnum
 For floating-point types, the number of \tcode{radix} digits in the
-mantissa.\footnote{Equivalent to \tcode{FLT_MANT_DIG}, \tcode{DBL_MANT_DIG},
-\tcode{LDBL_MANT_DIG}.} \end{itemdescr}
+mantissa.
+\begin{footnote}
+Equivalent to \tcode{FLT_MANT_DIG}, \tcode{DBL_MANT_DIG},
+\tcode{LDBL_MANT_DIG}.
+\end{footnote}
+\end{itemdescr}
 
 \indexlibrarymember{digits10}{numeric_limits}%
 \begin{itemdecl}
@@ -994,8 +1012,11 @@ static constexpr int digits10;
 \begin{itemdescr}
 \pnum
 Number of base 10 digits that can be represented without
-change.\footnote{Equivalent to \tcode{FLT_DIG}, \tcode{DBL_DIG},
-\tcode{LDBL_DIG}.}
+change.
+\begin{footnote}
+Equivalent to \tcode{FLT_DIG}, \tcode{DBL_DIG},
+\tcode{LDBL_DIG}.
+\end{footnote}
 
 \pnum
 Meaningful for all specializations in which
@@ -1065,12 +1086,18 @@ static constexpr int radix;
 \begin{itemdescr}
 \pnum
 For floating-point types, specifies the base or radix of the exponent representation
-(often 2).\footnote{Equivalent to \tcode{FLT_RADIX}.}
+(often 2).
+\begin{footnote}
+Equivalent to \tcode{FLT_RADIX}.
+\end{footnote}
 
 \pnum
 For integer types, specifies the base of the
-representation.\footnote{Distinguishes types with bases other than 2 (e.g.
-BCD).}
+representation.
+\begin{footnote}
+Distinguishes types with bases other than 2 (e.g.
+BCD).
+\end{footnote}
 
 \pnum
 Meaningful for all specializations.
@@ -1084,7 +1111,10 @@ static constexpr T epsilon() noexcept;
 \begin{itemdescr}
 \pnum
 Machine epsilon:  the difference between 1 and the least value greater than 1
-that is representable.\footnote{Equivalent to \tcode{FLT_EPSILON}, \tcode{DBL_EPSILON}, \tcode{LDBL_EPSILON}.}
+that is representable.
+\begin{footnote}
+Equivalent to \tcode{FLT_EPSILON}, \tcode{DBL_EPSILON}, \tcode{LDBL_EPSILON}.
+\end{footnote}
 
 \pnum
 Meaningful for all floating-point types.
@@ -1097,10 +1127,13 @@ static constexpr T round_error() noexcept;
 
 \begin{itemdescr}
 \pnum
-Measure of the maximum rounding error.\footnote{Rounding error is described in
+Measure of the maximum rounding error.
+\begin{footnote}
+Rounding error is described in
 LIA-1
 Section 5.2.4 and
-Annex C Rationale Section C.5.2.4 --- Rounding and rounding constants.}
+Annex C Rationale Section C.5.2.4 --- Rounding and rounding constants.
+\end{footnote}
 \end{itemdescr}
 
 \indexlibrarymember{min_exponent}{numeric_limits}%
@@ -1113,8 +1146,11 @@ static constexpr int  min_exponent;
 Minimum negative integer such that
 \tcode{radix}
 raised to the power of one less than that integer is a normalized floating-point
-number.\footnote{Equivalent to \tcode{FLT_MIN_EXP}, \tcode{DBL_MIN_EXP},
-\tcode{LDBL_MIN_EXP}.}
+number.
+\begin{footnote}
+Equivalent to \tcode{FLT_MIN_EXP}, \tcode{DBL_MIN_EXP},
+\tcode{LDBL_MIN_EXP}.
+\end{footnote}
 
 \pnum
 Meaningful for all floating-point types.
@@ -1128,8 +1164,11 @@ static constexpr int  min_exponent10;
 \begin{itemdescr}
 \pnum
 Minimum negative integer such that 10 raised to that power is in the range
-of normalized floating-point numbers.\footnote{Equivalent to
-\tcode{FLT_MIN_10_EXP}, \tcode{DBL_MIN_10_EXP}, \tcode{LDBL_MIN_10_EXP}.}
+of normalized floating-point numbers.
+\begin{footnote}
+Equivalent to
+\tcode{FLT_MIN_10_EXP}, \tcode{DBL_MIN_10_EXP}, \tcode{LDBL_MIN_10_EXP}.
+\end{footnote}
 
 \pnum
 Meaningful for all floating-point types.
@@ -1145,8 +1184,11 @@ static constexpr int  max_exponent;
 Maximum positive integer such that
 \tcode{radix}
 raised to the power one less than that integer is a representable finite
-floating-point number.\footnote{Equivalent to \tcode{FLT_MAX_EXP},
-\tcode{DBL_MAX_EXP}, \tcode{LDBL_MAX_EXP}.}
+floating-point number.
+\begin{footnote}
+Equivalent to \tcode{FLT_MAX_EXP},
+\tcode{DBL_MAX_EXP}, \tcode{LDBL_MAX_EXP}.
+\end{footnote}
 
 \pnum
 Meaningful for all floating-point types.
@@ -1160,8 +1202,11 @@ static constexpr int  max_exponent10;
 \begin{itemdescr}
 \pnum
 Maximum positive integer such that 10 raised to that power is in the
-range of representable finite floating-point numbers.\footnote{Equivalent to
-\tcode{FLT_MAX_10_EXP}, \tcode{DBL_MAX_10_EXP}, \tcode{LDBL_MAX_10_EXP}.}
+range of representable finite floating-point numbers.
+\begin{footnote}
+Equivalent to
+\tcode{FLT_MAX_10_EXP}, \tcode{DBL_MAX_10_EXP}, \tcode{LDBL_MAX_10_EXP}.
+\end{footnote}
 
 \pnum
 Meaningful for all floating-point types.
@@ -1194,7 +1239,10 @@ static constexpr bool has_quiet_NaN;
 \begin{itemdescr}
 \pnum
 \tcode{true} if the type has a representation for a quiet (non-signaling) ``Not a
-Number''.\footnote{Required by LIA-1.}
+Number''.
+\begin{footnote}
+Required by LIA-1.
+\end{footnote}
 
 \pnum
 Meaningful for all floating-point types.
@@ -1213,7 +1261,10 @@ static constexpr bool has_signaling_NaN;
 
 \begin{itemdescr}
 \pnum
-\tcode{true} if the type has a representation for a signaling ``Not a Number''.\footnote{Required by LIA-1.}
+\tcode{true} if the type has a representation for a signaling ``Not a Number''.
+\begin{footnote}
+Required by LIA-1.
+\end{footnote}
 
 \pnum
 Meaningful for all floating-point types.
@@ -1235,7 +1286,10 @@ static constexpr float_denorm_style has_denorm;
 \pnum
 \tcode{denorm_present}
 if the type allows subnormal values
-(variable number of exponent bits)\footnote{Required by LIA-1.},
+(variable number of exponent bits)
+\begin{footnote}
+Required by LIA-1.
+\end{footnote},
 \tcode{denorm_absent}
 if the type does not allow subnormal values,
 and
@@ -1255,8 +1309,11 @@ static constexpr bool has_denorm_loss;
 \begin{itemdescr}
 \pnum
 \tcode{true} if loss of accuracy is detected as a
-denormalization loss, rather than as an inexact result.\footnote{See
-ISO/IEC/IEEE 60559.}
+denormalization loss, rather than as an inexact result.
+\begin{footnote}
+See
+ISO/IEC/IEEE 60559.
+\end{footnote}
 \end{itemdescr}
 
 \indexlibrarymember{infinity}{numeric_limits}%
@@ -1266,7 +1323,10 @@ static constexpr T infinity() noexcept;
 
 \begin{itemdescr}
 \pnum
-Representation of positive infinity, if available.\footnote{Required by LIA-1.}
+Representation of positive infinity, if available.
+\begin{footnote}
+Required by LIA-1.
+\end{footnote}
 
 \pnum
 Meaningful for all specializations for which
@@ -1282,7 +1342,10 @@ static constexpr T quiet_NaN() noexcept;
 
 \begin{itemdescr}
 \pnum
-Representation of a quiet ``Not a Number'', if available.\footnote{Required by LIA-1.}
+Representation of a quiet ``Not a Number'', if available.
+\begin{footnote}
+Required by LIA-1.
+\end{footnote}
 
 \pnum
 Meaningful for all specializations for which
@@ -1298,7 +1361,10 @@ static constexpr T signaling_NaN() noexcept;
 
 \begin{itemdescr}
 \pnum
-Representation of a signaling ``Not a Number'', if available.\footnote{Required by LIA-1.}
+Representation of a signaling ``Not a Number'', if available.
+\begin{footnote}
+Required by LIA-1.
+\end{footnote}
 
 \pnum
 Meaningful for all specializations for which
@@ -1315,7 +1381,10 @@ static constexpr T denorm_min() noexcept;
 \begin{itemdescr}
 \indextext{number!subnormal}%
 \pnum
-Minimum positive subnormal value.\footnote{Required by LIA-1.}
+Minimum positive subnormal value.
+\begin{footnote}
+Required by LIA-1.
+\end{footnote}
 
 \pnum
 Meaningful for all floating-point types.
@@ -1334,7 +1403,10 @@ static constexpr bool is_iec559;
 \begin{itemdescr}
 \pnum
 \tcode{true} if and only if the type adheres to ISO/IEC/IEEE
-60559.\footnote{ISO/IEC/IEEE 60559:2011 is the same as IEEE 754-2008.}
+60559.
+\begin{footnote}
+ISO/IEC/IEEE 60559:2011 is the same as IEEE 754-2008.
+\end{footnote}
 
 \pnum
 Meaningful for all floating-point types.
@@ -1347,7 +1419,10 @@ static constexpr bool is_bounded;
 
 \begin{itemdescr}
 \pnum
-\tcode{true} if the set of values representable by the type is finite.\footnote{Required by LIA-1.}
+\tcode{true} if the set of values representable by the type is finite.
+\begin{footnote}
+Required by LIA-1.
+\end{footnote}
 \begin{note}
 All fundamental types\iref{basic.fundamental} are bounded. This member would be \tcode{false} for arbitrary
 precision types.
@@ -1364,7 +1439,10 @@ static constexpr bool is_modulo;
 
 \begin{itemdescr}
 \pnum
-\tcode{true} if the type is modulo.\footnote{Required by LIA-1.}
+\tcode{true} if the type is modulo.
+\begin{footnote}
+Required by LIA-1.
+\end{footnote}
 A type is modulo if, for any operation involving \tcode{+}, \tcode{-}, or
 \tcode{*} on values of that type whose result would fall outside the range
 \crange{min()}{max()}, the value returned differs from the true value by an
@@ -1390,7 +1468,10 @@ static constexpr bool traps;
 \pnum
 \tcode{true}
 if, at the start of the program, there exists a value of the type that would cause
-an arithmetic operation using that value to trap.\footnote{Required by LIA-1.}
+an arithmetic operation using that value to trap.
+\begin{footnote}
+Required by LIA-1.
+\end{footnote}
 
 \pnum
 Meaningful for all specializations.
@@ -1404,9 +1485,12 @@ static constexpr bool tinyness_before;
 \begin{itemdescr}
 \pnum
 \tcode{true}
-if tinyness is detected before rounding.\footnote{Refer to
+if tinyness is detected before rounding.
+\begin{footnote}
+Refer to
 ISO/IEC/IEEE 60559.
-Required by LIA-1.}
+Required by LIA-1.
+\end{footnote}
 
 \pnum
 Meaningful for all floating-point types.
@@ -1419,8 +1503,11 @@ static constexpr float_round_style round_style;
 
 \begin{itemdescr}
 \pnum
-The rounding style for the type.\footnote{Equivalent to \tcode{FLT_ROUNDS}.
-Required by LIA-1.}
+The rounding style for the type.
+\begin{footnote}
+Equivalent to \tcode{FLT_ROUNDS}.
+Required by LIA-1.
+\end{footnote}
 
 \pnum
 Meaningful for all floating-point types.
@@ -1887,17 +1974,23 @@ First, objects with thread storage duration and associated with the current thre
 are destroyed. Next, objects with static storage duration are destroyed
 and functions registered by calling
 \tcode{atexit}
-are called.\footnote{A function is called for every time it is registered.}
+are called.
+\begin{footnote}
+A function is called for every time it is registered.
+\end{footnote}
 See~\ref{basic.start.term} for the order of destructions and calls.
 (Objects with automatic storage duration are not destroyed as a result of calling
-\tcode{exit()}.)\footnote{Objects with automatic storage duration are all destroyed in a program whose
+\tcode{exit()}.)
+\begin{footnote}
+Objects with automatic storage duration are all destroyed in a program whose
 \tcode{main} function\iref{basic.start.main}
 contains no objects with automatic storage duration and executes the call to
 \tcode{exit()}.
 Control can be transferred directly to such a
 \tcode{main} function
 by throwing an exception that is caught in
-\tcode{main}.}
+\tcode{main}.
+\end{footnote}
 
 If control leaves a registered function called by \tcode{exit} because the function does
 not provide a handler for a thrown exception, the function \tcode{std::terminate} shall be called\iref{except.terminate}.%
@@ -1923,9 +2016,11 @@ If \tcode{status} is
 an \impldef{exit status} form of the status
 \term{unsuccessful termination}
 is returned.
-Otherwise the status returned is \impldef{exit status}.%
-\footnote{The macros \tcode{EXIT_FAILURE} and \tcode{EXIT_SUCCESS}
-are defined in \libheaderref{cstdlib}.}
+Otherwise the status returned is \impldef{exit status}.
+\begin{footnote}
+The macros \tcode{EXIT_FAILURE} and \tcode{EXIT_SUCCESS}
+are defined in \libheaderref{cstdlib}.
+\end{footnote}
 \end{itemize}
 \end{itemdescr}
 
@@ -2378,8 +2473,9 @@ called by the array form of a
 to allocate
 \tcode{size} bytes of storage.
 The second form is called for a type with new-extended alignment, and
-the first form is called otherwise.%
-\footnote{It is not the direct responsibility of
+the first form is called otherwise.
+\begin{footnote}
+It is not the direct responsibility of
 \tcode{operator new[]}
 or
 \tcode{operator delete[]}
@@ -2393,7 +2489,8 @@ The array
 \tcode{new}
 expression, can, however, increase the \tcode{size} argument to
 \tcode{operator new[]}
-to obtain space to store supplemental information.}
+to obtain space to store supplemental information.
+\end{footnote}
 
 \pnum
 \replaceable
@@ -4113,8 +4210,10 @@ The \tcode{partial_ordering} type is typically used
 as the result type of a three-way comparison operator\iref{expr.spaceship}
 that (a) admits all of the six two-way comparison operators (\ref{expr.rel}, \ref{expr.eq}),
 (b) does not imply substitutability,
-and (c) permits two values to be incomparable.%
-\footnote{That is, \tcode{a < b}, \tcode{a == b}, and \tcode{a > b} might all be \tcode{false}.}
+and (c) permits two values to be incomparable.
+\begin{footnote}
+That is, \tcode{a < b}, \tcode{a == b}, and \tcode{a > b} might all be \tcode{false}.
+\end{footnote}
 
 \indexlibraryglobal{partial_ordering}%
 \indexlibrarymember{less}{partial_ordering}%
@@ -5467,12 +5566,15 @@ The parameter
 \tcode{parmN}
 is the rightmost parameter in the variable parameter list
 of the function definition (the one just before the
-\tcode{...}).\footnote{Note that
+\tcode{...}).
+\begin{footnote}
+Note that
 \tcode{va_start}
 is required to work as specified even if unary
 \tcode{operator\&}
 is overloaded for the type of
-\tcode{parmN}.}
+\tcode{parmN}.
+\end{footnote}
 If the parameter \tcode{parmN} is a pack expansion\iref{temp.variadic} or
 an entity resulting from a lambda capture\iref{expr.prim.lambda},
 the program is ill-formed, no diagnostic required.
@@ -5610,8 +5712,11 @@ control entering a \grammarterm{try-block} or \grammarterm{function-try-block};
 
 \item
 initialization of a variable with static storage duration
-requiring dynamic initialization~(\ref{basic.start.dynamic}, \ref{stmt.dcl})%
-\footnote{Such initialization might occur because it is the first odr-use\iref{basic.def.odr} of that variable.}; or
+requiring dynamic initialization~(\ref{basic.start.dynamic}, \ref{stmt.dcl})
+\begin{footnote}
+Such initialization might occur because it is the first odr-use\iref{basic.def.odr} of that variable.
+\end{footnote}%
+; or
 
 \item
 waiting for the completion of the initialization of a variable with static storage duration\iref{stmt.dcl}.

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -277,8 +277,9 @@ names a template type parameter.
 \tcode{typename}
 followed by a
 \grammarterm{qualified-id}
-denotes the type in a non-type%
-\footnote{Since template
+denotes the type in a non-type
+\begin{footnote}
+Since template
 \grammarterm{template-parameter}{s}
 and template
 \grammarterm{template-argument}{s}
@@ -286,7 +287,8 @@ are treated as types for descriptive purposes, the terms
 \term{non-type parameter}
 and
 \term{non-type argument}
-are used to refer to non-type, non-template parameters and arguments.}
+are used to refer to non-type, non-template parameters and arguments.
+\end{footnote}
 \grammarterm{parameter-declaration}.
 A \grammarterm{template-parameter} of the form
 \tcode{class} \grammarterm{identifier} is a \grammarterm{type-parameter}.
@@ -718,12 +720,14 @@ is always taken as the delimiter of a
 and never as the less-than operator.
 When parsing a \grammarterm{template-argument-list},
 the first non-nested
-\tcode{>}\footnote{A \tcode{>} that encloses the \grammarterm{type-id}
+\tcode{>}
+\begin{footnote}
+A \tcode{>} that encloses the \grammarterm{type-id}
 of a \tcode{dynamic_cast}, \tcode{static_cast}, \tcode{reinterpret_cast}
 or \tcode{const_cast}, or which encloses the \grammarterm{template-argument}{s}
 of a subsequent \grammarterm{template-id}, is considered nested for the purpose
 of this description.
-}
+\end{footnote}
 is taken as the ending delimiter
 rather than a greater-than operator.
 Similarly, the first non-nested \tcode{>{>}} is treated as two
@@ -996,12 +1000,15 @@ an ambiguity between a
 and an expression is resolved to a
 \grammarterm{type-id},
 regardless of the form of the corresponding
-\grammarterm{template-parameter}.\footnote{There is no such ambiguity in a default
+\grammarterm{template-parameter}.
+\begin{footnote}
+There is no such ambiguity in a default
 \grammarterm{template-argument}
 because the form of the
 \grammarterm{template-parameter}
 determines the allowable forms of the
-\grammarterm{template-argument}.}
+\grammarterm{template-argument}.
+\end{footnote}
 \begin{example}
 \begin{codeblock}
 template<class T> void f();
@@ -1933,7 +1940,8 @@ The associated constraints of \#3 are
 A constraint $P$ \defnx{subsumes}{constraint!subsumption} a constraint $Q$
 if and only if,
 for every disjunctive clause $P_i$
-in the disjunctive normal form\footnote{
+in the disjunctive normal form
+\begin{footnote}
 A constraint is in disjunctive normal form when it is a disjunction of
 clauses where each clause is a conjunction of atomic constraints.
 For atomic constraints $A$, $B$, and $C$, the disjunctive normal form
@@ -1943,16 +1951,17 @@ is
 $(A \land B) \lor (A \land C)$.
 %
 Its disjunctive clauses are $(A \land B)$ and $(A \land C)$.
-}
+\end{footnote}
 of $P$, $P_i$ subsumes every conjunctive clause $Q_j$
-in the conjunctive normal form\footnote{
+in the conjunctive normal form
+\begin{footnote}
 A constraint is in conjunctive normal form when it is a conjunction
 of clauses where each clause is a disjunction of atomic constraints.
 For atomic constraints $A$, $B$, and $C$, the constraint
 $A \land (B \lor C)$ is in conjunctive normal form.
 %
 Its conjunctive clauses are $A$ and $(B \lor C)$.
-}
+\end{footnote}
 of $Q$, where
 \begin{itemize}
 \item
@@ -2066,8 +2075,11 @@ they are of floating-point type and their values are identical, or
 they are of type \tcode{std::nullptr_t}, or
 
 \item
-they are of enumeration type and their values are the same,%
-\footnote{The identity of enumerators is not preserved.} or
+they are of enumeration type and their values are the same,
+\begin{footnote}
+The identity of enumerators is not preserved.
+\end{footnote}
+or
 
 \item
 they are of pointer type and they have the same pointer value, or
@@ -2080,8 +2092,11 @@ or are both the null member pointer value, or
 they are of reference type and they refer to the same object or function, or
 
 \item
-they are of array type and their corresponding elements are template-argument-equivalent,%
-\footnote{An array as a \grammarterm{template-parameter} decays to a pointer.} or
+they are of array type and their corresponding elements are template-argument-equivalent,
+\begin{footnote}
+An array as a \grammarterm{template-parameter} decays to a pointer.
+\end{footnote}
+or
 
 \item
 they are of union type and either
@@ -3341,7 +3356,10 @@ template\iref{temp.class.order}.
 
 \item
 The template parameter list of a specialization shall not contain default
-template argument values.\footnote{There is no way in which they could be used.}
+template argument values.
+\begin{footnote}
+There is no way in which they could be used.
+\end{footnote}
 \item
 An argument shall not contain an unexpanded pack. If
 an argument is a pack expansion\iref{temp.variadic}, it shall be
@@ -3629,13 +3647,16 @@ A non-template function is not
 related to a function template
 (i.e., it is never considered to be a specialization),
 even if it has the same name and type
-as a potentially generated function template specialization.\footnote{That is,
+as a potentially generated function template specialization.
+\begin{footnote}
+That is,
 declarations of non-template functions do not merely guide
 overload resolution of
 function template specializations
 with the same name.
 If such a non-template function is odr-used\iref{basic.def.odr} in a program, it must be defined;
-it will not be implicitly instantiated using the function template definition.}
+it will not be implicitly instantiated using the function template definition.
+\end{footnote}
 
 \rSec3[temp.over.link]{Function template overloading}
 
@@ -4400,8 +4421,11 @@ is assumed to name a type if
 \begin{itemize}
 \item \grammarterm{simple-declaration} or a \grammarterm{function-definition} in namespace scope,
 \item \grammarterm{member-declaration},
-\item \grammarterm{parameter-declaration} in a \grammarterm{member-declaration}%
-\footnote{This includes friend function declarations.},
+\item \grammarterm{parameter-declaration} in a \grammarterm{member-declaration}
+\begin{footnote}
+This includes friend function declarations.
+\end{footnote}%
+,
 unless that \grammarterm{parameter-declaration} appears in a default argument,
 \item \grammarterm{parameter-declaration} in a \grammarterm{declarator}
 of a function or function template declaration
@@ -5331,9 +5355,11 @@ a function type whose exception specification is value-dependent,
 denoted by a \grammarterm{simple-template-id}
 in which either the template name is a template parameter or any of the
 template arguments is a dependent type or an expression that is type-dependent
-or value-dependent or is a pack expansion,%
-\footnote{This includes an injected-class-name\iref{class.pre} of a class template
-used without a \grammarterm{template-argument-list}.}
+or value-dependent or is a pack expansion,
+\begin{footnote}
+This includes an injected-class-name\iref{class.pre} of a class template
+used without a \grammarterm{template-argument-list}.
+\end{footnote}
 or
 \item denoted by \tcode{decltype(}\grammarterm{expression}{}\tcode{)},
 where \grammarterm{expression} is type-dependent\iref{temp.dep.expr}.
@@ -5920,9 +5946,12 @@ As with non-template classes, the names of namespace-scope friend
 functions of a class template specialization are not visible during
 an ordinary lookup unless explicitly declared at namespace scope\iref{class.friend}.
 Such names may be found under the rules for associated
-classes\iref{basic.lookup.argdep}.\footnote{Friend declarations do not
+classes\iref{basic.lookup.argdep}.
+\begin{footnote}
+Friend declarations do not
 introduce new names into any scope, either
-when the template is declared or when it is instantiated.}
+when the template is declared or when it is instantiated.
+\end{footnote}
 \begin{example}
 \begin{codeblock}
 template<typename T> struct number {
@@ -8304,9 +8333,12 @@ the partial ordering is done:
 \begin{itemize}
 \item
 In the context of a function call, the types used are those function parameter types
-for which the function call has arguments.\footnote{Default arguments
+for which the function call has arguments.
+\begin{footnote}
+Default arguments
 are not considered to be arguments in this context; they only become arguments
-after a function has been selected.}
+after a function has been selected.
+\end{footnote}
 \item
 In the context of a call to a conversion function, the return types of
 the conversion function templates are used.
@@ -9018,7 +9050,9 @@ of the corresponding template parameter
 of the template named by the enclosing \grammarterm{simple-template-id},
 deduction fails.
 If \tcode{P} has a form that contains \tcode{[i]}, and if the type of
-\tcode{i} is not an integral type, deduction fails.\footnote{Although the
+\tcode{i} is not an integral type, deduction fails.
+\begin{footnote}
+Although the
 \grammarterm{template-argument}
 corresponding to a
 \grammarterm{template-parameter}
@@ -9026,7 +9060,8 @@ of type
 \tcode{bool}
 can be deduced from an array bound, the resulting value will always be
 \tcode{true}
-because the array bound will be nonzero.}
+because the array bound will be nonzero.
+\end{footnote}
 \begin{example}
 \begin{codeblock}
 template<int i> class A { @\commentellip@ };
@@ -9178,7 +9213,9 @@ the same name.
 The synthesized declarations are
 treated like any other functions in
 the remainder of overload resolution, except as explicitly noted
-in~\ref{over.match.best}.\footnote{The parameters of function template
+in~\ref{over.match.best}.
+\begin{footnote}
+The parameters of function template
 specializations contain no
 template parameter types.
 The set of conversions allowed on deduced arguments is limited, because the
@@ -9188,7 +9225,8 @@ bridged by the allowed limited conversions.
 Non-deduced arguments allow the full range of conversions.
 Note also that~\ref{over.match.best} specifies that a non-template function will
 be given preference over a template specialization if the two functions
-are otherwise equally good candidates for an overload match.}
+are otherwise equally good candidates for an overload match.
+\end{footnote}
 
 \pnum
 \begin{example}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -93,9 +93,12 @@ $D_m$. The delay durations may vary from timeout to timeout, but in all cases sh
 \pnum
 The functions whose names end in \tcode{_for} take an argument that
 specifies a duration. These functions produce relative timeouts. Implementations
-should use a steady clock to measure time for these functions.%
-\footnote{Implementations for which standard time units are meaningful will typically
-have a steady clock within their hardware implementation.} Given a duration
+should use a steady clock to measure time for these functions.
+\begin{footnote}
+Implementations for which standard time units are meaningful will typically
+have a steady clock within their hardware implementation.
+\end{footnote}
+Given a duration
 argument $D_t$, the real-time duration of the timeout is $D_t + D_i + D_m$.
 
 \pnum

--- a/source/time.tex
+++ b/source/time.tex
@@ -11437,11 +11437,13 @@ namespace std {
 \end{codeblock}
 
 \pnum
-The contents of the header \libheader{ctime} are the same as the C standard library header \libheader{time.h}.%
-\footnote{\tcode{strftime} supports the C conversion specifiers
+The contents of the header \libheader{ctime} are the same as the C standard library header \libheader{time.h}.
+\begin{footnote}
+\tcode{strftime} supports the C conversion specifiers
 \tcode{C}, \tcode{D}, \tcode{e}, \tcode{F}, \tcode{g}, \tcode{G}, \tcode{h},
 \tcode{r}, \tcode{R}, \tcode{t}, \tcode{T}, \tcode{u}, \tcode{V}, and
-\tcode{z}, and the modifiers \tcode{E} and \tcode{O}.}
+\tcode{z}, and the modifiers \tcode{E} and \tcode{O}.
+\end{footnote}
 
 \pnum
 The functions \tcode{asctime}, \tcode{ctime}, \tcode{gmtime}, and

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7531,9 +7531,12 @@ safety\iref{basic.stc.dynamic.safety}. It is
 whether
 \tcode{get_pointer_safety} returns \tcode{pointer_safety::relaxed} or
 \tcode{point\-er_safety::preferred} if the implementation has relaxed pointer
-safety.\footnote{\tcode{pointer_safety::preferred} might be returned to indicate
+safety.
+\begin{footnote}
+\tcode{pointer_safety::preferred} might be returned to indicate
 that a leak detector is running so that the program can avoid spurious leak
-reports.}
+reports.
+\end{footnote}
 \end{itemdescr}
 
 
@@ -13046,9 +13049,13 @@ a.outer_allocator() == b.outer_allocator() && a.inner_allocator() == b.inner_all
 A \defnx{function object type}{function object!type} is an object
 type\iref{basic.types} that can be the type of the
 \grammarterm{postfix-expression} in a function call
-(\ref{expr.call}, \ref{over.match.call}).\footnote{Such a type is a function
+(\ref{expr.call}, \ref{over.match.call}).
+\begin{footnote}
+Such a type is a function
 pointer or a class type which has a member \tcode{operator()} or a class type
-which has a conversion to a pointer to function.} A \defn{function object} is an
+which has a conversion to a pointer to function.
+\end{footnote}
+A \defn{function object} is an
 object of a function object type. In the places where one would expect to pass a
 pointer to a function to an algorithmic template\iref{algorithms}, the
 interface is specified to accept a function object. This not only makes
@@ -19585,11 +19592,13 @@ a locale-independent, implementation-defined encoding.
 Implementations should use a Unicode encoding
 on platforms capable of displaying Unicode text in a terminal.
 \begin{note}
-This is the case for Windows%
-\footnote{
+This is the case for Windows
+\begin{footnote}
 Windows\textregistered\ is a registered trademark of Microsoft Corporation.
 This information is given for the convenience of users of this document and
-does not constitute an endorsement by ISO or IEC of this product.}-based and
+does not constitute an endorsement by ISO or IEC of this product.
+\end{footnote}%
+-based and
 many POSIX-based operating systems.
 \end{note}
 

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -88,7 +88,7 @@ grep -n '^\\rSec.\[[^]]*[^-a-z.0-9][^]]*\]{' $texfiles | sed 's/$/ <--- bad char
 
 # "shall", "may", or "should" inside a note
 for f in $texfiles; do
-    sed -n '/begin{note}/,/end{note}/{/\(shall\|may\|should\)[^a-zA-Z]/{=;p}}' $f |
+    sed -n '/begin{\(note\|footnote\)}/,/end{\(note\|footnote\)}/{/\(shall\|may\|should\)[^a-zA-Z]/{=;p}}' $f |
     # prefix output with filename and line
     sed '/^[0-9]\+$/{N;s/\n/:/}' | sed "s/.*/$f:&/" |
     sed 's/$/ <--- "shall", "should", or "may" inside a note/'


### PR DESCRIPTION
Create a "footnoteenv" environment for footnotes.
This allows to clearly separate them in the LaTeX source, enabling automatic checking for normative words such as "shall" or "may" inside them.

[temp.constr.order] has an example each inside two footnotes that now gets formatted differently.
We should get rid of that for unrelated reasons (bad rendering with the new separate-paragraph examples).

With this compensated, this patch has no visible differences in "appearance" mode except for footnote 12 (different hyphenation) and footnote 256 (slight differences in spacing/kerning, it seems).