### PR TITLE
[declval] Indent example and fix phrasing in example

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -419,17 +419,17 @@ This function is not odr-used\iref{basic.def.odr}.
 \pnum
 \remarks
 The template parameter \tcode{T} of \tcode{declval} may be an incomplete type.
-\end{itemdescr}
 
 \pnum
 \begin{example}
 \begin{codeblock}
 template<class To, class From> decltype(static_cast<To>(declval<From>())) convert(From&&);
 \end{codeblock}
-declares a function template \tcode{convert} which only participates in overloading if the
+declares a function template \tcode{convert} which only participates in overload resolution if the
 type \tcode{From} can be explicitly converted to type \tcode{To}. For another example see class
 template \tcode{common_type}\iref{meta.trans.other}.
 \end{example}
+\end{itemdescr}
 
 \rSec2[utility.intcmp]{Integer comparison functions}
 


### PR DESCRIPTION
that refers to participation in overload resolution.

Fixes #4266