### PR TITLE
[ranges] Index "split_view::{outer,inner}-iterator" correctly.

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -5521,7 +5521,7 @@ Initializes \exposid{base_} with \tcode{views::all(std::forward<R>(r))}, and
 
 \rSec3[range.split.outer]{Class template \tcode{split_view::\exposid{outer-iterator}}}
 
-\indexlibraryglobal{split_view::outer-iterator}%
+\indexlibraryglobal{split_view::\exposid{outer-iterator}}%
 \begin{codeblock}
 namespace std::ranges {
   template<@\libconcept{input_range}@ V, @\libconcept{forward_range}@ Pattern>
@@ -5581,7 +5581,7 @@ Many of the following specifications refer to the notional member
 \placeholder{current} is equivalent to \exposid{current_} if \tcode{V}
 models \libconcept{forward_range}, and \tcode{\exposid{parent_}->\exposid{current_}} otherwise.
 
-\indexlibraryctor{split_view::outer-iterator}%
+\indexlibraryctor{split_view::\exposid{outer-iterator}}%
 \begin{itemdecl}
 constexpr explicit @\exposid{outer-iterator}@(@\exposid{Parent}@& parent)
   requires (!@\libconcept{forward_range}@<@\exposid{Base}@>);
@@ -5593,7 +5593,7 @@ constexpr explicit @\exposid{outer-iterator}@(@\exposid{Parent}@& parent)
 Initializes \exposid{parent_} with \tcode{addressof(parent)}.
 \end{itemdescr}
 
-\indexlibraryctor{split_view::outer-iterator}%
+\indexlibraryctor{split_view::\exposid{outer-iterator}}%
 \begin{itemdecl}
 constexpr @\exposid{outer-iterator}@(@\exposid{Parent}@& parent, iterator_t<@\exposid{Base}@> current)
   requires @\libconcept{forward_range}@<@\exposid{Base}@>;
@@ -5606,7 +5606,7 @@ Initializes \exposid{parent_} with \tcode{addressof(parent)}
 and \exposid{current_} with \tcode{std::move(current)}.
 \end{itemdescr}
 
-\indexlibraryctor{split_view::outer-iterator}%
+\indexlibraryctor{split_view::\exposid{outer-iterator}}%
 \begin{itemdecl}
 constexpr @\exposid{outer-iterator}@(@\exposid{outer-iterator}@<!Const> i)
   requires Const && @\libconcept{convertible_to}@<iterator_t<V>, iterator_t<@\exposid{Base}@>>;
@@ -5619,7 +5619,7 @@ Initializes \exposid{parent_} with \tcode{i.\exposid{parent_}} and
 \exposid{current_} with \tcode{std::move(i.\exposid{current_})}.
 \end{itemdescr}
 
-\indexlibrarymember{operator*}{split_view::outer-iterator}%
+\indexlibrarymember{operator*}{split_view::\exposid{outer-iterator}}%
 \begin{itemdecl}
 constexpr value_type operator*() const;
 \end{itemdecl}
@@ -5630,7 +5630,7 @@ constexpr value_type operator*() const;
 Equivalent to: \tcode{return value_type\{*this\};}
 \end{itemdescr}
 
-\indexlibrarymember{operator++}{split_view::outer-iterator}%
+\indexlibrarymember{operator++}{split_view::\exposid{outer-iterator}}%
 \begin{itemdecl}
 constexpr @\exposid{outer-iterator}@& operator++();
 \end{itemdecl}
@@ -5657,7 +5657,7 @@ return *this;
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{operator==}{split_view::outer-iterator}%
+\indexlibrarymember{operator==}{split_view::\exposid{outer-iterator}}%
 \begin{itemdecl}
 friend constexpr bool operator==(const @\exposid{outer-iterator}@& x, const @\exposid{outer-iterator}@& y)
   requires @\libconcept{forward_range}@<@\exposid{Base}@>;
@@ -5669,7 +5669,7 @@ friend constexpr bool operator==(const @\exposid{outer-iterator}@& x, const @\ex
 Equivalent to: \tcode{return x.\exposid{current_} == y.\exposid{current_};}
 \end{itemdescr}
 
-\indexlibrarymember{operator==}{split_view::outer-iterator}%
+\indexlibrarymember{operator==}{split_view::\exposid{outer-iterator}}%
 \begin{itemdecl}
 friend constexpr bool operator==(const @\exposid{outer-iterator}@& x, default_sentinel_t);
 \end{itemdecl}
@@ -5682,7 +5682,7 @@ Equivalent to: \tcode{return x.\placeholdernc{current} == ranges::end(x.\exposid
 
 \rSec3[range.split.outer.value]{Class \tcode{split_view::\exposid{outer-iterator}::value_type}}
 
-\indexlibraryglobal{split_view::outer-iterator::value_type}%
+\indexlibraryglobal{split_view::\exposid{outer-iterator}::value_type}%
 \begin{codeblock}
 namespace std::ranges {
   template<@\libconcept{input_range}@ V, @\libconcept{forward_range}@ Pattern>
@@ -5705,7 +5705,7 @@ namespace std::ranges {
 }
 \end{codeblock}
 
-\indexlibraryctor{split_view::outer-iterator::value_type}%
+\indexlibraryctor{split_view::\exposid{outer-iterator}::value_type}%
 \begin{itemdecl}
 constexpr explicit value_type(@\exposid{outer-iterator}@ i);
 \end{itemdecl}
@@ -5716,7 +5716,7 @@ constexpr explicit value_type(@\exposid{outer-iterator}@ i);
 Initializes \exposid{i_} with \tcode{std::move(i)}.
 \end{itemdescr}
 
-\indexlibrarymember{begin}{split_view::outer-iterator::value_type}%
+\indexlibrarymember{begin}{split_view::\exposid{outer-iterator}::value_type}%
 \begin{itemdecl}
 constexpr @\exposid{inner-iterator}@<Const> begin() const requires copyable<@\exposid{outer-iterator}@>;
 \end{itemdecl}
@@ -5727,7 +5727,7 @@ constexpr @\exposid{inner-iterator}@<Const> begin() const requires copyable<@\ex
 Equivalent to: \tcode{return \exposid{inner-iterator}<Const>\{\exposid{i_}\};}
 \end{itemdescr}
 
-\indexlibrarymember{begin}{split_view::outer-iterator::value_type}%
+\indexlibrarymember{begin}{split_view::\exposid{outer-iterator}::value_type}%
 \begin{itemdecl}
 constexpr @\exposid{inner-iterator}@<Const> begin() requires (!copyable<@\exposid{outer-iterator}@>);
 \end{itemdecl}
@@ -5737,7 +5737,7 @@ constexpr @\exposid{inner-iterator}@<Const> begin() requires (!copyable<@\exposi
 \effects
 Equivalent to: \tcode{return \exposid{inner-iterator}<Const>\{std::move(\exposid{i_})\};}
 \end{itemdescr}
-\indexlibrarymember{end}{split_view::outer-iterator::value_type}%
+\indexlibrarymember{end}{split_view::\exposid{outer-iterator}::value_type}%
 \begin{itemdecl}
 constexpr default_sentinel_t end() const;
 \end{itemdecl}
@@ -5750,7 +5750,7 @@ Equivalent to: \tcode{return default_sentinel;}
 
 \rSec3[range.split.inner]{Class template \tcode{split_view::\exposid{inner-iterator}}}
 
-\indexlibraryglobal{split_view::inner-iterator}%
+\indexlibraryglobal{split_view::\exposid{inner-iterator}}%
 \begin{codeblock}
 namespace std::ranges {
   template<@\libconcept{input_range}@ V, @\libconcept{forward_range}@ Pattern>
@@ -5811,7 +5811,7 @@ The \grammarterm{typedef-name} \tcode{iterator_category} denotes:
 \item otherwise, \tcode{iterator_traits<iterator_t<\exposid{Base}>>::iterator_category}.
 \end{itemize}
 
-\indexlibraryctor{split_view::inner-iterator}%
+\indexlibraryctor{split_view::\exposid{inner-iterator}}%
 \begin{itemdecl}
 constexpr explicit @\exposid{inner-iterator}@(@\exposid{outer-iterator}@<Const> i);
 \end{itemdecl}
@@ -5822,7 +5822,7 @@ constexpr explicit @\exposid{inner-iterator}@(@\exposid{outer-iterator}@<Const> 
 Initializes \exposid{i_} with \tcode{std::move(i)}.
 \end{itemdescr}
 
-\indexlibrarymember{operator++}{split_view::inner-iterator}%
+\indexlibrarymember{operator++}{split_view::\exposid{inner-iterator}}%
 \begin{itemdecl}
 constexpr @\exposid{inner-iterator}@& operator++();
 \end{itemdecl}
@@ -5843,7 +5843,7 @@ return *this;
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{operator==}{split_view::inner-iterator}%
+\indexlibrarymember{operator==}{split_view::\exposid{inner-iterator}}%
 \begin{itemdecl}
 friend constexpr bool operator==(const @\exposid{inner-iterator}@& x, const @\exposid{inner-iterator}@& y)
   requires @\libconcept{forward_range}@<@\exposid{Base}@>;
@@ -5855,7 +5855,7 @@ friend constexpr bool operator==(const @\exposid{inner-iterator}@& x, const @\ex
 Equivalent to: \tcode{return x.\exposid{i_}.\placeholder{current} == y.\exposid{i_}.\placeholder{current};}
 \end{itemdescr}
 
-\indexlibrarymember{operator==}{split_view::inner-iterator}%
+\indexlibrarymember{operator==}{split_view::\exposid{inner-iterator}}%
 \begin{itemdecl}
 friend constexpr bool operator==(const @\exposid{inner-iterator}@& x, default_sentinel_t);
 \end{itemdecl}
@@ -5885,7 +5885,7 @@ if constexpr (@\exposconcept{tiny-range}@<Pattern>) {
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{iter_swap}{split_view::inner-iterator}%
+\indexlibrarymember{iter_swap}{split_view::\exposid{inner-iterator}}%
 \begin{itemdecl}
 friend constexpr void iter_swap(const @\exposid{inner-iterator}@& x, const @\exposid{inner-iterator}@& y)
   noexcept(noexcept(ranges::iter_swap(x.@\exposid{i_}@.@\placeholdernc{current}@, y.@\exposid{i_}@.@\placeholdernc{current}@)))


### PR DESCRIPTION
The nested name is an exposition-only name and needs to be formatted accordingly.
