### PR TITLE
[concepts] Replace 'could' and 'might'

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -63,7 +63,7 @@ objects based on knowledge of the prior values as observed via
 equality-preserving expressions. It effectively forbids spontaneous changes to
 an object, changes to an object from another thread of execution, changes to an
 object as side effects of non-modifying expressions, and changes to an object as
-side effects of modifying a distinct object if those changes could be observable
+side effects of modifying a distinct object if those changes can be observable
 to a library function via an equality-preserving expression that is required to
 be valid for that object.
 \end{note}
@@ -394,7 +394,7 @@ and
 are modeled, then \tcode{T} and \tcode{U} share a
 \term{common reference type}, \tcode{C}.
 \begin{note}
-\tcode{C} could be the same as \tcode{T}, or \tcode{U}, or it could be a
+\tcode{C} can be the same as \tcode{T}, or \tcode{U}, or it can be a
 different type. \tcode{C} can be a reference type.
 \end{note}
 
@@ -437,8 +437,8 @@ If \tcode{T} and \tcode{U} can both be explicitly converted to some third type,
 \tcode{C}, then \tcode{T} and \tcode{U} share a \term{common type},
 \tcode{C}.
 \begin{note}
-\tcode{C} could be the same as \tcode{T}, or \tcode{U}, or it could be a
-different type. \tcode{C} might not be unique.
+\tcode{C} can be the same as \tcode{T}, or \tcode{U}, or it can be a
+different type. \tcode{C} is not necessarily unique.
 \end{note}
 
 \begin{itemdecl}
@@ -1138,7 +1138,7 @@ template<class T>
 \pnum
 \begin{note}
 The \libconcept{semiregular} concept is modeled by types that behave similarly
-to built-in types like \tcode{int}, except that they might not
+to built-in types like \tcode{int}, except that they need not
 be comparable with \tcode{==}.
 \end{note}
 

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -394,7 +394,7 @@ and
 are modeled, then \tcode{T} and \tcode{U} share a
 \term{common reference type}, \tcode{C}.
 \begin{note}
-\tcode{C} can be the same as \tcode{T}, or \tcode{U}, or it can be a
+\tcode{C} can be the same as \tcode{T} or \tcode{U}, or can be a
 different type. \tcode{C} can be a reference type.
 \end{note}
 
@@ -437,7 +437,7 @@ If \tcode{T} and \tcode{U} can both be explicitly converted to some third type,
 \tcode{C}, then \tcode{T} and \tcode{U} share a \term{common type},
 \tcode{C}.
 \begin{note}
-\tcode{C} can be the same as \tcode{T}, or \tcode{U}, or it can be a
+\tcode{C} can be the same as \tcode{T} or \tcode{U}, or can be a
 different type. \tcode{C} is not necessarily unique.
 \end{note}
 


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319