### PR TITLE
Address partial specialization merge conflicts

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -116,11 +116,8 @@ Its \grammarterm{declaration} shall not be an
 In a function template declaration, the \grammarterm{unqualified-id} of the
 \grammarterm{declarator-id} shall be a name.
 \begin{note}
-[NEEDS REVIEW] In a class or variable template declaration, if the
-declared name
-is a
-\grammarterm{simple-template-id},
-the declaration declares a partial specialization\iref{temp.spec.partial}.
+A class or variable template declaration of a \grammarterm{simple-template-id}
+declares a partial specialization\iref{temp.spec.partial}.
 \end{note}
 
 \pnum
@@ -2154,6 +2151,11 @@ e.g., by a \grammarterm{typedef-name}.
 \rSec2[temp.decls.general]{General}
 
 \pnum
+The template parameters of a template are specified in
+the angle bracket enclosed list
+that immediately follows the keyword \keyword{template}.
+
+\pnum
 A \defnadj{primary}{template} declaration is one
 in which the name of the template is not followed by
 a \grammarterm{template-argument-list}.
@@ -2161,8 +2163,9 @@ The template argument list of a primary template is
 the template argument list of its \grammarterm{template-head}\iref{temp.arg}.
 A template declaration in which the name of the template is followed by
 a \grammarterm{template-argument-list} is
-a partial specialization of
-the template named in the declaration\iref{temp.spec.partial}.
+a partial specialization\iref{temp.spec.partial} of
+the template named in the declaration,
+which shall be a class or variable template.
 
 \pnum
 For purposes of name lookup and instantiation,
@@ -3134,7 +3137,8 @@ A partial specialization of a template provides an alternative definition
 of the template that is used instead of the primary definition when the
 arguments in a specialization match those given in the partial
 specialization\iref{temp.spec.partial.match}.
-A declaration of the primary template shall precede any specialization of
+A declaration of the primary template shall precede
+any partial specialization of
 that template.
 A partial specialization shall be reachable from any use of a template
 specialization that would make use of the partial specialization as the result of
@@ -3180,10 +3184,8 @@ but the partial specialization is more constrained\iref{temp.constr.order}.
 \end{example}
 
 \pnum
-The template parameters of a template are specified in the angle bracket enclosed list
-that immediately follows the keyword \keyword{template}.
 The template argument list of a partial specialization is
-the \grammarterm{template-argument-list} of the \grammarterm{class-name}.
+the \grammarterm{template-argument-list} following the name of the template.
 
 \pnum
 A partial specialization may be declared in any


### PR DESCRIPTION
As requested by @tkoeppe, with the additional movement of "The template parameters of a template…" to follow the movement of "The template argument list of a primary template is…" by #4326.  The first change is written informally as befits a note.