### PR TITLE
Dismantle requirements table in [re.req] and [container.requirements]

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -456,10 +456,6 @@ swap(a, b)
 
 \begin{itemdescr}
 \pnum
-\result
-\keyword{void}
-
-\pnum
 \effects
 Equivalent to \tcode{a.swap(b)}.
 \end{itemdescr}
@@ -1530,20 +1526,8 @@ a.insert(p, il)
 
 \begin{itemdescr}
 \pnum
-\result
-\tcode{iterator}
-
-\pnum
 \effects
 Equivalent to \tcode{a.insert(p, il.begin(), il.end())}.
-
-\pnum
-\returns
-\begin{removedblock}
-An iterator
-that points to the copy of the first element inserted into \tcode{a}, or
-\tcode{p} if \tcode{il} is empty.
-\end{removedblock}
 \end{itemdescr}
 
 \indexcont{erase}%
@@ -1657,10 +1641,6 @@ a.assign(il)
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\result
-\keyword{void}
-
 \pnum
 \effects
 Equivalent to \tcode{a.assign(il.begin(), il.end())}.
@@ -3046,10 +3026,6 @@ a.insert(il)
 
 \begin{itemdescr}
 \pnum
-\result
-\keyword{void}
-
-\pnum
 \effects
 Equivalent to \tcode{a.insert(il.begin(), il.end())}.
 \end{itemdescr}
@@ -3403,10 +3379,6 @@ a.clear()
 
 \begin{itemdescr}
 \pnum
-\result
-\keyword{void}
-
-\pnum
 \effects
 Equivalent to \tcode{a.erase(a.begin(), a.end())}.
 
@@ -3512,10 +3484,6 @@ b.contains(k)
 \pnum
 \effects
 Equivalent to: \tcode{return b.find(k) != b.end();}
-
-\pnum
-\complexity
-Logarithmic.
 \end{itemdescr}
 
 \indexordmem{contains}%
@@ -3531,10 +3499,6 @@ a_tran.contains(ke)
 \pnum
 \effects
 Equivalent to: \tcode{return a_tran.find(ke) != a_tran.end();}
-
-\pnum
-\complexity
-Logarithmic.
 \end{itemdescr}
 
 \indexordmem{lower_bound}%
@@ -4631,10 +4595,6 @@ a.insert(il)
 
 \begin{itemdescr}
 \pnum
-\result
-\keyword{void}
-
-\pnum
 \effects
 Equivalent to \tcode{a.insert(il.begin(), il.end())}.
 \end{itemdescr}
@@ -5075,10 +5035,6 @@ b.contains(k)
 
 \begin{itemdescr}
 \pnum
-\result
-\tcode{bool}
-
-\pnum
 \effects
 Equivalent to \tcode{b.find(k) != b.end()}.
 \end{itemdescr}
@@ -5089,10 +5045,6 @@ a_tran.contains(ke)
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\result
-\tcode{bool}
-
 \pnum
 \effects
 Equivalent to \tcode{a_tran.find(ke) != a_tran.end()}.
@@ -5410,16 +5362,8 @@ a.reserve(n)
 
 \begin{itemdescr}
 \pnum
-\result
-\keyword{void}
-
-\pnum
 \effects
 Equivalent to \tcode{a.rehash(ceil(n / a.max_load_factor()))}.
-
-\pnum
-\complexity
-Average case linear in \tcode{a.size()}, worst case quadratic.
 \end{itemdescr}
 
 \pnum

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -31,10 +31,10 @@ as summarized in
 \end{libsumtab}
 
 
-\rSec1[container.requirements]{Container requirements}%
+\rSec1[container.requirements]{Requirements}%
 \indextext{requirements!container}
 
-\rSec2[container.requirements.general]{General container requirements}
+\rSec2[container.requirements.pre]{Preamble}
 
 \pnum
 Containers are objects that store other objects.
@@ -54,7 +54,7 @@ is itself linear.
 \end{example}
 
 \pnum
-Allocator-aware containers (\tref{container.alloc.req})
+Allocator-aware containers\iref{container.alloc.reqmts}
 other than \tcode{basic_string} construct elements using the function
 \tcode{allocator_traits<allocator_type>::rebind_traits<U>::\brk{}construct}
 and destroy elements using the function
@@ -69,10 +69,12 @@ means, for example, that a node-based container would need to construct nodes co
 aligned buffers and call \tcode{construct} to place the element into the buffer.
 \end{note}
 
+\rSec2[container.gen.reqmts]{General containers}
+
+\rSec3[container.requirements.general]{General}
+
 \pnum
-In Tables~\ref{tab:container.req},
-\ref{tab:container.rev.req}, and
-\ref{tab:container.opt},
+In subclause \ref{container.gen.reqmts},
 \begin{itemize}
 \item
 \tcode{X} denotes a container class containing objects of type \tcode{T},
@@ -87,6 +89,8 @@ In Tables~\ref{tab:container.req},
 \item
 \tcode{rv} denotes a non-const rvalue of type \tcode{X}.
 \end{itemize}
+
+\rSec3[container.reqmts]{Containers}
 
 % Local command to index names as members of all containers.
 \newcommand{\indexcont}[1]{%
@@ -106,236 +110,444 @@ In Tables~\ref{tab:container.req},
 \indexlibrarymemberx{unordered_multimap}{#1}%
 }
 
-\begin{libreqtab5}
-{Container requirements}
-{container.req}
-\\ \topline
-\lhdr{Expression}       &   \chdr{Return type}  &   \chdr{Operational}  &
-\chdr{Assertion/note}   &   \rhdr{Complexity}   \\
-    &   &   \chdr{semantics}    &   \chdr{pre-/post-condition}   &      \\ \capsep
-\endfirsthead
-\continuedcaption\\
-\topline
-\lhdr{Expression}       &   \chdr{Return type}  &   \chdr{Operational}  &
-\chdr{Assertion/note}   &   \rhdr{Complexity}   \\
-    &   &   \chdr{semantics}    &   \chdr{pre-/post-condition}   &      \\ \capsep
-\endhead
+\pnum
+A type \tcode{X} meets the \defn{container} requirements
+if the following types, statements, and expressions are well-formed and
+have the specified semantics.
 
 \indexcont{value_type}%
-\tcode{X::value_type}       &
- \tcode{T}                  &
-                            &
- \expects \tcode{T} is \oldconcept{Erasable} from \tcode{X} (see~\ref{container.requirements.general}, below) &
- compile time               \\ \rowsep
+\begin{itemdecl}
+typename X::value_type
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{T}
+
+\pnum
+\expects
+\tcode{T} is \oldconcept{Erasable} from \tcode{X}
+(see~\ref{container.alloc.reqmts}, below).
+\end{itemdescr}
 
 \indexcont{reference}%
-\tcode{X::reference}        &
- \tcode{T\&}                &
-                            &
-                            &
- compile time               \\ \rowsep
+\begin{itemdecl}
+typename X::reference
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{T\&}
+\end{itemdescr}
 
 \indexcont{const_reference}%
-\tcode{X::const_reference} &
- \tcode{const T\&}          &
-                            &
-                            &
- compile time               \\ \rowsep
+\begin{itemdecl}
+typename X::const_reference
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{const T\&}
+\end{itemdescr}
 
 \indexcont{iterator}%
-\tcode{X::iterator}         &
- iterator type whose value type is \tcode{T} &
-                            &
- any iterator category
- that meets the forward iterator requirements.
- convertible to \tcode{X::const_iterator}. &
- compile time               \\ \rowsep
+\begin{itemdecl}
+typename X::iterator
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+A type that meets the forward iterator requirements\iref{forward.iterators}
+with value type \tcode{T}.
+The type \tcode{X::iterator} is convertible to \tcode{X::const_iterator}.
+\end{itemdescr}
 
 \indexcont{const_iterator}%
-\tcode{X::const_iterator}  &
- constant iterator type whose value type is \tcode{T} &
-                            &
- any iterator category
- that meets the forward iterator requirements. &
- compile time               \\ \rowsep
+\begin{itemdecl}
+typename X::const_iterator
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+A type that meets the requirements of a constant iterator and
+those of a forward iterator with value type \tcode{T}.
+\end{itemdescr}
 
 \indexcont{difference_type}%
-\tcode{X::dif\-ference_type}    &
- signed integer type           &
-                                &
- is identical to the difference type of \tcode{X::iterator} and \tcode{X::const_iterator} &
- compile time               \\ \rowsep
+\begin{itemdecl}
+typename X::difference_type
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+A signed integer type,
+identical to the difference type of
+\tcode{X::iterator} and \tcode{X::const_iterator}.
+\end{itemdescr}
 
 \indexcont{size_type}%
-\tcode{X::size_type}        &
- unsigned integer type     &
-                            &
- \tcode{size_type} can represent any non-negative value of \tcode{difference_type} &
- compile time                \\ \rowsep
+\begin{itemdecl}
+typename X::size_type
+\end{itemdecl}
 
-\tcode{X u;}                &
-                            &
-                            &
- \ensures \tcode{u.empty()}    &
- constant                   \\ \rowsep
+\begin{itemdescr}
+\pnum
+\result
+An unsigned integer type
+that can represent any non-negative value of \tcode{X::difference_type}.
+\end{itemdescr}
 
-\tcode{X()}                 &
-                            &
-                            &
- \ensures \tcode{X().empty()}  &
- constant                   \\ \rowsep
+\begin{itemdecl}{}
+X u;
+X u = X();
+\end{itemdecl}
 
-\tcode{X(a)}                &
-                            &
-                            &
- \expects \tcode{T} is \oldconcept{CopyInsertable}
- into \tcode{X} (see below).\br \ensures \tcode{a == X(a)}.         &
- linear                     \\ \rowsep
+\begin{itemdescr}
+\pnum
+\ensures
+\tcode{u.empty()}
 
-\tcode{X u(a);}\br
-\tcode{X u = a;}            &
-                            &
-                            &
- \expects \tcode{T} is \oldconcept{CopyInsertable}
- into \tcode{X} (see below).\br
- \ensures \tcode{u == a}       &
- linear                     \\ \rowsep
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
 
-\tcode{X u(rv);}\br
-\tcode{X u = rv;}            &
-                            &
-                            &
-  \ensures \tcode{u} is equal to the value that \tcode{rv} had before this construction
-                            &
-  (Note B)                  \\ \rowsep
+\begin{itemdecl}
+X u(a);
+X u = a;
+\end{itemdecl}
 
-\tcode{a = rv}              &
-  \tcode{X\&}               &
-  All existing elements of \tcode{a} are either move assigned to or destroyed   &
-  \ensures If \tcode{a} and \tcode{rv} do not refer to the same object,
-  \tcode{a} is equal to the value that \tcode{rv}
-  had before this assignment.   &
-   linear                     \\ \rowsep
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{T} is \oldconcept{CopyInsertable} into \tcode{X} (see below).
 
-\tcode{a.\~X()}    &
- \keyword{void}               &
-                            &
- \effects destroys every element of \tcode{a}; any memory obtained is deallocated. &
- linear                     \\ \rowsep
+\pnum
+\ensures
+\tcode{u == a}
+
+\pnum
+\complexity
+Linear.
+\end{itemdescr}
+
+\begin{itemdecl}
+X u(rv);
+X u = rv;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ensures
+\tcode{u} is equal to the value that \tcode{rv} had before this construction.
+
+\pnum
+\complexity
+Linear for \tcode{array} and constant for all other standard containers.
+\end{itemdescr}
+
+\begin{itemdecl}
+a = rv
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{X\&}.
+
+\pnum
+\effects
+All existing elements of \tcode{a} are either move assigned to or destroyed.
+
+\pnum
+\ensures
+If \tcode{a} and \tcode{rv} do not refer to the same object,
+\tcode{a} is equal to the value that \tcode{rv} had before this assignment.
+
+\pnum
+\complexity
+Linear.
+\end{itemdescr}
+
+\begin{itemdecl}
+a.~X()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
+
+\pnum
+\effects
+Destroys every element of \tcode{a}; any memory obtained is deallocated.
+
+\pnum
+\complexity
+Linear.
+\end{itemdescr}
 
 \indexcont{begin}%
-\tcode{a.begin()}           &
- \tcode{iterator}; \tcode{const_iterator} for constant \tcode{a} &
-                            &
-                            &
- constant                   \\ \rowsep
+\begin{itemdecl}
+a.begin()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator};
+\tcode{const_iterator} for constant \tcode{a}.
+
+\pnum
+\cvalue
+An iterator referring to the first element in the container.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
 
 \indexcont{end}%
-\tcode{a.end()}             &
- \tcode{iterator}; \tcode{const_iterator} for constant \tcode{a} &
-                            &
-                            &
- constant                   \\ \rowsep
+\begin{itemdecl}
+a.end()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator};
+\tcode{const_iterator} for constant \tcode{a}.
+
+\pnum
+\cvalue
+An iterator which is the past-the-end value for the container.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
 
 \indexcont{cbegin}%
-\tcode{a.cbegin()}          &
- \tcode{const_iterator}     &
- \tcode{const_cast<\brk{}X const\&\brk{}>(a)\brk{}.begin();} &
-                            &
- constant                   \\ \rowsep
+\begin{itemdecl}
+a.cbegin()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{const_iterator}.
+
+\pnum
+\cvalue
+\tcode{const_cast<X const\&>(a).begin()}
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
 
 \indexcont{cend}%
-\tcode{a.cend()}            &
- \tcode{const_iterator}     &
- \tcode{const_cast<\brk{}X const\&\brk{}>(a)\brk{}.end();} &
-                            &
- constant                   \\ \rowsep
+\begin{itemdecl}
+a.cend()
+\end{itemdecl}
 
-\tcode{i <=> j}             &
-  \tcode{strong_ordering}   &
-                            &
-  \constraints \tcode{X::iterator} meets the random access iterator requirements. &
- constant                   \\ \rowsep
+\begin{itemdescr}
+\pnum
+\result
+\tcode{const_iterator}.
+
+\pnum
+\cvalue
+\tcode{const_cast<X const\&>(a).end()}
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
+
+\begin{itemdecl}
+i <=> j
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{strong_ordering}.
+
+\pnum
+\constraints
+\tcode{X::iterator} meets the random access iterator requirements.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
 
 \indexcont{operator==}%
-\tcode{a == b}                  &
- convertible to \tcode{bool}    &
- \tcode{==} is an equivalence relation.
- \tcode{equal(\brk{}a.begin(), a.end(), b.begin(), b.end())} &
- \expects \tcode{T} meets the \oldconcept{\-Equal\-ity\-Compar\-a\-ble} requirements &
- Constant if \tcode{a.size() != b.size()},
- linear otherwise                                   \\ \rowsep
+\begin{itemdecl}
+a == b
+\end{itemdecl}
 
-\indexcont{operator!=}%
-\tcode{a != b}                      &
- convertible to \tcode{bool}        &
- Equivalent to \tcode{!(a == b)}   &
-                                    &
- linear                             \\ \rowsep
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{T} meets the \oldconcept{EqualityComparable} requirements.
 
-\indexcont{swap}%
-\tcode{a.swap(b)}          &
- \keyword{void}               &
-                            &
- \effects exchanges the contents of \tcode{a} and \tcode{b}          &
- (Note A)                   \\ \rowsep
+\pnum
+\result
+Convertible to \tcode{bool}.
 
-\tcode{swap(a, b)}          &
-  \keyword{void}              &
-  Equivalent to \tcode{a.swap(b)}         &
-                            &
-  (Note A)                  \\ \rowsep
+\pnum
+\cvalue
+\tcode{equal(a.begin(), a.end(), b.begin(), b.end())}
 
-\indexcont{operator=}%
-\tcode{r = a}               &
- \tcode{X\&}                &
-                            &
- \ensures \tcode{r == a}.      &
- linear                     \\ \rowsep
-
-\indexcont{size}%
-\tcode{a.size()}                &
- \tcode{size_type}             &
- \tcode{distance(\brk{}a.begin(), a.end())}  &
-                                &
- constant                       \\ \rowsep
-
-\indexcont{max_size}%
-\tcode{a.max_size()}        &
- \tcode{size_type}         &
- \tcode{distance(\brk{}begin(), end())}
- for the largest possible container &
-                            &
- constant                   \\ \rowsep
-
-\indexcont{empty}%
-\tcode{a.empty()}               &
- convertible to \tcode{bool}    &
- \tcode{a.begin() == a.end()}          &
-                                &
-constant                        \\
-
-\end{libreqtab5}
-
-Those entries marked ``(Note A)'' or ``(Note B)''
-have linear complexity for \tcode{array} and have constant complexity
-for all other standard containers.
 \begin{note}
-The algorithm \tcode{equal} is defined in \ref{algorithms}.
+The algorithm \tcode{equal} is defined in \ref{alg.equal}.
 \end{note}
 
 \pnum
-The member function \tcode{size()} returns the number of elements in the container.
-The number of elements is defined by the rules of
-constructors, inserts, and erases.
+\complexity
+Constant if \tcode{a.size() != b.size()}, linear otherwise.
 
 \pnum
-\tcode{begin()}
-returns an iterator referring to the first element in the container.
-\tcode{end()}
-returns an iterator which is the past-the-end value for the container.
-If the container is empty, then
-\tcode{begin() == end()}.
+\remarks
+\tcode{==} is an equivalence relation.
+\end{itemdescr}
+
+\indexcont{operator!=}%
+\begin{itemdecl}
+a != b
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to \tcode{!(a == b)}.
+\end{itemdescr}
+
+\indexcont{swap}%
+\begin{itemdecl}
+a.swap(b)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
+
+\pnum
+\effects
+Exchanges the contents of \tcode{a} and \tcode{b}.
+
+\pnum
+\complexity
+Linear for \tcode{array} and constant for all other standard containers.
+\end{itemdescr}
+
+\begin{itemdecl}
+swap(a, b)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
+
+\pnum
+\effects
+Equivalent to \tcode{a.swap(b)}.
+\end{itemdescr}
+
+\indexcont{operator=}%
+\begin{itemdecl}
+r = a
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{X\&}.
+
+\pnum
+\ensures
+\tcode{r == a}.
+
+\pnum
+\complexity
+Linear.
+\end{itemdescr}
+
+\indexcont{size}%
+\begin{itemdecl}
+a.size()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{size_type}.
+
+\pnum
+\cvalue
+\tcode{distance(a.begin(), a.end())},
+i.e. the number of elements in the container.
+
+\pnum
+\complexity
+Constant.
+
+\pnum
+\remarks
+The number of elements is defined by the rules of
+constructors, inserts, and erases.
+\end{itemdescr}
+
+\indexcont{max_size}%
+\begin{itemdecl}
+a.max_size()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{size_type}.
+
+\pnum
+\returns
+\tcode{distance(begin(), end())} for the largest possible container.
+
+\complexity
+Constant.
+\end{itemdescr}
+
+\indexcont{empty}%
+\begin{itemdecl}
+a.empty()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+Convertible to \tcode{bool}.
+
+\pnum
+\cvalue
+\tcode{a.begin() == a.end()}
+
+\pnum
+\complexity
+Constant.
+
+\pnum
+\remarks
+If the container is empty, then \tcode{a.empty()} is true.
+\end{itemdescr}
 
 \pnum
 In the expressions
@@ -414,14 +626,7 @@ element in the other container after the swap. It is unspecified whether an iter
 with value \tcode{a.end()} before the swap will have value \tcode{b.end()} after the
 swap.
 
-\pnum
-\indextext{reversible container|see{container, reversible}}%
-If the iterator type of a container belongs to the bidirectional or
-random access iterator categories\iref{iterator.requirements},
-the container is called
-\defnx{reversible}{container!reversible}
-and meets the additional requirements
-in \tref{container.rev.req}.
+\rSec3[container.rev.reqmts]{Reversible container requirements}
 
 % Local command to index names as members of all containers.
 \renewcommand{\indexcont}[1]{%
@@ -440,51 +645,116 @@ in \tref{container.rev.req}.
 \indexlibrarymemberx{unordered_multimap}{#1}%
 }
 
-\begin{libreqtab4a}
-{Reversible container requirements}
-{container.rev.req}
-\\ \topline
-\lhdr{Expression}       &   \chdr{Return type}  &
-\chdr{Assertion/note}   &   \rhdr{Complexity}   \\
-    &   &   \chdr{pre-/post-condition}   &      \\ \capsep
-\endfirsthead
-\continuedcaption\\
-\hline
-\lhdr{Expression}       &   \chdr{Return type}  &
-\chdr{Assertion/note}   &   \rhdr{Complexity}   \\
-    &   &   \chdr{pre-/post-condition}   &      \\ \capsep
-\endhead
+\pnum
+A type \tcode{X} meets the \defnadj{reversible}{container} requirements if
+\tcode{X} meets the container requirements,
+the iterator type of \tcode{X} belongs to the
+bidirectional or random access iterator categories\iref{iterator.requirements},
+and
+the following types and expressions are well-formed and have
+the specified semantics.
+
 \indexcont{reverse_iterator}%
-\tcode{X::reverse_iterator}            &
-iterator type whose value type is \tcode{T}    &
- \tcode{reverse_iterator<iterator>}   &
- compile time                           \\ \rowsep
+\begin{itemdecl}
+typename X::reverse_iterator
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+The type \tcode{reverse_iterator<X::iterator>},
+an iterator type whose value type is \tcode{T}.
+\end{itemdescr}
+
 \indexcont{const_reverse_iterator}%
-\tcode{X::const_reverse_iterator}         &
- constant iterator type whose value type is \tcode{T}  &
- \tcode{reverse_iterator<const_iterator>}    &
- compile time                               \\ \rowsep
+\begin{itemdecl}
+typename X::const_reverse_iterator
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+The type \tcode{reverse_iterator<X::const_iterator>},
+a constant iterator type whose value type is \tcode{T}.
+\end{itemdescr}
+
 \indexcont{rbegin}%
-\tcode{a.rbegin()}                  &
- \tcode{reverse_iterator; const_reverse_iterator} for constant \tcode{a} &
- \tcode{reverse_iterator(end())}   &
- constant                           \\ \rowsep
+\begin{itemdecl}
+a.rbegin()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{reverse_iterator};
+\tcode{const_reverse_iterator} for constant \tcode{a}.
+
+\pnum
+\cvalue
+\tcode{reverse_iterator(end())}
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
+
 \indexcont{rend}%
-\tcode{a.rend()}                     &
- \tcode{reverse_iterator; const_reverse_iterator} for constant \tcode{a} &
- \tcode{reverse_iterator(begin())}    &
- constant                           \\ \rowsep
+\begin{itemdecl}
+a.rend()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{reverse_iterator};
+\tcode{const_reverse_iterator} for constant \tcode{a}.
+
+\pnum
+\cvalue
+\tcode{reverse_iterator(begin())}
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
+
 \indexcont{crbegin}%
-\tcode{a.crbegin()}         &
- \tcode{const_reverse_iterator}     &
- \tcode{const_cast<X const\&>(a).rbegin()} &
- constant                   \\ \rowsep
+\begin{itemdecl}
+a.crbegin()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{const_reverse_iterator}.
+
+\pnum
+\cvalue
+\tcode{\keyword{const_cast}<X \keyword{const}\&>(a).rbegin()}
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
+
 \indexcont{crend}%
-\tcode{a.crend()}         &
- \tcode{const_reverse_iterator}     &
- \tcode{const_cast<X const\&>(a).rend()} &
- constant                   \\
-\end{libreqtab4a}
+\begin{itemdecl}
+a.crend()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{const_reverse_iterator}.
+
+\pnum
+\cvalue
+\tcode{\keyword{const_cast}<X \keyword{const}\&>(a).rend()}
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
 
 \pnum
 Unless otherwise specified (see~\ref{associative.reqmts.except}, \ref{unord.req.except}, \ref{deque.modifiers}, and
@@ -545,51 +815,53 @@ meet the
 \oldconcept{RandomAccessIterator} requirements\iref{random.access.iterators} and
 model \libconcept{contiguous_iterator}\iref{iterator.concept.contiguous}.
 
+\rSec3[container.opt.reqmts]{Optional container requirements}
+
 \pnum
-\tref{container.opt} lists operations that are provided
+The following operations are provided
 for some types of containers but not others. Those containers for which the
-listed operations are provided shall implement the semantics described in
-\tref{container.opt} unless otherwise stated.
+listed operations are provided shall implement the semantics as described
+unless otherwise stated.
 If the iterators passed to \tcode{lexicographical_compare_three_way}
 meet the constexpr iterator requirements\iref{iterator.requirements.general}
-then the operations described in \tref{container.opt}
+then the operations described below
 are implemented by constexpr functions.
 
-\begin{libreqtab5}
-{Optional container operations}
-{container.opt}
-\\ \topline
-\lhdr{Expression}       &   \chdr{Return type}  &   \chdr{Operational}  &
-\chdr{Assertion/note}   &   \rhdr{Complexity}   \\
-    &   &   \chdr{semantics}    &   \chdr{pre-/post-condition}   &      \\ \capsep
-\endfirsthead
-\continuedcaption\\
-\topline
-\lhdr{Expression}       &   \chdr{Return type}  &   \chdr{Operational}  &
-\chdr{Assertion/note}   &   \rhdr{Complexity}   \\
-    &   &   \chdr{semantics}    &   \chdr{pre-/post-condition}   &      \\ \capsep
-\endhead
+\begin{itemdecl}
+a <=> b
+\end{itemdecl}
 
-\tcode{a <=> b}                  &
- \tcode{\placeholdernc{synth-three-\brk{}way-result}\brk{}<value_type>} &
- \tcode{lexicographical_compare_three_way(a.begin(), a.end(),
-    b.begin(), b.end(), \placeholdernc{synth-three-way})} &
- \expects
- Either \tcode{<=>} is defined for values of type (possibly const) \tcode{T},
- or \tcode{<} is defined for values of type (possibly const) \tcode{T} and
- \tcode{<} is a total ordering relationship.  &
- linear                         \\
-\end{libreqtab5}
+\begin{itemdescr}
+\pnum
+\result
+\tcode{\exposid{synth-three-way-result}<X::value_type>}.
 
+\pnum
+\expects
+Either \tcode{<=>} is defined for values of type (possibly const) \tcode{T},
+or \tcode{<} is defined for values of type (possibly const) \tcode{T} and
+\tcode{<} is a total ordering relationship.
+
+\pnum
+\cvalue
+\tcode{lexicographical_compare_three_way(a.begin(), a.end(),
+b.begin(), b.end(),\newline \exposidnc{synth-three-way})}
 \begin{note}
 The algorithm \tcode{lexicographical_compare_three_way}
 is defined in \ref{algorithms}.
 \end{note}
 
 \pnum
-All of the containers defined in this Clause and in~\ref{basic.string} except \tcode{array}
-meet the additional requirements of an allocator-aware container, as described in
-\tref{container.alloc.req}.
+\complexity
+Linear.
+\end{itemdescr}
+
+\rSec3[container.alloc.reqmts]{Allocator-aware containers}
+
+\pnum
+All of the containers defined in \ref{containers} and in~\ref{basic.string} except \tcode{array}
+meet the additional requirements of an \defnadj{allocator-aware}{container},
+as described below.
 
 \pnum
 Given an allocator type \tcode{A}
@@ -678,15 +950,17 @@ but specialized allocators can choose a different definition.
 \end{note}
 
 \pnum
-In \tref{container.alloc.req},
+In this subclause,
 \begin{itemize}
 \item
 \tcode{X} denotes an allocator-aware container class
-with a \tcode{value_type} of \tcode{T} using allocator of type \tcode{A},
+with a \tcode{value_type} of \tcode{T} using an allocator of type \tcode{A},
 \item
 \tcode{u} denotes a variable,
 \item
 \tcode{a} and \tcode{b} denote non-const lvalues of type \tcode{X},
+\item
+\tcode{c} denotes an lvalue of type \tcode{\keyword{const} X},
 \item
 \tcode{t} denotes an lvalue or a const rvalue of type \tcode{X},
 \item
@@ -712,112 +986,201 @@ with a \tcode{value_type} of \tcode{T} using allocator of type \tcode{A},
 \indexlibrarymemberx{unordered_multimap}{#1}%
 }
 
-\begin{libreqtab4a}
-{Allocator-aware container requirements}
-{container.alloc.req}
-\\ \topline
-\lhdr{Expression}       &   \chdr{Return type}  &
-\chdr{Assertion/note}   &   \rhdr{Complexity}   \\
-    &   &   \chdr{pre-/post-condition}   &      \\ \capsep
-\endfirsthead
-\continuedcaption\\
-\hline
-
-\lhdr{Expression}       &   \chdr{Return type}  &
-\chdr{Assertion/note}   &   \rhdr{Complexity}   \\
-    &   &   \chdr{pre-/post-condition}   &      \\ \capsep
-\endhead
+A type \tcode{X} meets the allocator-aware container requirements
+if \tcode{X} meets the container requirements and
+the following types, statements, and expressions are well-formed and have
+the specified semantics.
 
 \indexcont{allocator_type}%
-\tcode{allocator_type}		&
-  \tcode{A}								&
-  \mandates \tcode{allocator_type::value_type} is the same as \tcode{X::value_type}.					&
-  compile time										\\ \rowsep
+\begin{itemdecl}
+typename X::allocator_type
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{A}
+
+\pnum
+\expects
+\tcode{allocator_type::value_type} is the same as \tcode{X::value_type}.
+\end{itemdescr}
 
 \indexcont{get_allocator}%
-\tcode{get_-} \tcode{allocator()}	&
-  \tcode{A}								&
-																				&
-  constant												\\ \rowsep
+\begin{itemdecl}
+c.get_allocator()
+\end{itemdecl}
 
-\tcode{X()}\br
-\tcode{X u;}							&
-													&
-  \expects \tcode{A} meets the \oldconcept{DefaultConstructible} requirements.\br
-  \ensures \tcode{u.empty()} returns \tcode{true},
-  \tcode{u.get_allocator() == A()} &
-  constant												\\ \rowsep
+\begin{itemdescr}
+\pnum
+\result
+\tcode{A}
 
-\tcode{X(m)}							&
-																				&
-  \ensures
-  \tcode{u.empty()} returns \tcode{true}, &
-  constant												\\
-\tcode{X u(m);}					&
-																				&
-\tcode{u.get_allocator() == m} &
-																				\\ \rowsep
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
 
-\tcode{X(t, m)}\br
-\tcode{X u(t, m);}				&
-                          &
-  \expects
-  \tcode{T} is \oldconcept{CopyInsertable} into \tcode{X}.\br
-  \ensures
-  \tcode{u == t}, \tcode{u.get_allocator() == m} &
-  linear													\\ \rowsep
+\begin{itemdecl}
+X u;
+X u = X();
+\end{itemdecl}
 
-\tcode{X(rv)}\br
-\tcode{X u(rv);}
-           &
-           &
-  \ensures \tcode{u} has the same elements as \tcode{rv} had before this
-  construction; the value of \tcode{u.get_allocator()} is the same as the
-  value of \tcode{rv.get_allocator()} before this construction. &
-  constant                            \\ \rowsep
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{A} meets the \oldconcept{DefaultConstructible} requirements.
 
-\tcode{X(rv, m)}\br
-\tcode{X u(rv, m);}			&
-												&
-  \expects \tcode{T} is
-  \oldconcept{MoveInsertable} into \tcode{X}.\br
-  \ensures \tcode{u} has the same elements,
-  or copies of the elements, that \tcode{rv} had before
-  this construction, \tcode{u.get_allocator() == m}												&
-  constant if \tcode{m ==} \tcode{rv.get_allocator()}, otherwise linear	\\ \rowsep
+\pnum
+\ensures
+\tcode{u.empty()} returns \tcode{true}, \tcode{u.get_allocator() == A()}.
 
-\tcode{a = t}             &
-  \tcode{X\&}             &
-  \expects \tcode{T} is
-  \oldconcept{CopyInsertable} into \tcode{X}
-  and \oldconcept{CopyAssignable}.\br
-  \ensures \tcode{a == t}    &
-  linear                  \\ \rowsep
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
+
+\begin{itemdecl}
+X u(m);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ensures
+\tcode{u.empty()} returns \tcode{true}, \tcode{u.get_allocator() == m}.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
+
+\begin{itemdecl}
+X u(t, m);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{T} is \oldconcept{CopyInsertable} into \tcode{X}.
+
+\pnum
+\ensures
+\tcode{u == t}, \tcode{u.get_allocator() == m}
+
+\pnum
+\complexity
+Linear.
+\end{itemdescr}
+
+\begin{itemdecl}
+X u(rv);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ensures
+\tcode{u} has the same elements as \tcode{rv} had before this construction;
+the value of \tcode{u.get_allocator()} is the same as
+the value of \tcode{rv.get_allocator()} before this construction.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
+
+\begin{itemdecl}
+X u(rv, m);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{T} is \oldconcept{MoveInsertable} into \tcode{X}.
+
+\pnum
+\ensures
+\tcode{u} has the same elements, or copies of the elements,
+that \tcode{rv} had before this construction,
+\tcode{u.get_allocator() == m}.
+
+\pnum
+\complexity
+Constant if \tcode{m == rv.get_allocator()}, otherwise linear.
+\end{itemdescr}
+
+\begin{itemdecl}
+a = t
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{X\&}.
+
+\pnum
+\expects
+\tcode{T} is \oldconcept{CopyInsertable} into \tcode{X} and
+\oldconcept{CopyAssignable}.
+
+\pnum
+\ensures
+\tcode{a == t} is \tcode{true}.
+
+\pnum
+\complexity
+Linear.
+\end{itemdescr}
 
 \indexcont{operator=}%
-\tcode{a = rv}          &
-  \tcode{X\&}           &
-  \expects If \tcode{allocator_-}\br
-  \tcode{traits<allocator_type>}\br
-  \tcode{::propagate_on_container_-}\br
-  \tcode{move_assignment::value} is\br
-  \tcode{false}, \tcode{T} is
-  \oldconcept{MoveInsertable} into \tcode{X} and
-  \oldconcept{MoveAssignable}.\br
-  \effects All existing elements of \tcode{a}
-  are either move assigned to or destroyed.\br
-  \ensures If \tcode{a} and \tcode{rv} do not refer to the same object,
-  \tcode{a} is equal to the value that \tcode{rv} had before
-  this assignment.      &
-  linear                \\ \rowsep
+\begin{itemdecl}
+a = rv
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{X\&}.
+
+\pnum
+\expects
+If
+\tcode{allocator_traits<allocator_type>::propagate_on_container_move_assign\-ment::value}
+is \tcode{false},
+\tcode{T} is \oldconcept{MoveInsertable} into \tcode{X} and
+\oldconcept{MoveAssignable}.
+
+\pnum
+\effects
+All existing elements of \tcode{a} are either move assigned to or destroyed.
+
+\pnum
+\ensures
+If \tcode{a} and \tcode{rv} do not refer to the same object,
+\tcode{a} is equal to the value that \tcode{rv} had before this assignment.
+
+\pnum
+\complexity
+Linear.
+\end{itemdescr}
 
 \indexcont{swap}%
-\tcode{a.swap(b)}       &
-  \keyword{void}          &
-  \effects exchanges the contents of \tcode{a} and \tcode{b} &
-  constant      \\ \rowsep
+\begin{itemdecl}
+a.swap(b)
+\end{itemdecl}
 
-\end{libreqtab4a}
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
+
+\pnum
+\effects
+Exchanges the contents of \tcode{a} and \tcode{b}.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
 
 \pnum
 The behavior of certain container member functions and deduction guides
@@ -891,8 +1254,7 @@ leave a comment to explain if you choose from the rest!
 \end{note}
 
 \pnum
-In Tables~\ref{tab:container.seq.req}
-and \ref{tab:container.seq.opt},
+In this subclause,
 \begin{itemize}
 \item
 \tcode{X} denotes a sequence container class,
@@ -943,205 +1305,390 @@ The complexities of the expressions are sequence dependent.
 \indexlibrarymemberx{vector}{#1}%
 }
 
-\begin{libreqtab3}
-{Sequence container requirements (in addition to container)}
-{container.seq.req}
-\\ \topline
-\lhdr{Expression}       &   \chdr{Return type}  &   \rhdr{Assertion/note}       \\
-                        &                       &   \rhdr{pre-/post-condition}   \\ \capsep
-\endfirsthead
-\continuedcaption\\
-\hline
-\lhdr{Expression}       &   \chdr{Return type}  &   \rhdr{Assertion/note}       \\
-                        &                       &   \rhdr{pre-/post-condition}   \\ \capsep
-\endhead
-\tcode{X(n, t)}\br
-\tcode{X u(n, t);}   &
-                &
- \expects \tcode{T} is
- \oldconcept{CopyInsertable} into \tcode{X}.\br
- \ensures \tcode{distance(begin(), end()) == n}\br
- \effects Constructs a sequence container with \tcode{n} copies of \tcode{t}  \\ \rowsep
+\pnum
+A type \tcode{X} meets the \defnadj{sequence}{container} requirements
+if \tcode{X} meets the container requirements and
+the following statements and expressions are well-formed and have
+the specified semantics.
 
-\tcode{X(i, j)}\br
-\tcode{X u(i, j);}   &
-                    &
- \expects \tcode{T} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
- For \tcode{vector}, if the iterator does
- not meet the \oldconcept{\-Forward\-Iterator} requirements\iref{forward.iterators}, \tcode{T}
- is also
- \oldconcept{MoveInsertable} into \tcode{X}.\br
- \ensures \tcode{distance(begin(), end()) ==}
- \tcode{distance(i, j)}\br
- \effects Constructs a sequence container equal to the range \tcode{[i, j)}.
- Each iterator in the range \range{i}{j} is dereferenced exactly once. \\ \rowsep
+\begin{itemdecl}
+X u(n, t);
+\end{itemdecl}
 
-\tcode{X(il)}      &
-                    &
-  Equivalent to \tcode{X(il.begin(), il.end())} \\ \rowsep
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{T} is \oldconcept{CopyInsertable} into \tcode{X}.
 
-\tcode{a = il}     &
-  \tcode{X\&}               &
-  \expects \tcode{T} is
-  \oldconcept{CopyInsertable} into \tcode{X}
-  and \oldconcept{CopyAssignable}.\br
-  \effects Assigns the range \range{il.begin()}{il.end()} into \tcode{a}. All existing
-  elements of \tcode{a} are either assigned to or destroyed.\br
-  \returns\ \tcode{*this}.
-  \\ \rowsep
+\pnum
+\effects
+Constructs a sequence container with \tcode{n} copies of \tcode{t}.
+
+\pnum
+\ensures
+\tcode{distance(u.begin(), u.end()) == n} is \tcode{true}.
+\end{itemdescr}
+
+\begin{itemdecl}
+X u(i, j);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{T} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
+For \tcode{vector},
+if the iterator does not meet
+the \oldconcept{ForwardIterator} requirements\iref{forward.iterators},
+\tcode{T} is also \oldconcept{MoveInsertable} into \tcode{X}.
+
+\pnum
+\effects
+Constructs a sequence container equal to the range \tcode{[i, j)}.
+Each iterator in the range \range{i}{j} is dereferenced exactly once.
+
+\pnum
+\ensures
+\tcode{distance(u.begin(), u.end()) == distance(i, j)} is \tcode{true}.
+\end{itemdescr}
+
+\begin{itemdecl}
+X(il)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to \tcode{X(il.begin(), il.end())}.
+\end{itemdescr}
+
+\begin{itemdecl}
+a = il
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{X\&}.
+
+\pnum
+\expects
+\tcode{T} is \oldconcept{CopyInsertable} into \tcode{X} and
+\oldconcept{CopyAssignable}.
+
+\pnum
+\effects
+Assigns the range \range{il.begin()}{il.end()} into \tcode{a}.
+All existing elements of \tcode{a} are either assigned to or destroyed.
+
+\pnum
+\returns
+\tcode{*this}.
+\end{itemdescr}
 
 \indexcont{emplace}%
-\tcode{a.emplace(p, args)}  &
- \tcode{iterator}            &
- \expects \tcode{T} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}. For \tcode{vector} and \tcode{deque},
- \tcode{T} is also
- \oldconcept{MoveInsertable} into \tcode{X} and \oldconcept{MoveAssignable}.\br
- \effects Inserts an object of type \tcode{T} constructed with
- \tcode{std::forward<\brk{}Args\brk{}>(\brk{}args)...} before \tcode{p}.
- \begin{tailnote}
-\tcode{args} can directly or indirectly refer to
- a value in \tcode{a}.
-\end{tailnote}
- \\ \rowsep
+\begin{itemdecl}
+a.emplace(p, args)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}.
+
+\pnum
+\expects
+\tcode{T} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.
+For \tcode{vector} and \tcode{deque},
+\tcode{T} is also \oldconcept{MoveInsertable} into \tcode{X} and
+\oldconcept{MoveAssignable}.
+
+\pnum
+\effects
+Inserts an object of type \tcode{T}
+constructed with \tcode{std::forward<Args>(args)...}
+before \tcode{p}.
+\begin{note}
+\tcode{args} can directly or indirectly refer to a value in \tcode{a}.
+\end{note}
+
+\pnum
+\returns
+An iterator that points to
+the new element constructed from \tcode{args} into \tcode{a}.
+\end{itemdescr}
 
 \indexcont{insert}%
-\tcode{a.insert(p,t)}   &
- \tcode{iterator}       &
- \expects \tcode{T} is
- \oldconcept{CopyInsertable} into \tcode{X}. For \tcode{vector} and \tcode{deque},
- \tcode{T} is also \oldconcept{CopyAssignable}.\br
- \effects\ Inserts a copy of \tcode{t} before \tcode{p}. \\ \rowsep
+\begin{itemdecl}
+a.insert(p, t)
+\end{itemdecl}
 
-\tcode{a.insert(p,rv)}   &
- \tcode{iterator}       &
- \expects \tcode{T} is
- \oldconcept{MoveInsertable} into \tcode{X}. For \tcode{vector} and \tcode{deque},
-  \tcode{T} is also \oldconcept{MoveAssignable}.\br
- \effects\ Inserts a copy of \tcode{rv} before \tcode{p}. \\ \rowsep
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}.
 
-\tcode{a.insert(p,n,t)}     &
- \tcode{iterator}               &
- \expects \tcode{T} is
- \oldconcept{CopyInsertable} into \tcode{X}
- and \oldconcept{CopyAssignable}.\br
- \effects Inserts \tcode{n} copies of \tcode{t} before \tcode{p}. \\ \rowsep
+\pnum
+\expects
+\tcode{T} is \oldconcept{CopyInsertable} into \tcode{X}.
+For \tcode{vector} and \tcode{deque},
+\tcode{T} is also \oldconcept{CopyAssignable}.
 
-\tcode{a.insert(p,i,j)}    &
- \tcode{iterator}           &
- \expects \tcode{T} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
- For \tcode{vector} and \tcode{deque}, \tcode{T} is also
- \oldconcept{MoveInsertable} into \tcode{X}, \oldconcept{MoveConstructible}, \oldconcept{MoveAssignable},
- and swappable\iref{swappable.requirements}.
- Neither \tcode{i} nor \tcode{j} are iterators into \tcode{a}.\br
- \effects Inserts copies of elements in \tcode{[i, j)} before \tcode{p}.
- Each iterator in the range \range{i}{j} shall be dereferenced exactly once.  \\ \rowsep
+\pnum
+\effects
+Inserts a copy of \tcode{t} before \tcode{p}.
 
-\tcode{a.insert(p, il)}  &
-  \tcode{iterator}            &
-  \tcode{a.insert(p, il.begin(), il.end())}.  \\ \rowsep
+\pnum
+\returns
+An iterator that points to the copy of \tcode{t} inserted into \tcode{a}.
+\end{itemdescr}
+
+\begin{itemdecl}
+a.insert(p, rv)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}.
+
+\pnum
+\expects
+\tcode{T} is \oldconcept{MoveInsertable} into \tcode{X}.
+For \tcode{vector} and \tcode{deque},
+\tcode{T} is also \oldconcept{MoveAssignable}.
+
+\pnum
+\effects
+Inserts a copy of \tcode{rv} before \tcode{p}.
+
+\pnum
+\returns
+An iterator that points to the copy of \tcode{rv} inserted into \tcode{a}.
+\end{itemdescr}
+
+\begin{itemdecl}
+a.insert(p, n, t)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}.
+
+\pnum
+\expects
+\tcode{T} is \oldconcept{CopyInsertable} into \tcode{X}
+and \oldconcept{CopyAssignable}.
+
+\pnum
+\effects
+Inserts \tcode{n} copies of \tcode{t} before \tcode{p}.
+
+\pnum
+\returns
+An iterator
+that points to the copy of the first element inserted into \tcode{a}, or
+\tcode{p} if \tcode{n == 0}.
+\end{itemdescr}
+
+\begin{itemdecl}
+a.insert(p, i, j)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}.
+
+\pnum
+\expects
+\tcode{T} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
+For \tcode{vector} and \tcode{deque},
+\tcode{T} is also
+\oldconcept{MoveInsertable} into \tcode{X},
+\oldconcept{MoveConstructible},
+\oldconcept{MoveAssignable}, and
+swappable\iref{swappable.requirements}.
+Neither \tcode{i} nor \tcode{j} are iterators into \tcode{a}.
+
+\pnum
+\effects
+Inserts copies of elements in \tcode{[i, j)} before \tcode{p}.
+Each iterator in the range \range{i}{j} shall be dereferenced exactly once.
+
+\pnum
+\returns
+An iterator
+that points to the copy of the first element inserted into \tcode{a}, or
+\tcode{p} if \tcode{i == j}.
+\end{itemdescr}
+
+\begin{itemdecl}
+a.insert(p, il)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}
+
+\pnum
+\effects
+Equivalent to \tcode{a.insert(p, il.begin(), il.end())}.
+
+\pnum
+\returns
+\begin{removedblock}
+An iterator
+that points to the copy of the first element inserted into \tcode{a}, or
+\tcode{p} if \tcode{il} is empty.
+\end{removedblock}
+\end{itemdescr}
 
 \indexcont{erase}%
-\tcode{a.erase(q)}  &
- \tcode{iterator}   &
- \expects For \tcode{vector} and \tcode{deque},
- \tcode{T} is \oldconcept{MoveAssignable}.\br
- \effects\ Erases the element pointed to by \tcode{q}. \\ \rowsep
+\begin{itemdecl}
+a.erase(q)
+\end{itemdecl}
 
-\tcode{a.erase(q1,q2)}  &
- \tcode{iterator}   &
- \expects For \tcode{vector} and \tcode{deque},
- \tcode{T} is \oldconcept{MoveAssignable}.\br
- \effects\ Erases the elements in the range \tcode{[q1, q2)}.  \\ \rowsep
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}.
+
+\pnum
+\expects
+For \tcode{vector} and \tcode{deque},
+\tcode{T} is \oldconcept{MoveAssignable}.
+
+\pnum
+\effects
+Erases the element pointed to by \tcode{q}.
+
+\pnum
+\returns
+An iterator that points to the element immediately following \tcode{q}
+prior to the element being erased.
+If no such element exists, \tcode{a.end()} is returned.
+\end{itemdescr}
+
+\begin{itemdecl}
+a.erase(q1, q2)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}.
+
+\pnum
+\expects
+For \tcode{vector} and \tcode{deque}, \tcode{T} is \oldconcept{MoveAssignable}.
+
+\pnum
+\effects
+Erases the elements in the range \tcode{[q1, q2)}.
+
+\pnum
+\returns
+An iterator that points to the element pointed to by \tcode{q2}
+prior to any elements being erased.
+If no such element exists, \tcode{a.end()} is returned.
+\end{itemdescr}
 
 \indexcont{clear}%
-\tcode{a.clear()}   &
- \keyword{void}       &
- \effects Destroys all elements in \tcode{a}. Invalidates all references, pointers, and
- iterators referring to the elements of \tcode{a} and may invalidate the past-the-end iterator.\br
- \ensures \tcode{a.empty()} is \tcode{true}.\br
- \complexity Linear.      \\ \rowsep
+\begin{itemdecl}
+a.clear()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
+
+\pnum
+\effects
+Destroys all elements in \tcode{a}.
+Invalidates all references, pointers, and iterators
+referring to the elements of \tcode{a} and
+may invalidate the past-the-end iterator.
+
+\pnum
+\ensures
+\tcode{a.empty()} is \tcode{true}.
+
+\pnum
+\complexity
+Linear.
+\end{itemdescr}
 
 \indexcont{assign}%
-\tcode{a.assign(i,j)}   &
- \keyword{void}           &
- \expects \tcode{T} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}
- and assignable from \tcode{*i}. For \tcode{vector}, if the iterator does not
- meet the forward iterator requirements\iref{forward.iterators}, \tcode{T}
- is also
- \oldconcept{MoveInsertable} into \tcode{X}.
- Neither \tcode{i} nor \tcode{j} are iterators into \tcode{a}.\br
- \effects
- Replaces elements in \tcode{a} with a copy of \tcode{[i, j)}.
- Invalidates all references, pointers and iterators
- referring to the elements of \tcode{a}.
- For \tcode{vector} and \tcode{deque},
- also invalidates the past-the-end iterator.
- Each iterator in the range \range{i}{j} shall be dereferenced exactly once.  \\ \rowsep
+\begin{itemdecl}
+a.assign(i, j)
+\end{itemdecl}
 
-\tcode{a.assign(il)}    &
-  \keyword{void}          &
-  \tcode{a.assign(il.begin(), il.end())}. \\ \rowsep
-
-\tcode{a.assign(n,t)}   &
- \keyword{void}           &
- \expects \tcode{T} is
- \oldconcept{CopyInsertable} into \tcode{X}
- and \oldconcept{CopyAssignable}.
- \tcode{t} is not a reference into \tcode{a}.\br
- \effects Replaces elements in \tcode{a} with \tcode{n} copies of \tcode{t}.
- Invalidates all references, pointers and iterators
- referring to the elements of \tcode{a}.
- For \tcode{vector} and \tcode{deque},
- also invalidates the past-the-end iterator.  \\
-\end{libreqtab3}
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
 
 \pnum
-The iterator returned from
-\tcode{a.insert(p, t)}
-points to the copy of
-\tcode{t}
-inserted into
-\tcode{a}.
+\expects
+\tcode{T} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}
+and assignable from \tcode{*i}.
+For \tcode{vector},
+if the iterator does not meet
+the forward iterator requirements\iref{forward.iterators},
+\tcode{T} is also \oldconcept{MoveInsertable} into \tcode{X}.
+Neither \tcode{i} nor \tcode{j} are iterators into \tcode{a}.
 
 \pnum
-The iterator returned from \tcode{a.insert(p, rv)} points to the copy of \tcode{rv}
-inserted into \tcode{a}.
+\effects
+Replaces elements in \tcode{a} with a copy of \tcode{[i, j)}.
+Invalidates all references, pointers and iterators
+referring to the elements of \tcode{a}.
+For \tcode{vector} and \tcode{deque},
+also invalidates the past-the-end iterator.
+Each iterator in the range \range{i}{j} shall be dereferenced exactly once.
+\end{itemdescr}
+
+\begin{itemdecl}
+a.assign(il)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
 
 \pnum
-The iterator returned from \tcode{a.insert(p, n, t)} points to the copy of the first
-element inserted into \tcode{a}, or \tcode{p} if \tcode{n == 0}.
+\effects
+Equivalent to \tcode{a.assign(il.begin(), il.end())}.
+\end{itemdescr}
+
+\begin{itemdecl}
+a.assign(n, t)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
 
 \pnum
-The iterator returned from \tcode{a.insert(p, i, j)} points to the copy of the first
-element inserted into \tcode{a}, or \tcode{p} if \tcode{i == j}.
+\expects
+\tcode{T} is \oldconcept{CopyInsertable} into \tcode{X}
+and \oldconcept{CopyAssignable}.
+\tcode{t} is not a reference into \tcode{a}.
 
 \pnum
-The iterator returned from \tcode{a.insert(p, il)} points to the copy of the first
-element inserted into \tcode{a}, or \tcode{p} if \tcode{il} is empty.
-
-\pnum
-The iterator returned from \tcode{a.emplace(p, args)} points to the new element
-constructed from \tcode{args} into \tcode{a}.
-
-\pnum
-The iterator returned from
-\tcode{a.erase(q)}
-points to the element immediately following
-\tcode{q}
-prior to the element being erased.
-If no such element exists,
-\tcode{a.end()}
-is returned.
-
-\pnum
-The iterator returned by
-\tcode{a.erase(q1, q2)}
-points to the element pointed to by
-\tcode{q2}
-prior to any elements being erased.
-If no such element exists,
-\tcode{a.end()}
-is returned.
+\effects
+Replaces elements in \tcode{a} with \tcode{n} copies of \tcode{t}.
+Invalidates all references, pointers and iterators
+referring to the elements of \tcode{a}.
+For \tcode{vector} and \tcode{deque},
+also invalidates the past-the-end iterator.
+\end{itemdescr}
 
 \pnum
 For every sequence container defined in this Clause and in \ref{strings}:
@@ -1181,165 +1728,324 @@ qualify as an allocator is deduced for that parameter.
 \end{itemize}
 
 \pnum
-\tref{container.seq.opt} lists operations
-that are provided for some types of
-sequence containers but not others.
-An implementation shall provide
-these operations for all container types shown in the ``container''
-column, and shall implement them so as to take amortized constant
-time.
+The following operations are provided for
+some types of sequence containers but not others.
+An implementation shall implement them so as to take amortized constant time.
 
-\begin{libreqtab4a}
-{Optional sequence container operations}
-{container.seq.opt}
-\\ \topline
-\lhdr{Expression}       &   \chdr{Return type}  &   \chdr{Operational semantics}       &   \rhdr{Container}    \\ \capsep
-\endfirsthead
-\continuedcaption\\
-\hline
-\lhdr{Expression}       &   \chdr{Return type}  &   \chdr{Operational semantics}       &   \rhdr{Container}    \\ \capsep
-\endhead
+\begin{itemdecl}
+a.front()
+\end{itemdecl}
 
-\tcode{a.front()}       &
- \tcode{reference; const_reference} for constant \tcode{a}    &
- \tcode{*a.begin()}     &
- \tcode{basic_string},
- \tcode{array},
- \tcode{deque},
- \tcode{forward_list},
- \tcode{list},
- \tcode{vector}
- \\ \rowsep
-
-\tcode{a.back()}        &
- \tcode{reference; const_reference} for constant \tcode{a}    &
- \tcode{\{ auto tmp = a.end();}\br
- \tcode{    --tmp;}\br
- \tcode{    return *tmp; \}}    &
- \tcode{basic_string},
- \tcode{array},
- \tcode{deque},
- \tcode{list},
- \tcode{vector}
- \\ \rowsep
-
-\tcode{a.emplace_\-front(args)}      &
- \tcode{reference}                &
- \effects Prepends an object of type \tcode{T} constructed with \tcode{std::forward<\brk{}Args\brk{}>(\brk{}args)...}.\br
- \expects \tcode{T} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.\br
- \returns \tcode{a.front()}.  &
- \tcode{deque},
- \tcode{forward_list},
- \tcode{list}
- \\ \rowsep
-
-\tcode{a.emplace_\-back(args)}      &
- \tcode{reference}                &
- \effects Appends an object of type \tcode{T} constructed with \tcode{std::forward<\brk{}Args\brk{}>(\brk{}args)...}.\br
- \expects \tcode{T} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}. For \tcode{vector}, \tcode{T}
- is also
- \oldconcept{MoveInsertable} into \tcode{X}.
- \returns \tcode{a.back()}.  &
- \tcode{deque},
- \tcode{list},
- \tcode{vector}
- \\ \rowsep
-
-\tcode{a.push_front(t)} &
-  \keyword{void}          &
-  \effects Prepends a copy of \tcode{t}.\br
-  \expects \tcode{T} is
-  \oldconcept{CopyInsertable} into \tcode{X}.
-    &
-  \tcode{deque},
-  \tcode{forward_list},
-  \tcode{list}
-  \\ \rowsep
-
-\tcode{a.push_front(rv)} &
-  \keyword{void}          &
-  \effects Prepends a copy of \tcode{rv}.\br
-  \expects \tcode{T} is
-  \oldconcept{MoveInsertable} into \tcode{X}.
-    &
-  \tcode{deque},
-  \tcode{forward_list},
-  \tcode{list}
-  \\ \rowsep
-
-\tcode{a.push_back(t)} &
-  \keyword{void}          &
-  \effects Appends a copy of \tcode{t}.\br
-  \expects \tcode{T} is
-  \oldconcept{CopyInsertable} into \tcode{X}.
-    &
-  \tcode{basic_string},
-  \tcode{deque},
-  \tcode{list},
-  \tcode{vector}
-  \\ \rowsep
-
-\tcode{a.push_back(rv)} &
-  \keyword{void}          &
-  \effects Appends a copy of \tcode{rv}.\br
-  \expects \tcode{T} is
-  \oldconcept{MoveInsertable} into \tcode{X}.
-    &
-  \tcode{basic_string},
-  \tcode{deque},
-  \tcode{list},
-  \tcode{vector}
-  \\ \rowsep
-
-\tcode{a.pop_front()}      &
- \keyword{void}               &
- \effects Destroys the first element.\br
- \expects \tcode{a.empty()} is \tcode{false}. &
- \tcode{deque},
- \tcode{forward_list},
- \tcode{list}
- \\ \rowsep
-
-\tcode{a.pop_back()}       &
- \keyword{void}               &
- \effects Destroys the last element.\br
- \expects \tcode{a.empty()} is \tcode{false}. &
- \tcode{basic_string},
- \tcode{deque},
- \tcode{list},
- \tcode{vector}
- \\ \rowsep
-
-\tcode{a[n]}                &
- \tcode{reference; const_reference} for constant \tcode{a}    &
- \tcode{*(a.begin() + n)}   &
- \tcode{basic_string},
- \tcode{array},
- \tcode{deque},
- \tcode{vector}
- \\ \rowsep
-
-\tcode{a.at(n)}             &
- \tcode{reference; const_reference} for constant \tcode{a}    &
- \tcode{*(a.begin() + n)}   &
- \tcode{basic_string},
- \tcode{array},
- \tcode{deque},
- \tcode{vector}
- \\
-
-\end{libreqtab4a}
+\begin{itemdescr}
+\pnum
+\result
+\tcode{reference; const_reference} for constant \tcode{a}.
 
 \pnum
-The member function
-\tcode{at()}
-provides bounds-checked access to container elements.
-\tcode{at()}
-throws
-\tcode{out_of_range}
-if
-\tcode{n >= a.size()}.
+\returns
+\tcode{*a.begin()}
 
+\pnum
+\remarks
+Required for
+\tcode{basic_string},
+\tcode{array},
+\tcode{deque},
+\tcode{forward_list},
+\tcode{list}, and
+\tcode{vector}.
+\end{itemdescr}
+
+\begin{itemdecl}
+a.back()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{reference; const_reference} for constant \tcode{a}.
+
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+auto tmp = a.end();
+--tmp;
+return *tmp;
+\end{codeblock}
+
+\pnum
+\remarks
+Required for
+\tcode{basic_string},
+\tcode{array},
+\tcode{deque},
+\tcode{list}, and
+\tcode{vector}.
+\end{itemdescr}
+
+\begin{itemdecl}
+a.emplace_front(args)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{reference}
+
+\pnum
+\expects
+\tcode{T} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.
+
+\pnum
+\effects
+Prepends an object of type \tcode{T}
+constructed with \tcode{std::forward<Args>(args)...}.
+
+\pnum
+\returns
+\tcode{a.front()}.
+
+\pnum
+\remarks
+Required for
+\tcode{deque},
+\tcode{forward_list}, and
+\tcode{list}.
+\end{itemdescr}
+
+\begin{itemdecl}
+a.emplace_back(args)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{reference}
+
+\pnum
+\expects
+\tcode{T} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.
+For \tcode{vector},
+\tcode{T} is also \oldconcept{MoveIn\-sert\-able} into \tcode{X}.
+
+\pnum
+\effects
+Appends an object of type \tcode{T}
+constructed with \tcode{std::forward<Args>(args)...}.
+
+\pnum
+\returns
+\tcode{a.back()}.
+
+\pnum
+\remarks
+Required for
+\tcode{deque},
+\tcode{list}, and
+\tcode{vector}.
+\end{itemdescr}
+
+\begin{itemdecl}
+a.push_front(t)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
+
+\pnum
+\expects
+\tcode{T} is \oldconcept{CopyInsertable} into \tcode{X}.
+
+\pnum
+\effects
+Prepends a copy of \tcode{t}.
+
+\pnum
+\remarks
+Required for
+\tcode{deque},
+\tcode{forward_list}, and
+\tcode{list}.
+\end{itemdescr}
+
+\begin{itemdecl}
+a.push_front(rv)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
+
+\pnum
+\expects
+\tcode{T} is \oldconcept{MoveInsertable} into \tcode{X}.
+
+\pnum
+\effects
+Prepends a copy of \tcode{rv}.
+
+\pnum
+\remarks
+Required for
+\tcode{deque},
+\tcode{forward_list}, and
+\tcode{list}.
+\end{itemdescr}
+
+\begin{itemdecl}
+a.push_back(t)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
+
+\pnum
+\expects
+\tcode{T} is \oldconcept{CopyInsertable} into \tcode{X}.
+
+\pnum
+\effects
+Appends a copy of \tcode{t}.
+
+\pnum
+\remarks
+Required for
+\tcode{basic_string},
+\tcode{deque},
+\tcode{list}, and
+\tcode{vector}.
+\end{itemdescr}
+
+\begin{itemdecl}
+a.push_back(rv)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
+
+\pnum
+\expects
+\tcode{T} is \oldconcept{MoveInsertable} into \tcode{X}.
+
+\pnum
+\effects
+Appends a copy of \tcode{rv}.
+
+\pnum
+\remarks
+Required for
+\tcode{basic_string},
+\tcode{deque},
+\tcode{list}, and
+\tcode{vector}.
+\end{itemdescr}
+
+\begin{itemdecl}
+a.pop_front()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
+
+\pnum
+\expects
+\tcode{a.empty()} is \tcode{false}.
+
+\pnum
+\effects
+Destroys the first element.
+
+\pnum
+\remarks
+Required for
+\tcode{deque},
+\tcode{forward_list}, and
+\tcode{list}.
+\end{itemdescr}
+
+\begin{itemdecl}
+a.pop_back()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
+
+\pnum
+\expects
+\tcode{a.empty()} is \tcode{false}.
+
+\pnum
+\effects
+Destroys the last element.
+
+\pnum
+\remarks
+Required for
+\tcode{basic_string},
+\tcode{deque},
+\tcode{list}, and
+\tcode{vector}.
+\end{itemdescr}
+
+\begin{itemdecl}
+a[n]
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{reference; const_reference} for constant \tcode{a}
+
+\pnum
+\returns
+\tcode{*(a.begin() + n)}
+
+\pnum
+\remarks
+Required for
+\tcode{basic_string},
+\tcode{array},
+\tcode{deque}, and
+\tcode{vector}.
+\end{itemdescr}
+
+\begin{itemdecl}
+a.at(n)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{reference; const_reference} for constant \tcode{a}
+
+\pnum
+\returns
+\tcode{*(a.begin() + n)}
+
+\pnum
+\throws
+\tcode{out_of_range} if \tcode{n >= a.size()}.
+
+\pnum
+\remarks
+Required for
+\tcode{basic_string},
+\tcode{array},
+\tcode{deque}, and
+\tcode{vector}.
+\end{itemdescr}
 
 \rSec2[container.node]{Node handles}
 
@@ -1393,7 +2099,7 @@ undefined.
 template<@\unspecnc@>
 class @\placeholder{node-handle}@ {
 public:
-  // These type declarations are described in Tables \ref{tab:container.assoc.req} and \ref{tab:container.hash.req}.
+  // These type declarations are described in \ref{associative.reqmts} and \ref{unord.req}.
   using value_type     = @\seebelownc{}@;     // not present for map containers
   using key_type       = @\seebelownc{}@;     // not present for set containers
   using mapped_type    = @\seebelownc{}@;     // not present for set containers
@@ -1742,20 +2448,7 @@ are the same type.
 \end{note}
 
 \pnum
-The associative containers meet all the requirements of Allocator-aware
-containers\iref{container.requirements.general}, except that for
-\tcode{map} and \tcode{multimap}, the requirements placed on \tcode{value_type}
-in \tref{container.alloc.req} apply instead to \tcode{key_type}
-and \tcode{mapped_type}.
-\begin{note}
-For example, in some cases \tcode{key_type} and \tcode{mapped_type}
-are required to be \oldconcept{CopyAssignable} even though the associated
-\tcode{value_type}, \tcode{pair<const key_type, mapped_type>}, is not
-\oldconcept{CopyAssignable}.
-\end{note}
-
-\pnum
-In \tref{container.assoc.req},
+In this subclause,
 \begin{itemize}
 \item
 \tcode{X} denotes an associative container class,
@@ -1833,6 +2526,23 @@ either \tcode{iterator} or \tcode{const_iterator}; and
 and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \end{itemize}
 
+\pnum
+A type \tcode{X} meets the \defnadj{associative}{container} requirements
+if \tcode{X} meets all the requirements of an allocator-aware
+container\iref{container.requirements.general} and
+the following types, statements, and expressions are well-formed and
+have the specified semantics,
+except that for
+\tcode{map} and \tcode{multimap}, the requirements placed on \tcode{value_type}
+in \ref{container.alloc.reqmts} apply instead to \tcode{key_type}
+and \tcode{mapped_type}.
+\begin{note}
+For example, in some cases \tcode{key_type} and \tcode{mapped_type}
+are required to be \oldconcept{CopyAssignable} even though the associated
+\tcode{value_type}, \tcode{pair<const key_type, mapped_type>}, is not
+\oldconcept{CopyAssignable}.
+\end{note}
+
 % Local command to index names as members of all ordered containers.
 \newcommand{\indexordmem}[1]{%
 \indexlibrary{\idxcode{#1}!ordered associative containers}%
@@ -1842,436 +2552,1113 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \indexlibrary{\idxcode{multimap}!\idxcode{#1}}%
 }
 
-\begin{libreqtab4b}
-{Associative container requirements (in addition to container)}
-{container.assoc.req}
-\\ \topline
-\lhdr{Expression}       &   \chdr{Return type}  &   \chdr{Assertion/note}       &   \rhdr{Complexity}   \\
-                        &                       &   \chdr{pre-/post-condition}   &                       \\ \capsep
-\endfirsthead
-\continuedcaption\\
-\hline
-\lhdr{Expression}       &   \chdr{Return type}  &   \chdr{Assertion/note}       &   \rhdr{Complexity}   \\
-                        &                       &   \chdr{pre-/post-condition}   &                       \\ \capsep
-\endhead
-
 \indexordmem{key_type}%
-\tcode{X::key_type}     &
- \tcode{Key}            &
-                        &
-  compile time \\ \rowsep
+\begin{itemdecl}
+typename X::key_type
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{Key}.
+\end{itemdescr}
 
 \indexordmem{mapped_type}%
-\tcode{X::mapped_type} (\tcode{map} and \tcode{multimap} only) &
-  \tcode{T}             &
-                        &
-  compile time          \\ \rowsep
+\begin{itemdecl}
+typename X::mapped_type
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{T}.
+
+\pnum
+\remarks
+For \tcode{map} and \tcode{multimap} only.
+\end{itemdescr}
 
 \indexordmem{value_type}%
-\tcode{X::value_type} (\tcode{set} and \tcode{multiset} only) &
- \tcode{Key}            &
-  \expects \tcode{value_type} is \oldconcept{Erasable} from \tcode{X} &
-  compile time \\ \rowsep
+\begin{itemdecl}
+typename X::value_type
+\end{itemdecl}
 
-\tcode{X::value_type} (\tcode{map} and \tcode{multimap} only) &
- \tcode{pair<const Key, T>}            &
-  \expects \tcode{value_type} is \oldconcept{Erasable} from \tcode{X} &
-  compile time \\ \rowsep
+\begin{itemdescr}
+\pnum
+\result
+\tcode{Key} for \tcode{set} and \tcode{multiset} only;
+\tcode{pair<const Key, T>} for \tcode{map} and \tcode{multimap} only.
+
+\pnum
+\expects
+\tcode{X::value_type} is \oldconcept{Erasable} from \tcode{X}.
+\end{itemdescr}
 
 \indexordmem{key_compare}%
-\tcode{X::key_compare}  &
-  \tcode{Compare}       &
-  \expects \tcode{key_compare} is \oldconcept{CopyConstructible}. &
-  compile time   \\ \rowsep
+\begin{itemdecl}
+typename X::key_compare
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{Compare}.
+
+\pnum
+\expects
+\tcode{key_compare} is \oldconcept{CopyConstructible}.
+\end{itemdescr}
 
 \indexordmem{value_compare}%
-\tcode{X::value_compare}           &
- a binary predicate type           &
- is the same as \tcode{key_compare} for \tcode{set} and
- \tcode{multiset}; is an ordering relation on pairs induced by the
- first component (i.e., \tcode{Key}) for \tcode{map} and \tcode{multimap}. &
- compile time                       \\ \rowsep
+\begin{itemdecl}
+typename X::value_compare
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+A binary predicate type.
+It is the same as \tcode{key_compare} for \tcode{set} and
+\tcode{multiset}; is an ordering relation on pairs induced by the
+first component (i.e., \tcode{Key}) for \tcode{map} and \tcode{multimap}.
+\end{itemdescr}
 
 \indexordmem{node_type}%
-\tcode{X::node_type} &
- A specialization of a \exposid{node-handle}
- class template, such that the public nested types are
- the same types as the corresponding types in \tcode{X}. &
- see~\ref{container.node} &
- compile time \\ \rowsep
+\begin{itemdecl}
+typename X::node_type
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+A specialization of
+the \exposid{node-handle} class template\iref{container.node},
+such that the public nested types are
+the same types as the corresponding types in \tcode{X}.
+\end{itemdescr}
 
 \indexlibraryctor{set}%
 \indexlibraryctor{map}%
 \indexlibraryctor{multiset}%
 \indexlibraryctor{multimap}%
-\tcode{X(c)}\br
-\tcode{X u(c);}                         &
-                                        &
-  \effects\ Constructs an empty container.
-  Uses a copy of \tcode{c} as a comparison object.  &
- constant                               \\ \rowsep
+\begin{itemdecl}
+X(c)
+\end{itemdecl}
 
-\tcode{X()}\br\tcode{X u;}                      &
-                                                &
-  \expects \tcode{key_compare} meets the \oldconcept{DefaultConstructible} requirements.\br
-  \effects\ Constructs an empty container.
-  Uses \tcode{Compare()} as a comparison object  &
-  constant                                       \\ \rowsep
+\begin{itemdescr}
+\pnum
+\effects
+Constructs an empty container.
+Uses a copy of \tcode{c} as a comparison object.
 
-\tcode{X(i,j,c)}\br
-\tcode{X~u(i,j,c);}     &
-                        &
-  \expects \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
-  \effects\ Constructs an empty container and inserts elements from the
-  range \tcode{[i, j)} into it; uses \tcode{c} as a comparison object. &
-  $N \log N$ in general, where $N$ has the value \tcode{distance(i, j)};
-  linear if \tcode{[i, j)} is sorted with \tcode{value_comp()} \\ \rowsep
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
 
-\tcode{X(i,j)}\br\tcode{X~u(i,j);}    &
-                                    &
-  \expects \tcode{key_compare} meets the \oldconcept{DefaultConstructible} requirements.
-  \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
-  \effects\ Same as above, but uses \tcode{Compare()} as a comparison object.  &
-  same as above                      \\ \rowsep
+\indexlibraryctor{set}%
+\indexlibraryctor{map}%
+\indexlibraryctor{multiset}%
+\indexlibraryctor{multimap}%
+\begin{itemdecl}
+X u = X();
+X u;
+\end{itemdecl}
 
-\tcode{X(il)}            &
-                          &
-  same as \tcode{X(il.begin(), il.end())}  &
-  same as \tcode{X(il.begin(), il.end())}  \\ \rowsep
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{key_compare} meets the \oldconcept{DefaultConstructible} requirements.
 
-\tcode{X(il,c)}          &
-                          &
-  same as \tcode{X(il.begin(), il.end(), c)}  &
-  same as \tcode{X(il.begin(), il.end(), c)}  \\ \rowsep
+\pnum
+\effects
+Constructs an empty container.
+Uses \tcode{Compare()} as a comparison object.
 
-\tcode{a = il}     &
-  \tcode{X\&}               &
-  \expects \tcode{value_type} is
-  \oldconcept{CopyInsertable} into \tcode{X}
-  and \oldconcept{CopyAssignable}.\br
-  \effects Assigns the range \range{il.begin()}{il.end()} into \tcode{a}. All
-  existing elements of \tcode{a} are either assigned to or destroyed. &
-  $N \log N$ in general, where $N$ has the value \tcode{il.size() + a.size()};
-  linear if \range{il.begin()}{il.end()} is sorted with \tcode{value_comp()}
-  \\ \rowsep
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
+
+\indexlibraryctor{set}%
+\indexlibraryctor{map}%
+\indexlibraryctor{multiset}%
+\indexlibraryctor{multimap}%
+\begin{itemdecl}
+X(i, j, c)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{value_type} is
+\oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
+
+\pnum
+\effects
+Constructs an empty container and
+inserts elements from the range \range{i}{j} into it;
+uses \tcode{c} as a comparison object.
+
+\pnum
+\complexity
+$N \log N$ in general, where $N$ has the value \tcode{distance(i, j)};
+linear if \range{i}{j} is sorted with \tcode{value_comp()}.
+\end{itemdescr}
+
+\indexlibraryctor{set}%
+\indexlibraryctor{map}%
+\indexlibraryctor{multiset}%
+\indexlibraryctor{multimap}%
+\begin{itemdecl}
+X(i, j)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{key_compare} meets the \oldconcept{DefaultConstructible} requirements.
+\tcode{value_type} is
+\oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
+
+\pnum
+\effects
+Constructs an empty container and
+inserts elements from the range \range{i}{j} into it;
+uses \tcode{Compare()} as a comparison object.
+
+\pnum
+\complexity
+$N \log N$ in general, where $N$ has the value \tcode{distance(i, j)};
+linear if \range{i}{j} is sorted with \tcode{value_comp()}.
+\end{itemdescr}
+
+\indexlibraryctor{set}%
+\indexlibraryctor{map}%
+\indexlibraryctor{multiset}%
+\indexlibraryctor{multimap}%
+\begin{itemdecl}
+X(il, c)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to \tcode{X(il.begin(), il.end(), c)}.
+\end{itemdescr}
+
+\indexlibraryctor{set}%
+\indexlibraryctor{map}%
+\indexlibraryctor{multiset}%
+\indexlibraryctor{multimap}%
+\begin{itemdecl}
+X(il)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to \tcode{X(il.begin(), il.end())}.
+\end{itemdescr}
+
+\begin{itemdecl}
+a = il
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{X\&}
+
+\pnum
+\expects
+\tcode{value_type} is \oldconcept{CopyInsertable} into \tcode{X}
+and \oldconcept{CopyAssignable}.
+
+\pnum
+\effects
+Assigns the range \range{il.begin()}{il.end()} into \tcode{a}.
+All existing elements of \tcode{a} are either assigned to or destroyed.
+
+\pnum
+\complexity
+$N \log N$ in general, where $N$ has the value \tcode{il.size() + a.size()};
+linear if \range{il.begin()}{il.end()} is sorted with \tcode{value_comp()}.
+\end{itemdescr}
 
 \indexordmem{key_comp}%
-\tcode{b.key_comp()}       &
- \tcode{X::key_compare}    &
- \returns the comparison object out of which \tcode{b} was constructed. &
- constant                   \\ \rowsep
+\begin{itemdecl}
+b.key_comp()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{X::key_compare}
+
+\pnum
+\returns
+The comparison object out of which \tcode{b} was constructed.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
 
 \indexordmem{value_comp}%
-\tcode{b.value_comp()}     &
- \tcode{X::value_compare}  &
- \returns an object of \tcode{value_compare} constructed out of the comparison object &
- constant                   \\ \rowsep
+\begin{itemdecl}
+b.value_comp()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{X::value_compare}
+
+\pnum
+\returns
+An object of \tcode{value_compare} constructed out of the comparison object.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
 
 \indexordmem{emplace}%
-\tcode{a_uniq.\brk{}emplace(\brk{}args)} &
- \tcode{pair<\brk{}iterator, bool>} &
-  \expects \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.\br
-  \effects\ Inserts a \tcode{value_type} object \tcode{t} constructed with
-  \tcode{std::forward<\brk{}Args\brk{}>(\brk{}args)...} if and only if there is no
-  element in the container with key equivalent to the key of \tcode{t}.
-  The \tcode{bool} component of the returned
-  pair is \tcode{true} if and only if the insertion takes place, and the iterator
-  component of the pair points to the element with key equivalent to the
-  key of \tcode{t}.  &
-  logarithmic \\ \rowsep
+\begin{itemdecl}
+a_uniq.emplace(args)
+\end{itemdecl}
 
-\tcode{a_eq.\brk{}emplace(\brk{}args)}  &
- \tcode{iterator}    &
- \expects \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.\br
- \effects\ Inserts a \tcode{value_type} object \tcode{t} constructed with
- \tcode{std::forward<\brk{}Args\brk{}>(\brk{}args)...} and returns the iterator pointing
- to the newly inserted element.
- If a range containing elements equivalent to \tcode{t} exists in \tcode{a_eq},
- \tcode{t} is inserted at the end of that range. &
- logarithmic    \\ \rowsep
+\begin{itemdescr}
+\pnum
+\result
+\tcode{pair<iterator, bool>}
+
+\pnum
+\expects
+\tcode{value_type} is
+\oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.
+
+\pnum
+\effects
+Inserts a \tcode{value_type} object \tcode{t}
+constructed with \tcode{std::forward<Args>(args)...}
+if and only if there is no element in the container
+with key equivalent to the key of \tcode{t}.
+
+\pnum
+\returns
+The \tcode{bool} component of the returned pair is \tcode{true}
+if and only if the insertion takes place, and
+the iterator component of the pair points to
+the element with key equivalent to the key of \tcode{t}.
+
+\pnum
+\complexity
+Logarithmic.
+\end{itemdescr}
+
+\indexordmem{emplace}%
+\begin{itemdecl}
+a_eq.emplace(args)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}
+
+\pnum
+\expects
+\tcode{value_type} is
+\oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.
+
+\pnum
+\effects
+Inserts a \tcode{value_type} object \tcode{t}
+constructed with \tcode{std::forward<Args>(args)...}.
+If a range containing elements equivalent to \tcode{t} exists in \tcode{a_eq},
+\tcode{t} is inserted at the end of that range.
+
+\pnum
+\returns
+An iterator pointing to the newly inserted element.
+
+\pnum
+\complexity
+Logarithmic.
+\end{itemdescr}
 
 \indexordmem{emplace_hint}%
-\tcode{a.emplace_\-hint(\brk{}p, args)}  &
- \tcode{iterator}    &
- \effects
- Equivalent to \tcode{a.emplace(} \tcode{std::forward<\brk{}Args\brk{}>(\brk{}args)...)}.
- Return value is an iterator pointing to the element with the key equivalent
- to the newly inserted element.
- The element is inserted as close as possible to the position just prior
- to \tcode{p}.  &
- logarithmic in general, but amortized constant if the element
- is inserted right before \tcode{p}    \\ \rowsep
+\begin{itemdecl}
+a.emplace_hint(p, args)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}
+
+\pnum
+\effects
+Equivalent to \tcode{a.emplace(std::forward<Args>(args)...)},
+except that the element is inserted as close as possible to
+the position just prior to \tcode{p}.
+
+\pnum
+\returns
+An iterator pointing to the element
+with the key equivalent to the newly inserted element.
+
+\pnum
+\complexity
+Logarithmic in general, but
+amortized constant if the element is inserted right before \tcode{p}.
+\end{itemdescr}
 
 \indexordmem{insert}%
-\tcode{a_uniq.\brk{}insert(\brk{}t)}      &
-  \tcode{pair<\brk{}iterator, bool>}   &
-  \expects If \tcode{t} is a non-const rvalue, \tcode{value_type} is
-  \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} is
-  \oldconcept{CopyInsertable} into \tcode{X}.\br
-  \effects\ Inserts \tcode{t} if and only if there is no element in the container
-  with key equivalent to the key of \tcode{t}. The \tcode{bool} component of
-  the returned pair is \tcode{true} if and only if the insertion
-  takes place, and the \tcode{iterator}
-  component of the pair points to the element with key
-  equivalent to the key of \tcode{t}.    &
-  logarithmic                    \\ \rowsep
+\begin{itemdecl}
+a_uniq.insert(t)
+\end{itemdecl}
 
-\tcode{a_eq.\brk{}insert(\brk{}t)}        &
-  \tcode{iterator}               &
-  \expects If \tcode{t} is a non-const rvalue, \tcode{value_type} is
-  \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} is
-  \oldconcept{CopyInsertable} into \tcode{X}.\br
-  \effects\ Inserts \tcode{t} and returns the iterator pointing
-  to the newly inserted element.
-  If a range containing elements equivalent to
-  \tcode{t} exists in \tcode{a_eq}, \tcode{t}
-  is inserted at the end of that range. &
-  logarithmic                    \\ \rowsep
+\begin{itemdescr}
+\pnum
+\result
+\tcode{pair<iterator, bool>}
 
-\tcode{a.\brk{}insert(\brk{}p, t)}                         &
-  \tcode{iterator}               &
-  \expects If \tcode{t} is a non-const rvalue, \tcode{value_type} is
-  \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} is
-  \oldconcept{CopyInsertable} into \tcode{X}.\br
-  \effects\ Inserts \tcode{t} if and only if there is no element with key
-  equivalent to the key of \tcode{t} in containers with unique keys;
-  always inserts \tcode{t} in containers with equivalent keys. Always
-  returns the iterator pointing to the element with key equivalent to
-  the key of \tcode{t}. \tcode{t} is inserted as close as possible to the position
-  just prior to \tcode{p}.&
-  logarithmic in general, but amortized constant if \tcode{t}
-  is inserted right before \tcode{p}. \\ \rowsep
+\pnum
+\expects
+If \tcode{t} is a non-const rvalue,
+\tcode{value_type} is \oldconcept{MoveInsertable} into \tcode{X};
+otherwise, \tcode{value_type} is \oldconcept{CopyInsertable} into \tcode{X}.
 
-\tcode{a.\brk{}insert(\brk{}i, j)}          &
-  \keyword{void}                   &
-  \expects \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
-  Neither \tcode{i} nor \tcode{j} are iterators into \tcode{a}.\br
-  \effects Inserts each element from the range \range{i}{j} if and only if there
-  is no element with key equivalent to the key of that element in containers
-  with unique keys; always inserts that element in containers with equivalent keys.  &
-  $N \log (\tcode{a.size()} + N)$, where $N$ has the value \tcode{distance(i, j)} \\ \rowsep
+\pnum
+\effects
+Inserts \tcode{t} if and only if there is no element in the container
+with key equivalent to the key of \tcode{t}.
 
-\tcode{a.\brk{}insert(\brk{}il)}           &
-  \keyword{void}                  &
-  \effects
-  Equivalent to \tcode{a.insert(il.begin(), il.end())} &
-                                          \\ \rowsep
+\pnum
+\returns
+The \tcode{bool} component of the returned pair is \tcode{true}
+if and only if the insertion takes place, and
+the \tcode{iterator} component of the pair points to
+the element with key equivalent to the key of \tcode{t}.
 
-\tcode{a_uniq.\brk{}insert(\brk{}nh)}           &
- \tcode{insert_return_type}   &
- \expects \tcode{nh} is empty or
- \tcode{a_uniq.get_allocator() == nh.get_allocator()}.\br
- \effects If \tcode{nh} is empty, has no effect. Otherwise, inserts the
- element owned by \tcode{nh} if and only if there is no element in the
- container with a key equivalent to \tcode{nh.key()}.\br
- \ensures If \tcode{nh} is empty, \tcode{inserted} is \tcode{false},
- \tcode{position} is \tcode{end()}, and \tcode{node} is empty.
- Otherwise if the insertion took place, \tcode{inserted} is \tcode{true},
- \tcode{position} points to the inserted element, and \tcode{node} is empty;
- if the insertion failed, \tcode{inserted} is \tcode{false},
- \tcode{node} has the previous value of \tcode{nh}, and \tcode{position}
- points to an element with a key equivalent to \tcode{nh.key()}. &
- logarithmic                             \\ \rowsep
+\pnum
+\complexity
+Logarithmic.
+\end{itemdescr}
 
-\tcode{a_eq.\brk{}insert(\brk{}nh)}           &
- \tcode{iterator}   &
- \expects \tcode{nh} is empty or
- \tcode{a_eq.get_allocator() == nh.get_allocator()}.\br
- \effects If \tcode{nh} is empty, has no effect and returns \tcode{a_eq.end()}.
- Otherwise, inserts the element owned by \tcode{nh} and returns an iterator
- pointing to the newly inserted element. If a range containing elements with
- keys equivalent to \tcode{nh.key()} exists in \tcode{a_eq}, the element is
- inserted at the end of that range.\br
- \ensures \tcode{nh} is empty. &
- logarithmic                             \\ \rowsep
+\indexordmem{insert}%
+\begin{itemdecl}
+a_eq.insert(t)
+\end{itemdecl}
 
-\tcode{a.\brk{}insert(\brk{}p, nh)}           &
- \tcode{iterator}   &
- \expects \tcode{nh} is empty or
- \tcode{a.get_allocator() == nh.get_allocator()}.\br
- \effects If \tcode{nh} is empty, has no effect and returns \tcode{a.end()}.
- Otherwise, inserts the element owned by \tcode{nh} if and only if there
- is no element with key equivalent to \tcode{nh.key()} in containers with
- unique keys; always inserts the element owned by \tcode{nh} in containers
- with equivalent keys. Always returns the iterator pointing to the element
- with key equivalent to \tcode{nh.key()}. The element is inserted as close
- as possible to the position just prior to \tcode{p}.\br
- \ensures \tcode{nh} is empty if insertion succeeds, unchanged if insertion fails.  &
- logarithmic in general, but amortized constant if the element is inserted right
- before \tcode{p}.                             \\ \rowsep
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}
+
+\pnum
+\expects
+If \tcode{t} is a non-const rvalue,
+\tcode{value_type} is \oldconcept{MoveInsertable} into \tcode{X};
+otherwise, \tcode{value_type} is \oldconcept{CopyInsertable} into \tcode{X}.
+
+\pnum
+\effects
+Inserts \tcode{t} and returns the iterator pointing to
+the newly inserted element.
+If a range containing elements equivalent to \tcode{t} exists in \tcode{a_eq},
+\tcode{t} is inserted at the end of that range.
+
+\pnum
+\complexity
+Logarithmic.
+\end{itemdescr}
+
+\indexordmem{insert}%
+\begin{itemdecl}
+a.insert(p, t)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}
+
+\pnum
+\expects
+If \tcode{t} is a non-const rvalue,
+\tcode{value_type} is \oldconcept{MoveInsertable} into \tcode{X};
+otherwise, \tcode{value_type} is \oldconcept{CopyInsertable} into \tcode{X}.
+
+\pnum
+\effects
+Inserts \tcode{t} if and only if there is no element
+with key equivalent to the key of \tcode{t} in containers with unique keys;
+always inserts \tcode{t} in containers with equivalent keys.
+\tcode{t} is inserted as close as possible to
+the position just prior to \tcode{p}.
+
+\pnum
+\returns
+An iterator pointing to the element with key equivalent to the key of \tcode{t}.
+
+\pnum
+\complexity
+Logarithmic in general, but
+amortized constant if \tcode{t} is inserted right before \tcode{p}.
+\end{itemdescr}
+
+\indexordmem{insert}%
+\begin{itemdecl}
+a.insert(i, j)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
+
+\pnum
+\expects
+\tcode{value_type} is
+\oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
+Neither \tcode{i} nor \tcode{j} are iterators into \tcode{a}.
+
+\pnum
+\effects
+Inserts each element from the range \range{i}{j}
+if and only if there is no element
+with key equivalent to the key of that element in containers with unique keys;
+always inserts that element in containers with equivalent keys.
+
+\pnum
+\complexity
+$N \log (\tcode{a.size()} + N)$, where $N$ has the value \tcode{distance(i, j)}.
+\end{itemdescr}
+
+\indexordmem{insert}%
+\begin{itemdecl}
+a.insert(il)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
+
+\pnum
+\effects
+Equivalent to \tcode{a.insert(il.begin(), il.end())}.
+\end{itemdescr}
+
+\indexordmem{insert}%
+\begin{itemdecl}
+a_uniq.insert(nh)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{insert_return_type}
+
+\pnum
+\expects
+\tcode{nh} is empty or
+\tcode{a_uniq.get_allocator() == nh.get_allocator()} is \tcode{true}.
+
+\pnum
+\effects
+If \tcode{nh} is empty, has no effect.
+Otherwise, inserts the element owned by \tcode{nh} if and only if
+there is no element in the container with a key equivalent to \tcode{nh.key()}.
+
+\pnum
+\returns
+If \tcode{nh} is empty, \tcode{inserted} is \tcode{false},
+\tcode{position} is \tcode{end()}, and \tcode{node} is empty.
+Otherwise if the insertion took place, \tcode{inserted} is \tcode{true},
+\tcode{position} points to the inserted element, and \tcode{node} is empty;
+if the insertion failed, \tcode{inserted} is \tcode{false},
+\tcode{node} has the previous value of \tcode{nh}, and
+\tcode{position} points to an element with a key equivalent to \tcode{nh.key()}.
+
+\complexity
+Logarithmic.
+\end{itemdescr}
+
+\indexordmem{insert}%
+\begin{itemdecl}
+a_eq.insert(nh)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}
+
+\pnum
+\expects
+\tcode{nh} is empty or
+\tcode{a_eq.get_allocator() == nh.get_allocator()} is \tcode{true}.
+
+\pnum
+\effects
+If \tcode{nh} is empty, has no effect and returns \tcode{a_eq.end()}.
+Otherwise, inserts the element owned by \tcode{nh} and
+returns an iterator pointing to the newly inserted element.
+If a range containing elements with keys equivalent to \tcode{nh.key()}
+exists in \tcode{a_eq},
+the element is inserted at the end of that range.
+
+\pnum
+\ensures
+\tcode{nh} is empty.
+
+\pnum
+\complexity
+Logarithmic.
+\end{itemdescr}
+
+\indexordmem{insert}%
+\begin{itemdecl}
+a.insert(p, nh)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}
+
+\pnum
+\expects
+\tcode{nh} is empty or
+\tcode{a.get_allocator() == nh.get_allocator()} is \tcode{true}.
+
+\pnum
+\effects
+If \tcode{nh} is empty, has no effect and returns \tcode{a.end()}.
+Otherwise, inserts the element owned by \tcode{nh} if and only if
+there is no element with key equivalent to \tcode{nh.key()}
+in containers with unique keys;
+always inserts the element owned by \tcode{nh}
+in containers with equivalent keys.
+The element is inserted as close as possible to
+the position just prior to \tcode{p}.
+
+\pnum
+\ensures
+\tcode{nh} is empty if insertion succeeds, unchanged if insertion fails.
+
+\pnum
+\returns
+An iterator pointing to the element with key equivalent to \tcode{nh.key()}.
+
+\pnum
+\complexity
+Logarithmic in general, but
+amortized constant if the element is inserted right before \tcode{p}.
+\end{itemdescr}
+
 
 \indexordmem{extract}%
-\tcode{a.\brk{}extract(\brk{}k)}              &
- \tcode{node_type}             &
- \effects Removes the first element in the container with key equivalent to \tcode{k}.\br
- \returns A \tcode{node_type} owning the element if found, otherwise an empty
- \tcode{node_type}. &
- $\log (\tcode{a.size()})$       \\ \rowsep
+\begin{itemdecl}
+a.extract(k)
+\end{itemdecl}
 
-\tcode{a_tran.\brk{}extract(\brk{}kx)}       &
- \tcode{node_type}          &
- \effects Removes the first element in the container with key \tcode{r}
- such that \tcode{!c(r, kx) \&\& !c(kx, r)} is \tcode{true}.\br
- \returns A \tcode{node_type} owning the element if found,
- otherwise an empty \tcode{node_type}. &
- $\log(\tcode{a_tran.size()})$       \\ \rowsep
+\begin{itemdescr}
+\pnum
+\result
+\tcode{node_type}
 
-\tcode{a.\brk{}extract(\brk{}q)}              &
- \tcode{node_type}             &
- \effects Removes the element pointed to by \tcode{q}.\br
- \returns A \tcode{node_type} owning that element. &
- amortized constant       \\ \rowsep
+\pnum
+\effects
+Removes the first element in the container with key equivalent to \tcode{k}.
+
+\pnum
+\returns
+A \tcode{node_type} owning the element if found,
+otherwise an empty \tcode{node_type}.
+
+\pnum
+\complexity
+$\log (\tcode{a.size()})$
+\end{itemdescr}
+
+\indexordmem{extract}%
+\begin{itemdecl}
+a_tran.extract(kx)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{node_type}
+
+\pnum
+\effects
+Removes the first element in the container with key \tcode{r}
+such that \tcode{!c(r, kx) \&\& !c(kx, r)} is \tcode{true}.
+
+\pnum
+\returns
+A \tcode{node_type} owning the element if found,
+otherwise an empty \tcode{node_type}.
+
+\pnum
+\complexity
+$\log(\tcode{a_tran.size()})$
+\end{itemdescr}
+
+\indexordmem{extract}%
+\begin{itemdecl}
+a.extract(q)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{node_type}
+
+\pnum
+\effects
+Removes the element pointed to by \tcode{q}.
+
+\pnum
+\returns
+A \tcode{node_type} owning that element.
+
+\pnum
+\complexity
+Amortized constant.
+\end{itemdescr}
 
 \indexordmem{merge}%
-\tcode{a.merge(a2)}              &
- \keyword{void}             &
- \expects \tcode{a.get_allocator() == a2.get_allocator()}.\br
- \effects Attempts to extract each element in \tcode{a2} and insert it into \tcode{a}
- using the comparison object of \tcode{a}. In containers with unique keys,
- if there is an element in \tcode{a} with key equivalent to the key of an
- element from \tcode{a2}, then that element is not extracted from \tcode{a2}.\br
- \ensures Pointers and references to the transferred elements of \tcode{a2}
- refer to those same elements but as members of \tcode{a}. Iterators referring
- to the transferred elements will continue to refer to their elements, but
- they now behave as iterators into \tcode{a}, not into \tcode{a2}.\br
- \throws Nothing unless the comparison object throws.  &
- $N \log(\tcode{a.size()+} N)$, where $N$ has the value \tcode{a2.size()}.    \\ \rowsep
+\begin{itemdecl}
+a.merge(a2)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
+
+\pnum
+\expects
+\tcode{a.get_allocator() == a2.get_allocator()}.
+
+\pnum
+\effects
+Attempts to extract each element in \tcode{a2} and insert it into \tcode{a}
+using the comparison object of \tcode{a}.
+In containers with unique keys,
+if there is an element in \tcode{a} with key equivalent to
+the key of an element from \tcode{a2},
+then that element is not extracted from \tcode{a2}.
+
+\pnum
+\ensures
+Pointers and references to the transferred elements of \tcode{a2}
+refer to those same elements but as members of \tcode{a}.
+Iterators referring to the transferred elements
+will continue to refer to their elements,
+but they now behave as iterators into \tcode{a}, not into \tcode{a2}.
+
+\pnum
+\throws
+Nothing unless the comparison object throws.
+
+\pnum
+\complexity
+$N \log(\tcode{a.size()+} N)$, where $N$ has the value \tcode{a2.size()}.
+\end{itemdescr}
 
 \indexordmem{erase}%
-\tcode{a.erase(k)}              &
- \tcode{size_type}             &
- \effects Erases all elements in the container with key equivalent to
- \tcode{k}.\br
- \returns The number of erased elements.  &
- $\log (\tcode{a.size()}) + \tcode{a.count(k)}$       \\ \rowsep
+\begin{itemdecl}
+a.erase(k)
+\end{itemdecl}
 
-\tcode{a_tran.\brk{}erase(kx)}      &
- \tcode{size_type}           &
- \effects Erases all elements in the container with key \tcode{r}
- such that \tcode{!c(r, kx) \&\& !c(kx, r)} is \tcode{true}.\br
- \returns The number of erased elements.  &
- $\log(\tcode{a_tran.size())} + \tcode{a_tran.count(kx)}$       \\ \rowsep
+\begin{itemdescr}
+\pnum
+\result
+\tcode{size_type}
 
-\tcode{a.erase(q)}              &
- \tcode{iterator}               &
- \effects Erases the element pointed to by \tcode{q}.\br
- \returns An iterator pointing to
- the element immediately following \tcode{q} prior to the element being erased.
- If no such element exists, returns \tcode{a.end()}.     &
- amortized constant             \\ \rowsep
+\pnum
+\effects
+Erases all elements in the container with key equivalent to \tcode{k}.
 
-\tcode{a.erase(r)}              &
- \tcode{iterator}               &
- \effects Erases the element pointed to by \tcode{r}.\br
- \returns An iterator pointing to
- the element immediately following \tcode{r} prior to the element being erased.
- If no such element exists, returns \tcode{a.end()}.     &
- amortized constant             \\ \rowsep
+\pnum
+\returns
+The number of erased elements.
 
-\tcode{a.erase(}\br
- \tcode{q1, q2)}  &
- \tcode{iterator}        &
- \effects Erases all the elements in the range \range{q1}{q2}.\br
- \returns An iterator pointing to
- the element pointed to by \tcode{q2} prior to any elements being erased. If no such element
- exists, \tcode{a.end()} is returned.  &
- $\log(\tcode{a.size()}) + N$, where $N$ has the value \tcode{distance(q1, q2)}.    \\ \rowsep
+\pnum
+\complexity
+$\log (\tcode{a.size()}) + \tcode{a.count(k)}$
+\end{itemdescr}
+
+\indexordmem{erase}%
+\begin{itemdecl}
+a_tran.erase(kx)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{size_type}
+
+\pnum
+\effects
+Erases all elements in the container with key \tcode{r}
+such that \tcode{!c(r, kx) \&\& !c(kx, r)} is \tcode{true}.
+
+\pnum
+\returns
+The number of erased elements.
+
+\pnum
+\complexity
+$\log(\tcode{a_tran.size())} + \tcode{a_tran.count(kx)}$
+\end{itemdescr}
+
+\indexordmem{erase}%
+\begin{itemdecl}
+a.erase(q)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}
+
+\pnum
+\effects
+Erases the element pointed to by \tcode{q}.
+
+\returns
+An iterator pointing to the element immediately following \tcode{q}
+prior to the element being erased.
+If no such element exists, returns \tcode{a.end()}.
+
+\pnum
+\complexity
+Amortized constant.
+\end{itemdescr}
+
+\indexordmem{erase}%
+\begin{itemdecl}
+a.erase(r)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}
+
+\pnum
+\effects
+Erases the element pointed to by \tcode{r}.
+
+\pnum
+\returns
+An iterator pointing to the element immediately following \tcode{r}
+prior to the element being erased.
+If no such element exists, returns \tcode{a.end()}.
+
+\pnum
+\complexity
+Amortized constant.
+\end{itemdescr}
+
+\indexordmem{erase}%
+\begin{itemdecl}
+a.erase(q1, q2)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}
+
+\pnum
+\effects
+Erases all the elements in the range \range{q1}{q2}.
+
+\pnum
+\returns
+An iterator pointing to the element pointed to by \tcode{q2}
+prior to any elements being erased.
+If no such element exists, \tcode{a.end()} is returned.
+
+\pnum
+\complexity
+$\log(\tcode{a.size()}) + N$, where $N$ has the value \tcode{distance(q1, q2)}.
+\end{itemdescr}
 
 \indexordmem{clear}%
-\tcode{a.clear()}       &
- \keyword{void}           &
- \effects Equivalent to \tcode{a.erase(a.begin(), a.end())}.\br
- \ensures \tcode{a.empty()} is \tcode{true}.  &
- linear in \tcode{a.size()}.  \\ \rowsep
+\begin{itemdecl}
+a.clear()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
+
+\pnum
+\effects
+Equivalent to \tcode{a.erase(a.begin(), a.end())}.
+
+\pnum
+\ensures
+\tcode{a.empty()} is \tcode{true}.
+
+\pnum
+\complexity
+Linear in \tcode{a.size()}.
+\end{itemdescr}
 
 \indexordmem{find}%
-\tcode{b.find(k)}       &
- \tcode{iterator}; \tcode{const_iterator} for constant \tcode{b}.  &
- \returns An iterator pointing to an element with the key equivalent
- to \tcode{k}, or \tcode{b.end()} if such an element is not found.    &
- logarithmic            \\ \rowsep
+\begin{itemdecl}
+b.find(k)
+\end{itemdecl}
 
-\tcode{a_tran.}\br
- \tcode{find(ke)}       &
- \tcode{iterator}; \tcode{const_iterator} for constant \tcode{a_tran}.  &
- \returns An iterator pointing to an element with key \tcode{r} such that
- \tcode{!c(r, ke) \&\& !c(ke, r)}, or \tcode{a_tran.end()} if such an element
- is not found.    &
- logarithmic            \\ \rowsep
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}; \tcode{const_iterator} for constant \tcode{b}.
+
+\pnum
+\returns
+An iterator pointing to an element with the key equivalent to \tcode{k}, or
+\tcode{b.end()} if such an element is not found.
+
+\pnum
+\complexity
+Logarithmic.
+\end{itemdescr}
+
+\indexordmem{find}%
+\begin{itemdecl}
+a_tran.find(ke)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}; \tcode{const_iterator} for constant \tcode{a_tran}.
+
+\pnum
+\returns
+An iterator pointing to an element with key \tcode{r}
+such that \tcode{!c(r, ke) \&\& !c(ke, r)} is \tcode{true}, or
+\tcode{a_tran.end()} if such an element is not found.
+
+\pnum
+\complexity
+Logarithmic.
+\end{itemdescr}
 
 \indexordmem{count}%
-\tcode{b.count(k)}        &
- \tcode{size_type}        &
- \returns The number of elements with key equivalent to \tcode{k}.    &
- $\log (\tcode{b.size()}) + \tcode{b.count(k)}$   \\ \rowsep
+\begin{itemdecl}
+b.count(k)
+\end{itemdecl}
 
-\tcode{a_tran.}\br
- \tcode{count(ke)}        &
- \tcode{size_type}        &
- \returns The number of elements with key \tcode{r} such that
- \tcode{!c(r, ke) \&\& !c(ke, r)}    &
- $\log (\tcode{a_tran.size()}) + \tcode{a_tran.count(ke)}$   \\ \rowsep
+\begin{itemdescr}
+\pnum
+\result
+\tcode{size_type}
+
+\pnum
+\returns
+The number of elements with key equivalent to \tcode{k}.
+
+\pnum
+\complexity
+$\log (\tcode{b.size()}) + \tcode{b.count(k)}$
+\end{itemdescr}
+
+\indexordmem{count}%
+\begin{itemdecl}
+a_tran.count(ke)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{size_type}
+
+\pnum
+\returns
+The number of elements with key \tcode{r}
+such that \tcode{!c(r, ke) \&\& !c(ke, r)}.
+
+\pnum
+\complexity
+$\log (\tcode{a_tran.size()}) + \tcode{a_tran.count(ke)}$
+\end{itemdescr}
 
 \indexordmem{contains}%
-\tcode{b.}\br
- \tcode{contains(k)}  &
- \tcode{bool}         &
- \effects Equivalent to: \tcode{return b.find(k) != b.end();}  &
- logarithmic            \\ \rowsep
+\begin{itemdecl}
+b.contains(k)
+\end{itemdecl}
 
-\tcode{a_tran.}\br
- \tcode{con\-tains(ke)} &
- \tcode{bool}         &
- \effects Equivalent to: \tcode{return a_tran.find(ke) != a_tran.end();}  &
- logarithmic            \\ \rowsep
+\begin{itemdescr}
+\pnum
+\result
+\tcode{bool}
+
+\pnum
+\effects
+Equivalent to: \tcode{return b.find(k) != b.end();}
+
+\pnum
+\complexity
+Logarithmic.
+\end{itemdescr}
+
+\indexordmem{contains}%
+\begin{itemdecl}
+a_tran.contains(ke)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{bool}
+
+\pnum
+\effects
+Equivalent to: \tcode{return a_tran.find(ke) != a_tran.end();}
+
+\pnum
+\complexity
+Logarithmic.
+\end{itemdescr}
 
 \indexordmem{lower_bound}%
-\tcode{b.lower_bound(k)}   &
- \tcode{iterator}; \tcode{const_iterator} for constant \tcode{b}.  &
- \returns An iterator pointing to the first element with
- key not less than \tcode{k},
- or \tcode{b.end()} if such an element is not found.   &
- logarithmic            \\ \rowsep
+\begin{itemdecl}
+b.lower_bound(k)
+\end{itemdecl}
 
-\tcode{a_tran.}\br
- \tcode{lower_bound(kl)}   &
- \tcode{iterator}; \tcode{const_iterator} for constant \tcode{a_tran}.  &
- \returns An iterator pointing to the first element with
- key \tcode{r} such that \tcode{!c(r, kl)},
- or \tcode{a_tran.end()} if such an element is not found.   &
- logarithmic            \\ \rowsep
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}; \tcode{const_iterator} for constant \tcode{b}.
+
+\pnum
+\returns
+An iterator pointing to the first element with key not less than \tcode{k},
+or \tcode{b.end()} if such an element is not found.
+
+\pnum
+\complexity
+Logarithmic.
+\end{itemdescr}
+
+\indexordmem{lower_bound}%
+\begin{itemdecl}
+a_tran.lower_bound(kl)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}; \tcode{const_iterator} for constant \tcode{a_tran}.
+
+\pnum
+\returns
+An iterator pointing to the first element with key \tcode{r}
+such that \tcode{!c(r, kl)},
+or \tcode{a_tran.end()} if such an element is not found.
+
+\pnum
+\complexity
+Logarithmic.
+\end{itemdescr}
 
 \indexordmem{upper_bound}%
-\tcode{b.upper_bound(k)}       &
- \tcode{iterator}; \tcode{const_iterator} for constant \tcode{b}.  &
- \returns An iterator pointing to the first element with
- key greater than \tcode{k},
- or \tcode{b.end()} if such an element is not found.   &
- logarithmic                    \\ \rowsep
+\begin{itemdecl}
+b.upper_bound(k)
+\end{itemdecl}
 
-\tcode{a_tran.}\br
- \tcode{upper_bound(ku)}       &
- \tcode{iterator}; \tcode{const_iterator} for constant \tcode{a_tran}.  &
- \returns An iterator pointing to the first element with
- key \tcode{r} such that \tcode{c(ku, r)},
- or \tcode{a_tran.end()} if such an element is not found.   &
- logarithmic                    \\ \rowsep
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}; \tcode{const_iterator} for constant \tcode{b}.
+
+\pnum
+\returns
+An iterator pointing to the first element with key greater than \tcode{k},
+or \tcode{b.end()} if such an element is not found.
+
+\pnum
+\complexity
+Logarithmic,
+\end{itemdescr}
+
+\indexordmem{upper_bound}%
+\begin{itemdecl}
+a_tran.upper_bound(ku)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}; \tcode{const_iterator} for constant \tcode{a_tran}.
+
+\pnum
+\returns
+An iterator pointing to the first element with key \tcode{r}
+such that \tcode{c(ku, r)},
+or \tcode{a_tran.end()} if such an element is not found.
+
+\pnum
+\complexity
+Logarithmic.
+\end{itemdescr}
 
 \indexordmem{equal_range}%
-\tcode{b.equal_range(k)}       &
- \tcode{pair<\brk{}iterator, iterator>};
- \tcode{pair<\brk{}const_iterator, const_iterator>} for constant \tcode{b}.     &
- \effects Equivalent to: \tcode{return make_pair(b.lower_bound(k), b.upper_bound(k));}    &
- logarithmic                    \\ \rowsep
+\begin{itemdecl}
+b.equal_range(k)
+\end{itemdecl}
 
-\tcode{a_tran.}\br
- \tcode{equal_range(ke)}       &
- \tcode{pair<\brk{}iterator, iterator>};
- \tcode{pair<\brk{}const_iterator, const_iterator>} for constant \tcode{a_tran}.     &
- \effects Equivalent to: \tcode{return make_pair(}\br
- \tcode{a_tran.lower_bound(ke), a_tran.upper_bound(ke));}    &
- logarithmic                    \\
-\end{libreqtab4b}
+\begin{itemdescr}
+\pnum
+\result
+\tcode{pair<iterator, iterator>};
+\tcode{pair<const_iterator, const_iterator>} for constant \tcode{b}.
+
+\pnum
+\effects
+Equivalent to: \tcode{return make_pair(b.lower_bound(k), b.upper_bound(k));}
+
+\pnum
+\complexity
+Logarithmic.
+\end{itemdescr}
+
+\indexordmem{equal_range}%
+\begin{itemdecl}
+a_tran.equal_range(ke)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{pair<iterator, iterator>};
+\tcode{pair<const_iterator, const_iterator>} for constant \tcode{a_tran}.
+
+\pnum
+\effects
+Equivalent to:
+\tcode{return make_pair(a_tran.lower_bound(ke), a_tran.upper_bound(ke));}
+
+\pnum
+\complexity
+Logarithmic.
+\end{itemdescr}
 
 \pnum
 The \tcode{insert} and \tcode{emplace} members shall not affect the validity of
@@ -2481,26 +3868,13 @@ references to elements. For \tcode{unordered_multiset} and
 equivalent elements.
 
 \pnum
-The unordered associative containers meet all the requirements of Allocator-aware
-containers\iref{container.requirements.general}, except that for
-\tcode{unordered_map} and \tcode{unordered_multimap}, the requirements placed on \tcode{value_type}
-in \tref{container.alloc.req} apply instead to \tcode{key_type}
-and \tcode{mapped_type}.
-\begin{note}
-For example, \tcode{key_type} and \tcode{mapped_type}
-are sometimes required to be \oldconcept{CopyAssignable} even though the associated
-\tcode{value_type}, \tcode{pair<const key_type, mapped_type>}, is not
-\oldconcept{CopyAssignable}.
-\end{note}
-
-\pnum
 \indextext{unordered associative containers}%
 \indextext{unordered associative containers!requirements}%
 \indextext{requirements!unordered associative container}%
 \indextext{unordered associative containers!unique keys}%
 \indextext{unordered associative containers!equivalent keys}%
 \indextext{requirements!container}%
-In \tref{container.hash.req},
+In this subclause,
 \begin{itemize}
 \item
 \tcode{X} denotes an unordered associative container class,
@@ -2573,6 +3947,24 @@ In \tref{container.hash.req},
 \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \end{itemize}
 
+\pnum
+A type \tcode{X} meets
+the \defnadj{unordered associative}{container} requirements
+if \tcode{X} meets all the requirements of
+an allocator-aware container\iref{container.requirements.general} and
+the following types, statements, and expressions are well-formed and
+have the specified semantics,
+except that for \tcode{unordered_map} and \tcode{unordered_multimap},
+the requirements placed on \tcode{value_type} in \ref{container.alloc.reqmts}
+apply instead to \tcode{key_type} and \tcode{mapped_type}.
+\begin{note}
+For example, \tcode{key_type} and \tcode{mapped_type}
+are sometimes required to be \oldconcept{CopyAssignable}
+even though the associated \tcode{value_type},
+\tcode{pair<const key_type, mapped_type>},
+is not \oldconcept{CopyAssignable}.
+\end{note}
+
 % Local command to index names as members of all unordered containers.
 \newcommand{\indexunordmem}[1]{%
 \indexlibrary{\idxcode{#1}!unordered associative containers}%
@@ -2582,633 +3974,1454 @@ In \tref{container.hash.req},
 \indexlibrary{\idxcode{unordered_multimap}!\idxcode{#1}}%
 }
 
-\begin{libreqtab4d}
-  {Unordered associative container requirements (in addition to container)}
-  {container.hash.req}
-\\ \topline
-\lhdr{Expression} & \chdr{Return type}   & \chdr{Assertion/note}      & \rhdr{Complexity} \\
-                  &                      & \chdr{pre-/post-condition} & \\ \capsep
-\endfirsthead
-\continuedcaption\\
-\hline
-\lhdr{Expression} & \chdr{Return type}   & \chdr{Assertion/note}      & \rhdr{Complexity} \\
-                  &                      & \chdr{pre-/post-condition} & \\ \capsep
-\endhead
-%%
 \indexunordmem{key_type}%
-\tcode{X::key_type}   &
-  \tcode{Key}         &
-                      &
-  compile time        \\ \rowsep
+\begin{itemdecl}
+typename X::key_type
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{Key}.
+\end{itemdescr}
 
 \indexunordmem{mapped_type}%
-\tcode{X::mapped_type} (\tcode{unordered_map} and \tcode{unordered_multimap} only)  &
-  \tcode{T}             &
-                        &
-  compile time          \\ \rowsep
+\begin{itemdecl}
+typename X::mapped_type
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{T}.
+
+\pnum
+\remarks
+For \tcode{unordered_map} and \tcode{unordered_multimap} only.
+\end{itemdescr}
 
 \indexunordmem{value_type}%
-\tcode{X::value_type} (\tcode{unordered_set} and \tcode{unordered_multiset} only) &
- \tcode{Key}            &
-  \expects \tcode{value_type} is \oldconcept{Erasable} from \tcode{X} &
-  compile time \\ \rowsep
+\begin{itemdecl}
+typename X::value_type
+\end{itemdecl}
 
-\tcode{X::value_type} (\tcode{unordered_map} and \tcode{unordered_multimap} only) &
- \tcode{pair<const Key, T>}            &
-  \expects \tcode{value_type} is \oldconcept{Erasable} from \tcode{X} &
-  compile time \\ \rowsep
+\begin{itemdescr}
+\pnum
+\result
+\tcode{Key} for \tcode{unordered_set} and \tcode{unordered_multiset} only;
+\tcode{pair<const Key, T>}
+for \tcode{unordered_map} and \tcode{unordered_multimap} only.
+
+\pnum
+\expects
+\tcode{value_type} is \oldconcept{Erasable} from \tcode{X}.
+\end{itemdescr}
 
 \indexunordmem{hasher}%
-\tcode{X::hasher}
-&   \tcode{Hash}
-&   \expects \tcode{Hash} is a unary function object type such that the expression
-    \tcode{hf(k)} has type \tcode{size_t}.%
-&   compile time
-\\ \rowsep
-%
+\begin{itemdecl}
+typename X::hasher
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{Hash}.
+
+\pnum
+\expects
+\tcode{Hash} is a unary function object type
+such that the expression \tcode{hf(k)} has type \tcode{size_t}.
+\end{itemdescr}
+
 \indexunordmem{key_equal}%
-\tcode{X::key_equal}
-&   \tcode{Pred}
-&   \expects \tcode{Pred} meets the \oldconcept{CopyConstructible} requirements.\br
-    \tcode{Pred} is a binary predicate that takes two arguments
-    of type \tcode{Key}.  \tcode{Pred} is an equivalence relation.%
-&   compile time
-\\ \rowsep
-%
+\begin{itemdecl}
+typename X::key_equal
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{Pred}.
+
+\pnum
+\expects
+\tcode{Pred} meets the \oldconcept{CopyConstructible} requirements.
+\tcode{Pred} is a binary predicate that takes two arguments of type \tcode{Key}.
+\tcode{Pred} is an equivalence relation.
+\end{itemdescr}
+
 \indexunordmem{local_iterator}%
-\tcode{X::local_iterator}
-&   An iterator type whose category, value type,
-    difference type, and pointer and reference types are the same as
-    \tcode{X::iterator}'s. \indextext{\idxcode{local_iterator}}
-&   A \tcode{local_iterator} object may be used to iterate through a
-    single bucket, but may not be used to iterate across
-    buckets.%
-&   compile time
-\\ \rowsep
-%
+\begin{itemdecl}
+typename X::local_iterator
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+An iterator type
+whose category, value type, difference type, and pointer and reference types
+are the same as \tcode{X::iterator}'s.
+\begin{note}
+A \tcode{local_iterator} object can be used to iterate through a single bucket,
+but cannot be used to iterate across buckets.
+\end{note}
+\end{itemdescr}
+
 \indexunordmem{const_local_iterator}%
-\tcode{X::const_local_iterator}
-&   An iterator type whose category, value type,
-    difference type, and pointer and reference types are the same as
-    \tcode{X::const_iterator}'s. \indextext{\idxcode{const_local_iterator}}
-&   A \tcode{const_local_iterator} object may be used to iterate through a
-    single bucket, but may not be used to iterate across
-    buckets.%
-&   compile time
-\\ \rowsep
-%
+\begin{itemdecl}
+typename X::const_local_iterator
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+An iterator type
+whose category, value type, difference type, and pointer and reference types
+are the same as \tcode{X::const_iterator}'s.
+\begin{note}
+A \tcode{const_local_iterator} object can be used to iterate
+through a single bucket,
+but cannot be used to iterate across buckets.
+\end{note}
+\end{itemdescr}
+
 \indexunordmem{node_type}%
-\tcode{X::node_type} &
- a specialization of a \exposid{node-handle}
- class template, such that the public nested types are
- the same types as the corresponding types in \tcode{X}. &
- see~\ref{container.node} &
- compile time \\ \rowsep
-%
+\begin{itemdecl}
+typename X::node_type
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+A specialization of a \exposid{node-handle} class template\iref{container.node},
+such that the public nested types are the same types
+as the corresponding types in \tcode{X}.
+\end{itemdescr}
+
 \indexlibraryctor{unordered_set}%
 \indexlibraryctor{unordered_map}%
 \indexlibraryctor{unordered_multiset}%
 \indexlibraryctor{unordered_multimap}%
-\tcode{X(n, hf, eq)}\br \tcode{X a(n, hf, eq);}
-&   \tcode{X}
-&   \effects\ Constructs an empty container with at least \tcode{n} buckets,
-using \tcode{hf} as the hash function and \tcode{eq} as the key
-equality predicate.
-&   \bigoh{\tcode{n}}
-\\ \rowsep
-%
-\tcode{X(n, hf)}\br \tcode{X a(n, hf);}
-&   \tcode{X}
-&   \expects \tcode{key_equal} meets the \oldconcept{DefaultConstructible} requirements.\br
-    \effects\ Constructs an empty container with at least \tcode{n} buckets,
-using \tcode{hf} as the hash function and \tcode{key_equal()} as the key
-equality predicate.
-&   \bigoh{\tcode{n}}
-\\ \rowsep
-%
-\tcode{X(n)}\br \tcode{X a(n);}
-&   \tcode{X}
-&   \expects \tcode{hasher} and \tcode{key_equal} meet the \oldconcept{DefaultConstructible} requirements.\br
-    \effects\ Constructs an empty container with at least \tcode{n} buckets,
-using \tcode{hasher()} as the hash function and \tcode{key_equal()}
-as the key equality predicate.
-&   \bigoh{\tcode{n}}
-\\ \rowsep
-%
-\tcode{X()}\br \tcode{X a;}
-&   \tcode{X}
-&   \expects \tcode{hasher} and \tcode{key_equal} meet the \oldconcept{DefaultConstructible} requirements.\br
-    \effects\ Constructs an empty container with an unspecified number of
-  buckets, using \tcode{hasher()} as the hash function and
-  \tcode{key_equal()} as the key equality predicate.
-&   constant
-\\ \rowsep
-%
-\tcode{X(i, j, n, hf, eq)}\br \tcode{X a(i, j, n, hf, eq);}
-&   \tcode{X}
-&   \expects \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
-    \effects\ Constructs an empty container with at least \tcode{n} buckets,
-using \tcode{hf} as the hash function and \tcode{eq} as the key
-equality predicate, and inserts elements from \tcode{[i, j)} into it.
-&   Average case \bigoh{N} ($N$ is \tcode{distance(i, j)}), worst case
-\bigoh{N^2}
-\\ \rowsep
-%
-\tcode{X(i, j, n, hf)}\br \tcode{X a(i, j, n, hf);}
-&   \tcode{X}
-&   \expects \tcode{key_equal} meets the \oldconcept{DefaultConstructible} requirements.
-    \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
-    \effects\ Constructs an empty container with at least \tcode{n} buckets,
-using \tcode{hf} as the hash function and \tcode{key_equal()} as the key
-equality predicate, and inserts elements from \tcode{[i, j)} into it.
-&   Average case \bigoh{N} ($N$ is \tcode{distance(i, j)}), worst case
-\bigoh{N^2}
-\\ \rowsep
-%
-\tcode{X(i, j, n)}\br \tcode{X a(i, j, n);}
-&   \tcode{X}
-&   \expects \tcode{hasher} and \tcode{key_equal} meet the \oldconcept{DefaultConstructible} requirements.
-    \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
-    \effects\ Constructs an empty container with at least \tcode{n} buckets,
-using \tcode{hasher()} as the hash function and \tcode{key_equal()}
-as the key equality predicate, and inserts elements from \tcode{[i, j)}
-into it.
-&   Average case \bigoh{N} ($N$ is \tcode{distance(i, j)}), worst case
-\bigoh{N^2}
-\\ \rowsep
-%
-\tcode{X(i, j)}\br \tcode{X a(i, j);}
-&   \tcode{X}
-&   \expects \tcode{hasher} and \tcode{key_equal} meet the \oldconcept{DefaultConstructible} requirements.
-    \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.\br
-    \effects\ Constructs an empty container with an unspecified number of
-buckets, using \tcode{hasher()} as the hash function and
-\tcode{key_equal()} as the key equality predicate, and inserts elements
-from \tcode{[i, j)} into it.
-&   Average case \bigoh{N} ($N$ is \tcode{distance(i, j)}), worst case
-\bigoh{N^2}
-\\ \rowsep
-%
-\tcode{X(il)}
-&   \tcode{X}
-&   Same as \tcode{X(il.begin(), il.end())}.
-&   Same as \tcode{X(il.begin(),} \tcode{il.end())}.
-\\ \rowsep
-%
-\tcode{X(il, n)}
-&   \tcode{X}
-&   Same as \tcode{X(il.begin(), il.end(), n)}.
-&   Same as \tcode{X(il.begin(),} \tcode{il.end(), n)}.
-\\ \rowsep
-%
-\tcode{X(il, n, hf)}
-&   \tcode{X}
-&   Same as \tcode{X(il.begin(), il.end(), n, hf)}.
-&   Same as \tcode{X(il.begin(),} \tcode{il.end(), n, hf)}.
-\\ \rowsep
-%
-\tcode{X(il, n, hf, eq)}
-&   \tcode{X}
-&   Same as \tcode{X(il.begin(), il.end(), n, hf, eq)}.
-&   Same as \tcode{X(il.begin(),} \tcode{il.end(), n, hf, eq)}.
-\\ \rowsep
-%
-\tcode{X(b)}\br \tcode{X a(b);}
-&   \tcode{X}
-&   Copy constructor.  In addition to the requirements
-    of \tref{container.req}, copies the
-  hash function, predicate, and maximum load factor.
-&   Average case linear in \tcode{b.size()}, worst case quadratic.
-\\ \rowsep
-%
-\tcode{a = b}
-&   \tcode{X\&}
-&   Copy assignment operator.  In addition to the
-    requirements of \tref{container.req}, copies
-  the hash function, predicate, and maximum load factor.
-&   Average case linear in \tcode{b.size()}, worst case quadratic.
-\\ \rowsep
-%
-\tcode{a = il}
-&   \tcode{X\&}
-&   \expects \tcode{value_type} is
-\oldconcept{CopyInsertable} into \tcode{X}
-and \oldconcept{CopyAssignable}.\br
-    \effects\ Assigns the range \range{il.begin()}{il.end()} into \tcode{a}. All
-    existing elements of \tcode{a} are either assigned to or destroyed.
-&   Same as \tcode{a = X(il)}.
-\\ \rowsep
-%
+\begin{itemdecl}
+X(n, hf, eq)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Constructs an empty container with at least \tcode{n} buckets,
+using \tcode{hf} as the hash function and
+\tcode{eq} as the key equality predicate.
+
+\pnum
+\complexity
+\bigoh{\tcode{n}}
+\end{itemdescr}
+
+\begin{itemdecl}
+X(n, hf)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{key_equal} meets the \oldconcept{DefaultConstructible} requirements.
+
+\pnum
+\effects
+Constructs an empty container with at least \tcode{n} buckets,
+using \tcode{hf} as the hash function and
+\tcode{key_equal()} as the key equality predicate.
+
+\pnum
+\complexity
+\bigoh{\tcode{n}}
+\end{itemdescr}
+
+\begin{itemdecl}
+X(n)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{hasher} and \tcode{key_equal}
+meet the \oldconcept{DefaultConstructible} requirements.
+
+\pnum
+\effects
+Constructs an empty container with at least \tcode{n} buckets,
+using \tcode{hasher()} as the hash function and
+\tcode{key_equal()} as the key equality predicate.
+
+\pnum
+\complexity
+\bigoh{\tcode{n}}
+\end{itemdescr}
+
+\begin{itemdecl}
+X a = X();
+X a;
+\end{itemdecl}
+
+\begin{itemdescr}
+\expects
+\tcode{hasher} and \tcode{key_equal} meet
+the \oldconcept{DefaultConstructible} requirements.
+
+\pnum
+\effects
+Constructs an empty container with an unspecified number of buckets,
+using \tcode{hasher()} as the hash function and
+\tcode{key_equal()} as the key equality predicate.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
+
+\begin{itemdecl}
+X(i, j, n, hf, eq)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{value_type} is
+\oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
+
+\pnum
+\effects
+Constructs an empty container with at least \tcode{n} buckets,
+using \tcode{hf} as the hash function and
+\tcode{eq} as the key equality predicate, and
+inserts elements from \range{i}{j} into it.
+
+\pnum
+\complexity
+Average case \bigoh{N} ($N$ is \tcode{distance(i, j)}), worst case \bigoh{N^2}.
+\end{itemdescr}
+
+\begin{itemdecl}
+X(i, j, n, hf)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{key_equal} meets the \oldconcept{DefaultConstructible} requirements.
+\tcode{value_type} is
+\oldconcept{\-EmplaceConstructible} into \tcode{X} from \tcode{*i}.
+
+\pnum
+\effects
+Constructs an empty container with at least \tcode{n} buckets,
+using \tcode{hf} as the hash function and
+\tcode{key_equal()} as the key equality predicate, and
+inserts elements from \range{i}{j} into it.
+
+\pnum
+\complexity
+Average case \bigoh{N} ($N$ is \tcode{distance(i, j)}), worst case \bigoh{N^2}.
+\end{itemdescr}
+
+\begin{itemdecl}
+X(i, j, n)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{hasher} and \tcode{key_equal} meet
+the \oldconcept{DefaultConstructible} requirements.
+\tcode{value_type} is
+\oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
+
+\pnum
+\effects
+Constructs an empty container with at least \tcode{n} buckets,
+using \tcode{hasher()} as the hash function and
+\tcode{key_equal()} as the key equality predicate, and
+inserts elements from \range{i}{j} into it.
+
+\pnum
+\complexity
+Average case \bigoh{N} ($N$ is \tcode{distance(i, j)}), worst case \bigoh{N^2}.
+\end{itemdescr}
+
+\begin{itemdecl}
+X(i, j)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{hasher} and \tcode{key_equal} meet
+the \oldconcept{DefaultConstructible} requirements.
+\tcode{value_type} is
+\oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
+
+\pnum
+\effects
+Constructs an empty container with an unspecified number of buckets,
+using \tcode{hasher()} as the hash function and
+\tcode{key_equal()} as the key equality predicate, and
+inserts elements from \range{i}{j} into it.
+
+\pnum
+\complexity
+Average case \bigoh{N} ($N$ is \tcode{distance(i, j)}), worst case \bigoh{N^2}.
+\end{itemdescr}
+
+\begin{itemdecl}
+X(il)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to \tcode{X(il.begin(), il.end())}.
+\end{itemdescr}
+
+\begin{itemdecl}
+X(il, n)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to  \tcode{X(il.begin(), il.end(), n)}.
+\end{itemdescr}
+
+\begin{itemdecl}
+X(il, n, hf)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to \tcode{X(il.begin(), il.end(), n, hf)}.
+\end{itemdescr}
+
+\begin{itemdecl}
+X(il, n, hf, eq)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to \tcode{X(il.begin(), il.end(), n, hf, eq)}.
+\end{itemdescr}
+
+\begin{itemdecl}
+X(b)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+In addition to the container requirements\iref{container.requirements.general},
+copies the hash function, predicate, and maximum load factor.
+
+\pnum
+\complexity
+Average case linear in \tcode{b.size()}, worst case quadratic.
+\end{itemdescr}
+
+\begin{itemdecl}
+a = b
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{X\&}
+
+\pnum
+\effects
+In addition to the container requirements,
+copies the hash function, predicate, and maximum load factor.
+
+\pnum
+\complexity
+Average case linear in \tcode{b.size()}, worst case quadratic.
+\end{itemdescr}
+
+\begin{itemdecl}
+a = il
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{X\&}
+
+\pnum
+\expects
+\tcode{value_type} is \oldconcept{CopyInsertable} into \tcode{X}
+and \oldconcept{CopyAssignable}.
+
+\pnum
+\effects
+Assigns the range \range{il.begin()}{il.end()} into \tcode{a}.
+All existing elements of \tcode{a} are either assigned to or destroyed.
+
+\pnum
+\complexity
+Average case linear in \tcode{il.size()}, worst case quadratic.
+\end{itemdescr}
+
 \indexunordmem{hash_function}%
-\tcode{b.hash_function()}
-&   \tcode{hasher}
-&   \returns \tcode{b}'s hash function.%
-&   constant
-\\ \rowsep
-%
+\begin{itemdecl}
+b.hash_function()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{hasher}
+
+\pnum
+\returns
+\tcode{b}'s hash function.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
+
 \indexunordmem{key_eq}%
-\tcode{b.key_eq()}
-&   \tcode{key_equal}
-&   \returns \tcode{b}'s key equality predicate.%
-&   constant
-\\ \rowsep
-%
+\begin{itemdecl}
+b.key_eq()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{key_equal}
+
+\pnum
+\returns
+\tcode{b}'s key equality predicate.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
 
 \indexunordmem{emplace}%
-\tcode{a_uniq.} \tcode{emplace(args)} &
-  \tcode{pair<iterator,} \tcode{bool>} &
-  \expects \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.\br
-  \effects\ Inserts a \tcode{value_type} object \tcode{t} constructed with
-  \tcode{std::forward<\brk{}Args\brk{}>(\brk{}args)...} if and only if there is no
-  element in the container with key equivalent to the key of \tcode{t}.
-  The \tcode{bool} component of the returned
-  pair is \tcode{true} if and only if the insertion takes place, and the iterator
-  component of the pair points to the element with key equivalent to the
-  key of \tcode{t}.  &
-  Average case \bigoh{1}, worst case \bigoh{\tcode{a_uniq.}\br\tcode{size()}}.
-\\ \rowsep
+\begin{itemdecl}
+a_uniq.emplace(args)
+\end{itemdecl}
 
-\tcode{a_eq.}\tcode{emplace(args)}  &
-  \tcode{iterator}    &
-  \expects \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.\br
-  \effects\ Inserts a \tcode{value_type} object \tcode{t} constructed with
-  \tcode{std::forward<\brk{}Args>(\brk{}args)...} and returns the iterator pointing
-  to the newly inserted element.    &
-  Average case \bigoh{1}, worst case \bigoh{\tcode{a_eq.}\br\tcode{size()}}.
-\\ \rowsep
+\begin{itemdescr}
+\pnum
+\result
+\tcode{pair<iterator,} \tcode{bool>}
+
+\pnum
+\expects
+\tcode{value_type} is
+\oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.
+
+\pnum
+\effects
+Inserts a \tcode{value_type} object \tcode{t}
+constructed with \tcode{std::forward<Args>(args)...} if and only if
+there is no element in the container
+with key equivalent to the key of \tcode{t}.
+
+\pnum
+\returns
+The \tcode{bool} component of the returned pair is \tcode{true}
+if and only if the insertion takes place, and
+the iterator component of the pair points to
+the element with key equivalent to the key of \tcode{t}.
+
+\pnum
+\complexity
+Average case \bigoh{1}, worst case \bigoh{\tcode{a_uniq.size()}}.
+\end{itemdescr}
+
+\indexunordmem{emplace}%
+\begin{itemdecl}
+a_eq.emplace(args)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}
+
+\pnum
+\expects
+\tcode{value_type} is
+\oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.
+
+\pnum
+\effects
+Inserts a \tcode{value_type} object \tcode{t}
+constructed with \tcode{std::forward<Args>(args)...} and
+
+\pnum
+\returns
+An iterator pointing to the newly inserted element.
+
+\pnum
+\complexity
+Average case \bigoh{1}, worst case \bigoh{\tcode{a_eq.size()}}.
+\end{itemdescr}
 
 \indexunordmem{emplace_hint}%
-\tcode{a.emplace_hint(p, args)}  &
-  \tcode{iterator}    &
-  \expects \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.\br
-  \effects\ Equivalent to \tcode{a.emplace(} \tcode{std::forward<\brk{}Args>(\brk{}args)...)}.
-  Return value is an iterator pointing to the element with the key equivalent
-  to the newly inserted element. The \tcode{const_iterator} \tcode{p}
-  is a hint pointing to where the search should start. Implementations are
-  permitted to ignore the hint. &
-  Average case \bigoh{1}, worst case \bigoh{\tcode{a.} \tcode{size()}}.
-\\ \rowsep
+\begin{itemdecl}
+a.emplace_hint(p, args)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}
+
+\pnum
+\expects
+\tcode{value_type} is
+\oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}.
+
+\pnum
+\effects
+Equivalent to \tcode{a.emplace(std::forward<Args>(args)...)}.
+
+\pnum
+\returns
+An iterator pointing to the element
+with the key equivalent to the newly inserted element.
+The \tcode{const_iterator} \tcode{p} is a hint
+pointing to where the search should start.
+Implementations are permitted to ignore the hint.
+
+\pnum
+\complexity
+Average case \bigoh{1}, worst case \bigoh{\tcode{a.size()}}.
+\end{itemdescr}
 
 \indexunordmem{insert}%
-\tcode{a_uniq.insert(t)}
-&   \tcode{pair<iterator, bool>}
-&   \expects If \tcode{t} is a non-const rvalue, \tcode{value_type} is
-    \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} is
-    \oldconcept{CopyInsertable} into \tcode{X}.\br
-    \effects\ Inserts \tcode{t} if and only if there is no element in the container
-    with key equivalent to the key of \tcode{t}.  The \tcode{bool}
-    component of the returned pair indicates whether the insertion
-    takes place, and the \tcode{iterator} component points to the element
-    with key equivalent to the key of \tcode{t}.%
-&   Average case \bigoh{1}, worst case \bigoh{\tcode{a_uniq.}\br\tcode{size()}}.
-\\ \rowsep
-%
-\tcode{a_eq.insert(t)}
-&   \tcode{iterator}
-&   \expects If \tcode{t} is a non-const rvalue, \tcode{value_type} is
-    \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} is
-    \oldconcept{CopyInsertable} into \tcode{X}.\br
-    \effects\ Inserts \tcode{t}, and returns an iterator pointing to the newly
-    inserted element.
-&   Average case \bigoh{1}, worst case \bigoh{\tcode{a_eq.}\br\tcode{size()}}.
-\\ \rowsep
-%
-\tcode{a.insert(p, t)}
-&   \tcode{iterator}
-&   \expects If \tcode{t} is a non-const rvalue, \tcode{value_type} is
-    \oldconcept{MoveInsertable} into \tcode{X}; otherwise, \tcode{value_type} is
-    \oldconcept{CopyInsertable} into \tcode{X}.\br
-    \effects Equivalent to \tcode{a.insert(t)}.  Return value is an iterator pointing
-to the element with the key equivalent to that of \tcode{t}.  The
-iterator \tcode{p} is a hint pointing to where the search should
-start.  Implementations are permitted to ignore the hint.%
-&   Average case \bigoh{1}, worst case \bigoh{\tcode{a.size()}}.
-\\ \rowsep
-%
-\tcode{a.insert(i, j)}
-&   \keyword{void}
-&   \expects \tcode{value_type} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
-    Neither \tcode{i} nor \tcode{j} are iterators into \tcode{a}.\br
-    \effects Equivalent to \tcode{a.insert(t)} for each element in \tcode{[i,j)}.%
-&   Average case \bigoh{N}, where $N$ is \tcode{distance(i, j)},
-    worst case \bigoh{N(\tcode{a.size()}\brk{}+\brk{}1)}.
-\\ \rowsep
-%
-\tcode{a.insert(il)}
-&   \keyword{void}
-&   Same as \tcode{a.insert(il.begin(), il.end())}.
-&   Same as \tcode{a.insert(} \tcode{il.begin(),} \tcode{il.end())}.
-\\ \rowsep
-%
-\tcode{a_uniq.}\br
- \tcode{insert(nh)}           &
- \tcode{insert_return_type}   &
- \expects \tcode{nh} is empty or
- \tcode{a_uniq.get_allocator() == nh.get_allocator()}.\br
- \effects If \tcode{nh} is empty, has no effect. Otherwise, inserts the
- element owned by \tcode{nh} if and only if there is no element in the
- container with a key equivalent to \tcode{nh.key()}.\br
- \ensures If \tcode{nh} is empty, \tcode{inserted} is \tcode{false},
- \tcode{position} is \tcode{end()}, and \tcode{node} is empty.
- Otherwise if the insertion took place, \tcode{inserted} is \tcode{true},
- \tcode{position} points to the inserted element, and \tcode{node} is empty;
- if the insertion failed, \tcode{inserted} is \tcode{false},
- \tcode{node} has the previous value of \tcode{nh}, and \tcode{position}
- points to an element with a key equivalent to \tcode{nh.key()}. &
- Average case \bigoh{1}, worst case \bigoh{\brk{}\tcode{a_uniq.}\brk{}\tcode{size()}}.  \\ \rowsep
-%
-\tcode{a_eq.}\br
- \tcode{insert(nh)}           &
- \tcode{iterator}   &
- \expects \tcode{nh} is empty or
- \tcode{a_eq.get_allocator() == nh.get_allocator()}.\br
- \effects If \tcode{nh} is empty, has no effect and returns \tcode{a_eq.end()}.
- Otherwise, inserts the element owned by \tcode{nh} and returns an iterator
- pointing to the newly inserted element.\br
- \ensures \tcode{nh} is empty. &
- Average case \bigoh{1}, worst case \bigoh{\brk{}\tcode{a_eq.}\brk{}\tcode{size()}}.  \\ \rowsep
-%
-\tcode{a.insert(q, nh)}           &
- \tcode{iterator}   &
- \expects \tcode{nh} is empty or
- \tcode{a.get_allocator() == nh.get_allocator()}.\br
- \effects If \tcode{nh} is empty, has no effect and returns \tcode{a.end()}.
- Otherwise, inserts the element owned by \tcode{nh} if and only if there
- is no element with key equivalent to \tcode{nh.key()} in containers with
- unique keys; always inserts the element owned by \tcode{nh} in containers
- with equivalent keys. Always returns the iterator pointing to the element
- with key equivalent to \tcode{nh.key()}. The iterator \tcode{q} is a hint
- pointing to where the search should start. Implementations are permitted
- to ignore the hint.\br
- \ensures \tcode{nh} is empty if insertion succeeds, unchanged if insertion fails.  &
- Average case \bigoh{1}, worst case \bigoh{\tcode{a.size()}}.  \\ \rowsep
-%
+\begin{itemdecl}
+a_uniq.insert(t)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{pair<iterator, bool>}
+
+\pnum
+\expects
+If \tcode{t} is a non-const rvalue,
+\tcode{value_type} is \oldconcept{MoveInsertable} into \tcode{X};
+otherwise, \tcode{value_type} is \oldconcept{CopyInsertable} into \tcode{X}.
+
+\pnum
+\effects
+Inserts \tcode{t} if and only if there is no element in the container
+with key equivalent to the key of \tcode{t}.
+
+\pnum
+\returns
+The \tcode{bool} component of the returned pair indicates
+whether the insertion takes place, and
+the \tcode{iterator} component points to
+the element with key equivalent to the key of \tcode{t}.
+
+\pnum
+\complexity
+Average case \bigoh{1}, worst case \bigoh{\tcode{a_uniq.size()}}.
+\end{itemdescr}
+
+\indexunordmem{insert}%
+\begin{itemdecl}
+a_eq.insert(t)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}
+
+\pnum
+\expects
+If \tcode{t} is a non-const rvalue,
+\tcode{value_type} is \oldconcept{MoveInsertable} into \tcode{X};
+otherwise, \tcode{value_type} is \oldconcept{CopyInsertable} into \tcode{X}.
+
+\pnum
+\effects
+Inserts \tcode{t}.
+
+\pnum
+\returns
+An iterator pointing to the newly inserted element.
+
+\pnum
+\complexity
+Average case \bigoh{1}, worst case \bigoh{\tcode{a_eq.size()}}.
+\end{itemdescr}
+
+\indexunordmem{insert}%
+\begin{itemdecl}
+a.insert(p, t)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}
+
+\pnum
+\expects
+If \tcode{t} is a non-const rvalue,
+\tcode{value_type} is \oldconcept{MoveInsertable} into \tcode{X};
+otherwise, \tcode{value_type} is \oldconcept{CopyInsertable} into \tcode{X}.
+
+\pnum
+\effects
+Equivalent to \tcode{a.insert(t)}.
+The iterator \tcode{p} is a hint pointing to where the search should start.
+Implementations are permitted to ignore the hint.
+
+\pnum
+\returns
+An iterator pointing to
+the element with the key equivalent to that of \tcode{t}.
+
+\pnum
+\complexity
+Average case \bigoh{1}, worst case \bigoh{\tcode{a.size()}}.
+\end{itemdescr}
+
+\indexunordmem{insert}%
+\begin{itemdecl}
+a.insert(i, j)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
+
+\pnum
+\expects
+\tcode{value_type} is
+\oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
+Neither \tcode{i} nor \tcode{j} are iterators into \tcode{a}.
+
+\pnum
+\effects
+Equivalent to \tcode{a.insert(t)} for each element in \tcode{[i,j)}.
+
+\pnum
+\complexity
+Average case \bigoh{N}, where $N$ is \tcode{distance(i, j)},
+worst case \bigoh{N(\tcode{a.size()} + 1)}.
+\end{itemdescr}
+
+\indexunordmem{insert}%
+\begin{itemdecl}
+a.insert(il)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
+
+\pnum
+\effects
+Equivalent to \tcode{a.insert(il.begin(), il.end())}.
+\end{itemdescr}
+
+\indexunordmem{insert}%
+\begin{itemdecl}
+a_uniq.insert(nh)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{insert_return_type}
+
+\pnum
+\expects
+\tcode{nh} is empty or
+\tcode{a_uniq.get_allocator() == nh.get_allocator()} is \tcode{true}.
+
+\pnum
+\effects
+If \tcode{nh} is empty, has no effect.
+Otherwise, inserts the element owned by \tcode{nh} if and only if
+there is no element in the container with a key equivalent to \tcode{nh.key()}.
+
+\pnum
+\ensures
+If \tcode{nh} is empty, \tcode{inserted} is \tcode{false},
+\tcode{position} is \tcode{end()}, and \tcode{node} is empty.
+Otherwise if the insertion took place, \tcode{inserted} is \tcode{true},
+\tcode{position} points to the inserted element, and \tcode{node} is empty;
+if the insertion failed, \tcode{inserted} is \tcode{false},
+\tcode{node} has the previous value of \tcode{nh}, and \tcode{position}
+points to an element with a key equivalent to \tcode{nh.key()}.
+
+\pnum
+\complexity
+Average case \bigoh{1}, worst case \bigoh{\tcode{a_uniq.size()}}.
+\end{itemdescr}
+
+\indexunordmem{insert}%
+\begin{itemdecl}
+a_eq.insert(nh)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}
+
+\pnum
+\expects
+\tcode{nh} is empty or
+\tcode{a_eq.get_allocator() == nh.get_allocator()} is \tcode{true}.
+
+\pnum
+\effects
+If \tcode{nh} is empty, has no effect and returns \tcode{a_eq.end()}.
+Otherwise, inserts the element owned by \tcode{nh} and
+returns an iterator  pointing to the newly inserted element.
+
+\pnum
+\ensures
+\tcode{nh} is empty.
+
+\pnum
+\complexity
+Average case \bigoh{1}, worst case \bigoh{\tcode{a_eq.size()}}.
+\end{itemdescr}
+
+\indexunordmem{insert}%
+\begin{itemdecl}
+a.insert(q, nh)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}
+
+\pnum
+\expects
+\tcode{nh} is empty or
+\tcode{a.get_allocator() == nh.get_allocator()} is \tcode{true}.
+
+\pnum
+\effects
+If \tcode{nh} is empty, has no effect and returns \tcode{a.end()}.
+Otherwise, inserts the element owned by \tcode{nh} if and only if
+there is no element with key equivalent to \tcode{nh.key()}
+in containers with unique keys;
+always inserts the element owned by \tcode{nh}
+in containers with equivalent keys.
+The iterator \tcode{q} is a hint pointing to where the search should start.
+Implementations are permitted to ignore the hint.
+
+\ensures
+\tcode{nh} is empty if insertion succeeds, unchanged if insertion fails.
+
+\pnum
+\returns
+An iterator pointing to the element with key equivalent to \tcode{nh.key()}.
+
+\pnum
+\complexity
+Average case \bigoh{1}, worst case \bigoh{\tcode{a.size()}}.
+\end{itemdescr}
+
 \indexunordmem{extract}%
-\tcode{a.extract(k)}              &
- \tcode{node_type}             &
- \effects Removes an element in the container with key equivalent to \tcode{k}.\br
- \returns A \tcode{node_type} owning the element if found, otherwise an empty
- \tcode{node_type}. &
- Average case \bigoh{1}, worst case \bigoh{\tcode{a.size()}}.  \\ \rowsep
-%
-\tcode{a_tran.\brk{}extract(kx)}              &
- \tcode{node_type}             &
- \effects Removes an element in the container with key equivalent to \tcode{kx}.\br
- \returns A \tcode{node_type} owning the element if found,
-    otherwise an empty \tcode{node_type}. &
- Average case \bigoh{1}, worst case \bigoh{\tcode{a_tran.}\br{}\tcode{size()}}.  \\ \rowsep
-%
-\tcode{a.extract(q)}              &
- \tcode{node_type}             &
- \effects Removes the element pointed to by \tcode{q}.\br
- \returns A \tcode{node_type} owning that element. &
- Average case \bigoh{1}, worst case \bigoh{\tcode{a.size()}}.  \\ \rowsep
-%
+\begin{itemdecl}
+a.extract(k)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{node_type}
+
+\pnum
+\effects
+Removes an element in the container with key equivalent to \tcode{k}.
+
+\pnum
+\returns
+A \tcode{node_type} owning the element if found,
+otherwise an empty \tcode{node_type}.
+
+\pnum
+\complexity
+Average case \bigoh{1}, worst case \bigoh{\tcode{a.size()}}.
+\end{itemdescr}
+
+\indexunordmem{extract}%
+\begin{itemdecl}
+a_tran.extract(kx)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{node_type}
+
+\pnum
+\effects
+Removes an element in the container with key equivalent to \tcode{kx}.
+
+\pnum
+\returns
+A \tcode{node_type} owning the element if found,
+otherwise an empty \tcode{node_type}.
+
+\pnum
+\complexity
+Average case \bigoh{1}, worst case \bigoh{\tcode{a_tran.size()}}.
+\end{itemdescr}
+
+\indexunordmem{extract}%
+\begin{itemdecl}
+a.extract(q)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{node_type}
+
+\pnum
+\effects
+Removes the element pointed to by \tcode{q}.
+
+\returns
+A \tcode{node_type} owning that element.
+
+\pnum
+\complexity
+Average case \bigoh{1}, worst case \bigoh{\tcode{a.size()}}.
+\end{itemdescr}
+
 \indexunordmem{merge}%
-\tcode{a.merge(a2)}              &
- \keyword{void}             &
- \expects \tcode{a.get_allocator() == a2.get_allocator()}.\br
- Attempts to extract each element in \tcode{a2} and insert it into \tcode{a}
- using the hash function and key equality predicate of \tcode{a}.
- In containers with unique keys, if there is an element in \tcode{a} with
- key equivalent to the key of an element from \tcode{a2}, then that
- element is not extracted from \tcode{a2}.\par
- \ensures Pointers and references to the transferred elements of \tcode{a2}
- refer to those same elements but as members of \tcode{a}. Iterators referring
- to the transferred elements and all iterators referring to \tcode{a} will
- be invalidated, but iterators to elements remaining in \tcode{a2} will
- remain valid. &
- Average case \bigoh{N}, where $N$ is \tcode{a2.size()},
- worst case \bigoh{N\tcode{*a.size()}\br\tcode{+} N}.  \\ \rowsep
-%
+\begin{itemdecl}
+a.merge(a2)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
+
+\pnum
+\expects
+\tcode{a.get_allocator() == a2.get_allocator()}.
+
+\pnum
+\effects
+Attempts to extract each element in \tcode{a2} and insert it into \tcode{a}
+using the hash function and key equality predicate of \tcode{a}.
+In containers with unique keys, if there is an element in \tcode{a}
+with key equivalent to the key of an element from \tcode{a2},
+then that element is not extracted from \tcode{a2}.
+
+\pnum
+\ensures
+Pointers and references to the transferred elements of \tcode{a2} refer to
+those same elements but as members of \tcode{a}.
+Iterators referring to the transferred elements and
+all iterators referring to \tcode{a} will be invalidated,
+but iterators to elements remaining in \tcode{a2} will remain valid.
+
+\pnum
+\complexity
+Average case \bigoh{N}, where $N$ is \tcode{a2.size()},
+worst case \bigoh{N\tcode{*a.size() + N}}.
+\end{itemdescr}
+
 \indexunordmem{erase}%
-\tcode{a.erase(k)}
-&   \tcode{size_type}
-&   \effects Erases all elements with key equivalent to \tcode{k}.\br
-    \returns The number of elements erased.
-&   Average case \bigoh{\tcode{a.count(k)}}, worst case
-    \bigoh{\tcode{a.size()}}.
-\\ \rowsep
-%
-\tcode{a_tran.\brk{}erase(kx)}
-&   \tcode{size_type}
-&   \effects Erases all elements with key equivalent to \tcode{kx}.\br
-    \returns The number of elements erased.
-&    Average case \bigoh{\tcode{a_tran.}\br{}\tcode{count(kx)}}, worst case
-    \bigoh{\tcode{a_tran.}\br{}\tcode{size()}}.
-\\ \rowsep
-%
-\tcode{a.erase(q)}
-&   \tcode{iterator}
-&   \effects Erases the element pointed to by \tcode{q}.\br
-    \returns The iterator immediately following \tcode{q} prior to the erasure.
-&   Average case \bigoh{1}, worst case \bigoh{\tcode{a.size()}}.
-\\ \rowsep
-%
-\tcode{a.erase(r)}
-&   \tcode{iterator}
-&   \effects Erases the element pointed to by \tcode{r}.\br
-    \returns The iterator immediately following \tcode{r} prior to the erasure.
-&   Average case \bigoh{1}, worst case \bigoh{\tcode{a.size()}}.
-\\ \rowsep
-%
-\tcode{a.erase(q1, q2)}
-&   \tcode{iterator}
-&   \effects Erases all elements in the range \tcode{[q1, q2)}.\br
-    \returns The iterator immediately following the erased elements prior to the
-    erasure.
-&   Average case linear in \tcode{distance(q1, q2)},
-    worst case \bigoh{\tcode{a.size()}}.
-\\ \rowsep
-%
+\begin{itemdecl}
+a.erase(k)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{size_type}
+
+\pnum
+\effects
+Erases all elements with key equivalent to \tcode{k}.
+
+\pnum
+\returns
+The number of elements erased.
+
+\pnum
+\complexity
+Average case \bigoh{\tcode{a.count(k)}}, worst case \bigoh{\tcode{a.size()}}.
+\end{itemdescr}
+
+\indexunordmem{erase}%
+\begin{itemdecl}
+a_tran.erase(kx)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{size_type}
+
+\pnum
+\effects
+Erases all elements with key equivalent to \tcode{kx}.
+
+\pnum
+\returns
+The number of elements erased.
+
+\pnum
+\complexity
+Average case \bigoh{\tcode{a_tran.count(kx)}},
+worst case \bigoh{\tcode{a_tran.size()}}.
+\end{itemdescr}
+
+\indexunordmem{erase}%
+\begin{itemdecl}
+a.erase(q)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}
+
+\pnum
+\effects
+Erases the element pointed to by \tcode{q}.
+
+\pnum
+\returns
+The iterator immediately following \tcode{q} prior to the erasure.
+
+\pnum
+\complexity
+Average case \bigoh{1}, worst case \bigoh{\tcode{a.size()}}.
+\end{itemdescr}
+
+\indexunordmem{erase}%
+\begin{itemdecl}
+a.erase(r)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}
+
+\pnum
+\effects
+Erases the element pointed to by \tcode{r}.
+
+\pnum
+\returns
+The iterator immediately following \tcode{r} prior to the erasure.
+
+\pnum
+\complexity
+Average case \bigoh{1}, worst case \bigoh{\tcode{a.size()}}.
+\end{itemdescr}
+
+\indexunordmem{erase}%
+\begin{itemdecl}
+a.erase(q1, q2)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}
+
+\pnum
+\effects
+Erases all elements in the range \tcode{[q1, q2)}.
+
+\pnum
+\returns
+The iterator immediately following the erased elements prior to the erasure.
+
+\pnum
+\complexity
+Average case linear in \tcode{distance(q1, q2)},
+worst case \bigoh{\tcode{a.size()}}.
+\end{itemdescr}
+
 \indexunordmem{clear}%
-\tcode{a.clear()}
-& \keyword{void}
-& \effects Erases all elements in the container.\br
-   \ensures \tcode{a.empty()} is \tcode{true}%
-& Linear in \tcode{a.size()}.
-\\ \rowsep
-%
+\begin{itemdecl}
+a.clear()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
+
+\pnum
+\effects
+Erases all elements in the container.
+
+\pnum
+\ensures
+\tcode{a.empty()} is \tcode{true}.
+
+\pnum
+\complexity
+Linear in \tcode{a.size()}.
+\end{itemdescr}
+
 \indexunordmem{find}%
-\tcode{b.find(k)}
-&   \tcode{iterator}; \br \tcode{const_iterator} for const \tcode{b}.
-&   \returns An iterator pointing to an element with key equivalent to
-    \tcode{k}, or \tcode{b.end()} if no such element exists.
-&   Average case \bigoh{1}, worst case \bigoh{\tcode{b.size()}}.
-\\ \rowsep
-%
-\tcode{a_tran.find(ke)}
-&   \tcode{iterator}; \br \tcode{const_iterator} for const \tcode{a_tran}.
-&   \returns An iterator pointing to an element with key equivalent to
-    \tcode{ke}, or \tcode{a_tran.end()} if no such element exists.
-&   Average case \bigoh{1},
-    worst case \bigoh{\tcode{a_tran.}\br{}\tcode{size()}}. % avoid overfull
-\\ \rowsep
-%
+\begin{itemdecl}
+b.find(k)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}; \tcode{const_iterator} for const \tcode{b}.
+
+\pnum
+\returns
+An iterator pointing to an element with key equivalent to \tcode{k}, or
+\tcode{b.end()} if no such element exists.
+
+\pnum
+\complexity
+Average case \bigoh{1}, worst case \bigoh{\tcode{b.size()}}.
+\end{itemdescr}
+
+\indexunordmem{find}%
+\begin{itemdecl}
+a_tran.find(ke)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{iterator}; \tcode{const_iterator} for const \tcode{a_tran}.
+
+\pnum
+\returns
+An iterator pointing to an element with key equivalent to \tcode{ke}, or
+\tcode{a_tran.end()} if no such element exists.
+
+\pnum
+\complexity
+Average case \bigoh{1}, worst case \bigoh{\tcode{a_tran.size()}}.
+\end{itemdescr}
+
 \indexunordmem{count}%
-\tcode{b.count(k)}
-&   \tcode{size_type}
-&   \returns The number of elements with key equivalent to \tcode{k}.%
-&   Average case \bigoh{\tcode{b.count(k)}}, worst case \bigoh{\tcode{b.size()}}.
-\\ \rowsep
-%
-\tcode{a_tran.count(ke)}
-&   \tcode{size_type}
-&   \returns The number of elements with key equivalent to \tcode{ke}.%
-&   Average case
-    \bigoh{\tcode{a_tran.}\br{}\tcode{count(ke)}}, % avoid overfull
-    worst case \bigoh{\tcode{a_tran.}\br{}\tcode{size()}}. % avoid overfull
-\\ \rowsep
-%
+\begin{itemdecl}
+b.count(k)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{size_type}
+
+\pnum
+\returns
+The number of elements with key equivalent to \tcode{k}.
+
+\pnum
+\complexity
+Average case \bigoh{\tcode{b.count(k)}}, worst case \bigoh{\tcode{b.size()}}.
+\end{itemdescr}
+
+\indexunordmem{count}%
+\begin{itemdecl}
+a_tran.count(ke)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{size_type}
+
+\pnum
+\returns
+The number of elements with key equivalent to \tcode{ke}.
+
+\pnum
+\complexity
+Average case \bigoh{\tcode{a_tran.count(ke)}},
+worst case \bigoh{\tcode{a_tran.size()}}.
+\end{itemdescr}
+
 \indexunordmem{contains}%
-\tcode{b.contains(k)}
-&   \tcode{bool}
-&   \effects Equivalent to \tcode{b.find(k) != b.end()}%
-&   Average case \bigoh{1}, worst case \bigoh{\tcode{b.size()}}.
-\\ \rowsep
-%
-\tcode{a_tran.contains(ke)}
-&   \tcode{bool}
-&   \effects Equivalent to \tcode{a_tran.find(ke) != a_tran.end()}%
-&   Average case \bigoh{1},
-    worst case \bigoh{\tcode{a_tran.}\br{}\tcode{size()}}. % avoid overfull
-\\ \rowsep
-%
+\begin{itemdecl}
+b.contains(k)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{bool}
+
+\pnum
+\effects
+Equivalent to \tcode{b.find(k) != b.end()}.
+\end{itemdescr}
+
+\indexunordmem{contains}%
+\begin{itemdecl}
+a_tran.contains(ke)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{bool}
+
+\pnum
+\effects
+Equivalent to \tcode{a_tran.find(ke) != a_tran.end()}.
+\end{itemdescr}
+
 \indexunordmem{equal_range}%
-\tcode{b.equal_range(k)}
-&   \tcode{pair<iterator, iterator>}; \br
-    \tcode{pair<const_iterator, const_iterator>} for const \tcode{b}.
-&   \returns A range containing all elements with keys equivalent to
-    \tcode{k}.  Returns \tcode{make_pair(b.end(), b.end())} if
-    no such elements exist.%
-&   Average case \bigoh{\tcode{b.count(k)}}, worst case
-    \bigoh{\tcode{b.size()}}.
-\\ \rowsep
-%
-\tcode{a_tran.equal_range(ke)}
-&   \tcode{pair<iterator, iterator>}; \br
-    \tcode{pair<const_iterator, const_iterator>} for const \tcode{a_tran}.
-&   \returns A range containing all elements with keys equivalent to
-    \tcode{ke}.  Returns \tcode{make_pair(a_tran.end(), a_tran.end())} if
-    no such elements exist.%
-&   Average case
-    \bigoh{\tcode{a_tran.}\br{}\tcode{count(ke)}}, % avoid overfull
-    worst case \bigoh{\tcode{a_tran.}\br{}\tcode{size()}}. % avoid overfull
-\\ \rowsep
-%
+\begin{itemdecl}
+b.equal_range(k)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{pair<iterator, iterator>};
+\tcode{pair<const_iterator, const_iterator>} for const \tcode{b}.
+
+\pnum
+\returns
+A range containing all elements with keys equivalent to \tcode{k}.
+Returns \tcode{make_pair(b.end(), b.end())} if no such elements exist.
+
+\pnum
+\complexity
+Average case \bigoh{\tcode{b.count(k)}}, worst case \bigoh{\tcode{b.size()}}.
+\end{itemdescr}
+
+\indexunordmem{equal_range}%
+\begin{itemdecl}
+a_tran.equal_range(ke)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{pair<iterator, iterator>};
+\tcode{pair<const_iterator, const_iterator>} for const \tcode{a_tran}.
+
+\pnum
+\returns
+A range containing all elements with keys equivalent to \tcode{ke}.
+Returns \tcode{make_pair(a_tran.end(), a_tran.end())} if no such elements exist.
+
+\pnum
+\complexity
+Average case \bigoh{\tcode{a_tran.count(ke)}},
+worst case \bigoh{\tcode{a_tran.size()}}.
+\end{itemdescr}
+
 \indexunordmem{bucket_count}%
-\tcode{b.bucket_count()}
-&   \tcode{size_type}
-&   \returns The number of buckets that \tcode{b} contains.%
-&   Constant
-\\ \rowsep
-%
+\begin{itemdecl}
+b.bucket_count()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{size_type}
+
+\pnum
+\returns
+The number of buckets that \tcode{b} contains.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
+
 \indexunordmem{max_bucket_count}%
-\tcode{b.max_bucket_count()}
-&   \tcode{size_type}
-&   \returns An upper bound on the number of buckets that \tcode{b} can
-    ever contain.%
-&   Constant
-\\ \rowsep
-%
+\begin{itemdecl}
+b.max_bucket_count()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{size_type}
+
+\pnum
+\returns
+An upper bound on the number of buckets that \tcode{b} can ever contain.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
+
 \indexunordmem{bucket}%
-\tcode{b.bucket(k)}
-& \tcode{size_type}
-&
-  \expects \tcode{b.bucket_count() > 0}.\br
-    \returns The index of the bucket in which elements with keys equivalent
-    to \tcode{k} would be found, if any such element existed.\br
-    \ensures The return value is in the range \tcode{[0, b.bucket_count())}.%
-& Constant
-\\ \rowsep
-%
+\begin{itemdecl}
+b.bucket(k)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{size_type}
+
+\pnum
+\expects
+\tcode{b.bucket_count() > 0}.
+
+\pnum
+\returns
+The index of the bucket
+in which elements with keys equivalent to \tcode{k} would be found,
+if any such element existed.
+The return value is in the range \tcode{[0, b.bucket_count())}.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
+
 \indexunordmem{bucket_size}%
-\tcode{b.bucket_size(n)}
-&   \tcode{size_type}
-&   \expects \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.
-    \returns The number of elements in the $\tcode{n}^\text{th}$ bucket.%
-&   \bigoh{\tcode{b.bucket_}\-\tcode{size(n)}}
-\\ \rowsep
-%
+\begin{itemdecl}
+b.bucket_size(n)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{size_type}
+
+\pnum
+\expects
+\tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.
+
+\pnum
+\returns
+The number of elements in the $\tcode{n}^\text{th}$ bucket.
+
+\pnum
+\complexity
+\bigoh{\tcode{b.bucket_size(n)}}
+\end{itemdescr}
+
 \indexunordmem{begin}%
-\tcode{b.begin(n)}
-&   \tcode{local_iterator}; \br
-    \tcode{const_local_iterator} for const \tcode{b}.
-&   \expects \tcode{n} is in the range \tcode{[0, b.bucket_count())}.\br
-    \returns An iterator referring to the
-    first element in the bucket. If the bucket is empty, then
-    \tcode{b.begin(n) == b.end(n)}.%
-&   Constant
-\\ \rowsep
-%
+\begin{itemdecl}
+b.begin(n)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{local_iterator}; \tcode{const_local_iterator} for const \tcode{b}.
+
+\pnum
+\expects
+\tcode{n} is in the range \tcode{[0, b.bucket_count())}.
+
+\pnum
+\returns
+An iterator referring to the first element in the bucket.
+If the bucket is empty, then \tcode{b.begin(n) == b.end(n)}.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
+
 \indexunordmem{end}%
-\tcode{b.end(n)}
-&   \tcode{local_iterator}; \br
-    \tcode{const_local_iterator} for const \tcode{b}.
-&   \expects \tcode{n} is in the range \tcode{[0, b.bucket_count())}.\br
-    \returns An iterator which is the past-the-end
-    value for the bucket.%
-&   Constant
-\\ \rowsep
-%
+\begin{itemdecl}
+b.end(n)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{local_iterator}; \tcode{const_local_iterator} for const \tcode{b}.
+
+\pnum
+\expects
+\tcode{n} is in the range \tcode{[0, b.bucket_count())}.
+
+\pnum
+\returns
+An iterator which is the past-the-end value for the bucket.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
+
 \indexunordmem{cbegin}%
-\tcode{b.cbegin(n)}
-&   \tcode{const_local_iterator}
-&   \expects \tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.\br
-    \returns An iterator referring to the
-    first element in the bucket. If the bucket is empty, then
-    \tcode{b.cbegin(n) == b.cend(n)}.%
-&   Constant
-\\ \rowsep
-%
+\begin{itemdecl}
+b.cbegin(n)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{const_local_iterator}
+
+\pnum
+\expects
+\tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.
+
+\pnum
+\returns
+An iterator referring to the first element in the bucket.
+If the bucket is empty, then \tcode{b.cbegin(n) == b.cend(n)}.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
+
 \indexunordmem{cend}%
-\tcode{b.cend(n)}
-&   \tcode{const_local_iterator}
-&   \expects \tcode{n} is in the range \tcode{[0, b.bucket_count())}.\br
-    \returns An iterator which is the past-the-end
-    value for the bucket.%
-&   Constant
-\\ \rowsep
-%
+\begin{itemdecl}
+b.cend(n)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{const_local_iterator}
+
+\pnum
+\expects
+\tcode{n} is in the range \tcode{[0, b.bucket_count())}.
+
+\pnum
+\returns
+An iterator which is the past-the-end value for the bucket.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
+
 \indexunordmem{load_factor}%
-\tcode{b.load_factor()}
-&   \tcode{float}
-&   \returns The average number of elements per bucket.%
-&   Constant
-\\ \rowsep
-%
+\begin{itemdecl}
+b.load_factor()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{float}
+
+\pnum
+\returns
+The average number of elements per bucket.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
+
 \indexunordmem{max_load_factor}%
-\tcode{b.max_load_factor()}
-&   \tcode{float}
-&   \returns A positive number that the container attempts to keep the load factor
-    less than or equal to. The container automatically increases the
-    number of buckets as necessary to keep the load factor below this
-    number.%
-&   Constant
-\\ \rowsep
-%
-\tcode{a.max_load_factor(z)}
-&   \keyword{void}
-&   \expects \tcode{z} is positive.
-    May change the container's maximum load factor, using \tcode{z} as a hint.%
-& Constant
-\\ \rowsep
-%
+\begin{itemdecl}
+b.max_load_factor()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{float}
+
+\pnum
+\returns
+A positive number
+that the container attempts to keep the load factor less than or equal to.
+The container automatically increases the number of buckets as necessary
+to keep the load factor below this number.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
+
+\indexunordmem{max_load_factor}%
+\begin{itemdecl}
+a.max_load_factor(z)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
+
+\pnum
+\expects
+\tcode{z} is positive.
+May change the container's maximum load factor, using \tcode{z} as a hint.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
+
 \indexunordmem{rehash}%
-\tcode{a.rehash(n)}
-& \keyword{void}
-& \ensures \tcode{a.bucket_count() >= a.size() / a.max_load_factor()} and
-        \tcode{a.bucket_count() >= n}.%
-& Average case linear in \tcode{a.size()}, worst case quadratic.
-\\ \rowsep
+\begin{itemdecl}
+a.rehash(n)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
+
+\pnum
+\ensures
+\tcode{a.bucket_count() >= a.size() / a.max_load_factor()} and
+\tcode{a.bucket_count() >= n}.%
+
+\pnum
+\complexity
+Average case linear in \tcode{a.size()}, worst case quadratic.
+\end{itemdescr}
 
 \indexunordmem{reserve}%
-\tcode{a.reserve(n)}  &
-  \keyword{void}        &
-  Same as \tcode{a.rehash(ceil(n /} \tcode{a.max_load_factor()))}.  &
-  Average case linear in \tcode{a.size()}, worst case quadratic. \\
+\begin{itemdecl}
+a.reserve(n)
+\end{itemdecl}
 
-\end{libreqtab4d}
+\begin{itemdescr}
+\pnum
+\result
+\keyword{void}
+
+\pnum
+\effects
+Equivalent to \tcode{a.rehash(ceil(n / a.max_load_factor()))}.
+
+\pnum
+\complexity
+Average case linear in \tcode{a.size()}, worst case quadratic.
+\end{itemdescr}
+
 \pnum
 Two unordered containers \tcode{a} and \tcode{b} compare equal if
 \tcode{a.size() == b.size()} and, for every equivalent-key group
@@ -3572,8 +5785,10 @@ to \tcode{N} elements whose types are convertible to \tcode{T}.
 
 \pnum
 \indextext{requirements!container}%
-An \tcode{array} meets all of the requirements of a container and
-of a reversible container\iref{container.requirements}, except that a default
+An \tcode{array} meets all of the requirements
+of a container\iref{container.reqmts} and
+of a reversible container\iref{container.rev.reqmts},
+except that a default
 constructed \tcode{array} object is not empty and that \tcode{swap} does not have constant
 complexity. An \tcode{array} meets some of the requirements of a sequence
 container\iref{sequence.reqmts}.
@@ -3887,11 +6102,12 @@ That is, a deque is especially optimized for pushing and popping elements at the
 Storage management is handled automatically.
 
 \pnum
-A
-\tcode{deque}
-meets all of the requirements of a container, of a reversible container
-(given in tables in~\ref{container.requirements}), of a sequence container,
-including the optional sequence container requirements\iref{sequence.reqmts}, and of an allocator-aware container (\tref{container.alloc.req}).
+A \tcode{deque} meets all of the requirements
+of a container\iref{container.reqmts},
+of a reversible container\iref{container.rev.reqmts},
+of an allocator-aware container\iref{container.alloc.reqmts}, and
+of a sequence container,
+including the optional sequence container requirements\iref{sequence.reqmts}.
 Descriptions are provided here only for operations on
 \tcode{deque}
 that are not described in one of these tables
@@ -4303,14 +6519,15 @@ that goal have been omitted.
 \end{note}
 
 \pnum
-A \tcode{forward_list} meets all of the requirements of a container
-(\tref{container.req}), except that the \tcode{size()}
-member function is not provided and \tcode{operator==} has linear complexity.
-A \tcode{forward_list} also meets all of the requirements for an allocator-aware
-container (\tref{container.alloc.req}). In addition, a \tcode{forward_list}
-provides the \tcode{assign} member functions
-(\tref{container.seq.req}) and several of the optional
-container requirements (\tref{container.seq.opt}).
+A \tcode{forward_list} meets all of the requirements
+of a container\iref{container.reqmts},
+except that the \tcode{size()} member function is not provided and
+\tcode{operator==} has linear complexity,
+A \tcode{forward_list} also meets all of the requirements
+for an allocator-aware container\iref{container.alloc.reqmts}.
+In addition, a \tcode{forward_list}
+provides the \tcode{assign} member functions and
+several of the optional sequence container requirements\iref{sequence.reqmts}.
 Descriptions are provided here only for operations on
 \tcode{forward_list} that are not described in that table or for operations where there
 is additional semantic information.
@@ -5104,12 +7321,13 @@ fast random access to list elements is not supported, but many
 algorithms only need sequential access anyway.
 
 \pnum
-A \tcode{list} meets all of the requirements of a container, of
-a reversible container (given in two tables in
-\ref{container.requirements}), of a sequence container,
+A \tcode{list} meets all of the requirements
+of a container\iref{container.reqmts},
+of a reversible container\iref{container.rev.reqmts},
+of an allocator-aware container\iref{container.alloc.reqmts}, and
+of a sequence container,
 including most of the optional sequence container
-requirements\iref{sequence.reqmts}, and of an allocator-aware container
-(\tref{container.alloc.req}).
+requirements\iref{sequence.reqmts}.
 The exceptions are the
 \tcode{operator[]}
 and
@@ -5816,11 +8034,12 @@ Storage management is handled automatically, though hints can be given
 to improve efficiency.
 
 \pnum
-A \tcode{vector} meets all of the requirements of a container and of a
-reversible container (given in two tables in~\ref{container.requirements}), of a
-sequence container, including most of the optional sequence container
-requirements\iref{sequence.reqmts}, of an allocator-aware container
-(\tref{container.alloc.req}),
+A \tcode{vector} meets all of the requirements
+of a container\iref{container.reqmts},
+of a reversible container\iref{container.rev.reqmts},
+of an allocator-aware container\iref{container.alloc.reqmts},
+of a sequence container, including most of the optional sequence container
+requirements\iref{sequence.reqmts},
 and, for an element type other than \tcode{bool},
 of a contiguous container\iref{container.requirements.general}.
 The exceptions are the
@@ -6695,10 +8914,11 @@ provides for fast retrieval of values of another type \tcode{T} based
 on the keys. The \tcode{map} class supports bidirectional iterators.
 
 \pnum
-A
-\tcode{map}
-meets all of the requirements of a container, of a reversible container\iref{container.requirements}, of
-an associative container\iref{associative.reqmts}, and of an allocator-aware container (\tref{container.alloc.req}).
+A \tcode{map} meets all of the requirements of
+a container\iref{container.reqmts},
+of a reversible container\iref{container.rev.reqmts},
+of an allocator-aware container\iref{container.alloc.reqmts}. and
+of an associative container\iref{associative.reqmts}.
 A
 \tcode{map}
 also provides most operations described in~\ref{associative.reqmts}
@@ -7242,11 +9462,11 @@ class
 supports bidirectional iterators.
 
 \pnum
-A
-\tcode{multimap} meets all of the requirements of a container and of a
-reversible container\iref{container.requirements}, of an associative
-container\iref{associative.reqmts}, and of an allocator-aware container
-(\tref{container.alloc.req}).
+A \tcode{multimap} meets all of the requirements
+of a container\iref{container.reqmts},
+of a reversible container\iref{container.rev.reqmts},
+of an allocator-aware container\iref{container.alloc.reqmts}, and
+of an associative container\iref{associative.reqmts}.
 A
 \tcode{multimap}
 also provides most operations described in~\ref{associative.reqmts}
@@ -7563,10 +9783,11 @@ The
 supports bidirectional iterators.
 
 \pnum
-A \tcode{set} meets all of the requirements of a container, of a reversible
-container\iref{container.requirements}, of an associative
-container\iref{associative.reqmts}, and of an allocator-aware container
-(\tref{container.alloc.req}).
+A \tcode{set} meets all of the requirements
+of a container\iref{container.reqmts},
+of a reversible container\iref{container.rev.reqmts},
+of an allocator-aware container\iref{container.alloc.reqmts}. and
+of an associative container\iref{associative.reqmts}.
 A
 \tcode{set}
 also provides most operations described in~\ref{associative.reqmts}
@@ -7841,10 +10062,11 @@ The
 supports bidirectional iterators.
 
 \pnum
-A \tcode{multiset} meets all of the requirements of a container, of a
-reversible container\iref{container.requirements}, of an associative
-container\iref{associative.reqmts}, and of an allocator-aware container
-(\tref{container.alloc.req}).
+A \tcode{multiset} meets all of the requirements
+of a container\iref{container.reqmts},
+of a reversible container\iref{container.rev.reqmts},
+of an allocator-aware container\iref{container.alloc.reqmts},
+of an associative container\iref{associative.reqmts}.
 \tcode{multiset}
 also provides most operations described in~\ref{associative.reqmts}
 for duplicate keys.
@@ -8272,7 +10494,11 @@ The \tcode{unordered_map} class
 supports forward iterators.
 
 \pnum
-An \tcode{unordered_map} meets all of the requirements of a container, of an unordered associative container, and of an allocator-aware container (\tref{container.alloc.req}). It provides the operations described in the preceding requirements table for unique keys; that is, an \tcode{unordered_map} supports the \tcode{a_uniq} operations in that table, not the \tcode{a_eq} operations. For an \tcode{unordered_map<Key, T>} the \tcode{key type} is \tcode{Key}, the mapped type is \tcode{T}, and the value type is \tcode{pair<const Key, T>}.
+An \tcode{unordered_map} meets all of the requirements
+of a container\iref{container.reqmts},
+of an allocator-aware container\iref{container.alloc.reqmts}, and
+of an unordered associative container\iref{unord.req}.
+It provides the operations described in the preceding requirements table for unique keys; that is, an \tcode{unordered_map} supports the \tcode{a_uniq} operations in that table, not the \tcode{a_eq} operations. For an \tcode{unordered_map<Key, T>} the \tcode{key type} is \tcode{Key}, the mapped type is \tcode{T}, and the value type is \tcode{pair<const Key, T>}.
 
 \pnum
 Subclause~\ref{unord.map} only describes operations on \tcode{unordered_map} that
@@ -8864,9 +11090,11 @@ The \tcode{unordered_multimap} class
 supports forward iterators.
 
 \pnum
-An \tcode{unordered_multimap} meets all of the requirements of a container, of an
-unordered associative container, and of an allocator-aware container
-(\tref{container.alloc.req}). It provides the operations described in the
+An \tcode{unordered_multimap} meets all of the requirements
+of a container\iref{container.reqmts},
+of an allocator-aware container\iref{container.alloc.reqmts}, and
+of an unordered associative container\iref{unord.req}.
+It provides the operations described in the
 preceding requirements table for equivalent keys; that is, an \tcode{unordered_multimap}
 supports the \tcode{a_eq} operations in that table, not the \tcode{a_uniq} operations.
 For an \tcode{unordered_multimap<Key, T>} the \tcode{key type} is \tcode{Key}, the
@@ -9240,7 +11468,11 @@ The \tcode{unordered_set} class
 supports forward iterators.
 
 \pnum
-An \tcode{unordered_set} meets all of the requirements of a container, of an unordered associative container, and of an allocator-aware container (\tref{container.alloc.req}). It provides the operations described in the preceding requirements table for unique keys; that is, an \tcode{unordered_set} supports the \tcode{a_uniq} operations in that table, not the \tcode{a_eq} operations. For an \tcode{unordered_set<Key>} the \tcode{key type} and the value type are both \tcode{Key}. The \tcode{iterator} and \tcode{const_iterator} types are both constant iterator types. It is unspecified whether they are the same type.
+An \tcode{unordered_set} meets all of the requirements
+of a container\iref{container.reqmts},
+of an allocator-aware container\iref{container.alloc.reqmts},
+of an unordered associative container\iref{unord.req}.
+It provides the operations described in the preceding requirements table for unique keys; that is, an \tcode{unordered_set} supports the \tcode{a_uniq} operations in that table, not the \tcode{a_eq} operations. For an \tcode{unordered_set<Key>} the \tcode{key type} and the value type are both \tcode{Key}. The \tcode{iterator} and \tcode{const_iterator} types are both constant iterator types. It is unspecified whether they are the same type.
 
 \pnum
 Subclause~\ref{unord.set} only describes operations on \tcode{unordered_set} that
@@ -9561,9 +11793,11 @@ The \tcode{unordered_multiset} class
 supports forward iterators.
 
 \pnum
-An \tcode{unordered_multiset} meets all of the requirements of a container, of an
-unordered associative container, and of an allocator-aware container
-(\tref{container.alloc.req}). It provides the operations described in the
+An \tcode{unordered_multiset} meets all of the requirements
+of a container\iref{container.reqmts},
+of an allocator-aware container\iref{container.alloc.reqmts}, and
+of an unordered associative container\iref{unord.req}.
+It provides the operations described in the
 preceding requirements table for equivalent keys; that is, an \tcode{unordered_multiset}
 supports the \tcode{a_eq} operations in that table, not the \tcode{a_uniq} operations.
 For an \tcode{unordered_multiset<Key>} the \tcode{key type} and the value type are

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -1991,10 +1991,10 @@ namespace std {
 
 \pnum
 The class template \tcode{basic_stacktrace} satisfies
-the requirements of
-an allocator-aware container (\tref{container.alloc.req}),
-a sequence container\iref{sequence.reqmts}, and
-a reversible container\iref{container.requirements.general}
+the requirements
+of a reversible container\iref{container.rev.reqmts},
+of an allocator-aware container\iref{container.alloc.reqmts}, and
+of a sequence container\iref{sequence.reqmts},
 except that
 \begin{itemize}
 \item

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -350,6 +350,15 @@ the conditions (sometimes termed observable results)
 established by the function.
 
 \item
+\result
+for a \grammarterm{typename-specifier}, a description of the named type;
+for an \grammarterm{expression},
+a description of the type of the expression;
+the expression is an lvalue if the type is an lvalue reference type,
+an xvalue if the type is an rvalue reference type, and
+a prvalue otherwise.
+
+\item
 \returns
 a description of the value(s) returned by the function.
 

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -339,6 +339,7 @@
 \newcommand{\sync}{\Fundesc{Synchronization}}
 \newcommand{\implimits}{\Fundesc{Implementation limits}}
 \newcommand{\replaceable}{\Fundesc{Replaceable}}
+\newcommand{\result}{\Fundesc{Result}}
 \newcommand{\returntype}{\Fundesc{Return type}}
 \newcommand{\cvalue}{\Fundesc{Value}}
 \newcommand{\ctype}{\Fundesc{Type}}

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -63,130 +63,283 @@ expression traits class \tcode{Traits}, use \tcode{basic_regex<CharT, Traits>}.
 \indextext{requirements!regular expression traits}%
 \indextext{regular expression!requirements}%
 \indextext{locale}%
-In \tref{re.req} \tcode{X} denotes a traits class
-defining types and functions for the character container
-type \tcode{charT}; \tcode{u} is an object of
-type \tcode{X}; \tcode{v} is an object of type \tcode{const
-X}; \tcode{p} is a value of type \tcode{const charT*}; \tcode{I1}
-and \tcode{I2} are input iterators\iref{input.iterators};
+In the following requirements,
+\begin{itemize}
+\item
+\tcode{X} denotes a traits class defining types and functions
+for the character container type \tcode{charT};
+\item
+\tcode{u} is an object of type \tcode{X};
+\item
+\tcode{v} is an object of type \tcode{const X};
+\item
+\tcode{p} is a value of type \tcode{const charT*};
+\item
+\tcode{I1} and \tcode{I2} are input iterators\iref{input.iterators};
+\item
 \tcode{F1} and \tcode{F2} are forward iterators\iref{forward.iterators};
+\item
 \tcode{c} is a value of type \tcode{const charT};
+\item
 \tcode{s} is an object of type \tcode{X::string_type};
+\item
 \tcode{cs} is an object of type \tcode{const X::string_type};
+\item
 \tcode{b} is a value of  type \tcode{bool};
+\item
 \tcode{I} is a value of type \tcode{int};
-\tcode{cl} is an object of type \tcode{X::char_class_type},
-and \tcode{loc} is an object of type \tcode{X::locale_type}.
+\item
+\tcode{cl} is an object of type \tcode{X::char_class_type}; and
+\item
+\tcode{loc} is an object of type \tcode{X::locale_type}.
+\end{itemize}
 
-\begin{libreqtab3}
-  {Regular expression traits class requirements}
-  {re.req}
-\\ \topline
-\lhdr{Expression} & \chdr{Return type} & \rhdr{Assertion/note pre-/post-condition } \\ \capsep
-\endfirsthead
-\continuedcaption\\
-\hline
-\lhdr{Expression} & \chdr{Return type} & \rhdr{Assertion/note pre-/post-condition } \\ \capsep
-\endhead
-%%
+\pnum
+A traits class \tcode{X} meets the regular expression traits requirements
+if the following types and expressions are well-formed and have the specified
+semantics.
+
+\begin{itemdecl}
+typename X::char_type
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{charT},
+the character container type used in the implementation of class
+template \tcode{basic_regex}.
+\end{itemdescr}
+
+\begin{itemdecl}
+typename X::string_type
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{basic_string<charT>}
+\end{itemdescr}
+
+\begin{itemdecl}
+typename X::locale_type
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+A copy constructible type
+that represents the locale used by the traits class.
+\end{itemdescr}
+
+\begin{itemdecl}
+typename X::char_class_type
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+A bitmask type\iref{bitmask.types}
+representing a particular character classification.
+\end{itemdescr}
+
+\begin{itemdecl}
+X::length(p)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{size_t}
+
+\pnum
+\returns
+The smallest \tcode{i} such that \tcode{p[i] == 0}.
+
+\pnum
+\complexity
+Linear in \tcode{i}.
+\end{itemdescr}
+
+\begin{itemdecl}
+v.translate(c)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
 \tcode{X::char_type}
-  & \tcode{charT}
-  & The character container type used in the implementation of class
-    template \tcode{basic_regex}.
-  \\ \rowsep
+
+\pnum
+\returns
+A character such that for any character \tcode{d}
+that is to be considered equivalent to \tcode{c}
+then \tcode{v.translate(c) == v.translate(d)}.
+\end{itemdescr}
+
+\begin{itemdecl}
+v.translate_nocase(c)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{X::char_type}
+
+\pnum
+\returns
+For all characters \tcode{C} that are to be considered equivalent to \tcode{c}
+when comparisons are to be performed without regard to case,
+then \tcode{v.translate_nocase(c) == v.translate_nocase(C)}.
+\end{itemdescr}
+
+\begin{itemdecl}
+v.transform(F1, F2)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
 \tcode{X::string_type}
-  & \tcode{basic_string<charT>}
-  &
-  \\ \rowsep
-\tcode{X::locale_type}
-  & A copy constructible type
-  & A type that represents the locale used by the traits class. \indextext{locale}
- \\ \rowsep
+
+\pnum
+\returns
+A sort key for the character sequence designated by
+the iterator range \range{F1}{F2} such that
+if the character sequence \range{G1}{G2} sorts before
+the character sequence \range{H1}{H2}
+then \tcode{v.transform(G1, G2) < v.transform(H1, H2)}.
+\end{itemdescr}
+
+\begin{itemdecl}
+v.transform_primary(F1, F2)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\indextext{regular expression traits!\idxcode{transform_primary}}%
+\indextext{transform_primary@\tcode{transform_primary}!regular expression traits}%
+\result
+\tcode{X::string_type}
+
+\pnum
+\returns
+A sort key for the character sequence designated by
+the iterator range \range{F1}{F2} such that
+if the character sequence \range{G1}{G2} sorts before
+the character sequence \range{H1}{H2}
+when character case is not considered
+then \tcode{v.transform_primary(G1, G2) < v.transform_primary(H1, H2)}.
+\end{itemdescr}
+
+\begin{itemdecl}
+v.lookup_collatename(F1, F2)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{X::string_type}
+
+\pnum
+\returns
+A sequence of characters that represents the collating element
+consisting of the character sequence designated by
+the iterator range \range{F1}{F2}.
+Returns an empty string
+if the character sequence is not a valid collating element.
+\end{itemdescr}
+
+\begin{itemdecl}
+v.lookup_classname(F1, F2, b)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
 \tcode{X::char_class_type}
- & A bitmask type\iref{bitmask.types}.
- & A bitmask type representing a particular character classification.
- \\ \rowsep
-\tcode{X::length(p)}
-  & \tcode{size_t}
-  & Yields the smallest \tcode{i} such that \tcode{p[i] == 0}. Complexity is
-    linear in \tcode{i}.
-  \\ \rowsep
-\tcode{v.translate(c)}
-  & \tcode{X::char_type}
-  & Returns a character such that for any character \tcode{d} that is to
-    be considered equivalent to \tcode{c} then \tcode{v.translate(c) == v.translate(d)}.
-  \\ \rowsep
-\tcode{v.translate_nocase(c)}
-  & \tcode{X::char_type}
-  & For all characters \tcode{C} that are to be considered equivalent
-    to \tcode{c} when comparisons are to be performed without regard to
-  case, then \tcode{v.translate_nocase(c) == v.translate_nocase(C)}.
-  \\ \rowsep
-\tcode{v.transform(F1, F2)}
-  & \tcode{X::string_type}
-  & Returns a sort key for the character sequence designated by the
-    iterator range \range{F1}{F2} such that if the character sequence
-  \range{G1}{G2} sorts before the character sequence \range{H1}{H2}
-  then \tcode{v.transform(G1, G2) < v.transform(H1, H2)}.
-  \\ \rowsep
-\tcode{v.transform_primary(F1, F2)}
-  & \tcode{X::string_type}
-  & Returns a sort key for the character sequence designated by the
-    iterator range \range{F1}{F2} such that if the character sequence
-  \range{G1}{G2} sorts before the character sequence \range{H1}{H2}
-  when character case is not considered
-  then \tcode{v.transform_primary(G1, G2) < v.transform_primary(H1, H2)}.
-   \indextext{regular expression traits!\idxcode{transform_primary}}%
-   \indextext{transform_primary@\tcode{transform_primary}!regular expression traits}%
-  \\ \rowsep
-\tcode{v.lookup_collatename(F1, F2)}
-  & \tcode{X::string_type}
-  & Returns a sequence of characters that represents the collating element
-    consisting of the character sequence designated by the iterator range
-  \range{F1}{F2}. Returns an empty string if the character sequence is not
-  a valid collating element.
-  \\ \rowsep
-\tcode{v.lookup_classname(F1, F2, b)}
-  & \tcode{X::char_class_type}
-  &  Converts the character sequence designated by the iterator range
-   \range{F1}{F2} into a value of a bitmask type that can
-    subsequently be passed to \tcode{isctype}. Values returned from
-    \tcode{lookup_classname} can be bitwise \logop{OR}'ed together; the
-    resulting value represents membership in either of the
-    corresponding character classes.
-  If \tcode{b} is \tcode{true}, the returned bitmask is suitable for
-  matching characters without regard to their case.
-  Returns \tcode{0} if the character
-    sequence is not the name of a character class recognized by
-    \tcode{X}.  The value returned shall be independent of the case of
-    the characters in the sequence.
-  \\ \rowsep
-\tcode{v.isctype(c, cl)}
-  & \tcode{bool}
-  & Returns \tcode{true} if character \tcode{c} is a member of
-    one of the character classes designated by \tcode{cl},
-    \tcode{false} otherwise.
-  \\ \rowsep
-\tcode{v.value(c, I)}
-  & \tcode{int}
-  & Returns the value represented by the digit \textit{c} in base
-    \textit{I} if the character \textit{c} is a valid digit in base \textit{I};
-  otherwise returns \tcode{-1}.
-\begin{tailnote}
-The value of \textit{I} will only
-  be 8, 10, or 16.
-\end{tailnote}
-  \\ \rowsep
-\tcode{u.imbue(loc)}
-  & \tcode{X::locale_type}
-  & Imbues \tcode{u} with the locale \tcode{loc} and returns the previous locale
-    used by \tcode{u} if any. \indextext{locale}%
-  \\ \rowsep
-\tcode{v.getloc()}
-  & \tcode{X::locale_type}
-  & Returns the current locale used by \tcode{v}, if any. \indextext{locale}%
-  \\
-\end{libreqtab3}
+
+\pnum
+\returns
+Converts the character sequence designated by the iterator range
+\range{F1}{F2} into a value of a bitmask type that can
+subsequently be passed to \tcode{isctype}.
+Values returned from \tcode{lookup_classname} can be bitwise \logop{OR}'ed together;
+the resulting value represents membership
+in either of the corresponding character classes.
+If \tcode{b} is \tcode{true}, the returned bitmask is suitable for
+matching characters without regard to their case.
+Returns \tcode{0}
+if the character sequence is not the name of
+a character class recognized by  \tcode{X}.
+The value returned shall be independent of
+the case of the characters in the sequence.
+\end{itemdescr}
+
+\begin{itemdecl}
+v.isctype(c, cl)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{bool}
+
+\pnum
+\returns
+Returns \tcode{true} if character \tcode{c} is a member of
+one of the character classes designated by \tcode{cl},
+\tcode{false} otherwise.
+\end{itemdescr}
+
+\begin{itemdecl}
+v.value(c, I)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{int}
+
+\pnum
+\returns
+Returns the value represented by the digit \textit{c} in base
+\textit{I} if the character \textit{c} is a valid digit in base \textit{I};
+otherwise returns \tcode{-1}.
+\begin{note}
+The value of \textit{I} will only be 8, 10, or 16.
+\end{note}
+\end{itemdescr}
+
+\begin{itemdecl}
+u.imbue(loc)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{X::locale_type}
+
+\indextext{locale}%
+\pnum
+\effects
+Imbues \tcode{u} with the locale \tcode{loc} and
+returns the previous locale used by \tcode{u} if any.
+\end{itemdescr}
+
+\begin{itemdecl}
+v.getloc()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{X::locale_type}
+
+\pnum
+\returns
+Returns the current locale used by \tcode{v}, if any. \indextext{locale}%
+\end{itemdescr}
 
 \pnum
 \begin{note}

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -1317,7 +1317,7 @@ iterator\iref{container.requirements.general}.
 \pnum
 \effects
 Constructs a string from the values in the range \range{begin}{end},
-as indicated in \tref{container.seq.req}.
+as specified in \ref{sequence.reqmts}.
 \end{itemdescr}
 
 \indexlibraryctor{basic_string}%


### PR DESCRIPTION
We've wanted to get rid of the huge requirement tables since ages. Here's a specific suggestion, converting [re.req] as a guinea pig. Note that this is a fairly mechanical conversion, avoiding larger rephrasing.

Fixes #120.
Fixes #4785
Partially addresses #1571.

![regex](https://user-images.githubusercontent.com/23412755/103954080-bc600480-5143-11eb-83e0-889d40dbc1ec.png)
