### PR TITLE
[std] Use tailnote and tailexample to avoid empty space in tables.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -875,10 +875,10 @@ The complexities of the expressions are sequence dependent.
  \oldconcept{MoveInsertable} into \tcode{X} and \oldconcept{MoveAssignable}.\br
  \effects Inserts an object of type \tcode{T} constructed with
  \tcode{std::forward<\brk{}Args\brk{}>(\brk{}args)...} before \tcode{p}.
- \begin{note}
+ \begin{tailnote}
 \tcode{args} can directly or indirectly refer to
  a value in \tcode{a}.
-\end{note}
+\end{tailnote}
  \\ \rowsep
 
 \tcode{a.insert(p,t)}   &

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1404,11 +1404,11 @@ convertible to \tcode{bool} &
   \tcode{T(rv)} is equivalent to the value of \tcode{rv} before the construction \\ \rowsep
 \multicolumn{2}{|p{5.3in}|}{
   \tcode{rv}'s state is unspecified
-  \begin{note}
+  \begin{tailnote}
 \tcode{rv} must still meet the requirements of the library
   component that is using it. The operations listed in those requirements must
   work as specified whether \tcode{rv} has been moved from or not.
-\end{note}
+\end{tailnote}
 }\\
 \end{oldconcepttable}
 
@@ -1430,12 +1430,12 @@ convertible to \tcode{bool} &
   \tcode{t} is equivalent to the value of \tcode{rv} before the assignment\\ \rowsep
 \multicolumn{4}{|p{5.3in}|}{
   \tcode{rv}'s state is unspecified.
-  \begin{note}
+  \begin{tailnote}
   \tcode{rv} must still meet the requirements of the library
   component that is using it, whether or not \tcode{t} and \tcode{rv} refer to the same object.
   The operations listed in those requirements must
   work as specified whether \tcode{rv} has been moved from or not.
-\end{note}
+\end{tailnote}
 }\\
 \end{oldconcepttable}
 
@@ -1452,9 +1452,9 @@ convertible to \tcode{bool} &
 \hdstyle{Expression}      &   \hdstyle{Post-condition}  \\ \capsep
 \tcode{u.\~T()} &   All resources owned by \tcode{u} are reclaimed, no exception is propagated. \\ \rowsep
 \multicolumn{2}{|l|}{
-  \begin{note}
+  \begin{tailnote}
   Array types and non-object types are not \oldconcept{Destructible}.
-  \end{note}
+  \end{tailnote}
 } \\
 \end{oldconcepttable}
 

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -234,10 +234,10 @@ and \tcode{loc} is an object of type \tcode{X::locale_type}.
   & Returns the value represented by the digit \textit{c} in base
     \textit{I} if the character \textit{c} is a valid digit in base \textit{I};
   otherwise returns \tcode{-1}.
-\begin{note}
+\begin{tailnote}
 The value of \textit{I} will only
   be 8, 10, or 16.
-\end{note}
+\end{tailnote}
   \\ \rowsep
 \tcode{u.imbue(loc)}
   & \tcode{X::locale_type}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16713,14 +16713,14 @@ The compilation of the
   unrelated to \tcode{T} and \tcode{U}.
   Only the validity of the immediate context
   of the \tcode{swap} expressions is considered.
-  \begin{note}
+  \begin{tailnote}
   The compilation of the expressions can result in side effects
   such as the instantiation of class template specializations and
   function template specializations,
   the generation of implicitly-defined functions, and so on.
   Such side effects are not in the ``immediate context'' and
   can result in the program being ill-formed.
-  \end{note}
+  \end{tailnote}
 &
   \tcode{T} and \tcode{U} shall be complete types,
   \cv{}~\tcode{void}, or
@@ -17289,11 +17289,11 @@ Each of the templates in \ref{meta.trans} shall be a
  The member typedef \tcode{type} names
  the same type as \tcode{T}
  except that any top-level const-qualifier has been removed.
- \begin{example}
+ \begin{tailexample}
 \tcode{remove_const_t<const volatile int>} evaluates
  to \tcode{volatile int}, whereas \tcode{remove_const_t<const int*>} evaluates to
  \tcode{const int*}.
-\end{example}
+\end{tailexample}
 \\  \rowsep
 
 \indexlibraryglobal{remove_volatile}%
@@ -17302,11 +17302,11 @@ Each of the templates in \ref{meta.trans} shall be a
  The member typedef \tcode{type} names
  the same type as \tcode{T}
  except that any top-level volatile-qualifier has been removed.
- \begin{example}
+ \begin{tailexample}
 \tcode{remove_volatile_t<const volatile int>}
  evaluates to \tcode{const int},
  whereas \tcode{remove_volatile_t<volatile int*>} evaluates to \tcode{volatile int*}.
- \end{example}
+ \end{tailexample}
 \\  \rowsep
 
 \indexlibraryglobal{remove_cv}%
@@ -17314,11 +17314,11 @@ Each of the templates in \ref{meta.trans} shall be a
  struct remove_cv;}                 &
  The member typedef \tcode{type} shall be the same as \tcode{T}
  except that any top-level cv-qualifier has been removed.
- \begin{example}
+ \begin{tailexample}
 \tcode{remove_cv_t<const volatile int>}
  evaluates to \tcode{int}, whereas \tcode{remove_cv_t<const volatile int*>}
  evaluates to \tcode{const volatile int*}.
-\end{example}
+\end{tailexample}
 \\  \rowsep
 
 \indexlibraryglobal{add_const}%
@@ -17369,9 +17369,9 @@ Each of the templates in \ref{meta.trans} shall be a
  If \tcode{T} names a referenceable type\iref{defns.referenceable} then
  the member typedef \tcode{type} names \tcode{T\&};
  otherwise, \tcode{type} names \tcode{T}.
- \begin{note}
+ \begin{tailnote}
  This rule reflects the semantics of reference collapsing\iref{dcl.ref}.
- \end{note}
+ \end{tailnote}
 \\ \rowsep
 
 \indexlibraryglobal{add_rvalue_reference}%
@@ -17380,11 +17380,11 @@ Each of the templates in \ref{meta.trans} shall be a
  If \tcode{T} names a referenceable type then
  the member typedef \tcode{type} names \tcode{T\&\&};
  otherwise, \tcode{type} names \tcode{T}.
- \begin{note}
+ \begin{tailnote}
 This rule reflects the semantics of reference collapsing\iref{dcl.ref}.
  For example, when a type \tcode{T} names a type \tcode{T1\&}, the type
  \tcode{add_rvalue_reference_t<T>} is not an rvalue reference.
- \end{note}
+ \end{tailnote}
 \\
 \end{libreqtab2a}
 
@@ -17572,13 +17572,13 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  \tcode{remove_extent_t<U>*}. If \tcode{is_function_v<U>} is \tcode{true},
  the member typedef \tcode{type} equals \tcode{add_pointer_t<U>}. Otherwise
  the member typedef \tcode{type} equals \tcode{remove_cv_t<U>}.
-\begin{note}
+\begin{tailnote}
 This behavior is similar to the lvalue-to-rvalue\iref{conv.lval},
 array-to-pointer\iref{conv.array}, and function-to-pointer\iref{conv.func}
 conversions applied when an lvalue is used as an rvalue, but also
 strips cv-qualifiers from class types in order to more closely model by-value
 argument passing.
-\end{note}
+\end{tailnote}
  \\ \rowsep
 
 \indexlibraryglobal{enable_if}%

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -59,6 +59,10 @@ grep -ne '^.*[^ ]\s*\\\(begin\|end\){\(example\|note\)}' $texfiles && exit 1
 grep -ne '\\\(begin\|end\){\(example\|note\)}[^%]\+$' $texfiles && exit 1
 # Fixup: sed 's/\(\\\(begin\|end\){\(example\|note\)}\)\s*\([^ ].*\)$/\1\n\4/'
 
+# \end{note} or \end{example} at the end of a table cell
+grep -n -A1 '\\end{\(example\|note\)}' $texfiles | grep -- '- *\(\\\\\|&\)' |
+sed 's/$/ <--- needs tailnote or tailexample/' | grep . && exit 1
+
 # Blank line between "begin example" and "begin codeblock"
 for f in $texfiles; do
     sed -n '/\\begin{example}/{N;N;/\n\n\\begin{codeblock}$/{=;p}}' $f |


### PR DESCRIPTION
Also add an automated check.

Partially addresses #4228 

Must be applied to "master" as well.