### PR TITLE
Replace "could" and "might", Clauses 1-15.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3472,7 +3472,7 @@ In particular, before the lifetime of an object starts and after its
 lifetime ends there are significant restrictions on the use of the
 object, as described below, in~\ref{class.base.init} and
 in~\ref{class.cdtor}. Also, the behavior of an object under construction
-and destruction is possibly not the same as the behavior of an object whose
+and destruction can differ from the behavior of an object whose
 lifetime has started and not ended. \ref{class.base.init}
 and~\ref{class.cdtor} describe the behavior of an object during its periods
 of construction and destruction.
@@ -4229,7 +4229,7 @@ reachable\iref{util.dynamic.safety}.
 \begin{note}
 The effect of using an invalid pointer value (including passing it to a
 deallocation function) is undefined, see~\ref{basic.stc}.
-This is true even if the unsafely-derived pointer value compares equal to
+This is true even if the unsafely-derived pointer value would compare equal to
 some safely-derived pointer value.
 \end{note}
 It is

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -702,7 +702,7 @@ still applies to these declarations. In particular,
 appearing in the type of \tcode{D} can result
 in the different declarations having distinct types, and
 \grammarterm{lambda-expression}{s} appearing in a default argument of \tcode{D}
-can still denote different types in different translation units.
+might still denote different types in different translation units.
 \end{note}
 
 \pnum
@@ -2956,7 +2956,7 @@ that is not an odr-use\iref{basic.def.odr},
 or defines a constexpr variable initialized to a TU-local value (defined below).
 \begin{note}
 An inline function template can be an exposure even though
-explicit specializations of it are possibly usable in other translation units.
+explicit specializations of it might be usable in other translation units.
 \end{note}
 
 \pnum
@@ -3051,7 +3051,7 @@ namespace N {
 }
 void adl(double);
 
-inline void h(auto x) { adl(x); }   // OK, but a specialization can be an exposure
+inline void h(auto x) { adl(x); }   // OK, but a specialization might be an exposure
 \end{codeblocktu}
 \begin{codeblocktu}{Translation unit \#2}
 module A;
@@ -3108,7 +3108,7 @@ A \defn{memory location} is either an object of scalar type that is not a bit-fi
 or a maximal sequence of adjacent bit-fields all having nonzero width.
 \begin{note}
 Various
-features of the language, such as references and virtual functions, can
+features of the language, such as references and virtual functions, might
 involve additional memory locations that are not accessible to programs but are
 managed by the implementation.
 \end{note}
@@ -3816,7 +3816,7 @@ Any other use of an invalid pointer value has
 \impldef{any use of an invalid pointer other than to perform indirection or deallocate}
 behavior.
 \begin{footnote}
-An implementation can define that
+Some implementations might define that
 copying an invalid pointer value
 causes a system-generated runtime fault.
 \end{footnote}
@@ -4592,7 +4592,7 @@ containing the \grammarterm{expression-list}.
 
 \item A temporary bound to a reference in a \grammarterm{new-initializer}\iref{expr.new} persists until the completion of the full-expression containing the \grammarterm{new-initializer}.
 \begin{note}
-This can introduce a dangling reference.
+This might introduce a dangling reference.
 \end{note}
 \begin{example}
 \begin{codeblock}
@@ -5894,7 +5894,7 @@ The value of an object visible to a thread $T$ at a particular point is the
 initial value of the object, a value assigned to the object by $T$, or a
 value assigned to the object by another thread, according to the rules below.
 \begin{note}
-In some cases, there can instead be undefined behavior. Much of this
+In some cases, there might instead be undefined behavior. Much of this
 subclause is motivated by the desire to support atomic operations with explicit
 and detailed visibility constraints. However, it also implicitly supports a
 simpler view for more restricted programs.

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -699,10 +699,10 @@ including in the application of these requirements to other entities.
 The entity is still declared in multiple translation units, and \ref{basic.link}
 still applies to these declarations. In particular,
 \grammarterm{lambda-expression}{s}\iref{expr.prim.lambda}
-appearing in the type of \tcode{D} might result
+appearing in the type of \tcode{D} can result
 in the different declarations having distinct types, and
 \grammarterm{lambda-expression}{s} appearing in a default argument of \tcode{D}
-might still denote different types in different translation units.
+can still denote different types in different translation units.
 \end{note}
 
 \pnum
@@ -1542,7 +1542,7 @@ A name used in the definition of a class \tcode{X}
 \begin{footnote}
 This
 refers to unqualified names following the class name;
-such a name might be used in a \grammarterm{base-specifier} or
+such a name can be used in a \grammarterm{base-specifier} or
 in the \grammarterm{member-specification} of the class definition.
 \end{footnote}
 outside of a complete-class context\iref{class.mem} of \tcode{X}
@@ -2859,7 +2859,7 @@ Similarly,
 \grammarterm{using-directive}{s}
 do not declare entities.
 Enumerators do not have linkage,
-but might serve as the name of an enumeration with linkage\iref{dcl.enum}.
+but can serve as the name of an enumeration with linkage\iref{dcl.enum}.
 \end{note}
 
 \pnum
@@ -2956,7 +2956,7 @@ that is not an odr-use\iref{basic.def.odr},
 or defines a constexpr variable initialized to a TU-local value (defined below).
 \begin{note}
 An inline function template can be an exposure even though
-explicit specializations of it might be usable in other translation units.
+explicit specializations of it are possibly usable in other translation units.
 \end{note}
 
 \pnum
@@ -2987,7 +2987,7 @@ a specialization of a template with any TU-local template argument, or
 a specialization of a template
 whose (possibly instantiated) declaration is an exposure.
 \begin{note}
-The specialization might have been implicitly or explicitly instantiated.
+A specialization can be produced by implicit or explicit instantiation.
 \end{note}
 \end{itemize}
 
@@ -3051,7 +3051,7 @@ namespace N {
 }
 void adl(double);
 
-inline void h(auto x) { adl(x); }   // OK, but a specialization might be an exposure
+inline void h(auto x) { adl(x); }   // OK, but a specialization can be an exposure
 \end{codeblocktu}
 \begin{codeblocktu}{Translation unit \#2}
 module A;
@@ -3108,7 +3108,7 @@ A \defn{memory location} is either an object of scalar type that is not a bit-fi
 or a maximal sequence of adjacent bit-fields all having nonzero width.
 \begin{note}
 Various
-features of the language, such as references and virtual functions, might
+features of the language, such as references and virtual functions, can
 involve additional memory locations that are not accessible to programs but are
 managed by the implementation.
 \end{note}
@@ -3472,7 +3472,7 @@ In particular, before the lifetime of an object starts and after its
 lifetime ends there are significant restrictions on the use of the
 object, as described below, in~\ref{class.base.init} and
 in~\ref{class.cdtor}. Also, the behavior of an object under construction
-and destruction might not be the same as the behavior of an object whose
+and destruction is possibly not the same as the behavior of an object whose
 lifetime has started and not ended. \ref{class.base.init}
 and~\ref{class.cdtor} describe the behavior of an object during its periods
 of construction and destruction.
@@ -3816,7 +3816,7 @@ Any other use of an invalid pointer value has
 \impldef{any use of an invalid pointer other than to perform indirection or deallocate}
 behavior.
 \begin{footnote}
-Some implementations might define that
+An implementation can define that
 copying an invalid pointer value
 causes a system-generated runtime fault.
 \end{footnote}
@@ -4229,7 +4229,7 @@ reachable\iref{util.dynamic.safety}.
 \begin{note}
 The effect of using an invalid pointer value (including passing it to a
 deallocation function) is undefined, see~\ref{basic.stc}.
-This is true even if the unsafely-derived pointer value might compare equal to
+This is true even if the unsafely-derived pointer value compares equal to
 some safely-derived pointer value.
 \end{note}
 It is
@@ -4592,7 +4592,7 @@ containing the \grammarterm{expression-list}.
 
 \item A temporary bound to a reference in a \grammarterm{new-initializer}\iref{expr.new} persists until the completion of the full-expression containing the \grammarterm{new-initializer}.
 \begin{note}
-This might introduce a dangling reference.
+This can introduce a dangling reference.
 \end{note}
 \begin{example}
 \begin{codeblock}
@@ -5329,8 +5329,8 @@ respectively.
 \begin{note}
 A pointer past the end of an object\iref{expr.add}
 is not considered to point to an unrelated object
-of the object's type
-that might be located at that address.
+of the object's type,
+even if the unrelated object is located at that address.
 A pointer value becomes invalid
 when the storage it denotes
 reaches the end of its storage duration;
@@ -5731,7 +5731,7 @@ Evaluations \placeholder{A} and \placeholder{B} are
 \placeholder{B} or \placeholder{B} is sequenced before \placeholder{A}, but it is unspecified which.
 \begin{note}
 Indeterminately sequenced evaluations cannot overlap, but either
-could be executed first.
+can be executed first.
 \end{note}
 An expression \placeholder{X}
 is said to be sequenced before
@@ -5894,7 +5894,7 @@ The value of an object visible to a thread $T$ at a particular point is the
 initial value of the object, a value assigned to the object by $T$, or a
 value assigned to the object by another thread, according to the rules below.
 \begin{note}
-In some cases, there might instead be undefined behavior. Much of this
+In some cases, there can instead be undefined behavior. Much of this
 subclause is motivated by the desire to support atomic operations with explicit
 and detailed visibility constraints. However, it also implicitly supports a
 simpler view for more restricted programs.
@@ -5937,7 +5937,7 @@ particular total order, called the \defn{modification order} of $M$.
 There is a separate order for each
 atomic object. There is no requirement that these can be combined into a single
 total order for all objects. In general this will be impossible since different
-threads might observe modifications to different objects in inconsistent orders.
+threads can observe modifications to different objects in inconsistent orders.
 \end{note}
 
 \pnum
@@ -6355,7 +6355,7 @@ condition that it blocks on to be satisfied.
 \begin{example}
 A library I/O function that blocks until the I/O operation is complete can
 be considered to continuously check whether the operation is complete. Each
-such check might consist of one or more execution steps, for example using
+such check consists of one or more execution steps, for example using
 observable behavior of the abstract machine.
 \end{example}
 
@@ -6460,7 +6460,7 @@ A thread of execution $B$ thus can temporarily provide an effectively
 stronger forward progress guarantee for a certain amount of time, due to a
 second thread of execution $A$ being blocked on it with forward
 progress guarantee delegation. In turn, if $B$ then blocks with
-forward progress guarantee delegation on $C$, this could also temporarily
+forward progress guarantee delegation on $C$, this can also temporarily
 provide a stronger forward progress guarantee to $C$.
 \end{note}
 

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1659,7 +1659,7 @@ implicitly declared as defaulted if and only if
 
 \begin{note}
 When the move constructor is not implicitly declared or explicitly supplied,
-expressions that otherwise would have invoked the move constructor can instead invoke
+expressions that otherwise would have invoked the move constructor might instead invoke
 a copy constructor.
 \end{note}
 
@@ -1998,7 +1998,7 @@ a base class copy/move assignment operator is always hidden
 by the corresponding assignment operator of a derived class\iref{over.ass}.
 A
 \grammarterm{using-declaration}\iref{namespace.udecl} that brings in from a base class an assignment operator
-with a parameter type that can be that of a
+with a parameter type that could be that of a
 copy/move assignment operator for the
 derived class is not considered an explicit declaration of such an
 operator and does not suppress the implicit declaration of the derived class
@@ -4780,7 +4780,7 @@ private:
 \begin{note}
 In a derived class, the lookup of a base class name will find the
 injected-class-name instead of the name of the base class in the scope
-in which it was declared. The injected-class-name can be less accessible
+in which it was declared. The injected-class-name might be less accessible
 than the name of the base class in the scope in which it was declared.
 \end{note}
 

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -738,8 +738,8 @@ members have higher addresses within a class object\iref{expr.rel}.
 The order of allocation of non-static data members
 with different access control
 is unspecified.
-Implementation alignment requirements might cause two adjacent members
-not to be allocated immediately after each other; so might requirements
+Implementation alignment requirements can cause two adjacent members
+not to be allocated immediately after each other; so can requirements
 for space for managing virtual functions\iref{class.virtual} and
 virtual base classes\iref{class.mi}.
 \end{note}
@@ -837,7 +837,7 @@ is the same as the address of its first non-static data member
 if that member is not a bit-field. Its
 address is also the same as the address of each of its base class subobjects.
 \begin{note}
-There might therefore be unnamed padding within a standard-layout struct object
+There can therefore be unnamed padding within a standard-layout struct object
 inserted by an implementation, but
 not at its beginning, as necessary to achieve appropriate alignment.
 \end{note}
@@ -1659,7 +1659,7 @@ implicitly declared as defaulted if and only if
 
 \begin{note}
 When the move constructor is not implicitly declared or explicitly supplied,
-expressions that otherwise would have invoked the move constructor might instead invoke
+expressions that otherwise would have invoked the move constructor can instead invoke
 a copy constructor.
 \end{note}
 
@@ -1998,7 +1998,7 @@ a base class copy/move assignment operator is always hidden
 by the corresponding assignment operator of a derived class\iref{over.ass}.
 A
 \grammarterm{using-declaration}\iref{namespace.udecl} that brings in from a base class an assignment operator
-with a parameter type that could be that of a
+with a parameter type that can be that of a
 copy/move assignment operator for the
 derived class is not considered an explicit declaration of such an
 operator and does not suppress the implicit declaration of the derived class
@@ -3613,9 +3613,9 @@ constructors; see~\ref{class.base.init}.
 
 \pnum
 \begin{note}
-A base class subobject might have a layout different
+A base class subobject can have a layout different
 from the layout of a most derived object of the same type. A base class
-subobject might have a polymorphic behavior\iref{class.cdtor}
+subobject can have a polymorphic behavior\iref{class.cdtor}
 different from the polymorphic behavior of a most derived object of the
 same type. A base class subobject can be of zero size;
 however, two subobjects that have the same class type and that belong to
@@ -3705,7 +3705,7 @@ shown in \fref{class.nonvirt}.
 \end{importgraphic}
 
 In such lattices, explicit qualification can be used to specify which
-subobject is meant. The body of function \tcode{C::f} could refer to the
+subobject is meant. The body of function \tcode{C::f} can refer to the
 member \tcode{next} of each \tcode{L} subobject:
 \begin{codeblock}
 void C::f() { A::next = B::next; }      // well-formed
@@ -3792,8 +3792,8 @@ called a \defnadj{polymorphic}{class}.
 \begin{footnote}
 If
 all virtual functions are immediate functions,
-the class is still polymorphic even though
-its internal representation might not otherwise require
+the class is still polymorphic even if
+its internal representation does not otherwise require
 any additions for that polymorphic behavior.
 \end{footnote}
 
@@ -4485,7 +4485,7 @@ void g() {
 \pnum
 \begin{note}
 Even if the result of name lookup is unambiguous, use of a name found in
-multiple subobjects might still be
+multiple subobjects can still be
 ambiguous~(\ref{conv.mem}, \ref{expr.ref}, \ref{class.access.base}).
 \end{note}
 \begin{example}
@@ -4780,7 +4780,7 @@ private:
 \begin{note}
 In a derived class, the lookup of a base class name will find the
 injected-class-name instead of the name of the base class in the scope
-in which it was declared. The injected-class-name might be less accessible
+in which it was declared. The injected-class-name can be less accessible
 than the name of the base class in the scope in which it was declared.
 \end{note}
 
@@ -4874,12 +4874,12 @@ and
 
 \pnum
 \begin{note}
-A member of a private base class might be inaccessible as an inherited
+A member of a private base class can be inaccessible as an inherited
 member name, but accessible directly.
 Because of the rules on pointer conversions\iref{conv.ptr} and
 explicit casts~(\ref{expr.type.conv}, \ref{expr.static.cast}, \ref{expr.cast}),
 a conversion from a pointer to a derived class to a pointer
-to an inaccessible base class might be ill-formed if an implicit conversion
+to an inaccessible base class can be ill-formed if an implicit conversion
 is used, but well-formed if an explicit cast is used.
 For example,
 
@@ -6579,7 +6579,7 @@ where an expression is evaluated in a context
 requiring a constant expression\iref{expr.const}
 and in constant initialization\iref{basic.start.static}.
 \begin{note}
-Copy elision might be performed
+It is possible that copy elision is performed
 if the same expression
 is evaluated in another context.
 \end{note}
@@ -7247,7 +7247,7 @@ void f(int i) {
 \pnum
 Access to the deallocation function is checked statically.
 \begin{note}
-Hence, even though a different one might actually be executed,
+Hence, even if a different one is actually executed,
 the statically visible deallocation function is required to be accessible.
 \end{note}
 \begin{example}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1236,7 +1236,7 @@ function types.
 Redundant cv-qualifications are ignored.
 \begin{note}
 For example,
-these could be introduced by typedefs.
+these can be introduced by typedefs.
 \end{note}
 
 \pnum
@@ -3596,7 +3596,7 @@ Typedefs and \grammarterm{trailing-return-type}{s} are sometimes convenient when
 For example,
 the function
 \tcode{fpif}
-above could have been declared
+above can be declared
 \begin{codeblock}
 typedef int  IFUNC(int);
 IFUNC*  fpif(int);
@@ -4610,7 +4610,7 @@ In most cases
 this is the defining declaration\iref{basic.def} of the variable,
 but the initializing declaration
 of a non-inline static data member\iref{class.static.data}
-might be the declaration within the class definition
+can be the declaration within the class definition
 and not the definition at namespace scope.
 \end{note}
 
@@ -5828,7 +5828,7 @@ a temporary array to a reference member, so the program is
 ill-formed\iref{class.base.init}.
 \end{example}
 \begin{note}
-The implementation is free to allocate the array in read-only memory if an explicit array with the same initializer could be so allocated.
+The implementation is free to allocate the array in read-only memory if an explicit array with the same initializer can be so allocated.
 \end{note}
 
 \pnum
@@ -5863,8 +5863,8 @@ list-initializations.
 int x = 999;                    // \tcode{x} is not a constant expression
 const int y = 999;
 const int z = 99;
-char c1 = x;                    // OK, though it might narrow (in this case, it does narrow)
-char c2{x};                     // error: might narrow
+char c1 = x;                    // OK, though it potentially narrows (in this case, it does narrow)
+char c2{x};                     // error: potentially narrows
 char c3{y};                     // error: narrows (assuming \tcode{char} is 8 bits)
 char c4{z};                     // OK: no narrowing needed
 unsigned char uc1 = {5};        // OK: no narrowing needed
@@ -5873,7 +5873,7 @@ unsigned int ui1 = {-1};        // error: narrows
 signed int si1 =
   { (unsigned int)-1 };         // error: narrows
 int ii = {2.0};                 // error: narrows
-float f1 { x };                 // error: might narrow
+float f1 { x };                 // error: potentially narrows
 float f2 { 7 };                 // OK: 7 can be exactly represented as a \tcode{float}
 bool b = {"meow"};              // error: narrows
 int f(int);
@@ -8749,7 +8749,7 @@ program is ill-formed, no diagnostic required.
 \pnum
 \begin{note}
 The \tcode{carries_dependency} attribute does not change the meaning of the
-program, but might result in generation of more efficient code.
+program, but can result in generation of more efficient code.
 \end{note}
 
 \pnum
@@ -8792,9 +8792,10 @@ need not constrain ordering upon return from \tcode{f}. Implementations of
 hardware memory ordering instructions (a.k.a.\ fences).
 Function \tcode{g}'s second parameter has a \tcode{carries_dependency} attribute,
 but its first parameter does not. Therefore, function \tcode{h}'s first call to
-\tcode{g} carries a dependency into \tcode{g}, but its second call does not. The
-implementation might need to insert a fence prior to the second call to
-\tcode{g}.
+\tcode{g} carries a dependency into \tcode{g}, but its second call does not.
+It is possible
+that the implementation needs to insert a fence
+prior to the second call to \tcode{g}.
 \end{example}
 \indextext{attribute|)}%
 \indextext{declaration|)}
@@ -9188,6 +9189,6 @@ public:
 };
 \end{codeblock}
 Here, \tcode{hasher}, \tcode{pred}, and \tcode{alloc}
-could have the same address as \tcode{buckets}
+can have the same address as \tcode{buckets}
 if their respective types are all empty.
 \end{example}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1236,7 +1236,7 @@ function types.
 Redundant cv-qualifications are ignored.
 \begin{note}
 For example,
-these can be introduced by typedefs.
+these could be introduced by typedefs.
 \end{note}
 
 \pnum
@@ -8749,7 +8749,7 @@ program is ill-formed, no diagnostic required.
 \pnum
 \begin{note}
 The \tcode{carries_dependency} attribute does not change the meaning of the
-program, but can result in generation of more efficient code.
+program, but might result in generation of more efficient code.
 \end{note}
 
 \pnum
@@ -9189,6 +9189,6 @@ public:
 };
 \end{codeblock}
 Here, \tcode{hasher}, \tcode{pred}, and \tcode{alloc}
-can have the same address as \tcode{buckets}
+could have the same address as \tcode{buckets}
 if their respective types are all empty.
 \end{example}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -8792,10 +8792,9 @@ need not constrain ordering upon return from \tcode{f}. Implementations of
 hardware memory ordering instructions (a.k.a.\ fences).
 Function \tcode{g}'s second parameter has a \tcode{carries_dependency} attribute,
 but its first parameter does not. Therefore, function \tcode{h}'s first call to
-\tcode{g} carries a dependency into \tcode{g}, but its second call does not.
-It is possible
-that the implementation needs to insert a fence
-prior to the second call to \tcode{g}.
+\tcode{g} carries a dependency into \tcode{g}, but its second call does not. The
+implementation might need to insert a fence prior to the second call to
+\tcode{g}.
 \end{example}
 \indextext{attribute|)}%
 \indextext{declaration|)}

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -800,9 +800,9 @@ void g() noexcept {
 \end{codeblock}
 The call to
 \tcode{f}
-is well-formed even though, when called,
-\tcode{f}
-might throw an exception.
+is well-formed even though
+it is possible for \tcode{f} to
+throw an exception when called.
 \end{example}
 
 \pnum

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -800,9 +800,9 @@ void g() noexcept {
 \end{codeblock}
 The call to
 \tcode{f}
-is well-formed even though
-it is possible for \tcode{f} to
-throw an exception when called.
+is well-formed even though, when called,
+\tcode{f}
+might throw an exception.
 \end{example}
 
 \pnum

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -260,7 +260,7 @@ a prvalue of type \tcode{int} is required.
 \begin{note}
 There are no prvalue bit-fields; if a bit-field is converted to a
 prvalue\iref{conv.lval}, a prvalue of the type of the bit-field is
-created, which might then be promoted\iref{conv.prom}.
+created, which can then be promoted\iref{conv.prom}.
 \end{note}
 
 \pnum
@@ -1685,7 +1685,7 @@ The trailing \grammarterm{requires-clause} of the function call operator
 or operator template is the \grammarterm{requires-clause}
 of the \grammarterm{lambda-declarator}, if any.
 \begin{note}
-The function call operator template for a generic lambda might be
+The function call operator template for a generic lambda can be
 an abbreviated function template\iref{dcl.fct}.
 \end{note}
 \begin{example}
@@ -1951,7 +1951,7 @@ has a \grammarterm{lambda-capture} and defaulted copy and move assignment
 operators otherwise\iref{class.copy.assign}.
 \begin{note}
 These special member functions are implicitly defined as
-usual, and might therefore be defined as deleted.
+usual, which can result in them being defined as deleted.
 \end{note}
 
 \pnum
@@ -2159,7 +2159,7 @@ void test() {
 
   auto g2 = [=](auto a) {
     int selector[sizeof(a) == 1 ? 1 : 2]{};
-    f(x, selector);             // OK: captures \tcode{x}, might call \#1 or \#2
+    f(x, selector);             // OK: captures \tcode{x}, can call \#1 or \#2
   };
 
   auto g3 = [=](auto a) {
@@ -2167,12 +2167,12 @@ void test() {
   };
 }
 \end{codeblock}
-Within \tcode{g1}, an implementation might optimize away
+Within \tcode{g1}, an implementation can optimize away
 the capture of \tcode{x} as it is not odr-used.
 \end{example}
 \begin{note}
 The set of captured entities is determined syntactically,
-and entities might be implicitly captured
+and entities are implicitly captured
 even if the expression denoting a local entity
 is within a discarded statement\iref{stmt.if}.
 \begin{example}
@@ -2875,7 +2875,7 @@ Postfix expressions group left-to-right.
 The \tcode{>} token following the
 \grammarterm{type-id} in a \tcode{dynamic_cast},
 \tcode{static_cast}, \tcode{reinterpret_cast}, or
-\tcode{const_cast} might be the product of replacing a
+\tcode{const_cast} can be the product of replacing a
 \tcode{>>} token by two consecutive \tcode{>}
 tokens\iref{temp.names}.
 \end{note}
@@ -3051,7 +3051,7 @@ checked at the point of call in the calling function. If a constructor
 or destructor for a function parameter throws an exception, the search
 for a handler starts in the scope of the calling function; in
 particular, if the function called has a \grammarterm{function-try-block}\iref{except.pre}
-with a handler that could handle the exception,
+with a handler that can handle the exception,
 this handler is not considered.
 \end{example}
 
@@ -4143,7 +4143,7 @@ pointer, lvalue or pointer to data member resulting from a
 is not limited to conversions that cast away a
 const-qualifier.
 \end{footnote}
-might produce undefined behavior\iref{dcl.type.cv}.
+can produce undefined behavior\iref{dcl.type.cv}.
 \end{note}
 
 \pnum
@@ -4319,7 +4319,7 @@ called. The operand of \tcode{\&} shall not be a bit-field.
 The address of an overloaded function\iref{over} can be taken
 only in a context that uniquely determines which version of the
 overloaded function is referred to (see~\ref{over.over}).
-Since the context might determine whether the operand is a static or
+Since the context can determine whether the operand is a static or
 non-static member function, the context can also affect whether the
 expression has type ``pointer to function'' or ``pointer to member
 function''.
@@ -4990,7 +4990,7 @@ these functions\iref{replacement.functions} and/or class-specific
 versions\iref{class.free}.
 The set of allocation and deallocation functions that can be called
 by a \grammarterm{new-expression}
-could include functions that do not perform allocation or deallocation;
+can include functions that do not perform allocation or deallocation;
 for example, see \ref{new.delete.placement}.
 \end{note}
 
@@ -5246,7 +5246,7 @@ invoked\iref{class.dtor}.
 \indextext{\idxcode{new}!exception and}%
 If any part of the object initialization described above%
 \begin{footnote}
-This might
+This can
 include evaluating a \grammarterm{new-initializer} and/or calling
 a constructor.
 \end{footnote}
@@ -6828,7 +6828,7 @@ undefined.
 \begin{note}
 This restriction applies to the relationship
 between the left and right sides of the assignment operation; it is not a
-statement about how the target of the assignment might be aliased in general.
+statement about how the target of the assignment can be aliased in general.
 See~\ref{basic.lval}.
 \end{note}
 
@@ -7411,7 +7411,7 @@ that is usable in constant expressions or
 has constant initialization\iref{basic.start.static}.
 \begin{footnote}
 Testing this condition
-might involve a trial evaluation of its initializer as described above.
+can involve a trial evaluation of its initializer as described above.
 \end{footnote}
 \begin{example}
 \begin{codeblock}
@@ -7426,7 +7426,7 @@ int c = y + (std::is_constant_evaluated() ? 2 : y);     // dynamic initializatio
 
 constexpr int f() {
   const int n = std::is_constant_evaluated() ? 13 : 17; // \tcode{n} is 13
-  int m = std::is_constant_evaluated() ? 13 : 17;       // \tcode{m} might be 13 or 17 (see below)
+  int m = std::is_constant_evaluated() ? 13 : 17;       // \tcode{m} can be 13 or 17 (see below)
   char arr[n] = {}; // char[13]
   return m + sizeof(arr);
 }
@@ -7454,14 +7454,14 @@ a potentially-evaluated expression\iref{basic.def.odr},
 \item
 an immediate subexpression of a \grammarterm{braced-init-list},
 \begin{footnote}
-Constant evaluation might be necessary to determine whether a narrowing conversion is performed\iref{dcl.init.list}.
+In some cases, constant evaluation is needed to determine whether a narrowing conversion is performed\iref{dcl.init.list}.
 \end{footnote}
 
 \item
 an expression of the form \tcode{\&} \grammarterm{cast-expression}
 that occurs within a templated entity,
 \begin{footnote}
-Constant evaluation might be necessary to determine whether such an expression is value-dependent\iref{temp.dep.constexpr}.
+In some cases, constant evaluation is needed to determine whether such an expression is value-dependent\iref{temp.dep.constexpr}.
 \end{footnote}
 or
 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -260,7 +260,7 @@ a prvalue of type \tcode{int} is required.
 \begin{note}
 There are no prvalue bit-fields; if a bit-field is converted to a
 prvalue\iref{conv.lval}, a prvalue of the type of the bit-field is
-created, which can then be promoted\iref{conv.prom}.
+created, which might then be promoted\iref{conv.prom}.
 \end{note}
 
 \pnum

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4319,7 +4319,7 @@ called. The operand of \tcode{\&} shall not be a bit-field.
 The address of an overloaded function\iref{over} can be taken
 only in a context that uniquely determines which version of the
 overloaded function is referred to (see~\ref{over.over}).
-Since the context can determine whether the operand is a static or
+Since the context can affect whether the operand is a static or
 non-static member function, the context can also affect whether the
 expression has type ``pointer to function'' or ``pointer to member
 function''.

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -416,8 +416,8 @@ The program fragment \tcode{0xe+foo} is parsed as a
 preprocessing number token (one that is not a valid
 \grammarterm{integer-literal} or \grammarterm{floating-point-literal} token),
 even though a parse as three preprocessing tokens
-\tcode{0xe}, \tcode{+}, and \tcode{foo} might produce a valid expression (for example,
-if \tcode{foo} were a macro defined as \tcode{1}). Similarly, the
+\tcode{0xe}, \tcode{+}, and \tcode{foo} can produce a valid expression (for example,
+if \tcode{foo} is a macro defined as \tcode{1}). Similarly, the
 program fragment \tcode{1E1} is parsed as a preprocessing number (one
 that is a valid \grammarterm{floating-point-literal} token),
 whether or not \tcode{E} is a macro name.
@@ -428,7 +428,7 @@ whether or not \tcode{E} is a macro name.
 The program fragment \tcode{x+++++y} is parsed as \tcode{x
 ++ ++ + y}, which, if \tcode{x} and \tcode{y} have integral types,
 violates a constraint on increment operators, even though the parse
-\tcode{x ++ + ++ y} might yield a correct expression.
+\tcode{x ++ + ++ y} can yield a correct expression.
 \end{example}
 \indextext{token!preprocessing|)}
 
@@ -586,7 +586,7 @@ is conditionally-supported with \impldef{meaning of \tcode{'}, \tcode{\textbacks
 \tcode{"} in an \grammarterm{h-char-sequence}.
 \begin{footnote}
 Thus, a sequence of characters
-that resembles an escape sequence might result in an error, be interpreted as the
+that resembles an escape sequence can result in an error, be interpreted as the
 character corresponding to the escape sequence, or have a completely different meaning,
 depending on the implementation.
 \end{footnote}

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2182,12 +2182,12 @@ Run a simple tournament to find a function
 that is not
 worse than any
 opponent it faced.
-Although another function
+Although it is possible that another function
 \tcode{F}
 that
 \tcode{W}
 did not face
-might be at least as good as
+is at least as good as
 \tcode{W},
 \tcode{F}
 cannot be the best function because at some point in the
@@ -2284,7 +2284,7 @@ alignment, accessibility of the argument, whether the argument is a bit-field,
 and whether a function is deleted\iref{dcl.fct.def.delete}, are ignored.
 So, although an implicit
 conversion sequence can be defined for a given argument-parameter
-pair, the conversion from the argument to the parameter might still
+pair, the conversion from the argument to the parameter can still
 be ill-formed in the final analysis.
 \end{note}
 

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2284,7 +2284,7 @@ alignment, accessibility of the argument, whether the argument is a bit-field,
 and whether a function is deleted\iref{dcl.fct.def.delete}, are ignored.
 So, although an implicit
 conversion sequence can be defined for a given argument-parameter
-pair, the conversion from the argument to the parameter can still
+pair, the conversion from the argument to the parameter might still
 be ill-formed in the final analysis.
 \end{note}
 

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1032,7 +1032,7 @@ If a
 preprocessing token,
 followed by an identifier,
 occurs lexically
-at the point at which a preprocessing directive could begin,
+at the point at which a preprocessing directive can begin,
 the identifier is not subject to macro replacement.
 
 \pnum
@@ -1665,8 +1665,9 @@ replace the value of this macro with a greater value.
 The macros defined in \tref{cpp.predefined.ft} shall be defined to
 the corresponding integer literal.
 \begin{note}
-Future revisions of \Cpp{} might replace
-the values of these macros with greater values.
+Future revisions of \Cpp{} will replace
+the values of these macros with greater values
+when the corresponding feature is modified.
 \end{note}
 
 \item

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1665,9 +1665,8 @@ replace the value of this macro with a greater value.
 The macros defined in \tref{cpp.predefined.ft} shall be defined to
 the corresponding integer literal.
 \begin{note}
-Future revisions of \Cpp{} will replace
-the values of these macros with greater values
-when the corresponding feature is modified.
+Future revisions of \Cpp{} might replace
+the values of these macros with greater values.
 \end{note}
 
 \item

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -1015,7 +1015,7 @@ of the initialization.
 \begin{note}
 A conforming implementation cannot introduce
 any deadlock around execution of the initializer.
-Deadlocks might still be caused by the program logic;
+Deadlocks can still be caused by the program logic;
 the implementation need only avoid deadlocks
 due to its own synchronization operations.
 \end{note}
@@ -1057,7 +1057,7 @@ indistinguishable from a \grammarterm{declaration} where the first
 If the \grammarterm{statement} cannot syntactically be a
 \grammarterm{declaration}, there is no ambiguity,
 so this rule does not apply.
-The whole \grammarterm{statement} might need to be examined
+In some cases, the whole \grammarterm{statement} needs to be examined
 to determine whether this is the case. This resolves the meaning
 of many examples.
 \begin{example}

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -1015,7 +1015,7 @@ of the initialization.
 \begin{note}
 A conforming implementation cannot introduce
 any deadlock around execution of the initializer.
-Deadlocks can still be caused by the program logic;
+Deadlocks might still be caused by the program logic;
 the implementation need only avoid deadlocks
 due to its own synchronization operations.
 \end{note}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3797,7 +3797,7 @@ are functionally equivalent if, for any given set of template arguments,
 the expressions perform
 the same operations in the same order with the same entities.
 \begin{note}
-For instance, one can have redundant parentheses.
+For instance, one could have redundant parentheses.
 \end{note}
 
 \pnum

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -736,8 +736,8 @@ as the end of the \grammarterm{template-argument-list} and completes
 the \grammarterm{template-id}.
 \begin{note}
 The second \tcode{>}
-token produced by this replacement rule could terminate an enclosing
-\grammarterm{template-id} construct or it could be part of a different
+token produced by this replacement rule can terminate an enclosing
+\grammarterm{template-id} construct or it can be part of a different
 construct (e.g., a cast).
 \end{note}
 \begin{example}
@@ -2226,13 +2226,13 @@ for an unbounded set of related types.
 
 \pnum
 \begin{example}
-A single class template
+It is possible for a single class template
 \tcode{List}
-might provide an unbounded set of class definitions:
+to provide an unbounded set of class definitions:
 one class \tcode{List<T>} for every type \tcode{T},
 each describing a linked list of elements of type \tcode{T}.
 Similarly, a class template \tcode{Array} describing a contiguous,
-dynamic array might be defined like this:
+dynamic array can be defined like this:
 \begin{codeblock}
 template<class T> class Array {
   T* v;
@@ -2245,9 +2245,8 @@ public:
 \end{codeblock}
 The prefix \tcode{\keyword{template}<class T>}
 specifies that a template is being declared and that a
-\grammarterm{type-name}
-\tcode{T}
-may be used in the declaration.
+\grammarterm{type-name} \tcode{T}
+can be used in the declaration.
 In other words,
 \tcode{Array}
 is a parameterized type with
@@ -2342,7 +2341,7 @@ public:
 \end{codeblock}
 
 declares three member functions of a class template.
-The subscript function might be defined like this:
+The subscript function can be defined like this:
 
 \begin{codeblock}
 template<class T> T& Array<T>::operator[](int i) {
@@ -3358,7 +3357,7 @@ template\iref{temp.class.order}.
 The template parameter list of a specialization shall not contain default
 template argument values.
 \begin{footnote}
-There is no way in which they could be used.
+There is no context in which they would be used.
 \end{footnote}
 \item
 An argument shall not contain an unexpanded pack. If
@@ -3632,7 +3631,7 @@ A<char>::B<int>  abci;                                          // uses \#1
 \pnum
 A function template defines an unbounded set of related functions.
 \begin{example}
-A family of sort functions might be declared like this:
+A family of sort functions can be declared like this:
 
 \begin{codeblock}
 template<class T> class Array { };
@@ -3798,7 +3797,7 @@ are functionally equivalent if, for any given set of template arguments,
 the expressions perform
 the same operations in the same order with the same entities.
 \begin{note}
-For instance, one could have redundant parentheses.
+For instance, one can have redundant parentheses.
 \end{note}
 
 \pnum
@@ -8696,8 +8695,8 @@ template<class T> void f(T x, T y) { @\commentellip@ }
 struct A { @\commentellip@ };
 struct B : A { @\commentellip@ };
 void g(A a, B b) {
-  f(a,b);           // error: \tcode{T} could be \tcode{A} or \tcode{B}
-  f(b,a);           // error: \tcode{T} could be \tcode{A} or \tcode{B}
+  f(a,b);           // error: \tcode{T} deduced as both \tcode{A} and \tcode{B}
+  f(b,a);           // error: \tcode{T} deduced as both \tcode{A} and \tcode{B}
   f(a,a);           // OK: \tcode{T} is \tcode{A}
   f(b,b);           // OK: \tcode{T} is \tcode{B}
 }
@@ -8717,8 +8716,8 @@ int g3( int, char, float);
 
 void r() {
   f(g1);            // OK: \tcode{T} is \tcode{int} and \tcode{U} is \tcode{float}
-  f(g2);            // error: \tcode{T} could be \tcode{char} or \tcode{int}
-  f(g3);            // error: \tcode{U} could be \tcode{char} or \tcode{float}
+  f(g2);            // error: \tcode{T} deduced as both \tcode{char} and \tcode{int}
+  f(g3);            // error: \tcode{U} deduced as both \tcode{char} and \tcode{float}
 }
 \end{codeblock}
 
@@ -9247,7 +9246,7 @@ Adding the non-template function
 int max(int,int);
 \end{codeblock}
 to the example above would resolve the third call, by providing a function that
-could be called for
+can be called for
 \tcode{max(a,c)}
 after using the standard conversion of
 \tcode{char}


### PR DESCRIPTION
These changes editorially remove the words "could" and "might".

Please review this change carefully with the following goals:

* Flag anything that seems even remotely non-editorial, e.g. even if the explanation provided by a Note becomes less useful or (more) misleading.
* Also flag anything that could conceivably be worded better by a wider review.

I would like all remaining instances of "could" and "might" to be reviewed by CWG/LWG, so please don't hold back on rejecting anything at this point.