### PR TITLE
[class] Replace 'could' and 'might'

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -614,7 +614,7 @@ struct S {
 In a \grammarterm{member-declarator} for a bit-field,
 the \grammarterm{constant-expression} is parsed as
 the longest sequence of tokens
-that could syntactically form a \grammarterm{constant-expression}.
+that matches the syntax of a \grammarterm{constant-expression}.
 \begin{example}
 \begin{codeblock}
 int a;
@@ -733,8 +733,8 @@ members have higher addresses within a class object.
 The order of allocation of non-static data members
 with different access control
 is unspecified.
-Implementation alignment requirements might cause two adjacent members
-not to be allocated immediately after each other; so might requirements
+Implementation alignment requirements can cause two adjacent members
+not to be allocated immediately after each other; so can requirements
 for space for managing virtual functions\iref{class.virtual} and
 virtual base classes\iref{class.mi}.
 \end{note}
@@ -832,7 +832,7 @@ is the same as the address of its first non-static data member
 if that member is not a bit-field. Its
 address is also the same as the address of each of its base class subobjects.
 \begin{note}
-There might therefore be unnamed padding within a standard-layout struct object
+There can therefore be unnamed padding within a standard-layout struct object
 inserted by an implementation, but
 not at its beginning, as necessary to achieve appropriate alignment.
 \end{note}
@@ -1441,7 +1441,7 @@ its non-static data members are implicitly defined.
 \begin{note}
 An implicitly-declared default constructor has an
 exception specification\iref{except.spec}.
-An explicitly-defaulted definition might have an
+An explicitly-defaulted definition can have an
 implicit exception specification, see~\ref{dcl.fct.def}.
 \end{note}
 
@@ -1649,7 +1649,7 @@ implicitly declared as defaulted if and only if
 
 \begin{note}
 When the move constructor is not implicitly declared or explicitly supplied,
-expressions that otherwise would have invoked the move constructor might instead invoke
+expressions that otherwise would have invoked the move constructor can instead invoke
 a copy constructor.
 \end{note}
 
@@ -1982,7 +1982,7 @@ a base class copy/move assignment operator is always hidden
 by the corresponding assignment operator of a derived class\iref{over.ass}.
 A
 \grammarterm{using-declaration}\iref{namespace.udecl} that brings in from a base class an assignment operator
-with a parameter type that could be that of a
+with a parameter type that can be that of a
 copy/move assignment operator for the
 derived class is not considered an explicit declaration of such an
 operator and does not suppress the implicit declaration of the derived class
@@ -2301,11 +2301,9 @@ derived classes.
 Bases and members are destroyed in the reverse order of the completion of
 their constructor (see~\ref{class.base.init}).
 \begin{note}
-A
-\tcode{return}
-statement\iref{stmt.return} in a destructor might not directly return to the
-caller; before transferring control to the caller, the destructors for the
-members and bases are called.
+A \tcode{return} statement\iref{stmt.return} in a destructor
+calls the destructors for the members and bases (if any)
+before transferring control to the caller.
 \end{note}
 \indextext{order of execution!destructor and array}%
 Destructors for elements of an array are called in reverse order of their
@@ -2692,7 +2690,7 @@ The
 in a
 \grammarterm{conversion-function-id}
 is the longest sequence of
-tokens that could possibly form a \grammarterm{conversion-type-id}.
+tokens that matches the syntax of a \grammarterm{conversion-type-id}.
 \begin{note}
 This prevents ambiguities between the declarator operator \tcode{*} and its expression
 counterparts.
@@ -3600,9 +3598,9 @@ constructors; see~\ref{class.base.init}.
 
 \pnum
 \begin{note}
-A base class subobject might have a layout different
+A base class subobject can have a layout different
 from the layout of a most derived object of the same type. A base class
-subobject might have a polymorphic behavior\iref{class.cdtor}
+subobject can have a polymorphic behavior\iref{class.cdtor}
 different from the polymorphic behavior of a most derived object of the
 same type. A base class subobject can be of zero size;
 however, two subobjects that have the same class type and that belong to
@@ -3692,7 +3690,7 @@ shown in \fref{class.nonvirt}.
 \end{importgraphic}
 
 In such lattices, explicit qualification can be used to specify which
-subobject is meant. The body of function \tcode{C::f} could refer to the
+subobject is meant. The body of function \tcode{C::f} can refer to the
 member \tcode{next} of each \tcode{L} subobject:
 \begin{codeblock}
 void C::f() { A::next = B::next; }      // well-formed
@@ -3774,8 +3772,8 @@ programming.
 A class that declares or inherits a virtual function is
 called a \defnadj{polymorphic}{class}.\footnote{If
 all virtual functions are immediate functions,
-the class is still polymorphic even though
-its internal representation might not otherwise require
+the class is still polymorphic even if
+its internal representation does not otherwise require
 any additions for that polymorphic behavior.}
 
 \pnum
@@ -4134,7 +4132,7 @@ a \defnx{pure virtual function}{function!virtual!pure} by using a
 \grammarterm{pure-specifier}\iref{class.mem} in the function declaration
 in the class definition.
 \begin{note}
-Such a function might be inherited: see below.
+Such a function can be inherited: see below.
 \end{note}
 A class is an \defnadj{abstract}{class}
 if it has at least one pure virtual function.
@@ -4464,7 +4462,7 @@ void g() {
 \pnum
 \begin{note}
 Even if the result of name lookup is unambiguous, use of a name found in
-multiple subobjects might still be
+multiple subobjects can still be
 ambiguous~(\ref{conv.mem}, \ref{expr.ref}, \ref{class.access.base}).
 \end{note}
 \begin{example}
@@ -4756,7 +4754,7 @@ private:
 \begin{note}
 In a derived class, the lookup of a base class name will find the
 injected-class-name instead of the name of the base class in the scope
-in which it was declared. The injected-class-name might be less accessible
+in which it was declared. The injected-class-name can be less accessible
 than the name of the base class in the scope in which it was declared.
 \end{note}
 
@@ -4847,12 +4845,12 @@ and
 
 \pnum
 \begin{note}
-A member of a private base class might be inaccessible as an inherited
+A member of a private base class can be inaccessible as an inherited
 member name, but accessible directly.
 Because of the rules on pointer conversions\iref{conv.ptr} and
 explicit casts~(\ref{expr.type.conv}, \ref{expr.static.cast}, \ref{expr.cast}),
 a conversion from a pointer to a derived class to a pointer
-to an inaccessible base class might be ill-formed if an implicit conversion
+to an inaccessible base class can be ill-formed if an implicit conversion
 is used, but well-formed if an explicit cast is used.
 For example,
 
@@ -6331,7 +6329,7 @@ struct D : virtual A { D(A*); };
 struct X { X(A*); };
 
 struct E : C, D, X {
-  E() : D(this),    // undefined behavior: upcast from \tcode{E*} to \tcode{A*} might use path \tcode{E*} $\rightarrow$ \tcode{D*} $\rightarrow$ \tcode{A*}
+  E() : D(this),    // undefined behavior: upcast from \tcode{E*} to \tcode{A*} can use path \tcode{E*} $\rightarrow$ \tcode{D*} $\rightarrow$ \tcode{A*}
                     // but \tcode{D} is not constructed
 
                     // ``\tcode{D((C*)this)}\!'' would be defined: \tcode{E*} $\rightarrow$ \tcode{C*} is defined because \tcode{E()} has started,
@@ -6546,7 +6544,7 @@ where an expression is evaluated in a context
 requiring a constant expression\iref{expr.const}
 and in constant initialization\iref{basic.start.static}.
 \begin{note}
-Copy elision might be performed
+It is possible that copy elision is performed
 if the same expression
 is evaluated in another context.
 \end{note}
@@ -7212,7 +7210,7 @@ void f(int i) {
 \pnum
 Access to the deallocation function is checked statically.
 \begin{note}
-Hence, even though a different one might actually be executed,
+Hence, even if a different one is actually executed,
 the statically visible deallocation function is required to be accessible.
 \end{note}
 \begin{example}


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319