### PR TITLE
[expr.prim.req.type] Clarify example comment re: validity of name only

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2737,7 +2737,8 @@ template<typename T> using Ref = T&;
 
 template<typename T> concept C = requires {
   typename T::inner;    // required nested member name
-  typename S<T>;        // required class template specialization
+  typename S<T>;        // required valid~(\ref{temp.names}) \grammarterm{template-id};
+                        // fails if \tcode{T::type} does not exist as a type to which \tcode{0} can be implicitly converted
   typename Ref<T>;      // required alias template substitution, fails if \tcode{T} is void
 };
 \end{codeblock}


### PR DESCRIPTION
The comment that a class template specialization is required can be taken as meaning that more is required than the validity of the _template-id_ (which is all that the requirement really checks).