### PR TITLE
[over.built] Correct note re: "hiding" to match over.match.oper/3

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3421,10 +3421,10 @@ described in~\ref{over.match.oper}, after a built-in operator is selected
 by overload resolution the expression is subject to the requirements for
 the built-in operator given in \ref{expr.compound}, and therefore to any
 additional semantic constraints given there.
-If there is a user-written
-candidate with the same name and parameter types as a built-in
-candidate operator function, the built-in operator function
-is hidden and is not included in the set of candidate functions.
+In some cases, user-written candidates
+with the same name and parameter types as a built-in
+candidate operator function cause the built-in operator function
+to not be included in the set of candidate functions.
 \end{note}
 
 \pnum


### PR DESCRIPTION
The note in [over.built] uses "hidden" to describe how built-in candidates are removed from consideration; however, this is not hiding in the sense of name lookup. This PR removes the bad terminology and also corrects the note to defer to the normative text regarding the conditions upon user-written candidates that suppress built-in candidates.
