### PR TITLE
Fix missing `ranges::` qualifier in example

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2751,7 +2751,7 @@ from its corresponding input stream.
 \begin{example}
 \begin{codeblock}
 auto ints = istringstream{"0 1  2   3     4"};
-ranges::copy(istream_view<int>(ints), ostream_iterator<int>{cout, "-"});
+ranges::copy(ranges::istream_view<int>(ints), ostream_iterator<int>{cout, "-"});
 // prints \tcode{0-1-2-3-4-}
 \end{codeblock}
 \end{example}


### PR DESCRIPTION
There is a `ranges::` qualifier missing here.