### PR TITLE
[localization] Reformat LaTeX source code.

### DIFF
--- a/source/locales.tex
+++ b/source/locales.tex
@@ -7,14 +7,17 @@
 This Clause describes components that \Cpp{} programs may use to
 encapsulate (and therefore be more portable when confronting)
 cultural differences.
-The locale facility includes internationalization
-support for character classification and string collation, numeric,
-monetary, and date/time formatting and parsing, and message retrieval.
+The locale facility includes
+internationalization support for character classification and string collation,
+numeric, monetary, and date/time formatting and parsing, and
+message retrieval.
 
 \pnum
 The following subclauses describe components for
-locales themselves, the standard facets, and facilities
-from the ISO C library, as summarized in \tref{localization.summary}.
+locales themselves,
+the standard facets, and
+facilities from the ISO C library,
+as summarized in \tref{localization.summary}.
 
 \begin{libsumtab}{Localization library summary}{localization.summary}
 \ref{locales} & Locales                   &   \tcode{<locale>}    \\
@@ -102,11 +105,10 @@ namespace std {
 
 \pnum
 The header \libheader{locale}
-defines classes and declares functions that encapsulate and manipulate
-the information peculiar to a locale.
+defines classes and declares functions
+that encapsulate and manipulate the information peculiar to a locale.
 \begin{footnote}
-In this subclause, the type name
-\tcode{struct tm}
+In this subclause, the type name \tcode{struct tm}
 is an incomplete type that is defined in \libheaderref{ctime}.
 \end{footnote}
 
@@ -161,25 +163,19 @@ namespace std {
 \end{codeblock}
 
 \pnum
-Class
-\tcode{locale}
-implements a type-safe polymorphic set of facets, indexed by facet
-\textit{type}.
-In other words, a facet has a dual role: in one
-sense, it's just a class interface; at the same time, it's an index
-into a locale's set of facets.
+Class \tcode{locale} implements a type-safe polymorphic set of facets,
+indexed by facet \textit{type}.
+In other words, a facet has a dual role:
+in one sense, it's just a class interface;
+at the same time, it's an index into a locale's set of facets.
 
 \pnum
-Access to the facets of a
-\tcode{locale}
-is via two function templates,
-\tcode{use_facet<>}
-and
-\tcode{has_facet<>}.
+Access to the facets of a \tcode{locale} is via two function templates,
+\tcode{use_facet<>} and \tcode{has_facet<>}.
 
 \pnum
 \begin{example}
-An iostream \tcode{operator<<} can be implemented as:%
+An iostream \tcode{operator<<} can be implemented as:
 \begin{footnote}
 Note that in the call to \tcode{put},
 the stream is implicitly converted
@@ -205,29 +201,20 @@ operator<< (basic_ostream<charT, traits>& s, Date d) {
 \end{example}
 
 \pnum
-In the call to
-\tcode{use_facet<Facet>(loc)},
-the type argument chooses a facet, making available all members
-of the named type.
-If
-\tcode{Facet}
-is not present in a
-locale,
-it throws the standard exception
-\tcode{bad_cast}.
-A \Cpp{} program can check if a locale implements a particular
-facet with the
-function template
-\tcode{has_facet<Facet>()}.
-User-defined facets may be installed in a locale, and used identically as
-may standard facets.
+In the call to \tcode{use_facet<Facet>(loc)},
+the type argument chooses a facet,
+making available all members of the named type.
+If \tcode{Facet} is not present in a locale,
+it throws the standard exception \tcode{bad_cast}.
+A \Cpp{} program can check if a locale implements a particular facet
+with the function template \tcode{has_facet<Facet>()}.
+User-defined facets may be installed in a locale, and
+used identically as may standard facets.
 
 \pnum
 \begin{note}
 All locale semantics are accessed via
-\tcode{use_facet<>}
-and
-\tcode{has_facet<>},
+\tcode{use_facet<>} and \tcode{has_facet<>},
 except that:
 
 \begin{itemize}
@@ -239,51 +226,47 @@ operator()(const basic_string<C, T, A>&, const basic_string<C, T, A>&)
 is provided so that a locale can be used as a predicate argument to
 the standard collections, to collate strings.
 \item
-Convenient global interfaces are provided for traditional
-\tcode{ctype}
-functions such as
-\tcode{isdigit()}
-and
-\tcode{isspace()},
-so that given a locale
-object \tcode{loc} a \Cpp{} program can call
-\tcode{isspace(c, loc)}.
+Convenient global interfaces are provided for
+traditional \tcode{ctype} functions such as
+\tcode{isdigit()} and \tcode{isspace()},
+so that given a locale object \tcode{loc}
+a \Cpp{} program can call \tcode{isspace(c, loc)}.
 (This eases upgrading existing extractors\iref{istream.formatted}.)
 \end{itemize}
 \end{note}
 
 \pnum
-Once a facet reference is obtained from a locale object by calling
-\tcode{use_facet<>},
-that reference remains usable, and the results from member functions
-of it may be cached and re-used, as long as some locale object refers
-to that facet.
+Once a facet reference is obtained from a locale object
+by calling \tcode{use_facet<>},
+that reference remains usable,
+and the results from member functions of it may be cached and re-used,
+as long as some locale object refers to that facet.
 
 \pnum
-In successive calls to a locale facet member function on a facet object
-installed in the same locale, the returned result shall be identical.
+In successive calls to a locale facet member function
+on a facet object installed in the same locale,
+the returned result shall be identical.
 
 \pnum
-A
-\tcode{locale}
-constructed from a name string (such as \tcode{"POSIX"}), or from parts of
-two named locales, has a name; all others do not.
-Named locales may be compared for equality; an unnamed locale is equal
-only to (copies of) itself.
-For an unnamed locale,
-\tcode{locale::name()}
-returns the string
-\tcode{"*"}.
+A \tcode{locale} constructed
+from a name string (such as \tcode{"POSIX"}), or
+from parts of two named locales, has a name;
+all others do not.
+Named locales may be compared for equality;
+an unnamed locale is equal only to (copies of) itself.
+For an unnamed locale, \tcode{locale::name()} returns the string \tcode{"*"}.
 
 \pnum
-Whether there is one global locale object for the entire program or one global locale
-object per thread is \impldef{whether locale object is global or per-thread}.
-Implementations should provide one global locale object per
-thread. If there is a single global locale object for the entire program,
-implementations are not required to avoid data races on it\iref{res.on.data.races}.
+Whether there is
+one global locale object for the entire program or
+one global locale object per thread
+is \impldef{whether locale object is global or per-thread}.
+Implementations should provide one global locale object per thread.
+If there is a single global locale object for the entire program,
+implementations are not required to
+avoid data races on it\iref{res.on.data.races}.
 
 \rSec3[locale.types]{Types}
-
 
 \rSec4[locale.category]{Type \tcode{locale::category}}
 
@@ -293,11 +276,8 @@ using category = int;
 \end{itemdecl}
 
 \pnum
-\textit{Valid}
-\tcode{category}
-values include the
-\tcode{locale}
-member bitmask elements
+\textit{Valid} \tcode{category} values
+include the \tcode{locale} member bitmask elements
 \tcode{collate},
 \tcode{ctype},
 \tcode{monetary},
@@ -306,42 +286,27 @@ member bitmask elements
 and
 \tcode{messages},
 each of which represents a single locale category.
-In addition,
-\tcode{locale}
-member bitmask constant
-\tcode{none}
-is defined as zero and represents no category. And
-\tcode{locale}
-member bitmask constant
-\tcode{all}
+In addition, \tcode{locale} member bitmask constant \tcode{none}
+is defined as zero and represents no category.
+And \tcode{locale} member bitmask constant \tcode{all}
 is defined such that the expression
 \begin{codeblock}
 (collate | ctype | monetary | numeric | time | messages | all) == all
 \end{codeblock}
-is
-\tcode{true},
+is \tcode{true},
 and represents the union of all categories.
-Further, the expression
-\tcode{(X | Y)},
-where
-\tcode{X}
-and
-\tcode{Y}
-each represent a single category, represents the union of the two categories.
+Further, the expression \tcode{(X | Y)},
+where \tcode{X} and \tcode{Y} each represent a single category,
+represents the union of the two categories.
 
 \pnum
-\tcode{locale}
-member functions expecting a
-\tcode{category}
-argument require one of the
-\tcode{category}
-values defined above, or the union of two or more such values.
-Such a
-\tcode{category}
-value identifies a set of locale categories.
-Each locale category,
-in turn, identifies a set of locale facets, including at least those
-shown in \tref{locale.category.facets}.
+\tcode{locale} member functions
+expecting a \tcode{category} argument
+require one of the \tcode{category} values defined above, or
+the union of two or more such values.
+Such a \tcode{category} value identifies a set of locale categories.
+Each locale category, in turn, identifies a set of locale facets,
+including at least those shown in \tref{locale.category.facets}.
 
 \begin{floattable}{Locale category facets}{locale.category.facets}
 {ll}
@@ -367,22 +332,17 @@ messages    &   \tcode{messages<char>}, \tcode{messages<wchar_t>}               
 
 \pnum
 For any locale \tcode{loc}
-either constructed, or returned by
-\tcode{locale::classic()},
-and any facet \tcode{Facet}
-shown in \tref{locale.category.facets},
-\tcode{has_facet<Facet>(loc)}
-is \tcode{true}.
-Each
-\tcode{locale}
-member function which takes a
-\tcode{locale::category}
-argument operates on the corresponding set of facets.
+either constructed, or returned by \tcode{locale::classic()},
+and any facet \tcode{Facet} shown in \tref{locale.category.facets},
+\tcode{has_facet<Facet>(loc)} is \tcode{true}.
+Each \tcode{locale} member function
+which takes a \tcode{locale::category} argument
+operates on the corresponding set of facets.
 
 \pnum
-An implementation is required to provide those specializations for
-facet templates identified as members of a category, and for those
-shown in \tref{locale.spec}.
+An implementation is required to provide those specializations
+for facet templates identified as members of a category, and
+for those shown in \tref{locale.spec}.
 
 \begin{floattable}{Required specializations}{locale.spec}
 {ll}
@@ -413,46 +373,28 @@ messages    &   \tcode{messages_byname<char>}, \tcode{messages_byname<wchar_t>} 
 
 
 \pnum
-The provided implementation of members of facets
-\tcode{num_get<charT>}
-and
-\tcode{num_put<charT>}
-calls
-\tcode{use_fac\-et<F>(l)}
-only for facet
-\tcode{F}
-of types
-\tcode{numpunct<charT>}
-and
-\tcode{ctype<charT>},
-and for locale
-\tcode{l}
-the value obtained
-by calling member
-\tcode{getloc()}
-on the
-\tcode{ios_base\&}
-argument to these functions.
+The provided implementation of members of
+facets \tcode{num_get<charT>} and \tcode{num_put<charT>}
+calls \tcode{use_fac\-et<F>(l)} only for facet \tcode{F} of
+types \tcode{numpunct<charT>} and \tcode{ctype<charT>},
+and for locale \tcode{l} the value obtained by calling member \tcode{getloc()}
+on the \tcode{ios_base\&} argument to these functions.
 
 \pnum
-In declarations of facets, a template parameter with name
-\tcode{InputIterator}
-or
-\tcode{OutputIterator}
-indicates the set of
-all possible specializations on parameters that meet the
-\oldconcept{InputIterator} requirements or \oldconcept{OutputIterator}
-requirements, respectively\iref{iterator.requirements}.
-A template parameter with name
-\tcode{C}
-represents the set
-of types containing \tcode{char}, \tcode{wchar_t}, and any other
-\impldef{set of character types that iostreams templates can be instantiated for}
-character types that meet
-the requirements for a character on which any of the iostream
-components can be instantiated.
-A template parameter with name
-\tcode{International}
+In declarations of facets,
+a template parameter with name \tcode{InputIterator} or \tcode{OutputIterator}
+indicates the set of all possible specializations on parameters that meet the
+\oldconcept{InputIterator} requirements or
+\oldconcept{OutputIterator} requirements,
+respectively\iref{iterator.requirements}.
+A template parameter with name \tcode{C} represents
+the set of types containing \tcode{char}, \tcode{wchar_t}, and any other
+\impldef{set of character types
+that iostreams templates can be instantiated for}
+character types
+that meet the requirements for a character
+on which any of the iostream components can be instantiated.
+A template parameter with name \tcode{International}
 represents the set of all possible specializations on a bool parameter.
 
 \rSec4[locale.facet]{Class \tcode{locale::facet}}
@@ -486,63 +428,49 @@ static ::std::locale::id id;
 \end{codeblock}
 
 \pnum
-Template parameters in this Clause which are required to be facets are those named
-\tcode{Facet}
-in declarations.
-A program that passes a type that is
-\textit{not}
-a facet, or a type that refers to a volatile-qualified facet, as an
-(explicit or deduced) template parameter to a locale
-function expecting a facet, is ill-formed. A const-qualified facet is a
-valid template argument to any locale function that expects a
-\tcode{Facet} template parameter.
+Template parameters in this Clause
+which are required to be facets
+are those named \tcode{Facet} in declarations.
+A program that passes
+a type that is \textit{not} a facet, or
+a type that refers to a volatile-qualified facet,
+as an (explicit or deduced) template parameter to
+a locale function expecting a facet,
+is ill-formed.
+A const-qualified facet is a valid template argument to
+any locale function that expects a \tcode{Facet} template parameter.
 
 \pnum
-The \tcode{refs}
-argument to the constructor is used for lifetime management.
-For
-\tcode{refs == 0},
-the implementation performs
-\tcode{delete static_cast<locale::facet*>(f)}
-(where
-\tcode{f}
-is a point\-er to the facet) when the last
-\tcode{locale}
-object containing the facet is destroyed;
-for
-\tcode{refs == 1},
-the implementation never destroys the facet.
+The \tcode{refs} argument to the constructor is used for lifetime management.
+For \tcode{refs == 0},
+the implementation performs \tcode{delete static_cast<locale::facet*>(f)}
+(where \tcode{f} is a point\-er to the facet)
+when the last \tcode{locale} object containing the facet is destroyed;
+for \tcode{refs == 1}, the implementation never destroys the facet.
 
 \pnum
-Constructors of all
-facets defined in this Clause take such an argument and pass it
-along to their
-\tcode{facet}
-base class constructor.
-All one-argument constructors defined
-in this Clause are
-\term{explicit},
+Constructors of all facets defined in this Clause
+take such an argument and pass it along to
+their \tcode{facet} base class constructor.
+All one-argument constructors defined in this Clause are \term{explicit},
 preventing their participation in automatic conversions.
 
 \pnum
-For some standard facets a standard
-``$\ldots$\tcode{_byname}''
-class, derived from it, implements the virtual function semantics
-equivalent to that facet of the locale constructed by
-\tcode{locale(const char*)}
-with the same name.
-Each such facet provides a constructor that takes a
-\tcode{const char*}
-argument, which names the locale, and a \tcode{refs}
-argument, which is passed to the base class constructor.
-Each such facet also provides a constructor that takes a
-\tcode{string} argument \tcode{str} and a \tcode{refs}
-argument, which has the same effect as calling the first constructor with the
-two arguments \tcode{str.c_str()} and \tcode{refs}.
-If there is no
-``$\ldots$\tcode{_byname}''
-version of a facet, the base class implements named locale
-semantics itself by reference to other facets.
+For some standard facets a standard ``$\ldots$\tcode{_byname}'' class,
+derived from it, implements the virtual function semantics
+equivalent to that facet of the locale
+constructed by \tcode{locale(const char*)} with the same name.
+Each such facet provides a constructor that takes
+a \tcode{const char*} argument, which names the locale, and
+a \tcode{refs} argument, which is passed to the base class constructor.
+Each such facet also provides a constructor that takes
+a \tcode{string} argument \tcode{str} and
+a \tcode{refs} argument,
+which has the same effect as calling the first constructor
+with the two arguments \tcode{str.c_str()} and \tcode{refs}.
+If there is no ``$\ldots$\tcode{_byname}'' version of a facet,
+the base class implements named locale semantics itself
+by reference to other facets.
 
 \rSec4[locale.id]{Class \tcode{locale::id}}
 
@@ -559,21 +487,20 @@ namespace std {
 \end{codeblock}
 
 \pnum
-The class \tcode{locale::id} provides identification of a locale facet
-interface, used as an index for lookup
-and to encapsulate initialization.
+The class \tcode{locale::id} provides
+identification of a locale facet interface,
+used as an index for lookup and to encapsulate initialization.
 
 \pnum
 \begin{note}
-Because facets are used by iostreams, potentially while static constructors are
-running, their initialization cannot depend on programmed static
-initialization.
-One initialization strategy is for
-\tcode{locale}
-to initialize each facet's
-\tcode{id}
-member the first time an instance of the facet is installed into a locale.
-This depends only on static storage being zero before constructors run\iref{basic.start.static}.
+Because facets are used by iostreams,
+potentially while static constructors are running,
+their initialization cannot depend on programmed static initialization.
+One initialization strategy is for \tcode{locale}
+to initialize each facet's \tcode{id} member
+the first time an instance of the facet is installed into a locale.
+This depends only on static storage being zero
+before constructors run\iref{basic.start.static}.
 \end{note}
 
 \rSec3[locale.cons]{Constructors and destructor}
@@ -588,9 +515,9 @@ locale() noexcept;
 \effects
 Constructs a copy of the argument last passed to
 \tcode{locale::global(locale\&)},
-if it has been called; else, the resulting facets have virtual
-function semantics identical to those of
-\tcode{locale::classic()}.
+if it has been called;
+else, the resulting facets have virtual function semantics identical to
+those of \tcode{locale::classic()}.
 \begin{note}
 This constructor yields a copy of the current global locale.
 It is commonly used as a default argument for
@@ -612,13 +539,12 @@ with that name.
 
 \pnum
 \throws
-\tcode{runtime_error}
-if the argument is not valid, or is null.
+\tcode{runtime_error} if the argument is not valid, or is null.
 
 \pnum
 \remarks
-The set of valid string argument values is \tcode{"C"}, \tcode{""},
-and any \impldef{locale names} values.
+The set of valid string argument values is
+\tcode{"C"}, \tcode{""}, and any \impldef{locale names} values.
 \end{itemdescr}
 
 \indexlibraryctor{locale}%
@@ -640,23 +566,17 @@ locale(const locale& other, const char* std_name, category);
 \begin{itemdescr}
 \pnum
 \effects
-Constructs a locale as a copy of
-\tcode{other}
-except for the facets identified by the
-\tcode{category}
-argument, which instead implement the same semantics as
-\tcode{locale(std_name)}.
+Constructs a locale as a copy of \tcode{other}
+except for the facets identified by the \tcode{category} argument,
+which instead implement the same semantics as \tcode{locale(std_name)}.
 
 \pnum
 \throws
-\tcode{runtime_error}
-if the argument is not valid, or is null.
+\tcode{runtime_error} if the argument is not valid, or is null.
 
 \pnum
 \remarks
-The locale has a name if and only if
-\tcode{other}
-has a name.
+The locale has a name if and only if \tcode{other} has a name.
 \end{itemdescr}
 
 \indexlibraryctor{locale}%
@@ -678,12 +598,10 @@ template<class Facet> locale(const locale& other, Facet* f);
 \begin{itemdescr}
 \pnum
 \effects
-Constructs a locale incorporating all facets from the first
-argument except that of type
-\tcode{Facet},
+Constructs a locale incorporating all facets from the first argument
+except that of type \tcode{Facet},
 and installs the second argument as the remaining facet.
-If \tcode{f}
-is null, the resulting object is a copy of \tcode{other}.
+If \tcode{f} is null, the resulting object is a copy of \tcode{other}.
 
 \pnum
 \remarks
@@ -699,14 +617,13 @@ locale(const locale& other, const locale& one, category cats);
 \pnum
 \effects
 Constructs a locale incorporating all facets from the first argument
-except those that implement
-\tcode{cats},
+except those that implement \tcode{cats},
 which are instead incorporated from the second argument.
 
 \pnum
 \remarks
-The resulting locale has a name if and only if the first two arguments
-have names.
+The resulting locale has a name if and only if
+the first two arguments have names.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{locale}%
@@ -734,13 +651,8 @@ template<class Facet> locale combine(const locale& other) const;
 \begin{itemdescr}
 \pnum
 \effects
-Constructs a locale incorporating
-all facets from
-\tcode{*this}
-except for that one facet of
-\tcode{other}
-that is identified by
-\tcode{Facet}.
+Constructs a locale incorporating all facets from \tcode{*this}
+except for that one facet of \tcode{other} that is identified by \tcode{Facet}.
 
 \pnum
 \returns
@@ -748,10 +660,7 @@ The newly created locale.
 
 \pnum
 \throws
-\tcode{runtime_error}
-if
-\tcode{has_facet<Facet>(other)}
-is \tcode{false}.
+\tcode{runtime_error} if \tcode{has_facet<Facet>(other)} is \tcode{false}.
 
 \pnum
 \remarks
@@ -766,9 +675,8 @@ string name() const;
 \begin{itemdescr}
 \pnum
 \returns
-The name of
-\tcode{*this},
-if it has one; otherwise, the string \tcode{"*"}.
+The name of \tcode{*this}, if it has one;
+otherwise, the string \tcode{"*"}.
 \end{itemdescr}
 
 \rSec3[locale.operators]{Operators}
@@ -781,11 +689,11 @@ bool operator==(const locale& other) const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{true}
-if both arguments are the same locale, or one is a copy of the
-other, or each has a name and the names are identical;
-\tcode{false}
-otherwise.
+\tcode{true} if
+both arguments are the same locale, or
+one is a copy of the other, or
+each has a name and the names are identical;
+\tcode{false} otherwise.
 \end{itemdescr}
 
 \indexlibrarymember{locale}{operator()}%
@@ -798,9 +706,7 @@ template<class charT, class traits, class Allocator>
 \begin{itemdescr}
 \pnum
 \effects
-Compares two strings according to the
-\tcode{collate<charT>}
-facet.
+Compares two strings according to the \tcode{collate<charT>} facet.
 
 \pnum
 \returns
@@ -811,17 +717,14 @@ use_facet<collate<charT>>(*this).compare(s1.data(), s1.data() + s1.size(),
 
 \pnum
 \remarks
-This member operator template (and therefore
-\tcode{locale}
-itself) meets the requirements for a comparator predicate template argument\iref{algorithms}
-applied to strings.
+This member operator template (and therefore \tcode{locale} itself)
+meets the requirements for
+a comparator predicate template argument\iref{algorithms} applied to strings.
 
 \pnum
 \begin{example}
-A vector of strings
-\tcode{v}
-can be collated according to collation rules in locale
-\tcode{loc}
+A vector of strings \tcode{v}
+can be collated according to collation rules in locale \tcode{loc}
 simply by~(\ref{alg.sort}, \ref{vector}):
 
 \begin{codeblock}
@@ -841,30 +744,26 @@ static locale global(const locale& loc);
 \pnum
 \effects
 Sets the global locale to its argument.
-Causes future calls to the constructor
-\tcode{locale()}
+Causes future calls to the constructor \tcode{locale()}
 to return a copy of the argument.
 If the argument has a name, does
 \begin{codeblock}
 setlocale(LC_ALL, loc.name().c_str());
 \end{codeblock}
-otherwise, the effect on the C locale, if any, is \impldef{effect on C locale of calling
-\tcode{locale::global}}.
+otherwise, the effect on the C locale, if any, is
+\impldef{effect on C locale of calling \tcode{locale::global}}.
 
 \pnum
 \returns
-The previous value of
-\tcode{locale()}.
+The previous value of \tcode{locale()}.
 
 \pnum
 \remarks
-No library function other than
-\tcode{locale::global()}
-affects the value returned by
-\tcode{locale()}.
+No library function other than \tcode{locale::global()}
+affects the value returned by \tcode{locale()}.
 \begin{note}
-See~\ref{c.locales} for data race considerations when
-\tcode{setlocale} is invoked.
+See~\ref{c.locales} for data race considerations
+when \tcode{setlocale} is invoked.
 \end{note}
 \end{itemdescr}
 
@@ -879,13 +778,12 @@ The \tcode{"C"} locale.
 
 \pnum
 \returns
-A locale that implements the classic \tcode{"C"} locale semantics, equivalent
-to the value \tcode{locale("C")}.
+A locale that implements the classic \tcode{"C"} locale semantics,
+equivalent to the value \tcode{locale("C")}.
 
 \pnum
 \remarks
-This locale, its facets, and their member functions, do not change
-with time.
+This locale, its facets, and their member functions, do not change with time.
 \end{itemdescr}
 
 \rSec2[locale.global.templates]{\tcode{locale} globals}
@@ -898,9 +796,8 @@ template<class Facet> const Facet& use_facet(const locale& loc);
 \begin{itemdescr}
 \pnum
 \mandates
-\tcode{Facet}
-is a facet class whose definition contains the public static member
-\tcode{id}
+\tcode{Facet} is a facet class
+whose definition contains the public static member \tcode{id}
 as defined in~\ref{locale.facet}.
 
 \pnum
@@ -909,16 +806,12 @@ A reference to the corresponding facet of \tcode{loc}, if present.
 
 \pnum
 \throws
-\tcode{bad_cast}
-if
-\tcode{has_facet<Facet>(loc)}
-is
-\tcode{false}.
+\tcode{bad_cast} if \tcode{has_facet<Facet>(loc)} is \tcode{false}.
 
 \pnum
 \remarks
-The reference returned remains valid at least as long as any copy of
-\tcode{loc} exists.
+The reference returned remains valid
+at least as long as any copy of \tcode{loc} exists.
 \end{itemdescr}
 
 \indexlibrarymember{locale}{has_facet}%
@@ -929,7 +822,8 @@ template<class Facet> bool has_facet(const locale& loc) noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{true} if the facet requested is present in \tcode{loc}; otherwise \tcode{false}.
+\tcode{true} if the facet requested is present in \tcode{loc};
+otherwise \tcode{false}.
 \end{itemdescr}
 
 \rSec2[locale.convenience]{Convenience interfaces}
@@ -964,21 +858,17 @@ template<class charT> bool isblank (charT c, const locale& loc);
 \end{itemdecl}
 
 \pnum
-Each of these functions
-\tcode{is\placeholder{F}}
+Each of these functions \tcode{is\placeholder{F}}
 returns the result of the expression:
 \begin{codeblock}
 use_facet<ctype<charT>>(loc).is(ctype_base::@\placeholder{F}@, c)
 \end{codeblock}
-where \tcode{\placeholder{F}} is the
-\tcode{ctype_base::mask}
-value corresponding to that function\iref{category.ctype}.
+where \tcode{\placeholder{F}} is the \tcode{ctype_base::mask} value
+corresponding to that function\iref{category.ctype}.
 \begin{footnote}
-When
-used in a loop, it is faster to cache the
-\tcode{ctype<>}
-facet and use it directly, or use the vector form of
-\tcode{ctype<>::is}.
+When used in a loop,
+it is faster to cache the \tcode{ctype<>} facet and use it directly, or
+use the vector form of \tcode{ctype<>::is}.
 \end{footnote}
 
 \rSec3[conversions.character]{Character conversions}
@@ -1011,18 +901,12 @@ template<class charT> charT tolower(charT c, const locale& loc);
 
 \pnum
 Each of the standard categories includes a family of facets.
-Some of these implement formatting or parsing of a datum, for use
-by standard or users' iostream operators
-\tcode{<<} and \tcode{>>},
-as members
-\tcode{put()}
-and
-\tcode{get()},
-respectively.
+Some of these implement formatting or parsing of a datum,
+for use by standard or users' iostream operators \tcode{<<} and \tcode{>>},
+as members \tcode{put()} and \tcode{get()}, respectively.
 Each such member function takes an
 \indexlibrarymember{flags}{ios_base}%
-\tcode{ios_base\&}
-argument whose members
+\tcode{ios_base\&} argument whose members
 \indexlibrarymember{flags}{ios_base}%
 \tcode{flags()},
 \indexlibrarymember{precision}{ios_base}%
@@ -1031,26 +915,18 @@ and
 \indexlibrarymember{width}{ios_base}%
 \tcode{width()},
 specify the format of the corresponding datum\iref{ios.base}.
-Those functions which need to use other facets call its member
-\tcode{getloc()}
+Those functions which need to use other facets call its member \tcode{getloc()}
 to retrieve the locale imbued there.
-Formatting facets use the character argument
-\tcode{fill}
+Formatting facets use the character argument \tcode{fill}
 to fill out the specified width where necessary.
 
 \pnum
-The
-\tcode{put()}
-members make no provision for error reporting.
-(Any failures of the
-OutputIterator argument can be extracted from the returned iterator.)
-The
-\tcode{get()}
-members take an
-\tcode{ios_base::iostate\&}
-argument whose value they ignore, but set to
-\tcode{ios_base::failbit}
-in case of a parse error.
+The \tcode{put()} members make no provision for error reporting.
+(Any failures of the OutputIterator argument can be extracted from
+the returned iterator.)
+The \tcode{get()} members take an \tcode{ios_base::iostate\&} argument
+whose value they ignore,
+but set to \tcode{ios_base::failbit} in case of a parse error.
 
 \pnum
 Within subclause \ref{locale.categories} it is unspecified whether
@@ -1085,9 +961,7 @@ namespace std {
 \end{codeblock}
 
 \pnum
-The type
-\tcode{mask}
-is a bitmask type\iref{bitmask.types}.
+The type \tcode{mask} is a bitmask type\iref{bitmask.types}.
 
 \rSec3[locale.ctype]{Class template \tcode{ctype}}
 
@@ -1140,16 +1014,13 @@ namespace std {
 
 \pnum
 Class \tcode{ctype} encapsulates the C library \libheader{cctype} features.
-\tcode{istream}
-members are required to use
-\tcode{ctype<>}
+\tcode{istream} members are required to use \tcode{ctype<>}
 for character classing during input parsing.
 
 \pnum
-The specializations required in \tref{locale.category.facets}\iref{locale.category}, namely
-\tcode{ctype<char>}
-and
-\tcode{ctype<wchar_t>},
+The specializations
+required in \tref{locale.category.facets}\iref{locale.category},
+namely \tcode{ctype<char>} and \tcode{ctype<wchar_t>},
 implement character classing appropriate
 to the implementation's native character set.
 
@@ -1164,9 +1035,7 @@ const charT* is(const charT* low, const charT* high, mask* vec) const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{do_is(m, c)}
-or
-\tcode{do_is(low, high, vec)}.
+\tcode{do_is(m, c)} or \tcode{do_is(low, high, vec)}.
 \end{itemdescr}
 
 \indexlibrarymember{ctype}{scan_is}%
@@ -1200,9 +1069,7 @@ const charT* toupper(charT* low, const charT* high) const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{do_toupper(c)}
-or
-\tcode{do_toupper(low, high)}.
+\tcode{do_toupper(c)} or \tcode{do_toupper(low, high)}.
 \end{itemdescr}
 
 \indexlibrarymember{ctype}{tolower}%
@@ -1214,9 +1081,7 @@ const charT* tolower(charT* low, const charT* high) const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{do_tolower(c)}
-or
-\tcode{do_tolower(low, high)}.
+\tcode{do_tolower(c)} or \tcode{do_tolower(low, high)}.
 \end{itemdescr}
 
 \indexlibrarymember{ctype}{widen}%
@@ -1228,9 +1093,7 @@ const char* widen(const char* low, const char* high, charT* to) const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{do_widen(c)}
-or
-\tcode{do_widen(low, high, to)}.
+\tcode{do_widen(c)} or \tcode{do_widen(low, high, to)}.
 \end{itemdescr}
 
 \indexlibrarymember{ctype}{narrow}%
@@ -1242,9 +1105,7 @@ const charT* narrow(const charT* low, const charT* high, char dfault, char* to) 
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{do_narrow(c, dfault)}
-or
-\tcode{do_narrow(low, high, dfault, to)}.
+\tcode{do_narrow(c, dfault)} or \tcode{do_narrow(low, high, dfault, to)}.
 \end{itemdescr}
 
 \rSec4[locale.ctype.virtuals]{\tcode{ctype} virtual functions}
@@ -1259,26 +1120,16 @@ const charT* do_is(const charT* low, const charT* high, mask* vec) const;
 \pnum
 \effects
 Classifies a character or sequence of characters.
-For each argument character, identifies a value
-\tcode{M}
-of type
-\tcode{ctype_base::mask}.
-The second form identifies a value \tcode{M} of type
-\tcode{ctype_base::mask}
-for each
-\tcode{*p}
-where
-\tcode{(low <= p \&\& p < high)},
-and places it into
-\tcode{vec[p - low]}.
+For each argument character,
+identifies a value \tcode{M} of type \tcode{ctype_base::mask}.
+The second form identifies a value \tcode{M} of type \tcode{ctype_base::mask}
+for each \tcode{*p} where \tcode{(low <= p \&\& p < high)},
+and places it into \tcode{vec[p - low]}.
 
 \pnum
 \returns
-The first form returns the result of the expression
-\tcode{(M \& m) != 0};
-i.e.,
-\tcode{true}
-if the character has the characteristics specified.
+The first form returns the result of the expression \tcode{(M \& m) != 0};
+i.e., \tcode{true} if the character has the characteristics specified.
 The second form returns \tcode{high}.
 \end{itemdescr}
 
@@ -1290,17 +1141,12 @@ const charT* do_scan_is(mask m, const charT* low, const charT* high) const;
 \begin{itemdescr}
 \pnum
 \effects
-Locates a character in a buffer that conforms to a classification
-\tcode{m}.
+Locates a character in a buffer that conforms to a classification \tcode{m}.
 
 \pnum
 \returns
-The smallest pointer \tcode{p} in the range
-\range{low}{high}
-such that
-\tcode{is(m, *p)}
-would return
-\tcode{true};
+The smallest pointer \tcode{p} in the range \range{low}{high}
+such that \tcode{is(m, *p)} would return \tcode{true};
 otherwise, returns \tcode{high}.
 \end{itemdescr}
 
@@ -1317,12 +1163,8 @@ Locates a character in a buffer that fails to conform to a classification
 
 \pnum
 \returns
-The smallest pointer \tcode{p}, if any, in the range
-\range{low}{high}
-such that
-\tcode{is(m, *p)}
-would return
-\tcode{false};
+The smallest pointer \tcode{p}, if any, in the range \range{low}{high}
+such that \tcode{is(m, *p)} would return \tcode{false};
 otherwise, returns \tcode{high}.
 \end{itemdescr}
 
@@ -1336,17 +1178,16 @@ const charT* do_toupper(charT* low, const charT* high) const;
 \pnum
 \effects
 Converts a character or characters to upper case.
-The second form replaces each character
-\tcode{*p}
-in the range
-\range{low}{high}
-for which a corresponding upper-case character exists, with
-that character.
+The second form replaces
+each character \tcode{*p} in the range \range{low}{high}
+for which a corresponding upper-case character exists,
+with that character.
 
 \pnum
 \returns
-The first form returns the corresponding upper-case character if it
-is known to exist, or its argument if not.
+The first form returns
+the corresponding upper-case character if it is known to exist, or
+its argument if not.
 The second form returns \tcode{high}.
 \end{itemdescr}
 
@@ -1360,17 +1201,16 @@ const charT* do_tolower(charT* low, const charT* high) const;
 \pnum
 \effects
 Converts a character or characters to lower case.
-The second form replaces each character
-\tcode{*p}
-in the range
-\range{low}{high}
+The second form replaces
+each character \tcode{*p} in the range \range{low}{high}
 and for which a corresponding lower-case character exists,
 with that character.
 
 \pnum
 \returns
-The first form returns the corresponding lower-case character if it
-is known to exist, or its argument if not.
+The first form returns
+the corresponding lower-case character if it is known to exist, or
+its argument if not.
 The second form returns \tcode{high}.
 \end{itemdescr}
 
@@ -1383,43 +1223,30 @@ const char*  do_widen(const char* low, const char* high, charT* dest) const;
 \begin{itemdescr}
 \pnum
 \effects
-Applies the simplest reasonable transformation from a
-\tcode{char}
-value or sequence of
-\tcode{char}
-values to the corresponding
-\tcode{charT}
-value or values.
+Applies the simplest reasonable transformation
+from a \tcode{char} value or sequence of \tcode{char} values
+to the corresponding \tcode{charT} value or values.
 \begin{footnote}
-The char argument of
-\tcode{do_widen}
-is intended to accept values derived from \grammarterm{character-literal}s for conversion
-to the locale's encoding.
+The char argument of \tcode{do_widen} is intended to
+accept values derived from \grammarterm{character-literal}s
+for conversion to the locale's encoding.
 \end{footnote}
 The only characters for which unique transformations are required
 are those in the basic source character set\iref{lex.charset}.
 
-For any named
-\tcode{ctype}
-category with a
-\tcode{ctype <charT>}
-facet \tcode{ctc} and valid
-\tcode{ctype_base::mask}
-value \tcode{M},
-\tcode{(ctc.\brk{}is(M, c) || !is(M, do_widen(c)) )}
-is
-\tcode{true}.
+For any named \tcode{ctype} category with
+a \tcode{ctype<charT>} facet \tcode{ctc} and
+valid \tcode{ctype_base::mask} value \tcode{M},
+\tcode{(ctc.\brk{}is(M, c) || !is(M, do_widen(c)) )} is \tcode{true}.
 \begin{footnote}
-In other words, the transformed character is not a member
-of any character classification that \tcode{c} is not also a member of.
+In other words, the transformed character is not
+a member of any character classification
+that \tcode{c} is not also a member of.
 \end{footnote}
 
-The second form transforms each character
-\tcode{*p}
-in the range
-\range{low}{high},
-placing the result in
-\tcode{dest[p - low]}.
+The second form transforms
+each character \tcode{*p} in the range \range{low}{high},
+placing the result in \tcode{dest[p - low]}.
 
 \pnum
 \returns
@@ -1436,13 +1263,9 @@ const charT* do_narrow(const charT* low, const charT* high, char dfault, char* d
 \begin{itemdescr}
 \pnum
 \effects
-Applies the simplest reasonable transformation from a
-\tcode{charT}
-value or sequence of
-\tcode{charT}
-values to the corresponding
-\tcode{char}
-value or values.
+Applies the simplest reasonable transformation
+from a \tcode{charT} value or sequence of \tcode{charT} values
+to the corresponding \tcode{char} value or values.
 
 For any character \tcode{c} in the basic source character set\iref{lex.charset}
 the transformation is such that
@@ -1450,38 +1273,26 @@ the transformation is such that
 do_widen(do_narrow(c, 0)) == c
 \end{codeblock}
 
-For any named
-\tcode{ctype}
-category with a
-\tcode{ctype<char>}
-facet \tcode{ctc} however, and
-\tcode{ctype_base::mask}
-value \tcode{M},
+For any named \tcode{ctype} category with
+a \tcode{ctype<char>} facet \tcode{ctc} however, and
+\tcode{ctype_base::mask} value \tcode{M},
 \begin{codeblock}
 (is(M, c) || !ctc.is(M, do_narrow(c, dfault)) )
 \end{codeblock}
-is
-\tcode{true}
-(unless
-\tcode{do_narrow}
-returns
-\tcode{dfault}).
+is \tcode{true} (unless \tcode{do_narrow} returns \tcode{dfault}).
 In addition, for any digit character \tcode{c},
-the expression
-\tcode{(do_narrow(c, dfault) - '0')}
+the expression \tcode{(do_narrow(c, dfault) - '0')}
 evaluates to the digit value of the character.
-The second form transforms each character
-\tcode{*p}
-in the range
-\range{low}{high},
-placing the result (or \tcode{dfault}
-if no simple transformation is readily available) in
-\tcode{dest[p - low]}.
+The second form transforms
+each character \tcode{*p} in the range \range{low}{high},
+placing the result
+(or \tcode{dfault} if no simple transformation is readily available)
+in \tcode{dest[p - low]}.
 
 \pnum
 \returns
-The first form returns the transformed value; or \tcode{dfault}
-if no mapping is readily available.
+The first form returns the transformed value;
+or \tcode{dfault} if no mapping is readily available.
 The second form returns \tcode{high}.
 \end{itemdescr}
 
@@ -1555,27 +1366,17 @@ namespace std {
 \end{codeblock}
 
 \pnum
-A specialization
-\tcode{ctype<char>}
-is provided so that the member functions on type
-\tcode{char}
-can be implemented
-inline.
+A specialization \tcode{ctype<char>} is provided
+so that the member functions on type \tcode{char} can be implemented inline.
 \begin{footnote}
-Only the
-\tcode{char}
-(not
-\tcode{unsigned char}
-and
-\tcode{signed char})
+Only the \tcode{char} (not \tcode{unsigned char} and \tcode{signed char})
 form is provided.
-The specialization is specified in the standard, and not left as an
-implementation detail, because it affects the derivation interface for
-\tcode{ctype<char>}.
+The specialization is specified in the standard,
+and not left as an implementation detail,
+because it affects the derivation interface for \tcode{ctype<char>}.
 \end{footnote}
-The \impldef{value of \tcode{ctype<char>::table_size}} value of member
-\tcode{table_size}
-is at least 256.
+The \impldef{value of \tcode{ctype<char>::table_size}} value of
+member \tcode{table_size} is at least 256.
 
 \rSec4[facet.ctype.char.dtor]{Destructor}
 
@@ -1587,21 +1388,20 @@ is at least 256.
 \begin{itemdescr}
 \pnum
 \effects
-If the constructor's first argument was nonzero, and its second argument
-was \tcode{true}, does
-\tcode{delete [] table()}.
+If the constructor's first argument was nonzero, and
+its second argument was \tcode{true},
+does \tcode{delete [] table()}.
 \end{itemdescr}
 
 \rSec4[facet.ctype.char.members]{Members}
 
 \pnum
 \indexlibrarymember{ctype<char>}{ctype<char>}%
-In the following member descriptions, for
-\tcode{unsigned char}
-values \tcode{v} where \tcode{v >= table_size},
-\tcode{table()[v]} is assumed to have an
-implementation-specific value (possibly different for each
-such value \tcode{v}) without performing the array lookup.
+In the following member descriptions,
+for \tcode{unsigned char} values \tcode{v} where \tcode{v >= table_size},
+\tcode{table()[v]} is assumed to have an implementation-specific value
+(possibly different for each such value \tcode{v})
+without performing the array lookup.
 
 \indexlibraryctor{ctype<char>}%
 \begin{itemdecl}
@@ -1611,7 +1411,8 @@ explicit ctype(const mask* tbl = nullptr, bool del = false, size_t refs = 0);
 \begin{itemdescr}
 \pnum
 \expects
-Either \tcode{tbl == nullptr} is \tcode{true} or \range{tbl}{tbl+table_size} is a valid range.
+Either \tcode{tbl == nullptr} is \tcode{true} or
+\range{tbl}{tbl+table_size} is a valid range.
 
 \pnum
 \effects
@@ -1627,20 +1428,12 @@ const char* is(const char* low, const char* high, mask* vec) const;
 \begin{itemdescr}
 \pnum
 \effects
-The second form, for all
-\tcode{*p}
-in the range
-\range{low}{high},
-assigns
-into
-\tcode{vec[p - low]}
-the value
-\tcode{table()[(unsigned char)*p]}.
+The second form, for all \tcode{*p} in the range \range{low}{high},
+assigns into \tcode{vec[p - low]} the value \tcode{table()[(unsigned char)*p]}.
 
 \pnum
 \returns
-The first form returns
-\tcode{table()[(unsigned char)c] \& m};
+The first form returns \tcode{table()[(unsigned char)c] \& m};
 the second form returns \tcode{high}.
 \end{itemdescr}
 
@@ -1652,16 +1445,11 @@ const char* scan_is(mask m, const char* low, const char* high) const;
 \begin{itemdescr}
 \pnum
 \returns
-The smallest
-\tcode{p}
-in the range
-\range{low}{high}
-such that
+The smallest \tcode{p} in the range \range{low}{high} such that
 \begin{codeblock}
 table()[(unsigned char) *p] & m
 \end{codeblock}
-is
-\tcode{true}.
+is \tcode{true}.
 \end{itemdescr}
 
 \indexlibrarymember{ctype<char>}{scan_not}%
@@ -1672,16 +1460,11 @@ const char* scan_not(mask m, const char* low, const char* high) const;
 \begin{itemdescr}
 \pnum
 \returns
-The smallest
-\tcode{p}
-in the range
-\range{low}{high}
-such that
+The smallest \tcode{p} in the range \range{low}{high} such that
 \begin{codeblock}
 table()[(unsigned char) *p] & m
 \end{codeblock}
-is
-\tcode{false}.
+is \tcode{false}.
 \end{itemdescr}
 
 \indexlibrarymember{ctype<char>}{toupper}%
@@ -1693,10 +1476,7 @@ const char* toupper(char* low, const char* high) const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{do_toupper(c)}
-or
-\tcode{do_toupper(low, high)},
-respectively.
+\tcode{do_toupper(c)} or \tcode{do_toupper(low, high)}, respectively.
 \end{itemdescr}
 
 \indexlibrarymember{ctype<char>}{tolower}%
@@ -1708,10 +1488,7 @@ const char* tolower(char* low, const char* high) const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{do_tolower(c)}
-or
-\tcode{do_tolower(low, high)},
-respectively.
+\tcode{do_tolower(c)} or \tcode{do_tolower(low, high)}, respectively.
 \end{itemdescr}
 
 \indexlibrarymember{ctype<char>}{widen}%
@@ -1723,11 +1500,9 @@ const char* widen(const char* low, const char* high, char* to) const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{do_widen(c)}
-or
+\tcode{do_widen(c)} or
 \indexlibraryglobal{do_widen}%
-\tcode{do_widen(low, high, to)},
-respectively.
+\tcode{do_widen(low, high, to)}, respectively.
 \end{itemdescr}
 
 \indexlibrarymember{ctype<char>}{narrow}%
@@ -1740,8 +1515,7 @@ const char* narrow(const char* low, const char* high, char dfault, char* to) con
 \pnum
 \returns
 \indexlibraryglobal{do_narrow}%
-\tcode{do_narrow(c, dfault)}
-or
+\tcode{do_narrow(c, dfault)} or
 \indexlibraryglobal{do_narrow}%
 \tcode{do_narrow(low, high, dfault, to)},
 respectively.
@@ -1755,8 +1529,8 @@ const mask* table() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-The first constructor argument, if it was nonzero, otherwise
-\tcode{classic_table()}.
+The first constructor argument, if it was nonzero,
+otherwise \tcode{classic_table()}.
 \end{itemdescr}
 
 \rSec4[facet.ctype.char.statics]{Static members}
@@ -1769,8 +1543,7 @@ static const mask* classic_table() noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-A pointer to the initial element of an array of size
-\tcode{table_size}
+A pointer to the initial element of an array of size \tcode{table_size}
 which represents the classifications of characters in the \tcode{"C"} locale.
 \end{itemdescr}
 
@@ -1794,10 +1567,8 @@ virtual const char* do_narrow(const char* low, const char* high,
 \end{codeblock}
 
 \pnum
-These functions are described identically as those members of the
-same name in the
-\tcode{ctype}
-class template\iref{locale.ctype.members}.
+These functions are described identically as those members of the same name
+in the \tcode{ctype} class template\iref{locale.ctype.members}.
 
 \rSec3[locale.codecvt]{Class template \tcode{codecvt}}
 
@@ -1864,23 +1635,20 @@ namespace std {
 \end{codeblock}
 
 \pnum
-The class
-\tcode{codecvt<internT, externT, stateT>}
-is for use when
-converting from one character encoding to another, such as from wide characters
-to multibyte characters or between wide character encodings such as
-UTF-32 and EUC.
+The class \tcode{codecvt<internT, externT, stateT>} is for use
+when converting from one character encoding to another,
+such as from wide characters to multibyte characters or
+between wide character encodings such as UTF-32 and EUC.
 
 \pnum
-The
-\tcode{stateT}
-argument selects the pair of character encodings being mapped between.
+The \tcode{stateT} argument selects
+the pair of character encodings being mapped between.
 
 \pnum
-The specializations required in \tref{locale.category.facets}\iref{locale.category}
+The specializations required
+in \tref{locale.category.facets}\iref{locale.category}
 convert the implementation-defined native character set.
-\tcode{codecvt<char, char, mbstate_t>}
-implements a degenerate conversion;
+\tcode{codecvt<char, char, mbstate_t>} implements a degenerate conversion;
 it does not convert at all.
 The specialization \tcode{codecvt<char16_t, char8_t, mbstate_t>}
 converts between the UTF-16 and UTF-8 encoding forms, and
@@ -1888,20 +1656,13 @@ the specialization \tcode{codecvt} \tcode{<char32_t, char8_t, mbstate_t>}
 converts between the UTF-32 and UTF-8 encoding forms.
 \tcode{codecvt<wchar_t, char, mbstate_t>}
 converts between the native character sets for ordinary and wide characters.
-Specializations on
-\tcode{mbstate_t}
+Specializations on \tcode{mbstate_t}
 perform conversion between encodings known to the library implementer.
-Other encodings can be converted by specializing on a program-defined
-\tcode{stateT}
-type.
-Objects of type
-\tcode{stateT}
-can contain any state that is useful to communicate to or from
-the specialized
-\tcode{do_in}
-or
-\tcode{do_out}
-members.
+Other encodings can be converted by specializing on
+a program-defined \tcode{stateT} type.
+Objects of type \tcode{stateT} can contain any state
+that is useful to communicate to or from
+the specialized \tcode{do_in} or \tcode{do_out} members.
 
 \rSec4[locale.codecvt.members]{Members}
 
@@ -2009,89 +1770,73 @@ result do_in(
 \expects
 \tcode{(from <= from_end \&\& to <= to_end)} is well-defined and \tcode{true};
 \tcode{state} is initialized, if at the beginning of a sequence,
-or else is equal to the result of converting the preceding characters in the sequence.
+or else is equal to the result of converting
+the preceding characters in the sequence.
 
 \pnum
 \effects
-Translates characters in the source range
-\range{from}{from_end},
+Translates characters in the source range \range{from}{from_end},
 placing the results in sequential positions starting at destination \tcode{to}.
-Converts no more than
-\tcode{(from_end - from)}
-source elements, and
-stores no more than
-\tcode{(to_end - to)}
-destination elements.
+Converts no more than \tcode{(from_end - from)} source elements, and
+stores no more than \tcode{(to_end - to)} destination elements.
 
 \pnum
 Stops if it encounters a character it cannot convert.
 It always leaves the \tcode{from_next} and \tcode{to_next} pointers
 pointing one beyond the last element successfully converted.
-If returns
-\tcode{noconv},
-\tcode{internT}
-and
-\tcode{externT}
-are the same type and the converted sequence is
-identical to the input sequence
-\range{from}{from\textunderscore\nobreak next}.
-\tcode{to_next} is set equal to \tcode{to}, the value of \tcode{state} is
-unchanged, and there are no changes to the values in
-\range{to}{to_end}.
+If returns \tcode{noconv},
+\tcode{internT} and \tcode{externT} are the same type and
+the converted sequence is identical to
+the input sequence \range{from}{from\textunderscore\nobreak next}.
+\tcode{to_next} is set equal to \tcode{to},
+the value of \tcode{state} is unchanged, and
+there are no changes to the values in \range{to}{to_end}.
 
 \pnum
-A
-\tcode{codecvt}
-facet that is used by
-\tcode{basic_filebuf}\iref{file.streams} shall have the property that if
+A \tcode{codecvt} facet
+that is used by \tcode{basic_filebuf}\iref{file.streams}
+shall have the property that if
 \begin{codeblock}
 do_out(state, from, from_end, from_next, to, to_end, to_next)
 \end{codeblock}
-would return
-\tcode{ok},
-where
-\tcode{from != from_end},
+would return \tcode{ok},
+where \tcode{from != from_end},
 then
 \begin{codeblock}
 do_out(state, from, from + 1, from_next, to, to_end, to_next)
 \end{codeblock}
-shall also return
-\tcode{ok},
+shall also return \tcode{ok},
 and that if
 \begin{codeblock}
 do_in(state, from, from_end, from_next, to, to_end, to_next)
 \end{codeblock}
-would return
-\tcode{ok},
-where
-\tcode{to != to_end},
+would return \tcode{ok},
+where \tcode{to != to_end},
 then
 \begin{codeblock}
 do_in(state, from, from_end, from_next, to, to + 1, to_next)
 \end{codeblock}
-shall also return
-\tcode{ok}.
+shall also return \tcode{ok}.
 \begin{footnote}
-Informally, this means that
-\tcode{basic_filebuf}
-assumes that the mappings from internal to external characters is
-1 to N: that a
-\tcode{codecvt}
-facet that is used by
-\tcode{basic_filebuf}
+Informally, this means that \tcode{basic_filebuf}
+assumes that the mappings from internal to external characters is 1 to N:
+that a \tcode{codecvt} facet that is used by \tcode{basic_filebuf}
 can translate characters one internal character at a time.
 \end{footnote}
 \begin{note}
-As a result of operations on \tcode{state}, it can return \tcode{ok} or \tcode{partial} and set \tcode{from_next == from} and \tcode{to_next != to}.
+As a result of operations on \tcode{state},
+it can return \tcode{ok} or \tcode{partial} and
+set \tcode{from_next == from} and \tcode{to_next != to}.
 \end{note}
 
 \pnum
 \remarks
 Its operations on \tcode{state} are unspecified.
 \begin{note}
-This argument can be used, for example, to maintain
-shift state, to specify conversion options (such as count only), or to
-identify a cache of seek offsets.
+This argument can be used, for example,
+to maintain shift state,
+to specify conversion options (such as count only), or
+to identify a cache of seek offsets.
 \end{note}
 
 \pnum
@@ -2112,13 +1857,13 @@ that cannot be converted                                           \\
 sequence is identical to converted sequence                         \\
 \end{floattable}
 
-A return value of
-\tcode{partial},
-if
-\tcode{(from_next == from_end)},
-indicates that either the destination sequence has not absorbed all the
-available destination elements, or that additional source elements are
-needed before another destination element can be produced.
+A return value of \tcode{partial},
+if \tcode{(from_next == from_end)},
+indicates
+that either the destination sequence has not absorbed
+all the available destination elements, or
+that additional source elements are needed
+before another destination element can be produced.
 \end{itemdescr}
 
 \indexlibrarymember{codecvt}{do_unshift}%
@@ -2131,22 +1876,19 @@ result do_unshift(stateT& state, externT* to, externT* to_end, externT*& to_next
 \expects
 \tcode{(to <= to_end)} is well-defined and \tcode{true};
 \tcode{state} is initialized, if at the beginning of a sequence,
-or else is equal to the result of converting the preceding characters in the
-sequence.
+or else is equal to the result of converting
+the preceding characters in the sequence.
 
 \pnum
 \effects
-Places characters starting at \tcode{to} that should be appended
-to terminate a sequence when the current
-\tcode{stateT}
-is given by \tcode{state}.
+Places characters starting at \tcode{to}
+that should be appended to terminate a sequence
+when the current \tcode{stateT} is given by \tcode{state}.
 \begin{footnote}
-Typically these will be characters to return the state to
-\tcode{stateT()}.
+Typically these will be characters to return the state to \tcode{stateT()}.
 \end{footnote}
-Stores no more than
-\tcode{(to_end - to)}
-destination elements, and leaves the \tcode{to_next} pointer
+Stores no more than \tcode{(to_end - to)} destination elements, and
+leaves the \tcode{to_next} pointer
 pointing one beyond the last element successfully stored.
 
 \pnum
@@ -2174,15 +1916,16 @@ int do_encoding() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{-1} if the encoding of the \tcode{externT} sequence is state-dependent; else the
-constant number of \tcode{externT} characters needed to produce an internal
-character; or \tcode{0} if this number is not a constant.
+\tcode{-1} if the encoding of the \tcode{externT} sequence is state-dependent;
+else the constant number of \tcode{externT} characters
+needed to produce an internal character;
+or \tcode{0} if this number is not a constant.
 \begin{footnote}
-If \tcode{encoding()}
-yields \tcode{-1}, then more than \tcode{max_length()} \tcode{externT} elements
-can be consumed when producing a single \tcode{internT} character, and additional
-\tcode{externT} elements can appear at the end of a sequence after those that
-yield the final \tcode{internT} character.
+If \tcode{encoding()} yields \tcode{-1},
+then more than \tcode{max_length()} \tcode{externT} elements
+can be consumed when producing a single \tcode{internT} character, and
+additional \tcode{externT} elements can appear at the end of a sequence
+after those that yield the final \tcode{internT} character.
 \end{footnote}
 \end{itemdescr}
 
@@ -2194,17 +1937,9 @@ bool do_always_noconv() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{true}
-if
-\tcode{do_in()}
-and
-\tcode{do_out()}
-return
-\tcode{noconv}
+\tcode{true} if \tcode{do_in()} and \tcode{do_out()} return \tcode{noconv}
 for all valid argument values.
-\tcode{codecvt<char, char, mbstate_t>}
-returns
-\tcode{true}.
+\tcode{codecvt<char, char, mbstate_t>} returns \tcode{true}.
 \end{itemdescr}
 
 \indexlibrarymember{codecvt}{do_length}%
@@ -2217,33 +1952,24 @@ int do_length(stateT& state, const externT* from, const externT* from_end, size_
 \expects
 \tcode{(from <= from_end)} is well-defined and \tcode{true};
 \tcode{state} is initialized, if at the beginning of a sequence,
-or else is equal to the result of converting the preceding characters in the sequence.
+or else is equal to the result of converting
+the preceding characters in the sequence.
 
 \pnum
 \effects
-The effect on the \tcode{state} argument is as if it called
-\tcode{do_in(state, from, from_end, from, to, to+max, to)}
+The effect on the \tcode{state} argument is as if
+it called \tcode{do_in(state, from, from_end, from, to, to+max, to)}
 for \tcode{to} pointing to a buffer of at least \tcode{max} elements.
 
 \pnum
 \returns
-\tcode{(from_next-from)}
-where
-\tcode{from_next}
-is the largest value in the range
-\crange{from}{from_end}
-such that the sequence of values in the range
-\range{from}{from_next}
+\tcode{(from_next-from)} where
+\tcode{from_next} is the largest value in the range \crange{from}{from_end}
+such that the sequence of values in the range \range{from}{from_next}
 represents
-\tcode{max}
-or fewer valid complete characters of type
-\tcode{internT}.
-The specialization
-\tcode{codecvt<char, char, mbstate_t>},
-returns the lesser of
-\tcode{max}
-and
-\tcode{(from_end-from)}.
+\tcode{max} or fewer valid complete characters of type \tcode{internT}.
+The specialization \tcode{codecvt<char, char, mbstate_t>},
+returns the lesser of \tcode{max} and \tcode{(from_end-from)}.
 \end{itemdescr}
 
 \indexlibrarymember{codecvt}{do_max_length}%
@@ -2254,16 +1980,10 @@ int do_max_length() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-The maximum value that
-\tcode{do_length(state, from, from_end, 1)}
-can return for any valid range
-\range{from}{from_end}
-and
-\tcode{stateT}
-value
-\tcode{state}.
-The specialization
-\tcode{codecvt<char, char, mbstate_t>::do_max_length()}
+The maximum value that \tcode{do_length(state, from, from_end, 1)} can return
+for any valid range \range{from}{from_end}
+and \tcode{stateT} value \tcode{state}.
+The specialization \tcode{codecvt<char, char, mbstate_t>::do_max_length()}
 returns 1.
 \end{itemdescr}
 
@@ -2289,54 +2009,39 @@ namespace std {
 \rSec3[category.numeric.general]{General}
 
 \pnum
-The classes
-\tcode{num_get<>}
-and
-\tcode{num_put<>}
+The classes \tcode{num_get<>} and \tcode{num_put<>}
 handle numeric formatting and parsing.
 Virtual functions are provided for several numeric types.
-Implementations may (but are not required to) delegate extraction
-of smaller types to extractors for larger types.
+Implementations may (but are not required to) delegate
+extraction of smaller types to extractors for larger types.
 \begin{footnote}
-Parsing
-\tcode{"-1"} correctly into, e.g., an
-\tcode{unsigned short}
-requires that the corresponding member
-\tcode{get()}
+Parsing \tcode{"-1"} correctly into, e.g., an \tcode{unsigned short}
+requires that the corresponding member \tcode{get()}
 at least extract the sign before delegating.
 \end{footnote}
 
 \pnum
-All specifications of member functions for
-\tcode{num_put}
-and
-\tcode{num_get}
-in the subclauses of~\ref{category.numeric} only apply to the
-specializations required in Tables~\ref{tab:locale.category.facets}
+All specifications of member functions for \tcode{num_put} and \tcode{num_get}
+in the subclauses of~\ref{category.numeric} only apply to
+the specializations required in Tables~\ref{tab:locale.category.facets}
 and~\ref{tab:locale.spec}\iref{locale.category}, namely
 \tcode{num_get<char>},
 \tcode{num_get<wchar_t>},
 \tcode{num_get<C, InputIterator>},
 \tcode{num_put<char>},
-\tcode{num_put<wchar_t>},
-and
+\tcode{num_put<wchar_t>}, and
 \tcode{num_put<C, OutputIterator>}.
-These specializations refer to the
-\tcode{ios_base\&}
-argument for formatting specifications\iref{locale.categories},
-and to its imbued locale for the
-\tcode{numpunct<>}
-facet to identify all numeric punctuation preferences,
-and also for the
-\tcode{ctype<>}
-facet to perform character classification.
+These specializations refer to the \tcode{ios_base\&} argument for
+formatting specifications\iref{locale.categories},
+and to its imbued locale for the \tcode{numpunct<>} facet to
+identify all numeric punctuation preferences,
+and also for the \tcode{ctype<>} facet to perform character classification.
 
 \pnum
 Extractor and inserter members of the standard iostreams use
-\tcode{num_get<>}
-and
-\tcode{num_put<>}
-member functions for formatting and parsing numeric values~(\ref{istream.formatted.reqmts}, \ref{ostream.formatted.reqmts}).
+\tcode{num_get<>} and \tcode{num_put<>} member functions for
+formatting and parsing
+numeric values~(\ref{istream.formatted.reqmts}, \ref{ostream.formatted.reqmts}).
 
 \rSec3[locale.num.get]{Class template \tcode{num_get}}
 
@@ -2407,9 +2112,8 @@ namespace std {
 \end{codeblock}
 
 \pnum
-The facet
-\tcode{num_get}
-is used to parse numeric values from an input sequence such as an istream.
+The facet \tcode{num_get} is used to parse numeric values
+from an input sequence such as an istream.
 
 \rSec4[facet.num.get.members]{Members}
 
@@ -2477,13 +2181,9 @@ iter_type do_get(iter_type in, iter_type end, ios_base& str,
 Reads characters from \tcode{in},
 interpreting them according to
 \tcode{str.flags()},
-\tcode{use_facet<ctype<\brk{}charT>>(loc)},
-and
+\tcode{use_facet<ctype<\brk{}charT>>(loc)}, and
 \tcode{use_facet<numpunct<charT>>(loc)},
-where
-\tcode{loc}
-is
-\tcode{str.getloc()}.
+where \tcode{loc} is \tcode{str.getloc()}.
 
 \pnum
 The details of this operation occur in three stages
@@ -2493,10 +2193,10 @@ The details of this operation occur in three stages
 Stage 1:
 Determine a conversion specifier
 \item
-Stage 2: Extract characters from \tcode{in} and determine a corresponding
-\tcode{char}
-value for the format expected by the conversion specification determined
-in stage 1.
+Stage 2:
+Extract characters from \tcode{in} and
+determine a corresponding \tcode{char} value for
+the format expected by the conversion specification determined in stage 1.
 \item
 Stage 3:
 Store results
@@ -2515,9 +2215,9 @@ fmtflags uppercase = (flags & ios_base::uppercase);
 fmtflags boolalpha = (flags & ios_base::boolalpha);
 \end{codeblock}
 
-For conversion to an integral type, the
-function determines the integral conversion specifier as indicated in
-\tref{facet.num.get.int}.
+For conversion to an integral type,
+the function determines the integral conversion specifier
+as indicated in \tref{facet.num.get.int}.
 The table is ordered.
 That is, the first line whose condition is true applies.
 
@@ -2532,13 +2232,9 @@ That is, the first line whose condition is true applies.
 \tcode{unsigned} integral type  &   \tcode{\%u}                 \\
 \end{floattable}
 
-For conversions to a floating-point type the specifier is
-\tcode{\%g}.
+For conversions to a floating-point type the specifier is \tcode{\%g}.
 
-For conversions to
-\tcode{void*}
-the specifier is
-\tcode{\%p}.
+For conversions to \tcode{void*} the specifier is \tcode{\%p}.
 
 A length modifier is added to the conversion specification, if needed,
 as indicated in \tref{facet.num.get.length}.
@@ -2558,12 +2254,9 @@ as indicated in \tref{facet.num.get.length}.
 \end{floattable}
 
 \stage{2}
-If
-\tcode{in == end}
-then stage 2 terminates.
-Otherwise a
-\tcode{charT}
-is taken from \tcode{in} and local variables are initialized as if by
+If \tcode{in == end} then stage 2 terminates.
+Otherwise a \tcode{charT} is taken from \tcode{in} and
+local variables are initialized as if by
 \begin{codeblock}
 char_type ct = *in;
 char c = src[find(atoms, atoms + sizeof(src) - 1, ct) - atoms];
@@ -2573,64 +2266,62 @@ bool discard =
   ct == use_facet<numpunct<charT>>(loc).thousands_sep()
   && use_facet<numpunct<charT>>(loc).grouping().length() != 0;
 \end{codeblock}
-where the values
-\tcode{src}
-and
-\tcode{atoms}
-are defined as if by:
+where the values \tcode{src} and \tcode{atoms} are defined as if by:
 \begin{codeblock}
 static const char src[] = "0123456789abcdefxABCDEFX+-";
 char_type atoms[sizeof(src)];
 use_facet<ctype<charT>>(loc).widen(src, src + sizeof(src), atoms);
 \end{codeblock}
-for this value of
-\tcode{loc}.
+for this value of \tcode{loc}.
 
-If \tcode{discard} is \tcode{true}, then if
-\tcode{'.'}
-has not yet been accumulated, then the position of the character is remembered,
+If \tcode{discard} is \tcode{true},
+then if \tcode{'.'} has not yet been accumulated,
+then the position of the character is remembered,
 but the character is otherwise ignored.
-Otherwise, if
-\tcode{'.'}
-has already been accumulated, the character is discarded and
-Stage 2 terminates.
-If it is not discarded, then a check is made to determine if \tcode{c} is
-allowed as the next character of an input field of the conversion specifier
-returned by Stage 1. If so, it is accumulated.
+Otherwise, if \tcode{'.'} has already been accumulated,
+the character is discarded and Stage 2 terminates.
+If it is not discarded,
+then a check is made to determine
+if \tcode{c} is allowed as the next character of
+an input field of the conversion specifier returned by Stage 1.
+If so, it is accumulated.
 
-If the character is either discarded or accumulated then \tcode{in}
-is advanced by
-\tcode{++in}
+If the character is either discarded or accumulated
+then \tcode{in} is advanced by \tcode{++in}
 and processing returns to the beginning of stage 2.
 
 \stage{3}
-The sequence of \tcode{char}{s} accumulated in stage 2 (the field) is converted to a numeric value by the rules of one of the functions declared in the header \libheader{cstdlib}:
+The sequence of \tcode{char}{s} accumulated in stage 2 (the field)
+is converted to a numeric value by the rules of one of the functions
+declared in the header \libheader{cstdlib}:
 
 \begin{itemize}
-\item For a signed integer value, the function \tcode{strtoll}.
-
-\item For an unsigned integer value, the function \tcode{strtoull}.
-
-\item For a \tcode{float} value, the function \tcode{strtof}.
-
-\item For a \tcode{double} value, the function \tcode{strtod}.
-
-\item For a \tcode{long double} value, the function \tcode{strtold}.
+\item
+For a signed integer value, the function \tcode{strtoll}.
+\item
+For an unsigned integer value, the function \tcode{strtoull}.
+\item
+For a \tcode{float} value, the function \tcode{strtof}.
+\item
+For a \tcode{double} value, the function \tcode{strtod}.
+\item
+For a \tcode{long double} value, the function \tcode{strtold}.
 \end{itemize}
 
 The numeric value to be stored can be one of:
 \begin{itemize}
-\item zero, if the conversion function does not convert the entire field.
-
-\item the most positive (or negative) representable value,
+\item
+zero, if the conversion function does not convert the entire field.
+\item
+the most positive (or negative) representable value,
 if the field to be converted to a signed integer type represents a value
 too large positive (or negative) to be represented in \tcode{val}.
-
-\item the most positive representable value,
+\item
+the most positive representable value,
 if the field to be converted to an unsigned integer type represents a value
 that cannot be represented in \tcode{val}.
-
-\item the converted value, otherwise.
+\item
+the converted value, otherwise.
 \end{itemize}
 
 The resultant numeric value is stored in \tcode{val}.
@@ -2645,16 +2336,13 @@ Digit grouping is checked.
 That is, the positions of discarded
 separators is examined for consistency with
 \tcode{use_facet<numpunct<charT>>(loc).grouping()}.
-If they are not consistent then
-\tcode{ios_base::failbit}
-is assigned to \tcode{err}.
+If they are not consistent
+then \tcode{ios_base::failbit} is assigned to \tcode{err}.
 
 \pnum
-In any case, if stage 2 processing was terminated by the test for
-\tcode{in == end}
-then
-\tcode{err |= ios_base::eofbit}
-is performed.
+In any case,
+if stage 2 processing was terminated by the test for \tcode{in == end}
+then \tcode{err |= ios_base::eofbit} is performed.
 \end{itemdescr}
 
 \indexlibrarymember{do_get}{num_get}%
@@ -2666,81 +2354,51 @@ iter_type do_get(iter_type in, iter_type end, ios_base& str,
 \begin{itemdescr}
 \pnum
 \effects
-If
-\tcode{(str.flags()\&ios_base::boolalpha) == 0}
-then input proceeds as it would for a
-\tcode{long}
+If \tcode{(str.flags()\&ios_base::boolalpha) == 0}
+then input proceeds as it would for a \tcode{long}
 except that if a value is being stored into \tcode{val},
 the value is determined according to the following:
-If the value to be stored is 0 then
-\tcode{false}
-is stored.
-If the value is \tcode{1}
-then
-\tcode{true}
-is stored.
-Otherwise \tcode{true} is stored and \tcode{ios_base::failbit} is assigned to \tcode{err}.
+If the value to be stored is 0 then \tcode{false} is stored.
+If the value is \tcode{1} then \tcode{true} is stored.
+Otherwise \tcode{true} is stored and
+\tcode{ios_base::failbit} is assigned to \tcode{err}.
 
 \pnum
-Otherwise target sequences are determined ``as if'' by calling the
-members
-\tcode{falsename()}
-and
-\tcode{truename()}
-of the facet obtained by
-\tcode{use_facet<numpunct<charT>>(str.getloc())}.
-Successive characters in the range
-\range{in}{end}
-(see~\ref{sequence.reqmts}) are obtained and
-matched against corresponding positions in the target sequences only
-as necessary to identify a unique match. The input iterator \tcode{in} is
-compared to \tcode{end} only when necessary to obtain a character. If a target sequence is uniquely matched, \tcode{val} is set to the
-corresponding value. Otherwise \tcode{false} is stored and \tcode{ios_base::failbit} is assigned to \tcode{err}.
+Otherwise target sequences are determined ``as if'' by
+calling the members \tcode{falsename()} and \tcode{truename()} of
+the facet obtained by \tcode{use_facet<numpunct<charT>>(str.getloc())}.
+Successive characters in the range \range{in}{end} (see~\ref{sequence.reqmts})
+are obtained and matched against
+corresponding positions in the target sequences
+only as necessary to identify a unique match.
+The input iterator \tcode{in} is compared to \tcode{end}
+only when necessary to obtain a character.
+If a target sequence is uniquely matched,
+\tcode{val} is set to the corresponding value.
+Otherwise \tcode{false} is stored and
+\tcode{ios_base::failbit} is assigned to \tcode{err}.
 
 \pnum
-The \tcode{in} iterator is always left pointing one position beyond the last
-character successfully matched. If \tcode{val} is set, then \tcode{err} is set to
-\tcode{str.goodbit};
-or to
-\tcode{str.eofbit}
-if, when seeking another character to match, it is found that
-\tcode{(in == end)}.
-If \tcode{val} is not set, then \tcode{err} is set to
-\tcode{str.failbit};
-or to
-\tcode{(str.failbit|str.eofbit)}
-if the reason for the failure was that
-\tcode{(in == end)}.
+The \tcode{in} iterator is always left pointing one position beyond
+the last character successfully matched.
+If \tcode{val} is set, then \tcode{err} is set to \tcode{str.goodbit};
+or to \tcode{str.eofbit} if,
+when seeking another character to match,
+it is found that \tcode{(in == end)}.
+If \tcode{val} is not set, then \tcode{err} is set to \tcode{str.failbit};
+or to \tcode{(str.failbit|str.eofbit)}
+if the reason for the failure was that \tcode{(in == end)}.
 \begin{example}
-For targets
-\tcode{true}:
-\tcode{"a"}
-and
-\tcode{false}:
-\tcode{"abb"},
-the input sequence
- \tcode{"a"}
-yields
-\tcode{val == true}
-and
-\tcode{err == str.eofbit};
-the input sequence
- \tcode{"abc"}
-yields
-\tcode{err = str.failbit},
-with \tcode{in} ending at the
-\tcode{'c'}
-element. For targets
-\tcode{true}:
-\tcode{"1"}
-and
-\tcode{false}:
-\tcode{"0"}, the input sequence \tcode{"1"} yields
-\tcode{val == true}
-and
-\tcode{err == str.goodbit}.
-For empty targets \tcode{("")}, any input sequence yields
-\tcode{err == str.failbit}.
+For targets \tcode{true}: \tcode{"a"} and \tcode{false}: \tcode{"abb"},
+the input sequence \tcode{"a"} yields
+\tcode{val == true} and \tcode{err == str.eofbit};
+the input sequence \tcode{"abc"} yields
+\tcode{err = str.failbit}, with \tcode{in} ending at the \tcode{'c'} element.
+For targets \tcode{true}: \tcode{"1"} and \tcode{false}: \tcode{"0"},
+the input sequence \tcode{"1"} yields
+\tcode{val == true} and \tcode{err == str.goodbit}.
+For empty targets \tcode{("")},
+any input sequence yields \tcode{err == str.failbit}.
 \end{example}
 
 \pnum
@@ -2831,8 +2489,7 @@ iter_type do_put(iter_type out, ios_base& str, char_type fill, const void* val) 
 \effects
 Writes characters to the sequence \tcode{out},
 formatting \tcode{val} as desired.
-In the following description,
-\tcode{loc} names a local variable initialized as
+In the following description, \tcode{loc} names a local variable initialized as
 \begin{codeblock}
 locale loc = str.getloc();
 \end{codeblock}
@@ -2844,22 +2501,19 @@ The details of this operation occur in several stages:
 \item
 Stage 1:
 Determine a printf conversion specifier \tcode{spec} and
-determine the characters that would be printed by
-\tcode{printf}\iref{c.files}
+determine the characters
+that would be printed by \tcode{printf}\iref{c.files}
 given this conversion specifier for
 \begin{codeblock}
 printf(spec, val)
 \end{codeblock}
-assuming that the current locale is
-the \tcode{"C"} locale.
+assuming that the current locale is the \tcode{"C"} locale.
 \item
 Stage 2:
-Adjust the representation by converting each
-\tcode{char}
-determined by stage 1 to a
-\tcode{charT}
-using a conversion and values returned by members of
-\tcode{use_facet<numpunct<charT>>(loc)}.
+Adjust the representation by converting
+each \tcode{char} determined by stage 1 to a \tcode{charT}
+using a conversion and
+values returned by members of \tcode{use_facet<numpunct<charT>>(loc)}.
 \item
 Stage 3:
 Determine where padding is required.
@@ -2893,12 +2547,12 @@ fmtflags showpoint =  (flags & (ios_base::showpoint));
 
 All tables used in describing stage 1 are ordered.
 That is, the first line whose condition is true applies.
-A line without a condition is the default behavior when none of the earlier
-lines apply.
+A line without a condition is the default behavior
+when none of the earlier lines apply.
 
-For conversion from an integral type other than a character type, the
-function determines the integral conversion specifier as indicated in
-\tref{facet.num.put.int}.
+For conversion from an integral type other than a character type,
+the function determines the integral conversion specifier
+as indicated in \tref{facet.num.put.int}.
 
 \begin{floattable}{Integer conversions}{facet.num.put.int}
 {lc}
@@ -2911,8 +2565,9 @@ for a \tcode{signed} integral type                     &   \tcode{\%d} \\ \rowse
 for an \tcode{unsigned} integral type                  &   \tcode{\%u} \\
 \end{floattable}
 
-For conversion from a floating-point type, the function determines
-the floating-point conversion specifier as indicated in \tref{facet.num.put.fp}.
+For conversion from a floating-point type,
+the function determines the floating-point conversion specifier
+as indicated in \tref{facet.num.put.fp}.
 
 \begin{floattable}{Floating-point conversions}{facet.num.put.fp}
 {lc}
@@ -2927,9 +2582,9 @@ the floating-point conversion specifier as indicated in \tref{facet.num.put.fp}.
 \textit{otherwise}                                          &   \tcode{\%G} \\
 \end{floattable}
 
-For conversions from an integral or floating-point
-type a length modifier is added to the
-conversion specifier as indicated in  \tref{facet.num.put.length}.
+For conversions from an integral or floating-point type
+a length modifier is added to the conversion specifier
+as indicated in \tref{facet.num.put.length}.
 
 \begin{floattable}{Length modifier}{facet.num.put.length}
 {lc}
@@ -2958,24 +2613,19 @@ a floating-point type           &   \tcode{showpos}    &   \tcode{+}            
 
 For conversion from a floating-point type,
 if \tcode{floatfield != (ios_base::fixed | ios_base::\brk{}scientific)},
-\tcode{str.precision()}
-is specified as precision in the conversion specification.
+\tcode{str.precision()} is specified as precision
+in the conversion specification.
 Otherwise, no precision is specified.
 
-For conversion from
-\tcode{void*}
-the specifier is
-\tcode{\%p}.
+For conversion from \tcode{void*} the specifier is \tcode{\%p}.
 
-The representations at the end of stage 1 consists of the
-\tcode{char}'s
-that would be printed by a call of
-\tcode{printf(s, val)}
+The representations at the end of stage 1 consists of the \tcode{char}'s
+that would be printed by a call of \tcode{printf(s, val)}
 where \tcode{s} is the conversion specifier determined above.
 
 \stage{2}
-Any character \tcode{c} other than a decimal point(.) is converted to a
-\tcode{charT} via
+Any character \tcode{c} other than a decimal point(.) is converted to
+a \tcode{charT} via
 \begin{codeblock}
 use_facet<ctype<charT>>(loc).widen(c)
 \end{codeblock}
@@ -2986,14 +2636,11 @@ const numpunct<charT>& punct = use_facet<numpunct<charT>>(loc);
 \end{codeblock}
 
 For arithmetic types,
-\tcode{punct.thousands_sep()}
-characters are inserted into the sequence as determined by the value returned
-by
-\tcode{punct.do_grouping()}
-using the method described in~\ref{facet.numpunct.virtuals}
+\tcode{punct.thousands_sep()} characters are inserted into
+the sequence as determined by the value returned by \tcode{punct.do_grouping()}
+using the method described in~\ref{facet.numpunct.virtuals}.
 
-Decimal point characters(.) are replaced by
-\tcode{punct.decimal_point()}
+Decimal point characters(.) are replaced by \tcode{punct.decimal_point()}.
 
 \stage{3}
 A local variable is initialized as
@@ -3003,13 +2650,8 @@ fmtflags adjustfield = (flags & (ios_base::adjustfield));
 
 The location of any padding
 \begin{footnote}
-The conversion specification
-\tcode{\#o}
-generates a leading
-\tcode{0}
-which is
-\textit{not}
-a padding character.
+The conversion specification \tcode{\#o} generates a leading \tcode{0}
+which is \textit{not} a padding character.
 \end{footnote}
 is determined according to \tref{facet.num.put.fill}.
 
@@ -3026,23 +2668,16 @@ began with 0x or 0X                     &   pad after x or X                \\ \
 \textit{otherwise}                      &   pad before                      \\
 \end{floattable}
 
-If
-\tcode{str.width()}
-is nonzero and the number of
-\tcode{charT}'s
-in the sequence after stage 2 is less than
-\tcode{str.\brk{}width()},
-then enough \tcode{fill} characters are added to the sequence at the position
-indicated for padding to bring the length of the sequence to
-\tcode{str.width()}.
+If \tcode{str.width()} is nonzero and the number of \tcode{charT}'s
+in the sequence after stage 2 is less than \tcode{str.\brk{}width()},
+then enough \tcode{fill} characters are added to the sequence
+at the position indicated for padding
+to bring the length of the sequence to \tcode{str.width()}.
 
-\tcode{str.width(0)}
-is called.
+\tcode{str.width(0)} is called.
 
 \stage{4}
-The sequence of
-\tcode{charT}'s
-at the end of stage 3 are output via
+The sequence of \tcode{charT}'s at the end of stage 3 are output via
 \begin{codeblock}
 *out++ = c
 \end{codeblock}
@@ -3057,28 +2692,17 @@ iter_type do_put(iter_type out, ios_base& str, char_type fill, bool val) const;
 \begin{itemdescr}
 \pnum
 \returns
-If
-\tcode{(str.flags() \& ios_base::boolalpha) == 0}
-returns
-\tcode{do_put(out, str, fill,\\(int)val)},
-otherwise obtains a string
-\tcode{s}
-as if by
+If \tcode{(str.flags() \& ios_base::boolalpha) == 0}
+returns \tcode{do_put(out, str, fill,\\(int)val)},
+otherwise obtains a string \tcode{s} as if by
 \begin{codeblock}
 string_type s =
   val ? use_facet<numpunct<charT>>(loc).truename()
       : use_facet<numpunct<charT>>(loc).falsename();
 \end{codeblock}
-and then inserts each character
-\tcode{c}
-of
-\tcode{s}
-into
-\tcode{out}
-via
-\tcode{*out++ = c}
-and returns
-\tcode{out}.
+and then inserts each character \tcode{c} of \tcode{s} into \tcode{out}
+via \tcode{*out++ = c}
+and returns \tcode{out}.
 \end{itemdescr}
 
 \rSec2[facet.numpunct]{The numeric punctuation facet}
@@ -3118,20 +2742,14 @@ namespace std {
 \end{codeblock}
 
 \pnum
-\tcode{numpunct<>}
-specifies numeric punctuation.
-The specializations required in \tref{locale.category.facets}\iref{locale.category}, namely
-\tcode{numpunct<\brk{}wchar_t>}
-and
-\tcode{numpunct<char>},
-provide classic
-\tcode{"C"}
-numeric formats,
-i.e., they contain information equivalent to that contained in the
-\tcode{"C"}
-locale or their wide character counterparts as if obtained by
-a call to
-\tcode{widen}.
+\tcode{numpunct<>} specifies numeric punctuation.
+The specializations
+required in \tref{locale.category.facets}\iref{locale.category},
+namely \tcode{numpunct<\brk{}wchar_t>} and \tcode{numpunct<char>},
+provide classic \tcode{"C"} numeric formats,
+i.e., they contain information
+equivalent to that contained in the \tcode{"C"} locale or
+their wide character counterparts as if obtained by a call to \tcode{widen}.
 
 % FIXME: For now, keep the locale grammar productions out of the index;
 % they are conceptually unrelated to the main C++ grammar.
@@ -3141,8 +2759,8 @@ a call to
 
 \pnum
 The syntax for number formats is as follows,
-where \locgrammarterm{digit} represents the radix set specified by
-the \tcode{fmtflags} argument value, and
+where \locgrammarterm{digit} represents the radix set
+specified by the \tcode{fmtflags} argument value, and
 \locgrammarterm{thousands-sep} and \locgrammarterm{decimal-point}
 are the results of corresponding \tcode{numpunct<charT>} members.
 Integer values have the format:
@@ -3275,28 +2893,22 @@ string do_grouping() const;
 \pnum
 \returns
 A \tcode{string} \tcode{vec} used as a vector of integer values,
-in which each element
-\tcode{vec[i]}
-represents the number of digits
+in which each element \tcode{vec[i]} represents the number of digits
 \begin{footnote}
-Thus, the string
-\tcode{"\textbackslash003"} specifies groups of 3 digits each, and
+Thus,
+the string \tcode{"\textbackslash003"} specifies groups of 3 digits each, and
 \tcode{"3"} probably indicates groups of 51 (!) digits each,
 because 51 is the ASCII value of \tcode{"3"}.
 \end{footnote}
-in the group at position \tcode{i}, starting with position 0 as the
-rightmost group.
-If
-\tcode{vec.size() <= i},
-the number is the same as group
-\tcode{(i - 1)};
-if
-\tcode{(i < 0 || vec[i] <= 0 || vec[i] == CHAR_MAX)},
+in the group at position \tcode{i},
+starting with position 0 as the rightmost group.
+If \tcode{vec.size() <= i},
+the number is the same as group \tcode{(i - 1)};
+if \tcode{(i < 0 || vec[i] <= 0 || vec[i] == CHAR_MAX)},
 the size of the digit group is unlimited.
 
 \pnum
-The required specializations return the empty string, indicating
-no grouping.
+The required specializations return the empty string, indicating no grouping.
 \end{itemdescr}
 
 \indexlibrarymember{numpunct}{do_truename}%
@@ -3309,15 +2921,13 @@ string_type do_falsename() const;
 \begin{itemdescr}
 \pnum
 \returns
-A string representing the name of the boolean value
-\tcode{true}
-or
-\tcode{false},
-respectively.
+A string representing the name of
+the boolean value \tcode{true} or \tcode{false}, respectively.
 
 \pnum
-In the base class implementation these names are
-\tcode{"true"} and \tcode{"false"}, or \tcode{L"true"} and \tcode{L"false"}.
+In the base class implementation
+these names are \tcode{"true"} and \tcode{"false"},
+or \tcode{L"true"} and \tcode{L"false"}.
 \end{itemdescr}
 
 \rSec3[locale.numpunct.byname]{Class template \tcode{numpunct_byname}}
@@ -3376,25 +2986,20 @@ namespace std {
 \end{codeblock}
 
 \pnum
-The class
-\tcode{collate<charT>}
-provides features for use in the
-collation (comparison) and hashing of strings.
-A locale member function template,
-\tcode{operator()},
-uses the collate facet to allow a locale to act directly as the predicate
-argument for standard algorithms\iref{algorithms} and containers operating on strings.
-The specializations required in \tref{locale.category.facets}\iref{locale.category}, namely
-\tcode{collate<char>}
-and
-\tcode{collate<wchar_t>},
+The class \tcode{collate<charT>} provides features
+for use in the collation (comparison) and hashing of strings.
+A locale member function template, \tcode{operator()},
+uses the collate facet to allow a locale to act directly as
+the predicate argument for standard algorithms\iref{algorithms} and
+containers operating on strings.
+The specializations
+required in \tref{locale.category.facets}\iref{locale.category},
+namely \tcode{collate<char>} and \tcode{collate<wchar_t>},
 apply lexicographic ordering\iref{alg.lex.comparison}.
 
 \pnum
-Each function compares a string of characters
-\tcode{*p}
-in the range
-\range{low}{high}.
+Each function compares a string of characters \tcode{*p}
+in the range \range{low}{high}.
 
 \rSec4[locale.collate.members]{Members}
 
@@ -3443,16 +3048,13 @@ int do_compare(const charT* low1, const charT* high1,
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{1}
-if the first string is greater than the second,
-\tcode{-1}
-if less, zero otherwise.
-The specializations required in \tref{locale.category.facets}\iref{locale.category}, namely
-\tcode{collate<char>}
-and
-\tcode{collate<wchar_t>},
-implement
-a lexicographical comparison\iref{alg.lex.comparison}.
+\tcode{1} if the first string is greater than the second,
+\tcode{-1} if less,
+zero otherwise.
+The specializations
+required in \tref{locale.category.facets}\iref{locale.category},
+namely \tcode{collate<char>} and \tcode{collate<wchar_t>},
+implement a lexicographical comparison\iref{alg.lex.comparison}.
 \end{itemdescr}
 
 \indexlibrarymember{collate}{do_transform}%
@@ -3463,16 +3065,12 @@ string_type do_transform(const charT* low, const charT* high) const;
 \begin{itemdescr}
 \pnum
 \returns
-A
-\tcode{basic_string<charT>}
-value that, compared lexicographically with the result of calling
-\tcode{transform()}
-on another string, yields the same result as calling
-\tcode{do_compare()}
-on the same two strings.
+A \tcode{basic_string<charT>} value that,
+compared lexicographically with
+the result of calling \tcode{transform()} on another string,
+yields the same result as calling \tcode{do_compare()} on the same two strings.
 \begin{footnote}
-This function is useful when one string is
-being compared to many other strings.
+This function is useful when one string is being compared to many other strings.
 \end{footnote}
 \end{itemdescr}
 
@@ -3484,17 +3082,15 @@ long do_hash(const charT* low, const charT* high) const;
 \begin{itemdescr}
 \pnum
 \returns
-An integer value equal to the result of calling
-\tcode{hash()}
-on any other string for which
-\tcode{do_compare()}
-returns 0 (equal) when passed the two strings.
+An integer value equal to the result of calling \tcode{hash()}
+on any other string for which \tcode{do_compare()} returns 0 (equal)
+when passed the two strings.
 
 \pnum
 \recommended
-The probability that the result equals that for another string which does
-not compare equal should be very small, approaching
-\tcode{(1.0/numeric_limits<unsigned long>::max())}.
+The probability that the result equals that for another string
+which does not compare equal should be very small,
+approaching \tcode{(1.0/numeric_limits<unsigned long>::max())}.
 \end{itemdescr}
 
 \rSec3[locale.collate.byname]{Class template \tcode{collate_byname}}
@@ -3522,25 +3118,18 @@ namespace std {
 
 \pnum
 Templates
-\tcode{time_get<charT, InputIterator>}
-and
+\tcode{time_get<charT, InputIterator>} and
 \tcode{time_put<charT, OutputIterator>}
 provide date and time formatting and parsing.
-All specifications of member functions for
-\tcode{time_put}
-and
-\tcode{time_get}
+All specifications of member functions for \tcode{time_put} and \tcode{time_get}
 in the subclauses of~\ref{category.time} only apply to the
 specializations required in Tables~\ref{tab:locale.category.facets}
 and~\ref{tab:locale.spec}\iref{locale.category}.
 Their members use their
-\tcode{ios_base\&},
-\tcode{ios_base::iostate\&},
-and
-\tcode{fill}
-arguments as described in~\ref{locale.categories}, and the
-\tcode{ctype<>}
-facet, to determine formatting details.
+\tcode{ios_base\&}, \tcode{ios_base::iostate\&}, and \tcode{fill} arguments
+as described in~\ref{locale.categories},
+and the \tcode{ctype<>} facet,
+to determine formatting details.
 
 \rSec3[locale.time.get]{Class template \tcode{time_get}}
 
@@ -3601,15 +3190,9 @@ namespace std {
 \end{codeblock}
 
 \pnum
-\tcode{time_get}
-is used to
-parse a character sequence, extracting components of a time or date
-into a
-\tcode{struct tm}
-object.
-Each
-\tcode{get}
-member parses a format as produced by a corresponding format specifier to
+\tcode{time_get} is used to parse a character sequence,
+extracting components of a time or date into a \tcode{struct tm} object.
+Each \tcode{get} member parses a format as produced by a corresponding format specifier to
 \tcode{time_put<>::put}.
 If the sequence being parsed matches the correct format, the corresponding
 members of the
@@ -3723,56 +3306,64 @@ iter_type get(iter_type s, iter_type end, ios_base& f, ios_base::iostate& err,
 
 \pnum
 \effects
-The function starts by evaluating
-\tcode{err = ios_base::goodbit}. It then enters a loop, reading zero or more
-characters from \tcode{s} at each iteration. Unless otherwise specified below,
+The function starts by evaluating \tcode{err = ios_base::goodbit}.
+It then enters a loop,
+reading zero or more characters from \tcode{s} at each iteration.
+Unless otherwise specified below,
 the loop terminates when the first of the following conditions holds:
 
 \begin{itemize}
-\item The expression \tcode{fmt == fmtend} evaluates to \tcode{true}.
-
-\item The expression \tcode{err == ios_base::goodbit} evaluates to \tcode{false}.
-
-\item The expression \tcode{s == end} evaluates to \tcode{true},
-in which case the function
-evaluates \tcode{err = ios_base::eofbit | ios_base::failbit}.
-
-\item The next element of \tcode{fmt} is equal to
-\tcode{'\%'}, optionally followed by a
-modifier character, followed by a conversion specifier character,
-\tcode{format}, together forming a conversion specification valid for the
-ISO/IEC 9945 function \tcode{strptime}. If the number of elements in the range
-\range{fmt}{fmtend} is not sufficient to unambiguously determine whether the
-conversion specification is complete and valid, the function evaluates
-\tcode{err = ios_base::failbit}. Otherwise, the function evaluates
-\tcode{s = do_get(s, end, f, err, t, format, modifier)}, where the value
-of \tcode{modifier} is \tcode{'\textbackslash0'}
-when the optional modifier is absent from the conversion specification.
-If \tcode{err == ios_base::goodbit} holds after the evaluation of the
-expression, the function increments \tcode{fmt} to point just past the end of
-the conversion specification and continues looping.
-
-\item The expression \tcode{isspace(*fmt, f.getloc())} evaluates to \tcode{true},
+\item
+The expression \tcode{fmt == fmtend} evaluates to \tcode{true}.
+\item
+The expression \tcode{err == ios_base::goodbit} evaluates to \tcode{false}.
+\item
+The expression \tcode{s == end} evaluates to \tcode{true},
 in which case
-the function first increments \tcode{fmt} until
-\tcode{fmt == fmtend || !isspace(*fmt, f.getloc())} evaluates to \tcode{true},
-then advances \tcode{s} until
-\tcode{s == end || !isspace(*s, f.getloc())} is \tcode{true}, and finally resumes looping.
+the function evaluates \tcode{err = ios_base::eofbit | ios_base::failbit}.
+\item
+The next element of \tcode{fmt} is equal to \tcode{'\%'},
+optionally followed by a modifier character,
+followed by a conversion specifier character, \tcode{format},
+together forming a conversion specification
+valid for the ISO/IEC 9945 function \tcode{strptime}.
+If the number of elements in the range \range{fmt}{fmtend}
+is not sufficient to unambiguously determine
+whether the conversion specification is complete and valid,
+the function evaluates \tcode{err = ios_base::failbit}.
+Otherwise,
+the function evaluates \tcode{s = do_get(s, end, f, err, t, format, modifier)},
+where the value of \tcode{modifier} is \tcode{'\textbackslash0'}
+when the optional modifier is absent from the conversion specification.
+If \tcode{err == ios_base::goodbit} holds
+after the evaluation of the expression,
+the function increments \tcode{fmt}
+to point just past the end of the conversion specification and
+continues looping.
 
-\item The next character read from \tcode{s} matches the element
-pointed to by \tcode{fmt} in
-a case-insensitive comparison, in which case the function evaluates
-\tcode{++fmt, ++s} and continues looping. Otherwise, the function evaluates
-\tcode{err = ios_base::failbit}.
+\item
+The expression \tcode{isspace(*fmt, f.getloc())} evaluates to \tcode{true},
+in which case the function first increments \tcode{fmt} until
+\tcode{fmt == fmtend || !isspace(*fmt, f.getloc())} evaluates to \tcode{true},
+then advances \tcode{s}
+until \tcode{s == end || !isspace(*s, f.getloc())} is \tcode{true}, and
+finally resumes looping.
+
+\item
+The next character read from \tcode{s}
+matches the element pointed to by \tcode{fmt} in a case-insensitive comparison,
+in which case the function evaluates \tcode{++fmt, ++s} and continues looping.
+Otherwise, the function evaluates \tcode{err = ios_base::failbit}.
 \end{itemize}
 
 \pnum
 \begin{note}
-The function uses the \tcode{ctype<charT>}
-facet installed in \tcode{f}'s locale
-to determine valid whitespace characters. It is unspecified by what
-means the function performs case-insensitive comparison or whether
-multi-character sequences are considered while doing so.
+The function uses the \tcode{ctype<charT>} facet
+installed in \tcode{f}'s locale
+to determine valid whitespace characters.
+It is unspecified
+by what means the function performs case-insensitive comparison or
+whether multi-character sequences are considered while doing so.
 \end{note}
 
 \pnum
@@ -3790,19 +3381,13 @@ dateorder do_date_order() const;
 \begin{itemdescr}
 \pnum
 \returns
-An enumeration value indicating the preferred order of components for
-those date formats that are composed of day, month, and year.
+An enumeration value indicating the preferred order of components
+for those date formats that are composed of day, month, and year.
 \begin{footnote}
-This
-function is intended as a convenience only, for common
-formats, and can return
-\tcode{no_order}
-in valid locales.
+This function is intended as a convenience only, for common formats, and
+can return \tcode{no_order} in valid locales.
 \end{footnote}
-Returns
-\tcode{no_order}
-if the date format specified by
-\tcode{'x'}
+Returns \tcode{no_order} if the date format specified by \tcode{'x'}
 contains other variable components (e.g., Julian day, week number, week day).
 \end{itemdescr}
 
@@ -3816,18 +3401,16 @@ iter_type do_get_time(iter_type s, iter_type end, ios_base& str,
 \pnum
 \effects
 Reads characters starting at \tcode{s}
-until it has extracted those
-\tcode{struct tm}
-members, and remaining format characters, used by
-\tcode{time_put<>::put}
-to produce the format specified by
-\tcode{"\%H:\%M:\%S"},
+until it has extracted those \tcode{struct tm} members, and
+remaining format characters,
+used by \tcode{time_put<>::put}
+to produce the format specified by \tcode{"\%H:\%M:\%S"},
 or until it encounters an error or end of sequence.
 
 \pnum
 \returns
-An iterator pointing immediately beyond the last character recognized
-as possibly part of a valid time.
+An iterator pointing immediately beyond
+the last character recognized as possibly part of a valid time.
 \end{itemdescr}
 
 \indexlibrarymember{time_get}{do_get_date}%
@@ -3840,14 +3423,13 @@ iter_type do_get_date(iter_type s, iter_type end, ios_base& str,
 \pnum
 \effects
 Reads characters starting at \tcode{s}
-until it has extracted those
-\tcode{struct tm}
-members and remaining format characters used by
-\tcode{time_put<>::put}
+until it has extracted those \tcode{struct tm} members and
+remaining format characters
+used by \tcode{time_put<>::put}
 to produce one of the following formats,
-or until it encounters an error. The format depends on the value returned
-by \tcode{date_order()} as shown in
-\tref{locale.time.get.dogetdate}.
+or until it encounters an error.
+The format depends on the value returned by \tcode{date_order()}
+as shown in \tref{locale.time.get.dogetdate}.
 
 \begin{libtab2}{\tcode{do_get_date} effects}{locale.time.get.dogetdate}
 {ll}{\tcode{date_order()}}{Format}
@@ -3859,12 +3441,13 @@ by \tcode{date_order()} as shown in
 \end{libtab2}
 
 \pnum
-An implementation may also accept additional \impldef{additional formats for \tcode{time_get::do_get_date}} formats.
+An implementation may also accept additional
+\impldef{additional formats for \tcode{time_get::do_get_date}} formats.
 
 \pnum
 \returns
-An iterator pointing immediately beyond the last character recognized
-as possibly part of a valid date.
+An iterator pointing immediately beyond
+the last character recognized as possibly part of a valid date.
 \end{itemdescr}
 
 \indexlibrarymember{time_get}{do_get_weekday}%
@@ -3881,12 +3464,10 @@ iter_type do_get_monthname(iter_type s, iter_type end, ios_base& str,
 \effects
 Reads characters starting at \tcode{s}
 until it has extracted the (perhaps abbreviated) name of a weekday or month.
-If it finds an abbreviation that is followed by characters that can
-match a full name, it continues reading until it matches the full name or
-fails.
-It sets the appropriate
-\tcode{struct tm}
-member accordingly.
+If it finds an abbreviation
+that is followed by characters that can match a full name,
+it continues reading until it matches the full name or fails.
+It sets the appropriate \tcode{struct tm} member accordingly.
 
 \pnum
 \returns
@@ -3906,17 +3487,15 @@ iter_type do_get_year(iter_type s, iter_type end, ios_base& str,
 Reads characters starting at \tcode{s}
 until it has extracted an unambiguous year identifier.
 It is
-\impldef{whether \tcode{time_get::do_get_year} accepts two-digit year numbers} whether
-two-digit year numbers are accepted,
+\impldef{whether \tcode{time_get::do_get_year} accepts two-digit year numbers}
+whether two-digit year numbers are accepted,
 and (if so) what century they are assumed to lie in.
-Sets the
-\tcode{t->tm_year}
-member accordingly.
+Sets the \tcode{t->tm_year} member accordingly.
 
 \pnum
 \returns
-An iterator pointing immediately beyond the last character recognized
-as part of a valid year identifier.
+An iterator pointing immediately beyond
+the last character recognized as part of a valid year identifier.
 \end{itemdescr}
 
 \indexlibrarymember{do_get}{time_get}%
@@ -3932,43 +3511,43 @@ iter_type do_get(iter_type s, iter_type end, ios_base& f,
 
 \pnum
 \effects
-The function starts by evaluating
-\tcode{err = ios_base::goodbit}. It
-then reads characters starting at \tcode{s} until it encounters an error, or
-until it has extracted and assigned those \tcode{struct tm} members, and any
-remaining format characters, corresponding to a conversion directive
-appropriate for the ISO/IEC 9945 function \tcode{strptime}, formed by
-concatenating \tcode{'\%'}, the \tcode{modifier} character,
-when non-NUL, and the \tcode{format}
-character. When the concatenation fails to yield a complete valid
-directive the function leaves the object pointed to by \tcode{t} unchanged and
-evaluates \tcode{err |= ios_base::failbit}. When \tcode{s == end}
-evaluates to \tcode{true} after reading a character the function evaluates
-\tcode{err |= ios_base::eofbit}.
+The function starts by evaluating \tcode{err = ios_base::goodbit}.
+It then reads characters starting at \tcode{s} until it encounters an error, or
+until it has extracted and assigned those \tcode{struct tm} members, and
+any remaining format characters,
+corresponding to a conversion directive appropriate for
+the ISO/IEC 9945 function \tcode{strptime},
+formed by concatenating \tcode{'\%'},
+the \tcode{modifier} character, when non-NUL, and
+the \tcode{format} character.
+When the concatenation fails to yield a complete valid directive
+the function leaves the object pointed to by \tcode{t} unchanged and
+evaluates \tcode{err |= ios_base::failbit}.
+When \tcode{s == end} evaluates to \tcode{true} after reading a character
+the function evaluates \tcode{err |= ios_base::eofbit}.
 
 \pnum
-For complex conversion directives such as \tcode{\%c},
-\tcode{\%x}, or \tcode{\%X}, or directives
-that involve the optional modifiers \tcode{E} or \tcode{O},
-when the function is unable
-to unambiguously determine some or all \tcode{struct tm} members from the input
-sequence \range{s}{end}, it evaluates \tcode{err |= ios_base::eofbit}.
+For complex conversion directives
+such as \tcode{\%c}, \tcode{\%x}, or \tcode{\%X}, or
+directives that involve the optional modifiers \tcode{E} or \tcode{O},
+when the function is unable to unambiguously determine
+some or all \tcode{struct tm} members from the input sequence \range{s}{end},
+it evaluates \tcode{err |= ios_base::eofbit}.
 In such cases the values of those \tcode{struct tm} members are unspecified
 and may be outside their valid range.
 
 \pnum
 \returns
-An iterator pointing immediately beyond the last character
-recognized as possibly part of a valid input sequence for the given
-\tcode{format} and \tcode{modifier}.
+An iterator pointing immediately beyond
+the last character recognized as possibly part of
+a valid input sequence for the given \tcode{format} and \tcode{modifier}.
 
 \pnum
 \remarks
-It is unspecified whether multiple calls to
-\tcode{do_get()} with the
-address of the same \tcode{struct tm} object will update the current contents of
-the object or simply overwrite its members. Portable programs should zero
-out the object before invoking the function.
+It is unspecified whether multiple calls to \tcode{do_get()}
+with the address of the same \tcode{struct tm} object
+will update the current contents of the object or simply overwrite its members.
+Portable programs should zero out the object before invoking the function.
 \end{itemdescr}
 
 \rSec3[locale.time.get.byname]{Class template \tcode{time_get_byname}}
@@ -4033,57 +3612,37 @@ iter_type put(iter_type s, ios_base& str, char_type fill, const tm* t,
 \begin{itemdescr}
 \pnum
 \effects
-The first form steps through the sequence from
-\tcode{pattern}
-to
-\tcode{pat_end},
+The first form steps through the sequence
+from \tcode{pattern} to \tcode{pat_end},
 identifying characters that are part of a format sequence.
-Each character that is not part of a format sequence is written to
-\tcode{s}
-immediately, and each format sequence, as it is identified, results in
-a call to
-\tcode{do_put};
+Each character that is not part of a format sequence
+is written to \tcode{s} immediately, and
+each format sequence, as it is identified, results in a call to \tcode{do_put};
 thus, format elements and other characters are interleaved in the output
 in the order in which they appear in the pattern.
-Format sequences are identified by converting each character
-\tcode{c}
-to a
-\tcode{char}
-value as if by
-\tcode{ct.narrow(c, 0)},
-where
-\tcode{ct}
-is a reference to
-\tcode{ctype<charT>}
-obtained from
-\tcode{str.getloc()}.
-The first character of each sequence is equal to
-\tcode{'\%'},
-followed by an optional modifier character
-\tcode{mod}
+Format sequences are identified by converting each character \tcode{c} to
+a \tcode{char} value as if by \tcode{ct.narrow(c, 0)},
+where \tcode{ct} is a reference to \tcode{ctype<charT>}
+obtained from \tcode{str.getloc()}.
+The first character of each sequence is equal to \tcode{'\%'},
+followed by an optional modifier character \tcode{mod}
 \begin{footnote}
-Although the C programming language defines no modifiers,
-most vendors do.
+Although the C programming language defines no modifiers, most vendors do.
 \end{footnote}
-and a format specifier character
-\tcode{spec}
-as defined for the function
-\tcode{strftime}.
-If no modifier character is present,
-\tcode{mod}
-is zero.
-For each valid format sequence identified, calls
-\tcode{do_put(s, str, fill, t, spec, mod)}.
+and a format specifier character \tcode{spec}
+as defined for the function \tcode{strftime}.
+If no modifier character is present, \tcode{mod} is zero.
+For each valid format sequence identified,
+calls \tcode{do_put(s, str, fill, t, spec, mod)}.
 
 \pnum
-The second form calls
-\tcode{do_put(s, str, fill, t, format, modifier)}.
+The second form calls \tcode{do_put(s, str, fill, t, format, modifier)}.
 
 \pnum
 \begin{note}
-The \tcode{fill} argument can be used in the implementation-defined
-formats or by derivations. A space character is a reasonable
-default for this argument.
+The \tcode{fill} argument can be used
+in the implementation-defined formats or by derivations.
+A space character is a reasonable default for this argument.
 \end{note}
 
 \pnum
@@ -4105,26 +3664,26 @@ iter_type do_put(iter_type s, ios_base&, char_type fill, const tm* t,
 Formats the contents of the parameter \tcode{t}
 into characters placed on the output sequence \tcode{s}.
 Formatting is controlled by the parameters \tcode{format} and \tcode{modifier},
-interpreted identically as the format specifiers in the string
-argument to the standard library function
+interpreted identically as the format specifiers
+in the string argument to the standard library function
 \indexlibraryglobal{strftime}%
 \tcode{strftime()},
 except that the sequence of characters produced for those specifiers
-that are described as depending on the C locale are instead \impldef{formatted character
-sequence generated by \tcode{time_put::do_put} in C
-locale}.
+that are described as depending on the C locale
+are instead
+\impldef{formatted character sequence generated by \tcode{time_put::do_put}
+in C locale}.
 \begin{note}
-Interpretation of the \tcode{modifier}
-argument is implementation-defined.
+Interpretation of the \tcode{modifier} argument is implementation-defined.
 \end{note}
 
 \pnum
 \returns
 An iterator pointing immediately after the last character produced.
 \begin{note}
-The \tcode{fill} argument can be used in the implementation-defined
-formats or by derivations. A space character is a reasonable
-default for this argument.
+The \tcode{fill} argument can be used
+in the implementation-defined formats or by derivations.
+A space character is a reasonable default for this argument.
 \end{note}
 
 \pnum
@@ -4161,27 +3720,19 @@ namespace std {
 
 \pnum
 These templates handle monetary formats.
-A template parameter indicates whether
-local or international monetary formats are to be used.
+A template parameter indicates
+whether local or international monetary formats are to be used.
 
 \pnum
-All specifications of member functions for
-\tcode{money_put}
-and
-\tcode{money_get}
-in the subclauses of~\ref{category.monetary} only apply to the
-specializations required in Tables~\ref{tab:locale.category.facets}
+All specifications of member functions
+for \tcode{money_put} and \tcode{money_get}
+in the subclauses of~\ref{category.monetary} only apply to
+the specializations required in Tables~\ref{tab:locale.category.facets}
 and~\ref{tab:locale.spec}\iref{locale.category}.
-Their members use their
-\tcode{ios_base\&},
-\tcode{ios_base::io\-state\&},
-and
-\tcode{fill}
-arguments as described in~\ref{locale.categories}, and the
-\tcode{moneypunct<>}
-and
-\tcode{ctype<>}
-facets, to determine formatting details.
+Their members use their \tcode{ios_base\&}, \tcode{ios_base::io\-state\&},
+and \tcode{fill} arguments as described in~\ref{locale.categories}, and
+the \tcode{moneypunct<>} and \tcode{ctype<>} facets,
+to determine formatting details.
 
 \rSec3[locale.money.get]{Class template \tcode{money_get}}
 
@@ -4245,141 +3796,89 @@ iter_type do_get(iter_type s, iter_type end, bool intl, ios_base& str,
 \begin{itemdescr}
 \pnum
 \effects
-Reads characters from
-\tcode{s}
-to parse and construct a monetary value according to the
-format specified by a
-\tcode{moneypunct<charT, Intl>}
-facet reference
-\tcode{mp}
-and the character mapping specified by a
-\tcode{ctype<charT>}
-facet reference
-\tcode{ct}
-obtained from the locale returned by
-\tcode{str.getloc()},
-and
+Reads characters from \tcode{s} to parse and construct a monetary value
+according to the format specified by
+a \tcode{moneypunct<charT, Intl>} facet reference \tcode{mp}
+and the character mapping specified by
+a \tcode{ctype<charT>} facet reference \tcode{ct}
+obtained from the locale returned by \tcode{str.getloc()}, and
 \tcode{str.flags()}.
-If a valid sequence is recognized,
-does not change \tcode{err};
-otherwise, sets \tcode{err} to
-\tcode{(err|str.failbit)},
-or
-\tcode{(err|str.failbit|str.eof\-bit)}
-if no more characters are available,
+If a valid sequence is recognized, does not change \tcode{err};
+otherwise, sets \tcode{err} to \tcode{(err|str.failbit)}, or
+\tcode{(err|str.failbit|str.eof\-bit)} if no more characters are available,
 and does not change \tcode{units} or \tcode{digits}.
-Uses the pattern returned by
-\tcode{mp.neg_format()}
-to parse all values.
-The result is returned as an integral value stored in
-\tcode{units}
+Uses the pattern returned by \tcode{mp.neg_format()} to parse all values.
+The result is returned as an integral value stored in \tcode{units}
 or as a sequence of digits possibly preceded by a minus sign
-(as produced by
-\tcode{ct.widen(c)}
-where
-\tcode{c}
-is
-\tcode{'-'}
-or in the range from
-\tcode{'0'}
-through
-\tcode{'9'}
-(inclusive))
-stored in
-\tcode{digits}.
+(as produced by \tcode{ct.widen(c)}
+where \tcode{c} is \tcode{'-'} or
+in the range from \tcode{'0'} through \tcode{'9'} (inclusive))
+stored in \tcode{digits}.
 \begin{example}
-The sequence
-\tcode{\$1,056.23}
-in a common United States locale would yield, for
-\tcode{units},
-\tcode{105623},
-or, for
-\tcode{digits},
-\tcode{"105623"}.
+The sequence \tcode{\$1,056.23} in a common United States locale would yield,
+for \tcode{units}, \tcode{105623}, or,
+for \tcode{digits}, \tcode{"105623"}.
 \end{example}
-If
-\tcode{mp.grouping()}
-indicates that no thousands separators are permitted,
-any such characters are not read, and parsing is terminated at the point
-where they first appear.
+If \tcode{mp.grouping()} indicates that no thousands separators are permitted,
+any such characters are not read, and
+parsing is terminated at the point where they first appear.
 Otherwise, thousands separators are optional;
 if present, they are checked for correct placement only after
 all format components have been read.
 
 \pnum
-Where
-\tcode{money_base::space}
-or
-\tcode{money_base::none}
+Where \tcode{money_base::space} or \tcode{money_base::none}
 appears as the last element in the format pattern,
-no whitespace is consumed. Otherwise, where \tcode{money_base::space} appears in any of the
-initial elements of the format pattern, at least one whitespace character is required. Where
-\tcode{money_base::none} appears in any of the initial elements of the format pattern, white
-space is allowed but not required.
-If
-\tcode{(str.flags() \& str.showbase)}
-is \tcode{false}, the currency symbol is optional and is consumed only if
-other characters are needed to complete the format;
+no whitespace is consumed.
+Otherwise, where \tcode{money_base::space} appears in any of
+the initial elements of the format pattern,
+at least one whitespace character is required.
+Where \tcode{money_base::none} appears
+in any of the initial elements of the format pattern,
+white space is allowed but not required.
+If \tcode{(str.flags() \& str.showbase)} is \tcode{false},
+the currency symbol is optional and
+is consumed only if other characters are needed to complete the format;
 otherwise, the currency symbol is required.
 
 \pnum
-If the first character (if any) in the string
-\tcode{pos}
-returned by
-\tcode{mp.positive_sign()}
-or the string
-\tcode{neg}
-returned by
-\tcode{mp.negative_sign()}
-is recognized in the position indicated by
-\tcode{sign}
-in the format pattern, it is consumed and any remaining characters
-in the string are required after all the other format components.
+If the first character (if any) in
+the string \tcode{pos} returned by \tcode{mp.positive_sign()} or
+the string \tcode{neg} returned by \tcode{mp.negative_sign()}
+is recognized in the position indicated by \tcode{sign} in the format pattern,
+it is consumed and
+any remaining characters in the string are required
+after all the other format components.
 \begin{example}
-If
-\tcode{showbase}
-is off, then for a
-\tcode{neg}
-value of \tcode{"()"} and a currency symbol of \tcode{"L"},
+If \tcode{showbase} is off,
+then for a \tcode{neg} value of \tcode{"()"} and
+a currency symbol of \tcode{"L"},
 in \tcode{"(100 L)"} the \tcode{"L"} is consumed;
-but if
-\tcode{neg}
-is \tcode{"-"}, the \tcode{"L"} in \tcode{"-100 L"} is not consumed.
+but if \tcode{neg} is \tcode{"-"},
+the \tcode{"L"} in \tcode{"-100 L"} is not consumed.
 \end{example}
-If
-\tcode{pos}
-or
-\tcode{neg}
-is empty, the sign component is optional, and if no sign is
-detected, the result is given the sign that corresponds to the source
-of the empty string.
-Otherwise, the character in the indicated position must
-match the first character of
-\tcode{pos}
-or
-\tcode{neg},
+If \tcode{pos} or \tcode{neg} is empty,
+the sign component is optional, and
+if no sign is detected,
+the result is given the sign that corresponds to the source of the empty string.
+Otherwise,
+the character in the indicated position must match
+the first character of \tcode{pos} or \tcode{neg},
 and the result is given the corresponding sign.
-If the first character of
-\tcode{pos}
-is equal to the first character of
-\tcode{neg},
-or if both strings are empty, the result is given a positive sign.
+If the first character of \tcode{pos} is equal to
+the first character of \tcode{neg},
+or if both strings are empty,
+the result is given a positive sign.
 
 \pnum
-Digits in the numeric monetary component are extracted and placed in
-\tcode{digits},
-or into a character buffer
-\tcode{buf1}
-for conversion to produce a value for
-\tcode{units},
+Digits in the numeric monetary component are extracted and
+placed in \tcode{digits}, or into a character buffer \tcode{buf1}
+for conversion to produce a value for \tcode{units},
 in the order in which they appear,
 preceded by a minus sign if and only if the result is negative.
-The value
-\tcode{units}
-is produced as if by
+The value \tcode{units} is produced as if by
 \begin{footnote}
-The semantics here are different from
-\tcode{ct.narrow}.
+The semantics here are different from \tcode{ct.narrow}.
 \end{footnote}
 \begin{codeblock}
 for (int i = 0; i < n; ++i)
@@ -4387,16 +3886,9 @@ for (int i = 0; i < n; ++i)
 buf2[n] = 0;
 sscanf(buf2, "%Lf", &units);
 \end{codeblock}
-where
-\tcode{n}
-is the number of characters placed in
-\tcode{buf1},
-\tcode{buf2}
-is a character buffer, and the values
-\tcode{src}
-and
-\tcode{atoms}
-are defined as if by
+where \tcode{n} is the number of characters placed in \tcode{buf1},
+\tcode{buf2} is a character buffer, and
+the values \tcode{src} and \tcode{atoms} are defined as if by
 \begin{codeblock}
 static const char src[] = "0123456789-";
 charT atoms[sizeof(src)];
@@ -4405,8 +3897,8 @@ ct.widen(src, src + sizeof(src) - 1, atoms);
 
 \pnum
 \returns
-An iterator pointing immediately beyond the last character recognized
-as part of a valid monetary quantity.
+An iterator pointing immediately beyond
+the last character recognized as part of a valid monetary quantity.
 \end{itemdescr}
 
 \rSec3[locale.money.put]{Class template \tcode{money_put}}
@@ -4467,56 +3959,37 @@ iter_type do_put(iter_type s, bool intl, ios_base& str,
 \begin{itemdescr}
 \pnum
 \effects
-Writes characters to
-\tcode{s}
-according to the format specified by a
-\tcode{moneypunct<charT, Intl>}
-facet reference
-\tcode{mp}
-and the character mapping specified by a
-\tcode{ctype<charT>}
-facet reference
-\tcode{ct}
-obtained from the locale returned by
-\tcode{str.getloc()},
-and
-\tcode{str.flags()}.
-The argument
-\tcode{units}
-is transformed into a sequence of wide characters as if by
+Writes characters to \tcode{s} according to
+the format specified by
+a \tcode{moneypunct<charT, Intl>} facet reference \tcode{mp} and
+the character mapping specified by
+a \tcode{ctype<charT>} facet reference \tcode{ct}
+obtained from the locale returned by \tcode{str.getloc()},
+and \tcode{str.flags()}.
+The argument \tcode{units} is transformed into
+a sequence of wide characters as if by
 \begin{codeblock}
 ct.widen(buf1, buf1 + sprintf(buf1, "%.0Lf", units), buf2)
 \end{codeblock}
-for character buffers
-\tcode{buf1}
-and
-\tcode{buf2}.
-If the first character in
-\tcode{digits}
-or
-\tcode{buf2}
-is equal to
-\tcode{ct.widen('-')},
-then the pattern used for formatting is the result of
-\tcode{mp.neg_format()};
-otherwise the pattern is the result of
-\tcode{mp.pos_format()}.
-Digit characters are written, interspersed with any thousands separators
-and decimal point specified by the format, in the order they appear
-(after the optional leading minus sign)
-in
-\tcode{digits}
-or
-\tcode{buf2}.
-In
-\tcode{digits},
-only the optional leading minus sign and the immediately subsequent
-digit characters (as classified according to
-\tcode{ct})
-are used; any trailing characters (including digits appearing
-after a non-digit character) are ignored.
-Calls
-\tcode{str.width(0)}.
+for character buffers \tcode{buf1} and \tcode{buf2}.
+If the first character in \tcode{digits} or \tcode{buf2}
+is equal to \tcode{ct.widen('-')},
+then the pattern used for formatting is the result of \tcode{mp.neg_format()};
+otherwise the pattern is the result of \tcode{mp.pos_format()}.
+Digit characters are written,
+interspersed with any thousands separators and decimal point
+specified by the format,
+in the order they appear (after the optional leading minus sign) in
+\tcode{digits} or \tcode{buf2}.
+In \tcode{digits},
+only the optional leading minus sign and
+the immediately subsequent digit characters
+(as classified according to \tcode{ct})
+are used;
+any trailing characters
+(including digits appearing after a non-digit character)
+are ignored.
+Calls \tcode{str.width(0)}.
 
 \pnum
 \returns
@@ -4525,33 +3998,22 @@ An iterator pointing immediately after the last character produced.
 \pnum
 \remarks
 % issues 22-021, 22-030, 22-034 from 97-0058/N1096, 97-0036/N1074
-The currency symbol is generated if and only if
-\tcode{(str.flags() \& str.showbase)}
-is nonzero.
-If the number of characters generated for the specified format is less than the value
-returned by
-\tcode{str.width()}
-on entry to the function, then copies of
-\tcode{fill}
-are inserted as necessary to pad to the specified width.
-For the value
-\tcode{af}
-equal to
-\tcode{(str.flags() \& str.adjustfield)},
-if
-\tcode{(af == str.internal)}
-is \tcode{true}, the fill characters are placed where
-\tcode{none}
-or
-\tcode{space}
-appears in the formatting pattern; otherwise if
-\tcode{(af == str.left)}
-is \tcode{true}, they are placed after the other characters;
+The currency symbol is generated
+if and only if \tcode{(str.flags() \& str.showbase)} is nonzero.
+If the number of characters generated for the specified format
+is less than the value returned by \tcode{str.width()} on entry to the function,
+then copies of \tcode{fill} are inserted as necessary
+to pad to the specified width.
+For the value \tcode{af} equal to \tcode{(str.flags() \& str.adjustfield)},
+if \tcode{(af == str.internal)} is \tcode{true},
+the fill characters are placed
+where \tcode{none} or \tcode{space} appears in the formatting pattern;
+otherwise if \tcode{(af == str.left)} is \tcode{true},
+they are placed after the other characters;
 otherwise, they are placed before the other characters.
 \begin{note}
 It is possible, with some combinations of format patterns and flag values,
-to produce output that cannot be parsed using
-\tcode{num_get<>::get}.
+to produce output that cannot be parsed using \tcode{num_get<>::get}.
 \end{note}
 \end{itemdescr}
 
@@ -4605,82 +4067,41 @@ namespace std {
 \end{codeblock}
 
 \pnum
-The
-\tcode{moneypunct<>}
-facet defines monetary formatting parameters used by
-\tcode{money_get<>}
-and
-\tcode{money_put<>}.
+The \tcode{moneypunct<>} facet defines monetary formatting parameters
+used by \tcode{money_get<>} and \tcode{money_put<>}.
 A monetary format is a sequence of four components,
-specified by a
-\tcode{pattern}
-value
-\tcode{p},
-such that the
-\tcode{part}
-value
-\tcode{static_cast<part>(p.field[i])}
-determines the
-$\tcode{i}^\text{th}$
-component of the format
+specified by a \tcode{pattern} value \tcode{p},
+such that the \tcode{part} value \tcode{static_cast<part>(p.field[i])}
+determines the $\tcode{i}^\text{th}$ component of the format
 \begin{footnote}
-An array of
-\tcode{char},
-rather than an array of
-\tcode{part},
-is specified for
-\tcode{pattern::field}
-purely for efficiency.
+An array of \tcode{char},
+rather than an array of \tcode{part},
+is specified for \tcode{pattern::field} purely for efficiency.
 \end{footnote}
-In the
-\tcode{field}
-member of a
-\tcode{pattern}
-object, each value
-\tcode{symbol},
-\tcode{sign},
-\tcode{value},
-and either
-\tcode{space}
-or
-\tcode{none}
+In the \tcode{field} member of a \tcode{pattern} object,
+each value \tcode{symbol}, \tcode{sign}, \tcode{value}, and
+either \tcode{space} or \tcode{none}
 appears exactly once.
-The value
-\tcode{none},
-if present, is not first;
-the value
-\tcode{space},
-if present, is neither first nor last.
+The value \tcode{none}, if present, is not first;
+the value \tcode{space}, if present, is neither first nor last.
 
 \pnum
-Where
-\tcode{none}
-or
-\tcode{space}
-appears, whitespace is permitted in the format,
-except where
-\tcode{none}
-appears at the end, in which case no whitespace is permitted.
-The value
-\tcode{space}
-indicates that at least one space is required at that position.
-Where
-\tcode{symbol}
-appears, the sequence of characters returned by
-\tcode{curr_symbol()}
-is permitted, and can be required.
-Where
-\tcode{sign}
-appears, the first (if any) of the sequence of characters returned by
-\tcode{positive_sign()}
-or
-\tcode{negative_sign()}
+Where \tcode{none} or \tcode{space} appears,
+whitespace is permitted in the format,
+except where \tcode{none} appears at the end,
+in which case no whitespace is permitted.
+The value \tcode{space} indicates that
+at least one space is required at that position.
+Where \tcode{symbol} appears,
+the sequence of characters returned by \tcode{curr_symbol()} is permitted, and
+can be required.
+Where \tcode{sign} appears,
+the first (if any) of the sequence of characters returned by
+\tcode{positive_sign()} or \tcode{negative_sign()}
 (respectively as the monetary value is non-negative or negative) is required.
-Any remaining characters of the sign sequence are required after all
-other format components.
-Where
-\tcode{value}
-appears, the absolute numeric monetary value is required.
+Any remaining characters of the sign sequence are required after
+all other format components.
+Where \tcode{value} appears, the absolute numeric monetary value is required.
 
 \pnum
 The format of the numeric monetary value is a decimal number:
@@ -4714,8 +4135,8 @@ The other symbols are defined as follows:
     adigit \opt{digits}
 \end{ncbnf}
 
-In the syntax specification, the symbol \locgrammarterm{adigit}
-is any of the values \tcode{ct.widen(c)}
+In the syntax specification,
+the symbol \locgrammarterm{adigit} is any of the values \tcode{ct.widen(c)}
 for \tcode{c} in the range \tcode{'0'} through \tcode{'9'} (inclusive) and
 \tcode{ct} is a reference of type \tcode{const ctype<charT>\&}
 obtained as described in the definitions
@@ -4730,10 +4151,8 @@ is exactly the value returned by \tcode{frac_digits()}.
 
 \pnum
 The placement of thousands-separator characters (if any)
-is determined by the value returned by
-\tcode{grouping()},
-defined identically as the member
-\tcode{numpunct<>::do_grouping()}.
+is determined by the value returned by \tcode{grouping()},
+defined identically as the member \tcode{numpunct<>::do_grouping()}.
 
 \rSec4[locale.moneypunct.members]{Members}
 
@@ -4774,12 +4193,10 @@ charT do_decimal_point() const;
 \begin{itemdescr}
 \pnum
 \returns
-The radix separator to use in case
-\tcode{do_frac_digits()}
-is greater than zero.
+The radix separator to use
+in case \tcode{do_frac_digits()} is greater than zero.
 \begin{footnote}
-In common U.S. locales this is
-\tcode{'.'}.
+In common U.S. locales this is \tcode{'.'}.
 \end{footnote}
 \end{itemdescr}
 
@@ -4791,12 +4208,10 @@ charT do_thousands_sep() const;
 \begin{itemdescr}
 \pnum
 \returns
-The digit group separator to use in case
-\tcode{do_grouping()}
-specifies a digit grouping pattern.
+The digit group separator to use
+in case \tcode{do_grouping()} specifies a digit grouping pattern.
 \begin{footnote}
-In common U.S. locales this is
-\tcode{','}.
+In common U.S. locales this is \tcode{','}.
 \end{footnote}
 \end{itemdescr}
 
@@ -4808,13 +4223,11 @@ string do_grouping() const;
 \begin{itemdescr}
 \pnum
 \returns
-A pattern defined identically as, but not necessarily equal to, the result of
-\tcode{numpunct<charT>::\brk{}do_grouping()}.
+A pattern defined identically as, but not necessarily equal to,
+the result of \tcode{numpunct<charT>::\brk{}do_grouping()}.
 \begin{footnote}
 To specify grouping by 3s,
-the value is \tcode{"\textbackslash003"}
-\textit{not}
-\tcode{"3"}.
+the value is \tcode{"\textbackslash003"} \textit{not} \tcode{"3"}.
 \end{footnote}
 \end{itemdescr}
 
@@ -4829,8 +4242,8 @@ string_type do_curr_symbol() const;
 A string to use as the currency identifier symbol.
 \begin{note}
 For specializations where the second template parameter is \tcode{true},
-this is typically four characters long: a three-letter code as specified
-by ISO 4217 followed by a space.
+this is typically four characters long:
+a three-letter code as specified by ISO 4217 followed by a space.
 \end{note}
 \end{itemdescr}
 
@@ -4845,8 +4258,7 @@ string_type do_negative_sign() const;
 \pnum
 \returns
 \tcode{do_positive_sign()}
-returns the string to use to indicate a
-positive monetary value;
+returns the string to use to indicate a positive monetary value;
 \begin{footnote}
 This is usually the empty string.
 \end{footnote}
@@ -4864,8 +4276,7 @@ int do_frac_digits() const;
 \returns
 The number of digits after the decimal radix separator, if any.
 \begin{footnote}
-In
-common U.S.\ locales, this is 2.
+In common U.S.\ locales, this is 2.
 \end{footnote}
 \end{itemdescr}
 
@@ -4883,18 +4294,13 @@ The specializations required in \tref{locale.spec}\iref{locale.category}, namely
 \begin{itemize}
 \item \tcode{moneypunct<char>},
 \item \tcode{moneypunct<wchar_t>},
-\item \tcode{moneypunct<char, true>},
-and
+\item \tcode{moneypunct<char, true>}, and
 \item \tcode{moneypunct<wchar_t, true>},
 \end{itemize}
-return an object of type
-\tcode{pattern}
-initialized to
-\tcode{\{ symbol, sign, none, value \}}.
+return an object of type \tcode{pattern}
+initialized to \tcode{\{ symbol, sign, none, value \}}.
 \begin{footnote}
-Note that the international
-symbol returned by
-\tcode{do_curr_symbol()}
+Note that the international symbol returned by \tcode{do_curr_symbol()}
 usually contains a space, itself;
 for example, \tcode{"USD "}.
 \end{footnote}
@@ -4925,8 +4331,7 @@ namespace std {
 \rSec3[category.messages.general]{General}
 
 \pnum
-Class
-\tcode{messages<charT>}
+Class \tcode{messages<charT>}
 implements retrieval of strings from message catalogs.
 
 \rSec3[locale.messages]{Class template \tcode{messages}}
@@ -4967,14 +4372,9 @@ namespace std {
 \end{codeblock}
 
 \pnum
-Values of type
-\tcode{messages_base::catalog}
-usable as arguments to members
-\tcode{get}
-and
-\tcode{close}
-can be obtained only by calling member
-\tcode{open}.
+Values of type \tcode{messages_base::catalog}
+usable as arguments to members \tcode{get} and \tcode{close}
+can be obtained only by calling member \tcode{open}.
 
 \rSec4[locale.messages.members]{Members}
 
@@ -5008,8 +4408,7 @@ void close(catalog cat) const;
 \begin{itemdescr}
 \pnum
 \effects
-Calls
-\tcode{do_close(cat)}.
+Calls \tcode{do_close(cat)}.
 \end{itemdescr}
 
 \rSec4[locale.messages.virtuals]{Virtual functions}
@@ -5022,22 +4421,20 @@ catalog do_open(const string& name, const locale& loc) const;
 \begin{itemdescr}
 \pnum
 \returns
-A value that may be passed to
-\tcode{get()}
-to retrieve a message from the message catalog identified by the string
-\tcode{name} according to an \impldef{mapping from name to catalog when calling
+A value that may be passed to \tcode{get()}
+to retrieve a message from the message catalog
+identified by the string \tcode{name}
+according to an \impldef{mapping from name to catalog when calling
 \tcode{mes\-sages::do_open}} mapping.
-The result can be used until it is passed to
-\tcode{close()}.
+The result can be used until it is passed to \tcode{close()}.
 
 \pnum
 Returns a value less than 0 if no such catalog can be opened.
 
 \pnum
 \remarks
-The locale argument \tcode{loc}
-is used for character set code conversion when retrieving
-messages, if needed.
+The locale argument \tcode{loc} is used for
+character set code conversion when retrieving messages, if needed.
 \end{itemdescr}
 
 \indexlibrarymember{messages}{do_get}%
@@ -5048,15 +4445,15 @@ string_type do_get(catalog cat, int set, int msgid, const string_type& dfault) c
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{cat} is a catalog obtained from
-\tcode{open()}
-and not yet closed.
+\tcode{cat} is a catalog obtained from \tcode{open()} and not yet closed.
 
 \pnum
 \returns
-A message identified by arguments \tcode{set}, \tcode{msgid}, and \tcode{dfault}, according
-to an \impldef{mapping to message when calling \tcode{messages::do_get}} mapping. If no
-such message can be found, returns \tcode{dfault}.
+A message identified by
+arguments \tcode{set}, \tcode{msgid}, and \tcode{dfault},
+according to
+an \impldef{mapping to message when calling \tcode{messages::do_get}} mapping.
+If no such message can be found, returns \tcode{dfault}.
 \end{itemdescr}
 
 \indexlibrarymember{message}{do_close}%
@@ -5067,9 +4464,7 @@ void do_close(catalog cat) const;
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{cat} is a catalog obtained from
-\tcode{open()}
-and not yet closed.
+\tcode{cat} is a catalog obtained from \tcode{open()} and not yet closed.
 
 \pnum
 \effects
@@ -5077,7 +4472,8 @@ Releases unspecified resources associated with  \tcode{cat}.
 
 \pnum
 \remarks
-The limit on such resources, if any, is \impldef{resource limits on a message catalog}.
+The limit on such resources, if any, is
+\impldef{resource limits on a message catalog}.
 \end{itemdescr}
 
 \rSec3[locale.messages.byname]{Class template \tcode{messages_byname}}
@@ -5138,9 +4534,10 @@ are the same as the C standard library header \libheader{locale.h}.
 \rSec2[clocale.data.races]{Data races}
 
 \pnum
-Calls to the function \tcode{setlocale} may introduce a data
-race\iref{res.on.data.races} with other calls to \tcode{setlocale} or with calls to
-the functions listed in \tref{setlocale.data.races}.
+Calls to the function \tcode{setlocale}
+may introduce a data race\iref{res.on.data.races}
+with other calls to \tcode{setlocale} or
+with calls to the functions listed in \tref{setlocale.data.races}.
 
 \xrefc{7.11}
 


### PR DESCRIPTION
Also add two missing periods and remove one instance
of superfluous whitespace.