### PR TITLE
C++20 tweaks

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -652,9 +652,9 @@ non-const rvalue of type \tcode{X}, and \tcode{m} is a value of type \tcode{A}.
 
 \tcode{X(m)}							&
 																				&
-\ensures
-\tcode{u.empty()} returns \tcode{true}, &
-constant												\\
+  \ensures
+  \tcode{u.empty()} returns \tcode{true}, &
+  constant												\\
 \tcode{X u(m);}					&
 																				&
 \tcode{u.get_allocator() == m} &
@@ -663,11 +663,11 @@ constant												\\
 \tcode{X(t, m)}\br
 \tcode{X u(t, m);}				&
                           &
-\expects
-\tcode{T} is \oldconcept{CopyInsertable} into \tcode{X}.\br
-\ensures
-\tcode{u == t}, \tcode{u.get_allocator() == m} &
-linear													\\ \rowsep
+  \expects
+  \tcode{T} is \oldconcept{CopyInsertable} into \tcode{X}.\br
+  \ensures
+  \tcode{u == t}, \tcode{u.get_allocator() == m} &
+  linear													\\ \rowsep
 
 \tcode{X(rv)}\br
 \tcode{X u(rv);}

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -1802,18 +1802,18 @@ namespace std {
       explicit codecvt(size_t refs = 0);
 
       result out(
-          stateT& state,
-          const internT* from, const internT* from_end, const internT*& from_next,
-                externT*   to,       externT*   to_end,       externT*&   to_next) const;
+        stateT& state,
+        const internT* from, const internT* from_end, const internT*& from_next,
+              externT*   to,       externT*   to_end,       externT*&   to_next) const;
 
       result unshift(
-          stateT& state,
-                externT*    to,      externT*   to_end,       externT*&   to_next) const;
+        stateT& state,
+              externT*    to,      externT*   to_end,       externT*&   to_next) const;
 
       result in(
-          stateT& state,
-          const externT* from, const externT* from_end, const externT*& from_next,
-                internT*   to,       internT*   to_end,       internT*&   to_next) const;
+        stateT& state,
+        const externT* from, const externT* from_end, const externT*& from_next,
+              internT*   to,       internT*   to_end,       internT*&   to_next) const;
 
       int encoding() const noexcept;
       bool always_noconv() const noexcept;
@@ -1825,16 +1825,16 @@ namespace std {
     protected:
       ~codecvt();
       virtual result do_out(
-          stateT& state,
-          const internT* from, const internT* from_end, const internT*& from_next,
-                externT* to,         externT*   to_end,       externT*&   to_next) const;
+        stateT& state,
+        const internT* from, const internT* from_end, const internT*& from_next,
+              externT* to,         externT*   to_end,       externT*&   to_next) const;
       virtual result do_in(
-          stateT& state,
-          const externT* from, const externT* from_end, const externT*& from_next,
-                internT* to,         internT*   to_end,       internT*&   to_next) const;
+        stateT& state,
+        const externT* from, const externT* from_end, const externT*& from_next,
+              internT* to,         internT*   to_end,       internT*&   to_next) const;
       virtual result do_unshift(
-          stateT& state,
-                externT* to,         externT*   to_end,       externT*&   to_next) const;
+        stateT& state,
+              externT* to,         externT*   to_end,       externT*&   to_next) const;
 
       virtual int do_encoding() const noexcept;
       virtual bool do_always_noconv() const noexcept;
@@ -1889,9 +1889,9 @@ members.
 \indexlibrarymember{codecvt}{out}%
 \begin{itemdecl}
 result out(
-    stateT& state,
-    const internT* from, const internT* from_end, const internT*& from_next,
-    externT* to, externT* to_end, externT*& to_next) const;
+  stateT& state,
+  const internT* from, const internT* from_end, const internT*& from_next,
+  externT* to, externT* to_end, externT*& to_next) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1914,9 +1914,9 @@ result unshift(stateT& state, externT* to, externT* to_end, externT*& to_next) c
 \indexlibrarymember{codecvt}{in}%
 \begin{itemdecl}
 result in(
-    stateT& state,
-    const externT* from, const externT* from_end, const externT*& from_next,
-    internT* to, internT* to_end, internT*& to_next) const;
+  stateT& state,
+  const externT* from, const externT* from_end, const externT*& from_next,
+  internT* to, internT* to_end, internT*& to_next) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1975,14 +1975,14 @@ int max_length() const noexcept;
 \indexlibrarymember{codecvt}{do_in}%
 \begin{itemdecl}
 result do_out(
-    stateT& state,
-    const internT* from, const internT* from_end, const internT*& from_next,
-    externT* to, externT* to_end, externT*& to_next) const;
+  stateT& state,
+  const internT* from, const internT* from_end, const internT*& from_next,
+  externT* to, externT* to_end, externT*& to_next) const;
 
 result do_in(
-    stateT& state,
-    const externT* from, const externT* from_end, const externT*& from_next,
-    internT* to, internT* to_end, internT*& to_next) const;
+  stateT& state,
+  const externT* from, const externT* from_end, const externT*& from_next,
+  internT* to, internT* to_end, internT*& to_next) const;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/time.tex
+++ b/source/time.tex
@@ -3848,27 +3848,27 @@ clock_time_conversion<DestClock, SourceClock>{}(t)
 \item
 \begin{codeblock}
 clock_time_conversion<DestClock, system_clock>{}(
-    clock_time_conversion<system_clock, SourceClock>{}(t))
+  clock_time_conversion<system_clock, SourceClock>{}(t))
 \end{codeblock}
 
 \item
 \begin{codeblock}
 clock_time_conversion<DestClock, utc_clock>{}(
-    clock_time_conversion<utc_clock, SourceClock>{}(t))
+  clock_time_conversion<utc_clock, SourceClock>{}(t))
 \end{codeblock}
 
 \item
 \begin{codeblock}
 clock_time_conversion<DestClock, utc_clock>{}(
-    clock_time_conversion<utc_clock, system_clock>{}(
-        clock_time_conversion<system_clock, SourceClock>{}(t)))
+  clock_time_conversion<utc_clock, system_clock>{}(
+    clock_time_conversion<system_clock, SourceClock>{}(t)))
 \end{codeblock}
 
 \item
 \begin{codeblock}
 clock_time_conversion<DestClock, system_clock>{}(
-    clock_time_conversion<system_clock, utc_clock>{}(
-        clock_time_conversion<utc_clock, SourceClock>{}(t)))
+  clock_time_conversion<system_clock, utc_clock>{}(
+    clock_time_conversion<utc_clock, SourceClock>{}(t)))
 \end{codeblock}
 \end{itemize}
 


### PR DESCRIPTION
Build fix:
* 30353134 [tab:container.alloc.req] Indent clauses to fix the build.

Optional fixes:
* 727aff3e [locale.codecvt] Use 2 space indentation (but leave inconsistent indentation for parameters in synopsis as is).
* 6ab88976 [time.clock.cast.fn] Use 2 space indentation in the constraints for clock_cast.