### PR TITLE
[diff.cpp03.temp] 'export' was resurrected for modules.

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1405,11 +1405,12 @@ non-throwing.
 
 \diffref{temp.param}
 \change
-Remove \tcode{export}.
+Repurpose \keyword{export} for modules
+(\ref{module}, \ref{cpp.module}, \ref{cpp.import}).
 \rationale
-No implementation consensus.
+No implementation consensus for the \CppIII{} meaning of \keyword{export}.
 \effect
-A valid \CppIII{} declaration containing \tcode{export} is ill-formed in this
+A valid \CppIII{} program containing \tcode{export} is ill-formed in this
 revision of \Cpp{}.
 
 \diffref{temp.arg}


### PR DESCRIPTION
Fixes #4034