### PR TITLE
Replace "could" and "might", Clauses 16-32.

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -137,7 +137,7 @@ When the cost of doing the operation dominates the cost of copy,
 the copying version is not included.
 For example, \tcode{sort_copy} is not included
 because the cost of sorting is much more significant,
-and users might as well do \tcode{copy} followed by \tcode{sort}.
+and users can invoke \tcode{copy} followed by \tcode{sort}.
 \end{footnote}
 When such a version is provided for \textit{algorithm} it is called
 \textit{algorithm\tcode{_copy}}.
@@ -8587,7 +8587,7 @@ of the first corresponding pair of elements that are not equivalent.
 \pnum
 \begin{example}
 \tcode{ranges::lexicographical_compare(I1, S1, I2, S2, Comp, Proj1, Proj2)}
-could be implemented as:
+can be implemented as:
 \begin{codeblock}
 for ( ; first1 != last1 && first2 != last2 ; ++first1, (void) ++first2) {
   if (invoke(comp, invoke(proj1, *first1), invoke(proj2, *first2))) return true;
@@ -9536,7 +9536,7 @@ The difference between \tcode{exclusive_scan} and \tcode{inclusive_scan} is
 that \tcode{exclusive_scan} excludes the $i^\text{th}$ input element
 from the $i^\text{th}$ sum.
 If \tcode{binary_op} is not mathematically associative,
-the behavior of \tcode{exclusive_scan} might be nondeterministic.
+the behavior of \tcode{exclusive_scan} can be nondeterministic.
 \end{note}
 \end{itemdescr}
 
@@ -9663,7 +9663,7 @@ The difference between \tcode{exclusive_scan} and \tcode{inclusive_scan} is
 that \tcode{inclusive_scan} includes the $i^\text{th}$ input element
 in the $i^\text{th}$ sum.
 If \tcode{binary_op} is not mathematically associative,
-the behavior of \tcode{inclusive_scan} might be nondeterministic.
+the behavior of \tcode{inclusive_scan} can be nondeterministic.
 \end{note}
 \end{itemdescr}
 
@@ -9738,7 +9738,7 @@ The difference between \tcode{transform_exclusive_scan} and
 \tcode{transform_inclusive_scan} is that \tcode{trans\-form\-_\-exclusive_scan}
 excludes the $i^\text{th}$ input element from the $i^\text{th}$ sum.
 If \tcode{binary_op} is not mathematically associative,
-the behavior of \tcode{transform_exclusive_scan} might be nondeterministic.
+the behavior of \tcode{transform_exclusive_scan} can be nondeterministic.
 \tcode{transform_exclusive_scan}
 does not apply \tcode{unary_op} to \tcode{init}.
 \end{note}
@@ -9842,7 +9842,7 @@ The difference between \tcode{transform_exclusive_scan} and
 \tcode{transform_inclusive_scan} is that \tcode{trans\-form\-_\-inclusive_scan}
 includes the $i^\text{th}$ input element in the $i^\text{th}$ sum.
 If \tcode{binary_op} is not mathematically associative,
-the behavior of \tcode{transform_inclusive_scan} might be nondeterministic.
+the behavior of \tcode{transform_inclusive_scan} can be nondeterministic.
 \tcode{transform_inclusive_scan} does not
 apply \tcode{unary_op} to \tcode{init}.
 \end{note}

--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -770,7 +770,7 @@ through a referencing \tcode{atomic_ref} are atomic with respect to
 atomic operations applied through any other \tcode{atomic_ref}
 referencing the same object.
 \begin{note}
-Atomic operations or the \tcode{atomic_ref} constructor could acquire
+Atomic operations or the \tcode{atomic_ref} constructor can acquire
 a shared resource, such as a lock associated with the referenced object,
 to enable atomic operations to be applied to the referenced object.
 \end{note}
@@ -1608,7 +1608,7 @@ The program is ill-formed if any of
 is \tcode{false}.
 \begin{note}
 Type arguments that are
-not also statically initializable might be difficult to use.
+not also statically initializable can be difficult to use.
 \end{note}
 
 \pnum
@@ -1971,7 +1971,7 @@ would not, the strong one is preferable.
 \pnum
 \begin{note}
 Under cases where the \tcode{memcpy} and \tcode{memcmp} semantics of the compare-and-exchange
-operations apply, the outcome might be failed comparisons for values that compare equal with
+operations apply, the comparisons can fail for values that compare equal with
 \tcode{operator==} if the value representation has trap bits or alternate
 representations of the same value. Notably, on implementations conforming to
 ISO/IEC/IEEE 60559, floating-point \tcode{-0.0} and \tcode{+0.0}

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -394,7 +394,7 @@ and
 are modeled, then \tcode{T} and \tcode{U} share a
 \term{common reference type}, \tcode{C}.
 \begin{note}
-\tcode{C} could be the same as \tcode{T}, or \tcode{U}, or it could be a
+\tcode{C} can be the same as \tcode{T} or \tcode{U}, or can be a
 different type. \tcode{C} can be a reference type.
 \end{note}
 
@@ -437,8 +437,8 @@ If \tcode{T} and \tcode{U} can both be explicitly converted to some third type,
 \tcode{C}, then \tcode{T} and \tcode{U} share a \term{common type},
 \tcode{C}.
 \begin{note}
-\tcode{C} could be the same as \tcode{T}, or \tcode{U}, or it could be a
-different type. \tcode{C} might not be unique.
+\tcode{C} can be the same as \tcode{T} or \tcode{U}, or can be a
+different type. \tcode{C} is not necessarily unique.
 \end{note}
 
 \begin{itemdecl}
@@ -1142,7 +1142,7 @@ template<class T>
 \pnum
 \begin{note}
 The \libconcept{semiregular} concept is modeled by types that behave similarly
-to built-in types like \tcode{int}, except that they might not
+to built-in types like \tcode{int}, except that they need not
 be comparable with \tcode{==}.
 \end{note}
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -65,7 +65,7 @@ These functions are called only for the
 container's element type, not for internal types used by the container.
 \begin{note}
 This
-means, for example, that a node-based container might need to construct nodes containing
+means, for example, that a node-based container would need to construct nodes containing
 aligned buffers and call \tcode{construct} to place the element into the buffer.
 \end{note}
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -3926,7 +3926,7 @@ Whether the input sequence is backed up or modified in any other way is unspecif
 \returns
 \tcode{traits::eof()}
 to indicate failure.
-Failure may occur because the input sequence cannot be backed up, or if for some
+Failure may occur because the input sequence could not be backed up, or if for some
 other reason the pointers cannot be set consistent with the constraints.
 \tcode{pbackfail()}
 is called only when put back has really failed.
@@ -14942,7 +14942,7 @@ as a \tcode{directory_iterator} unless otherwise specified.
 \pnum
 \begin{note}
 If the directory structure being iterated over contains cycles
-then it is possible for the end iterator to be unreachable.
+then it is possible that the end iterator is unreachable.
 \end{note}
 
 \rSec3[fs.rec.dir.itr.members]{Members}
@@ -15865,7 +15865,7 @@ The \tcode{current_path()} name was chosen to emphasize that the returned value 
 \pnum
 \begin{note}
 The current path as returned by many operating systems is a dangerous
-  global variable, and can be changed unexpectedly by third-party or system
+  global variable and can be changed unexpectedly by third-party or system
   library functions, or by another thread.
 \end{note}
 \end{itemdescr}
@@ -15892,7 +15892,7 @@ As specified in~\ref{fs.err.report}.
 \pnum
 \begin{note}
 The current path for many operating systems is a dangerous
-  global state, and can be changed unexpectedly by a third-party or system
+  global state and can be changed unexpectedly by third-party or system
   library functions, or by another thread.
 \end{note}
 \end{itemdescr}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -3696,7 +3696,7 @@ will fail.
 \tcode{underflow}
 or
 \tcode{uflow}
-might fail by throwing an exception prematurely.
+can fail by throwing an exception prematurely.
 The intention is not only that the calls will not return
 \tcode{eof()}
 but that they will return ``immediately''.
@@ -3926,8 +3926,8 @@ Whether the input sequence is backed up or modified in any other way is unspecif
 \returns
 \tcode{traits::eof()}
 to indicate failure.
-Failure may occur because the input sequence could not be backed up, or if for some
-other reason the pointers could not be set consistent with the constraints.
+Failure may occur because the input sequence cannot be backed up, or if for some
+other reason the pointers cannot be set consistent with the constraints.
 \tcode{pbackfail()}
 is called only when put back has really failed.
 
@@ -7883,7 +7883,7 @@ according to \tcode{mode}.
 \pnum
 \begin{note}
 For efficiency reasons,
-stream buffer operations might violate invariants of \tcode{buf}
+stream buffer operations can violate invariants of \tcode{buf}
 while it is held encapsulated in the \tcode{basic_stringbuf},
 e.g., by writing to characters in the range
 \range{\tcode{buf.data() + buf.size()}}{\tcode{buf.data() + buf.capacity()}}.
@@ -12691,8 +12691,8 @@ template<class Source>
 \effects
 Appends \tcode{path(x).native()} to the pathname in the native format.
 \begin{note}
-This directly manipulates the value of \tcode{native()}
-and might not be portable between operating systems.
+This directly manipulates the value of \tcode{native()},
+which is not necessarily portable between operating systems.
 \end{note}
 
 \pnum
@@ -13877,7 +13877,7 @@ for file systems supporting additional types of file}
 \tcode{file_type} constants
 to separately identify each of those additional file types \\ \rowsep
 \tcode{unknown} &
-The file exists but the type could not be determined \\
+The file exists but the type cannot be determined \\
 \end{floattable}
 
 \rSec3[fs.enum.copy.opts]{Enum class \tcode{copy_options}}
@@ -14942,7 +14942,7 @@ as a \tcode{directory_iterator} unless otherwise specified.
 \pnum
 \begin{note}
 If the directory structure being iterated over contains cycles
-then the end iterator might be unreachable.
+then it is possible for the end iterator to be unreachable.
 \end{note}
 
 \rSec3[fs.rec.dir.itr.members]{Members}
@@ -15290,8 +15290,8 @@ As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{note}
-To resolve symlinks,
-or perform other sanitization which might require queries to secondary storage,
+To resolve symlinks
+or perform other sanitization that can involve queries to secondary storage,
 such as hard disks, consider \tcode{canonical}\iref{fs.op.canonical}.
 \end{note}
 
@@ -15865,7 +15865,7 @@ The \tcode{current_path()} name was chosen to emphasize that the returned value 
 \pnum
 \begin{note}
 The current path as returned by many operating systems is a dangerous
-  global variable. It might be changed unexpectedly by third-party or system
+  global variable, and can be changed unexpectedly by third-party or system
   library functions, or by another thread.
 \end{note}
 \end{itemdescr}
@@ -15892,7 +15892,7 @@ As specified in~\ref{fs.err.report}.
 \pnum
 \begin{note}
 The current path for many operating systems is a dangerous
-  global state. It might be changed unexpectedly by a third-party or system
+  global state, and can be changed unexpectedly by a third-party or system
   library functions, or by another thread.
 \end{note}
 \end{itemdescr}
@@ -16380,8 +16380,8 @@ As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{note}
-A postcondition of \tcode{last_write_time(p) == new_time} is not specified since it might not hold for file systems
-  with coarse time granularity.
+A postcondition of \tcode{last_write_time(p) == new_time} is not specified
+because it does not necessarily hold for file systems with coarse time granularity.
 \end{note}
 \end{itemdescr}
 

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2079,7 +2079,7 @@ such an algorithm should be a single-pass algorithm.
 The only valid use of an \tcode{operator*}
 is on the left side of the assignment statement.
 Assignment through the same value of the iterator happens only once.
-Equality and inequality might not be defined.
+Equality and inequality are not necessarily defined.
 \end{note}
 
 \rSec3[forward.iterators]{Forward iterators}
@@ -2637,12 +2637,9 @@ namespace std {
 
 \pnum
 \begin{example}
-For a program-defined iterator
-\tcode{BinaryTreeIterator},
-it could be included
-into the bidirectional iterator category by specializing the
-\tcode{iterator_traits}
-template:
+A program-defined iterator \tcode{BinaryTreeIterator}
+can be included into the bidirectional iterator category by
+specializing the \tcode{iterator_traits} template:
 
 \begin{codeblock}
 template<class T> struct iterator_traits<BinaryTreeIterator<T>> {

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -308,7 +308,7 @@ in overload resolution\iref{over.match}.
 Failure to meet such a condition results in the function's silent non-viability.
 \end{note}
 \begin{example}
-An implementation might express such a condition
+An implementation can express such a condition
 via a \grammarterm{constraint-expression}\iref{temp.constr.decl}.
 \end{example}
 
@@ -316,12 +316,12 @@ via a \grammarterm{constraint-expression}\iref{temp.constr.decl}.
 \mandates
 the conditions that, if not met, render the program ill-formed.
 \begin{example}
-An implementation might express such a condition
+An implementation can express such a condition
 via the \grammarterm{constant-expression}
 in a \grammarterm{static_assert-declaration}\iref{dcl.pre}.
 If the diagnostic is to be emitted only after the function
 has been selected by overload resolution,
-an implementation might express such a condition
+an implementation can express such a condition
 via a \grammarterm{constraint-expression}\iref{temp.constr.decl}
 and also define the function as deleted.
 \end{example}
@@ -1640,7 +1640,7 @@ The null value shall be equivalent only to itself. A default-initialized object
 of type \tcode{P} may have an indeterminate value.
 \begin{note}
 Operations involving
-indeterminate values might cause undefined behavior.
+indeterminate values can cause undefined behavior.
 \end{note}
 
 \pnum
@@ -2733,7 +2733,7 @@ an lvalue to an xvalue while passing that lvalue to a library function
 (e.g., by calling the function with the argument \tcode{std::move(x)}), the program
 is effectively asking that function to treat that lvalue as a temporary object.
 The implementation
-is free to optimize away aliasing checks which might be needed if the argument was
+is free to optimize away aliasing checks which would possibly be needed if the argument was
 an lvalue.
 \end{note}
 \end{itemize}
@@ -2982,7 +2982,7 @@ arguments, including \tcode{this}.
 \pnum
 \begin{note}
 This means, for example, that implementations can't use an object with static storage duration for
-internal purposes without synchronization because it could cause a data race even in
+internal purposes without synchronization because doing so can cause a data race even in
 programs that do not explicitly share objects between threads.
 \end{note}
 

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -179,7 +179,7 @@ and
 
 \pnum
 \begin{example}
-An iostream \tcode{operator<<} might be implemented as:
+An iostream \tcode{operator<<} can be implemented as:%
 \begin{footnote}
 Note that in the call to \tcode{put},
 the stream is implicitly converted
@@ -197,7 +197,7 @@ operator<< (basic_ostream<charT, traits>& s, Date d) {
       use_facet<time_put<charT, ostreambuf_iterator<charT, traits>>>(
         s.getloc()).put(s, s, s.fill(), &tmbuf, 'x').failed();
     if (failed)
-      s.setstate(s.badbit);     // might throw
+      s.setstate(s.badbit);     // can throw
   }
   return s;
 }
@@ -2106,7 +2106,7 @@ An enumeration value, as summarized in \tref{locale.codecvt.inout}.
 \tcode{partial}             &   not all source characters converted \\
 \tcode{error}               &
 encountered a character in \range{from}{from_end}
-that it could not convert                                           \\
+that cannot be converted                                           \\
 \tcode{noconv}              &
 \tcode{internT} and \tcode{externT} are the same type, and input
 sequence is identical to converted sequence                         \\
@@ -3881,7 +3881,7 @@ iter_type do_get_monthname(iter_type s, iter_type end, ios_base& str,
 \effects
 Reads characters starting at \tcode{s}
 until it has extracted the (perhaps abbreviated) name of a weekday or month.
-If it finds an abbreviation that is followed by characters that could
+If it finds an abbreviation that is followed by characters that can
 match a full name, it continues reading until it matches the full name or
 fails.
 It sets the appropriate

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -4011,7 +4011,7 @@ explicit random_device(const string& token);
 \throws
 A value of an \impldef{exception type when \tcode{random_device} constructor fails} type
  derived from \tcode{exception}
- if the \tcode{random_device} could not be initialized.
+ if the \tcode{random_device} cannot be initialized.
 
 \pnum
 \remarks
@@ -4068,7 +4068,7 @@ A nondeterministic random value,
 \throws
 A value of an \impldef{exception type when \tcode{random_device::operator()} fails}
  type derived from \tcode{exception}
- if a random number could not be obtained.
+ if a random number cannot be obtained.
 \end{itemdescr}
 
 

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1016,8 +1016,9 @@ type models \libconcept{forward_iterator} to multiple
 algorithms and making multiple passes over the range by repeated calls to
 \tcode{ranges::begin} and \tcode{ranges::end}.
 Since \tcode{ranges::begin} is not required to be equality-preserving
-when the return type does not model \libconcept{forward_iterator}, repeated calls
-might not return equal values or might not be well-defined.
+when the return type does not model \libconcept{forward_iterator},
+it is possible for repeated calls
+to not return equal values or to not be well-defined.
 \end{note}
 \end{itemdescr}
 
@@ -1104,7 +1105,7 @@ and is equal to \tcode{ranges::distance(t)}, and
 \begin{note}
 \tcode{ranges::size(t)} is otherwise not required to be
 well-defined after evaluating \tcode{ranges::begin(t)}.
-For example, \tcode{ranges::size(t)} might be well-defined
+For example, it is possible for \tcode{ranges::size(t)} to be well-defined
 for a \libconcept{sized_range} whose iterator type
 does not model \libconcept{forward_iterator}
 only if evaluated before the first call to \tcode{ranges::begin(t)}.
@@ -1844,7 +1845,7 @@ static_assert(@\libconcept{same_as}@<decltype(result3), vector<int>::iterator>);
 \end{codeblock}
 The call to \tcode{ranges::find} at \#1 returns \tcode{ranges::dangling}
 since \tcode{f()} is an rvalue \tcode{vector};
-the \tcode{vector} could potentially be destroyed
+it is possible for the \tcode{vector} to be destroyed
 before a returned iterator is dereferenced.
 However, the calls at \#2 and \#3 both return iterators
 since the lvalue \tcode{vec} and specializations of \tcode{subrange}

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -749,61 +749,61 @@ conditions described in \tref{re.err}:
   {re.err}
 \tcode{error_collate}
 &
-The expression contained an invalid collating element name.  \\ \rowsep
+The expression contains an invalid collating element name.  \\ \rowsep
 %
 \tcode{error_ctype}
 &
-The expression contained an invalid character class name.  \\ \rowsep
+The expression contains an invalid character class name.  \\ \rowsep
 %
 \tcode{error_escape}
 &
-The expression contained an invalid escaped character, or a trailing
+The expression contains an invalid escaped character, or a trailing
 escape.  \\ \rowsep
 %
 \tcode{error_backref}
 &
-The expression contained an invalid back reference.  \\ \rowsep
+The expression contains an invalid back reference.  \\ \rowsep
 %
 \tcode{error_brack}
 &
-The expression contained mismatched \verb|[| and \verb|]|.  \\ \rowsep
+The expression contains mismatched \verb|[| and \verb|]|.  \\ \rowsep
 %
 \tcode{error_paren}
 &
-The expression contained mismatched \verb|(| and \verb|)|.  \\ \rowsep
+The expression contains mismatched \verb|(| and \verb|)|.  \\ \rowsep
 %
 \tcode{error_brace}
 &
-The expression contained mismatched \verb|{| and \verb|}| \\ \rowsep
+The expression contains mismatched \verb|{| and \verb|}| \\ \rowsep
 %
 \tcode{error_badbrace}
 &
-The expression contained an invalid range in a \verb|{}| expression.  \\
+The expression contains an invalid range in a \verb|{}| expression.  \\
 \rowsep
 %
 \tcode{error_range}
 &
-The expression contained an invalid character range, such as
+The expression contains an invalid character range, such as
 \verb|[b-a]| in most encodings.  \\ \rowsep
 %
 \tcode{error_space}
 &
-There was insufficient memory to convert the expression into a finite
+There is insufficient memory to convert the expression into a finite
 state machine.  \\ \rowsep
 %
 \tcode{error_badrepeat}
 &
-One of \verb|*?+{| was not preceded by a valid regular expression.  \\ \rowsep
+One of \verb|*?+{| is not preceded by a valid regular expression.  \\ \rowsep
 %
 \tcode{error_complexity}
 &
 The complexity of an attempted match against a regular expression
-exceeded a pre-set level.  \\ \rowsep
+exceeds a pre-set level.  \\ \rowsep
 %
 \tcode{error_stack}
 &
-There was insufficient memory to determine whether the regular
-expression could match the specified character sequence.  \\
+There is insufficient memory to determine whether the regular
+expression matches the specified character sequence.  \\
 %
 \end{longliberrtab}
 

--- a/source/std.tex
+++ b/source/std.tex
@@ -79,7 +79,7 @@
 
 %%--------------------------------------------------
 %% add special hyphenation rules
-\hyphenation{tem-plate ex-am-ple in-put-it-er-a-tor name-space name-spaces non-zero cus-tom-i-za-tion}
+\hyphenation{tem-plate ex-am-ple in-put-it-er-a-tor name-space name-spaces non-zero cus-tom-i-za-tion im-ple-men-ted}
 
 %%--------------------------------------------------
 %% turn off all ligatures inside \texttt

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -3681,7 +3681,7 @@ The converted result.
 \pnum
 \throws
 \tcode{invalid_argument} if \tcode{strtol}, \tcode{strtoul},
-\tcode{strtoll}, or \tcode{strtoull} reports that no conversion could be
+\tcode{strtoll}, or \tcode{strtoull} reports that no conversion can be
 performed. Throws \tcode{out_of_range} if \tcode{strtol}, \tcode{strtoul},
 \tcode{strtoll} or \tcode{strtoull} sets \tcode{errno} to \tcode{ERANGE},
 or if the converted value is outside the range of representable values
@@ -3716,7 +3716,7 @@ The converted result.
 \pnum
 \throws
 \tcode{invalid_argument} if \tcode{strtof}, \tcode{strtod}, or
-\tcode{strtold} reports that no conversion could be performed. Throws
+\tcode{strtold} reports that no conversion can be performed. Throws
 \tcode{out_of_range} if \tcode{strtof}, \tcode{strtod}, or
 \tcode{strtold} sets \tcode{errno} to \tcode{ERANGE}
 or if the converted value is outside the range of representable
@@ -3785,7 +3785,7 @@ The converted result.
 \pnum
 \throws
 \tcode{invalid_argument} if \tcode{wcstol}, \tcode{wcstoul}, \tcode{wcstoll}, or
-\tcode{wcstoull} reports that no conversion could be performed. Throws
+\tcode{wcstoull} reports that no conversion can be performed. Throws
 \tcode{out_of_range} if the converted value is outside the range of representable values
 for the return type.
 \end{itemdescr}
@@ -3817,7 +3817,7 @@ The converted result.
 \pnum
 \throws
 \tcode{invalid_argument} if \tcode{wcstof}, \tcode{wcstod}, or \tcode{wcstold} reports that no
-conversion could be performed. Throws \tcode{out_of_range} if \tcode{wcstof}, \tcode{wcstod}, or
+conversion can be performed. Throws \tcode{out_of_range} if \tcode{wcstof}, \tcode{wcstod}, or
 \tcode{wcstold} sets \tcode{errno} to \tcode{ERANGE}.
 \end{itemdescr}
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -547,8 +547,9 @@ Each of the macros defined in \libheader{version} is also defined
 after inclusion of any member of the set of library headers
 indicated in the corresponding comment in this synopsis.
 \begin{note}
-Future revisions of \Cpp{} might replace
-the values of these macros with greater values.
+Future revisions of \Cpp{} will replace
+the values of these macros with greater values
+when the corresponding feature is modified.
 \end{note}
 
 \begin{codeblock}
@@ -3761,7 +3762,7 @@ enumeration, or pointer type.
 
 \pnum
 \begin{note}
-An implementation might use a reference-counted smart
+An implementation can use a reference-counted smart
 pointer as \tcode{exception_ptr}.
 \end{note}
 
@@ -4213,7 +4214,7 @@ that (a) admits all of the six two-way comparison operators (\ref{expr.rel}, \re
 (b) does not imply substitutability,
 and (c) permits two values to be incomparable.
 \begin{footnote}
-That is, \tcode{a < b}, \tcode{a == b}, and \tcode{a > b} might all be \tcode{false}.
+That is, \tcode{a < b}, \tcode{a == b}, and \tcode{a > b} can all be \tcode{false}.
 \end{footnote}
 
 \indexlibraryglobal{partial_ordering}%
@@ -5715,8 +5716,8 @@ control entering a \grammarterm{try-block} or \grammarterm{function-try-block};
 initialization of a variable with static storage duration
 requiring dynamic initialization~(\ref{basic.start.dynamic}, \ref{stmt.dcl})
 \begin{footnote}
-Such initialization might occur because it is the first odr-use\iref{basic.def.odr} of that variable.
-\end{footnote}%
+Such initialization can occur because it is the first odr-use\iref{basic.def.odr} of that variable.
+\end{footnote}
 ; or
 
 \item

--- a/source/support.tex
+++ b/source/support.tex
@@ -547,9 +547,8 @@ Each of the macros defined in \libheader{version} is also defined
 after inclusion of any member of the set of library headers
 indicated in the corresponding comment in this synopsis.
 \begin{note}
-Future revisions of \Cpp{} will replace
-the values of these macros with greater values
-when the corresponding feature is modified.
+Future revisions of \Cpp{} might replace
+the values of these macros with greater values.
 \end{note}
 
 \begin{codeblock}
@@ -4214,7 +4213,7 @@ that (a) admits all of the six two-way comparison operators (\ref{expr.rel}, \re
 (b) does not imply substitutability,
 and (c) permits two values to be incomparable.
 \begin{footnote}
-That is, \tcode{a < b}, \tcode{a == b}, and \tcode{a > b} can all be \tcode{false}.
+That is, \tcode{a < b}, \tcode{a == b}, and \tcode{a > b} might all be \tcode{false}.
 \end{footnote}
 
 \indexlibraryglobal{partial_ordering}%

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -7175,7 +7175,7 @@ the shared state is made ready.
 \begin{note}
 These apply regardless of the provided \tcode{policy} argument, and
 even if the corresponding \tcode{future} object is moved to another thread.
-It is possible for \tcode{f} not to be called at all,
+However, it is possible for \tcode{f} not to be called at all,
 in which case its completion never happens.
 \end{note}
 

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -4245,7 +4245,7 @@ all objects with thread storage duration associated with the current thread.
 \pnum
 \begin{note}
 The supplied lock is held until the thread exits,
-which can cause deadlock due to lock ordering issues.
+which might cause deadlock due to lock ordering issues.
 \end{note}
 
 \pnum
@@ -6927,7 +6927,7 @@ the return type and return value of the member function \tcode{get}.
 \pnum
 \begin{note}
 Access to a value object stored in the shared state is
-unsynchronized, so it is possible for operations on \tcode{R} to
+unsynchronized, so operations on \tcode{R} might
 introduce a data race\iref{intro.multithread}.
 \end{note}
 

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -136,8 +136,8 @@ should decrease the duration of the wait when the clock is adjusted forwards.
 
 \pnum
 \begin{note}
-If the clock is not synchronized with a steady clock, e.g., a CPU time clock, these
-timeouts might not provide useful functionality.
+If the clock is not synchronized with a steady clock, e.g., a CPU time clock,
+it is possible that these timeouts do not provide useful functionality.
 \end{note}
 
 \pnum
@@ -641,7 +641,7 @@ and \tcode{stop_requested()} is \tcode{false}.
 
 \pnum
 \throws
-\tcode{bad_alloc} if memory could not be allocated for the stop state.
+\tcode{bad_alloc} if memory cannot be allocated for the stop state.
 \end{itemdescr}
 
 \indexlibraryctor{stop_source}%
@@ -1274,7 +1274,7 @@ If \tcode{joinable()}, invokes \tcode{terminate}\iref{except.terminate}.
 Otherwise, has no effects.
 \begin{note}
 Either implicitly detaching or joining a \tcode{joinable()} thread in its
-destructor could result in difficult to debug correctness (for detach) or performance
+destructor can result in difficult to debug correctness (for detach) or performance
 (for join) bugs encountered only when an exception is thrown.
 These bugs can be avoided by ensuring that
 the destructor is never executed while the thread is still joinable.
@@ -4245,7 +4245,7 @@ all objects with thread storage duration associated with the current thread.
 \pnum
 \begin{note}
 The supplied lock is held until the thread exits,
-which might cause deadlock due to lock ordering issues.
+which can cause deadlock due to lock ordering issues.
 \end{note}
 
 \pnum
@@ -4329,7 +4329,7 @@ limitation prevents initialization.
 There is no thread blocked on \tcode{*this}.
 \begin{note}
 That is, all
-threads have been notified; they could subsequently block on the lock specified in the
+threads have been notified; they can subsequently block on the lock specified in the
 wait.
 This relaxes the usual rules, which would have required all wait calls to happen before
 destruction. Only the notification to unblock the wait needs to happen before destruction.
@@ -4771,7 +4771,7 @@ privilege to perform the operation.
 There is no thread blocked on \tcode{*this}.
 \begin{note}
 That is, all
-threads have been notified; they could subsequently block on the lock specified in the
+threads have been notified; they can subsequently block on the lock specified in the
 wait.
 This relaxes the usual rules, which would have required all wait calls to happen before
 destruction. Only the notification to unblock the wait needs to happen before destruction.
@@ -6927,7 +6927,7 @@ the return type and return value of the member function \tcode{get}.
 \pnum
 \begin{note}
 Access to a value object stored in the shared state is
-unsynchronized, so operations on \tcode{R} might
+unsynchronized, so it is possible for operations on \tcode{R} to
 introduce a data race\iref{intro.multithread}.
 \end{note}
 
@@ -7175,8 +7175,8 @@ the shared state is made ready.
 \begin{note}
 These apply regardless of the provided \tcode{policy} argument, and
 even if the corresponding \tcode{future} object is moved to another thread.
-However, \tcode{f} might not be called at all,
-so its completion might never happen.
+It is possible for \tcode{f} not to be called at all,
+in which case its completion never happens.
 \end{note}
 
 If the implementation chooses the \tcode{launch::async} policy,
@@ -7202,7 +7202,7 @@ happens first.
 \tcode{system_error} if \tcode{policy == launch::async} and the
 implementation is unable to start a new thread, or
 \tcode{std::bad_alloc} if memory for the internal data structures
-could not be allocated.
+cannot be allocated.
 
 \pnum
 \errors
@@ -7329,7 +7329,7 @@ initializes the object's stored task with \tcode{std::forward<F>(f)}.
 \throws
 Any exceptions thrown by the copy or move constructor of \tcode{f}, or
 \tcode{bad_alloc} if memory for the internal data structures
-could not be allocated.
+cannot be allocated.
 \end{itemdescr}
 
 \indexlibraryctor{packaged_task}%
@@ -7521,7 +7521,7 @@ old state is abandoned\iref{futures.state}.
 \pnum
 \throws
 \begin{itemize}
-\item \tcode{bad_alloc} if memory for the new shared state could not be allocated.
+\item \tcode{bad_alloc} if memory for the new shared state cannot be allocated.
 \item any exception thrown by the move constructor of the task stored in the shared
 state.
 \item \tcode{future_error} with an error condition of \tcode{no_state} if \tcode{*this}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -136,8 +136,8 @@ should decrease the duration of the wait when the clock is adjusted forwards.
 
 \pnum
 \begin{note}
-If the clock is not synchronized with a steady clock, e.g., a CPU time clock,
-it is possible that these timeouts do not provide useful functionality.
+If the clock is not synchronized with a steady clock, e.g., a CPU time clock, these
+timeouts can fail to provide useful functionality.
 \end{note}
 
 \pnum

--- a/source/time.tex
+++ b/source/time.tex
@@ -6382,7 +6382,7 @@ Initializes
 \tcode{d_} with \tcode{ymdl.day()}.
 \begin{note}
 This conversion from \tcode{year_month_day_last} to \tcode{year_month_day}
-might be more efficient than converting a \tcode{year_month_day_last} to a \tcode{sys_days},
+can be more efficient than converting a \tcode{year_month_day_last} to a \tcode{sys_days},
 and then converting that \tcode{sys_days} to a \tcode{year_month_day}.
 \end{note}
 \end{itemdescr}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -4726,7 +4726,8 @@ Returns \tcode{false} if and only if the \tcode{variant} holds a value.
 
 \pnum
 \begin{note}
-A \tcode{variant} might not hold a value if an exception is thrown during a
+It is possible for a \tcode{variant} to hold no value
+if an exception is thrown during a
 type-changing assignment or emplacement. The latter means that even a
 \tcode{variant<float, int>} can become \tcode{valueless_by_exception()}, for
 instance by
@@ -7533,7 +7534,7 @@ whether
 \tcode{point\-er_safety::preferred} if the implementation has relaxed pointer
 safety.
 \begin{footnote}
-\tcode{pointer_safety::preferred} might be returned to indicate
+\tcode{pointer_safety::preferred} can be returned to indicate
 that a leak detector is running so that the program can avoid spurious leak
 reports.
 \end{footnote}
@@ -9875,7 +9876,7 @@ when \tcode{T} is not an array type, \tcode{delete[] p} otherwise.
 \pnum
 \throws
 \tcode{bad_alloc}, or an \impldef{exception type when \tcode{shared_ptr}
-constructor fails} exception when a resource other than memory could not be obtained.
+constructor fails} exception when a resource other than memory cannot be obtained.
 \end{itemdescr}
 
 \indexlibraryctor{shared_ptr}%
@@ -9929,7 +9930,7 @@ If an exception is thrown, \tcode{d(p)} is called.
 \throws
 \tcode{bad_alloc}, or an \impldef{exception type when \tcode{shared_ptr}
 constructor fails} exception
-when a resource other than memory could not be obtained.
+when a resource other than memory cannot be obtained.
 \end{itemdescr}
 
 \indexlibraryctor{shared_ptr}%
@@ -11618,9 +11619,9 @@ virtual bool do_is_equal(const memory_resource& other) const noexcept = 0;
 A derived class shall implement this function to return \tcode{true} if memory allocated from \tcode{this} can be deallocated from \tcode{other} and vice-versa,
 otherwise \tcode{false}.
 \begin{note}
-The most-derived type of \tcode{other} might not match the type of \tcode{this}.
+It is possible that the most-derived type of \tcode{other} does not match the type of \tcode{this}.
 For a derived class \tcode{D}, an implementation of this function
-could immediately return \tcode{false}
+can immediately return \tcode{false}
 if \tcode{dynamic_cast<const D*>(\&other) == nullptr}.
 \end{note}
 \end{itemdescr}
@@ -18566,10 +18567,10 @@ sort(execution::par_unseq, v.begin(), v.end());
 \end{codeblock}
 \end{example}
 \begin{note}
-Because different parallel architectures might require idiosyncratic
-parameters for efficient execution, implementations
-can provide additional execution policies to those described in this
-standard as extensions.
+Implementations can provide additional execution policies
+to those described in this standard as extensions
+to address parallel architectures that require idiosyncratic
+parameters for efficient execution.
 \end{note}
 
 \rSec2[execution.syn]{Header \tcode{<execution>} synopsis}
@@ -19727,7 +19728,7 @@ are specified in \tref{format.type.int}.
 string s0 = format("{}", 42);                           // value of \tcode{s0} is \tcode{"42"}
 string s1 = format("{0:b} {0:d} {0:o} {0:x}", 42);      // value of \tcode{s1} is \tcode{"101010 42 52 2a"}
 string s2 = format("{0:#x} {0:#X}", 42);                // value of \tcode{s2} is \tcode{"0x2a 0X2A"}
-string s3 = format("{:L}", 1234);                       // value of \tcode{s3} might be \tcode{"1,234"}
+string s3 = format("{:L}", 1234);                       // value of \tcode{s3} can be \tcode{"1,234"}
                                                         // (depending on the locale)
 \end{codeblock}
 \end{example}


### PR DESCRIPTION
These changes editorially remove the words "could" and "might".

Please review this change carefully with the following goals:

Flag anything that seems even remotely non-editorial, e.g. even if the explanation provided by a Note becomes less useful or (more) misleading.
Also flag anything that could conceivably be worded better by a wider review.
I would like all remaining instances of "could" and "might" to be reviewed by CWG/LWG, so please don't hold back on rejecting anything at this point.