### PR TITLE
[ostream.manip] Introduce SYNCBUF to detect basic_syncbuf

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -6771,6 +6771,24 @@ Each instantiation of any of the function templates
 specified in this subclause
 is a designated addressable function\iref{namespace.std}.
 
+\pnum
+In this subclause,
+\exposid{SYNCBUF}\tcode{(p)} for a pointer \tcode{p} of type \tcode{B*}
+is determined as follows.
+If \tcode{*p} is a base class subobject of an object of type \tcode{S},
+where \tcode{S} is a specialization generated from
+the \tcode{basic_syncbuf} primary template,
+and \tcode{is_convertible_v<S*, B*>} is \tcode{true},
+then \exposid{SYNCBUF}\tcode{(p)} is \tcode{dynamic_cast<S*>(p)}.
+Otherwise, \exposid{SYNCBUF}\tcode{(p)} is \tcode{static_cast<void*>(nullptr)}.
+
+\begin{note}
+To work around the issue that the
+\tcode{Allocator} template argument of \tcode{S} cannot be deduced,
+implementations can introduce an intermediate base class
+to \tcode{basic_syncbuf} that manages its \tcode{emit_on_sync} flag.
+\end{note}
+
 \indexlibraryglobal{endl}%
 \begin{itemdecl}
 template<class charT, class traits>
@@ -6833,18 +6851,12 @@ template<class charT, class traits>
 
 \begin{itemdescr}
 \pnum
+Let \tcode{p} be \exposid{SYNCBUF}\tcode{(os.rdbuf())}.
+
+\pnum
 \effects
-If \tcode{os.rdbuf()} is a
-\tcode{basic_syncbuf<charT, traits, Allocator>*},
-called \tcode{buf} for the purpose of exposition,
-calls \tcode{buf->set_emit_on_sync(true)}.
+If \tcode{p} is not null, calls \tcode{p->set_emit_on_sync(true)}.
 Otherwise this manipulator has no effect.
-\begin{note}
-To work around the issue that the
-\tcode{Allocator} template argument cannot be deduced,
-implementations can introduce an intermediate base class
-to \tcode{basic_syncbuf} that manages its \tcode{emit_on_sync} flag.
-\end{note}
 
 \pnum
 \returns
@@ -6859,11 +6871,11 @@ template<class charT, class traits>
 
 \begin{itemdescr}
 \pnum
+Let \tcode{p} be \exposid{SYNCBUF}\tcode{(os.rdbuf())}.
+
+\pnum
 \effects
-If \tcode{os.rdbuf()} is a
-\tcode{basic_syncbuf<charT, traits, Allocator>*},
-called \tcode{buf} for the purpose of exposition,
-calls \tcode{buf->set_emit_on_sync(false)}.
+If \tcode{p} is not null, calls \tcode{p->set_emit_on_sync(false)}.
 Otherwise this manipulator has no effect.
 
 \pnum
@@ -6879,12 +6891,12 @@ template<class charT, class traits>
 
 \begin{itemdescr}
 \pnum
+Let \tcode{p} be \exposid{SYNCBUF}\tcode{(os.rdbuf())}.
+
+\pnum
 \effects
 Calls \tcode{os.flush()}.
-Then, if \tcode{os.rdbuf()} is a
-\tcode{basic_syncbuf<charT, traits, Allocator>*},
-called \tcode{buf} for the purpose of exposition,
-calls \tcode{buf->emit()}.
+If \tcode{p} is not null, calls \tcode{p->emit()}.
 
 \pnum
 \returns


### PR DESCRIPTION
This attempts to address the problem of `Allocator` being mentioned in
the function descriptions without being defined. We cannot say that

> `os.rdbuf()` is a `basic_syncbuf<charT, traits, Allocator>*`

because firstly, that type is not defined, and secondly `os.rdbuf()` is
a `basic_streambuf<charT, traits>*` and not any other type.

By introducing SYNCBUF we can define the manipulators properly, by
talking about a base class subobject rather than "is a".

This introduces an apparently normative change that the syncbuf type
must not use a program-defined specialization. Without that additional
restriction the implementation suggested by the note doesn't work,
because program-defined specializations cannot derive from the
intermediate base class, and therefore cannot be detected by SYNCBUF.