### PR TITLE
[dcl.constexpr] Remove use of 'identifier label'.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -778,7 +778,7 @@ its class shall not have any virtual base classes;
 its \grammarterm{function-body} shall not enclose\iref{stmt.pre}
 \begin{itemize}
 \item a \tcode{goto} statement,
-\item an identifier label\iref{stmt.label},
+\item a label with an \grammarterm{identifier}\iref{stmt.label},
 \item a definition of a variable
 of non-literal type or
 of static or thread storage duration.


### PR DESCRIPTION
The definition of the term was removed by
P1787R6 Declarations and where to find them.

Fixes #4413