### PR TITLE
[iterators] Replace 'could' and 'might'

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2081,7 +2081,7 @@ such an algorithm should be a single-pass algorithm.
 The only valid use of an \tcode{operator*}
 is on the left side of the assignment statement.
 Assignment through the same value of the iterator happens only once.
-Equality and inequality might not be defined.
+Equality and inequality are not necessarily defined.
 \end{note}
 
 \rSec3[forward.iterators]{Forward iterators}
@@ -2636,12 +2636,9 @@ namespace std {
 
 \pnum
 \begin{example}
-For a program-defined iterator
-\tcode{BinaryTreeIterator},
-it could be included
-into the bidirectional iterator category by specializing the
-\tcode{iterator_traits}
-template:
+A program-defined iterator \tcode{BinaryTreeIterator}
+can be included into the bidirectional iterator category by
+specializing the \tcode{iterator_traits} template:
 
 \begin{codeblock}
 template<class T> struct iterator_traits<BinaryTreeIterator<T>> {


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319