### PR TITLE
[ranges] Replace 'could' and 'might'

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1016,8 +1016,9 @@ type models \libconcept{forward_iterator} to multiple
 algorithms and making multiple passes over the range by repeated calls to
 \tcode{ranges::begin} and \tcode{ranges::end}.
 Since \tcode{ranges::begin} is not required to be equality-preserving
-when the return type does not model \libconcept{forward_iterator}, repeated calls
-might not return equal values or might not be well-defined.
+when the return type does not model \libconcept{forward_iterator},
+it is possible for repeated calls
+to not return equal values or to not be well-defined.
 \end{note}
 \end{itemdescr}
 
@@ -1104,7 +1105,7 @@ and is equal to \tcode{ranges::distance(t)}, and
 \begin{note}
 \tcode{ranges::size(t)} is otherwise not required to be
 well-defined after evaluating \tcode{ranges::begin(t)}.
-For example, \tcode{ranges::size(t)} might be well-defined
+For example, it is possible for \tcode{ranges::size(t)} to be well-defined
 for a \libconcept{sized_range} whose iterator type
 does not model \libconcept{forward_iterator}
 only if evaluated before the first call to \tcode{ranges::begin(t)}.
@@ -1817,7 +1818,7 @@ with the template aliases \tcode{borrowed_iterator_t} and \tcode{borrowed_subran
 to indicate that an algorithm
 that typically returns an iterator into or subrange of a \tcode{range} argument
 does not return an iterator or subrange
-which could potentially reference a range
+which would potentially reference a range
 whose lifetime has ended for a particular rvalue \tcode{range} argument
 which does not model \libconcept{borrowed_range}\iref{range.range}.
 \indexlibraryglobal{dangling}%
@@ -1845,7 +1846,7 @@ static_assert(@\libconcept{same_as}@<decltype(result3), vector<int>::iterator>);
 \end{codeblock}
 The call to \tcode{ranges::find} at \#1 returns \tcode{ranges::dangling}
 since \tcode{f()} is an rvalue \tcode{vector};
-the \tcode{vector} could potentially be destroyed
+it is possible for the \tcode{vector} to be destroyed
 before a returned iterator is dereferenced.
 However, the calls at \#2 and \#3 both return iterators
 since the lvalue \tcode{vec} and specializations of \tcode{subrange}


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319