### PR TITLE
[utilities] Replace 'could' and 'might'

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2288,9 +2288,9 @@ is a tuple containing all but the first element of \tcode{r}.
 \pnum
 \begin{note}
 The above definition does not require \tcode{t$_{\mathrm{tail}}$}
-(or \tcode{u$_{\mathrm{tail}}$}) to be constructed. It might not
-even be possible, as \tcode{t} and \tcode{u} are not required to be copy
-constructible. Also, all comparison operator functions are short circuited;
+(or \tcode{u$_{\mathrm{tail}}$}) to be constructed;
+this is impossible if \tcode{t} or \tcode{u} is not copy-constructible.
+Also, all comparison operator functions are short circuited;
 they do not perform element accesses beyond what is required to determine the
 result of the comparison.
 \end{note}
@@ -4724,7 +4724,8 @@ Returns \tcode{false} if and only if the \tcode{variant} holds a value.
 
 \pnum
 \begin{note}
-A \tcode{variant} might not hold a value if an exception is thrown during a
+It is possible for a \tcode{variant} to hold no value
+if an exception is thrown during a
 type-changing assignment or emplacement. The latter means that even a
 \tcode{variant<float, int>} can become \tcode{valueless_by_exception()}, for
 instance by
@@ -5400,7 +5401,7 @@ Implementations should avoid the use of dynamically allocated memory for a small
 However, any such small-object optimization shall only be applied to types \tcode{T} for which
 \tcode{is_nothrow_move_constructible_v<T>} is \tcode{true}.
 \begin{example}
-A contained value of type \tcode{int} could be stored in an internal buffer,
+A contained value of type \tcode{int} can be stored in an internal buffer,
 not in separately-allocated memory.
 \end{example}
 
@@ -7529,7 +7530,7 @@ safety\iref{basic.stc.dynamic.safety}. It is
 whether
 \tcode{get_pointer_safety} returns \tcode{pointer_safety::relaxed} or
 \tcode{point\-er_safety::preferred} if the implementation has relaxed pointer
-safety.\footnote{\tcode{pointer_safety::preferred} might be returned to indicate
+safety.\footnote{\tcode{pointer_safety::preferred} can be returned to indicate
 that a leak detector is running so that the program can avoid spurious leak
 reports.}
 \end{itemdescr}
@@ -7607,10 +7608,10 @@ Nothing.
 \begin{note}
 The alignment assumption on an object \tcode{X}
 expressed by a call to \tcode{assume_aligned}
-might result in generation of more efficient code.
+can result in generation of more efficient code.
 It is up to the program to ensure that the assumption actually holds.
 The call does not cause the compiler to verify or enforce this.
-An implementation might only make the assumption
+An implementation can only make the assumption
 for those operations on \tcode{X} that access \tcode{X}
 through the pointer returned by \tcode{assume_aligned}.
 \end{note}
@@ -9057,7 +9058,7 @@ stored pointer, \tcode{old_p}, was not equal to \tcode{nullptr}, calls
 \tcode{get_deleter()(old_p)}.
 \begin{note}
 The order of these operations is significant
-because the call to \tcode{get_deleter()} might destroy \tcode{*this}.
+because the call to \tcode{get_deleter()} can destroy \tcode{*this}.
 \end{note}
 
 \pnum
@@ -9870,7 +9871,7 @@ when \tcode{T} is not an array type, \tcode{delete[] p} otherwise.
 \pnum
 \throws
 \tcode{bad_alloc}, or an \impldef{exception type when \tcode{shared_ptr}
-constructor fails} exception when a resource other than memory could not be obtained.
+constructor fails} exception when a resource other than memory cannot be obtained.
 \end{itemdescr}
 
 \indexlibraryctor{shared_ptr}%
@@ -9924,7 +9925,7 @@ If an exception is thrown, \tcode{d(p)} is called.
 \throws
 \tcode{bad_alloc}, or an \impldef{exception type when \tcode{shared_ptr}
 constructor fails} exception
-when a resource other than memory could not be obtained.
+when a resource other than memory cannot be obtained.
 \end{itemdescr}
 
 \indexlibraryctor{shared_ptr}%
@@ -10323,8 +10324,8 @@ can affect the return value of \tcode{use_count()}.
 
 \pnum
 \begin{note}
-When multiple threads
-might affect the return value of \tcode{use_count()},
+When it is possible that multiple threads
+affect the return value of \tcode{use_count()},
 the result is approximate.
 In particular, \tcode{use_count() == 1} does not imply that accesses through
 a previously destroyed \tcode{shared_ptr} have in any sense completed.
@@ -11615,9 +11616,9 @@ virtual bool do_is_equal(const memory_resource& other) const noexcept = 0;
 A derived class shall implement this function to return \tcode{true} if memory allocated from \tcode{this} can be deallocated from \tcode{other} and vice-versa,
 otherwise \tcode{false}.
 \begin{note}
-The most-derived type of \tcode{other} might not match the type of \tcode{this}.
+It is possible that the most-derived type of \tcode{other} does not match the type of \tcode{this}.
 For a derived class \tcode{D}, an implementation of this function
-could immediately return \tcode{false}
+can immediately return \tcode{false}
 if \tcode{dynamic_cast<const D*>(\&other) == nullptr}.
 \end{note}
 \end{itemdescr}
@@ -15122,7 +15123,8 @@ is \tcode{R(ArgTypes...)}.
 \pnum
 \begin{note}
 The types deduced by the deduction guides for \tcode{function}
-might change in future revisions of \Cpp{}.
+have been identified as candidates
+for being changed in a future revision of \Cpp{}.
 \end{note}
 
 \rSec4[func.wrap.func.con]{Constructors and destructor}
@@ -15896,8 +15898,8 @@ The behavior of a program is undefined if:
   directly or indirectly depends on
   an incompletely-defined object type \tcode{T}, and
 \item
-  that instantiation could yield a different result
-  were \tcode{T} hypothetically completed.
+  that instantiation would yield a different result
+  if performed in a context where \tcode{T} were a complete type.
 \end{itemize}
 
 \rSec2[meta.type.synop]{Header \tcode{<type_traits>} synopsis}
@@ -18562,10 +18564,10 @@ sort(execution::par_unseq, v.begin(), v.end());
 \end{codeblock}
 \end{example}
 \begin{note}
-Because different parallel architectures might require idiosyncratic
-parameters for efficient execution, implementations
-can provide additional execution policies to those described in this
-standard as extensions.
+Implementations can provide additional execution policies
+to those described in this standard as extensions
+to address parallel architectures that require idiosyncratic
+parameters for efficient execution.
 \end{note}
 
 \rSec2[execution.syn]{Header \tcode{<execution>} synopsis}
@@ -19723,7 +19725,7 @@ are specified in \tref{format.type.int}.
 string s0 = format("{}", 42);                           // value of \tcode{s0} is \tcode{"42"}
 string s1 = format("{0:b} {0:d} {0:o} {0:x}", 42);      // value of \tcode{s1} is \tcode{"101010 42 52 2a"}
 string s2 = format("{0:#x} {0:#X}", 42);                // value of \tcode{s2} is \tcode{"0x2a 0X2A"}
-string s3 = format("{:L}", 1234);                       // value of \tcode{s3} might be \tcode{"1,234"}
+string s3 = format("{:L}", 1234);                       // value of \tcode{s3} can be \tcode{"1,234"}
                                                         // (depending on the locale)
 \end{codeblock}
 \end{example}


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319