### PR TITLE
[dcl.array] Arrays of unknown bound are allowed in function parameters.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3192,7 +3192,7 @@ and numbered \tcode{0} to \tcode{N-1}.
 
 \pnum
 In addition to declarations in which an incomplete object type is allowed,
-an array bound may be omitted in some cases in the declaration of a function
+an array bound may be omitted in the declaration of a function
 parameter\iref{dcl.fct}.
 An array bound may also be omitted
 when an object (but not a non-static data member) of array type is initialized


### PR DESCRIPTION
Fixes #4387