### PR TITLE
[concepts.equality] Turn 'e.g.' into a proper example.

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -46,10 +46,14 @@ The operands of the expression \tcode{a = std::move(b)} are
 \end{example}
 
 \pnum
-Not all input values need be valid for a given expression; e.g., for integers
-\tcode{a} and \tcode{b}, the expression \tcode{a / b} is not well-defined when
-\tcode{b} is \tcode{0}. This does not preclude the expression \tcode{a / b}
-being equality-preserving. The \term{domain} of an expression is the set of
+Not all input values need be valid for a given expression.
+\begin{example}
+For integers \tcode{a} and \tcode{b},
+the expression \tcode{a / b} is not well-defined
+when \tcode{b} is \tcode{0}.
+This does not preclude the expression \tcode{a / b} being equality-preserving.
+\end{example}
+The \defnx{domain}{expression!domain} of an expression is the set of
 input values for which the expression is required to be well-defined.
 
 \pnum


### PR DESCRIPTION
Fixes #4432