### PR TITLE
[macros] Add "\exposidnc", like \exposid without italic correction

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -221,6 +221,7 @@
 \newcommand{\placeholder}[1]{\textit{#1}}
 \newcommand{\placeholdernc}[1]{\textit{#1\nocorr}}
 \newcommand{\exposid}[1]{\tcode{\placeholder{#1}}}
+\newcommand{\exposidnc}[1]{\tcode{\placeholdernc{#1}}}
 \newcommand{\defnxname}[1]{\indextext{\idxxname{#1}}\xname{#1}}
 \newcommand{\defnlibxname}[1]{\indexlibrary{\idxxname{#1}}\xname{#1}}
 


### PR DESCRIPTION
Fixes #4381.