### PR TITLE
[strings] Replace 'could' and 'might'

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -3679,7 +3679,7 @@ The converted result.
 \pnum
 \throws
 \tcode{invalid_argument} if \tcode{strtol}, \tcode{strtoul},
-\tcode{strtoll}, or \tcode{strtoull} reports that no conversion could be
+\tcode{strtoll}, or \tcode{strtoull} reports that no conversion can be
 performed. Throws \tcode{out_of_range} if \tcode{strtol}, \tcode{strtoul},
 \tcode{strtoll} or \tcode{strtoull} sets \tcode{errno} to \tcode{ERANGE},
 or if the converted value is outside the range of representable values
@@ -3716,7 +3716,7 @@ The converted result.
 \pnum
 \throws
 \tcode{invalid_argument} if \tcode{strtof}, \tcode{strtod}, or
-\tcode{strtold} reports that no conversion could be performed. Throws
+\tcode{strtold} reports that no conversion can be performed. Throws
 \tcode{out_of_range} if \tcode{strtof}, \tcode{strtod}, or
 \tcode{strtold} sets \tcode{errno} to \tcode{ERANGE}
 or if the converted value is outside the range of representable
@@ -3785,7 +3785,7 @@ The converted result.
 \pnum
 \throws
 \tcode{invalid_argument} if \tcode{wcstol}, \tcode{wcstoul}, \tcode{wcstoll}, or
-\tcode{wcstoull} reports that no conversion could be performed. Throws
+\tcode{wcstoull} reports that no conversion can be performed. Throws
 \tcode{out_of_range} if the converted value is outside the range of representable values
 for the return type.
 \end{itemdescr}
@@ -3817,7 +3817,7 @@ The converted result.
 \pnum
 \throws
 \tcode{invalid_argument} if \tcode{wcstof}, \tcode{wcstod}, or \tcode{wcstold} reports that no
-conversion could be performed. Throws \tcode{out_of_range} if \tcode{wcstof}, \tcode{wcstod}, or
+conversion can be performed. Throws \tcode{out_of_range} if \tcode{wcstof}, \tcode{wcstod}, or
 \tcode{wcstold} sets \tcode{errno} to \tcode{ERANGE}.
 \end{itemdescr}
 


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319