### PR TITLE
[stmt.stmt] Replace 'could' and 'might'

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -1006,7 +1006,7 @@ of the initialization.
 \begin{note}
 A conforming implementation cannot introduce
 any deadlock around execution of the initializer.
-Deadlocks might still be caused by the program logic;
+Deadlocks can still be caused by the program logic;
 the implementation need only avoid deadlocks
 due to its own synchronization operations.
 \end{note}
@@ -1048,7 +1048,7 @@ indistinguishable from a \grammarterm{declaration} where the first
 If the \grammarterm{statement} cannot syntactically be a
 \grammarterm{declaration}, there is no ambiguity,
 so this rule does not apply.
-The whole \grammarterm{statement} might need to be examined
+In some cases, the whole \grammarterm{statement} needs to be examined
 to determine whether this is the case. This resolves the meaning
 of many examples.
 \begin{example}


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319