### PR TITLE
[lex] Replace 'could' and 'might'

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -344,7 +344,7 @@ given character:
 \begin{itemize}
 \item
 \indextext{literal!string!raw}%
-If the next character begins a sequence of characters that could be the prefix
+If the next character begins a sequence of characters that can be the prefix
 and initial double quote of a raw string literal, such as \tcode{R"}, the next preprocessing
 token shall be a raw string literal. Between the initial and final
 double quote characters of the raw string, any transformations performed in phases
@@ -362,7 +362,7 @@ itself and not as the first character of the alternative token \tcode{<:}.
 
 \item Otherwise,
 the next preprocessing token is the longest sequence of
-characters that could constitute a preprocessing token, even if that
+characters that matches the syntax of a preprocessing token, even if that
 would cause further lexical analysis to fail,
 except that a \grammarterm{header-name}\iref{lex.header} is only formed
 \begin{itemize}
@@ -401,8 +401,8 @@ The program fragment \tcode{0xe+foo} is parsed as a
 preprocessing number token (one that is not a valid
 \grammarterm{integer-literal} or \grammarterm{floating-point-literal} token),
 even though a parse as three preprocessing tokens
-\tcode{0xe}, \tcode{+}, and \tcode{foo} might produce a valid expression (for example,
-if \tcode{foo} were a macro defined as \tcode{1}). Similarly, the
+\tcode{0xe}, \tcode{+}, and \tcode{foo} can produce a valid expression (for example,
+if \tcode{foo} is a macro defined as \tcode{1}). Similarly, the
 program fragment \tcode{1E1} is parsed as a preprocessing number (one
 that is a valid \grammarterm{floating-point-literal} token),
 whether or not \tcode{E} is a macro name.
@@ -413,7 +413,7 @@ whether or not \tcode{E} is a macro name.
 The program fragment \tcode{x+++++y} is parsed as \tcode{x
 ++ ++ + y}, which, if \tcode{x} and \tcode{y} have integral types,
 violates a constraint on increment operators, even though the parse
-\tcode{x ++ + ++ y} might yield a correct expression.
+\tcode{x ++ + ++ y} can yield a correct expression.
 \end{example}
 \indextext{token!preprocessing|)}
 
@@ -561,7 +561,7 @@ is conditionally-supported with \impldef{meaning of \tcode{'}, \tcode{\textbacks
 \tcode{/*}, or \tcode{//} in a \grammarterm{q-char-sequence} or an
 \grammarterm{h-char-sequence}} semantics, as is the appearance of the character
 \tcode{"} in an \grammarterm{h-char-sequence}.\footnote{Thus, a sequence of characters
-that resembles an escape sequence might result in an error, be interpreted as the
+that resembles an escape sequence can result in an error, be interpreted as the
 character corresponding to the escape sequence, or have a completely different meaning,
 depending on the implementation.}%
 \indextext{header!name|)}
@@ -1893,7 +1893,7 @@ is a \grammarterm{user-defined-literal}, but \tcode{12LL} is an
 \end{example}
 The syntactic non-terminal preceding the \grammarterm{ud-suffix} in a
 \grammarterm{user-defined-literal} is taken to be the longest sequence of
-characters that could match that non-terminal.
+characters that matches the syntax of that non-terminal.
 
 \pnum
 A \grammarterm{user-defined-literal} is treated as a call to a literal operator or


### PR DESCRIPTION
as directed by ISO/CS.

Partially addresses #4319