### PR TITLE
[stacktrace.basic.cmp] Update 'lexicographical_­compare_­3way'

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -21723,7 +21723,7 @@ friend strong_ordering
 \pnum
 \returns
 \tcode{x.size() <=> y.size()} if \tcode{x.size() != y.size()};
-\tcode{lexicographical_compare_three_way(\newline
+\tcode{lexicographical_compare_three_way(
 x.begin(), x.end(), y.begin(), y.end())}
 otherwise.
 \end{itemdescr}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -21723,7 +21723,7 @@ friend strong_ordering
 \pnum
 \returns
 \tcode{x.size() <=> y.size()} if \tcode{x.size() != y.size()};
-\tcode{lexicographical_compare_3way(\newline
+\tcode{lexicographical_compare_three_way(\newline
 x.begin(), x.end(), y.begin(), y.end())}
 otherwise.
 \end{itemdescr}


### PR DESCRIPTION
The name has been changed to `lexicographical_compare_three_way` by [P1614R2](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1614r2.html#clause-25-algorithms-library).