### PR TITLE
[iomanip.syn] Use 'unspecified' instead of type meta-variables.

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4114,32 +4114,31 @@ namespace std {
 \indexheader{iomanip}%
 \begin{codeblock}
 namespace std {
-  // types \tcode{T1}, \tcode{T2}, ... are unspecified implementation types
-  @\textit{T1}@ resetiosflags(ios_base::fmtflags mask);
-  @\textit{T2}@ setiosflags  (ios_base::fmtflags mask);
-  @\textit{T3}@ setbase(int base);
-  template<class charT> @\textit{T4}@ setfill(charT c);
-  @\textit{T5}@ setprecision(int n);
-  @\textit{T6}@ setw(int n);
-  template<class moneyT> @\textit{T7}@ get_money(moneyT& mon, bool intl = false);
-  template<class moneyT> @\textit{T8}@ put_money(const moneyT& mon, bool intl = false);
-  template<class charT> @\textit{T9}@ get_time(struct tm* tmb, const charT* fmt);
-  template<class charT> @\textit{T10}@ put_time(const struct tm* tmb, const charT* fmt);
+  @\unspec@ resetiosflags(ios_base::fmtflags mask);
+  @\unspec@ setiosflags  (ios_base::fmtflags mask);
+  @\unspec@ setbase(int base);
+  template<class charT> @\unspec@ setfill(charT c);
+  @\unspec@ setprecision(int n);
+  @\unspec@ setw(int n);
+  template<class moneyT> @\unspec@ get_money(moneyT& mon, bool intl = false);
+  template<class moneyT> @\unspec@ put_money(const moneyT& mon, bool intl = false);
+  template<class charT> @\unspec@ get_time(struct tm* tmb, const charT* fmt);
+  template<class charT> @\unspec@ put_time(const struct tm* tmb, const charT* fmt);
 
   template<class charT>
-    @\textit{T11}@ quoted(const charT* s, charT delim = charT('"'), charT escape = charT('\\'));
+    @\unspec@ quoted(const charT* s, charT delim = charT('"'), charT escape = charT('\\'));
 
   template<class charT, class traits, class Allocator>
-    @\textit{T12}@ quoted(const basic_string<charT, traits, Allocator>& s,
-    @\itcorr@           charT delim = charT('"'), charT escape = charT('\\'));
+    @\unspec@ quoted(const basic_string<charT, traits, Allocator>& s,
+    @\itcorr@                   charT delim = charT('"'), charT escape = charT('\\'));
 
   template<class charT, class traits, class Allocator>
-    @\textit{T13}@ quoted(basic_string<charT, traits, Allocator>& s,
-    @\itcorr@           charT delim = charT('"'), charT escape = charT('\\'));
+    @\unspec@ quoted(basic_string<charT, traits, Allocator>& s,
+    @\itcorr@                   charT delim = charT('"'), charT escape = charT('\\'));
 
   template<class charT, class traits>
-    @\textit{T14}@ quoted(basic_string_view<charT, traits> s,
-    @\itcorr@           charT delim = charT('"'), charT escape = charT('\\'));
+    @\unspec@ quoted(basic_string_view<charT, traits> s,
+    @\itcorr@                   charT delim = charT('"'), charT escape = charT('\\'));
 }
 \end{codeblock}
 


### PR DESCRIPTION
Fixes #4259 