### PR TITLE
[over.match.conv]: added missing "can"

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1006,7 +1006,7 @@ those that can be converted to type \tcode{T}
 via a standard conversion sequence\iref{over.ics.scs}.
 For direct-initialization,
 the permissible types for explicit conversion functions are
-those that be converted to type \tcode{T}
+those that can be converted to type \tcode{T}
 with a (possibly trivial) qualification conversion\iref{conv.qual};
 otherwise there are none.
 \end{itemize}


### PR DESCRIPTION
the word "can" seems to have been accidentally dropped when applying P1787R6