### PR TITLE
[expr.type.conv] Remove unnecessary indirection of "specified type" when the resulting type will always be unqualified void

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3219,7 +3219,7 @@ expression\iref{expr.cast}.
 Otherwise, if the type is \cv{}~\tcode{void}
 and the initializer is \tcode{()} or \tcode{\{\}}
 (after pack expansion, if any),
-the expression is a prvalue of the specified type
+the expression is a prvalue of type \tcode{void}
 that performs no initialization.
 Otherwise,
 the expression is a prvalue of the specified type


### PR DESCRIPTION
[expr.type.conv]/2 states that:
> Otherwise, if the type is `cv void` and the initializer is `()` or `{}` [...], the expression is a prvalue of the specified type that performs no initialization.

This is unnecessarily indirect. As per Richard Smith in a [clang bug report](https://bugs.llvm.org/show_bug.cgi?id=48331#c1):
> See [expr.type]p2:
>
> "If a prvalue initially has the type “cv T”, where T is a cv-unqualified non-class, non-array type, the type of the expression is adjusted to T prior to any further analysis."

The specification can be made clearer by changing the reference to "the specified type" to explicit state that the type is void without any semantic impact, and as such is an editorial change.