### PR TITLE
[intro.compliance.general, implimits] Cite Annex B normatively.

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -718,7 +718,8 @@ execution of programs. Such requirements have the following meaning:
 If a program contains no violations of the rules in
 \ref{lex} through \ref{\lastlibchapter} and \ref{depr},
 a conforming implementation shall,
-within its resource limits, accept and correctly execute\footnote{``Correct execution'' can include undefined behavior, depending on
+within its resource limits as described in \ref{implimits},
+accept and correctly execute\footnote{``Correct execution'' can include undefined behavior, depending on
 the data being processed; see \ref{intro.defs} and~\ref{intro.execution}.}
 that program.
 \item

--- a/source/limits.tex
+++ b/source/limits.tex
@@ -1,5 +1,5 @@
 %!TEX root = std.tex
-\infannex{implimits}{Implementation quantities}
+\normannex{implimits}{Implementation quantities}
 
 \pnum
 Because computers are finite, \Cpp{}  implementations are inevitably


### PR DESCRIPTION
This change also promotes Annex B [implimits] to a "normative" annex. The existing wording in the annex is already normative in character.