### PR TITLE
[stringbuf.assign] Fix typo.

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -7810,7 +7810,7 @@ void swap(basic_stringbuf& rhs) noexcept(@\seebelow@);
 \expects
 \tcode{allocator_traits<Allocator>::propagate_on_container_swap::value}
 is \tcode{true} or
-\tcode{get_allocator() == s.get_allocator()} is \tcode{true}.
+\tcode{get_allocator() == rhs.get_allocator()} is \tcode{true}.
 
 \pnum
 \effects


### PR DESCRIPTION
`swap`'s parameter is `rhs`; there is no `s` here. (This appears to have been copy-pasted from `[string.swap]` where the parameter is named `s`.)