### PR TITLE
[atomics.syn] Move macro definitions to the global namespace.

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -32,20 +32,22 @@ namespace std {
   enum class memory_order : @\unspec@;
   template<class T>
     T kill_dependency(T y) noexcept;
+}
 
-  // \ref{atomics.lockfree}, lock-free property
-  #define ATOMIC_BOOL_LOCK_FREE @\unspec@
-  #define ATOMIC_CHAR_LOCK_FREE @\unspec@
-  #define ATOMIC_CHAR8_T_LOCK_FREE @\unspec@
-  #define ATOMIC_CHAR16_T_LOCK_FREE @\unspec@
-  #define ATOMIC_CHAR32_T_LOCK_FREE @\unspec@
-  #define ATOMIC_WCHAR_T_LOCK_FREE @\unspec@
-  #define ATOMIC_SHORT_LOCK_FREE @\unspec@
-  #define ATOMIC_INT_LOCK_FREE @\unspec@
-  #define ATOMIC_LONG_LOCK_FREE @\unspec@
-  #define ATOMIC_LLONG_LOCK_FREE @\unspec@
-  #define ATOMIC_POINTER_LOCK_FREE @\unspec@
+// \ref{atomics.lockfree}, lock-free property
+#define ATOMIC_BOOL_LOCK_FREE @\unspec@
+#define ATOMIC_CHAR_LOCK_FREE @\unspec@
+#define ATOMIC_CHAR8_T_LOCK_FREE @\unspec@
+#define ATOMIC_CHAR16_T_LOCK_FREE @\unspec@
+#define ATOMIC_CHAR32_T_LOCK_FREE @\unspec@
+#define ATOMIC_WCHAR_T_LOCK_FREE @\unspec@
+#define ATOMIC_SHORT_LOCK_FREE @\unspec@
+#define ATOMIC_INT_LOCK_FREE @\unspec@
+#define ATOMIC_LONG_LOCK_FREE @\unspec@
+#define ATOMIC_LLONG_LOCK_FREE @\unspec@
+#define ATOMIC_POINTER_LOCK_FREE @\unspec@
 
+namespace std {
   // \ref{atomics.ref.generic}, class template \tcode{atomic_ref}
   template<class T> struct atomic_ref;
   // \ref{atomics.ref.pointer}, partial specialization for pointers


### PR DESCRIPTION
Fixes #4378