### PR TITLE
[thread.stoptoken.intro] Fix typo

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -312,7 +312,7 @@ for the current execution agent.
 
 \pnum
 Subclause \ref{thread.stoptoken} describes components that can be used
-to asynchonously request that an operation stops execution in a timely manner,
+to asynchronously request that an operation stops execution in a timely manner,
 typically because the result is no longer required.
 Such a request is called a \defn{stop request}.
 


### PR DESCRIPTION
[thread.stoptoken.intro] Fix typo by changing “asynchonously” to “asynchronously”.