### PR TITLE
[time] Replace 'could' and 'might'

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -1324,7 +1324,7 @@ No overflow is induced in the conversion and
 \begin{note}
 This
 requirement prevents implicit truncation error when converting between
-integral-based \tcode{duration} types. Such a construction could easily lead to
+integral-based \tcode{duration} types. Such a construction can lead to
 confusion about the value of the \tcode{duration}.
 \end{note}
 \begin{example}
@@ -6386,7 +6386,7 @@ Initializes
 \tcode{d_} with \tcode{ymdl.day()}.
 \begin{note}
 This conversion from \tcode{year_month_day_last} to \tcode{year_month_day}
-might be more efficient than converting a \tcode{year_month_day_last} to a \tcode{sys_days},
+can be more efficient than converting a \tcode{year_month_day_last} to a \tcode{sys_days},
 and then converting that \tcode{sys_days} to a \tcode{year_month_day}.
 \end{note}
 \end{itemdescr}
@@ -6957,7 +6957,7 @@ Otherwise, the returned value is unspecified.
 
 \pnum
 \begin{note}
-This value might be computed on demand.
+This value can be computed on demand.
 \end{note}
 \end{itemdescr}
 
@@ -9267,13 +9267,14 @@ offset = local_time - sys_time
 The \tcode{save} data member is extra information not normally needed
 for conversion between \tcode{local_time} and \tcode{sys_time}.
 If \tcode{save != 0min}, this \tcode{sys_info} is said to be on ``daylight saving'' time,
-and \tcode{offset - save} suggests what offset this \tcode{time_zone} might use
+and \tcode{offset - save} provides a non-authoritative suggestion of
+the offset this \tcode{time_zone} would use
 if it were off daylight saving time.
-However, this information should not be taken as authoritative.
-The only sure way to get such information
-is to query the \tcode{time_zone} with a \tcode{time_point}
+A correct offset for the \tcode{time_zone} off daylight saving time
+can be obtained by querying the \tcode{time_zone} with a \tcode{time_point}
 that returns a \tcode{sys_info} where \tcode{save == 0min}.
-There is no guarantee what \tcode{time_point} might return such a \tcode{sys_info}
+There is no guarantee
+what \tcode{time_point} (if any) returns such a \tcode{sys_info}
 except that it is guaranteed not to be in the range \range{begin}{end}
 (if \tcode{save != 0min} for this \tcode{sys_info}).
 


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319