### PR TITLE
[specialized.algorithms] Qualify declarator-id with sub-namespace.

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -10368,14 +10368,12 @@ for (; first != last; ++first)
 
 \indexlibraryglobal{uninitialized_default_construct}%
 \begin{itemdecl}
-namespace ranges {
-  template<@\placeholdernc{nothrow-forward-iterator}@ I, @\placeholder{nothrow-sentinel-for}@<I> S>
-    requires @\libconcept{default_initializable}@<iter_value_t<I>>
-    I uninitialized_default_construct(I first, S last);
-  template<@\placeholdernc{nothrow-forward-range}@ R>
-    requires @\libconcept{default_initializable}@<range_value_t<R>>
-    borrowed_iterator_t<R> uninitialized_default_construct(R&& r);
-}
+template<@\placeholdernc{nothrow-forward-iterator}@ I, @\placeholder{nothrow-sentinel-for}@<I> S>
+  requires @\libconcept{default_initializable}@<iter_value_t<I>>
+  I ranges::uninitialized_default_construct(I first, S last);
+template<@\placeholdernc{nothrow-forward-range}@ R>
+  requires @\libconcept{default_initializable}@<range_value_t<R>>
+  borrowed_iterator_t<R> ranges::uninitialized_default_construct(R&& r);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10409,11 +10407,9 @@ return first;
 
 \indexlibraryglobal{uninitialized_default_construct_n}%
 \begin{itemdecl}
-namespace ranges {
-  template<@\placeholdernc{nothrow-forward-iterator}@ I>
-    requires @\libconcept{default_initializable}@<iter_value_t<I>>
-    I uninitialized_default_construct_n(I first, iter_difference_t<I> n);
-}
+template<@\placeholdernc{nothrow-forward-iterator}@ I>
+  requires @\libconcept{default_initializable}@<iter_value_t<I>>
+  I ranges::uninitialized_default_construct_n(I first, iter_difference_t<I> n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10447,14 +10443,12 @@ for (; first != last; ++first)
 
 \indexlibraryglobal{uninitialized_value_construct}%
 \begin{itemdecl}
-namespace ranges {
-  template<@\placeholdernc{nothrow-forward-iterator}@ I, @\placeholder{nothrow-sentinel-for}@<I> S>
-    requires @\libconcept{default_initializable}@<iter_value_t<I>>
-    I uninitialized_value_construct(I first, S last);
-  template<@\placeholdernc{nothrow-forward-range}@ R>
-    requires @\libconcept{default_initializable}@<range_value_t<R>>
-    borrowed_iterator_t<R> uninitialized_value_construct(R&& r);
-}
+template<@\placeholdernc{nothrow-forward-iterator}@ I, @\placeholder{nothrow-sentinel-for}@<I> S>
+  requires @\libconcept{default_initializable}@<iter_value_t<I>>
+  I ranges::uninitialized_value_construct(I first, S last);
+template<@\placeholdernc{nothrow-forward-range}@ R>
+  requires @\libconcept{default_initializable}@<range_value_t<R>>
+  borrowed_iterator_t<R> ranges::uninitialized_value_construct(R&& r);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10488,11 +10482,9 @@ return first;
 
 \indexlibraryglobal{uninitialized_value_construct_n}%
 \begin{itemdecl}
-namespace ranges {
-  template<@\placeholdernc{nothrow-forward-iterator}@ I>
-    requires @\libconcept{default_initializable}@<iter_value_t<I>>
-    I uninitialized_value_construct_n(I first, iter_difference_t<I> n);
-}
+template<@\placeholdernc{nothrow-forward-iterator}@ I>
+  requires @\libconcept{default_initializable}@<iter_value_t<I>>
+  I ranges::uninitialized_value_construct_n(I first, iter_difference_t<I> n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10535,17 +10527,15 @@ for (; first != last; ++result, (void) ++first)
 
 \indexlibraryglobal{uninitialized_copy}%
 \begin{itemdecl}
-namespace ranges {
-  template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S1,
-           @\placeholdernc{nothrow-forward-iterator}@ O, @\placeholder{nothrow-sentinel-for}@<O> S2>
-    requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_reference_t<I>>
-    uninitialized_copy_result<I, O>
-      uninitialized_copy(I ifirst, S1 ilast, O ofirst, S2 olast);
-  template<@\libconcept{input_range}@ IR, @\placeholdernc{nothrow-forward-range}@ OR>
-    requires @\libconcept{constructible_from}@<range_value_t<OR>, range_reference_t<IR>>
-    uninitialized_copy_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
-      uninitialized_copy(IR&& in_range, OR&& out_range);
-}
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S1,
+         @\placeholdernc{nothrow-forward-iterator}@ O, @\placeholder{nothrow-sentinel-for}@<O> S2>
+  requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_reference_t<I>>
+  ranges::uninitialized_copy_result<I, O>
+    ranges::uninitialized_copy(I ifirst, S1 ilast, O ofirst, S2 olast);
+template<@\libconcept{input_range}@ IR, @\placeholdernc{nothrow-forward-range}@ OR>
+  requires @\libconcept{constructible_from}@<range_value_t<OR>, range_reference_t<IR>>
+  ranges::uninitialized_copy_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
+    ranges::uninitialized_copy(IR&& in_range, OR&& out_range);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10591,12 +10581,10 @@ for ( ; n > 0; ++result, (void) ++first, --n)
 
 \indexlibraryglobal{uninitialized_copy_n}%
 \begin{itemdecl}
-namespace ranges {
-  template<@\libconcept{input_iterator}@ I, @\placeholdernc{nothrow-forward-iterator}@ O, @\placeholder{nothrow-sentinel-for}@<O> S>
-    requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_reference_t<I>>
-    uninitialized_copy_n_result<I, O>
-      uninitialized_copy_n(I ifirst, iter_difference_t<I> n, O ofirst, S olast);
-}
+template<@\libconcept{input_iterator}@ I, @\placeholdernc{nothrow-forward-iterator}@ O, @\placeholder{nothrow-sentinel-for}@<O> S>
+  requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_reference_t<I>>
+  ranges::uninitialized_copy_n_result<I, O>
+    ranges::uninitialized_copy_n(I ifirst, iter_difference_t<I> n, O ofirst, S olast);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10642,17 +10630,15 @@ return result;
 
 \indexlibraryglobal{uninitialized_move}%
 \begin{itemdecl}
-namespace ranges {
-  template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S1,
-           @\placeholdernc{nothrow-forward-iterator}@ O, @\placeholder{nothrow-sentinel-for}@<O> S2>
-    requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_rvalue_reference_t<I>>
-    uninitialized_move_result<I, O>
-      uninitialized_move(I ifirst, S1 ilast, O ofirst, S2 olast);
-  template<@\libconcept{input_range}@ IR, @\placeholdernc{nothrow-forward-range}@ OR>
-    requires @\libconcept{constructible_from}@<range_value_t<OR>, range_rvalue_reference_t<IR>>
-    uninitialized_move_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
-      uninitialized_move(IR&& in_range, OR&& out_range);
-}
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S1,
+         @\placeholdernc{nothrow-forward-iterator}@ O, @\placeholder{nothrow-sentinel-for}@<O> S2>
+  requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_rvalue_reference_t<I>>
+  ranges::uninitialized_move_result<I, O>
+    ranges::uninitialized_move(I ifirst, S1 ilast, O ofirst, S2 olast);
+template<@\libconcept{input_range}@ IR, @\placeholdernc{nothrow-forward-range}@ OR>
+  requires @\libconcept{constructible_from}@<range_value_t<OR>, range_rvalue_reference_t<IR>>
+  ranges::uninitialized_move_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
+    ranges::uninitialized_move(IR&& in_range, OR&& out_range);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10702,12 +10688,10 @@ return {first, result};
 
 \indexlibraryglobal{uninitialized_move_n}%
 \begin{itemdecl}
-namespace ranges {
-  template<@\libconcept{input_iterator}@ I, @\placeholdernc{nothrow-forward-iterator}@ O, @\placeholder{nothrow-sentinel-for}@<O> S>
-    requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_rvalue_reference_t<I>>
-    uninitialized_move_n_result<I, O>
-      uninitialized_move_n(I ifirst, iter_difference_t<I> n, O ofirst, S olast);
-}
+template<@\libconcept{input_iterator}@ I, @\placeholdernc{nothrow-forward-iterator}@ O, @\placeholder{nothrow-sentinel-for}@<O> S>
+  requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_rvalue_reference_t<I>>
+  ranges::uninitialized_move_n_result<I, O>
+    ranges::uninitialized_move_n(I ifirst, iter_difference_t<I> n, O ofirst, S olast);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10753,14 +10737,12 @@ for (; first != last; ++first)
 
 \indexlibraryglobal{uninitialized_fill}%
 \begin{itemdecl}
-namespace ranges {
-  template<@\placeholdernc{nothrow-forward-iterator}@ I, @\placeholder{nothrow-sentinel-for}@<I> S, class T>
-    requires @\libconcept{constructible_from}@<iter_value_t<I>, const T&>
-    I uninitialized_fill(I first, S last, const T& x);
-  template<@\placeholdernc{nothrow-forward-range}@ R, class T>
-    requires @\libconcept{constructible_from}@<range_value_t<R>, const T&>
-    borrowed_iterator_t<R> uninitialized_fill(R&& r, const T& x);
-}
+template<@\placeholdernc{nothrow-forward-iterator}@ I, @\placeholder{nothrow-sentinel-for}@<I> S, class T>
+  requires @\libconcept{constructible_from}@<iter_value_t<I>, const T&>
+  I ranges::uninitialized_fill(I first, S last, const T& x);
+template<@\placeholdernc{nothrow-forward-range}@ R, class T>
+  requires @\libconcept{constructible_from}@<range_value_t<R>, const T&>
+  borrowed_iterator_t<R> ranges::uninitialized_fill(R&& r, const T& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10794,11 +10776,9 @@ return first;
 
 \indexlibraryglobal{uninitialized_fill_n}%
 \begin{itemdecl}
-namespace ranges {
-  template<@\placeholdernc{nothrow-forward-iterator}@ I, class T>
-    requires @\libconcept{constructible_from}@<iter_value_t<I>, const T&>
-    I uninitialized_fill_n(I first, iter_difference_t<I> n, const T& x);
-}
+template<@\placeholdernc{nothrow-forward-iterator}@ I, class T>
+  requires @\libconcept{constructible_from}@<iter_value_t<I>, const T&>
+  I ranges::uninitialized_fill_n(I first, iter_difference_t<I> n, const T& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10817,10 +10797,8 @@ return uninitialized_fill(counted_iterator(first, n), default_sentinel, x).base(
 template<class T, class... Args>
   constexpr T* construct_at(T* location, Args&&... args);
 
-namespace ranges {
-  template<class T, class... Args>
-    constexpr T* construct_at(T* location, Args&&... args);
-}
+template<class T, class... Args>
+  constexpr T* ranges::construct_at(T* location, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10843,10 +10821,8 @@ return ::new (@\placeholdernc{voidify}@(*location)) T(std::forward<Args>(args)..
 \begin{itemdecl}
 template<class T>
   constexpr void destroy_at(T* location);
-namespace ranges {
-  template<@\libconcept{destructible}@ T>
-    constexpr void destroy_at(T* location) noexcept;
-}
+template<@\libconcept{destructible}@ T>
+  constexpr void ranges::destroy_at(T* location) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10878,14 +10854,12 @@ for (; first != last; ++first)
 
 \indexlibraryglobal{destroy}%
 \begin{itemdecl}
-namespace ranges {
-  template<@\placeholdernc{nothrow-input-iterator}@ I, @\placeholder{nothrow-sentinel-for}@<I> S>
-    requires @\libconcept{destructible}@<iter_value_t<I>>
-    constexpr I destroy(I first, S last) noexcept;
-  template<@\placeholdernc{nothrow-input-range}@ R>
-    requires @\libconcept{destructible}@<range_value_t<R>>
-    constexpr borrowed_iterator_t<R> destroy(R&& r) noexcept;
-}
+template<@\placeholdernc{nothrow-input-iterator}@ I, @\placeholder{nothrow-sentinel-for}@<I> S>
+  requires @\libconcept{destructible}@<iter_value_t<I>>
+  constexpr I ranges::destroy(I first, S last) noexcept;
+template<@\placeholdernc{nothrow-input-range}@ R>
+  requires @\libconcept{destructible}@<range_value_t<R>>
+  constexpr borrowed_iterator_t<R> ranges::destroy(R&& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10918,11 +10892,9 @@ return first;
 
 \indexlibraryglobal{destroy_n}%
 \begin{itemdecl}
-namespace ranges {
-  template<@\placeholdernc{nothrow-input-iterator}@ I>
-    requires @\libconcept{destructible}@<iter_value_t<I>>
-    constexpr I destroy_n(I first, iter_difference_t<I> n) noexcept;
-}
+template<@\placeholdernc{nothrow-input-iterator}@ I>
+  requires @\libconcept{destructible}@<iter_value_t<I>>
+  constexpr I ranges::destroy_n(I first, iter_difference_t<I> n) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
As decided in #2656, return types from the sub-namespace were qualified as well.
"namespace ranges { ... }" was excised from \itemdecl.

Partially addresses #2512
Fixes #4253