### PR TITLE
[dcl.fct] Clarify which declarations we're talking about in example.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3755,16 +3755,14 @@ void g2(C1 auto&...);
 void g3(C3 auto...);
 void g4(C3 auto);
 \end{codeblock}
-
-These declarations are functionally equivalent (but not equivalent) to
-the following declarations.
+The declarations above are functionally equivalent (but not equivalent) to
+their respective declarations below:
 \begin{codeblock}
 template<C1 T, C2 U> void g1(const T*, U&);
 template<C1... Ts>   void g2(Ts&...);
 template<C3... Ts>   void g3(Ts...);
 template<C3 T>       void g4(T);
 \end{codeblock}
-
 Abbreviated function templates can be specialized like all function templates.
 \begin{codeblock}
 template<> void g1<int>(const int*, const double&); // OK, specialization of \tcode{g1<int, const double>}


### PR DESCRIPTION
This changes "These declarations" to "The declarations above" inn example so it's clear which declarations we're talking about.