### PR TITLE
[class.mem.general] Move note to the end of the list item.

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -745,12 +745,11 @@ have a name different from \tcode{T}:
 \begin{itemize}
 \item every static data member of class \tcode{T};
 
-\item every member function of class \tcode{T}
+\item every member function of class \tcode{T};
 \begin{note}
 This restriction does not apply to constructors, which do not have
 names\iref{class.ctor}
 \end{note}%
-;
 
 \item every member of class \tcode{T} that is itself a type;
 


### PR DESCRIPTION
With the new note style, notes should no longer appear in the middle of a sentence.

Fixes #4236.