### PR TITLE
 [time.clock.gps.members]/2 return type typo

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -3233,7 +3233,7 @@ template<class Duration>
 \pnum
 \returns
 \begin{codeblock}
-gps_time<common_type_t<Duration, seconds>>{t.time_since_epoch()} + 315964809s
+utc_time<common_type_t<Duration, seconds>>{t.time_since_epoch()} + 315964809s
 \end{codeblock}
 \begin{note}
 \begin{codeblock}


### PR DESCRIPTION
The returns specification for `gps_clock::to_utc` says `gps_time` instead of `utc_time`, probably a copy-paste typo from p3. The original proposal, [P0355R7](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0355r7.html), also says `gps_time`, but the intent seems obvious, and the status quo doesn't compile.