### PR TITLE
[library] Replace 'could' and 'might'

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -296,7 +296,7 @@ in overload resolution\iref{over.match}.
 Failure to meet such a condition results in the function's silent non-viability.
 \end{note}
 \begin{example}
-An implementation might express such a condition
+An implementation can express such a condition
 via a \grammarterm{constraint-expression}\iref{temp.constr.decl}.
 \end{example}
 
@@ -304,12 +304,12 @@ via a \grammarterm{constraint-expression}\iref{temp.constr.decl}.
 \mandates
 the conditions that, if not met, render the program ill-formed.
 \begin{example}
-An implementation might express such a condition
+An implementation can express such a condition
 via the \grammarterm{constant-expression}
 in a \grammarterm{static_assert-declaration}\iref{dcl.pre}.
 If the diagnostic is to be emitted only after the function
 has been selected by overload resolution,
-an implementation might express such a condition
+an implementation can express such a condition
 via a \grammarterm{constraint-expression}\iref{temp.constr.decl}
 and also define the function as deleted.
 \end{example}
@@ -1583,7 +1583,7 @@ The null value shall be equivalent only to itself. A default-initialized object
 of type \tcode{P} may have an indeterminate value.
 \begin{note}
 Operations involving
-indeterminate values might cause undefined behavior.
+indeterminate values can cause undefined behavior.
 \end{note}
 
 \pnum
@@ -2661,7 +2661,7 @@ an lvalue to an xvalue while passing that lvalue to a library function
 (e.g., by calling the function with the argument \tcode{std::move(x)}), the program
 is effectively asking that function to treat that lvalue as a temporary object.
 The implementation
-is free to optimize away aliasing checks which might be needed if the argument was
+is free to optimize away aliasing checks which would possibly be needed if the argument was
 an lvalue.
 \end{note}
 \end{itemize}


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319