### PR TITLE
[atomics] Replace 'could' and 'might'

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -769,7 +769,7 @@ through a referencing \tcode{atomic_ref} are atomic with respect to
 atomic operations applied through any other \tcode{atomic_ref}
 referencing the same object.
 \begin{note}
-Atomic operations or the \tcode{atomic_ref} constructor could acquire
+Atomic operations or the \tcode{atomic_ref} constructor can acquire
 a shared resource, such as a lock associated with the referenced object,
 to enable atomic operations to be applied to the referenced object.
 \end{note}
@@ -791,14 +791,15 @@ which is at least \tcode{alignof(T)}.
 
 \pnum
 \begin{note}
-Hardware could require an object
+Hardware can require an object
 referenced by an \tcode{atomic_ref}
 to have stricter alignment\iref{basic.align}
 than other objects of type \tcode{T}.
 Further, whether operations on an \tcode{atomic_ref}
-are lock-free could depend on the alignment of the referenced object.
-For example, lock-free operations on \tcode{std::complex<double>}
-could be supported only if aligned to \tcode{2*alignof(double)}.
+are lock-free can depend on the alignment of the referenced object.
+For example, it is possible that the hardware supports
+lock-free atomic operations on a \tcode{std::complex<double>} object
+only if the object is aligned to \tcode{2*alignof(double)}.
 \end{note}
 \end{itemdescr}
 
@@ -1607,7 +1608,7 @@ The program is ill-formed if any of
 is \tcode{false}.
 \begin{note}
 Type arguments that are
-not also statically initializable might be difficult to use.
+not also statically initializable can be difficult to use.
 \end{note}
 
 \pnum
@@ -1970,7 +1971,7 @@ would not, the strong one is preferable.
 \pnum
 \begin{note}
 Under cases where the \tcode{memcpy} and \tcode{memcmp} semantics of the compare-and-exchange
-operations apply, the outcome might be failed comparisons for values that compare equal with
+operations apply, the comparisons can fail for values that compare equal with
 \tcode{operator==} if the value representation has trap bits or alternate
 representations of the same value. Notably, on implementations conforming to
 ISO/IEC/IEEE 60559, floating-point \tcode{-0.0} and \tcode{+0.0}
@@ -1999,7 +2000,7 @@ bool zap() {
 \end{note}
 \begin{note}
 For a union with bits that participate in the value representation
-of some members but not others, compare-and-exchange might always fail.
+of some members but not others, it is possible for compare-and-exchange to always fail.
 This is because such padding bits have an indeterminate value when they
 do not participate in the value representation of the active member.
 As a consequence, the following code is not guaranteed to ever succeed:


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319