### PR TITLE
[numerics] Replace 'could' and 'might'

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -4119,7 +4119,7 @@ explicit random_device(const string& token);
 \throws
 A value of an \impldef{exception type when \tcode{random_device} constructor fails} type
  derived from \tcode{exception}
- if the \tcode{random_device} could not be initialized.
+ if the \tcode{random_device} cannot be initialized.
 \end{itemdescr}
 
 \indexlibrarymember{entropy}{random_device}%
@@ -4162,7 +4162,7 @@ A nondeterministic random value,
 \throws
 A value of an \impldef{exception type when \tcode{random_device::operator()} fails}
  type derived from \tcode{exception}
- if a random number could not be obtained.
+ if a random number cannot be obtained.
 \end{itemdescr}
 
 


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319