### PR TITLE
[std] Move punctuation to before the footnote marker.

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -641,12 +641,12 @@ block\iref{intro.progress}.
 
 \pnum
 \recommended
-Operations that are lock-free should also be address-free
+Operations that are lock-free should also be address-free.
 \begin{footnote}
 That is,
 atomic operations on the same memory location via two different addresses will
 communicate atomically.
-\end{footnote}.
+\end{footnote}
 The implementation of these operations should not depend on any per-process state.
 \begin{note}
 This restriction enables communication by memory that is

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -171,7 +171,7 @@ the
 Appearing inside the brace-enclosed
 \grammarterm{declaration-seq} in a \grammarterm{linkage-specification} does
 not affect whether a declaration is a definition.
-\end{footnote}%
+\end{footnote}
 \iref{dcl.link}
 and neither an \grammarterm{initializer} nor a
 \grammarterm{function-body},
@@ -885,11 +885,11 @@ function template, or
 each declares a function or function template, except when
 \begin{itemize}
 \item
-both declare functions with the same parameter-type-list
+both declare functions with the same parameter-type-list,
 \begin{footnote}
 An implicit object parameter\iref{over.match.funcs}
 is not part of the parameter-type-list.
-\end{footnote},
+\end{footnote}
 equivalent\iref{temp.over.link} trailing \grammarterm{requires-clause}s
 (if any, except as specified in \ref{temp.friend}), and,
 if both are non-static members,
@@ -2220,13 +2220,13 @@ int main() {
 
 \pnum
 In a lookup for a qualified name $N$ whose lookup context is a class $C$
-in which function names are not ignored
+in which function names are not ignored,
 \begin{footnote}
 Lookups in which
 function names are ignored include names appearing in a
 \grammarterm{nested-name-specifier}, an
 \grammarterm{elaborated-type-specifier}, or a \grammarterm{base-specifier}.
-\end{footnote},
+\end{footnote}
 \begin{itemize}
 \item
 if the search finds the injected-class-name of \tcode{C}\iref{class.pre}, or
@@ -3950,14 +3950,14 @@ whose parameters after the first are
 \item
 optionally, a parameter of type \tcode{std::destroying_delete_t}, then
 \item
-optionally, a parameter of type \tcode{std::size_t}
+optionally, a parameter of type \tcode{std::size_t},
 \begin{footnote}
 The global \tcode{operator delete(void*, std::size_t)}
 precludes use of an
 allocation function \tcode{void operator new(std::size_t, std::size_t)} as a placement
 allocation function~(\ref{diff.cpp11.basic}).
-\end{footnote}%
-, then
+\end{footnote}
+then
 \item
 optionally, a parameter of type \tcode{std::align_val_t}.
 \end{itemize}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -7054,11 +7054,11 @@ function\iref{dcl.constexpr} that is being evaluated as part
 of $E$;
 
 \item
-an invocation of a non-constexpr function
+an invocation of a non-constexpr function;
 \begin{footnote}
 Overload resolution\iref{over.match}
 is applied as usual.
-\end{footnote};
+\end{footnote}
 
 \item
 an invocation of an undefined constexpr function;
@@ -7082,13 +7082,13 @@ limits (see \ref{implimits});
 
 \item
 an operation that would have undefined behavior
-as specified in \ref{intro} through \ref{cpp}
+as specified in \ref{intro} through \ref{cpp};
 \begin{footnote}
 This includes,
 for example, signed integer overflow\iref{expr.prop}, certain
 pointer arithmetic\iref{expr.add}, division by
 zero\iref{expr.mul}, or certain shift operations\iref{expr.shift}.
-\end{footnote};
+\end{footnote}
 
 \item
 an lvalue-to-rvalue conversion\iref{conv.lval} unless

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -2665,7 +2665,7 @@ Calls
 
 \pnum
 \returns
-\tcode{str}
+\tcode{str}.
 \begin{footnote}
 The function signature
 \tcode{dec(ios_base\&)}
@@ -2676,8 +2676,7 @@ to permit expressions of the form
 \tcode{cout << dec}
 to change the format flags stored in
 \tcode{cout}.
-\end{footnote}%
-.
+\end{footnote}
 \end{itemdescr}
 
 \indexlibraryglobal{hex}%
@@ -3669,8 +3668,7 @@ Returns zero.
 \begin{itemdecl}
 streamsize showmanyc();@
 \begin{footnote}
-\textrm{The morphemes of \tcode{showmanyc}\
-are ``es-how-many-see'', not ``show-manic''.}
+The morphemes of \tcode{showmanyc} are ``es-how-many-see'', not ``show-manic''.
 \end{footnote}@
 \end{itemdecl}
 

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -462,7 +462,7 @@ then the implied object argument is \tcode{(*this)}.
 Otherwise,
 a contrived object of type
 \tcode{T}
-becomes the implied object argument
+becomes the implied object argument;
 \begin{footnote}
 An implied object argument is contrived to
 correspond to the implicit object
@@ -475,7 +475,7 @@ same implicit
 object parameter, the contrived object will not be the cause to select or
 reject a
 function.
-\end{footnote};
+\end{footnote}
 if overload resolution selects a non-static member function,
 the call is ill-formed.
 

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -894,11 +894,11 @@ within a function from point $P$ to point $Q$,
 all variables that are active at $P$ and not at $Q$ are destroyed in the reverse order of their construction.
 Then, all variables that are active at $Q$ but not at $P$ are initialized in declaration order;
 unless all such variables have vacuous initialization\iref{basic.life},
-the transfer of control shall not be a jump
+the transfer of control shall not be a jump.
 \begin{footnote}
 The transfer from the condition of a \tcode{switch} statement to a
 \tcode{case} label is considered a jump in this respect.
-\end{footnote}.
+\end{footnote}
 When a \grammarterm{declaration-statement} is executed,
 $P$ and $Q$ are the points immediately before and after it;
 when a function returns, $Q$ is after its body.

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -4074,8 +4074,7 @@ namespace std {
     using iterator               = const_iterator;@
 \begin{footnote}
 Because \tcode{basic_string_view} refers to a constant sequence, \tcode{iterator} and \tcode{const_iterator} are the same type.
-\end{footnote}%
-@
+\end{footnote}@
     using const_reverse_iterator = reverse_iterator<const_iterator>;
     using reverse_iterator       = const_reverse_iterator;
     using size_type              = size_t;

--- a/source/support.tex
+++ b/source/support.tex
@@ -304,7 +304,7 @@ Note that \tcode{offsetof}
 is required to work as specified even if unary
 \tcode{operator\&}
 is overloaded for any of the types involved.
-\end{footnote}\space
+\end{footnote}
 The expression \tcode{offsetof(\placeholder{type}, \placeholder{member-designator})}
 is never type-dependent\iref{temp.dep.expr} and it is
 value-dependent\iref{temp.dep.constexpr} if and only if \tcode{\placeholder{type}} is
@@ -1293,10 +1293,10 @@ static constexpr float_denorm_style has_denorm;
 \pnum
 \tcode{denorm_present}
 if the type allows subnormal values
-(variable number of exponent bits)
+(variable number of exponent bits),
 \begin{footnote}
 Required by LIA-1.
-\end{footnote},
+\end{footnote}
 \tcode{denorm_absent}
 if the type does not allow subnormal values,
 and

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -4349,11 +4349,10 @@ a \grammarterm{type-specifier} of a
 \begin{itemize}
 \item \grammarterm{simple-declaration} or a \grammarterm{function-definition} in namespace scope,
 \item \grammarterm{member-declaration},
-\item \grammarterm{parameter-declaration} in a \grammarterm{member-declaration}
+\item \grammarterm{parameter-declaration} in a \grammarterm{member-declaration},
 \begin{footnote}
 This includes friend function declarations.
-\end{footnote}%
-,
+\end{footnote}
 unless that \grammarterm{parameter-declaration} appears in a default argument,
 \item \grammarterm{parameter-declaration} in a \grammarterm{declarator}
 of a function or function template declaration
@@ -4926,11 +4925,12 @@ whose \grammarterm{conversion-type-id} is dependent, or
 its lookup context is dependent and is not the current instantiation, or
 \item
 its lookup context is the current instantiation and
-it is \tcode{\keyword{operator}=}
+it is \tcode{\keyword{operator}=},
 \begin{footnote}
 Every instantiation of a class template declares
 a different set of assignment operators.
-\end{footnote}, or
+\end{footnote}
+or
 \item
 its lookup context is the current instantiation and
 has at least one dependent base class, and

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -32,6 +32,9 @@ for f in $texfiles; do
     awk 'prev == $0 && /^\\pnum/ { print FILENAME ":" FNR ": duplicate \\pnum on consecutive lines" } { prev = $0 }' $f
 done | grep . && exit 1
 
+# punctuation after the footnote marker
+grep -n "\\end{footnote" $texfiles | grep -v '}[@)%]\?$' && exit 1
+
 # \opt used incorrectly.
 grep -n '\\opt[^{]' $texfiles && exit 1
 grep -n 'opt{}' *.tex && exit 1


### PR DESCRIPTION
Also add an automated check.

Fixes #4400 