### PR TITLE
[std] Use grammar typedef-name instead of 'typedef name'.

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -3825,7 +3825,7 @@ any declarations in namespace \tcode{std}.
 Each of the \grammarterm{using-declaration}s for
 \tcode{int$N$_t}, \tcode{uint$N$_t}, \tcode{intptr_t}, and \tcode{uintptr_t}
 listed above is defined if and only if the implementation defines
-the corresponding typedef name in \ref{atomics.syn}.
+the corresponding \grammarterm{typedef-name} in \ref{atomics.syn}.
 
 \pnum
 Neither the \tcode{_Atomic} macro,

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1106,7 +1106,7 @@ The locus of a \grammarterm{template-parameter} is immediately after it.
 \begin{codeblock}
 typedef unsigned char T;
 template<class T
-  = T               // lookup finds the typedef name of \tcode{\keyword{unsigned} \keyword{char}}
+  = T               // lookup finds the \grammarterm{typedef-name}
   , T               // lookup finds the template parameter
     N = 0> struct A { };
 \end{codeblock}
@@ -1912,7 +1912,7 @@ to be considered.
 The set of entities is determined entirely by
 the types of the function arguments
 (and any template template arguments).
-Typedef names and \grammarterm{using-declaration}{s}
+Any \grammarterm{typedef-name}s and \grammarterm{using-declaration}{s}
 used to specify the types
 do not contribute to this set.
 The set of entities

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -4141,8 +4141,8 @@ For an overload set, access control is applied only to
 the function selected by overload resolution.
 \begin{note}
 Because access control applies to the declarations named, if access control is applied to a
-typedef name, only the accessibility of the typedef name itself is considered.
-The accessibility of the entity referred to by the typedef is not considered.
+\grammarterm{typedef-name}, only the accessibility of the typedef or alias declaration itself is considered.
+The accessibility of the entity referred to by the \grammarterm{typedef-name} is not considered.
 For example,
 
 \begin{codeblock}
@@ -4153,7 +4153,7 @@ public:
 };
 
 void f() {
-  A::BB x;          // OK, typedef name \tcode{A::BB} is public
+  A::BB x;          // OK, typedef \tcode{A::BB} is public
   A::B y;           // access error, \tcode{A::B} is private
 }
 \end{codeblock}

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2241,9 +2241,9 @@ Common.
 
 \diffref{dcl.typedef}
 \change
-A \Cpp{} typedef name must be different from any class type name declared
+A \Cpp{} \grammarterm{typedef-name} must be different from any class type name declared
 in the same scope (except if the typedef is a synonym of the class name with the
-same name). In C, a typedef name and a struct tag name declared in the same scope
+same name). In C, a \grammarterm{typedef-name} and a struct tag name declared in the same scope
 can have the same name (because they have different name spaces).
 
 Example:
@@ -2669,7 +2669,7 @@ Seldom.
 
 \diffref{class.member.lookup}
 \change
-In \Cpp{}, a typedef name may not be redeclared in a class definition after being used in that definition.
+In \Cpp{}, a \grammarterm{typedef-name} may not be redeclared in a class definition after being used in that definition.
 
 Example:
 \begin{codeblock}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -664,18 +664,19 @@ struct T * p;                   // error
 \indextext{class name!\idxcode{typedef}}%
 \indextext{enum name!\idxcode{typedef}}%
 \indextext{class!unnamed}%
-If the typedef declaration defines an unnamed class or enumeration, the first
-\grammarterm{typedef-name} declared by the declaration to be that type
-is used to denote the type for linkage purposes only\iref{basic.link}.
+An unnamed class or enumeration $C$ defined in a typedef declaration has
+the first \grammarterm{typedef-name}
+declared by the declaration to be of type $C$
+as its \defn{typedef name for linkage purposes}\iref{basic.link}.
 \begin{note}
 A typedef declaration involving a \grammarterm{lambda-expression}
 does not itself define the associated closure type,
-and so the closure type is not given a name for linkage purposes.
+and so the closure type is not given a typedef name for linkage purposes.
 \end{note}
 \begin{example}
 \begin{codeblock}
-typedef struct { } *ps, S;      // \tcode{S} is the class name for linkage purposes
-typedef decltype([]{}) C;       // the closure type has no name for linkage purposes
+typedef struct { } *ps, S;      // \tcode{S} is the typedef name for linkage purposes
+typedef decltype([]{}) C;       // the closure type has no typedef name for linkage purposes
 \end{codeblock}
 \end{example}
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -18187,8 +18187,8 @@ which shall have the same semantics as the function signatures
 \pnum
 Each of the \tcode{PRI} macros listed in this subclause
 is defined if and only if the implementation
-defines the corresponding typedef name in~\ref{cstdint.syn}.
+defines the corresponding \grammarterm{typedef-name} in~\ref{cstdint.syn}.
 Each of the \tcode{SCN} macros listed in this subclause
 is defined if and only if the implementation
-defines the corresponding typedef name in~\ref{cstdint.syn} and
+defines the corresponding \grammarterm{typedef-name} in~\ref{cstdint.syn} and
 has a suitable \tcode{fscanf} length modifier for the type.

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -661,7 +661,7 @@ namespace std {
     constexpr typename basic_string<charT, traits, Allocator>::size_type
       erase_if(basic_string<charT, traits, Allocator>& c, Predicate pred);
 
-  // \tcode{basic_string} typedef names
+  // \tcode{basic_string} \grammarterm{typedef-name}s
   using @\libglobal{string}@    = basic_string<char>;
   using @\libglobal{u8string}@  = basic_string<char8_t>;
   using @\libglobal{u16string}@ = basic_string<char16_t>;
@@ -4013,7 +4013,7 @@ namespace std {
       operator<<(basic_ostream<charT, traits>& os,
                  basic_string_view<charT, traits> str);
 
-  // \tcode{basic_string_view} typedef names
+  // \tcode{basic_string_view} \grammarterm{typedef-name}s
   using string_view    = basic_string_view<char>;
   using u8string_view  = basic_string_view<char8_t>;
   using u16string_view = basic_string_view<char16_t>;

--- a/source/support.tex
+++ b/source/support.tex
@@ -1935,13 +1935,13 @@ for \placeholder{N} = \tcode{8}, \tcode{16}, \tcode{32}, and \tcode{64}
 are also optional;
 however, if an implementation defines integer types
 with the corresponding width and no padding bits,
-it defines the corresponding typedef names.
+it defines the corresponding \grammarterm{typedef-name}s.
 Each of the macros listed in this subclause
 is defined if and only if
-the implementation defines the corresponding typedef name.
+the implementation defines the corresponding \grammarterm{typedef-name}.
 \begin{note}
 The macros \tcode{INT\placeholdernc{N}_C} and \tcode{UINT\placeholdernc{N}_C}
-correspond to the typedef names
+correspond to the \grammarterm{typedef-name}s
 \tcode{int_least\placeholdernc{N}_t} and \tcode{uint_least\placeholdernc{N}_t},
 respectively.
 \end{note}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -21738,7 +21738,7 @@ namespace std {
   template<class Allocator>
     class basic_stacktrace;
 
-  // \tcode{basic_stacktrace} typedef names
+  // \tcode{basic_stacktrace} \grammarterm{typedef-name}s
   using stacktrace = basic_stacktrace<allocator<stacktrace_entry>>;
 
   // \ref{stacktrace.basic.nonmem}, non-member functions


### PR DESCRIPTION
The former includes names introduced by alias-declarations,
the latter (arguably) does not.

Fixes #4401