### PR TITLE
[input.output] Replace 'could' and 'might'

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -3659,7 +3659,7 @@ or
 will fail.\footnote{\tcode{underflow}
 or
 \tcode{uflow}
-might fail by throwing an exception prematurely.
+can fail by throwing an exception prematurely.
 The intention is not only that the calls will not return
 \tcode{eof()}
 but that they will return ``immediately''.}
@@ -3895,8 +3895,8 @@ are the same as for
 \returns
 \tcode{traits::eof()}
 to indicate failure.
-Failure may occur because the input sequence could not be backed up, or if for some
-other reason the pointers could not be set consistent with the constraints.
+Failure may occur because the input sequence cannot be backed up, or if for some
+other reason the pointers cannot be set consistent with the constraints.
 \tcode{pbackfail()}
 is called only when put back has really failed.
 
@@ -7774,7 +7774,7 @@ according to \tcode{mode}.
 \pnum
 \begin{note}
 For efficiency reasons,
-stream buffer operations might violate invariants of \tcode{buf}
+stream buffer operations can violate invariants of \tcode{buf}
 while it is held encapsulated in the \tcode{basic_stringbuf},
 e.g., by writing to characters in the range
 \range{\tcode{buf.data() + buf.size()}}{\tcode{buf.data() + buf.capacity()}}.
@@ -11165,7 +11165,7 @@ Initializes the base class with \tcode{basic_ostream<charT, traits>(addressof(sb
 \begin{note}
 The member functions of the provided stream buffer
 can be called from \tcode{emit()} while a lock is held,
-which might result in a deadlock if used incautiously.
+which can result in a deadlock if used incautiously.
 \end{note}
 
 \pnum
@@ -12512,9 +12512,9 @@ Otherwise, modifies \tcode{*this} as if by these steps:
 \pnum
 \begin{example}
 Even if \tcode{//host} is interpreted as a \grammarterm{root-name},
+and even if \tcode{operator/} appends a backslash as the separator,
 both of the paths \tcode{path("//host")/"foo"} and \tcode{path("//host/")/"foo"}
-equal \tcode{"//host/foo"} (although the former might use backslash as the
-preferred separator).
+equal \tcode{"//host/foo"}.
 
 Expression examples:
 \begin{codeblock}
@@ -12586,8 +12586,8 @@ template<class Source>
 \effects
 Appends \tcode{path(x).native()} to the pathname in the native format.
 \begin{note}
-This directly manipulates the value of \tcode{native()}
-and might not be portable between operating systems.
+This directly manipulates the value of \tcode{native()},
+which is not necessarily portable between operating systems.
 \end{note}
 
 \pnum
@@ -13772,7 +13772,7 @@ for file systems supporting additional types of file}
 \tcode{file_type} constants
 to separately identify each of those additional file types \\ \rowsep
 \tcode{unknown} &
-The file exists but the type could not be determined \\
+The file exists but the type cannot be determined \\
 \end{floattable}
 
 \rSec3[fs.enum.copy.opts]{Enum class \tcode{copy_options}}
@@ -14624,11 +14624,12 @@ as a friend of class \tcode{directory_entry}.
 
 \pnum
 \begin{note}
-A path obtained by dereferencing a directory iterator might not actually exist;
-it could be a symbolic link to a non-existent file.
+It is possible for a path obtained by dereferencing a directory iterator
+to not actually exist;
+for example if it is a symbolic link to a non-existent file.
 Recursively walking directory trees
 for purposes of removing and renaming entries
-might invalidate symbolic links that are being followed.
+can invalidate symbolic links that are being followed.
 \end{note}
 
 \pnum
@@ -14837,7 +14838,7 @@ as a \tcode{directory_iterator} unless otherwise specified.
 \pnum
 \begin{note}
 If the directory structure being iterated over contains cycles
-then the end iterator might be unreachable.
+then it is possible for the end iterator to be unreachable.
 \end{note}
 
 \rSec3[fs.rec.dir.itr.members]{Members}
@@ -15185,8 +15186,8 @@ As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{note}
-To resolve symlinks,
-or perform other sanitization which might require queries to secondary storage,
+To resolve symlinks
+or perform other sanitization that can involve queries to secondary storage,
 such as hard disks, consider \tcode{canonical}\iref{fs.op.canonical}.
 \end{note}
 
@@ -15201,7 +15202,7 @@ and not consider \tcode{!exists(p)} an error.
 For POSIX-based operating systems,
 \tcode{absolute(p)} is simply \tcode{current_path()/p}.
 For Windows-based operating systems,
-\tcode{absolute} might have the same semantics as \tcode{GetFullPathNameW}.
+\tcode{absolute} typically has the same semantics as \tcode{GetFullPathNameW}.
 \end{example}
 \end{itemdescr}
 
@@ -15762,7 +15763,7 @@ The \tcode{current_path()} name was chosen to emphasize that the returned value 
 \pnum
 \begin{note}
 The current path as returned by many operating systems is a dangerous
-  global variable. It might be changed unexpectedly by third-party or system
+  global variable, and can be changed unexpectedly by third-party or system
   library functions, or by another thread.
 \end{note}
 \end{itemdescr}
@@ -15789,7 +15790,7 @@ As specified in~\ref{fs.err.report}.
 \pnum
 \begin{note}
 The current path for many operating systems is a dangerous
-  global state. It might be changed unexpectedly by a third-party or system
+  global state, and can be changed unexpectedly by a third-party or system
   library functions, or by another thread.
 \end{note}
 \end{itemdescr}
@@ -16277,8 +16278,8 @@ As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{note}
-A postcondition of \tcode{last_write_time(p) == new_time} is not specified since it might not hold for file systems
-  with coarse time granularity.
+A postcondition of \tcode{last_write_time(p) == new_time} is not specified
+because it does not necessarily hold for file systems with coarse time granularity.
 \end{note}
 \end{itemdescr}
 
@@ -16520,7 +16521,7 @@ Renames \tcode{old_p} to \tcode{new_p}, as if by
     \tcode{new_p} is removed; otherwise,
 \item if \tcode{new_p} resolves to an existing directory,
     \tcode{new_p} is removed if empty on POSIX compliant operating systems
-    but might be an error on other operating systems.
+    but can be an error on other operating systems.
 \end{itemize}
 \end{itemize}
 A symbolic link is itself renamed, rather than the file it resolves to.
@@ -16583,8 +16584,7 @@ As specified in~\ref{fs.err.report}.
 The value of member \tcode{space_info::available}
       is operating system dependent.
 \begin{note}
-\tcode{available} might be
-      less than \tcode{free}.
+\tcode{available} can be less than \tcode{free}.
 \end{note}
 \end{itemdescr}
 
@@ -16789,12 +16789,12 @@ As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{example}
-For POSIX-based operating systems, an implementation might
+For POSIX-based operating systems, an implementation can
   return the path
   supplied by the first environment variable found in the list TMPDIR, TMP, TEMP, TEMPDIR,
   or if none of these are found, \tcode{"/tmp"}.
 
-For Windows-based operating systems, an implementation might return the path
+For Windows-based operating systems, an implementation can return the path
   reported by the Windows \tcode{GetTempPath} API function.
 \end{example}
 \end{itemdescr}


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319