### PR TITLE
[macros] Avoid page break between example and codeblock introducers

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -280,7 +280,7 @@
 \newcommand{\leftshift}[1]{\ensuremath{\mathbin{\mathsf{lshift}_{#1}}}}
 
 %% Notes and examples
-\newcommand{\noteintro}[1]{[\textit{#1}:}
+\newcommand{\noteintro}[1]{[\textit{#1}: }
 \newcommand{\noteoutro}[1]{\textit{\,---\,#1}\kern.5pt]}
 
 % \newnoteenvironment{ENVIRON}{BEGIN TEXT}{END TEXT}
@@ -292,7 +292,7 @@
 \newcommand{\newnoteenvironment}[3]{
 \newsubclausecounter{#1}
 \newenvironment{tail#1}
-{\par\small\stepcounter{#1}\noteintro{#2}}
+{\par\small\stepcounter{#1}\noteintro{#2}\hbox to 0pt{}\ignorespaces}
 {\noteoutro{#3}}
 \newenvironment{#1}
 {\begin{tail#1}}
@@ -497,7 +497,12 @@
 % Our usual abbreviation for 'listings'.  Comments are in
 % italics.  Arbitrary TeX commands can be used if they're
 % surrounded by @ signs.
-\newcommand{\CodeBlockSetup}{%
+\def\codeblockbeginpenalty{-1}    % default: no penalty change before codeblock
+\newcommand{\CodeBlockSetup}{
+\ifnum\codeblockbeginpenalty=-1
+\else
+  \presetkeys{lst}{beginpenalty=\codeblockbeginpenalty}{}%
+\fi
 \lstset{escapechar=@, aboveskip=\parskip, belowskip=0pt,
         midpenalty=500, endpenalty=-50,
         emptylinepenalty=-250, semicolonpenalty=0}%
@@ -508,8 +513,27 @@
 
 \lstnewenvironment{codeblock}{\CodeBlockSetup}{}
 
-% Left-align listings titles
 \makeatletter
+
+\newsavebox\@signalbox
+
+% Redefine \begin{codeblock} to look for an immediately-preceding
+% \begin{example}.
+\global\@namedef{codeblock}{%
+  \def\lstenv@name {codeblock}\begingroup%
+  \ifhmode%                             no last box in vertical mode
+    \setbox\@signalbox=\lastbox%        grab and consume last box
+    \copy\@signalbox%                   typeset the last box again
+    \ifhbox\@signalbox%
+      \ifdim\wd\@signalbox=0pt%         zero-width box is our marker
+        \def\codeblockbeginpenalty{100}%
+      \fi%
+    \fi%
+  \fi%
+  \lst@setcatcodes \catcode \active=\active \csname codeblock@\endcsname%
+}
+
+% Left-align listings titles
 \def\lst@maketitle{\@makeleftcaption\lst@title@dropdelim}
 \long\def\@makeleftcaption#1#2{%
   \vskip\abovecaptionskip


### PR DESCRIPTION
if they are immediately following each other.

Partially addresses #4228 