### PR TITLE
Fix up the wording of one note, and add a second note, on implicit move.

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -758,11 +758,10 @@ the \tcode{return} statement initializes the
 glvalue result or prvalue result object of the (explicit or implicit) function call
 by copy-initialization\iref{dcl.init} from the operand.
 \begin{note}
-A \tcode{return} statement can involve
-an invocation of a constructor to perform a copy or move of the operand
+A \tcode{return} statement can involve a copy or move of the operand
 if it is not a prvalue or if its type differs from the return type of the function.
-A copy operation associated with a \tcode{return} statement can be elided or
-converted to a move operation if an automatic storage duration variable is returned\iref{class.copy.elision}.
+The copy operation associated with a \tcode{return} statement can be elided or
+converted to a move operation if an implicitly movable entity\iref{class.copy.elision} is returned.
 \end{note}
 
 \pnum
@@ -837,6 +836,10 @@ Otherwise,
 The expression \placeholder{p}\tcode{.return_void()}
 shall be a prvalue of type \tcode{void}.
 \end{itemize}
+\begin{note}
+The overload resolution associated with a \tcode{co_return} statement is affected
+by whether the operand is an implicitly movable entity\iref{class.copy.elision}.
+\end{note}
 
 \pnum
 If \placeholder{p}\tcode{.return_void()} is a valid expression,


### PR DESCRIPTION
These notes probably should have been changed when P1825 was adopted.

I'm not sure if this is editorial.

Also, I disagree with the use of the word "can" in the existing note; it seems to me that this is *not* a choice the user gets to make, and so this was an incorrect search-and-replace in e5455e3bb — but maybe this is just ISO style now, I dunno.