### PR TITLE
[diff] Replace 'could' and 'might'

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -379,9 +379,9 @@ and make it easier to write the full complement of equality operations.
 \effect
 Equality and inequality expressions between two objects of different types,
 where one is convertible to the other,
-could invoke a different operator.
+can invoke a different operator.
 Equality and inequality expressions between two objects of the same type
-could become ambiguous.
+can become ambiguous.
 \begin{codeblock}
 struct A {
   operator int() const;
@@ -517,7 +517,7 @@ changed from \tcode{void} to \tcode{container::size_type}.
 \rationale
 Improve efficiency and convenience of finding number of removed elements.
 \effect
-Code that depends on the return types might have different semantics in this revision of \Cpp{}.
+Code that depends on the return types can have different semantics in this revision of \Cpp{}.
 Translation units compiled against this version of \Cpp{} may be incompatible with
 translation units compiled against \CppXVII{}, either failing to link or having undefined behavior.
 
@@ -626,14 +626,14 @@ The function did not have a clear specification when multiple exceptions were
 active, and has been superseded by \tcode{uncaught_exceptions}.
 \effect
 A valid \CppXVII{} program that calls \tcode{std::uncaught_exception} may fail
-to compile. It might be revised to use \tcode{std::uncaught_exceptions} instead,
+to compile. It can be revised to use \tcode{std::uncaught_exceptions} instead,
 for clear and portable semantics.
 
 \nodiffref
 \change
 Remove support for adaptable function API.
 \rationale
-The deprecated support relied on a limited convention that could not be
+The deprecated support relied on a limited convention that cannot be
 extended to support the general case or new language features. It has been
 superseded by direct language support with \tcode{decltype}, and by the
 \tcode{std::bind} and \tcode{std::not_fn} function templates.
@@ -664,8 +664,8 @@ A valid \CppXVII{} program that directly makes use of the \tcode{pointer},
 \change
 Remove \tcode{raw_storage_iterator}.
 \rationale
-The iterator encouraged use of algorithms that might throw exceptions, but did
-not return the number of elements successfully constructed that might need to
+The iterator encouraged use of potentially-throwing algorithms, but did
+not return the number of elements successfully constructed, which need to
 be destroyed in order to avoid leaks.
 \effect
 A valid \CppXVII{} program that uses this iterator class may fail to compile.
@@ -701,7 +701,7 @@ Remove deprecated type traits.
 The traits had unreliable or awkward interfaces. The \tcode{is_literal_type}
 trait provided no way to detect which subset of constructors and member
 functions of a type were declared \tcode{constexpr}. The \tcode{result_of}
-trait had a surprising syntax that could not report the result of a regular
+trait had a surprising syntax that would not report the result of a regular
 function type. It has been superseded by the \tcode{invoke_result} trait.
 \effect
 A valid \CppXVII{} program that relies on the \tcode{is_literal_type} or
@@ -762,7 +762,7 @@ Obsolete feature with occasionally surprising semantics.
 \effect
 A valid \CppXIV{} expression utilizing the increment operator on
 a \tcode{bool} lvalue is ill-formed in this revision of \Cpp{}.
-Note that this might occur when the lvalue has a type given by a template
+Note that this can occur when the lvalue has a type given by a template
 parameter.
 
 \diffref{expr.new,expr.delete}
@@ -920,7 +920,7 @@ is rejected as ill-formed in this revision of \Cpp{}.
 Violating a non-throwing dynamic exception specification
 calls \tcode{terminate}
 rather than \tcode{unexpected}
-and might not perform stack unwinding prior to such a call.
+and it is unspecified whether stack unwinding is performed prior to such a call.
 
 \rSec2[diff.cpp14.library]{\ref{library}: library introduction}
 
@@ -948,7 +948,7 @@ invalid in this revision of \Cpp{}.
 New reserved namespaces.
 \rationale
 Reserve namespaces for future revisions of the standard library
-that might otherwise be incompatible with existing programs.
+that can otherwise be incompatible with existing programs.
 \effect
 The global namespaces \tcode{std}
 followed by an arbitrary sequence of \grammarterm{digit}{s}\iref{lex.name}
@@ -1109,7 +1109,7 @@ New usual (non-placement) deallocator.
 \rationale
 Required for sized deallocation.
 \effect
-Valid \CppXI{} code could declare a global placement allocation function and
+Valid \CppXI{} code can declare a global placement allocation function and
 deallocation function as follows:
 \begin{codeblock}
 void* operator new(std::size_t, std::size_t);
@@ -1117,7 +1117,7 @@ void operator delete(void*, std::size_t) noexcept;
 \end{codeblock}
 
 In this revision of \Cpp{}, however, the declaration of \tcode{operator delete}
-might match a predefined usual (non-placement)
+can match a predefined usual (non-placement)
 \tcode{operator delete}\iref{basic.stc.dynamic}. If so, the
 program is ill-formed, as it was for class member allocation functions and
 deallocation functions\iref{expr.new}.
@@ -1298,8 +1298,9 @@ Type of integer literals.
 \rationale
 C99 compatibility.
 \effect
-Certain integer literals larger than can be represented by \tcode{long} could
-change from an unsigned integer type to \tcode{signed long long}.
+Certain integer literals
+whose value is larger than the maximum representable value of type \tcode{long}
+can change from an unsigned integer type to \tcode{signed long long}.
 
 \rSec2[diff.cpp03.expr]{\ref{expr}: expressions}
 
@@ -1437,7 +1438,7 @@ Allow dependent calls of functions with internal linkage.
 \rationale
 Overly constrained, simplify overload resolution rules.
 \effect
-A valid \CppIII{} program could get a different result than in this
+A valid \CppIII{} program can get a different result than in this
 revision of \Cpp{}.
 
 \rSec2[diff.cpp03.library]{\ref{library}: library introduction}
@@ -1849,7 +1850,7 @@ from ``array of \tcode{wchar_t}''
 to ``array of \tcode{const wchar_t}''.
 \rationale
 This avoids calling an inappropriate overloaded function,
-which might expect to be able to modify its argument.
+which would possibly attempt to modify its argument.
 \effect
 Change to semantics of well-defined feature.
 \difficulty
@@ -1994,7 +1995,7 @@ to a pointer to object type.
 \effect
 Deletion of semantically well-defined feature.
 \difficulty
-Could be automated.
+Can be automated.
 Violations will be diagnosed by the \Cpp{} translator.
 The
 fix is to add a  cast.
@@ -2095,7 +2096,7 @@ resources which need to be de-allocated upon leaving the
 block.
 Allowing jump past initializers would require
 complicated runtime determination of allocation.
-Furthermore, any use of the uninitialized object could be a
+Furthermore, any use of the uninitialized object can be a
 disaster.
 With this simple compile-time rule, \Cpp{} assures that
 if an initialized variable is in scope, then it has assuredly been
@@ -2153,7 +2154,7 @@ with a type.
 In \Cpp{}, class members can be declared with the \tcode{static} storage
 class specifier.
 Allowing storage class specifiers on type
-declarations could render the code confusing for users.
+declarations can render the code confusing for users.
 \effect
 Deletion of semantically well-defined feature.
 \difficulty
@@ -2253,7 +2254,7 @@ deprecating implicit int in the next revision of C.
 Deletion of semantically well-defined feature.
 \difficulty
 Syntactic transformation.
-Could be automated.
+Can be automated.
 \howwide
 Common.
 
@@ -2545,7 +2546,7 @@ Seldom.
 \indextext{bit-field!implementation-defined sign of}%
 Bit-fields of type plain \tcode{int} are signed.
 \rationale
-Leaving the choice of signedness to implementations could lead to
+Leaving the choice of signedness to implementations can lead to
 inconsistent definitions of template specializations. For consistency,
 the implementation freedom was eliminated for non-dependent types,
 too.
@@ -2583,7 +2584,7 @@ Change to semantics of well-defined feature.
 \difficulty
 Semantic transformation.
 To make the struct type name visible in the scope of the enclosing
-struct, the struct tag could be declared in the scope of the
+struct, the struct tag can be declared in the scope of the
 enclosing struct, before the enclosing struct is defined.
 Example:
 \begin{codeblock}
@@ -2595,7 +2596,7 @@ struct X {
 
 All the definitions of C struct types enclosed in other struct
 definitions and accessed outside the scope of the enclosing
-struct could be exported to the scope of the enclosing struct.
+struct can be exported to the scope of the enclosing struct.
 Note: this is a consequence of the difference in scope rules,
 which is documented in \ref{basic.scope}.
 \howwide


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319