### PR TITLE
[time.clock.utc.overview] Move explicit line break in example.

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -2814,8 +2814,8 @@ from the \tcode{utc_time}.
 \begin{example}
 \\
 \tcode{clock_cast<utc_clock>(sys_seconds\{sys_days\{1970y/January/1\}\}).time_since_epoch()} is \tcode{0s}. \\
-\tcode{clock_cast<utc_clock>(sys_seconds\{sys_days\{2000y/January/1\}\}).time_since_epoch()} \\
-is \tcode{946'684'822s}, which is \tcode{10'957 * 86'400s + 22s}. \\
+\tcode{clock_cast<utc_clock>(sys_seconds\{sys_days\{2000y/January/1\}\}).time_since_epoch()} is \tcode{946'684'822s},\\
+which is \tcode{10'957 * 86'400s + 22s}. \\
 \end{example}
 
 \pnum


### PR DESCRIPTION
Fixes #4257