### PR TITLE
[cpp] Replace 'could' and 'might'

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1021,7 +1021,7 @@ If a
 preprocessing token,
 followed by an identifier,
 occurs lexically
-at the point at which a preprocessing directive could begin,
+at the point at which a preprocessing directive can begin,
 the identifier is not subject to macro replacement.
 
 \newpage
@@ -1644,8 +1644,9 @@ replace the value of this macro with a greater value.
 The macros defined in \tref{cpp.predefined.ft} shall be defined to
 the corresponding integer literal.
 \begin{note}
-Future revisions of \Cpp{} might replace
-the values of these macros with greater values.
+Future revisions of \Cpp{} will replace
+the values of these macros with greater values
+when the corresponding feature is modified.
 \end{note}
 
 \item


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319