### PR TITLE
[thread] Replace 'could' and 'might'

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -134,7 +134,7 @@ should decrease the duration of the wait when the clock is adjusted forwards.
 \pnum
 \begin{note}
 If the clock is not synchronized with a steady clock, e.g., a CPU time clock,
-it is possible for these timeouts not to provide useful functionality.
+it is possible that these timeouts do not provide useful functionality.
 \end{note}
 
 \pnum
@@ -7245,8 +7245,8 @@ int work(int value) {
 \begin{note}
 It is possible for line \#1 not to result in concurrency
 because the \tcode{async} call uses the default policy,
-which possibly uses \tcode{launch::deferred},
-in which case it is possible for the lambda not to be invoked until the
+which can use \tcode{launch::deferred},
+in which case it is possible that the lambda is not invoked until the
 \tcode{get()} call;
 in that case, \tcode{work1} and \tcode{work2} are called on the
 same thread and there is no concurrency.

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -133,8 +133,8 @@ should decrease the duration of the wait when the clock is adjusted forwards.
 
 \pnum
 \begin{note}
-If the clock is not synchronized with a steady clock, e.g., a CPU time clock, these
-timeouts might not provide useful functionality.
+If the clock is not synchronized with a steady clock, e.g., a CPU time clock,
+it is possible for these timeouts not to provide useful functionality.
 \end{note}
 
 \pnum
@@ -638,7 +638,7 @@ and \tcode{stop_requested()} is \tcode{false}.
 
 \pnum
 \throws
-\tcode{bad_alloc} if memory could not be allocated for the stop state.
+\tcode{bad_alloc} if memory cannot be allocated for the stop state.
 \end{itemdescr}
 
 \indexlibraryctor{stop_source}%
@@ -1270,7 +1270,7 @@ value of \tcode{x.get_id()} prior to the start of construction.
 If \tcode{joinable()}, calls \tcode{terminate()}. Otherwise, has no effects.
 \begin{note}
 Either implicitly detaching or joining a \tcode{joinable()} thread in its
-destructor could result in difficult to debug correctness (for detach) or performance
+destructor can result in difficult to debug correctness (for detach) or performance
 (for join) bugs encountered only when an exception is thrown.
 These bugs can be avoided by ensuring that
 the destructor is never executed while the thread is still joinable.
@@ -2194,7 +2194,7 @@ It is a standard-layout class\iref{class.prop}.
 \begin{note}
 A program can deadlock if the thread that owns a \tcode{mutex} object calls
 \tcode{lock()} on that object. If the implementation can detect the deadlock,
-a \tcode{resource_deadlock_would_occur} error condition might be observed.
+a \tcode{resource_deadlock_would_occur} error condition can be observed.
 \end{note}
 
 \pnum
@@ -4248,7 +4248,7 @@ all objects with thread storage duration associated with the current thread.
 \pnum
 \begin{note}
 The supplied lock is held until the thread exits,
-which might cause deadlock due to lock ordering issues.
+which can cause deadlock due to lock ordering issues.
 \end{note}
 
 \pnum
@@ -4332,7 +4332,7 @@ limitation prevents initialization.
 There is no thread blocked on \tcode{*this}.
 \begin{note}
 That is, all
-threads have been notified; they could subsequently block on the lock specified in the
+threads have been notified; they can subsequently block on the lock specified in the
 wait.
 This relaxes the usual rules, which would have required all wait calls to happen before
 destruction. Only the notification to unblock the wait needs to happen before destruction.
@@ -4776,7 +4776,7 @@ privilege to perform the operation.
 There is no thread blocked on \tcode{*this}.
 \begin{note}
 That is, all
-threads have been notified; they could subsequently block on the lock specified in the
+threads have been notified; they can subsequently block on the lock specified in the
 wait.
 This relaxes the usual rules, which would have required all wait calls to happen before
 destruction. Only the notification to unblock the wait needs to happen before destruction.
@@ -6934,7 +6934,7 @@ the return type and return value of the member function \tcode{get}.
 \pnum
 \begin{note}
 Access to a value object stored in the shared state is
-unsynchronized, so operations on \tcode{R} might
+unsynchronized, so it is possible for operations on \tcode{R} to
 introduce a data race\iref{intro.multithread}.
 \end{note}
 
@@ -7192,8 +7192,8 @@ another thread.
 The completion of the function \tcode{f} is sequenced before\iref{intro.multithread} the
 shared state is made ready.
 \begin{note}
-\tcode{f} might not be called at all,
-so its completion might never happen.
+It is possible for \tcode{f} not to be called at all,
+in which case its completion never happens.
 \end{note}
 \end{itemize}
 
@@ -7220,7 +7220,7 @@ happens first.
 \tcode{system_error} if \tcode{policy == launch::async} and the
 implementation is unable to start a new thread, or
 \tcode{std::bad_alloc} if memory for the internal data structures
-could not be allocated.
+cannot be allocated.
 
 \pnum
 \errors
@@ -7243,10 +7243,12 @@ int work(int value) {
 \end{codeblock}
 
 \begin{note}
-Line \#1 might not result in concurrency because
-the \tcode{async} call uses the default policy, which might use
-\tcode{launch::deferred}, in which case the lambda might not be invoked until the
-\tcode{get()} call; in that case, \tcode{work1} and \tcode{work2} are called on the
+It is possible for line \#1 not to result in concurrency
+because the \tcode{async} call uses the default policy,
+which possibly uses \tcode{launch::deferred},
+in which case it is possible for the lambda not to be invoked until the
+\tcode{get()} call;
+in that case, \tcode{work1} and \tcode{work2} are called on the
 same thread and there is no concurrency.
 \end{note}
 \end{example}
@@ -7347,7 +7349,7 @@ initializes the object's stored task with \tcode{std::forward<F>(f)}.
 \throws
 Any exceptions thrown by the copy or move constructor of \tcode{f}, or
 \tcode{bad_alloc} if memory for the internal data structures
-could not be allocated.
+cannot be allocated.
 \end{itemdescr}
 
 \indexlibraryctor{packaged_task}%
@@ -7539,7 +7541,7 @@ old state is abandoned\iref{futures.state}.
 \pnum
 \throws
 \begin{itemize}
-\item \tcode{bad_alloc} if memory for the new shared state could not be allocated.
+\item \tcode{bad_alloc} if memory for the new shared state cannot be allocated.
 \item any exception thrown by the move constructor of the task stored in the shared
 state.
 \item \tcode{future_error} with an error condition of \tcode{no_state} if \tcode{*this}


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319