### PR TITLE
[range.split.outer] Clarify scope of exposition-only 'current'

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -5603,7 +5603,7 @@ namespace std::ranges {
 \end{codeblock}
 
 \pnum
-Many of the following specifications refer to the notional member
+Many of the specifications in \ref{range.split} refer to the notional member
 \placeholder{current} of \exposid{outer-iterator}.
 \placeholder{current} is equivalent to \exposid{current_} if \tcode{V}
 models \libconcept{forward_range}, and \tcode{\exposid{parent_}->\exposid{current_}} otherwise.


### PR DESCRIPTION
Fixes #3847