### PR TITLE
[stmt.ranged] Align font for begin-expr and end-expr.

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -639,8 +639,8 @@ is equivalent to
 \terminal{\{}\br
 \bnfindent \opt{init-statement}\br
 \bnfindent \keyword{auto} \terminal{\&\&}\exposid{range} \terminal{=} for-range-initializer \terminal{;}\br
-\bnfindent \keyword{auto} \exposid{begin} \terminal{=} begin-expr \terminal{;}\br
-\bnfindent \keyword{auto} \exposid{end} \terminal{=} end-expr \terminal{;}\br
+\bnfindent \keyword{auto} \exposid{begin} \terminal{=} \exposid{begin-expr} \terminal{;}\br
+\bnfindent \keyword{auto} \exposid{end} \terminal{=} \exposid{end-expr} \terminal{;}\br
 \bnfindent \keyword{for} \terminal{(} \terminal{;} \exposid{begin} \terminal{!=} \exposid{end}\terminal{;} \terminal{++}\exposid{begin} \terminal{)} \terminal{\{}\br
 \bnfindent\bnfindent for-range-declaration \terminal{=} \terminal{*} \exposid{begin} \terminal{;}\br
 \bnfindent\bnfindent statement\br
@@ -658,11 +658,11 @@ cannot be reinterpreted as delimiting two \grammarterm{init-declarator}{s});
 exposition only; and
 
 \item
-\placeholder{begin-expr} and \placeholder{end-expr} are determined as follows:
+\exposid{begin-expr} and \exposid{end-expr} are determined as follows:
 
 \begin{itemize}
 \item if the \grammarterm{for-range-initializer} is an expression of
-array type \tcode{R}, \placeholder{begin-expr} and \placeholder{end-expr} are
+array type \tcode{R}, \exposid{begin-expr} and \exposid{end-expr} are
 \exposid{range} and \exposid{range} \tcode{+} \tcode{N}, respectively,
 where \tcode{N} is
 the array bound. If \tcode{R} is an array of unknown bound or an array of
@@ -672,11 +672,11 @@ incomplete type, the program is ill-formed;
 class type \tcode{C}, the \grammarterm{unqualified-id}{s}
 \tcode{begin} and \tcode{end} are looked up in the scope of \tcode{C}
 as if by class member access lookup\iref{basic.lookup.classref}, and if
-both find at least one declaration, \placeholder{begin-expr} and
-\placeholder{end-expr} are \tcode{\exposid{range}.begin()} and \tcode{\exposid{range}.end()},
+both find at least one declaration, \exposid{begin-expr} and
+\exposid{end-expr} are \tcode{\exposid{range}.begin()} and \tcode{\exposid{range}.end()},
 respectively;
 
-\item otherwise, \placeholder{begin-expr} and \placeholder{end-expr} are
+\item otherwise, \exposid{begin-expr} and \exposid{end-expr} are
 \tcode{begin(\exposid{range})} and \tcode{end(\exposid{range})}, respectively,
 where \tcode{begin} and \tcode{end} are looked
 up in the associated namespaces\iref{basic.lookup.argdep}.


### PR DESCRIPTION
Those are placeholders for expressions.

Fixes #4285 