### PR TITLE
[expr.prim.id.unqual] Restore "Otherwise"

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1374,7 +1374,7 @@ the innermost such intervening \grammarterm{lambda-expression}.
 If that \grammarterm{lambda-expression} is not declared \tcode{mutable},
 the type of such an identifier will typically be \tcode{const} qualified.
 \end{note}
-The type of the expression is the type of the result.
+Otherwise, the type of the expression is the type of the result.
 \begin{note}
 If the entity is a template parameter object for
 a template parameter of type \tcode{T}\iref{temp.param},


### PR DESCRIPTION
It is still needed for the naming-local-entity-in-lambda case.