### PR TITLE
[rand.eng.sub] drop no-op modulo operation

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -3419,7 +3419,7 @@ linear_congruential_engine<result_type,
  Then, to set each $X_k$,
  obtain new values $z_0, \dotsc, z_{n-1}$
  from $n = \lceil w/32 \rceil$ successive invocations
- of \tcode{e} taken modulo $2^{32}$.
+ of \tcode{e}.
  Set $X_k$ to $\left( \sum_{j=0}^{n-1} z_j \cdot 2^{32j}\right) \bmod m$.
 
 \pnum


### PR DESCRIPTION
The `e()` mod 2<sup>32</sup> operation is a no-op, because `e.max()` < 2<sup>32</sup>.

When I raised this on the LWG reflector @CaseyCarter agreed that this is the case. We should simplify the spec by removing the noise.