### PR TITLE
[over] Replace 'could' and 'might'

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2156,12 +2156,12 @@ Run a simple tournament to find a function
 that is not
 worse than any
 opponent it faced.
-Although another function
+Although it is possible that another function
 \tcode{F}
 that
 \tcode{W}
 did not face
-might be at least as good as
+is at least as good as
 \tcode{W},
 \tcode{F}
 cannot be the best function because at some point in the
@@ -2257,7 +2257,7 @@ alignment, accessibility of the argument, whether the argument is a bit-field,
 and whether a function is deleted\iref{dcl.fct.def.delete}, are ignored.
 So, although an implicit
 conversion sequence can be defined for a given argument-parameter
-pair, the conversion from the argument to the parameter might still
+pair, the conversion from the argument to the parameter can still
 be ill-formed in the final analysis.
 \end{note}
 
@@ -4199,7 +4199,7 @@ such a literal suffix identifier is ill-formed, no diagnostic required.
 \pnum
 A declaration whose \grammarterm{declarator-id} is a
 \grammarterm{literal-operator-id} shall be a declaration of a namespace-scope
-function or function template (it could be a friend
+function or function template (for example, it can be a friend
 function\iref{class.friend}), an explicit instantiation or specialization of a
 function template, or a \grammarterm{using-declaration}\iref{namespace.udecl}.
 A function declared with a \grammarterm{literal-operator-id} is a \defnx{literal


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319