### PR TITLE
[class.access.base] Clarify 'direct member' for access checks.

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -4927,7 +4927,7 @@ would be a public member of
 \tcode{N}, or
 \item
 \placeholder{R}
-occurs in a member or friend of class
+occurs in a direct member or friend of class
 \tcode{N},
 and an invented public member of
 \tcode{B}
@@ -4935,7 +4935,7 @@ would be a private or protected member of
 \tcode{N}, or
 \item
 \placeholder{R}
-occurs in a member or friend of a class
+occurs in a direct member or friend of a class
 \tcode{P}
 derived from
 \tcode{N},
@@ -5034,7 +5034,7 @@ as a member of
 \tcode{N}
 is private, and
 \placeholder{R}
-occurs in a member or friend of class
+occurs in a direct member or friend of class
 \tcode{N},
 or
 \item
@@ -5043,7 +5043,7 @@ as a member of
 \tcode{N}
 is protected, and
 \placeholder{R}
-occurs in a member or friend of class
+occurs in a direct member or friend of class
 \tcode{N},
 or in a member of a class
 \tcode{P}
@@ -5363,7 +5363,7 @@ additional check does not apply to other members,
 e.g., static data members or enumerator member constants.
 \end{footnote}
 As described earlier, access to a protected member is granted because the
-reference occurs in a friend or member of some class \tcode{C}. If the access is
+reference occurs in a friend or direct member of some class \tcode{C}. If the access is
 to form a pointer to member\iref{expr.unary.op}, the
 \grammarterm{nested-name-specifier} shall denote \tcode{C} or a class derived from
 \tcode{C}. All other accesses involve a (possibly implicit) object


### PR DESCRIPTION
Fixes #4033