### PR TITLE
[std] Introduce tailnote environment to avoid empty lines in tables.

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -13738,11 +13738,11 @@ The type of the file has not been determined or an error occurred while
     trying to determine the type. \\ \rowsep
 \tcode{not_found} &
 Pseudo-type indicating the file was not found.
-\begin{note}
+\begin{tailnote}
 The file
 not being found is not considered an error while determining the
 type of a file.
-\end{note}
+\end{tailnote}
 \\ \rowsep
 \tcode{regular} & Regular file \\ \rowsep
 \tcode{directory} & Directory file \\ \rowsep

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1839,9 +1839,9 @@ and obtain a pointer to it.
 of allocating a single object of type \tcode{T}, even when \tcode{sizeof(T)}
 is small. That is, there is no need for a container to maintain its own
 free list.}
-\begin{note}
+\begin{tailnote}
 If \tcode{n == 0}, the return value is unspecified.
-\end{note}
+\end{tailnote}
 &  \\ \rowsep
 
 \tcode{a.allocate(n, y)}    &

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -274,11 +274,15 @@
 % ending with END TEXT. A counter with name ENVIRON indicates the
 % number of this kind of note / example that has occurred in this
 % subclause.
+% Use ENVIRON* to avoid inserting a \par at the end.
 \newcommand{\newnoteenvironment}[3]{
 \newsubclausecounter{#1}
+\newenvironment{tail#1}
+{\par\small\stepcounter{#1}\noteintro{#2}}
+{\noteoutro{#3}}
 \newenvironment{#1}
-{\def\noteend{#3}\par\small\stepcounter{#1}\noteintro{#2}}
-{\noteoutro{\noteend}\par}
+{\begin{tail#1}}
+{\end{tail#1}\small\par}   % \small\par is for C++20 post-DIS compatibility
 }
 
 \newnoteenvironment{note}{Note \arabic{note}}{end note}

--- a/source/time.tex
+++ b/source/time.tex
@@ -11249,13 +11249,13 @@ the locale's alternative representation.
 \\ \rowsep
 \tcode{\%n} &
 Matches one white space character.
-\begin{note}
+\begin{tailnote}
 \tcode{\%n}, \tcode{\%t}, and a space
 can be combined to match a wide range of white-space patterns.
 For example,
 \tcode{"\%n "} matches one or more white space characters, and
 \tcode{"\%n\%t\%t"} matches one to three white space characters.
-\end{note}
+\end{tailnote}
 \\ \rowsep
 \tcode{\%p} &
 The locale's equivalent of the AM/PM designations associated with a 12-hour clock.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16593,10 +16593,10 @@ notwithstanding the restrictions of~\ref{declval}.
  \tcode{struct is_final;}               &
  \tcode{T} is a class type marked with the \grammarterm{class-virt-specifier}
  \tcode{final}\iref{class.pre}.
-\begin{note}
+\begin{tailnote}
 A union is a class type that
  can be marked with \tcode{final}.
-\end{note}
+\end{tailnote}
 &
  If \tcode{T} is a class type, \tcode{T} shall be a complete type.                          \\ \rowsep
 
@@ -16674,13 +16674,13 @@ A union is a class type that
   operand\iref{expr.prop}. Access checking is performed as if in a context
   unrelated to \tcode{T} and \tcode{U}. Only the validity of the immediate context
   of the assignment expression is considered.
-\begin{note}
+\begin{tailnote}
 The compilation of the
   expression can result in side effects such as the instantiation of class template
   specializations and function template specializations, the generation of
   implicitly-defined functions, and so on. Such side effects are not in the ``immediate
   context'' and can result in the program being ill-formed.
-\end{note}
+\end{tailnote}
 &
   \tcode{T} and \tcode{U} shall be complete types, \cv{}~\tcode{void},
   or arrays of unknown bound. \\ \rowsep
@@ -17121,10 +17121,10 @@ with a base characteristic of
 not possibly cv-qualified versions of the same type,
  \tcode{Derived} shall be a complete
  type.
- \begin{note}
+ \begin{tailnote}
 Base classes that are private, protected, or ambiguous
  are, nonetheless, base classes.
-\end{note}
+\end{tailnote}
 \\ \rowsep
 
 \indexlibraryglobal{is_convertible}%
@@ -17447,11 +17447,11 @@ This rule reflects the semantics of reference collapsing\iref{dcl.ref}.
  If \tcode{T} names a type ``array of \tcode{U}'',
  the member typedef \tcode{type} shall
  be \tcode{U}, otherwise \tcode{T}.
- \begin{note}
+ \begin{tailnote}
 For multidimensional arrays, only the first array dimension is
  removed. For a type ``array of \tcode{const U}'', the resulting type is
  \tcode{const U}.
-\end{note}
+\end{tailnote}
 \\  \rowsep
 
 \indexlibraryglobal{remove_all_extents}%
@@ -19493,11 +19493,11 @@ Indicates that a sign should be used for both non-negative and negative
 numbers.
 The \tcode{+} sign is inserted before the output of \tcode{to_chars} for
 non-negative numbers other than negative zero.
-\begin{note}
+\begin{tailnote}
 For negative numbers and negative zero
 the output of \tcode{to_chars} will already contain the sign
 so no additional transformation is performed.
-\end{note}
+\end{tailnote}
 \\ \rowsep
 %
 \tcode{-} &
@@ -19768,10 +19768,10 @@ the base prefix is \tcode{0X}.
 %
 none &
 The same as \tcode{d}.
-\begin{note}
+\begin{tailnote}
 If the formatting argument type is \tcode{charT} or \tcode{bool},
 the default is instead \tcode{c} or \tcode{s}, respectively.
-\end{note}
+\end{tailnote}
 \\
 \end{floattable}
 


### PR DESCRIPTION
Partially addresses #4228.

This should also be applied to master.