### PR TITLE
[intro.defs] Integrate [re.def].

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -206,6 +206,11 @@ It is used for one of the template parameters of the string,
 iostream, and regular expression class templates.
 \end{defnote}
 
+\definition{collating element}{defns.regex.collating.element}
+\indexdefn{collating element}%
+sequence of one or more characters within the
+current locale that collate as if they were a single character
+
 \definition{component}{defns.component}
 \defncontext{library}
 \indexdefn{component}%
@@ -301,6 +306,19 @@ and
 are expression-equivalent.
 \end{example}
 
+\definition{finite state machine}{defns.regex.finite.state.machine}
+\defncontext{regular expression}
+\indexdefn{finite state machine}%
+unspecified data structure that is used to
+represent a regular expression, and which permits efficient matches
+against the regular expression to be obtained
+
+\definition{format specifier}{defns.regex.format.specifier}
+\defncontext{regular expression}
+\indexdefn{format specifier}%
+sequence of one or more characters that is to be
+replaced with some part of a regular expression match
+
 \definition{handler function}{defns.handler}
 \defncontext{library}
 \indexdefn{function!handler}%
@@ -353,6 +371,13 @@ necessary to implement the iostream class templates.
 \definition{locale-specific behavior}{defns.locale.specific}
 behavior that depends on local conventions of nationality, culture, and
 language that each implementation documents
+
+\definition{matched}{defns.regex.matched}
+\defncontext{regular expression}
+\indexdefn{matched}%
+\indexdefn{regular expression!matched}%
+condition when a sequence of zero or more characters
+correspond to a sequence of characters defined by the pattern
 
 \definition{modifier function}{defns.modifier}
 \defncontext{library}
@@ -423,6 +448,14 @@ following the macro name
 \definition{parameter}{defns.parameter.templ}
 \defncontext{template} member of a \grammarterm{template-parameter-list}
 
+\definition{primary equivalence class}{defns.regex.primary.equivalence.class}
+\defncontext{regular expression}
+\indexdefn{primary equivalence class}%
+set of one or more characters which
+share the same primary sort key: that is the sort key weighting that
+depends only upon character shape, and not accents, case, or
+locale specific tailorings
+
 \definition{program-defined specialization}{defns.prog.def.spec}
 \defncontext{library}
 \indexdefn{specialization!program-defined}%
@@ -471,6 +504,10 @@ object type, a function type that does not have cv-qualifiers or a
 The term describes a type to which a reference can be created,
 including reference types.
 \end{defnote}
+
+\definition{regular expression}{defns.regex.regular.expression}
+pattern that selects specific strings
+from a set of character strings
 
 \definition{replacement function}{defns.replacement}
 \defncontext{library}
@@ -611,6 +648,12 @@ The static type of an expression depends only on the form of the program in
 which the expression appears, and does not change while the program is
 executing.
 \end{defnote}
+
+\definition{sub-expression}{defns.regex.subexpression}
+\defncontext{regular expression}
+\indexdefn{sub-expression!regular expression}%
+subset of a regular expression that has
+been marked by parentheses
 
 \definition{traits class}{defns.traits}
 \defncontext{library}

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -21,7 +21,6 @@ and two iterator types for
 enumerating regular expression matches, as summarized in \tref{re.summary}.
 
 \begin{libsumtab}{Regular expressions library summary}{re.summary}
-\ref{re.def}        &   Definitions                 &                       \\
 \ref{re.req}        &   Requirements                &                       \\ \rowsep
 \ref{re.const}      &   Constants                   & \tcode{<regex>}       \\
 \ref{re.badexp}     &   Exception type              &                       \\
@@ -33,53 +32,6 @@ enumerating regular expression matches, as summarized in \tref{re.summary}.
 \ref{re.iter}       &   Iterators                   &                       \\ \rowsep
 \ref{re.grammar}    &   Grammar                     &                       \\
 \end{libsumtab}
-
-
-\rSec1[re.def]{Definitions}
-
-\pnum
-The following definitions shall apply to this Clause:
-
-\indextext{collating element}%
-\indextext{locale}%
-\definition{collating element}{defns.regex.collating.element}
-a sequence of one or more characters within the
-current locale that collate as if they were a single character.
-
-\indextext{finite state machine}%
-\definition{finite state machine}{defns.regex.finite.state.machine}
-an unspecified data structure that is used to
-represent a regular expression, and which permits efficient matches
-against the regular expression to be obtained.
-
-\indextext{format specifier}%
-\definition{format specifier}{defns.regex.format.specifier}
-a sequence of one or more characters that is to be
-replaced with some part of a regular expression match.
-
-\indextext{matched}%
-\indextext{regular expression!matched}%
-\definition{matched}{defns.regex.matched}
-a sequence of zero or more characters is matched by
-a regular expression when the characters in the sequence
-correspond to a sequence of characters defined by the pattern.
-
-\indextext{primary equivalence class}%
-\indextext{locale}%
-\definition{primary equivalence class}{defns.regex.primary.equivalence.class}
-a set of one or more characters which
-share the same primary sort key: that is the sort key weighting that
-depends only upon character shape, and not accents, case, or
-locale specific tailorings.
-
-\definition{regular expression}{defns.regex.regular.expression}
-a pattern that selects specific strings
-from a set of character strings.
-
-\indextext{sub-expression!regular expression}%
-\definition{sub-expression}{defns.regex.subexpression}
-a subset of a regular expression that has
-been marked by parenthesis.
 
 \rSec1[re.req]{Requirements}
 

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -23,5 +23,7 @@
 %\movedxrefiii{old.label}{new.label.1}{new.label.2}{new.label.3}
 %\movedxrefs{old.label}{new place (eg \tref{blah})}
 
+\movedxref{re.def}{intro.refs}
+
 % Deprecated features.
 %\deprxref{old.label}  (if moved to depr.old.label, otherwise use \movedxref)


### PR DESCRIPTION
Also rephrase the regular expression definitions to fit
the ISO-mandate style.

Fixes #4283 