### PR TITLE
[cpp.import] Clarify header units as the source of macro definitions.

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -811,18 +811,22 @@ in the \tcode{import} \grammarterm{control-line}
 are processed just as in normal text
 (i.e., each identifier currently defined as a macro name
 is replaced by its replacement list of preprocessing tokens).
+\begin{note}
 An \tcode{import} directive
 matching the first two forms of a \grammarterm{pp-import}
 instructs the preprocessor to import macros
 from the header unit\iref{module.import}
-denoted by the \grammarterm{header-name}.
+denoted by the \grammarterm{header-name},
+as described below.
+\end{note}
 \indextext{point of!macro import|see{macro, point of import}}%
 The \defnx{point of macro import}{macro!point of import} for the
 first two forms of \grammarterm{pp-import} is
 immediately after the \grammarterm{new-line} terminating
 the \grammarterm{pp-import}.
 The last form of \grammarterm{pp-import} is only considered
-if the first two forms did not match.
+if the first two forms did not match, and
+does not have a point of macro import.
 
 \pnum
 If a \grammarterm{pp-import} is produced by source file inclusion
@@ -862,22 +866,25 @@ Implementations providing mechanisms to predefine additional macros
 are encouraged to not treat them
 as being introduced by a \tcode{\#define} directive.
 \end{note}
-Importing macros from a header unit makes macro definitions
-from a translation unit visible in other translation units.
 Each macro definition has at most one point of definition in
 each translation unit and at most one point of undefinition, as follows:
 \begin{itemize}
 \item
 \indextext{point of!macro definition|see{macro, point of definition}}%
 The \defnx{point of definition}{macro!point of definition}
-of a macro definition within a translation unit
-is the point at which its \tcode{\#define} directive occurs (in the translation
-unit containing the \tcode{\#define} directive), or,
+of a macro definition within a translation unit $T$ is
+\begin{itemize}
+\item
+if the \tcode{\#define} directive of the macro definition occurs within $T$,
+the point at which that directive occurs, or otherwise,
+\item
 if the macro name is not lexically identical to a keyword\iref{lex.key}
 or to the \grammarterm{identifier}{s} \tcode{module} or \tcode{import},
-the first point
-of macro import of a translation unit containing a point of definition for the
-macro definition, if any (in any other translation unit).
+the first point of macro import in $T$ of a header unit
+containing a point of definition for the macro definition, if any.
+\end{itemize}
+In the latter case, the macro is said
+to be \defnx{imported}{macro!import} from the header unit.
 
 \item
 \indextext{point of!macro undefinition|see{macro, point of undefinition}}%
@@ -885,7 +892,7 @@ The \defnx{point of undefinition}{macro!point of undefinition}
 of a macro definition within a translation unit
 is the first point at which a \tcode{\#undef} directive naming the macro occurs
 after its point of definition, or the first point
-of macro import of a translation unit containing a point of undefinition for the
+of macro import of a header unit containing a point of undefinition for the
 macro definition, whichever (if any) occurs first.
 \end{itemize}
 
@@ -926,8 +933,12 @@ import "a.h";   // point of definition of \#1, \#2, and \#3, point of undefiniti
 \end{codeblocktu}
 
 \begin{codeblocktu}{Importable header \tcode{"d.h"}}
-import "a.h";   // point of definition of \#1, \#2, and \#3, point of undefinition of \#1 in \tcode{"d.h"}
 import "c.h";   // point of definition of \#4 and \#5 in \tcode{"d.h"}
+\end{codeblocktu}
+
+\begin{codeblocktu}{Importable header \tcode{"e.h"}}
+import "a.h";   // point of definition of \#1, \#2, and \#3, point of undefinition of \#1 in \tcode{"e.h"}
+import "d.h";   // point of definition of \#4 and \#5 in \tcode{"e.h"}
 int a = Y;      // OK, active macro definitions \#2 and \#4 are valid redefinitions
 int c = Z;      // error: active macro definitions \#3 and \#5 are not valid redefinitions of \tcode{Z}
 \end{codeblocktu}


### PR DESCRIPTION
Fixes #4404