### PR TITLE
[diagnostics] Replace 'could' and 'might'

### DIFF
--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -1051,7 +1051,7 @@ system_category())}. What constitutes correspondence for any given operating
 system is unspecified.
 \begin{note}
 The number of potential system error codes is large
-and unbounded, and some possibly do not correspond to any POSIX \tcode{errno} value. Thus
+and unbounded, and it is possible that some do not correspond to any POSIX \tcode{errno} value. Thus
 implementations are given latitude in determining correspondence.
 \end{note}
 \end{itemdescr}

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -1051,7 +1051,7 @@ system_category())}. What constitutes correspondence for any given operating
 system is unspecified.
 \begin{note}
 The number of potential system error codes is large
-and unbounded, and some might not correspond to any POSIX \tcode{errno} value. Thus
+and unbounded, and some possibly do not correspond to any POSIX \tcode{errno} value. Thus
 implementations are given latitude in determining correspondence.
 \end{note}
 \end{itemdescr}
@@ -1673,7 +1673,7 @@ const char* what() const noexcept override;
 An \ntbs{} incorporating the arguments supplied in the constructor.
 
 \begin{note}
-The returned \ntbs{} might be the contents of \tcode{what_arg + ": " +
+The returned \ntbs{} can be the contents of \tcode{what_arg + ": " +
 code.message()}.
 \end{note}
 \end{itemdescr}


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319