### PR TITLE
[basic] Replace 'could' and 'might'

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -695,10 +695,10 @@ including in the application of these requirements to other entities.
 The entity is still declared in multiple translation units, and \ref{basic.link}
 still applies to these declarations. In particular,
 \grammarterm{lambda-expression}{s}\iref{expr.prim.lambda}
-appearing in the type of \tcode{D} might result
+appearing in the type of \tcode{D} can result
 in the different declarations having distinct types, and
 \grammarterm{lambda-expression}{s} appearing in a default argument of \tcode{D}
-might still denote different types in different translation units.
+can still denote different types in different translation units.
 \end{note}
 
 \pnum
@@ -1534,7 +1534,7 @@ void A::N::f() {
 A name used in the definition of a class \tcode{X}%
 \footnote{This
 refers to unqualified names following the class name;
-such a name might be used in a \grammarterm{base-specifier} or
+such a name can be used in a \grammarterm{base-specifier} or
 in the \grammarterm{member-specification} of the class definition.}
 outside of a complete-class context\iref{class.mem} of \tcode{X}
 shall be declared in one of the following ways:
@@ -2837,7 +2837,7 @@ Similarly,
 \grammarterm{using-directive}{s}
 do not declare entities.
 Enumerators do not have linkage,
-but might serve as the name of an enumeration with linkage\iref{dcl.enum}.
+but can serve as the name of an enumeration with linkage\iref{dcl.enum}.
 \end{note}
 
 \pnum
@@ -2934,7 +2934,7 @@ that is not an odr-use\iref{basic.def.odr},
 or defines a constexpr variable initialized to a TU-local value (defined below).
 \begin{note}
 An inline function template can be an exposure even though
-explicit specializations of it might be usable in other translation units.
+explicit specializations of it are possibly usable in other translation units.
 \end{note}
 
 \pnum
@@ -2965,7 +2965,7 @@ a specialization of a template with any TU-local template argument, or
 a specialization of a template
 whose (possibly instantiated) declaration is an exposure.
 \begin{note}
-The specialization might have been implicitly or explicitly instantiated.
+A specialization can be produced by implicit or explicit instantiation.
 \end{note}
 \end{itemize}
 
@@ -3029,7 +3029,7 @@ namespace N {
 }
 void adl(double);
 
-inline void h(auto x) { adl(x); }   // OK, but a specialization might be an exposure
+inline void h(auto x) { adl(x); }   // OK, but a specialization can be an exposure
 \end{codeblocktu}
 \begin{codeblocktu}{Translation unit \#2}
 module A;
@@ -3081,7 +3081,7 @@ A \defn{memory location} is either an object of scalar type or a maximal
 sequence of adjacent bit-fields all having nonzero width.
 \begin{note}
 Various
-features of the language, such as references and virtual functions, might
+features of the language, such as references and virtual functions, can
 involve additional memory locations that are not accessible to programs but are
 managed by the implementation.
 \end{note}
@@ -3442,7 +3442,7 @@ In particular, before the lifetime of an object starts and after its
 lifetime ends there are significant restrictions on the use of the
 object, as described below, in~\ref{class.base.init} and
 in~\ref{class.cdtor}. Also, the behavior of an object under construction
-and destruction might not be the same as the behavior of an object whose
+and destruction is possibly not the same as the behavior of an object whose
 lifetime has started and not ended. \ref{class.base.init}
 and~\ref{class.cdtor} describe the behavior of an object during its periods
 of construction and destruction.
@@ -3778,7 +3778,7 @@ passing an invalid pointer value to a deallocation function
 have undefined behavior.
 Any other use of an invalid pointer value has
 \impldef{any use of an invalid pointer other than to perform indirection or deallocate}
-behavior.\footnote{Some implementations might define that
+behavior.\footnote{An implementation can define that
 copying an invalid pointer value
 causes a system-generated runtime fault.}
 
@@ -4181,7 +4181,7 @@ reachable\iref{util.dynamic.safety}.
 \begin{note}
 The effect of using an invalid pointer value (including passing it to a
 deallocation function) is undefined, see~\ref{basic.stc}.
-This is true even if the unsafely-derived pointer value might compare equal to
+This is true even if the unsafely-derived pointer value compares equal to
 some safely-derived pointer value.
 \end{note}
 It is
@@ -4224,9 +4224,10 @@ struct D : virtual B { char c; };
 
 When \tcode{D} is the type of a complete object, it will have a subobject of
 type \tcode{B}, so it must be aligned appropriately for a \tcode{long double}.
-If \tcode{D} appears as a subobject of another object that also has \tcode{B}
-as a virtual base class, the \tcode{B} subobject might be part of a different
-subobject, reducing the alignment requirements on the \tcode{D} subobject.
+If \tcode{D} appears as a base class subobject,
+it is possible that the alignment requirement of \tcode{B}
+influences the alignment of only the most-derived object,
+reducing the alignment requirements on the \tcode{D} subobject.
 \end{example}
 The result of the \tcode{alignof} operator reflects the alignment
 requirement of the type in the complete-object case.
@@ -4543,7 +4544,7 @@ containing the \grammarterm{expression-list}.
 
 \item A temporary bound to a reference in a \grammarterm{new-initializer}\iref{expr.new} persists until the completion of the full-expression containing the \grammarterm{new-initializer}.
 \begin{note}
-This might introduce a dangling reference.
+This can introduce a dangling reference.
 \end{note}
 \begin{example}
 \begin{codeblock}
@@ -4697,7 +4698,7 @@ subsequently hold its original value.
 constexpr std::size_t N = sizeof(T);
 char buf[N];
 T obj;                          // \tcode{obj} initialized to its original value
-std::memcpy(buf, &obj, N);      // between these two calls to \tcode{std::memcpy}, \tcode{obj} might be modified
+std::memcpy(buf, &obj, N);      // between these two calls to \tcode{std::memcpy}, \tcode{obj} can be modified
 std::memcpy(&obj, buf, N);      // at this point, each subobject of \tcode{obj} of scalar type holds its original value
 \end{codeblock}
 \end{example}
@@ -4856,7 +4857,7 @@ of non-volatile literal types.
 \end{itemize}
 \begin{note}
 A literal type is one for which
-it might be possible to create an object
+it is superficially possible for an object to be created
 within a constant expression.
 It is not a guarantee that it is possible to create such an object,
 nor is it a guarantee that any object of that type
@@ -5262,8 +5263,8 @@ respectively.
 \begin{note}
 A pointer past the end of an object\iref{expr.add}
 is not considered to point to an unrelated object
-of the object's type
-that might be located at that address.
+of the object's type,
+even if the unrelated object is located at that address.
 A pointer value becomes invalid
 when the storage it denotes
 reaches the end of its storage duration;
@@ -5661,7 +5662,7 @@ Evaluations \placeholder{A} and \placeholder{B} are
 \placeholder{B} or \placeholder{B} is sequenced before \placeholder{A}, but it is unspecified which.
 \begin{note}
 Indeterminately sequenced evaluations cannot overlap, but either
-could be executed first.
+can be executed first.
 \end{note}
 An expression \placeholder{X}
 is said to be sequenced before
@@ -5816,7 +5817,7 @@ The value of an object visible to a thread $T$ at a particular point is the
 initial value of the object, a value assigned to the object by $T$, or a
 value assigned to the object by another thread, according to the rules below.
 \begin{note}
-In some cases, there might instead be undefined behavior. Much of this
+In some cases, there can instead be undefined behavior. Much of this
 subclause is motivated by the desire to support atomic operations with explicit
 and detailed visibility constraints. However, it also implicitly supports a
 simpler view for more restricted programs.
@@ -5859,7 +5860,7 @@ particular total order, called the \defn{modification order} of $M$.
 There is a separate order for each
 atomic object. There is no requirement that these can be combined into a single
 total order for all objects. In general this will be impossible since different
-threads might observe modifications to different objects in inconsistent orders.
+threads can observe modifications to different objects in inconsistent orders.
 \end{note}
 
 \pnum
@@ -6183,19 +6184,19 @@ in $B$.
 \begin{note}
 Compiler transformations that introduce assignments to a potentially
 shared memory location that would not be modified by the abstract machine are
-generally precluded by this document, since such an assignment might overwrite
+generally precluded by this document, since such an assignment can overwrite
 another assignment by a different thread in cases in which an abstract machine
 execution would not have encountered a data race. This includes implementations
 of data member assignment that overwrite adjacent members in separate memory
 locations. Reordering of atomic loads in cases in which the atomics in question
-might alias is also generally precluded, since this could violate the coherence
+can alias is also generally precluded, since this can violate the coherence
 rules.
 \end{note}
 
 \pnum
 \begin{note}
 Transformations that introduce a speculative read of a potentially
-shared memory location might not preserve the semantics of the \Cpp{} program as
+shared memory location do not, in general, preserve the semantics of the \Cpp{} program as
 defined in this document, since they potentially introduce a data race. However,
 they are typically valid in the context of an optimizing compiler that targets a
 specific machine with well-defined semantics for data races. They would be
@@ -6231,7 +6232,7 @@ are \defnx{lock-free executions}{lock-free execution}.
   a lock-free execution in that thread shall complete.
   \begin{note}
     Concurrently executing threads
-    might prevent progress of a lock-free execution.
+    can prevent progress of a lock-free execution.
     For example,
     this situation can occur
     with load-locked store-conditional implementations.
@@ -6245,7 +6246,7 @@ are \defnx{lock-free executions}{lock-free execution}.
     to provide absolute guarantees to this effect,
     since repeated and particularly inopportune interference
     from other threads
-    could prevent forward progress,
+    can prevent forward progress,
     e.g.,
     by repeatedly stealing a cache line
     for unrelated purposes
@@ -6277,7 +6278,7 @@ condition that it blocks on to be satisfied.
 \begin{example}
 A library I/O function that blocks until the I/O operation is complete can
 be considered to continuously check whether the operation is complete. Each
-such check might consist of one or more execution steps, for example using
+such check consists of one or more execution steps, for example using
 observable behavior of the abstract machine.
 \end{example}
 
@@ -6351,9 +6352,9 @@ Concurrent forward progress guarantees are stronger than parallel forward progre
 guarantees, which in turn are stronger than weakly parallel forward progress
 guarantees.
 \begin{note}
-For example, some kinds of synchronization between threads of execution might only
+For example, some kinds of synchronization between threads of execution are only guaranteed to
 make progress if the respective threads of execution provide parallel forward progress
-guarantees, but will fail to make progress under weakly parallel guarantees.
+guarantees, but will not necessarily make progress under weakly parallel guarantees.
 \end{note}
 
 \pnum
@@ -6382,7 +6383,7 @@ A thread of execution $B$ thus can temporarily provide an effectively
 stronger forward progress guarantee for a certain amount of time, due to a
 second thread of execution $A$ being blocked on it with forward
 progress guarantee delegation. In turn, if $B$ then blocks with
-forward progress guarantee delegation on $C$, this could also temporarily
+forward progress guarantee delegation on $C$, this can also temporarily
 provide a stronger forward progress guarantee to $C$.
 \end{note}
 


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319