### PR TITLE
atomic wait/notify_one/notify_all : add volatile constraints

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -2030,6 +2030,11 @@ void wait(T old, memory_order order = memory_order::seq_cst) const noexcept;
 
 \begin{itemdescr}
 \pnum
+\constraints
+For the \tcode{volatile} overload of this function,
+\tcode{is_always_lock_free} is \tcode{true}.
+
+\pnum
 \expects
 \tcode{order} is neither \tcode{memory_order::release} nor \tcode{memory_order::acq_rel}.
 
@@ -2063,6 +2068,11 @@ void notify_one() noexcept;
 
 \begin{itemdescr}
 \pnum
+\constraints
+For the \tcode{volatile} overload of this function,
+\tcode{is_always_lock_free} is \tcode{true}.
+
+\pnum
 \effects
 Unblocks the execution of at least one atomic waiting operation
 that is eligible to be unblocked\iref{atomics.wait} by this call,
@@ -2083,6 +2093,11 @@ void notify_all() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\constraints
+For the \tcode{volatile} overload of this function,
+\tcode{is_always_lock_free} is \tcode{true}.
+
 \pnum
 \effects
 Unblocks the execution of all atomic waiting operations


### PR DESCRIPTION
apply volatile constraints (http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1831r1.html) to wait/notify operations.