### PR TITLE
[except] Replace 'could' and 'might'

### DIFF
--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -797,7 +797,7 @@ non-throwing exception specification,
 the function \tcode{std::terminate} is called\iref{except.terminate}.
 \begin{note}
 An implementation is not permitted to reject an expression merely because, when
-executed, it throws or might
+executed, it throws or can
 throw an exception from a function with a non-throwing exception specification.
 \end{note}
 \begin{example}
@@ -811,9 +811,9 @@ void g() noexcept {
 \end{codeblock}
 The call to
 \tcode{f}
-is well-formed even though, when called,
-\tcode{f}
-might throw an exception.
+is well-formed even though
+it is possible for \tcode{f} to
+throw an exception when called.
 \end{example}
 
 \pnum


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319