### PR TITLE
[range.reverse.overview] Use \cv{} instead of "cv-qualified"

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -6093,10 +6093,7 @@ Given a subexpression \tcode{E}, the expression
   a (possibly cv-qualified) specialization of \tcode{reverse_view},
   equivalent to \tcode{E.base()}.
 \item
-  Otherwise, if the type of \tcode{E} is cv-qualified
-\begin{codeblock}
-subrange<reverse_iterator<I>, reverse_iterator<I>, K>
-\end{codeblock}
+  Otherwise, if the type of \tcode{E} is \cv{} \tcode{subrange<reverse_iterator<I>, reverse_iterator<I>, K>}
   for some iterator type \tcode{I} and
   value \tcode{K} of type \tcode{subrange_kind},
   \begin{itemize}


### PR DESCRIPTION
We clearly meant for this to cover cv-unqualified `subrange`s of that form too.