### PR TITLE
Rewordings to avoid "might" and "could"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2870,7 +2870,7 @@ that is not an odr-use\iref{term.odr.use},
 or defines a constexpr variable initialized to a TU-local value (defined below).
 \begin{note}
 An inline function template can be an exposure even though
-explicit specializations of it might be usable in other translation units.
+certain explicit specializations of it would be usable in other translation units.
 \end{note}
 
 \pnum
@@ -2965,7 +2965,7 @@ namespace N {
 }
 void adl(double);
 
-inline void h(auto x) { adl(x); }   // OK, but a specialization might be an exposure
+inline void h(auto x) { adl(x); }   // OK, but certain specializations are exposures
 \end{codeblocktu}
 \begin{codeblocktu}{Translation unit \#2}
 module A;

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -631,11 +631,11 @@ reversed and rewritten candidates.
 Improve consistency of equality with three-way comparison
 and make it easier to write the full complement of equality operations.
 \effect
-Equality and inequality expressions between two objects of different types,
-where one is convertible to the other,
-could invoke a different operator.
-Equality and inequality expressions between two objects of the same type
-could become ambiguous.
+For certain pairs of types where one is convertible to the other,
+equality or inequality expressions between an object of one type
+and an object of the other type invoke a different operator.
+Also, for certain types, equality or inequality expressions
+between two objects of that type become ambiguous.
 For example:
 \begin{codeblock}
 struct A {
@@ -921,9 +921,9 @@ A valid \CppXVII{} program that directly makes use of the \tcode{pointer},
 \change
 Remove \tcode{raw_storage_iterator}.
 \rationale
-The iterator encouraged use of algorithms that might throw exceptions, but did
-not return the number of elements successfully constructed that might need to
-be destroyed in order to avoid leaks.
+The iterator encouraged use of potentially-throwing algorithms, but did
+not return the number of elements successfully constructed,
+as would be necessary to destroy them.
 \effect
 A valid \CppXVII{} program that uses this iterator class may fail to compile.
 
@@ -958,8 +958,8 @@ Remove deprecated type traits.
 The traits had unreliable or awkward interfaces. The \tcode{is_literal_type}
 trait provided no way to detect which subset of constructors and member
 functions of a type were declared \keyword{constexpr}. The \tcode{result_of}
-trait had a surprising syntax that could not report the result of a regular
-function type. It has been superseded by the \tcode{invoke_result} trait.
+trait had a surprising syntax that did not directly support function types.
+It has been superseded by the \tcode{invoke_result} trait.
 \effect
 A valid \CppXVII{} program that relies on the \tcode{is_literal_type} or
 \tcode{result_of} type traits, on the \tcode{is_literal_type_v} variable template,
@@ -1019,8 +1019,6 @@ Obsolete feature with occasionally surprising semantics.
 \effect
 A valid \CppXIV{} expression utilizing the increment operator on
 a \tcode{bool} lvalue is ill-formed in this revision of \Cpp{}.
-Note that this might occur when the lvalue has a type given by a template
-parameter.
 
 \diffref{expr.new,expr.delete}
 \change
@@ -1694,7 +1692,7 @@ Allow dependent calls of functions with internal linkage.
 \rationale
 Overly constrained, simplify overload resolution rules.
 \effect
-A valid \CppIII{} program could get a different result than in this
+A valid \CppIII{} program can get a different result in this
 revision of \Cpp{}.
 
 \rSec2[diff.cpp03.library]{\ref{library}: library introduction}
@@ -2354,8 +2352,8 @@ resources which need to be de-allocated upon leaving the
 block.
 Allowing jump past initializers would require
 complicated runtime determination of allocation.
-Furthermore, any use of the uninitialized object could be a
-disaster.
+Furthermore, many operations on such an uninitialized object
+have undefined behavior.
 With this simple compile-time rule, \Cpp{} assures that
 if an initialized variable is in scope, then it has assuredly been
 initialized.
@@ -2411,8 +2409,8 @@ Storage class specifiers don't have any meaning when associated
 with a type.
 In \Cpp{}, class members can be declared with the \keyword{static} storage
 class specifier.
-Allowing storage class specifiers on type
-declarations could render the code confusing for users.
+Storage class specifiers on type
+declarations can be confusing for users.
 \effect
 Deletion of semantically well-defined feature.
 \difficulty
@@ -2786,8 +2784,8 @@ Seldom.
 \indextext{bit-field!implementation-defined sign of}%
 Bit-fields of type plain \keyword{int} are signed.
 \rationale
-Leaving the choice of signedness to implementations could lead to
-inconsistent definitions of template specializations. For consistency,
+The signedness needs to be consistent among template specializations.
+For consistency,
 the implementation freedom was eliminated for non-dependent types,
 too.
 \effect

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -799,9 +799,7 @@ void g() noexcept {
 \end{codeblock}
 The call to
 \tcode{f}
-is well-formed even though, when called,
-\tcode{f}
-might throw an exception.
+is well-formed despite the possibility for it to throw an exception.
 \end{example}
 
 \pnum


### PR DESCRIPTION
These rewordings were proposed by @opensdh during earlier review. They are more extensive than local replacements of "might" or "could", and we should review them on their own merit, i.e. whether they are an improvement (or at least not making things worse), and we should also consider other (possible even wider-ranging) rewordings.