### PR TITLE
[class.mem.general] Allow non-defining declarations of nested classes.

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -666,11 +666,19 @@ The \grammarterm{decl-specifier-seq} may be omitted in constructor, destructor,
 and conversion function declarations only;
 when declaring another kind of member the \grammarterm{decl-specifier-seq}
 shall contain a \grammarterm{type-specifier} that is not a \grammarterm{cv-qualifier}.
-The
-\grammarterm{member-declarator-list} can be omitted only after a
-\grammarterm{class-specifier} or an \grammarterm{enum-specifier} or in a
-friend declaration\iref{class.friend}. A
-\grammarterm{pure-specifier} shall be used only in the declaration of a
+The \grammarterm{member-declarator-list} can be omitted only
+after
+\begin{itemize}
+\item
+a \grammarterm{class-specifier},
+\item
+an \grammarterm{enum-specifier}, or
+\item
+an \grammarterm{elaborated-type-specifier}
+that is the sole constituent of a declaration\iref{dcl.type.elab}, or
+\end{itemize}
+in a friend declaration\iref{class.friend}.
+A \grammarterm{pure-specifier} shall be used only in the declaration of a
 virtual function\iref{class.virtual}
 that is not a friend declaration.
 


### PR DESCRIPTION
Fixes #4409