### PR TITLE
CWG Poll 1: P2238R0 Core Language Working Group "tentatively ready" Issues

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -8313,8 +8313,9 @@ void f6() {
 \indextext{class!linkage specification}%
 A C language linkage is ignored
 in determining the language linkage of
-the names of class members and the
-function type of class member functions.
+the names of class members,
+the names of friend functions with a trailing \grammarterm{requires-clause}, and
+the function type of class member functions.
 \begin{example}
 \begin{codeblock}
 extern "C" typedef void FUNC_c();

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6581,7 +6581,7 @@ and if that finds at least one declaration
 that is a function template whose first template parameter
 is a non-type parameter,
 the initializer is
-\tcode{\exposid{e}.get<i>()}. Otherwise, the initializer is \tcode{get<i>(\exposid{e})},
+\tcode{\exposidnc{e}.get<i>()}. Otherwise, the initializer is \tcode{get<i>(\exposid{e})},
 where \tcode{get} is looked up in the associated namespaces\iref{basic.lookup.argdep}.
 In either case, \tcode{get<i>} is interpreted as a \grammarterm{template-id}.
 \begin{note}
@@ -6610,7 +6610,7 @@ Otherwise,
 all of \tcode{E}'s non-static data members
 shall be direct members of \tcode{E} or
 of the same base class of \tcode{E},
-well-formed when named as \tcode{\exposid{e}.\placeholder{name}}
+well-formed when named as \tcode{\exposidnc{e}.\placeholder{name}}
 in the context of the structured binding,
 \tcode{E} shall not have an anonymous union member, and
 the number of elements in the \grammarterm{identifier-list} shall be
@@ -6620,16 +6620,20 @@ $\tcode{m}_0$, $\tcode{m}_1$, $\tcode{m}_2, \dotsc$
 (in declaration order),
 each \tcode{v}$_i$ is the
 name of an lvalue that refers to the member \tcode{m}$_i$ of \exposid{e} and
-whose type is \cv{}~$\tcode{T}_i$, where $\tcode{T}_i$ is the declared type of
-that member; the referenced type is \cv{}~$\tcode{T}_i$. The lvalue is a
+whose type is
+that of \tcode{\exposidnc{e}.$\tcode{m}_i$}\iref{expr.ref};
+the referenced type is
+the declared type of $\tcode{m}_i$ if that type is a reference type, or
+the type of \tcode{\exposidnc{e}.$\tcode{m}_i$} otherwise.
+The lvalue is a
 bit-field if that member is a bit-field.
 \begin{example}
 \begin{codeblock}
-struct S { int x1 : 2; volatile double y1; };
+struct S { mutable int x1 : 2; volatile double y1; };
 S f();
 const auto [ x, y ] = f();
 \end{codeblock}
-The type of the \grammarterm{id-expression} \tcode{x} is ``\tcode{const int}'',
+The type of the \grammarterm{id-expression} \tcode{x} is ``\tcode{int}'',
 the type of the \grammarterm{id-expression} \tcode{y} is ``\tcode{const volatile double}''.
 \end{example}
 

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -924,8 +924,10 @@ shall be a prvalue of type \tcode{void}.
 
 \pnum
 If \placeholder{p}\tcode{.return_void()} is a valid expression,
-flowing off the end of a coroutine is equivalent to a \tcode{co_return} with no operand;
-otherwise flowing off the end of a coroutine results in undefined behavior.
+flowing off the end of a coroutine's \grammarterm{function-body}
+is equivalent to a \tcode{co_return} with no operand;
+otherwise flowing off the end of a coroutine's \grammarterm{function-body}
+results in undefined behavior.
 
 \rSec2[stmt.goto]{The \tcode{goto} statement}%
 \indextext{statement!\idxcode{goto}}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -5349,6 +5349,8 @@ a compound type constructed from any dependent type,
 an array type whose element type is dependent or whose
 bound (if any) is value-dependent,
 \item
+a function type whose parameters include one or more function parameter packs,
+\item
 a function type whose exception specification is value-dependent,
 \item
 denoted by a \grammarterm{simple-template-id}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -4532,9 +4532,10 @@ no valid specialization can be generated for a template
 or a substatement of a constexpr if statement\iref{stmt.if} within a template
 and the template is not instantiated, or
 \item
-no substitution of template arguments
-into a \grammarterm{type-constraint} or \grammarterm{requires-clause}
-would result in a valid expression, or
+any \grammarterm{constraint-expression} in the program, introduced or otherwise,
+has (in its normal form) an atomic constraint $A$ where
+no satisfaction check of $A$ could be well-formed and
+no satisfaction check of $A$ is performed, or
 \item
 every valid specialization of a variadic template requires an empty template
 parameter pack, or

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -7596,13 +7596,52 @@ void g() {
 
 When all template arguments have been deduced or obtained from
 default template arguments, all uses of template parameters in
-the template parameter list of the template and the function type
+the template parameter list of the template
 are replaced with the corresponding deduced
 or default argument values. If the substitution results in an
 invalid type, as described above, type deduction fails.
 If the function template has associated constraints\iref{temp.constr.decl},
 those constraints are checked for satisfaction\iref{temp.constr.constr}.
 If the constraints are not satisfied, type deduction fails.
+In the context of a function call, if type deduction has not yet failed, then
+for those function parameters for which the function call has arguments,
+each function parameter with a type that was non-dependent
+before substitution of any explicitly-specified template arguments
+is checked against its corresponding argument;
+if the corresponding argument cannot be implicitly converted
+to the parameter type, type deduction fails.
+\begin{note}
+Overload resolution will check the other parameters, including
+parameters with dependent types in which
+no template parameters participate in template argument deduction and
+parameters that became non-dependent due to substitution of
+explicitly-specified template arguments.
+\end{note}
+If type deduction has not yet failed, then
+all uses of template parameters in the function type are
+replaced with the corresponding deduced or default argument values.
+If the substitution results in an invalid type, as described above,
+type deduction fails.
+\begin{example}
+\begin{codeblock}
+template <class T> struct Z {
+  typedef typename T::x xx;
+};
+template <class T> concept C = requires { typename T::A; };
+template <C T> typename Z<T>::xx f(void *, T);          // \#1
+template <class T> void f(int, T);                      // \#2
+struct A {} a;
+struct ZZ {
+  template <class T, class = typename Z<T>::xx> operator T *();
+  operator int();
+};
+int main() {
+  ZZ zz;
+  f(1, a);              // OK, deduction fails for \#1 because there is no conversion from \tcode{int} to \tcode{void*}
+  f(zz, 42);            // OK, deduction fails for \#1 because \tcode{C<int>} is not satisfied
+}
+\end{codeblock}
+\end{example}
 
 \pnum
 At certain points in the template argument deduction process it is necessary
@@ -8157,35 +8196,6 @@ template <class T> int f(T, T (*p)(T));
 char g(char);
 template <class T> T g(T);
 int i = f(1, g);    // calls \tcode{f(int, int (*)(int))}
-\end{codeblock}
-\end{example}
-
-\pnum
-If deduction succeeds for all parameters that contain
-\grammarterm{template-parameter}{s} that participate in template argument
-deduction, and all template arguments are explicitly specified, deduced,
-or obtained from default template arguments, remaining parameters are then
-compared with the corresponding arguments. For each remaining parameter
-\tcode{P} with a type that was non-dependent before substitution of any
-explicitly-specified template arguments, if the corresponding argument
-\tcode{A} cannot be implicitly converted to \tcode{P}, deduction fails.
-\begin{note}
-Parameters with dependent types in which no \grammarterm{template-parameter}{s}
-participate in template argument deduction, and parameters that became
-non-dependent due to substitution of explicitly-specified template arguments,
-will be checked during overload resolution.
-\end{note}
-\begin{example}
-\begin{codeblock}
-template <class T> struct Z {
-  typedef typename T::x xx;
-};
-template <class T> typename Z<T>::xx f(void *, T);      // \#1
-template <class T> void f(int, T);                      // \#2
-struct A {} a;
-int main() {
-  f(1, a);          // OK, deduction fails for \#1 because there is no conversion from \tcode{int} to \tcode{void*}
-}
 \end{codeblock}
 \end{example}
 


### PR DESCRIPTION
Fixes #4322

Questions/comments:
* CWG2312 It looks like there's a space after the "e" in "e.mi".  I tried both `\tcode{\exposid{e}.$\tcode{m}_i$}` and `$\tcode{\exposid{e}.m}_i$` with the same results.  Is this space a problem? If so, how to fix?
