### PR TITLE
LWG Poll 3: P2236R0 Standard Library Ready and Tentatively Ready issues

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -262,11 +262,12 @@ dispatching to the overload in namespace \tcode{ranges}
 that takes separate iterator and sentinel arguments.
 
 \pnum
-The number and order of deducible template parameters for algorithm declarations
-are unspecified, except where explicitly stated otherwise.
+The well-formedness and behavior of a call to an algorithm with
+an explicitly-specified template argument list
+is unspecified, except where explicitly stated otherwise.
 \begin{note}
-Consequently, an implementation can reject calls
-that specify an explicit template argument list.
+Consequently, an implementation can declare an algorithm with
+different template parameters than those presented.
 \end{note}
 
 \rSec1[algorithms.parallel]{Parallel algorithms}

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -626,10 +626,11 @@ This requirement is optional in freestanding implementations\iref{compliance}.
 \end{note}
 
 \pnum
-The function \tcode{atomic_is_lock_free}\iref{atomics.types.operations}
-indicates whether the object is lock-free. In any given program execution, the
-result of the lock-free query shall be consistent for all pointers of the same
-type.
+The functions \tcode{atomic<T>::is_lock_free} and
+\tcode{atomic_is_lock_free}\iref{atomics.types.operations}
+indicate whether the object is lock-free. In any given program execution, the
+result of the lock-free query
+is the same for all atomic objects of the same type.
 
 \pnum
 Atomic operations that are not lock-free are considered to potentially

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -331,8 +331,8 @@ template<class Derived, class Base>
 
 \pnum
 Given types \tcode{From} and \tcode{To} and
-an expression \tcode{E} such that
-\tcode{decltype((E))} is \tcode{add_rvalue_reference_t<From>},
+an expression \tcode{E}
+whose type and value category are the same as those of \tcode{declval<From>()},
 \tcode{\libconcept{convertible_to}<From, To>} requires \tcode{E}
 to be both implicitly and explicitly convertible to type \tcode{To}.
 The implicit and explicit conversions are required to produce equal

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -907,7 +907,7 @@ in a function call\iref{temp.deduct.call} and
 A \defnadj{key}{parameter} of a function template \tcode{D}
 is a function parameter of type \cv{} \tcode{X} or reference thereto,
 where \tcode{X} names a specialization of a class template that
-is a member of the same namespace as \tcode{D}, and
+has the same innermost enclosing non-inline namespace as \tcode{D}, and
 \tcode{X} contains at least one template parameter that
 participates in template argument deduction.
 \begin{example}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -179,8 +179,9 @@ In Tables~\ref{tab:container.req},
 \tcode{a = rv}              &
   \tcode{X\&}               &
   All existing elements of \tcode{a} are either move assigned to or destroyed   &
-  \ensures \tcode{a} is equal to the value that \tcode{rv}
-  had before this assignment   &
+  \ensures If \tcode{a} and \tcode{rv} do not refer to the same object,
+  \tcode{a} is equal to the value that \tcode{rv}
+  had before this assignment.   &
    linear                     \\ \rowsep
 
 \tcode{a.\~X()}    &
@@ -707,7 +708,8 @@ non-const rvalue of type \tcode{X}, and \tcode{m} is a value of type \tcode{A}.
   \oldconcept{MoveAssignable}.\br
   \effects All existing elements of \tcode{a}
   are either move assigned to or destroyed.\br
-  \ensures \tcode{a} is equal to the value that \tcode{rv} had before
+  \ensures If \tcode{a} and \tcode{rv} do not refer to the same object,
+  \tcode{a} is equal to the value that \tcode{rv} had before
   this assignment.      &
   linear                \\ \rowsep
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1276,11 +1276,12 @@ public:
   using allocator_type = @\seebelownc{}@;
 
 private:
-  using container_node_type = @\unspecnc@;
-  using ator_traits = allocator_traits<allocator_type>;
+  using container_node_type = @\unspecnc@;                  // \expos
+  using ator_traits = allocator_traits<allocator_type>;     // \expos
 
-  typename ator_traits::template rebind_traits<container_node_type>::pointer ptr_;
-  optional<allocator_type> alloc_;
+  typename ator_traits::template
+    rebind_traits<container_node_type>::pointer ptr_;       // \expos
+  optional<allocator_type> alloc_;                          // \expos
 
 public:
   // \ref{container.node.cons}, constructors, copy, and assignment

--- a/source/future.tex
+++ b/source/future.tex
@@ -1529,6 +1529,35 @@ namespace std {
 }
 \end{codeblock}
 
+\rSec1[depr.mem.poly.allocator.mem]{Deprecated \tcode{polymorphic_allocator} member function}
+
+\pnum
+The following member is declared in addition to those members
+specified in \ref{mem.poly.allocator.mem}:
+
+\begin{codeblock}
+namespace std::pmr {
+  template<class Tp = byte>
+  class polymorphic_allocator {
+  public:
+    template <class T>
+      void destroy(T* p);
+  };
+}
+\end{codeblock}
+
+\indexlibrarymember{destroy}{polymorphic_allocator}%
+\begin{itemdecl}
+template<class T>
+  void destroy(T* p);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+As if by \tcode{p->\~T()}.
+\end{itemdescr}
+
 \rSec1[depr.meta.types]{Deprecated type traits}
 
 \pnum

--- a/source/future.tex
+++ b/source/future.tex
@@ -1514,6 +1514,21 @@ int pcount() const;
 \tcode{rdbuf()->pcount()}.
 \end{itemdescr}
 
+\rSec1[depr.default.allocator]{The default allocator}
+
+\pnum
+The following member is defined in addition to those
+specified in \ref{default.allocator}:
+
+\begin{codeblock}
+namespace std {
+  template<class T> class allocator {
+  public:
+    using is_always_equal = true_type;
+  };
+}
+\end{codeblock}
+
 \rSec1[depr.meta.types]{Deprecated type traits}
 
 \pnum

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -1604,6 +1604,7 @@ at such time that any
 member function called from within
 \tcode{fn}
 has well-defined results.
+Then, any memory obtained is deallocated.
 \end{itemdescr}
 
 \rSec2[fpos]{Class template \tcode{fpos}}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4986,6 +4986,8 @@ input function (as described above).
 \returns
 The number of characters
 extracted by the last unformatted input member function called for the object.
+If the number cannot be represented,
+returns \tcode{numeric_limits<streamsize>::max()}.
 \end{itemdescr}
 
 \indexlibrarymember{get}{basic_istream}%

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -17186,39 +17186,39 @@ namespace std {
   imaxdiv_t div(intmax_t, intmax_t);    // optional, see below
 }
 
-#define PRIdN @\seebelow@
-#define PRIiN @\seebelow@
-#define PRIoN @\seebelow@
-#define PRIuN @\seebelow@
-#define PRIxN @\seebelow@
-#define PRIXN @\seebelow@
-#define SCNdN @\seebelow@
-#define SCNiN @\seebelow@
-#define SCNoN @\seebelow@
-#define SCNuN @\seebelow@
-#define SCNxN @\seebelow@
-#define PRIdLEASTN @\seebelow@
-#define PRIiLEASTN @\seebelow@
-#define PRIoLEASTN @\seebelow@
-#define PRIuLEASTN @\seebelow@
-#define PRIxLEASTN @\seebelow@
-#define PRIXLEASTN @\seebelow@
-#define SCNdLEASTN @\seebelow@
-#define SCNiLEASTN @\seebelow@
-#define SCNoLEASTN @\seebelow@
-#define SCNuLEASTN @\seebelow@
-#define SCNxLEASTN @\seebelow@
-#define PRIdFASTN @\seebelow@
-#define PRIiFASTN @\seebelow@
-#define PRIoFASTN @\seebelow@
-#define PRIuFASTN @\seebelow@
-#define PRIxFASTN @\seebelow@
-#define PRIXFASTN @\seebelow@
-#define SCNdFASTN @\seebelow@
-#define SCNiFASTN @\seebelow@
-#define SCNoFASTN @\seebelow@
-#define SCNuFASTN @\seebelow@
-#define SCNxFASTN @\seebelow@
+#define PRId@\placeholdernc{N}@ @\seebelow@
+#define PRIi@\placeholdernc{N}@ @\seebelow@
+#define PRIo@\placeholdernc{N}@ @\seebelow@
+#define PRIu@\placeholdernc{N}@ @\seebelow@
+#define PRIx@\placeholdernc{N}@ @\seebelow@
+#define PRIX@\placeholdernc{N}@ @\seebelow@
+#define SCNd@\placeholdernc{N}@ @\seebelow@
+#define SCNi@\placeholdernc{N}@ @\seebelow@
+#define SCNo@\placeholdernc{N}@ @\seebelow@
+#define SCNu@\placeholdernc{N}@ @\seebelow@
+#define SCNx@\placeholdernc{N}@ @\seebelow@
+#define PRIdLEAST@\placeholdernc{N}@ @\seebelow@
+#define PRIiLEAST@\placeholdernc{N}@ @\seebelow@
+#define PRIoLEAST@\placeholdernc{N}@ @\seebelow@
+#define PRIuLEAST@\placeholdernc{N}@ @\seebelow@
+#define PRIxLEAST@\placeholdernc{N}@ @\seebelow@
+#define PRIXLEAST@\placeholdernc{N}@ @\seebelow@
+#define SCNdLEAST@\placeholdernc{N}@ @\seebelow@
+#define SCNiLEAST@\placeholdernc{N}@ @\seebelow@
+#define SCNoLEAST@\placeholdernc{N}@ @\seebelow@
+#define SCNuLEAST@\placeholdernc{N}@ @\seebelow@
+#define SCNxLEAST@\placeholdernc{N}@ @\seebelow@
+#define PRIdFAST@\placeholdernc{N}@ @\seebelow@
+#define PRIiFAST@\placeholdernc{N}@ @\seebelow@
+#define PRIoFAST@\placeholdernc{N}@ @\seebelow@
+#define PRIuFAST@\placeholdernc{N}@ @\seebelow@
+#define PRIxFAST@\placeholdernc{N}@ @\seebelow@
+#define PRIXFAST@\placeholdernc{N}@ @\seebelow@
+#define SCNdFAST@\placeholdernc{N}@ @\seebelow@
+#define SCNiFAST@\placeholdernc{N}@ @\seebelow@
+#define SCNoFAST@\placeholdernc{N}@ @\seebelow@
+#define SCNuFAST@\placeholdernc{N}@ @\seebelow@
+#define SCNxFAST@\placeholdernc{N}@ @\seebelow@
 #define PRIdMAX @\seebelow@
 #define PRIiMAX @\seebelow@
 #define PRIoMAX @\seebelow@
@@ -17264,3 +17264,12 @@ which shall have the same semantics as the function signatures
 \end{itemize}
 
 \xrefc{7.8}
+
+\pnum
+Each of the \tcode{PRI} macros listed in this subclause
+is defined if and only if the implementation
+defines the corresponding typedef name in~\ref{cstdint.syn}.
+Each of the \tcode{SCN} macros listed in this subclause
+is defined if and only if the implementation
+defines the corresponding typedef name in~\ref{cstdint.syn} and
+has a suitable \tcode{fscanf} length modifier for the type.

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -14219,6 +14219,11 @@ namespace std::filesystem {
     bool operator==(const directory_entry& rhs) const noexcept;
     strong_ordering operator<=>(const directory_entry& rhs) const noexcept;
 
+    // \ref{fs.dir.entry.io}, inserter
+    template<class charT, class traits>
+      friend basic_ostream<charT, traits>&
+        operator<<(basic_ostream<charT, traits>& os, const directory_entry& d);
+
   private:
     filesystem::path pathobject;        // \expos
     friend class directory_iterator;    // \expos
@@ -14635,6 +14640,21 @@ strong_ordering operator<=>(const directory_entry& rhs) const noexcept;
 \pnum
 \returns
 \tcode{pathobject <=> rhs.pathobject}.
+\end{itemdescr}
+
+\rSec3[fs.dir.entry.io]{Inserter}
+
+\indexlibrarymember{operator<<}{directory_entry}%
+\begin{itemdecl}
+template<class charT, class traits>
+  friend basic_ostream<charT, traits>&
+    operator<<(basic_ostream<charT, traits>& os, const directory_entry& d);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return os << d.path();}
 \end{itemdescr}
 
 \rSec2[fs.class.directory.iterator]{Class \tcode{directory_iterator}}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2264,7 +2264,7 @@ the following expressions are valid as shown in \tref{randomaccessiterator}.
 \tcode{a < b}       &
  contextually
  convertible to \tcode{bool}    &
- \tcode{b - a > 0}  &
+ \effects Equivalent to: \tcode{return b - a > 0;}  &
  \tcode{<} is a total ordering relation \\ \rowsep
 
 \tcode{a > b}       &

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1411,13 +1411,13 @@ For every (possibly cv-qualified) integer-class type \tcode{I},
 \end{itemize}
 
 \pnum
-A type \tcode{I} is \defn{integer-like}
+A type \tcode{I} other than \cv{}~\tcode{bool} is \defn{integer-like}
 if it models \tcode{\libconcept{integral}<I>} or
 if it is an integer-class type.
-A type \tcode{I} is \defn{signed-integer-like}
+An integer-like type \tcode{I} is \defn{signed-integer-like}
 if it models \tcode{\libconcept{signed_integral}<I>} or
 if it is a signed-integer-class type.
-A type \tcode{I} is \defn{unsigned-integer-like}
+An integer-like type \tcode{I} is \defn{unsigned-integer-like}
 if it models \tcode{\libconcept{unsigned_integral}<I>} or
 if it is an unsigned-integer-class type.
 

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -5339,6 +5339,10 @@ constexpr decltype(auto) operator*() const
 
 \begin{itemdescr}
 \pnum
+\expects
+\tcode{length > 0} is \tcode{true}.
+
+\pnum
 \effects
 Equivalent to: \tcode{return *current;}
 \end{itemdescr}
@@ -5642,6 +5646,10 @@ friend constexpr iter_rvalue_reference_t<I>
 
 \begin{itemdescr}
 \pnum
+\expects
+\tcode{i.length > 0} is \tcode{true}.
+
+\pnum
 \effects
 Equivalent to: \tcode{return ranges::iter_move(i.current);}
 \end{itemdescr}
@@ -5655,6 +5663,10 @@ template<@\libconcept{indirectly_swappable}@<I> I2>
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\expects
+Both \tcode{x.length > 0} and \tcode{y.length > 0} are \tcode{true}.
+
 \pnum
 \effects
 Equivalent to \tcode{ranges::iter_swap(x.current, y.current)}.

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2855,6 +2855,7 @@ template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<
 \begin{itemdescr}
 \pnum
 \expects
+Either \tcode{assignable_from<I\&, S> || sized_sentinel_for<S, I>} is modeled, or
 \range{i}{bound} denotes a range.
 
 \pnum

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -745,6 +745,12 @@ struct @\placeholder{cond-value-type}@<T> {
   using value_type = remove_cv_t<T>;
 };
 
+template<class T>
+  concept @\defexposconcept{has-member-value-type}@ = requires { typename T::value_type; };         // \expos
+
+template<class T>
+  concept @\defexposconcept{has-member-element-type}@ = requires { typename T::element_type; };     // \expos
+
 template<class> struct indirectly_readable_traits { };
 
 template<class T>
@@ -761,15 +767,19 @@ template<class I>
 struct indirectly_readable_traits<const I>
   : indirectly_readable_traits<I> { };
 
-template<class T>
-  requires requires { typename T::value_type; }
+template<@\exposconcept{has-member-value-type}@ T>
 struct indirectly_readable_traits<T>
   : @\placeholder{cond-value-type}@<typename T::value_type> { };
 
-template<class T>
-  requires requires { typename T::element_type; }
+template<@\exposconcept{has-member-element-type}@ T>
 struct indirectly_readable_traits<T>
   : @\placeholder{cond-value-type}@<typename T::element_type> { };
+
+template<@\exposconcept{has-member-value-type}@ T>
+  requires @\exposconcept{has-member-element-type}@<T> &&
+           @\libconcept{same_as}@<remove_cv_t<typename T::element_type>, remove_cv_t<typename T::value_type>>
+struct indirectly_readable_traits<T>
+  : @\placeholder{cond-value-type}@<typename T::value_type> { };
 
 template<class T> using iter_value_t = @\seebelow@;
 \end{codeblock}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -856,11 +856,11 @@ exposition-only concepts:
 \begin{codeblock}
 template<class I>
 concept @\defexposconcept{cpp17-iterator}@ =
-  @\libconcept{copyable}@<I> && requires(I i) {
+  requires(I i) {
     {   *i } -> @\exposconcept{can-reference}@;
     {  ++i } -> @\libconcept{same_as}@<I&>;
     { *i++ } -> @\exposconcept{can-reference}@;
-  };
+  } && @\libconcept{copyable}@<I>;
 
 template<class I>
 concept @\defexposconcept{cpp17-input-iterator}@ =

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1546,6 +1546,8 @@ Let \tcode{s} and \tcode{i} be values of type \tcode{S} and
 
 \item If \tcode{bool(i != s)} then \tcode{i} is dereferenceable and
       \range{++i}{s} denotes a range.
+
+\item \tcode{assignable_from<I\&, S>} is either modeled or not satisfied.
 \end{itemize}
 \end{itemdescr}
 

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -3198,6 +3198,11 @@ template<class U> constexpr reverse_iterator(const reverse_iterator<U>& u);
 
 \begin{itemdescr}
 \pnum
+\constraints
+\tcode{is_same_v<U, Iterator>} is \tcode{false} and
+\tcode{const U\&} models \tcode{\libconcept{convertible_to}<Iterator>}.
+
+\pnum
 \effects
 Initializes
 \tcode{current}
@@ -3214,8 +3219,14 @@ template<class U>
 
 \begin{itemdescr}
 \pnum
+\constraints
+\tcode{is_same_v<U, Iterator>} is \tcode{false},
+\tcode{const U\&} models \tcode{\libconcept{convertible_to}<Iterator>}, and
+\tcode{\libconcept{assignable_from}<Iterator\&, const U\&>} is modeled.
+
+\pnum
 \effects
-Assigns \tcode{u.base()} to \tcode{current}.
+Assigns \tcode{u.current} to \tcode{current}.
 
 \pnum
 \returns
@@ -4148,10 +4159,7 @@ constexpr move_iterator();
 \begin{itemdescr}
 \pnum
 \effects
-Constructs a \tcode{move_iterator}, value-initializing
-\tcode{current}. Iterator operations applied to the resulting
-iterator have defined behavior if and only if the corresponding operations are defined
-on a value-initialized iterator of type \tcode{Iterator}.
+Value-initializes \tcode{current}.
 \end{itemdescr}
 
 
@@ -4163,8 +4171,7 @@ constexpr explicit move_iterator(Iterator i);
 \begin{itemdescr}
 \pnum
 \effects
-Constructs a \tcode{move_iterator}, initializing
-\tcode{current} with \tcode{std::move(i)}.
+Initializes \tcode{current} with \tcode{std::move(i)}.
 \end{itemdescr}
 
 
@@ -4175,13 +4182,13 @@ template<class U> constexpr move_iterator(const move_iterator<U>& u);
 
 \begin{itemdescr}
 \pnum
-\mandates
-\tcode{U} is convertible to \tcode{Iterator}.
+\constraints
+\tcode{is_same_v<U, Iterator>} is \tcode{false} and
+\tcode{const U\&} models \tcode{\libconcept{convertible_to}<Iterator>}.
 
 \pnum
 \effects
-Constructs a \tcode{move_iterator}, initializing
-\tcode{current} with \tcode{u.base()}.
+Initializes \tcode{current} with \tcode{u.current}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{move_iterator}%
@@ -4191,12 +4198,14 @@ template<class U> constexpr move_iterator& operator=(const move_iterator<U>& u);
 
 \begin{itemdescr}
 \pnum
-\mandates
-\tcode{U} is convertible to \tcode{Iterator}.
+\constraints
+\tcode{is_same_v<U, Iterator>} is \tcode{false},
+\tcode{const U\&} models \tcode{\libconcept{convertible_to}<Iterator>}, and
+\tcode{\libconcept{assignable_from}<Iterator\&, const U\&>} is modeled.
 
 \pnum
 \effects
-Assigns \tcode{u.base()} to
+Assigns \tcode{u.current} to
 \tcode{current}.
 \end{itemdescr}
 

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2721,11 +2721,13 @@ pointer did point to the first element of such an array) are in fact valid.
 
 \item
 If a function argument binds to an rvalue reference parameter, the implementation may
-assume that this parameter is a unique reference to this argument.
+assume that this parameter is a unique reference to this argument,
+except that the argument passed to a move-assignment operator may be
+a reference to \tcode{*this}\iref{lib.types.movedfrom}.
 \begin{note}
-If the parameter is a generic parameter of the form \tcode{T\&\&} and an lvalue of type
-\tcode{A} is bound, the argument binds to an lvalue reference\iref{temp.deduct.call}
-and thus is not covered by the previous sentence.
+If the type of a parameter is a forwarding reference\iref{temp.deduct.call}
+that is deduced to an lvalue reference type, then
+the argument is not bound to an rvalue reference.
 \end{note}
 \begin{note}
 If a program casts
@@ -3166,3 +3168,9 @@ Objects of types defined in the \Cpp{} standard library may be moved
 from\iref{class.copy.ctor}. Move operations may be explicitly specified or
 implicitly generated. Unless otherwise specified, such moved-from objects shall
 be placed in a valid but unspecified state.
+
+\pnum
+An object of a type defined in the \Cpp{} standard library may be
+move-assigned\iref{class.copy.assign} to itself.
+Unless otherwise specified, such an assignment places the object in
+a valid but unspecified state.

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -4541,13 +4541,17 @@ namespace std::ranges {
     constexpr auto begin() requires (!@\exposconcept{simple-view}@<V>)
     { return ranges::begin(@\exposid{base_}@); }
 
-    constexpr auto begin() const requires range<const V>
+    constexpr auto begin() const
+      requires range<const V> &&
+               indirect_unary_predicate<const Pred, iterator_t<const V>>
     { return ranges::begin(@\exposid{base_}@); }
 
     constexpr auto end() requires (!@\exposconcept{simple-view}@<V>)
     { return @\exposid{sentinel}@<false>(ranges::end(@\exposid{base_}@), addressof(*@\exposid{pred_}@)); }
 
-    constexpr auto end() const requires range<const V>
+    constexpr auto end() const
+      requires range<const V> &&
+               indirect_unary_predicate<const Pred, iterator_t<const V>>
     { return @\exposid{sentinel}@<true>(ranges::end(@\exposid{base_}@), addressof(*@\exposid{pred_}@)); }
   };
 

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -4743,9 +4743,10 @@ namespace std::ranges {
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
     constexpr auto begin()
-      requires (!(@\exposconcept{simple-view}@<V> && @\libconcept{random_access_range}@<V>));
+      requires (!(@\exposconcept{simple-view}@<V> &&
+		  @\libconcept{random_access_range}@<const V> && @\libconcept{sized_range}@<const V>));
     constexpr auto begin() const
-      requires @\libconcept{random_access_range}@<const V>;
+      requires @\libconcept{random_access_range}@<const V> && @\libconcept{sized_range}@<const V>;
 
     constexpr auto end()
       requires (!@\exposconcept{simple-view}@<V>)
@@ -4799,9 +4800,10 @@ Initializes \exposid{base_} with \tcode{std::move(base)} and
 \indexlibrarymember{begin}{drop_view}%
 \begin{itemdecl}
 constexpr auto begin()
-  requires (!(@\exposconcept{simple-view}@<V> && @\libconcept{random_access_range}@<V>));
+  requires (!(@\exposconcept{simple-view}@<V> &&
+	      @\libconcept{random_access_range}@<const V> && @\libconcept{sized_range}@<const V>));
 constexpr auto begin() const
-  requires random_access_range<const V>;
+  requires random_access_range<const V> && @\libconcept{sized_range}@<const V>;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -160,6 +160,9 @@ namespace std::ranges {
 
   namespace views { inline constexpr @\unspec@ single = @\unspec@; }
 
+  template<bool Const, class T>
+    using @\exposid{maybe-const}@ = conditional_t<Const, const T, T>;   // \expos
+
   // \ref{range.iota}, iota view
   template<@\libconcept{weakly_incrementable}@ W, @\libconcept{semiregular}@ Bound = unreachable_sentinel_t>
     requires @\exposconcept{weakly-equality-comparable-with}@<W, Bound> && semiregular<W>
@@ -4168,14 +4171,19 @@ namespace std::ranges {
 
     constexpr sentinel_t<@\exposid{Base}@> base() const;
 
-    friend constexpr bool operator==(const @\exposid{iterator}@<Const>& x, const @\exposid{sentinel}@& y);
+    template<bool OtherConst>
+      requires @\libconcept{sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>
+    friend constexpr bool operator==(const @\exposid{iterator}@<OtherConst>& x, const @\exposid{sentinel}@& y);
 
-    friend constexpr range_difference_t<@\exposid{Base}@>
-      operator-(const @\exposid{iterator}@<Const>& x, const @\exposid{sentinel}@& y)
-        requires @\libconcept{sized_sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
-    friend constexpr range_difference_t<@\exposid{Base}@>
-      operator-(const @\exposid{sentinel}@& y, const @\exposid{iterator}@<Const>& x)
-        requires @\libconcept{sized_sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
+    template<bool OtherConst>
+      requires @\libconcept{sized_sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>
+    friend constexpr range_difference_t<@\exposid{maybe-const}@<OtherConst, V>>
+      operator-(const @\exposid{iterator}@<OtherConst>& x, const @\exposid{sentinel}@& y);
+
+    template<bool OtherConst>
+      requires @\libconcept{sized_sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>
+    friend constexpr range_difference_t<@\exposid{maybe-const}@<OtherConst, V>>
+      operator-(const @\exposid{sentinel}@& y, const @\exposid{iterator}@<OtherConst>& x);
   };
 }
 \end{codeblock}
@@ -4216,7 +4224,9 @@ Equivalent to: \tcode{return \exposid{end_};}
 
 \indexlibrarymember{operator==}{transform_view::sentinel}
 \begin{itemdecl}
-friend constexpr bool operator==(const @\exposid{iterator}@<Const>& x, const @\exposid{sentinel}@& y);
+template<bool OtherConst>
+  requires @\libconcept{sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>
+friend constexpr bool operator==(const @\exposid{iterator}@<OtherConst>& x, const @\exposid{sentinel}@& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4227,9 +4237,10 @@ Equivalent to: \tcode{return x.\exposid{current_} == y.\exposid{end_};}
 
 \indexlibrarymember{operator-}{transform_view::sentinel}%
 \begin{itemdecl}
-friend constexpr range_difference_t<@\exposid{Base}@>
-  operator-(const @\exposid{iterator}@<Const>& x, const @\exposid{sentinel}@& y)
-    requires @\libconcept{sized_sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
+template<bool OtherConst>
+  requires @\libconcept{sized_sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>
+friend constexpr range_difference_t<@\exposid{maybe-const}@<OtherConst, V>>
+  operator-(const @\exposid{iterator}@<OtherConst>& x, const @\exposid{sentinel}@& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4240,9 +4251,10 @@ Equivalent to: \tcode{return x.\exposid{current_} - y.\exposid{end_};}
 
 \indexlibrarymember{operator-}{transform_view::sentinel}%
 \begin{itemdecl}
-friend constexpr range_difference_t<@\exposid{Base}@>
-  operator-(const @\exposid{sentinel}@& y, const @\exposid{iterator}@<Const>& x)
-    requires @\libconcept{sized_sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
+template<bool OtherConst>
+  requires @\libconcept{sized_sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>
+friend constexpr range_difference_t<@\exposid{maybe-const}@<OtherConst, V>>
+  operator-(const @\exposid{sentinel}@& y, const @\exposid{iterator}@<OtherConst>& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5346,7 +5358,9 @@ namespace std::ranges {
     constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> s)
       requires Const && @\libconcept{convertible_to}@<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
 
-    friend constexpr bool operator==(const @\exposid{iterator}@<Const>& x, const @\exposid{sentinel}@& y);
+    template<bool OtherConst>
+      requires @\libconcept{sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>
+    friend constexpr bool operator==(const @\exposid{iterator}@<OtherConst>& x, const @\exposid{sentinel}@& y);
   };
 }
 \end{codeblock}
@@ -5377,7 +5391,9 @@ Initializes \exposid{end_} with \tcode{std::move(s.\exposid{end_})}.
 \indexlibrarymember{operator==}{join_view::sentinel}%3431
 
 \begin{itemdecl}
-friend constexpr bool operator==(const @\exposid{iterator}@<Const>& x, const @\exposid{sentinel}@& y);
+template<bool OtherConst>
+  requires @\libconcept{sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>
+friend constexpr bool operator==(const @\exposid{iterator}@<OtherConst>& x, const @\exposid{sentinel}@& y);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -4422,9 +4422,10 @@ namespace std::ranges {
   template<bool Const>
   class take_view<V>::@\exposid{sentinel}@ {
   private:
-    using @\exposid{Base}@ = @\exposid{maybe-const}@<Const, V>;                 // \expos
-    using @\exposid{CI}@ = counted_iterator<iterator_t<@\exposid{Base}@>>;      // \expos
-    sentinel_t<@\exposid{Base}@> @\exposid{end_}@ = sentinel_t<@\exposid{Base}@>();         // \expos
+    using @\exposid{Base}@ = @\exposid{maybe-const}@<Const, V>;                                     // \expos
+    template<bool OtherConst>
+      using @\exposid{CI}@ = counted_iterator<iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>;  // \expos
+    sentinel_t<@\exposid{Base}@> @\exposid{end_}@ = sentinel_t<@\exposid{Base}@>();                             // \expos
   public:
     @\exposid{sentinel}@() = default;
     constexpr explicit @\exposid{sentinel}@(sentinel_t<@\exposid{Base}@> end);
@@ -4433,7 +4434,11 @@ namespace std::ranges {
 
     constexpr sentinel_t<@\exposid{Base}@> base() const;
 
-    friend constexpr bool operator==(const @\exposid{CI}@& y, const @\exposid{sentinel}@& x);
+    friend constexpr bool operator==(const @\exposid{CI}@<Const>& y, const @\exposid{sentinel}@& x);
+
+    template<bool OtherConst = !Const>
+      requires @\libconcept{sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>
+    friend constexpr bool operator==(const @\exposid{CI}@<OtherConst>& y, const @\exposid{sentinel}@& x);
   };
 }
 \end{codeblock}
@@ -4474,7 +4479,11 @@ Equivalent to: \tcode{return \exposid{end_};}
 
 \indexlibrarymember{operator==}{take_view::sentinel}%
 \begin{itemdecl}
-friend constexpr bool operator==(const @\exposid{CI}@& y, const @\exposid{sentinel}@& x);
+friend constexpr bool operator==(const @\exposid{CI}@<Const>& y, const @\exposid{sentinel}@& x);
+
+template<bool OtherConst = !Const>
+  requires @\libconcept{sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>
+friend constexpr bool operator==(const @\exposid{CI}@<OtherConst>& y, const @\exposid{sentinel}@& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4611,6 +4620,11 @@ namespace std::ranges {
     constexpr sentinel_t<@\exposid{Base}@> base() const { return @\exposid{end_}@; }
 
     friend constexpr bool operator==(const iterator_t<@\exposid{Base}@>& x, const @\exposid{sentinel}@& y);
+
+    template<bool OtherConst = !Const>
+      requires @\libconcept{sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>
+    friend constexpr bool operator==(const iterator_t<@\exposid{maybe-const}@<OtherConst, V>>& x,
+                                     const @\exposid{sentinel}@& y);
   };
 }
 \end{codeblock}
@@ -4642,6 +4656,11 @@ Initializes \exposid{end_} with \tcode{s.\exposid{end_}} and
 \indexlibrarymember{operator==}{take_while_view::sentinel}%
 \begin{itemdecl}
 friend constexpr bool operator==(const iterator_t<@\exposid{Base}@>& x, const @\exposid{sentinel}@& y);
+
+template<bool OtherConst = !Const>
+  requires @\libconcept{sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>
+friend constexpr bool operator==(const iterator_t<@\exposid{maybe-const}@<OtherConst, V>>& x,
+                                 const @\exposid{sentinel}@& y);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1478,11 +1478,6 @@ namespace std::ranges {
       @\exposconcept{convertible-to-non-slicing}@<U, tuple_element_t<0, T>> &&
       @\libconcept{convertible_to}@<V, tuple_element_t<1, T>>;
 
-  template<class T>
-    concept @\defexposconcept{iterator-sentinel-pair}@ =                        // \expos
-      !range<T> && @\exposconcept{pair-like}@<T> &&
-      @\libconcept{sentinel_for}@<tuple_element_t<1, T>, tuple_element_t<0, T>>;
-
   template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S = I, subrange_kind K =
       @\libconcept{sized_sentinel_for}@<S, I> ? subrange_kind::sized : subrange_kind::unsized>
     requires (K == subrange_kind::sized || !@\libconcept{sized_sentinel_for}@<S, I>)
@@ -1543,13 +1538,6 @@ namespace std::ranges {
   template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
     subrange(I, S, @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>>) ->
       subrange<I, S, subrange_kind::sized>;
-
-  template<@\exposconcept{iterator-sentinel-pair}@ P>
-    subrange(P) -> subrange<tuple_element_t<0, P>, tuple_element_t<1, P>>;
-
-  template<@\exposconcept{iterator-sentinel-pair}@ P>
-    subrange(P, @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<tuple_element_t<0, P>>>) ->
-      subrange<tuple_element_t<0, P>, tuple_element_t<1, P>, subrange_kind::sized>;
 
   template<borrowed_range R>
     subrange(R&&) ->

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -3756,7 +3756,7 @@ namespace std::ranges {
     using @\exposid{Parent}@ =                              // \expos
       conditional_t<Const, const transform_view, transform_view>;
     using @\exposid{Base}@   =                              // \expos
-      conditional_t<Const, const V, V>;
+      @\exposid{maybe-const}@<Const, V>;
     iterator_t<@\exposid{Base}@> @\exposid{current_}@ =                 // \expos
       iterator_t<@\exposid{Base}@>();
     @\exposid{Parent}@* @\exposid{parent_}@ = nullptr;                  // \expos
@@ -4161,7 +4161,7 @@ namespace std::ranges {
   private:
     using @\exposid{Parent}@ =                                      // \expos
       conditional_t<Const, const transform_view, transform_view>;
-    using @\exposid{Base}@ = conditional_t<Const, const V, V>;      // \expos
+    using @\exposid{Base}@ = @\exposid{maybe-const}@<Const, V>;                 // \expos
     sentinel_t<@\exposid{Base}@> @\exposid{end_}@ = sentinel_t<@\exposid{Base}@>();         // \expos
   public:
     @\exposid{sentinel}@() = default;
@@ -4422,7 +4422,7 @@ namespace std::ranges {
   template<bool Const>
   class take_view<V>::@\exposid{sentinel}@ {
   private:
-    using @\exposid{Base}@ = conditional_t<Const, const V, V>;      // \expos
+    using @\exposid{Base}@ = @\exposid{maybe-const}@<Const, V>;                 // \expos
     using @\exposid{CI}@ = counted_iterator<iterator_t<@\exposid{Base}@>>;      // \expos
     sentinel_t<@\exposid{Base}@> @\exposid{end_}@ = sentinel_t<@\exposid{Base}@>();         // \expos
   public:
@@ -4598,7 +4598,7 @@ namespace std::ranges {
              @\libconcept{indirect_unary_predicate}@<const Pred, iterator_t<V>>
   template<bool Const>
   class take_while_view<V, Pred>::@\exposid{sentinel}@ {            // \expos
-    using @\exposid{Base}@ = conditional_t<Const, const V, V>;      // \expos
+    using @\exposid{Base}@ = @\exposid{maybe-const}@<Const, V>;                 // \expos
 
     sentinel_t<@\exposid{Base}@> @\exposid{end_}@ = sentinel_t<@\exposid{Base}@>();         // \expos
     const Pred* @\exposid{pred_}@ = nullptr;                        // \expos
@@ -5037,7 +5037,7 @@ namespace std::ranges {
   private:
     using @\exposid{Parent}@ =                                              // \expos
       conditional_t<Const, const join_view, join_view>;
-    using @\exposid{Base}@   = conditional_t<Const, const V, V>;            // \expos
+    using @\exposid{Base}@   = @\exposid{maybe-const}@<Const, V>;                       // \expos
 
     static constexpr bool @\exposid{ref-is-glvalue}@ =                      // \expos
       is_reference_v<range_reference_t<@\exposid{Base}@>>;
@@ -5349,7 +5349,7 @@ namespace std::ranges {
   private:
     using @\exposid{Parent}@ =                                      // \expos
       conditional_t<Const, const join_view, join_view>;
-    using @\exposid{Base}@   = conditional_t<Const, const V, V>;    // \expos
+    using @\exposid{Base}@   = @\exposid{maybe-const}@<Const, V>;               // \expos
     sentinel_t<@\exposid{Base}@> @\exposid{end_}@ = sentinel_t<@\exposid{Base}@>();         // \expos
   public:
     @\exposid{sentinel}@() = default;
@@ -5549,7 +5549,7 @@ namespace std::ranges {
     using @\exposid{Parent}@ =                          // \expos
       conditional_t<Const, const split_view, split_view>;
     using @\exposid{Base}@   =                          // \expos
-      conditional_t<Const, const V, V>;
+      @\exposid{maybe-const}@<Const, V>;
     @\exposid{Parent}@* @\exposid{parent_}@ = nullptr;              // \expos
     iterator_t<@\exposid{Base}@> @\exposid{current_}@ =             // \expos, present only if \tcode{V} models \libconcept{forward_range}
       iterator_t<@\exposid{Base}@>();
@@ -5775,7 +5775,7 @@ namespace std::ranges {
   template<bool Const>
   struct split_view<V, Pattern>::@\exposid{inner-iterator}@ {
   private:
-    using @\exposid{Base}@ = conditional_t<Const, const V, V>;      // \expos
+    using @\exposid{Base}@ = @\exposid{maybe-const}@<Const, V>;                 // \expos
     @\exposid{outer-iterator}@<Const> @\exposid{i_}@ = @\exposid{outer-iterator}@<Const>(); // \expos
     bool @\exposid{incremented_}@ = false;                          // \expos
   public:
@@ -6362,7 +6362,7 @@ namespace std::ranges {
              @\exposconcept{has-tuple-element}@<remove_reference_t<range_reference_t<V>>, N>
   template<bool Const>
   class elements_view<V, N>::@\exposid{iterator}@ {                 // \expos
-    using @\exposid{Base}@ = conditional_t<Const, const V, V>;      // \expos
+    using @\exposid{Base}@ = @\exposid{maybe-const}@<Const, V>;                 // \expos
 
     iterator_t<@\exposid{Base}@> @\exposid{current_}@ = iterator_t<@\exposid{Base}@>();
   public:
@@ -6706,7 +6706,7 @@ namespace std::ranges {
   template<bool Const>
   class elements_view<V, N>::@\exposid{sentinel}@ {                 // \expos
   private:
-    using @\exposid{Base}@ = conditional_t<Const, const V, V>;      // \expos
+    using @\exposid{Base}@ = @\exposid{maybe-const}@<Const, V>;                 // \expos
     sentinel_t<@\exposid{Base}@> @\exposid{end_}@ = sentinel_t<@\exposid{Base}@>();         // \expos
   public:
     @\exposid{sentinel}@() = default;

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1931,7 +1931,7 @@ namespace std::ranges {
     constexpr explicit single_view(T&& t);
     template<class... Args>
       requires @\libconcept{constructible_from}@<T, Args...>
-    constexpr single_view(in_place_t, Args&&... args);
+    constexpr explicit single_view(in_place_t, Args&&... args);
 
     constexpr T* begin() noexcept;
     constexpr const T* begin() const noexcept;
@@ -1970,7 +1970,7 @@ Initializes \exposid{value_} with \tcode{std::move(t)}.
 \begin{itemdecl}
 template<class... Args>
   requires @\libconcept{constructible_from}@<T, Args...>
-constexpr single_view(in_place_t, Args&&... args);
+constexpr explicit single_view(in_place_t, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -6294,13 +6294,13 @@ namespace std::ranges {
     constexpr auto begin() requires (!@\exposconcept{simple-view}@<V>)
     { return @\exposid{iterator}@<false>(ranges::begin(@\exposid{base_}@)); }
 
-    constexpr auto begin() const requires @\exposconcept{simple-view}@<V>
+    constexpr auto begin() const requires @\libconcept{range}@<const V>
     { return @\exposid{iterator}@<true>(ranges::begin(@\exposid{base_}@)); }
 
-    constexpr auto end()
+    constexpr auto end() requires (!@\exposconcept{simple-view}@<V> && !common_range<V>)
     { return @\exposid{sentinel}@<false>{ranges::end(@\exposid{base_}@)}; }
 
-    constexpr auto end() requires common_range<V>
+    constexpr auto end() requires (!@\exposconcept{simple-view}@<V> && common_range<V>)
     { return @\exposid{iterator}@<false>{ranges::end(@\exposid{base_}@)}; }
 
     constexpr auto end() const requires range<const V>
@@ -6700,15 +6700,19 @@ namespace std::ranges {
 
     constexpr sentinel_t<@\exposid{Base}@> base() const;
 
-    friend constexpr bool operator==(const @\exposid{iterator}@<Const>& x, const @\exposid{sentinel}@& y);
+    template<bool OtherConst>
+      requires @\libconcept{sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>
+    friend constexpr bool operator==(const @\exposid{iterator}@<OtherConst>& x, const @\exposid{sentinel}@& y);
 
+    template<bool OtherConst>
+      requires @\libconcept{sized_sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>
     friend constexpr range_difference_t<@\exposid{Base}@>
-      operator-(const @\exposid{iterator}@<Const>& x, const @\exposid{sentinel}@& y)
-        requires sized_sentinel_for<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
+      operator-(const @\exposid{iterator}@<OtherConst>& x, const @\exposid{sentinel}@& y);
 
-    friend constexpr range_difference_t<@\exposid{Base}@>
-      operator-(const @\exposid{sentinel}@& x, const @\exposid{iterator}@<Const>& y)
-        requires sized_sentinel_for<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
+    template<bool OtherConst>
+      requires @\libconcept{sized_sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>
+    friend constexpr range_difference_t<@\exposid{maybe-const}@<OtherConst, V>>
+      operator-(const @\exposid{sentinel}@& x, const @\exposid{iterator}@<OtherConst>& y);
   };
 }
 \end{codeblock}
@@ -6749,7 +6753,9 @@ Equivalent to: \tcode{return \exposid{end_};}
 
 \indexlibrarymember{operator==}{elements_view::sentinel}%
 \begin{itemdecl}
-friend constexpr bool operator==(const @\exposid{iterator}@<Const>& x, const @\exposid{sentinel}@& y);
+template<bool OtherConst>
+  requires @\libconcept{sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>
+friend constexpr bool operator==(const @\exposid{iterator}@<OtherConst>& x, const @\exposid{sentinel}@& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6760,9 +6766,10 @@ Equivalent to: \tcode{return x.\exposid{current_} == y.\exposid{end_};}
 
 \indexlibrarymember{operator-}{elements_view::sentinel}%
 \begin{itemdecl}
+template<bool OtherConst>
+  requires @\libconcept{sized_sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>
 friend constexpr range_difference_t<@\exposid{Base}@>
-  operator-(const @\exposid{iterator}@<Const>& x, const @\exposid{sentinel}@& y)
-    requires sized_sentinel_for<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
+  operator-(const @\exposid{iterator}@<OtherConst>& x, const @\exposid{sentinel}@& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6773,9 +6780,10 @@ Equivalent to: \tcode{return x.\exposid{current_} - y.\exposid{end_};}
 
 \indexlibrarymember{operator-}{elements_view::sentinel}%
 \begin{itemdecl}
-friend constexpr range_difference_t<@\exposid{Base}@>
-  operator-(const @\exposid{sentinel}@& x, const @\exposid{iterator}@<Const>& y)
-    requires sized_sentinel_for<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
+template<bool OtherConst>
+  requires @\libconcept{sized_sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>
+friend constexpr range_difference_t<@\exposid{maybe-const}@<OtherConst, V>>
+  operator-(const @\exposid{sentinel}@& x, const @\exposid{iterator}@<OtherConst>& y);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -3029,7 +3029,7 @@ constexpr @\exposid{semiregular-box}@() noexcept(is_nothrow_default_constructibl
 { }
 \end{codeblock}
 
-\item If \tcode{\libconcept{assignable_from}<T\&, const T\&>} is not
+\item If \tcode{\libconcept{copyable}<T>} is not
 modeled, the copy assignment operator is equivalent to:
 \begin{codeblock}
 @\exposid{semiregular-box}@& operator=(const @\exposid{semiregular-box}@& that)
@@ -3041,7 +3041,7 @@ modeled, the copy assignment operator is equivalent to:
 }
 \end{codeblock}
 
-\item If \tcode{\libconcept{assignable_from}<T\&, T>} is not modeled,
+\item If \tcode{\libconcept{movable}<T>} is not modeled,
 the move assignment operator is equivalent to:
 \begin{codeblock}
 @\exposid{semiregular-box}@& operator=(@\exposid{semiregular-box}@&& that)

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -4390,7 +4390,7 @@ namespace std::ranges {
     }
   };
 
-  template<@\libconcept{range}@ R>
+  template<class R>
     take_view(R&&, range_difference_t<R>)
       -> take_view<views::all_t<R>>;
 }

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -3815,7 +3815,7 @@ namespace std::ranges {
     friend constexpr @\exposid{iterator}@ operator-(@\exposid{iterator}@ i, difference_type n)
       requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
     friend constexpr difference_type operator-(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
+      requires @\libconcept{sized_sentinel_for}@<iterator_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
 
     friend constexpr decltype(auto) iter_move(const @\exposid{iterator}@& i)
       noexcept(noexcept(invoke(*i.@\exposid{parent_}@->@\exposid{fun_}@, *i.@\exposid{current_}@)))
@@ -4124,7 +4124,7 @@ Equivalent to: \tcode{return iterator\{*i.\exposid{parent_}, i.\exposid{current_
 \indexlibrarymember{operator-}{transform_view::iterator}%
 \begin{itemdecl}
 friend constexpr difference_type operator-(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
+  requires @\libconcept{sized_sentinel_for}@<iterator_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6440,7 +6440,7 @@ namespace std::ranges {
     friend constexpr @\exposid{iterator}@ operator-(const @\exposid{iterator}@& x, difference_type y)
       requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
     friend constexpr difference_type operator-(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
+      requires @\libconcept{sized_sentinel_for}@<iterator_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
   };
 }
 \end{codeblock}
@@ -6707,7 +6707,7 @@ Equivalent to: \tcode{return iterator\{x\} -= y;}
 \indexlibrarymember{operator-}{elements_view::iterator}%
 \begin{itemdecl}
 friend constexpr difference_type operator-(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires @\libconcept{random_access_range}@<@\exposid{Base}@>;
+  requires @\libconcept{sized_sentinel_for}@<iterator_t<@\exposid{Base}@>, iterator_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -6001,10 +6001,6 @@ namespace std::ranges {
 
     constexpr explicit common_view(V r);
 
-    template<@\libconcept{viewable_range}@ R>
-      requires (!common_range<R> && @\libconcept{constructible_from}@<V, views::all_t<R>>)
-    constexpr explicit common_view(R&& r);
-
     constexpr V base() const& requires @\libconcept{copy_constructible}@<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
@@ -6058,19 +6054,6 @@ constexpr explicit common_view(V base);
 \pnum
 \effects
 Initializes \exposid{base_} with \tcode{std::move(base)}.
-\end{itemdescr}
-
-\indexlibraryctor{common_view}%
-\begin{itemdecl}
-template<viewable_range R>
-  requires (!common_range<R> && @\libconcept{constructible_from}@<V, views::all_t<R>>)
-constexpr explicit common_view(R&& r);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Initializes \exposid{base_} with \tcode{views::all(std::forward<R>(r))}.
 \end{itemdescr}
 
 \rSec2[range.reverse]{Reverse view}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -330,6 +330,13 @@ For an expression \tcode{x} of type \tcode{X},
 \tcode{x} explicitly converted to
 \tcode{\placeholdernc{make-unsigned-like-t}<X>}.
 
+\pnum
+Also within this Clause,
+\tcode{\exposid{make-signed-like-t}<X>} for an integer-like type \tcode{X}
+denotes \tcode{make_signed_t<X>} if \tcode{X} is an integer type;
+otherwise, it denotes a corresponding unspecified signed-integer-like type
+of the same width as \tcode{X}.
+
 \rSec1[range.access]{Range access}
 
 \rSec2[range.access.general]{General}
@@ -790,19 +797,17 @@ type is integer-like.
 \pnum
 The name \tcode{ranges::ssize} denotes
 a customization point object\iref{customization.point.object}.
-The expression \tcode{ranges::ssize(\brk{}E)}
-for a subexpression \tcode{E} of type \tcode{T}
-is expression-equivalent to:
 
-\begin{itemize}
-\item
-If \tcode{range_difference_t<T>} has width less than \tcode{ptrdiff_t},
-\tcode{static_cast<ptrdiff_t>(ranges::\linebreak{}size(E))}.
-
-\item
-Otherwise,
-\tcode{static_cast<range_difference_t<T>>(ranges::size(E))}.
-\end{itemize}
+\pnum
+Given a subexpression \tcode{E} with type \tcode{T},
+let \tcode{t} be an lvalue that denotes the reified object for \tcode{E}.
+If \tcode{ranges::size(t)} is ill-formed,
+\tcode{ranges::ssize(E)} is ill-formed.
+Otherwise let \tcode{D} be
+\tcode{\exposid{make-signed-like-t}<decltype(ranges::\brk{}size(t))>}, or
+\tcode{ptrdiff_t} if it is wider than that type;
+\tcode{ranges::ssize(E)} is expression-equivalent to
+\tcode{static_cast<D>(ranges::size(t))}.
 
 \rSec2[range.prim.empty]{\tcode{ranges::empty}}
 \indexlibraryglobal{empty}%

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -4946,7 +4946,7 @@ The name \tcode{views::join} denotes a
 range adaptor object\iref{range.adaptor.object}.
 Given a subexpression \tcode{E}, the expression
 \tcode{views::join(E)} is expression-equivalent to
-\tcode{join_view\{E\}}.
+\tcode{join_view<views::all_t<decltype((E))>>\{E\}}.
 
 \pnum
 \begin{example}

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -4992,8 +4992,13 @@ template<class charT, class traits>
 
 \begin{itemdescr}
 \pnum
-Let \tcode{R} denote the type \tcode{traits::comparison_category} if it exists,
+Let \tcode{R} denote the type \tcode{traits::comparison_category} if
+that \grammarterm{qualified-id} is valid and denotes a type\iref{temp.deduct},
 otherwise \tcode{R} is \tcode{weak_ordering}.
+
+\pnum
+\mandates
+\tcode{R} denotes a comparison category type\iref{cmp.categories}.
 
 \pnum
 \returns

--- a/source/support.tex
+++ b/source/support.tex
@@ -652,7 +652,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_null_iterators}@                    201304L // also in \libheader{iterator}
 #define @\defnlibxname{cpp_lib_optional}@                          201606L // also in \libheader{optional}
 #define @\defnlibxname{cpp_lib_parallel_algorithm}@                201603L // also in \libheader{algorithm}, \libheader{numeric}
-#define @\defnlibxname{cpp_lib_polymorphic_allocator}@             201902L // also in \libheader{memory}
+#define @\defnlibxname{cpp_lib_polymorphic_allocator}@             201902L // also in \libheader{memory_resource}
 #define @\defnlibxname{cpp_lib_quoted_string_io}@                  201304L // also in \libheader{iomanip}
 #define @\defnlibxname{cpp_lib_ranges}@                            201911L
   // also in \libheader{algorithm}, \libheader{functional}, \libheader{iterator}, \libheader{memory}, \libheader{ranges}

--- a/source/support.tex
+++ b/source/support.tex
@@ -5011,8 +5011,9 @@ is expression-equivalent\iref{defns.expression-equivalent} to:
 \item
   Otherwise, \tcode{partial_order(E, F)} if it is a well-formed expression.
 \item
-  Otherwise, if the expressions \tcode{E == F} and \tcode{E < F}
-  are both well-formed and convertible to \tcode{bool},
+  Otherwise, if the expressions
+  \tcode{E == F}, \tcode{E < F}, and \tcode{F < E}
+  are all well-formed and convertible to \tcode{bool},
 \begin{codeblock}
 E == F ? partial_ordering::equivalent :
 E < F  ? partial_ordering::less :

--- a/source/support.tex
+++ b/source/support.tex
@@ -1825,20 +1825,23 @@ macros that specify limits of integer types.
 \indexlibraryglobal{uintptr_t}%
 \begin{codeblock}
 namespace std {
-  using int8_t         = @\textit{signed integer type}@;  // optional
-  using int16_t        = @\textit{signed integer type}@;  // optional
-  using int32_t        = @\textit{signed integer type}@;  // optional
-  using int64_t        = @\textit{signed integer type}@;  // optional
+  using int8_t         = @\textit{signed integer type}@;   // optional
+  using int16_t        = @\textit{signed integer type}@;   // optional
+  using int32_t        = @\textit{signed integer type}@;   // optional
+  using int64_t        = @\textit{signed integer type}@;   // optional
+  using int@\placeholdernc{N}@_t         = @\seebelow@;             // optional
 
   using int_fast8_t    = @\textit{signed integer type}@;
   using int_fast16_t   = @\textit{signed integer type}@;
   using int_fast32_t   = @\textit{signed integer type}@;
   using int_fast64_t   = @\textit{signed integer type}@;
+  using int_fast@\placeholdernc{N}@_t    = @\seebelow@;             // optional
 
   using int_least8_t   = @\textit{signed integer type}@;
   using int_least16_t  = @\textit{signed integer type}@;
   using int_least32_t  = @\textit{signed integer type}@;
   using int_least64_t  = @\textit{signed integer type}@;
+  using int_least@\placeholdernc{N}@_t   = @\seebelow@;             // optional
 
   using intmax_t       = @\textit{signed integer type}@;
   using intptr_t       = @\textit{signed integer type}@;   // optional
@@ -1847,35 +1850,61 @@ namespace std {
   using uint16_t       = @\textit{unsigned integer type}@; // optional
   using uint32_t       = @\textit{unsigned integer type}@; // optional
   using uint64_t       = @\textit{unsigned integer type}@; // optional
+  using uint@\placeholdernc{N}@_t        = @\seebelow@;             // optional
 
   using uint_fast8_t   = @\textit{unsigned integer type}@;
   using uint_fast16_t  = @\textit{unsigned integer type}@;
   using uint_fast32_t  = @\textit{unsigned integer type}@;
   using uint_fast64_t  = @\textit{unsigned integer type}@;
+  using uint_fast@\placeholdernc{N}@_t   = @\seebelow@;             // optional
 
   using uint_least8_t  = @\textit{unsigned integer type}@;
   using uint_least16_t = @\textit{unsigned integer type}@;
   using uint_least32_t = @\textit{unsigned integer type}@;
   using uint_least64_t = @\textit{unsigned integer type}@;
+  using uint_least@\placeholdernc{N}@_t  = @\seebelow@;             // optional
 
   using uintmax_t      = @\textit{unsigned integer type}@;
   using uintptr_t      = @\textit{unsigned integer type}@; // optional
 }
-\end{codeblock}
 
-\pnum
-The header also defines numerous macros of the form:
-\begin{codeblock}
-  INT_[FAST LEAST]{8 16 32 64}_MIN
-  [U]INT_[FAST LEAST]{8 16 32 64}_MAX
-  INT{MAX PTR}_MIN
-  [U]INT{MAX PTR}_MAX
-  {PTRDIFF SIG_ATOMIC WCHAR WINT}{_MAX _MIN}
-  SIZE_MAX
-\end{codeblock}
-plus function macros of the form:
-\begin{codeblock}
-  [U]INT{8 16 32 64 MAX}_C
+#define INT@\placeholdernc{N}@_MIN         @\seebelow@
+#define INT@\placeholdernc{N}@_MAX         @\seebelow@
+#define UINT@\placeholdernc{N}@_MAX        @\seebelow@
+
+#define INT_FAST@\placeholdernc{N}@_MIN    @\seebelow@
+#define INT_FAST@\placeholdernc{N}@_MAX    @\seebelow@
+#define UINT_FAST@\placeholdernc{N}@_MAX   @\seebelow@
+
+#define INT_LEAST@\placeholdernc{N}@_MIN   @\seebelow@
+#define INT_LEAST@\placeholdernc{N}@_MAX   @\seebelow@
+#define UINT_LEAST@\placeholdernc{N}@_MAX  @\seebelow@
+
+#define INTMAX_MIN       @\seebelow@
+#define INTMAX_MAX       @\seebelow@
+#define UINTMAX_MAX      @\seebelow@
+
+#define INTPTR_MIN       @\seebelow@              // optional
+#define INTPTR_MAX       @\seebelow@              // optional
+#define UINTPTR_MAX      @\seebelow@              // optional
+
+#define PTRDIFF_MIN      @\seebelow@
+#define PTRDIFF_MAX      @\seebelow@
+#define SIZE_MAX         @\seebelow@
+
+#define SIG_ATOMIC_MIN   @\seebelow@
+#define SIG_ATOMIC_MAX   @\seebelow@
+
+#define WCHAR_MIN        @\seebelow@
+#define WCHAR_MAX        @\seebelow@
+
+#define WINT_MIN         @\seebelow@
+#define WINT_MAX         @\seebelow@
+
+#define INT@\placeholdernc{N}@_C(value)    @\seebelow@
+#define UINT@\placeholdernc{N}@_C(value)   @\seebelow@
+#define INTMAX_C(value)  @\seebelow@
+#define UINTMAX_C(value) @\seebelow@
 \end{codeblock}
 
 \pnum
@@ -1883,6 +1912,27 @@ The header defines all types and macros the same as
 the C standard library header \libheader{stdint.h}.
 
 \xrefc{7.20}
+
+\pnum
+All types that use the placeholder \placeholder{N}
+are optional when \placeholder{N}
+is not \tcode{8}, \tcode{16}, \tcode{32}, or \tcode{64}.
+The exact-width types
+\tcode{int\placeholdernc{N}_t} and \tcode{uint\placeholdernc{N}_t}
+for \placeholder{N} = \tcode{8}, \tcode{16}, \tcode{32}, and \tcode{64}
+are also optional;
+however, if an implementation defines integer types
+with the corresponding width and no padding bits,
+it defines the corresponding typedef names.
+Each of the macros listed in this subclause
+is defined if and only if
+the implementation defines the corresponding typedef name.
+\begin{note}
+The macros \tcode{INT\placeholdernc{N}_C} and \tcode{UINT\placeholdernc{N}_C}
+correspond to the typedef names
+\tcode{int_least\placeholdernc{N}_t} and \tcode{uint_least\placeholdernc{N}_t},
+respectively.
+\end{note}
 
 \rSec1[support.start.term]{Startup and termination}
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -5137,18 +5137,35 @@ namespace std {
   };
 
   template<class Promise>
-  struct coroutine_handle : coroutine_handle<>
+  struct coroutine_handle
   {
     // \ref{coroutine.handle.con}, construct/reset
-    using coroutine_handle<>::coroutine_handle;
+    constexpr coroutine_handle() noexcept;
+    constexpr coroutine_handle(nullptr_t) noexcept;
     static coroutine_handle from_promise(Promise&);
     coroutine_handle& operator=(nullptr_t) noexcept;
 
     // \ref{coroutine.handle.export.import}, export/import
+    constexpr void* address() const noexcept;
     static constexpr coroutine_handle from_address(void* addr);
+
+    // \ref{coroutine.handle.conv}, conversion
+    constexpr operator coroutine_handle<>() const noexcept;
+
+    // \ref{coroutine.handle.observers}, observers
+    constexpr explicit operator bool() const noexcept;
+    bool done() const;
+
+    // \ref{coroutine.handle.resumption}, resumption
+    void operator()() const;
+    void resume() const;
+    void destroy() const;
 
     // \ref{coroutine.handle.promise}, promise access
     Promise& promise() const;
+
+  private:
+    void* ptr;  // \expos
   };
 }
 \end{codeblock}
@@ -5157,8 +5174,12 @@ namespace std {
 An object of type
 \tcode{coroutine_handle<T>} is called a \term{coroutine handle}
 and can be used to refer to a suspended or executing coroutine.
-A default-constructed \tcode{coroutine_handle} object does not refer to any
+A \tcode{coroutine_handle} object whose
+member \tcode{address()} returns a null pointer value
+does not refer to any
 coroutine.
+Two \tcode{coroutine_handle} objects refer to the same coroutine
+if and only if their member \tcode{address()} returns the same non-null value.
 
 \pnum
 If a program declares an explicit or partial specialization of
@@ -5212,6 +5233,19 @@ coroutine_handle& operator=(nullptr_t) noexcept;
 \tcode{*this}.
 \end{itemdescr}
 
+\rSec3[coroutine.handle.conv]{Conversion}
+
+\indexlibrarymember{operator coroutine_handle<>}{coroutine_handle}%
+\begin{itemdecl}
+constexpr operator coroutine_handle<>() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return coroutine_handle<>::from_address(address());}
+\end{itemdescr}
+
 \rSec3[coroutine.handle.export.import]{Export/import}
 
 \indexlibrarymember{address}{coroutine_handle}%
@@ -5228,13 +5262,29 @@ constexpr void* address() const noexcept;
 \indexlibrarymember{from_address}{coroutine_handle}%
 \begin{itemdecl}
 static constexpr coroutine_handle<> coroutine_handle<>::from_address(void* addr);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{addr} was obtained via a prior call to \tcode{address}
+on an object whose type is a specialization of \tcode{coroutine_handle}.
+
+\pnum
+\ensures
+\tcode{from_address(address()) == *this}.
+\end{itemdescr}
+
+\indexlibrarymember{from_address}{coroutine_handle}%
+\begin{itemdecl}
 static constexpr coroutine_handle<Promise> coroutine_handle<Promise>::from_address(void* addr);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{addr} was obtained via a prior call to \tcode{address}.
+\tcode{addr} was obtained via a prior call to \tcode{address}
+on an object of type \cv \tcode{coroutine_handle<Promise>}.
 
 \pnum
 \ensures
@@ -5397,8 +5447,11 @@ by \tcode{noop_coroutine_handle}\iref{coroutine.syn}.
 \begin{codeblock}
 namespace std {
   template<>
-  struct coroutine_handle<noop_coroutine_promise> : coroutine_handle<>
+  struct coroutine_handle<noop_coroutine_promise>
   {
+    // \ref{coroutine.handle.noop.conv}, conversion
+    constexpr operator coroutine_handle<>() const noexcept;
+
     // \ref{coroutine.handle.noop.observers}, observers
     constexpr explicit operator bool() const noexcept;
     constexpr bool done() const noexcept;
@@ -5415,9 +5468,23 @@ namespace std {
     constexpr void* address() const noexcept;
   private:
     coroutine_handle(@\unspec@);
+    void* ptr;  // \expos
   };
 }
 \end{codeblock}
+
+\rSec4[coroutine.handle.noop.conv]{Conversion}
+
+\indexlibrarymember{operator coroutine_handle<>}{coroutine_handle<noop_coroutine_promise>}%
+\begin{itemdecl}
+constexpr operator coroutine_handle<>() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return coroutine_handle<>::from_address(address());}
+\end{itemdescr}
 
 \rSec4[coroutine.handle.noop.observers]{Observers}
 

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -4692,11 +4692,13 @@ This can happen if the re-locking of the mutex throws an exception.
 \rSec3[thread.condition.condvarany.general]{General}
 
 \pnum
-A \tcode{Lock} type shall meet the \oldconcept{BasicLockable}
+In this subclause \ref{thread.condition.condvarany},
+template arguments for template parameters named \tcode{Lock}
+shall meet the \oldconcept{Basic\-Lockable}
 requirements\iref{thread.req.lockable.basic}.
 \begin{note}
 All of the standard
-mutex types meet this requirement. If a \tcode{Lock} type other than one of the
+mutex types meet this requirement. If a type other than one of the
 standard mutex types or a \tcode{unique_lock} wrapper for a standard mutex type
 is used with \tcode{condition_variable_any}, any
 necessary synchronization is assumed to be in place with respect to the predicate associated

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -1199,16 +1199,9 @@ template<class F, class... Args> explicit thread(F&& f, Args&&... args);
 The following are all \tcode{true}:
 \begin{itemize}
 \item \tcode{is_constructible_v<decay_t<F>, F>},
-\item \tcode{(is_constructible_v<decay_t<Args>, Args> \&\& ...)},
-\item \tcode{is_move_constructible_v<decay_t<F>>},
-\item \tcode{(is_move_constructible_v<decay_t<Args>> \&\& ...)}, and
+\item \tcode{(is_constructible_v<decay_t<Args>, Args> \&\& ...)}, and
 \item \tcode{is_invocable_v<decay_t<F>, decay_t<Args>...>}.
 \end{itemize}
-
-\pnum
-\expects
-\tcode{decay_t<F>} and each type in \tcode{decay_t<Args>} meet the
-\oldconcept{MoveConstructible} requirements.
 
 \pnum
 \effects
@@ -1536,16 +1529,9 @@ template<class F, class... Args> explicit jthread(F&& f, Args&&... args);
 The following are all \tcode{true}:
 \begin{itemize}
 \item \tcode{is_constructible_v<decay_t<F>, F>},
-\item \tcode{(is_constructible_v<decay_t<Args>, Args> \&\& ...)},
-\item \tcode{is_move_constructible_v<decay_t<F>>},
-\item \tcode{(is_move_constructible_v<decay_t<Args>> \&\& ...)}, and
+\item \tcode{(is_constructible_v<decay_t<Args>, Args> \&\& ...)}, and
 \item \tcode{is_invocable_v<decay_t<F>, decay_t<Args>...> ||} \\ \tcode{is_invocable_v<decay_t<F>, stop_token, decay_t<Args>...>}.
 \end{itemize}
-
-\pnum
-\expects
-\tcode{decay_t<F>} and each type in \tcode{decay_t<Args>} meet the
-\oldconcept{MoveConstructible} requirements.
 
 \pnum
 \effects
@@ -7100,15 +7086,9 @@ template<class F, class... Args>
 The following are all \tcode{true}:
 \begin{itemize}
 \item \tcode{is_constructible_v<decay_t<F>, F>},
-\item \tcode{(is_constructible_v<decay_t<Args>, Args> \&\&...)},
-\item \tcode{is_move_constructible_v<decay_t<F>>},
-\item \tcode{(is_move_constructible_v<decay_t<Args>> \&\&...)}, and
+\item \tcode{(is_constructible_v<decay_t<Args>, Args> \&\&...)}, and
 \item \tcode{is_invocable_v<decay_t<F>, decay_t<Args>...>}.
 \end{itemize}
-
-\pnum
-\expects
-\tcode{decay_t<F>} and each type in \tcode{decay_t<Args>} meet the \oldconcept{MoveConstructible} requirements.
 
 \pnum
 \effects

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -6151,6 +6151,10 @@ namespace std {
 \end{codeblock}
 
 \pnum
+For the primary template, \tcode{R} shall be an object type that
+meets the \oldconcept{Destructible} requirements.
+
+\pnum
 The implementation provides the template \tcode{promise} and two specializations,
 \tcode{promise<R\&>} and \tcode{promise<\brk{}void>}. These differ only in the argument type
 of the member functions \tcode{set_value} and \tcode{set_value_at_thread_exit},
@@ -6495,6 +6499,10 @@ namespace std {
 \end{codeblock}
 
 \pnum
+For the primary template, \tcode{R} shall be an object type that
+meets the \oldconcept{Destructible} requirements.
+
+\pnum
 The implementation provides the template \tcode{future} and two specializations,
 \tcode{future<R\&>} and \tcode{future<\brk{}void>}. These differ only in the return type and return
 value of the member function \tcode{get}, as set out in its description, below.
@@ -6793,6 +6801,10 @@ namespace std {
   };
 }
 \end{codeblock}
+
+\pnum
+For the primary template, \tcode{R} shall be an object type that
+meets the \oldconcept{Destructible} requirements.
 
 \pnum
 The implementation provides the template \tcode{shared_future} and two

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -2929,7 +2929,7 @@ namespace std {
   template<class... MutexTypes>
   class scoped_lock {
   public:
-    using mutex_type = Mutex;   // If \tcode{MutexTypes...} consists of the single type \tcode{Mutex}
+    using mutex_type = @\seebelow@;     // Only if \tcode{sizeof...(MutexTypes) == 1} is \tcode{true}
 
     explicit scoped_lock(MutexTypes&... m);
     explicit scoped_lock(adopt_lock_t, MutexTypes&... m);
@@ -2951,11 +2951,19 @@ objects throughout the \tcode{scoped_lock} object's lifetime\iref{basic.life}.
 The behavior of a program is undefined if the lockable objects referenced by
 \tcode{pm} do not exist for the entire lifetime of the \tcode{scoped_lock}
 object.
-When \tcode{sizeof...(MutexTypes)} is \tcode{1},
-the supplied \tcode{Mutex} type
+\begin{itemize}
+\item
+If \tcode{sizeof...(MutexTypes)} is one,
+let \tcode{Mutex} denote the sole type constituting the pack \tcode{MutexTypes}.
+\tcode{Mutex}
 shall meet the \oldconcept{BasicLockable} requirements\iref{thread.req.lockable.basic}.
-Otherwise, each of the mutex types
-shall meet the \oldconcept{Lockable} requirements\iref{thread.req.lockable.req}.
+The member \grammarterm{typedef-name} \tcode{mutex_type}
+denotes the same type as \tcode{Mutex}.
+\item
+Otherwise, all types in the template parameter pack \tcode{MutexTypes}
+shall meet the \oldconcept{Lockable} requirements\iref{thread.req.lockable.req}
+and there is no member \tcode{mutex_type}.
+\end{itemize}
 
 \indexlibraryctor{scoped_lock}%
 \begin{itemdecl}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -7283,6 +7283,11 @@ namespace std {
   };
 
   template<class R, class... ArgTypes>
+    packaged_task(R (*)(ArgTypes...)) -> packaged_task<R(ArgTypes...)>;
+
+  template<class F> packaged_task(F) -> packaged_task<@\seebelow@>;
+
+  template<class R, class... ArgTypes>
     void swap(packaged_task<R(ArgTypes...)>& x, packaged_task<R(ArgTypes...)>& y) noexcept;
 }
 \end{codeblock}
@@ -7330,6 +7335,25 @@ initializes the object's stored task with \tcode{std::forward<F>(f)}.
 Any exceptions thrown by the copy or move constructor of \tcode{f}, or
 \tcode{bad_alloc} if memory for the internal data structures
 cannot be allocated.
+\end{itemdescr}
+
+\indexlibraryctor{packaged_task}%
+\begin{itemdecl}
+template<class F> packaged_task(F) -> packaged_task<@\seebelow@>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{\&F::operator()} is well-formed when
+treated as an unevaluated operand and
+\tcode{decltype(\brk{}\&F::operator())} is of the form
+\tcode{R(G::*)(A...)}~\cv{}~\tcode{\opt{\&}~\opt{noexcept}}
+for a class type \tcode{G}.
+
+\pnum
+\remarks
+The deduced type is \tcode{packaged_task<R(A...)>}.
 \end{itemdescr}
 
 \indexlibraryctor{packaged_task}%

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1387,6 +1387,9 @@ constexpr functions.
 If \tcode{is_trivially_destructible_v<$\tcode{T}_i$>} is \tcode{true} for all $\tcode{T}_i$,
 then the destructor of \tcode{tuple} is trivial.
 
+\pnum
+The default constructor of \tcode{tuple<>} is trivial.
+
 \indexlibraryctor{tuple}%
 \begin{itemdecl}
 constexpr explicit(@\seebelow@) tuple();

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -8898,7 +8898,9 @@ Calls \tcode{reset(u.release())} followed by
 
 \pnum
 \ensures
-\tcode{u.get() == nullptr}.
+If \tcode{this != addressof(u)},
+\tcode{u.get() == nullptr},
+otherwise \tcode{u.get()} is unchanged.
 
 \pnum
 \returns

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -11699,9 +11699,6 @@ namespace std::pmr {
     template<class T, class... Args>
       void construct(T* p, Args&&... args);
 
-    template<class T>
-      void destroy(T* p);
-
     polymorphic_allocator select_on_container_copy_construction() const;
 
     memory_resource* resource() const;
@@ -11906,7 +11903,7 @@ template<class T>
 \effects
 Equivalent to:
 \begin{codeblock}
-destroy(p);
+allocator_traits<polymorphic_allocator>::destroy(*this, p);
 deallocate_object(p);
 \end{codeblock}
 \end{itemdescr}
@@ -11934,18 +11931,6 @@ and constructor arguments \tcode{std::forward<Args>(args)...}.
 \pnum
 \throws
 Nothing unless the constructor for \tcode{T} throws.
-\end{itemdescr}
-
-\indexlibrarymember{destroy}{polymorphic_allocator}%
-\begin{itemdecl}
-template<class T>
-  void destroy(T* p);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-As if by \tcode{p->\~T()}.
 \end{itemdescr}
 
 \indexlibrarymember{select_on_container_copy_construction}{polymorphic_allocator}%

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -10803,7 +10803,9 @@ template<class T>
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{compare_three_way()(a.get(), nullptr)}.
+\begin{codeblock}
+compare_three_way()(a.get(), static_cast<typename shared_ptr<T>::element_type*>(nullptr).
+\end{codeblock}
 \end{itemdescr}
 
 \rSec3[util.smartptr.shared.spec]{Specialized algorithms}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -11061,7 +11061,7 @@ constexpr weak_ptr() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Constructs an empty \tcode{weak_ptr} object.
+Constructs an empty \tcode{weak_ptr} object that stores a null pointer value.
 
 \pnum
 \ensures
@@ -11083,7 +11083,8 @@ For the second and third constructors, \tcode{Y*} is compatible with \tcode{T*}.
 \pnum
 \effects
 If \tcode{r} is empty, constructs
-an empty \tcode{weak_ptr} object; otherwise, constructs
+an empty \tcode{weak_ptr} object that stores a null pointer value;
+otherwise, constructs
 a \tcode{weak_ptr} object that shares ownership
 with \tcode{r} and stores a copy of the pointer stored in \tcode{r}.
 
@@ -11109,8 +11110,8 @@ Move constructs a \tcode{weak_ptr} instance from \tcode{r}.
 
 \pnum
 \ensures
-\tcode{*this} shall contain the old value of \tcode{r}.
-\tcode{r} shall be empty. \tcode{r.use_count() == 0}.
+\tcode{*this} contains the old value of \tcode{r}.
+\tcode{r} is empty, stores a null pointer value, and \tcode{r.use_count() == 0}.
 \end{itemdescr}
 
 \rSec3[util.smartptr.weak.dest]{Destructor}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -8229,7 +8229,6 @@ namespace std {
     using size_type                              = size_t;
     using difference_type                        = ptrdiff_t;
     using propagate_on_container_move_assignment = true_type;
-    using is_always_equal                        = true_type;
 
     constexpr allocator() noexcept;
     constexpr allocator(const allocator&) noexcept;
@@ -8242,6 +8241,10 @@ namespace std {
   };
 }
 \end{codeblock}
+
+\pnum
+\tcode{allocator_traits<allocator<T>>::is_always_equal::value}
+is \tcode{true} for any \tcode{T}.
 
 \rSec3[allocator.members]{Members}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -12382,29 +12382,6 @@ A \tcode{monotonic_buffer_resource} is a special-purpose memory resource
 intended for very fast memory allocations in situations
 where memory is used to build up a few objects
 and then is released all at once when the memory resource object is destroyed.
-It has the following qualities:
-\begin{itemize}
-\item
-A call to \tcode{deallocate} has no effect,
-thus the amount of memory consumed increases monotonically
-until the resource is destroyed.
-\item
-The program can supply an initial buffer,
-which the allocator uses to satisfy memory requests.
-\item
-When the initial buffer (if any) is exhausted,
-it obtains additional buffers from an \defn{upstream} memory resource
-supplied at construction.
-Each additional buffer is larger than the previous one,
-following a geometric progression.
-\item
-It is intended for access from one thread of control at a time.
-Specifically, calls to \tcode{allocate} and \tcode{deallocate}
-do not synchronize with one another.
-\item
-It frees the allocated memory on destruction,
-even if \tcode{deallocate} has not been called for some of the allocated blocks.
-\end{itemize}
 
 \indexlibraryglobal{monotonic_buffer_resource}%
 \begin{codeblock}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7116,8 +7116,8 @@ namespace std {
   template<class T, class D>
     bool operator>=(nullptr_t, const unique_ptr<T, D>& y);
   template<class T, class D>
-    requires @\libconcept{three_way_comparable_with}@<typename unique_ptr<T, D>::pointer, nullptr_t>
-    compare_three_way_result_t<typename unique_ptr<T, D>::pointer, nullptr_t>
+    requires @\libconcept{three_way_comparable}@<typename unique_ptr<T, D>::pointer>
+    compare_three_way_result_t<typename unique_ptr<T, D>::pointer>
       operator<=>(const unique_ptr<T, D>& x, nullptr_t);
 
   template<class E, class T, class Y, class D>
@@ -9617,15 +9617,17 @@ The second function template returns \tcode{!(nullptr < x)}.
 \indexlibrarymember{operator<=>}{unique_ptr}%
 \begin{itemdecl}
 template<class T, class D>
-  requires @\libconcept{three_way_comparable_with}@<typename unique_ptr<T, D>::pointer, nullptr_t>
-  compare_three_way_result_t<typename unique_ptr<T, D>::pointer, nullptr_t>
+  requires @\libconcept{three_way_comparable}@<typename unique_ptr<T, D>::pointer>
+  compare_three_way_result_t<typename unique_ptr<T, D>::pointer>
     operator<=>(const unique_ptr<T, D>& x, nullptr_t);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{compare_three_way()(x.get(), nullptr)}.
+\begin{codeblock}
+compare_three_way()(x.get(), static_cast<typename unique_ptr<T, D>::pointer>(nullptr)).
+\end{codeblock}
 \end{itemdescr}
 
 \rSec3[unique.ptr.io]{I/O}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -21029,6 +21029,13 @@ namespace std {
 \pnum
 An instance of \tcode{basic_format_args} provides access to formatting
 arguments.
+Implementations should
+optimize the representation of \tcode{basic_format_args}
+for a small number of formatting arguments.
+\begin{note}
+For example, by storing indices of type alternatives separately from values
+and packing the former.
+\end{note}
 
 \indexlibraryctor{basic_format_args}%
 \begin{itemdecl}
@@ -21065,15 +21072,6 @@ basic_format_arg<Context> get(size_t i) const noexcept;
 \returns
 \tcode{i < size_ ?\ data_[i] :\ basic_format_arg<Context>()}.
 \end{itemdescr}
-
-\pnum
-\begin{note}
-Implementations are encouraged
-to optimize the representation of \tcode{basic_format_args}
-for small number of formatting arguments
-by storing indices of type alternatives separately from values
-and packing the former.
-\end{note}
 
 \rSec2[format.error]{Class \tcode{format_error}}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -12493,6 +12493,8 @@ void release();
 \effects
 Calls \tcode{upstream_rsrc->deallocate()} as necessary
 to release all allocated memory.
+Resets \tcode{current_buffer} and \tcode{next_buffer_size}
+to their initial values at construction.
 
 \pnum
 \begin{note}


### PR DESCRIPTION
Fixes #4327
Fixes cplusplus/papers#936

Questions/comments on wording:
* LWG2820 Should the xrefs be *after* the new paragraphs?
* LWG3419 FYI, the referenced wording was changed by e5455e3b to replace 'may', addressing ISO/CS 017 (C++20 DIS).
* LWG3265 Fixed by LWG3435.

Could not apply due to wording conflicts:
* LWG3368 Conflicts with wording changed by P2091R0.

Could not apply because wording is for a TS:
* LWG3414 [networking.ts] service_already_exists has no usable constructors
* Note, LWG3443 and LWG3413 apply to TSes also but were explicitly excluded in the motion.
