### PR TITLE
[foreword] Exclude mentions of library headers from the index.

### DIFF
--- a/source/preface.tex
+++ b/source/preface.tex
@@ -1,4 +1,9 @@
 %!TEX root = std.tex
+
+\let\OldLibHeader\libheader
+\newcommand{\simplelibheader}[1]{\tcode{<#1>}}
+\let\libheader\simplelibheader
+
 \chapter{Foreword}
 
 ISO (the International Organization for Standardization) and IEC (the
@@ -114,3 +119,5 @@ Any feedback or questions on this document
 should be directed to the user's national standards body.
 A complete listing of these bodies can be found at
 \href{http://www.iso.org/members.html}{\tcode{www.iso.org/members.html}}.
+
+\let\libheader\OldLibHeader


### PR DESCRIPTION
It does not seem helpful to link into the mention of a header in the
foreword, esp. since these links would use the Roman frontmatter page numbers.