### PR TITLE
[temp.over.link] Remove (apparent) copy/paste extra lines from example code

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3748,9 +3748,6 @@ same function template differ in the result of this name lookup, the
 result for the first declaration is used.
 \begin{example}
 \begin{codeblock}
-template <int I, int J> void f(A<I+J>);         // \#1
-template <int K, int L> void f(A<K+L>);         // same as \#1
-
 template <class T> decltype(g(T())) h();
 int g(int);
 template <class T> decltype(g(T())) h()         // redeclaration of \tcode{h()} uses the earlier lookup\ldots


### PR DESCRIPTION
The first two lines in this example were an exact copy from the
previous example (about 40 lines up), and seem unrelated to the
topic being demonstrated, so look like a cut/paste error.