### PR TITLE
[algorithms] Replace 'could' and 'might'

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -136,7 +136,7 @@ When the cost of doing the operation dominates the cost of copy,
 the copying version is not included.
 For example, \tcode{sort_copy} is not included
 because the cost of sorting is much more significant,
-and users might as well do \tcode{copy} followed by \tcode{sort}.}
+and users can invoke \tcode{copy} followed by \tcode{sort}.}
 When such a version is provided for \textit{algorithm} it is called
 \textit{algorithm\tcode{_copy}}.
 Algorithms that take predicates end with the suffix \tcode{_if}
@@ -4398,7 +4398,7 @@ The ranges \range{first}{last} and \range{result}{result + (last - first)}
 do not overlap.
 \begin{note}
 For the overload with an \tcode{ExecutionPolicy},
-there might be a performance cost
+a performance cost is possible
 if \tcode{iterator_traits<For\-ward\-It\-er\-ator1>::value_type}
 is not \oldconcept{\-Move\-Constructible} (\tref{cpp17.moveconstructible}).
 \end{note}
@@ -5296,9 +5296,9 @@ The ranges \range{first}{last} and \range{result}{result + (last - first)}
 do not overlap.
 \begin{note}
 For the overloads with an \tcode{ExecutionPolicy},
-there might be a performance cost
-if \tcode{iterator_traits<ForwardIterator1>::value_type} does not meet
-the \oldconcept{\-Move\-Constructible} (\tref{cpp17.moveconstructible}) requirements.
+a performance cost is possible
+if \tcode{iterator_traits<For\-ward\-Iterator1>::value_type} does not meet
+the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) requirements.
 \end{note}
 
 \pnum
@@ -5483,7 +5483,7 @@ let $E$ be
     \oldconcept{CopyAssignable} requirements.
     \begin{note}
     For the overloads with an \tcode{ExecutionPolicy},
-    there might be a performance cost
+    a performance cost is possible
     if the value type of \tcode{ForwardIterator1} does not meet both the
     \oldconcept{CopyConstructible} and \oldconcept{CopyAssignable} requirements.
     \end{note}
@@ -7022,7 +7022,8 @@ The input range and output ranges do not overlap.
 
 \begin{note}
 For the overload with an \tcode{ExecutionPolicy},
-there might be a performance cost if \tcode{first}'s value type
+a performance cost is possible
+if \tcode{first}'s value type
 does not meet the \oldconcept{CopyConstructible} requirements.
 \end{note}
 
@@ -8598,7 +8599,7 @@ of the first corresponding pair of elements that are not equivalent.
 \pnum
 \begin{example}
 \tcode{ranges::lexicographical_compare(I1, S1, I2, S2, Comp, Proj1, Proj2)}
-could be implemented as:
+can be implemented as:
 \begin{codeblock}
 for ( ; first1 != last1 && first2 != last2 ; ++first1, (void) ++first2) {
   if (invoke(comp, invoke(proj1, *first1), invoke(proj2, *first2))) return true;
@@ -9541,7 +9542,7 @@ The difference between \tcode{exclusive_scan} and \tcode{inclusive_scan} is
 that \tcode{exclusive_scan} excludes the $i^\text{th}$ input element
 from the $i^\text{th}$ sum.
 If \tcode{binary_op} is not mathematically associative,
-the behavior of \tcode{exclusive_scan} might be nondeterministic.
+the behavior of \tcode{exclusive_scan} can be nondeterministic.
 \end{note}
 \end{itemdescr}
 
@@ -9668,7 +9669,7 @@ The difference between \tcode{exclusive_scan} and \tcode{inclusive_scan} is
 that \tcode{inclusive_scan} includes the $i^\text{th}$ input element
 in the $i^\text{th}$ sum.
 If \tcode{binary_op} is not mathematically associative,
-the behavior of \tcode{inclusive_scan} might be nondeterministic.
+the behavior of \tcode{inclusive_scan} can be nondeterministic.
 \end{note}
 \end{itemdescr}
 
@@ -9743,7 +9744,7 @@ The difference between \tcode{transform_exclusive_scan} and
 \tcode{transform_inclusive_scan} is that \tcode{trans\-form\-_\-exclusive_scan}
 excludes the $i^\text{th}$ input element from the $i^\text{th}$ sum.
 If \tcode{binary_op} is not mathematically associative,
-the behavior of \tcode{transform_exclusive_scan} might be nondeterministic.
+the behavior of \tcode{transform_exclusive_scan} can be nondeterministic.
 \tcode{transform_exclusive_scan}
 does not apply \tcode{unary_op} to \tcode{init}.
 \end{note}
@@ -9848,7 +9849,7 @@ The difference between \tcode{transform_exclusive_scan} and
 \tcode{transform_inclusive_scan} is that \tcode{trans\-form\-_\-inclusive_scan}
 includes the $i^\text{th}$ input element in the $i^\text{th}$ sum.
 If \tcode{binary_op} is not mathematically associative,
-the behavior of \tcode{transform_inclusive_scan} might be nondeterministic.
+the behavior of \tcode{transform_inclusive_scan} can be nondeterministic.
 \tcode{transform_inclusive_scan} does not
 apply \tcode{unary_op} to \tcode{init}.
 \end{note}

--- a/source/std.tex
+++ b/source/std.tex
@@ -78,7 +78,7 @@
 
 %%--------------------------------------------------
 %% add special hyphenation rules
-\hyphenation{tem-plate ex-am-ple in-put-it-er-a-tor name-space name-spaces non-zero cus-tom-i-za-tion}
+\hyphenation{tem-plate ex-am-ple in-put-it-er-a-tor name-space name-spaces non-zero cus-tom-i-za-tion im-ple-men-ted}
 
 %%--------------------------------------------------
 %% turn off all ligatures inside \texttt


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319