### PR TITLE
[iostream.objects.overview] Delete duplicate paragraph.

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -431,11 +431,6 @@ The objects are constructed and the associations are established at some
 time prior to or during the first time an object of class
 \tcode{ios_base::Init} is constructed, and in any case before the body
 of \tcode{main}\iref{basic.start.main} begins execution.
-
-\recommended
-If it is possible for them to do so, implementations should
-initialize the objects earlier than required.
-
 The objects are not destroyed during program execution.\footnote{Constructors and destructors for objects with
 static storage duration can
 access these objects to read input from


### PR DESCRIPTION
Initially, 75bea3cfb49cd07fb267d46b22aa0a5d40dc6735 moved a footnote into a new "recommended practice" paragraph. Later, cb07613ed7c6cfa19a5ce024a5a8ed1c6d9bf869 added the same "recommended practice" into the middle of the paragraph that originally contained the footnote.


Initial edit: https://github.com/cplusplus/draft/commit/75bea3cfb49cd07fb267d46b22aa0a5d40dc6735#diff-8d76c9854d3e844d443d7516819ba062

Bogus duplication: https://github.com/cplusplus/draft/commit/cb07613ed7c6cfa19a5ce024a5a8ed1c6d9bf869#diff-8d76c9854d3e844d443d7516819ba062