### PR TITLE
[layout] Make "small" line spacing equal to normal spacing.

### DIFF
--- a/source/layout.tex
+++ b/source/layout.tex
@@ -32,6 +32,12 @@
 \feetatbottom
 
 %%--------------------------------------------------
+%% Make the "small" size, used for notes and examples, have the same
+%% line height as the normal text.
+\renewcommand{\normalsize}{\fontsize{10pt}{12pt}\selectfont}
+\renewcommand{\small}{\fontsize{9pt}{12pt}\selectfont}
+
+%%--------------------------------------------------
 %% Paragraph and bullet numbering
 
 % create a new counter that resets for each new subclause


### PR DESCRIPTION
Now "normal" is 10pt/12pt (as it has always been) and "small" is
9pt/12pt. This makes notes and examples use the same line spacing as
the ambient text.


![image](https://user-images.githubusercontent.com/6378233/95389926-74370900-08ec-11eb-90c9-c04156743b13.png)

Left: new, right: before.