### PR TITLE
[expr] Use 'qualification-combined' and 'qualification-decomposition'.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -373,8 +373,8 @@ other type is ``pointer to function'', where the function types are otherwise th
 if \tcode{T1} is ``pointer to \cvqual{cv1} \tcode{C1}'' and \tcode{T2} is ``pointer to
 \cvqual{cv2} \tcode{C2}'', where \tcode{C1} is reference-related to \tcode{C2} or \tcode{C2} is
 reference-related to \tcode{C1}\iref{dcl.init.ref},
-the cv-combined type\iref{conv.qual}
-of \tcode{T1} and \tcode{T2} or the cv-combined type of \tcode{T2} and \tcode{T1},
+the qualification-combined type\iref{conv.qual}
+of \tcode{T1} and \tcode{T2} or the qualification-combined type of \tcode{T2} and \tcode{T1},
 respectively;
 
 \item
@@ -396,11 +396,11 @@ if \tcode{T1} is
 for some non-function type \tcode{U},
 where \tcode{C1} is
 reference-related to \tcode{C2} or \tcode{C2} is reference-related to
-\tcode{C1}\iref{dcl.init.ref}, the cv-combined type of \tcode{T2} and \tcode{T1} or the cv-combined type
+\tcode{C1}\iref{dcl.init.ref}, the qualification-combined type of \tcode{T2} and \tcode{T1} or the qualification-combined type
 of \tcode{T1} and \tcode{T2}, respectively;
 
 \item
-if \tcode{T1} and \tcode{T2} are similar types\iref{conv.qual}, the cv-combined type of \tcode{T1} and
+if \tcode{T1} and \tcode{T2} are similar types\iref{conv.qual}, the qualification-combined type of \tcode{T1} and
 \tcode{T2};
 
 \item
@@ -724,7 +724,7 @@ int k = X().n;      // OK, \tcode{X()} prvalue is converted to xvalue
 
 \indextext{conversion!qualification|(}%
 \pnum
-A \defn{cv-decomposition} of a type \tcode{T}
+A \defn{qualification-decomposition} of a type \tcode{T}
 is a sequence of
 $\cv{}_i$ and $P_i$
 such that \tcode{T} is
@@ -743,29 +743,29 @@ the cv-qualifiers $\cv{}_{i+1}$ on the element type are also taken as
 the cv-qualifiers $\cv{}_i$ of the array.
 \begin{example}
 The type denoted by the \grammarterm{type-id} \tcode{const int **}
-has three cv-decompositions,
+has three qualification-decompositions,
 taking \tcode{U}
 as ``\tcode{int}'',
 as ``pointer to \tcode{const int}'', and
 as ``pointer to pointer to \tcode{const int}''.
 \end{example}
 The $n$-tuple of cv-qualifiers after the first one
-in the longest cv-decomposition of \tcode{T}, that is,
+in the longest qualification-decomposition of \tcode{T}, that is,
 $\cv{}_1, \cv{}_2, \dotsc, \cv{}_n$, is called the
 \defn{cv-qualification signature} of \tcode{T}.
 
 \pnum
 \indextext{type!similar|see{similar types}}%
 Two types \tcode{T1} and \tcode{T2} are \defnx{similar}{similar types} if
-they have cv-decompositions with the same $n$
+they have qualification-decompositions with the same $n$
 such that corresponding $P_i$ components are either the same
 or one is ``array of $N_i$'' and the other is ``array of unknown bound of'',
 and the types denoted by \tcode{U} are the same.
 
 \pnum
-The \defnadj{cv-combined}{type} of two types \tcode{T1} and \tcode{T2}
+The \defnadj{qualification-combined}{type} of two types \tcode{T1} and \tcode{T2}
 is the type \tcode{T3}
-similar to \tcode{T1} whose cv-decomposition is such that:
+similar to \tcode{T1} whose qualification-decomposition is such that:
 \begin{itemize}
 \item
 for every $i > 0$, $\cv{}^3_i$ is the union of
@@ -779,10 +779,10 @@ or the resulting $P^3_i$ is different from $P^1_i$ or $P^2_i$,
 then \tcode{const} is added to every $\cv{}^3_k$ for $0 < k < i$,
 \end{itemize}
 where $\cv{}^j_i$ and $P^j_i$ are the components of
-the cv-decomposition of $\tcode{T}j$.
+the qualification-decomposition of $\tcode{T}j$.
 A prvalue of type \tcode{T1}
 can be converted to type \tcode{T2}
-if the cv-combined type of \tcode{T1} and \tcode{T2} is \tcode{T2}.
+if the qualification-combined type of \tcode{T1} and \tcode{T2} is \tcode{T2}.
 \begin{note}
 If a program could assign a pointer of type \tcode{T**} to a pointer of
 type \tcode{const} \tcode{T**} (that is, if line \#1 below were
@@ -801,7 +801,7 @@ int main() {
 \begin{note}
 Given similar types \tcode{T1} and \tcode{T2}, this
 construction ensures that
-both can be converted to the cv-combined type of \tcode{T1} and \tcode{T2}.
+both can be converted to the qualification-combined type of \tcode{T1} and \tcode{T2}.
 \end{note}
 
 \pnum
@@ -4144,7 +4144,7 @@ to its own type using a \tcode{const_cast} operator.
 For two similar types \tcode{T1} and \tcode{T2}\iref{conv.qual},
 a prvalue of type \tcode{T1} may be explicitly
 converted to the type \tcode{T2} using a \tcode{const_cast}
-if, considering the cv-decompositions of both types,
+if, considering the qualification-decompositions of both types,
 each $P^1_i$ is the same as $P^2_i$ for all $i$.
 The result of a \tcode{const_cast} refers to the original entity.
 \begin{example}
@@ -4203,9 +4203,9 @@ can produce undefined behavior\iref{dcl.type.cv}.
 A conversion from a type \tcode{T1} to a type \tcode{T2}
 \defnx{casts away constness}{casting away constness}
 if \tcode{T1} and \tcode{T2} are different,
-there is a cv-decomposition\iref{conv.qual} of \tcode{T1}
+there is a qualification-decomposition\iref{conv.qual} of \tcode{T1}
 yielding \placeholder{n} such that
-\tcode{T2} has a cv-decomposition of the form
+\tcode{T2} has a qualification-decomposition of the form
 \begin{indented}
 $\cv{}_0^2$ $P_0^2$ $\cv{}_1^2$ $P_1^2$ $\cdots$ $\cv{}_{n-1}^2$ $P_{n-1}^2$ $\cv{}_n^2$ $\mathtt{U}_2$,
 \end{indented}


### PR DESCRIPTION
The previous names 'cv-combined' and 'cv-decomposition' are
no longer adequate since a qualification conversion can now
convert to an array of unknown bounds.

Fixes #3088