### PR TITLE
[stacktrace.basic.cmp] Update 'lexicographical_compare_3way'

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -21723,8 +21723,7 @@ friend strong_ordering
 \pnum
 \returns
 \tcode{x.size() <=> y.size()} if \tcode{x.size() != y.size()};
-\tcode{lexicographical_compare_3way(\newline
-x.begin(), x.end(), y.begin(), y.end())}
+\tcode{lexicographical_compare_three_way(x.begin(), x.end(), y.begin(), y.end())}
 otherwise.
 \end{itemdescr}
 


### PR DESCRIPTION
P1614R2 changed the name to 'lexicographical_compare_three_way'.

Supersedes #4473 