### PR TITLE
[depr] Replace 'could' and 'might'

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -209,8 +209,6 @@ The implicit definition of a copy assignment operator\iref{class.copy.assign}
 as defaulted is deprecated if the class has
 a user-declared copy constructor or
 a user-declared destructor.
-In a future revision of \Cpp{}, these implicit definitions
-could become deleted\iref{dcl.fct.def.delete}.
 
 \rSec1[depr.c.headers]{C headers}
 
@@ -2758,7 +2756,7 @@ The macro expands to a token sequence suitable for constant initialization of
 an atomic variable of static storage duration of a type that
 is initialization-compatible with \tcode{value}.
 \begin{note}
-This operation might need to initialize locks.
+This operation possibly needs to initialize locks.
 \end{note}
 Concurrent access to the variable being initialized,
 even via an atomic operation,


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319