### PR TITLE
[rand.eng], [rand.adapt] Use maths to describe relations between constants

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -3197,10 +3197,8 @@ namespace std {
 \end{codeblock}
 
 \pnum
-The following relations shall hold:
-  \tcode{0 < r}
-and
-  \tcode{r <= p}.
+The following relation shall hold:
+  $0 < r \leq p$.
 
 \pnum
 The textual representation

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -2987,11 +2987,9 @@ namespace std {
 
 \pnum
 The following relations shall hold:
-  \tcode{0u < s},
-  \tcode{s < r},
-  \tcode{0 < w},
+  $0 < s < r$
 and
-  \tcode{w <= numeric_limits<UIntType>::digits}.
+  $0 < w \leq \tcode{numeric_limits<UIntType>::digits}$.
 
 \pnum
 The textual representation

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -3389,7 +3389,7 @@ The state transition is performed as follows:
 
 \pnum
 The generation algorithm
-yields the last value of \tcode{Y}
+yields the last value of $Y$
  produced while advancing \tcode{e}'s state as described above.
 
 \indexlibraryglobal{shuffle_order_engine}%

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -3341,10 +3341,8 @@ template<class Engine, size_t w, class UIntType>
 \end{codeblock}%
 
 \pnum
-The following relations shall hold:
-  \tcode{0 < w}
-and
-  \tcode{w <= numeric_limits<result_type>::digits}.
+The following relation shall hold:
+  $0 < w \leq \tcode{numeric_limits<result_type>::digits}$.
 
 \pnum
 The textual representation

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -2541,6 +2541,13 @@ and for equality and inequality operators
 are not shown in the synopses.
 
 \pnum
+In the descriptions of the random number engines
+and random number engine adaptors
+in \ref{rand.eng} and in \ref{rand.adapt},
+a constant such as $c$ takes the value of the non-type template parameter
+of the same name, \tcode{c}, unless otherwise specified.
+
+\pnum
 Each template specified in \ref{rand.eng}
 requires one or more relationships,
 involving the value(s) of its non-type template parameter(s), to hold.

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -2823,21 +2823,19 @@ namespace std {
 
 \pnum
 The following relations shall hold:
-  \tcode{0 < m},
-  \tcode{m <= n},
-  \tcode{2u < w},
-  \tcode{r <= w},
-  \tcode{u <= w},
-  \tcode{s <= w},
-  \tcode{t <= w},
-  \tcode{l <= w},
-  \tcode{w <= numeric_limits<UIntType>::digits},
-  \tcode{a <= (1u<<w) - 1u},
-  \tcode{b <= (1u<<w) - 1u},
-  \tcode{c <= (1u<<w) - 1u},
-  \tcode{d <= (1u<<w) - 1u},
+  $0 < m \leq n$,
+  $2 < w \leq \tcode{numeric_limits<UIntType>::digits}$,
+  $r \leq w$,
+  $u \leq w$,
+  $s \leq w$,
+  $t \leq w$,
+  $l \leq w$,
+  $a \leq 2^w - 1$,
+  $b \leq 2^w - 1$,
+  $c \leq 2^w - 1$,
+  $d \leq 2^w - 1$,
 and
-  \tcode{f <= (1u<<w) - 1u}.
+  $f \leq 2^w - 1$.
 
 \pnum
 The textual representation

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -3445,7 +3445,7 @@ namespace std {
 
 \pnum
 The following relation shall hold:
-  \tcode{0 < k}.
+  $0 < k$.
 
 \pnum
 The textual representation

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -2824,7 +2824,7 @@ namespace std {
 \pnum
 The following relations shall hold:
   $0 < m \leq n$,
-  $2 < w \leq \tcode{numeric_limits<UIntType>::digits}$,
+  $2 < w \leq \tcode{numeric_limits<result_type>::digits}$,
   $r \leq w$,
   $u \leq w$,
   $s \leq w$,
@@ -2989,7 +2989,7 @@ namespace std {
 The following relations shall hold:
   $0 < s < r$
 and
-  $0 < w \leq \tcode{numeric_limits<UIntType>::digits}$.
+  $0 < w \leq \tcode{numeric_limits<result_type>::digits}$.
 
 \pnum
 The textual representation

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -2673,9 +2673,9 @@ explicit linear_congruential_engine(result_type s);
 \begin{itemdescr}
 \pnum
 \effects
- If $c \bmod m$ is $0$ and $\tcode{s} \bmod m$ is $0$,
+ If $c \bmod m$ is $0$ and $s \bmod m$ is $0$,
  sets the engine's state to $1$,
- otherwise sets the engine's state to $\tcode{s} \bmod m$.
+ otherwise sets the engine's state to $s \bmod m$.
 \end{itemdescr}
 
 \indexlibraryctor{linear_congruential_engine}%

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -3027,7 +3027,7 @@ linear_congruential_engine<result_type,
 
 \pnum
 \complexity
-Exactly $n \cdot \tcode{r}$ invocations
+Exactly $n \cdot r$ invocations
  of \tcode{e}.
 \end{itemdescr}
 

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -2655,12 +2655,10 @@ is \tcode{numeric_limits<result_type>::max()} plus $1$.
 \end{note}
 
 \pnum
-If the template parameter
-\tcode{m} is not $0$,
-the following relations shall hold:
-  \tcode{a < m}
+The following relations shall hold:
+  $a < m$
 and
-  \tcode{c < m}.
+  $c < m$.
 
 \pnum
 The textual representation


### PR DESCRIPTION
Fixes #4292 

I know that "unless otherwise specified" is strictly unnecessary in the blanket wording, but I think it helps here. In [rand.eng.lcong] we have:

>  If the template parameter `m` is _0_, the modulus _m_ used throughout this subclause (...) is [...]

That specifies _m_ for the `m==0` case, but the blanket wording applies for all other values of `m`.