### PR TITLE
[support] Replace 'could' and 'might'

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -542,8 +542,9 @@ Each of the macros defined in \libheader{version} is also defined
 after inclusion of any member of the set of library headers
 indicated in the corresponding comment in this synopsis.
 \begin{note}
-Future revisions of \Cpp{} might replace
-the values of these macros with greater values.
+Future revisions of \Cpp{} will replace
+the values of these macros with greater values
+when the corresponding feature is modified.
 \end{note}
 
 \begin{codeblock}
@@ -1948,13 +1949,13 @@ The
 data race\iref{res.on.data.races}.
 \end{note}
 \begin{note}
-The order of registration could be indeterminate if \tcode{at_quick_exit} was called from more
-than one thread.
+The order of registration can be indeterminate
+if \tcode{at_quick_exit} is called from more than one thread.
 \end{note}
 \begin{note}
 The
 \tcode{at_quick_exit} registrations are distinct from the \tcode{atexit} registrations,
-and applications might need to call both registration functions with the same argument.
+and applications possibly need to call both registration functions with the same argument.
 \end{note}
 
 \pnum
@@ -2236,7 +2237,7 @@ If a function with a \tcode{size} parameter is defined,
 the program shall also define
 the corresponding version without the \tcode{size} parameter.
 \begin{note}
-The default behavior below might change in the future, which will require
+It is anticipated that the default behavior will change in the future and will instead require
 replacing both deallocation functions when replacing the allocation function.
 \end{note}
 
@@ -2491,7 +2492,7 @@ If a function with a \tcode{size} parameter is defined,
 the program shall also define
 the corresponding version without the \tcode{size} parameter.
 \begin{note}
-The default behavior below might change in the future, which will require
+It is anticipated that the default behavior will change in the future and will instead require
 replacing both deallocation functions when replacing the allocation function.
 \end{note}
 
@@ -3675,7 +3676,7 @@ enumeration, or pointer type.
 
 \pnum
 \begin{note}
-An implementation might use a reference-counted smart
+An implementation can use a reference-counted smart
 pointer as \tcode{exception_ptr}.
 \end{note}
 
@@ -4126,7 +4127,7 @@ as the result type of a three-way comparison operator\iref{expr.spaceship}
 that (a) admits all of the six two-way comparison operators (\ref{expr.rel}, \ref{expr.eq}),
 (b) does not imply substitutability,
 and (c) permits two values to be incomparable.%
-\footnote{That is, \tcode{a < b}, \tcode{a == b}, and \tcode{a > b} might all be \tcode{false}.}
+\footnote{That is, \tcode{a < b}, \tcode{a == b}, and \tcode{a > b} can all be \tcode{false}.}
 
 \indexlibraryglobal{partial_ordering}%
 \indexlibrarymember{less}{partial_ordering}%
@@ -5625,7 +5626,7 @@ control entering a \grammarterm{try-block} or \grammarterm{function-try-block};
 \item
 initialization of a variable with static storage duration
 requiring dynamic initialization~(\ref{basic.start.dynamic}, \ref{stmt.dcl})%
-\footnote{Such initialization might occur because it is the first odr-use\iref{basic.def.odr} of that variable.}; or
+\footnote{Such initialization can occur because it is the first odr-use\iref{basic.def.odr} of that variable.}; or
 
 \item
 waiting for the completion of the initialization of a variable with static storage duration\iref{stmt.dcl}.


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319