### PR TITLE
Add new note* and example* environments to suppress paragraph break.

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -746,10 +746,10 @@ have a name different from \tcode{T}:
 \item every static data member of class \tcode{T};
 
 \item every member function of class \tcode{T}
-\begin{note}
+\begin{note*}
 This restriction does not apply to constructors, which do not have
 names\iref{class.ctor}
-\end{note}%
+\end{note*}%
 ;
 
 \item every member of class \tcode{T} that is itself a type;

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6893,10 +6893,10 @@ of $E$;
 
 \item
 an invocation of a non-constexpr function
-\begin{note}
+\begin{note*}
 Overload resolution\iref{over.match}
 is applied as usual.
-\end{note}%
+\end{note*}%
 ;
 
 \item
@@ -6922,12 +6922,12 @@ limits (see \ref{implimits});
 \item
 an operation that would have undefined behavior
 as specified in \ref{intro} through \ref{cpp}
-\begin{note}
+\begin{note*}
 including,
 for example, signed integer overflow\iref{expr.prop}, certain
 pointer arithmetic\iref{expr.add}, division by
 zero\iref{expr.mul}, or certain shift operations\iref{expr.shift}
-\end{note}%
+\end{note*}%
 ;
 
 \item

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -275,12 +275,17 @@
 % ending with END TEXT. A counter with name ENVIRON indicates the
 % number of this kind of note / example that has occurred in this
 % subclause.
-\newcommand{\newnoteenvironment}[3]{
-\newsubclausecounter{#1}
-\newenvironment{#1}
-{\def\noteend{#3}\par\small\stepcounter{#1}\noteintro{#2}}
-{\noteoutro{\noteend}\par}
+\ExplSyntaxOn
+\NewDocumentCommand \newnoteenvironment { m m m } {
+  \newsubclausecounter{#1}
+  \NewDocumentEnvironment {#1*} { }
+    {\def\noteend{#3}\par\small\stepcounter{#1}\noteintro{#2}}
+    {\noteoutro{\noteend}}
+  \NewDocumentEnvironment {#1} { }
+    {\begin{#1*}}
+    {\end{#1*}\par}
 }
+\ExplSyntaxOff
 
 \newnoteenvironment{note}{Note \arabic{note}}{end note}
 \newnoteenvironment{example}{Example \arabic{example}}{end example}


### PR DESCRIPTION
The new `note*` and `example*` environments will suppress the trailing paragraph break. This is useful when the environment is followed by a punctuation mark.

This PR addresses issue #4236.