### PR TITLE
[expr] Replace 'could' and 'might'

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -770,7 +770,7 @@ if the cv-combined type of \tcode{T1} and \tcode{T2} is \tcode{T2}.
 If a program were able to assign a pointer of type \tcode{T**} to a pointer of
 type \tcode{const} \tcode{T**} (that is, if line \#1 below were
 allowed), it would be possible for a const object to be inadvertently modified
-(as it is done on line \#2). For example,
+(as is done on line \#2). For example,
 \begin{codeblock}
 int main() {
   const char c = 'c';

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -109,7 +109,7 @@ or
 \begin{codeblock}
 a = (a + (b + 32765));
 \end{codeblock}
-since the values for \tcode{a} and \tcode{b} might have been,
+since the values for \tcode{a} and \tcode{b} can be,
 respectively, 4 and -8 or -17 and 12. However on a machine in which
 overflows do not produce an exception and in which the results of
 overflows are reversible, the above expression statement can be
@@ -165,7 +165,7 @@ values they expect and yield are determined by their parameter and return types.
 \pnum
 \begin{note}
 Historically, lvalues and rvalues were so-called
-because they could appear on the left- and right-hand side of an assignment
+because they can appear on the left- and right-hand side of an assignment
 (although this is no longer generally true);
 glvalues are ``generalized'' lvalues,
 prvalues are ``pure'' rvalues,
@@ -252,7 +252,7 @@ a prvalue of type \tcode{int} is required.
 \begin{note}
 There are no prvalue bit-fields; if a bit-field is converted to a
 prvalue\iref{conv.lval}, a prvalue of the type of the bit-field is
-created, which might then be promoted\iref{conv.prom}.
+created, which can then be promoted\iref{conv.prom}.
 \end{note}
 
 \pnum
@@ -767,9 +767,9 @@ A prvalue of type \tcode{T1}
 can be converted to type \tcode{T2}
 if the cv-combined type of \tcode{T1} and \tcode{T2} is \tcode{T2}.
 \begin{note}
-If a program could assign a pointer of type \tcode{T**} to a pointer of
+If a program were able to assign a pointer of type \tcode{T**} to a pointer of
 type \tcode{const} \tcode{T**} (that is, if line \#1 below were
-allowed), a program could inadvertently modify a const object
+allowed), it would be possible for a const object to be inadvertently modified
 (as it is done on line \#2). For example,
 \begin{codeblock}
 int main() {
@@ -1661,7 +1661,7 @@ The trailing \grammarterm{requires-clause} of the function call operator
 or operator template is the \grammarterm{requires-clause}
 of the \grammarterm{lambda-declarator}, if any.
 \begin{note}
-The function call operator template for a generic lambda might be
+The function call operator template for a generic lambda can be
 an abbreviated function template\iref{dcl.fct}.
 \end{note}
 \begin{example}
@@ -1927,7 +1927,7 @@ has a \grammarterm{lambda-capture} and defaulted copy and move assignment
 operators otherwise\iref{class.copy.assign}.
 \begin{note}
 These special member functions are implicitly defined as
-usual, and might therefore be defined as deleted.
+usual, which can result in them being defined as deleted.
 \end{note}
 
 \pnum
@@ -2135,7 +2135,7 @@ void test() {
 
   auto g2 = [=](auto a) {
     int selector[sizeof(a) == 1 ? 1 : 2]{};
-    f(x, selector);             // OK: captures \tcode{x}, might call \#1 or \#2
+    f(x, selector);             // OK: captures \tcode{x}, can call \#1 or \#2
   };
 
   auto g3 = [=](auto a) {
@@ -2143,12 +2143,12 @@ void test() {
   };
 }
 \end{codeblock}
-Within \tcode{g1}, an implementation might optimize away
+Within \tcode{g1}, an implementation can optimize away
 the capture of \tcode{x} as it is not odr-used.
 \end{example}
 \begin{note}
 The set of captured entities is determined syntactically,
-and entities might be implicitly captured
+and entities are implicitly captured
 even if the expression denoting a local entity
 is within a discarded statement\iref{stmt.if}.
 \begin{example}
@@ -2853,7 +2853,7 @@ Postfix expressions group left-to-right.
 The \tcode{>} token following the
 \grammarterm{type-id} in a \tcode{dynamic_cast},
 \tcode{static_cast}, \tcode{reinterpret_cast}, or
-\tcode{const_cast} might be the product of replacing a
+\tcode{const_cast} can be the product of replacing a
 \tcode{>{>}} token by two consecutive \tcode{>}
 tokens\iref{temp.names}.
 \end{note}
@@ -3026,7 +3026,7 @@ checked at the point of call in the calling function. If a constructor
 or destructor for a function parameter throws an exception, the search
 for a handler starts in the scope of the calling function; in
 particular, if the function called has a \grammarterm{function-try-block}\iref{except.pre}
-with a handler that could handle the exception,
+with a handler that can handle the exception,
 this handler is not considered.
 \end{example}
 
@@ -3877,7 +3877,7 @@ its operand.
 
 \pnum
 \begin{note}
-The mapping performed by \tcode{reinterpret_cast} might, or might not, produce a
+The mapping performed by \tcode{reinterpret_cast} can produce a
 representation different from the original value.
 \end{note}
 
@@ -4090,7 +4090,7 @@ pointer, lvalue or pointer to data member resulting from a
 \tcode{const_cast} that casts away a const-qualifier\footnote{\tcode{const_cast}
 is not limited to conversions that cast away a
 const-qualifier.}
-might produce undefined behavior\iref{dcl.type.cv}.
+can produce undefined behavior\iref{dcl.type.cv}.
 \end{note}
 
 \pnum
@@ -4266,7 +4266,7 @@ called. The operand of \tcode{\&} shall not be a bit-field.
 The address of an overloaded function\iref{over} can be taken
 only in a context that uniquely determines which version of the
 overloaded function is referred to (see~\ref{over.over}).
-Since the context might determine whether the operand is a static or
+Since the context can determine whether the operand is a static or
 non-static member function, the context can also affect whether the
 expression has type ``pointer to function'' or ``pointer to member
 function''.
@@ -4929,7 +4929,7 @@ these functions\iref{replacement.functions} and/or class-specific
 versions\iref{class.free}.
 The set of allocation and deallocation functions that can be called
 by a \grammarterm{new-expression}
-could include functions that do not perform allocation or deallocation;
+can include functions that do not perform allocation or deallocation;
 for example, see \ref{new.delete.placement}.
 \end{note}
 
@@ -5183,7 +5183,7 @@ invoked\iref{class.dtor}.
 
 \pnum
 \indextext{\idxcode{new}!exception and}%
-If any part of the object initialization described above\footnote{This might
+If any part of the object initialization described above\footnote{This can
 include evaluating a \grammarterm{new-initializer} and/or calling
 a constructor.}
 terminates by throwing an exception and a suitable deallocation function
@@ -6486,8 +6486,8 @@ that conversion is applied to the chosen operand
 and the converted operand is used in place of the original operand for
 the remainder of this subclause.
 \begin{note}
-The conversion might be ill-formed even if an implicit conversion
-sequence could be formed.
+It is possible for the conversion to be ill-formed even if an implicit conversion
+sequence can be formed.
 \end{note}
 
 \pnum
@@ -6745,7 +6745,7 @@ undefined.
 \begin{note}
 This restriction applies to the relationship
 between the left and right sides of the assignment operation; it is not a
-statement about how the target of the assignment might be aliased in general.
+statement about how the target of the assignment can be aliased in general.
 See~\ref{basic.lval}.
 \end{note}
 
@@ -7321,7 +7321,7 @@ to determine whether it is satisfied\iref{temp.constr.atomic}, or
 that is usable in constant expressions or
 has constant initialization\iref{basic.start.static}.%
 \footnote{Testing this condition
-might involve a trial evaluation of its initializer as described above.}
+can involve a trial evaluation of its initializer as described above.}
 \begin{example}
 \begin{codeblock}
 template<bool> struct X {};
@@ -7335,7 +7335,7 @@ int c = y + (std::is_constant_evaluated() ? 2 : y);     // dynamic initializatio
 
 constexpr int f() {
   const int n = std::is_constant_evaluated() ? 13 : 17; // \tcode{n} is 13
-  int m = std::is_constant_evaluated() ? 13 : 17;       // \tcode{m} might be 13 or 17 (see below)
+  int m = std::is_constant_evaluated() ? 13 : 17;       // \tcode{m} can be 13 or 17 (see below)
   char arr[n] = {}; // char[13]
   return m + sizeof(arr);
 }
@@ -7362,12 +7362,12 @@ a potentially-evaluated expression\iref{basic.def.odr},
 
 \item
 an immediate subexpression of a \grammarterm{braced-init-list},%
-\footnote{Constant evaluation might be necessary to determine whether a narrowing conversion is performed\iref{dcl.init.list}.}
+\footnote{In some cases, constant evaluation is needed to determine whether a narrowing conversion is performed\iref{dcl.init.list}.}
 
 \item
 an expression of the form \tcode{\&} \grammarterm{cast-expression}
 that occurs within a templated entity,%
-\footnote{Constant evaluation might be necessary to determine whether such an expression is value-dependent\iref{temp.dep.constexpr}.}
+\footnote{In some cases, constant evaluation is needed to determine whether such an expression is value-dependent\iref{temp.dep.constexpr}.}
 or
 
 \item

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -165,7 +165,7 @@ values they expect and yield are determined by their parameter and return types.
 \pnum
 \begin{note}
 Historically, lvalues and rvalues were so-called
-because they can appear on the left- and right-hand side of an assignment
+because they appeared on the left- and right-hand side of an assignment
 (although this is no longer generally true);
 glvalues are ``generalized'' lvalues,
 prvalues are ``pure'' rvalues,


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319