### PR TITLE
Pull a bunch of changes from master onto the C++20 branch

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -4338,7 +4338,7 @@ to an integral type~(\ref{conv.integral}, \ref{class.conv}).
 \pnum
 \effects
 For each non-negative integer $i < N$,
-performs \tcode{*(result + i) = *(first + i)}.
+performs \tcode{*(result + $i$) = *(first + $i$)}.
 
 \pnum
 \returns

--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -10641,6 +10641,7 @@ namespace ranges {
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
 \effects
 Equivalent to:
 \begin{codeblock}

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -2722,8 +2722,8 @@ For the \tcode{volatile} overload of this function,
 Equivalent to: \tcode{return fetch_sub(1) - 1;}
 \end{itemdescr}
 
+\rSec2[util.smartptr.atomic]{Partial specializations for smart pointers}%
 \indextext{atomic!smart pointers|(}%
-\rSec2[util.smartptr.atomic]{Partial specializations for smart pointers}
 
 \rSec3[util.smartptr.atomic.general]{General}
 

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -1379,6 +1379,7 @@ may be different than the calling thread's floating-point environment.
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
 \effects
 Equivalent to:
 \tcode{return fetch_\placeholder{key}(operand) \placeholdernc{op} operand;}

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2216,7 +2216,7 @@ all namespaces $N_i$ nominated by \grammarterm{using-directive}{s} in
 
 \pnum
 Given \tcode{X::m} (where \tcode{X} is a user-declared namespace), or
-given \tcode{::m} (where X is the global namespace), if
+given \tcode{::m} (where \tcode{X} is the global namespace), if
 $S(X, m)$ is the empty set, the program is ill-formed. Otherwise, if
 $S(X, m)$ has exactly one member, or if the context of the reference is
 a \grammarterm{using-declaration}\iref{namespace.udecl}, $S(X, m)$

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -281,12 +281,12 @@ an incomplete type\iref{basic.types},
 an abstract class type\iref{class.abstract}, or
 a (possibly multi-dimensional) array thereof.
 
+\rSec1[basic.def.odr]{One-definition rule}%
 \indextext{object!definition}%
 \indextext{function!definition}%
 \indextext{class!definition}%
 \indextext{enumerator!definition}%
 \indextext{one-definition rule|(}%
-\rSec1[basic.def.odr]{One-definition rule}
 
 \pnum
 No translation unit shall contain more than one definition of any

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4314,7 +4314,7 @@ had been created and later destroyed.
 This includes accessibility\iref{class.access} and whether it is deleted,
 for the constructor selected and for the destructor. However, in the special
 case of the operand of a
-\grammarterm{decltype-specifier}\iref{expr.call}, no temporary is introduced,
+\grammarterm{decltype-specifier}\iref{dcl.type.decltype}, no temporary is introduced,
 so the foregoing does not apply to such a prvalue.
 \end{note}
 

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1010,7 +1010,7 @@ For point of instantiation of a template, see~\ref{temp.point}.
 
 \pnum
 \indextext{scope!block}%
-\indextext{local scope|see{block scope}}%
+\indextext{local scope|see{scope, block}}%
 A name declared in a block\iref{stmt.block} is local to that block; it has
 \defnx{block scope}{block (statement)!scope}.
 Its potential scope begins at its point of

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3850,7 +3850,7 @@ class \tcode{D2}.
 
 \pnum
 If a virtual function \tcode{f} in some class \tcode{B} is marked with the
-\grammarterm{virt-specifier} \tcode{final} and in a class \tcode{D} derived from \tcode{B}
+\grammarterm{virt-specifier} \keyword{final} and in a class \tcode{D} derived from \tcode{B}
 a function \tcode{D::f} overrides \tcode{B::f}, the program is ill-formed.
 \begin{example}
 \begin{codeblock}
@@ -3865,7 +3865,7 @@ struct D : B {
 \end{example}
 
 \pnum
-If a virtual function is marked with the \grammarterm{virt-specifier} \tcode{override} and
+If a virtual function is marked with the \grammarterm{virt-specifier} \keyword{override} and
 does not override a member function of a base class, the program is ill-formed.
 \begin{example}
 \begin{codeblock}

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1135,7 +1135,6 @@ see~\ref{class.ctor} and~\ref{class.dtor}.
 
 \rSec2[special]{Special member functions}
 
-\indextext{\idxcode{X(X\&)}|see{constructor, copy}}%
 \indextext{~@\tcode{\~}|see{destructor}}%
 \indextext{assignment!copy|see{assignment operator, copy}}%
 \indextext{assignment!move|see{assignment operator, move}}%

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3574,7 +3574,8 @@ The order in which the base class subobjects are allocated in the most
 derived object\iref{intro.object} is unspecified.
 \begin{note}
 \indextext{directed acyclic graph|see{DAG}}%
-\indextext{lattice|see{DAG, subobject}}%
+\indextext{lattice|see{DAG}}%
+\indextext{lattice|see{subobject}}%
 A derived class and its base class subobjects can be represented by a
 directed acyclic graph (DAG) where an arrow means ``directly derived
 from'' (see \fref{class.dag}).

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10608,7 +10608,7 @@ The header \libheader{span} defines the view \tcode{span}.
 \begin{codeblock}
 namespace std {
   // constants
-  inline constexpr size_t dynamic_extent = numeric_limits<size_t>::max();
+  inline constexpr size_t @\libglobal{dynamic_extent}@ = numeric_limits<size_t>::max();
 
   // \ref{views.span}, class template span
   template<class ElementType, size_t Extent = dynamic_extent>

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -370,10 +370,11 @@ with value \tcode{a.end()} before the swap will have value \tcode{b.end()} after
 swap.
 
 \pnum
+\indextext{reversible container|see{container, reversible}}%
 If the iterator type of a container belongs to the bidirectional or
 random access iterator categories\iref{iterator.requirements},
 the container is called
-\term{reversible}
+\defnx{reversible}{container!reversible}
 and meets the additional requirements
 in \tref{container.rev.req}.
 
@@ -469,8 +470,7 @@ shall not invalidate iterators to, or change the values of, objects
 within that container.
 
 \pnum
-\indextext{container!contiguous}%
-A \defn{contiguous container}
+A \defnadj{contiguous}{container}
 is a container
 whose member types \tcode{iterator} and \tcode{const_iterator}
 meet the

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -309,7 +309,7 @@ type, either or both may be replaced by an object of the container's
 \tcode{const_iterator} type referring to the same element with no change in semantics.
 
 \pnum
-Unless otherwise specified, all containers defined in this clause obtain memory
+Unless otherwise specified, all containers defined in this Clause obtain memory
 using an allocator (see~\ref{allocator.requirements}).
 \begin{note}
 In particular, containers and iterators do not store references

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -5416,7 +5416,7 @@ The number of elements erased.
 Nothing unless an exception is thrown by
 \tcode{*i == *(i-1)}
 or
-\tcode{pred(*i, *(i - 1))}
+\tcode{pred(*i, *(i - 1))}.
 
 \pnum
 \complexity

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -276,7 +276,7 @@ Those entries marked ``(Note A)'' or ``(Note B)''
 have linear complexity for \tcode{array} and have constant complexity
 for all other standard containers.
 \begin{note}
-The algorithm \tcode{equal()} is defined in \ref{algorithms}.
+The algorithm \tcode{equal} is defined in \ref{algorithms}.
 \end{note}
 
 \pnum

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2162,9 +2162,9 @@ and a type that does not qualify as an allocator is deduced for that parameter.
 and a type that qualifies as an allocator is deduced for that parameter.
 \end{itemize}
 
+\rSec3[associative.reqmts.except]{Exception safety guarantees}%
 \indextext{associative containers!exception safety}%
 \indextext{associative containers!requirements}%
-\rSec3[associative.reqmts.except]{Exception safety guarantees}
 
 \pnum
 For associative containers, no \tcode{clear()} function throws an exception.
@@ -2181,9 +2181,9 @@ For associative containers, no \tcode{swap} function throws an exception unless
 that exception is thrown by the
 swap of the container's \tcode{Compare} object (if any).
 
+\rSec2[unord.req]{Unordered associative containers}%
 \indextext{associative containers!unordered|see{unordered associative containers}}
 \indextext{hash tables|see{unordered associative containers}}
-\rSec2[unord.req]{Unordered associative containers}
 
 \rSec3[unord.req.general]{General}
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5974,6 +5974,7 @@ In the \grammarterm{function-body}, a
 storage duration that is implicitly defined (see~\ref{basic.scope.block}).
 
 \pnum
+\indextext{__func__@\mname{func}}%
 The function-local predefined variable \mname{func} is
 defined as if a definition of the form
 \begin{codeblock}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3673,9 +3673,9 @@ template<> void g1<int>(const int*, const double&); // OK, specialization of \tc
 
 \pnum
 An abbreviated function template can have a \grammarterm{template-head}.
-The invented \grammarterm{template-parameters} are
+The invented \grammarterm{template-parameter}{s} are
 appended to the \grammarterm{template-parameter-list} after
-the explicitly declared \grammarterm{template-parameters}.
+the explicitly declared \grammarterm{template-parameter}{s}.
 \begin{example}
 \begin{codeblock}
 template<typename> concept C = /* ... */;

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1999,7 +1999,7 @@ If the \grammarterm{placeholder-type-specifier} is of the form
 \opt{\grammarterm{type-constraint}} \tcode{decltype(auto)},
 \tcode{T} shall be the
 placeholder alone. The type deduced for \tcode{T} is
-determined as described in~\ref{dcl.type.simple}, as though
+determined as described in~\ref{dcl.type.decltype}, as though
 $E$ had
 been the operand of the \tcode{decltype}.
 \begin{example}
@@ -2746,7 +2746,7 @@ The optional \grammarterm{attribute-specifier-seq} appertains to the reference t
 Cv-qualified references are ill-formed except when the cv-qualifiers
 are introduced through the use of a
 \grammarterm{typedef-name}~(\ref{dcl.typedef}, \ref{temp.param}) or
-\grammarterm{decltype-specifier}\iref{dcl.type.simple},
+\grammarterm{decltype-specifier}\iref{dcl.type.decltype},
 in which case the cv-qualifiers are ignored.
 \begin{example}
 \begin{codeblock}
@@ -2873,7 +2873,7 @@ to a bit-field.
 \pnum
 \indextext{reference collapsing}%
 If a \grammarterm{typedef-name}~(\ref{dcl.typedef}, \ref{temp.param})
-or a \grammarterm{decltype-specifier}\iref{dcl.type.simple} denotes a type \tcode{TR} that
+or a \grammarterm{decltype-specifier}\iref{dcl.type.decltype} denotes a type \tcode{TR} that
 is a reference to a type \tcode{T}, an attempt to create the type ``lvalue reference to \cv{}~\tcode{TR}''
 creates the type ``lvalue reference to \tcode{T}'', while an attempt to create
 the type ``rvalue reference to \cv{}~\tcode{TR}'' creates the type \tcode{TR}.

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -503,7 +503,10 @@ the object is const~(\ref{basic.type.qualifier}, \ref{dcl.type.cv}).
 
 \rSec2[dcl.fct.spec]{Function specifiers}%
 \indextext{specifier!function}%
-\indextext{function|seealso{friend function; member function; inline function; virtual function}}
+\indextext{function|seealso{friend function}}
+\indextext{function|seealso{member function}}
+\indextext{function|seealso{inline function}}
+\indextext{function|seealso{virtual function}}
 
 \pnum
 A

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5953,7 +5953,7 @@ is used only in a constructor; see~\ref{class.ctor} and~\ref{class.init}.
 \pnum
 \begin{note}
 A \grammarterm{cv-qualifier-seq} affects the type of \tcode{this}
-in the body of a member function; see~\ref{dcl.ref}.
+in the body of a member function; see~\ref{expr.prim.this}.
 \end{note}
 
 \pnum

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -266,7 +266,7 @@ temporaries in~\ref{class.temporary} indicates the behavior of lvalues
 and rvalues in other significant contexts.
 
 \pnum
-Unless otherwise indicated\iref{dcl.type.simple},
+Unless otherwise indicated\iref{dcl.type.decltype},
 a prvalue shall always have complete type or the \tcode{void} type;
 if it has a class type or (possibly multi-dimensional) array of class type,
 that class shall not be an abstract class\iref{class.abstract}.
@@ -417,7 +417,7 @@ appear~(\ref{expr.prim.req},
 \ref{expr.typeid},
 \ref{expr.sizeof},
 \ref{expr.unary.noexcept},
-\ref{dcl.type.simple},
+\ref{dcl.type.decltype},
 \ref{temp.pre},
 \ref{temp.concept}).
 An unevaluated operand is not evaluated.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4668,9 +4668,12 @@ unless the \grammarterm{expression} is potentially-throwing\iref{except.spec}.
 
 \pnum
 \indextext{expression!\idxcode{new}}%
-\indextext{free store|seealso{\tcode{new}, \tcode{delete}}}%
-\indextext{memory management|see{\tcode{new}, \tcode{delete}}}%
-\indextext{storage management|see{\tcode{new}, \tcode{delete}}}%
+\indextext{free store|seealso{\tcode{new}}}%
+\indextext{free store|seealso{\tcode{delete}}}%
+\indextext{memory management|see{\tcode{new}}}%
+\indextext{memory management|see{\tcode{delete}}}%
+\indextext{storage management|see{\tcode{new}}}%
+\indextext{storage management|see{\tcode{delete}}}%
 \indextext{\idxcode{new}}%
 The \grammarterm{new-expression} attempts to create an object of the
 \grammarterm{type-id}\iref{dcl.name} or \grammarterm{new-type-id} to which

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6937,7 +6937,7 @@ it is applied to
 \end{itemize}
 
 \item
-an lvalue-to-rvalue conversion\iref{conv.lval}
+an lvalue-to-rvalue conversion
 that is applied to a glvalue
 that refers to a non-active member of a union or a subobject thereof;
 

--- a/source/future.tex
+++ b/source/future.tex
@@ -2333,7 +2333,8 @@ state_type state() const;
 
 \begin{itemdescr}
 \pnum
-returns \tcode{cvtstate}.
+\returns
+\tcode{cvtstate}.
 \end{itemdescr}
 
 \indexlibrarymember{state_type}{wstring_convert}%

--- a/source/future.tex
+++ b/source/future.tex
@@ -1548,6 +1548,7 @@ It is unspecified whether a closure type\iref{expr.prim.lambda.closure} is a POD
 
 \rSec1[depr.tuple]{Tuple}
 
+\pnum
 The header \libheaderref{tuple} has the following additions:
 
 \begin{codeblock}
@@ -2694,6 +2695,7 @@ namespace std {
 
 \rSec2[depr.atomics.volatile]{Volatile access}
 
+\pnum
 If an atomic specialization has one of the following overloads,
 then that overload participates in overload resolution
 even if \tcode{atomic<T>::is_always_lock_free} is \tcode{false}:

--- a/source/future.tex
+++ b/source/future.tex
@@ -404,8 +404,8 @@ results in undefined behavior
 unless the function's \throws element
 specifies throwing an exception when the precondition is violated.
 
+\rSec1[depr.relops]{Relational operators}%
 \indexlibraryglobal{rel_ops}%
-\rSec1[depr.relops]{Relational operators}
 
 \pnum
 The header \libheaderref{utility} has the following additions:

--- a/source/future.tex
+++ b/source/future.tex
@@ -1174,7 +1174,7 @@ explicit istrstream(char* s);
 Initializes the base class with \tcode{istream(\&sb)} and
 \tcode{sb} with \tcode{strstreambuf(s, 0)}.
 \tcode{s} shall designate the first element of an \ntbs{}.%
-\indextext{NTBS}
+\indextext{NTBS@\ntbs{}}
 \end{itemdescr}
 
 \indexlibraryctor{istrstream}%
@@ -1292,7 +1292,7 @@ If
 \tcode{(mode \& app) != 0},
 then \tcode{s} shall designate the first element of an array of \tcode{n} elements that
 contains an \ntbs{} whose first element is designated by \tcode{s}.
-\indextext{NTBS}%
+\indextext{NTBS@\ntbs{}}%
 The constructor is
 \tcode{strstreambuf(s, n, s + std::strlen(s))}.\footnote{The function signature
 \indexlibraryglobal{strlen}%

--- a/source/future.tex
+++ b/source/future.tex
@@ -2677,7 +2677,7 @@ as it is consistent with \tcode{path}'s handling of other encodings.
 \rSec2[depr.atomics.general]{General}
 
 \pnum
-The header \libheaderref{atomics} has the following additions.
+The header \libheaderrefx{atomic}{atomics.syn} has the following additions.
 
 \begin{codeblock}
 namespace std {

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -21,8 +21,8 @@ overloading, function name overloading, references, free store
 management operators, and additional library facilities.%
 \indextext{scope|)}
 
+\rSec0[intro.refs]{Normative references}%
 \indextext{normative references|see{references, normative}}%
-\rSec0[intro.refs]{Normative references}
 
 \pnum
 \indextext{references!normative|(}%
@@ -672,6 +672,7 @@ semantic rules, and the one-definition rule%
 
 \rSec0[intro]{General principles}
 
+\rSec1[intro.compliance]{Implementation compliance}%
 \indextext{diagnostic message|see{message, diagnostic}}%
 \indexdefn{conditionally-supported behavior|see{behavior, con\-ditionally-supported}}%
 \indextext{dynamic type|see{type, dynamic}}%
@@ -693,7 +694,6 @@ semantic rules, and the one-definition rule%
 \indextext{precedence of operator|see{operator, precedence of}}%
 \indextext{order of evaluation in expression|see{expression, order of evaluation of}}%
 \indextext{multiple threads|see{threads, multiple}}%
-\rSec1[intro.compliance]{Implementation compliance}
 
 \rSec2[intro.compliance.general]{General}
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -11383,7 +11383,7 @@ the condition that occurs
 when multiple threads, processes, or computers interleave access and
 modification of
 the same object within a file system.
-Behavior is undefined if calls to functions provided by subclause~\ref{fs.race.behavior} introduce a file system race.
+Behavior is undefined if calls to functions provided by subclause~\ref{filesystems} introduce a file system race.
 
 \pnum
 If the possibility of a file system race would make it unreliable for a

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -11831,7 +11831,7 @@ namespace std::filesystem {
     friend bool operator==(const path& lhs, const path& rhs) noexcept;
     friend strong_ordering operator<=>(const path& lhs, const path& rhs) noexcept;
 
-    friend path operator/ (const path& lhs, const path& rhs);
+    friend path operator/(const path& lhs, const path& rhs);
 
     // \ref{fs.path.native.obs}, native format observers
     const string_type& native() const noexcept;
@@ -13514,7 +13514,7 @@ Equivalent to \tcode{lhs.swap(rhs)}.
 
 \indexlibrarymember{hash_value}{path}%
 \begin{itemdecl}
-size_t hash_value (const path& p) noexcept;
+size_t hash_value(const path& p) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -13569,7 +13569,7 @@ friend strong_ordering operator<=>(const path& lhs, const path& rhs) noexcept;
 
 \indexlibrarymember{operator/}{path}%
 \begin{itemdecl}
-friend path operator/ (const path& lhs, const path& rhs);
+friend path operator/(const path& lhs, const path& rhs);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -39,7 +39,7 @@ as summarized in \tref{iostreams.summary}.
 \pnum
 \begin{note}
 \fref{iostreams.streampos} illustrates relationships among various types
-described in this clause. A line from \textbf{A} to \textbf{B} indicates that \textbf{A}
+described in this Clause. A line from \textbf{A} to \textbf{B} indicates that \textbf{A}
 is an alias (e.g., a typedef) for \textbf{B} or that \textbf{A} is defined in terms of
 \textbf{B}.
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4067,8 +4067,8 @@ namespace std {
   template<class charT, class traits>
     basic_istream<charT, traits>& ws(basic_istream<charT, traits>& is);
 
-  template<class charT, class traits, class T>
-    basic_istream<charT, traits>& operator>>(basic_istream<charT, traits>&& is, T&& x);
+  template<class Istream, class T>
+    Istream&& operator>>(Istream&& is, T&& x);
 }
 \end{codeblock}
 
@@ -4102,8 +4102,8 @@ namespace std {
   template<class charT, class traits>
     basic_ostream<charT, traits>& flush_emit(basic_ostream<charT, traits>& os);
 
-  template<class charT, class traits, class T>
-    basic_ostream<charT, traits>& operator<<(basic_ostream<charT, traits>&& os, const T& x);
+  template<class Ostream, class T>
+    Ostream&& operator<<(Ostream&& os, const T& x);
 }
 \end{codeblock}
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -11737,7 +11737,7 @@ identifies the location of a file when resolved relative to
 an implied starting location. The elements of a path that determine if it is
 relative are operating system dependent.
 \begin{note}
-Pathnames ``.'' and ``..'' are relative paths.
+Pathnames ``.''\ and ``..''\ are relative paths.
 \end{note}
 
 \pnum

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -30,8 +30,6 @@ as summarized in \tref{iterators.summary}.
 \rSec1[iterator.synopsis]{Header \tcode{<iterator>}\ synopsis}
 
 \indexheader{iterator}%
-\indexlibraryglobal{default_sentinel}%
-\indexlibraryglobal{unreachable_sentinel}%
 \begin{codeblock}
 #include <compare>              // see \ref{compare.syn}
 #include <concepts>             // see \ref{concepts.syn}
@@ -382,7 +380,7 @@ namespace std {
 
   // \ref{default.sentinel}, default sentinel
   struct default_sentinel_t;
-  inline constexpr default_sentinel_t default_sentinel{};
+  inline constexpr default_sentinel_t @\libglobal{default_sentinel}@{};
 
   // \ref{iterators.counted}, counted iterators
   template<@\libconcept{input_or_output_iterator}@ I> class counted_iterator;
@@ -395,7 +393,7 @@ namespace std {
 
   // \ref{unreachable.sentinel}, unreachable sentinel
   struct unreachable_sentinel_t;
-  inline constexpr unreachable_sentinel_t unreachable_sentinel{};
+  inline constexpr unreachable_sentinel_t @\libglobal{unreachable_sentinel}@{};
 
   // \ref{stream.iterators}, stream iterators
   template<class T, class charT = char, class traits = char_traits<charT>,

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -519,7 +519,7 @@ The six categories of iterators correspond to the iterator concepts
 \item \libconcept{input_iterator}\iref{iterator.concept.input},
 \item \libconcept{output_iterator}\iref{iterator.concept.output},
 \item \libconcept{forward_iterator}\iref{iterator.concept.forward},
-\item \libconcept{bidirectional_iterator}\iref{iterator.concept.bidir}
+\item \libconcept{bidirectional_iterator}\iref{iterator.concept.bidir},
 \item \libconcept{random_access_iterator}\iref{iterator.concept.random.access},
 and
 \item \libconcept{contiguous_iterator}\iref{iterator.concept.contiguous},

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1419,7 +1419,7 @@ if it is an unsigned-integer-class type.
 \tcode{\exposid{is-integer-like}<I>} is \tcode{true}
 if and only if \tcode{I} is an integer-like type.
 \tcode{\exposid{is-signed-integer-like}<I>} is \tcode{true}
-if and only if I is a signed-integer-like type.
+if and only if \tcode{I} is a signed-integer-like type.
 
 \pnum
 Let \tcode{i} be an object of type \tcode{I}. When \tcode{i} is in the domain of

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -4897,7 +4897,7 @@ decltype(auto) operator->() const
 
 \begin{itemdescr}
 \pnum
-The expression in the requires clause is equivalent to:
+The expression in the \grammarterm{requires-clause} is equivalent to:
 \begin{codeblock}
 @\libconcept{indirectly_readable}@<const I> &&
 (requires(const I& i) { i.operator->(); } ||

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -361,8 +361,8 @@ namespace std {
     const move_iterator<Iterator1>& x,
     const move_iterator<Iterator2>& y) -> decltype(x.base() - y.base());
   template<class Iterator>
-    constexpr move_iterator<Iterator> operator+(
-      typename move_iterator<Iterator>::difference_type n, const move_iterator<Iterator>& x);
+    constexpr move_iterator<Iterator>
+      operator+(iter_difference_t<Iterator> n, const move_iterator<Iterator>& x);
 
   template<class Iterator>
     constexpr move_iterator<Iterator> make_move_iterator(Iterator i);

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1710,7 +1710,7 @@ Two dereferenceable iterators \tcode{a} and \tcode{b} of type \tcode{X}
 offer the \defn{multi-pass guarantee} if:
 \begin{itemize}
 \item \tcode{a == b} implies \tcode{++a == ++b} and
-\item The expression
+\item the expression
 \tcode{((void)[](X x)\{++x;\}(a), *a)} is equivalent to the expression \tcode{*a}.
 \end{itemize}
 

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1431,7 +1431,7 @@ convertible to \tcode{bool} &
 \multicolumn{4}{|p{5.3in}|}{
   \tcode{rv}'s state is unspecified.
   \begin{note}
-\ \tcode{rv} must still meet the requirements of the library
+  \tcode{rv} must still meet the requirements of the library
   component that is using it, whether or not \tcode{t} and \tcode{rv} refer to the same object.
   The operations listed in those requirements must
   work as specified whether \tcode{rv} has been moved from or not.

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -1461,6 +1461,7 @@ with any fractional part discarded.
 
 \rSec2[bit.rotate]{Rotating}
 
+\pnum
 In the following descriptions,
 let \tcode{N} denote \tcode{numeric_limits<T>::digits}.
 

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -9883,7 +9883,7 @@ for just those argument values
 for which:
 \begin{itemize}
   \item
-  the function description's \returns clause
+  the function description's \returns element
   explicitly specifies a domain
   and those argument values fall
   outside the specified domain,

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -8718,7 +8718,7 @@ const mask_array& operator=(const mask_array&) const;
 These assignment operators have reference semantics, assigning the values
 of the argument array elements to selected elements of the
 \tcode{valarray<T>}
-object to which it refers.
+object to which the \tcode{mask_array} object refers.
 \end{itemdescr}
 
 \rSec3[mask.array.comp.assign]{Compound assignment}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -8752,7 +8752,7 @@ These compound assignments have reference semantics, applying the
 indicated operation to the elements of the argument array and selected elements
 of the
 \tcode{valarray<T>}
-object to which the mask object refers.
+object to which the \tcode{mask_array} object refers.
 \end{itemdescr}
 
 \rSec3[mask.array.fill]{Fill function}

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1891,7 +1891,7 @@ parameters is
 viable only if it has an ellipsis in its parameter list\iref{dcl.fct}.
 For the purposes of overload resolution,
 any argument for which there is no corresponding parameter is
-considered to ``match the ellipsis''\iref{over.ics.ellipsis} .
+considered to ``match the ellipsis''\iref{over.ics.ellipsis}.
 \item
 A candidate function having more than
 \textit{m}

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -598,7 +598,7 @@ ATTR_DEPRECATED("This function is deprecated") void anvil();
 \rSec1[cpp.include]{Source file inclusion}
 \indextext{preprocessing directive!header inclusion}
 \indextext{preprocessing directive!source-file inclusion}
-\indextext{inclusion!source file|see{preprocessing directives, source-file inclusion}}%
+\indextext{inclusion!source file|see{preprocessing directive, source-file inclusion}}%
 \indextext{\idxcode{\#include}}%
 
 \pnum
@@ -1528,7 +1528,7 @@ a macro name.
 
 \rSec1[cpp.line]{Line control}%
 \indextext{preprocessing directive!line control}%
-\indextext{\idxcode{\#line}|see{preprocessing directives, line control}}
+\indextext{\idxcode{\#line}|see{preprocessing directive, line control}}
 
 \pnum
 The \grammarterm{string-literal} of a
@@ -1584,7 +1584,7 @@ otherwise, the result is processed as appropriate.
 
 \rSec1[cpp.error]{Error directive}%
 \indextext{preprocessing directive!error}%
-\indextext{\idxcode{\#error}|see{preprocessing directives, error}}
+\indextext{\idxcode{\#error}|see{preprocessing directive, error}}
 
 \pnum
 A preprocessing directive of the form
@@ -1597,7 +1597,7 @@ and renders the program ill-formed.
 
 \rSec1[cpp.pragma]{Pragma directive}%
 \indextext{preprocessing directive!pragma}%
-\indextext{\idxcode{\#pragma}|see{preprocessing directives, pragma}}
+\indextext{\idxcode{\#pragma}|see{preprocessing directive, pragma}}
 
 \pnum
 A preprocessing directive of the form

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -6409,7 +6409,7 @@ namespace std::ranges {
       requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
     friend constexpr bool operator>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
       requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
-    friend constexpr bool operator<=(const @\exposid{iterator}@& y, const @\exposid{iterator}@& y)
+    friend constexpr bool operator<=(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
       requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
     friend constexpr bool operator>=(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
       requires @\libconcept{random_access_range}@<@\exposid{Base}@>;

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -318,7 +318,7 @@ namespace std {
 \pnum
 \indextext{to-unsigned-like@\exposid{to-unsigned-like}}%
 \indextext{make-unsigned-like-t@\exposid{make-unsigned-like-t}}%
-Within this clause,
+Within this Clause,
 for an integer-like type \tcode{X}\iref{iterator.concept.winc},
 \tcode{\placeholdernc{make-unsigned-like-t}<X>} denotes
 \tcode{make_unsigned_t<X>} if \tcode{X} is an integer type;

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -275,7 +275,7 @@ namespace std::ranges {
 
   // \ref{range.elements}, elements view
   template<@\libconcept{input_range}@ V, size_t N>
-    requires @\seebelow@;
+    requires @\seebelow@
   class elements_view;
 
   template<class R>

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -4,7 +4,7 @@
 \rSec1[ranges.general]{General}
 
 \pnum
-This clause describes components for dealing with ranges of elements.
+This Clause describes components for dealing with ranges of elements.
 
 \pnum
 The following subclauses describe

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -202,7 +202,8 @@ namespace std::ranges {
   // \ref{range.transform}, transform view
   template<@\libconcept{input_range}@ V, @\libconcept{copy_constructible}@ F>
     requires view<V> && is_object_v<F> &&
-             regular_invocable<F&, range_reference_t<V>>
+             regular_invocable<F&, range_reference_t<V>> &&
+             @\exposconcept{can-reference}@<invoke_result_t<F&, range_reference_t<V>>>
   class transform_view;
 
   namespace views { inline constexpr @\unspec@ transform = @\unspec@; }

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -4777,7 +4777,7 @@ constexpr auto begin() const
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{ranges::next(ranges::begin(base_), count_, ranges::end(base_))}.
+\tcode{ranges::next(ranges::begin(\exposid{base_}), \exposid{count_}, ranges::end(\exposid{base_}))}.
 
 \pnum
 \remarks

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1308,7 +1308,7 @@ template<class R>
 
 template<class I>
   concept @\defexposconcept{has-arrow}@ =                           // \expos
-    @\libconcept{input_iterator<I>}@ && (is_pointer_v<I> || requires(I i) { i.operator->(); });
+    @\libconcept{input_iterator}@<I> && (is_pointer_v<I> || requires(I i) { i.operator->(); });
 
 template<class T, class U>
   concept @\defexposconcept{not-same-as}@ =                         // \expos

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -159,7 +159,7 @@ and \tcode{loc} is an object of type \tcode{X::locale_type}.
 \tcode{X::length(p)}
   & \tcode{size_t}
   & Yields the smallest \tcode{i} such that \tcode{p[i] == 0}. Complexity is
-    linear in \tcode{i} .
+    linear in \tcode{i}.
   \\ \rowsep
 \tcode{v.translate(c)}
   & \tcode{X::char_type}
@@ -2849,7 +2849,7 @@ did not participate in the match, then \tcode{last}.
 &
 For all integers \tcode{0 < n < m.size()}, the end of the sequence that matched
 sub-expression \tcode{n}. Alternatively, if sub-expression \tcode{n} did not
-participate in the match, then \tcode{last} .
+participate in the match, then \tcode{last}.
 \\ \rowsep
 \tcode{m[n].matched}
 &

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -3705,17 +3705,17 @@ names shall be recognized:
 In addition the following expressions shall be equivalent:
 
 \begin{codeblock}
-\d and [[:digit:]]
+\d @\textnormal{and}@ [[:digit:]]
 
-\D and [^[:digit:]]
+\D @\textnormal{and}@ [^[:digit:]]
 
-\s and [[:space:]]
+\s @\textnormal{and}@ [[:space:]]
 
-\S and [^[:space:]]
+\S @\textnormal{and}@ [^[:space:]]
 
-\w and [_[:alnum:]]
+\w @\textnormal{and}@ [_[:alnum:]]
 
-\W and [^_[:alnum:]]
+\W @\textnormal{and}@ [^_[:alnum:]]
 \end{codeblock}
 
 \pnum

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -658,11 +658,11 @@ namespace std {
       erase_if(basic_string<charT, traits, Allocator>& c, Predicate pred);
 
   // \tcode{basic_string} typedef names
-  using string    = basic_string<char>;
-  using u8string  = basic_string<char8_t>;
-  using u16string = basic_string<char16_t>;
-  using u32string = basic_string<char32_t>;
-  using wstring   = basic_string<wchar_t>;
+  using @\libglobal{string}@    = basic_string<char>;
+  using @\libglobal{u8string}@  = basic_string<char8_t>;
+  using @\libglobal{u16string}@ = basic_string<char16_t>;
+  using @\libglobal{u32string}@ = basic_string<char32_t>;
+  using @\libglobal{wstring}@   = basic_string<wchar_t>;
 
   // \ref{string.conversions}, numeric conversions
   int stoi(const string& str, size_t* idx = nullptr, int base = 10);

--- a/source/support.tex
+++ b/source/support.tex
@@ -5358,7 +5358,7 @@ non-null pointer value.
 
 \rSec3[coroutine.noop.coroutine]{Function \tcode{noop_coroutine}}
 
-\indexlibrary{noop_coroutine}%
+\indexlibraryglobal{noop_coroutine}%
 \begin{itemdecl}
 noop_coroutine_handle noop_coroutine() noexcept;
 \end{itemdecl}

--- a/source/support.tex
+++ b/source/support.tex
@@ -2710,8 +2710,8 @@ this order.
 
 \rSec2[alloc.errors]{Storage allocation errors}
 
+\rSec3[bad.alloc]{Class \tcode{bad_alloc}}%
 \indexlibraryglobal{bad_alloc}%
-\rSec3[bad.alloc]{Class \tcode{bad_alloc}}
 
 \indexlibraryctor{bad_alloc}%
 \begin{codeblock}
@@ -2741,9 +2741,9 @@ const char* what() const noexcept override;
 An \impldef{return value of \tcode{bad_alloc::what}} \ntbs{}.
 \end{itemdescr}
 
+\rSec3[new.badlength]{Class \tcode{bad_array_new_length}}%
 \indexlibraryglobal{bad_array_new_length}%
 \indexlibraryctor{bad_array_new_length}%
-\rSec3[new.badlength]{Class \tcode{bad_array_new_length}}
 
 \begin{codeblock}
 namespace std {

--- a/source/support.tex
+++ b/source/support.tex
@@ -3153,6 +3153,7 @@ An \impldef{return value of \tcode{bad_typeid::what}} \ntbs{}.
 
 \rSec2[source.location.syn]{Header \tcode{<source_location>} synopsis}
 
+\pnum
 The header \libheaderdef{source_location} defines
 the class \tcode{source_location}
 that provides a means to obtain source location information.

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3830,7 +3830,7 @@ if they accept and are satisfied by\iref{temp.constr.constr}
 the same set of template argument lists.
 
 \pnum
-\indextext{template!function!equivalent|see{equivalent, function template}}%
+\indextext{template!function!equivalent|see{equivalent, function templates}}%
 Two function templates are
 \defnx{equivalent}{equivalent!function templates}
 if they
@@ -3844,7 +3844,7 @@ that are equivalent using the rules described above to compare
 expressions involving
 template parameters.
 \indextext{equivalent!functionally|see{functionally equivalent}}%
-\indextext{template!function!functionally equivalent|see{functionally equivalent, function template}}%
+\indextext{template!function!functionally equivalent|see{functionally equivalent, function templates}}%
 Two function templates are
 \defnx{functionally equivalent}{functionally equivalent!function templates}
 if they

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -856,10 +856,10 @@ namespace std {
 
     // \ref{stopcallback.cons}, constructors and destructor
     template<class C>
-    explicit stop_callback(const stop_token& st, C&& cb)
+      explicit stop_callback(const stop_token& st, C&& cb)
         noexcept(is_nothrow_constructible_v<Callback, C>);
     template<class C>
-    explicit stop_callback(stop_token&& st, C&& cb)
+      explicit stop_callback(stop_token&& st, C&& cb)
         noexcept(is_nothrow_constructible_v<Callback, C>);
     ~stop_callback();
 
@@ -873,7 +873,7 @@ namespace std {
   };
 
   template<class Callback>
-  stop_callback(stop_token, Callback) -> stop_callback<Callback>;
+    stop_callback(stop_token, Callback) -> stop_callback<Callback>;
 }
 \end{codeblock}
 

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -5592,7 +5592,7 @@ Each \defn{barrier phase} consists of the following steps:
   the next phase starts.
 \end{itemize}
 
-\indextext{phase synchronization point|see{barrier, phase synchronization point }}%
+\indextext{phase synchronization point|see{barrier, phase synchronization point}}%
 \pnum
 \indextext{block (execution)}%
 Each phase defines a \defnx{phase synchronization point}{barrier!phase synchronization point}.

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -373,8 +373,8 @@ namespace std {
 \end{codeblock}
 
 
+\rSec2[stoptoken]{Class \tcode{stop_token}}%
 \indexlibraryglobal{stop_token}%
-\rSec2[stoptoken]{Class \tcode{stop_token}}
 
 \rSec3[stoptoken.general]{General}
 
@@ -569,8 +569,8 @@ friend void swap(stop_token& x, stop_token& y) noexcept;
 Equivalent to: \tcode{x.swap(y)}.
 \end{itemdescr}
 
+\rSec2[stopsource]{Class \tcode{stop_source}}%
 \indexlibraryglobal{stop_source}%
-\rSec2[stopsource]{Class \tcode{stop_source}}
 
 \rSec3[stopsource.general]{General}
 
@@ -840,8 +840,8 @@ friend void swap(stop_source& x, stop_source& y) noexcept;
 Equivalent to: \tcode{x.swap(y)}.
 \end{itemdescr}
 
+\rSec2[stopcallback]{Class template \tcode{stop_callback}}%
 \indexlibraryglobal{stop_callback}%
-\rSec2[stopcallback]{Class template \tcode{stop_callback}}
 
 \rSec3[stopcallback.general]{General}
 

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -48,7 +48,7 @@ meeting its specifications. Failure to allocate storage is reported as described
 in~\ref{res.on.exception.handling}.
 
 \begin{example}
-Consider a function in this clause that is specified to throw exceptions of type
+Consider a function in this Clause that is specified to throw exceptions of type
 \tcode{system_error} and specifies error conditions that include
 \tcode{operation_not_permitted} for a thread that does not have the privilege to
 perform the operation. Assume that, during the execution of this function, an \tcode{errno}
@@ -5991,7 +5991,7 @@ Many of the classes introduced in subclause~\ref{futures} use some state to comm
 \defnx{shared state}{future!shared state} consists of some state information and some (possibly not
 yet evaluated) \term{result}, which can be a (possibly void) value or an exception.
 \begin{note}
-Futures, promises, and tasks defined in this clause reference such shared state.
+Futures, promises, and tasks defined in this Clause reference such shared state.
 \end{note}
 
 \pnum

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -5052,7 +5052,7 @@ during this call and then equivalent to:
 while (!stoken.stop_requested()) {
   if (pred())
     return true;
-  if (cv.wait_until(lock, abs_time) == cv_status::timeout)
+  if (wait_until(lock, abs_time) == cv_status::timeout)
     return pred();
 }
 return pred();

--- a/source/time.tex
+++ b/source/time.tex
@@ -8760,7 +8760,7 @@ A \tcode{time_zone_link} specifies an alternative name for a \tcode{time_zone}.
 \pnum
 \throws
 If a \tcode{const time_zone*} cannot be found
-as described in the \returns clause,
+as described in the \returns element,
 throws a \tcode{runtime_error}.
 \begin{note}
 On non-exceptional return, the return value is always a pointer to a valid \tcode{time_zone}.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -8285,7 +8285,7 @@ to the invocation of allocate which returned \tcode{p}.
 
 \pnum
 \effects
-Deallocates the storage referenced by \tcode{p} .
+Deallocates the storage referenced by \tcode{p}.
 
 \pnum
 \remarks

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -4009,8 +4009,8 @@ namespace std {
 }
 \end{codeblock}
 
+\rSec2[variant.variant]{Class template \tcode{variant}}%
 \indexlibraryglobal{variant}%
-\rSec2[variant.variant]{Class template \tcode{variant}}
 
 \rSec3[variant.variant.general]{General}
 
@@ -5160,8 +5160,8 @@ For $n > 1$, the invocation of the callable object has
 no complexity requirements.
 \end{itemdescr}
 
+\rSec2[variant.monostate]{Class \tcode{monostate}}%
 \indexlibraryglobal{monostate}%
-\rSec2[variant.monostate]{Class \tcode{monostate}}
 
 \begin{itemdecl}
 struct monostate{};
@@ -5214,8 +5214,8 @@ Equivalent to \tcode{v.swap(w)}.
 The expression inside \tcode{noexcept} is equivalent to \tcode{noexcept(v.swap(w))}.
 \end{itemdescr}
 
+\rSec2[variant.bad.access]{Class \tcode{bad_variant_access}}%
 \indexlibraryglobal{bad_variant_access}%
-\rSec2[variant.bad.access]{Class \tcode{bad_variant_access}}
 
 \begin{codeblock}
 class bad_variant_access : public exception {
@@ -9636,8 +9636,9 @@ Equivalent to: \tcode{os << p.get();}
 \tcode{os}.
 \end{itemdescr}
 
+\rSec2[util.smartptr.weak.bad]{Class \tcode{bad_weak_ptr}}%
 \indextext{smart pointers|(}%
-\rSec2[util.smartptr.weak.bad]{Class \tcode{bad_weak_ptr}}
+
 \indexlibraryglobal{bad_weak_ptr}%
 \begin{codeblock}
 namespace std {

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -21076,6 +21076,7 @@ basic_format_arg<Context> get(size_t i) const noexcept;
 \tcode{i < size_ ?\ data_[i] :\ basic_format_arg<Context>()}.
 \end{itemdescr}
 
+\pnum
 \begin{note}
 Implementations are encouraged
 to optimize the representation of \tcode{basic_format_args}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -9241,7 +9241,7 @@ This replaces the \constraints specification of the primary template.
 
 \indexlibrarymember{operator=}{unique_ptr}%
 \begin{itemdecl}
-template<class U, class E> unique_ptr& operator=(unique_ptr<U, E>&& u)noexcept;
+template<class U, class E> unique_ptr& operator=(unique_ptr<U, E>&& u) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16250,7 +16250,7 @@ namespace std {
       = is_nothrow_default_constructible<T>::value;
   template<class T>
     inline constexpr bool is_nothrow_copy_constructible_v
-    = is_nothrow_copy_constructible<T>::value;
+      = is_nothrow_copy_constructible<T>::value;
   template<class T>
     inline constexpr bool is_nothrow_move_constructible_v
       = is_nothrow_move_constructible<T>::value;

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -13407,6 +13407,7 @@ namespace std {
     template<class... ArgTypes>
       constexpr invoke_result_t<T&, ArgTypes...> operator()(ArgTypes&&...) const;
   };
+
   template<class T>
     reference_wrapper(T&) -> reference_wrapper<T>;
 }


### PR DESCRIPTION
This pull request contains all the changes on `master` but not on `c++20` that I think we might want to take for the IS. This aims to exclude changes that:

* that got too close to looking like a normative change (excluding misapplied motions), or
* that are trivial or unimportant or a wording cleanup (excluding changes that only affect the index or formatting fixes), or
* that doesn't affect the produced document.