### PR TITLE
[temp] Replace 'could' and 'might'

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -732,8 +732,8 @@ as the end of the \grammarterm{template-argument-list} and completes
 the \grammarterm{template-id}.
 \begin{note}
 The second \tcode{>}
-token produced by this replacement rule could terminate an enclosing
-\grammarterm{template-id} construct or it could be part of a different
+token produced by this replacement rule can terminate an enclosing
+\grammarterm{template-id} construct or it can be part of a different
 construct (e.g., a cast).
 \end{note}
 \begin{example}
@@ -2142,7 +2142,7 @@ denotes a unique dependent type. Two such \grammarterm{decltype-specifier}{s}
 refer to the same type only if their \grammarterm{expression}{s} are
 equivalent\iref{temp.over.link}.
 \begin{note}
-However, such a type might be aliased,
+However, such a type can be aliased,
 e.g., by a \grammarterm{typedef-name}.
 \end{note}
 
@@ -2214,13 +2214,13 @@ for an unbounded set of related types.
 
 \pnum
 \begin{example}
-A single class template
+It is possible for a single class template
 \tcode{List}
-might provide an unbounded set of class definitions:
+to provide an unbounded set of class definitions:
 one class \tcode{List<T>} for every type \tcode{T},
 each describing a linked list of elements of type \tcode{T}.
 Similarly, a class template \tcode{Array} describing a contiguous,
-dynamic array might be defined like this:
+dynamic array can be defined like this:
 \begin{codeblock}
 template<class T> class Array {
   T* v;
@@ -2233,9 +2233,8 @@ public:
 \end{codeblock}
 The prefix \tcode{\keyword{template}<class T>}
 specifies that a template is being declared and that a
-\grammarterm{type-name}
-\tcode{T}
-may be used in the declaration.
+\grammarterm{type-name} \tcode{T}
+can be used in the declaration.
 In other words,
 \tcode{Array}
 is a parameterized type with
@@ -2330,7 +2329,7 @@ public:
 \end{codeblock}
 
 declares three member functions of a class template.
-The subscript function might be defined like this:
+The subscript function can be defined like this:
 
 \begin{codeblock}
 template<class T> T& Array<T>::operator[](int i) {
@@ -2557,7 +2556,7 @@ apply to member template names.
 A destructor shall not be a member
 template.
 A non-template member function\iref{dcl.fct} with a given name
-and type and a member function template of the same name, which could be
+and type and a member function template of the same name, which can be
 used to generate a specialization of the same type, can both be
 declared in a class.
 When both exist, a use of that name and type refers to the
@@ -3344,7 +3343,7 @@ template\iref{temp.class.order}.
 
 \item
 The template parameter list of a specialization shall not contain default
-template argument values.\footnote{There is no way in which they could be used.}
+template argument values.\footnote{There is no context in which they would be used.}
 \item
 An argument shall not contain an unexpanded pack. If
 an argument is a pack expansion\iref{temp.variadic}, it shall be
@@ -3617,7 +3616,7 @@ A<char>::B<int>  abci;                                          // uses \#1
 \pnum
 A function template defines an unbounded set of related functions.
 \begin{example}
-A family of sort functions might be declared like this:
+A family of sort functions can be declared like this:
 
 \begin{codeblock}
 template<class T> class Array { };
@@ -3780,7 +3779,7 @@ are functionally equivalent if, for any given set of template arguments,
 the expressions perform
 the same operations in the same order with the same entities.
 \begin{note}
-For instance, one could have redundant parentheses.
+For instance, one can have redundant parentheses.
 \end{note}
 
 \pnum
@@ -5628,7 +5627,7 @@ template<class T> class Z {
 public:
   void f() {
     g(1);           // calls \tcode{g(double)}
-    h++;            // ill-formed: cannot increment function; this could be diagnosed
+    h++;            // ill-formed: cannot increment function; this can be diagnosed
                     // either here or at the point of instantiation
   }
 };
@@ -6479,7 +6478,7 @@ of instantiating the declaration of the specialization at that point.
 \pnum
 There is an \impldef{maximum depth of recursive template instantiations} quantity
 that specifies the limit on the total depth of recursive instantiations\iref{implimits},
-which could involve more than one template.
+which can involve more than one template.
 The result of an infinite recursion in instantiation is undefined.
 \begin{example}
 \begin{codeblock}
@@ -8678,8 +8677,8 @@ template<class T> void f(T x, T y) { @\commentellip@ }
 struct A { @\commentellip@ };
 struct B : A { @\commentellip@ };
 void g(A a, B b) {
-  f(a,b);           // error: \tcode{T} could be \tcode{A} or \tcode{B}
-  f(b,a);           // error: \tcode{T} could be \tcode{A} or \tcode{B}
+  f(a,b);           // error: \tcode{T} deduced as both \tcode{A} and \tcode{B}
+  f(b,a);           // error: \tcode{T} deduced as both \tcode{A} and \tcode{B}
   f(a,a);           // OK: \tcode{T} is \tcode{A}
   f(b,b);           // OK: \tcode{T} is \tcode{B}
 }
@@ -8699,8 +8698,8 @@ int g3( int, char, float);
 
 void r() {
   f(g1);            // OK: \tcode{T} is \tcode{int} and \tcode{U} is \tcode{float}
-  f(g2);            // error: \tcode{T} could be \tcode{char} or \tcode{int}
-  f(g3);            // error: \tcode{U} could be \tcode{char} or \tcode{float}
+  f(g2);            // error: \tcode{T} deduced as both \tcode{char} and \tcode{int}
+  f(g3);            // error: \tcode{U} deduced as both \tcode{char} and \tcode{float}
 }
 \end{codeblock}
 
@@ -9225,7 +9224,7 @@ Adding the non-template function
 int max(int,int);
 \end{codeblock}
 to the example above would resolve the third call, by providing a function that
-could be called for
+can be called for
 \tcode{max(a,c)}
 after using the standard conversion of
 \tcode{char}


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319