### PR TITLE
[syncstream.syncbuf.cons] Remove bogus rdbuf() calls

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -10974,7 +10974,7 @@ prior to calling this constructor.
 Output stored in \tcode{other}
 prior to calling this constructor
 will be stored in \tcode{*this} afterwards.
-\tcode{other.rdbuf()->pbase() == other.rdbuf()->pptr()}
+\tcode{other.pbase() == other.pptr()}
 and
 \tcode{other.get_wrapped() == nullptr}
 are \tcode{true}.


### PR DESCRIPTION
You don't call rdbuf() to get to the streambuf, this type is the streambuf.