### PR TITLE
[localization] Replace 'could' and 'might'

### DIFF
--- a/source/locales.tex
+++ b/source/locales.tex
@@ -176,7 +176,7 @@ and
 
 \pnum
 \begin{example}
-An iostream \tcode{operator<<} might be implemented as:%
+An iostream \tcode{operator<<} can be implemented as:%
 \footnote{Note that in the call to \tcode{put},
 the stream is implicitly converted
 to an \tcode{ostreambuf_iterator<charT, traits>}.}
@@ -192,7 +192,7 @@ operator<< (basic_ostream<charT, traits>& s, Date d) {
       use_facet<time_put<charT, ostreambuf_iterator<charT, traits>>>(
         s.getloc()).put(s, s, s.fill(), &tmbuf, 'x').failed();
     if (failed)
-      s.setstate(s.badbit);     // might throw
+      s.setstate(s.badbit);     // can throw
   }
   return s;
 }
@@ -2084,7 +2084,7 @@ An enumeration value, as summarized in \tref{locale.codecvt.inout}.
 \tcode{partial}             &   not all source characters converted \\
 \tcode{error}               &
 encountered a character in \range{from}{from_end}
-that it could not convert                                           \\
+that cannot be converted                                           \\
 \tcode{noconv}              &
 \tcode{internT} and \tcode{externT} are the same type, and input
 sequence is identical to converted sequence                         \\
@@ -3834,7 +3834,7 @@ iter_type do_get_monthname(iter_type s, iter_type end, ios_base& str,
 \effects
 Reads characters starting at \tcode{s}
 until it has extracted the (perhaps abbreviated) name of a weekday or month.
-If it finds an abbreviation that is followed by characters that could
+If it finds an abbreviation that is followed by characters that can
 match a full name, it continues reading until it matches the full name or
 fails.
 It sets the appropriate


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319