### PR TITLE
[class.init] Replace abominable temporary expression wording

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -5782,7 +5782,8 @@ a virtual base class is ignored during execution of a constructor of any class t
 not the most derived class.
 
 \pnum
-A temporary expression bound to a reference member in a \grammarterm{mem-initializer}
+A program extending the lifetime of a temporary object
+by binding it to a reference member in a \grammarterm{mem-initializer}
 is ill-formed.
 \begin{example}
 \begin{codeblock}
@@ -5888,7 +5889,8 @@ will not take place.
 \end{example}
 
 \pnum
-A temporary expression bound to a reference member from a
+A program extending the lifetime of a temporary object
+by binding it to a reference member from a
 default member initializer is ill-formed.
 \begin{example}
 \begin{codeblock}


### PR DESCRIPTION
Finally fixes #1910