### PR TITLE
[lib] Index all uses of public concepts

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -716,7 +716,7 @@ namespace std {
     template<class I, class F>
       using for_each_n_result = in_fun_result<I, F>;
 
-    template<input_iterator I, class Proj = identity,
+    template<@\libconcept{input_iterator}@ I, class Proj = identity,
              @\libconcept{indirectly_unary_invocable}@<projected<I, Proj>> Fun>
       constexpr for_each_n_result<I, Fun>
         for_each_n(I first, iter_difference_t<I> n, Fun f, Proj proj = {});
@@ -802,7 +802,7 @@ namespace std {
                  Proj1 proj1 = {}, Proj2 proj2 = {});
     template<@\libconcept{forward_range}@ R1, @\libconcept{forward_range}@ R2,
              class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
-      requires indirectly_comparable<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+      requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
       constexpr borrowed_subrange_t<R1>
         find_end(R1&& r1, R2&& r2, Pred pred = {},
                  Proj1 proj1 = {}, Proj2 proj2 = {});
@@ -832,7 +832,7 @@ namespace std {
                     BinaryPredicate pred);
 
   namespace ranges {
-    template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{forward_iterator}@ I2, sentinel_for<I2> S2,
+    template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{forward_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
              class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
       requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
       constexpr I1 find_first_of(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = {},
@@ -1435,7 +1435,7 @@ namespace std {
       constexpr replace_copy_if_result<I, O>
         replace_copy_if(I first, S last, O result, Pred pred, const T& new_value,
                         Proj proj = {});
-    template<@\libconcept{input_range}@ R, class T, output_iterator<const T&> O, class Proj = identity,
+    template<@\libconcept{input_range}@ R, class T, @\libconcept{output_iterator}@<const T&> O, class Proj = identity,
              @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
       requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O>
       constexpr replace_copy_if_result<borrowed_iterator_t<R>, O>
@@ -1511,7 +1511,7 @@ namespace std {
     template<@\libconcept{permutable}@ I, @\libconcept{sentinel_for}@<I> S, class T, class Proj = identity>
       requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T*>
       constexpr subrange<I> remove(I first, S last, const T& value, Proj proj = {});
-    template<forward_range R, class T, class Proj = identity>
+    template<@\libconcept{forward_range}@ R, class T, class Proj = identity>
       requires @\libconcept{permutable}@<iterator_t<R>> &&
                @\libconcept{indirect_binary_predicate}@<ranges::equal_to,
                                          projected<iterator_t<R>, Proj>, const T*>
@@ -1738,16 +1738,16 @@ namespace std {
                           UniformRandomBitGenerator&& g);
 
   namespace ranges {
-    template<input_iterator I, sentinel_for<I> S,
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S,
              @\libconcept{weakly_incrementable}@ O, class Gen>
-      requires (forward_iterator<I> || random_access_iterator<O>) &&
+      requires (@\libconcept{forward_iterator}@<I> || @\libconcept{random_access_iterator}@<O>) &&
                @\libconcept{indirectly_copyable}@<I, O> &&
-               uniform_random_bit_generator<remove_reference_t<Gen>>
+               @\libconcept{uniform_random_bit_generator}@<remove_reference_t<Gen>>
       O sample(I first, S last, O out, iter_difference_t<I> n, Gen&& g);
     template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O, class Gen>
-      requires (forward_range<R> || random_access_iterator<O>) &&
+      requires (@\libconcept{forward_range}@<R> || @\libconcept{random_access_iterator}@<O>) &&
                @\libconcept{indirectly_copyable}@<iterator_t<R>, O> &&
-               uniform_random_bit_generator<remove_reference_t<Gen>>
+               @\libconcept{uniform_random_bit_generator}@<remove_reference_t<Gen>>
       O sample(R&& r, O out, range_difference_t<R> n, Gen&& g);
   }
 
@@ -1762,7 +1762,7 @@ namespace std {
       requires @\libconcept{permutable}@<I> &&
                @\libconcept{uniform_random_bit_generator}@<remove_reference_t<Gen>>
       I shuffle(I first, S last, Gen&& g);
-    template<random_access_range R, class Gen>
+    template<@\libconcept{random_access_range}@ R, class Gen>
       requires @\libconcept{permutable}@<iterator_t<R>> &&
                @\libconcept{uniform_random_bit_generator}@<remove_reference_t<Gen>>
       borrowed_iterator_t<R> shuffle(R&& r, Gen&& g);
@@ -1809,7 +1809,7 @@ namespace std {
       requires @\libconcept{sortable}@<I, Comp, Proj>
       constexpr I
         sort(I first, S last, Comp comp = {}, Proj proj = {});
-    template<random_access_range R, class Comp = ranges::less, class Proj = identity>
+    template<@\libconcept{random_access_range}@ R, class Comp = ranges::less, class Proj = identity>
       requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
       constexpr borrowed_iterator_t<R>
         sort(R&& r, Comp comp = {}, Proj proj = {});
@@ -1833,7 +1833,7 @@ namespace std {
              class Proj = identity>
       requires @\libconcept{sortable}@<I, Comp, Proj>
       I stable_sort(I first, S last, Comp comp = {}, Proj proj = {});
-    template<random_access_range R, class Comp = ranges::less, class Proj = identity>
+    template<@\libconcept{random_access_range}@ R, class Comp = ranges::less, class Proj = identity>
       requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
       borrowed_iterator_t<R>
         stable_sort(R&& r, Comp comp = {}, Proj proj = {});
@@ -1860,7 +1860,7 @@ namespace std {
       requires @\libconcept{sortable}@<I, Comp, Proj>
       constexpr I
         partial_sort(I first, I middle, S last, Comp comp = {}, Proj proj = {});
-    template<random_access_range R, class Comp = ranges::less, class Proj = identity>
+    template<@\libconcept{random_access_range}@ R, class Comp = ranges::less, class Proj = identity>
       requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
       constexpr borrowed_iterator_t<R>
         partial_sort(R&& r, iterator_t<R> middle, Comp comp = {},
@@ -1987,7 +1987,7 @@ namespace std {
       requires @\libconcept{sortable}@<I, Comp, Proj>
       constexpr I
         nth_element(I first, I nth, S last, Comp comp = {}, Proj proj = {});
-    template<random_access_range R, class Comp = ranges::less, class Proj = identity>
+    template<@\libconcept{random_access_range}@ R, class Comp = ranges::less, class Proj = identity>
       requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
       constexpr borrowed_iterator_t<R>
         nth_element(R&& r, iterator_t<R> nth, Comp comp = {}, Proj proj = {});
@@ -2872,13 +2872,13 @@ namespace std::ranges {
     [[no_unique_address]] F fun;
 
     template<class I2, class F2>
-      requires convertible_to<const I&, I2> && convertible_to<const F&, F2>
+      requires @\libconcept{convertible_to}@<const I&, I2> && @\libconcept{convertible_to}@<const F&, F2>
     constexpr operator in_fun_result<I2, F2>() const & {
       return {in, fun};
     }
 
     template<class I2, class F2>
-      requires convertible_to<I, I2> && convertible_to<F, F2>
+      requires @\libconcept{convertible_to}@<I, I2> && @\libconcept{convertible_to}@<F, F2>
     constexpr operator in_fun_result<I2, F2>() && {
       return {std::move(in), std::move(fun)};
     }
@@ -2890,13 +2890,13 @@ namespace std::ranges {
     [[no_unique_address]] I2 in2;
 
     template<class II1, class II2>
-      requires convertible_to<const I1&, II1> && convertible_to<const I2&, II2>
+      requires @\libconcept{convertible_to}@<const I1&, II1> && @\libconcept{convertible_to}@<const I2&, II2>
     constexpr operator in_in_result<II1, II2>() const & {
       return {in1, in2};
     }
 
     template<class II1, class II2>
-      requires convertible_to<I1, II1> && convertible_to<I2, II2>
+      requires @\libconcept{convertible_to}@<I1, II1> && @\libconcept{convertible_to}@<I2, II2>
     constexpr operator in_in_result<II1, II2>() && {
       return {std::move(in1), std::move(in2)};
     }
@@ -2908,13 +2908,13 @@ namespace std::ranges {
     [[no_unique_address]] O out;
 
     template<class I2, class O2>
-      requires convertible_to<const I&, I2> && convertible_to<const O&, O2>
+      requires @\libconcept{convertible_to}@<const I&, I2> && @\libconcept{convertible_to}@<const O&, O2>
     constexpr operator in_out_result<I2, O2>() const & {
       return {in, out};
     }
 
     template<class I2, class O2>
-      requires convertible_to<I, I2> && convertible_to<O, O2>
+      requires @\libconcept{convertible_to}@<I, I2> && @\libconcept{convertible_to}@<O, O2>
     constexpr operator in_out_result<I2, O2>() && {
       return {std::move(in), std::move(out)};
     }
@@ -2927,17 +2927,17 @@ namespace std::ranges {
     [[no_unique_address]] O  out;
 
     template<class II1, class II2, class OO>
-      requires convertible_to<const I1&, II1> &&
-               convertible_to<const I2&, II2> &&
-               convertible_to<const O&, OO>
+      requires @\libconcept{convertible_to}@<const I1&, II1> &&
+               @\libconcept{convertible_to}@<const I2&, II2> &&
+               @\libconcept{convertible_to}@<const O&, OO>
     constexpr operator in_in_out_result<II1, II2, OO>() const & {
       return {in1, in2, out};
     }
 
     template<class II1, class II2, class OO>
-      requires convertible_to<I1, II1> &&
-               convertible_to<I2, II2> &&
-               convertible_to<O, OO>
+      requires @\libconcept{convertible_to}@<I1, II1> &&
+               @\libconcept{convertible_to}@<I2, II2> &&
+               @\libconcept{convertible_to}@<O, OO>
     constexpr operator in_in_out_result<II1, II2, OO>() && {
       return {std::move(in1), std::move(in2), std::move(out)};
     }
@@ -2950,17 +2950,17 @@ namespace std::ranges {
     [[no_unique_address]] O2 out2;
 
     template<class II, class OO1, class OO2>
-      requires convertible_to<const I&, II> &&
-               convertible_to<const O1&, OO1> &&
-               convertible_to<const O2&, OO2>
+      requires @\libconcept{convertible_to}@<const I&, II> &&
+               @\libconcept{convertible_to}@<const O1&, OO1> &&
+               @\libconcept{convertible_to}@<const O2&, OO2>
     constexpr operator in_out_out_result<II, OO1, OO2>() const & {
       return {in, out1, out2};
     }
 
     template<class II, class OO1, class OO2>
-      requires convertible_to<I, II> &&
-               convertible_to<O1, OO1> &&
-               convertible_to<O2, OO2>
+      requires @\libconcept{convertible_to}@<I, II> &&
+               @\libconcept{convertible_to}@<O1, OO1> &&
+               @\libconcept{convertible_to}@<O2, OO2>
     constexpr operator in_out_out_result<II, OO1, OO2>() && {
       return {std::move(in), std::move(out1), std::move(out2)};
     }
@@ -2972,13 +2972,13 @@ namespace std::ranges {
     [[no_unique_address]] T max;
 
     template<class T2>
-      requires convertible_to<const T&, T2>
+      requires @\libconcept{convertible_to}@<const T&, T2>
     constexpr operator min_max_result<T2>() const & {
       return {min, max};
     }
 
     template<class T2>
-      requires convertible_to<T, T2>
+      requires @\libconcept{convertible_to}@<T, T2>
     constexpr operator min_max_result<T2>() && {
       return {std::move(min), std::move(max)};
     }
@@ -2990,12 +2990,12 @@ namespace std::ranges {
     bool found;
 
     template<class I2>
-      requires convertible_to<const I&, I2>
+      requires @\libconcept{convertible_to}@<const I&, I2>
     constexpr operator in_found_result<I2>() const & {
       return {in, found};
     }
     template<class I2>
-      requires convertible_to<I, I2>
+      requires @\libconcept{convertible_to}@<I, I2>
     constexpr operator in_found_result<I2>() && {
       return {std::move(in), found};
     }
@@ -3328,7 +3328,7 @@ to make arbitrary copies of elements from the input sequence.
 
 \indexlibraryglobal{for_each_n}%
 \begin{itemdecl}
-template<input_iterator I, class Proj = identity,
+template<@\libconcept{input_iterator}@ I, class Proj = identity,
          @\libconcept{indirectly_unary_invocable}@<projected<I, Proj>> Fun>
   constexpr ranges::for_each_n_result<I, Fun>
     ranges::for_each_n(I first, iter_difference_t<I> n, Fun f, Proj proj = {});
@@ -5425,7 +5425,7 @@ template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O, cl
          @\libconcept{indirect_equivalence_relation}@<projected<iterator_t<R>, Proj>> C = ranges::equal_to>
   requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O> &&
            (@\libconcept{forward_iterator}@<iterator_t<R>> ||
-            (@\libconcept{input_iterator}@<O> && same_as<range_value_t<R>, iter_value_t<O>>) ||
+            (@\libconcept{input_iterator}@<O> && @\libconcept{same_as}@<range_value_t<R>, iter_value_t<O>>) ||
             @\libconcept{indirectly_copyable_storable}@<iterator_t<R>, O>)
   constexpr ranges::unique_copy_result<borrowed_iterator_t<R>, O>
     ranges::unique_copy(R&& r, O result, C comp = {}, Proj proj = {});
@@ -5737,15 +5737,15 @@ template<class PopulationIterator, class SampleIterator,
                         SampleIterator out, Distance n,
                         UniformRandomBitGenerator&& g);
 
-template<input_iterator I, sentinel_for<I> S, @\libconcept{weakly_incrementable}@ O, class Gen>
-  requires (forward_iterator<I> || random_access_iterator<O>) &&
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O, class Gen>
+  requires (@\libconcept{forward_iterator}@<I> || @\libconcept{random_access_iterator}@<O>) &&
            @\libconcept{indirectly_copyable}@<I, O> &&
-           uniform_random_bit_generator<remove_reference_t<Gen>>
+           @\libconcept{uniform_random_bit_generator}@<remove_reference_t<Gen>>
   O ranges::sample(I first, S last, O out, iter_difference_t<I> n, Gen&& g);
 template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O, class Gen>
-  requires (forward_range<R> || random_access_iterator<O>) &&
+  requires (@\libconcept{forward_range}@<R> || @\libconcept{random_access_iterator}@<O>) &&
            @\libconcept{indirectly_copyable}@<iterator_t<R>, O> &&
-           uniform_random_bit_generator<remove_reference_t<Gen>>
+           @\libconcept{uniform_random_bit_generator}@<remove_reference_t<Gen>>
   O ranges::sample(R&& r, O out, range_difference_t<R> n, Gen&& g);
 \end{itemdecl}
 
@@ -10145,9 +10145,9 @@ exposition-only concepts:
 \begin{itemdecl}
 template<class I>
 concept @\defexposconcept{no-throw-input-iterator}@ = // \expos
-  input_iterator<I> &&
+  @\libconcept{input_iterator}@<I> &&
   is_lvalue_reference_v<iter_reference_t<I>> &&
-  same_as<remove_cvref_t<iter_reference_t<I>>, iter_value_t<I>>;
+  @\libconcept{same_as}@<remove_cvref_t<iter_reference_t<I>>, iter_value_t<I>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10167,7 +10167,7 @@ operations to throw exceptions.
 
 \begin{itemdecl}
 template<class S, class I>
-concept @\defexposconcept{no-throw-sentinel-for}@ = sentinel_for<S, I>; // \expos
+concept @\defexposconcept{no-throw-sentinel-for}@ = @\libconcept{sentinel_for}@<S, I>; // \expos
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10203,7 +10203,7 @@ no exceptions are thrown from calls to \tcode{ranges::begin} and
 template<class I>
 concept @\defexposconcept{no-throw-forward-iterator}@ = // \expos
   @\placeholder{no-throw-input-iterator}@<I> &&
-  forward_iterator<I> &&
+  @\libconcept{forward_iterator}@<I> &&
   @\placeholder{no-throw-sentinel-for}@<I, I>;
 \end{itemdecl}
 
@@ -10245,10 +10245,10 @@ for (; first != last; ++first)
 \begin{itemdecl}
 namespace ranges {
   template<@\placeholdernc{no-throw-forward-iterator}@ I, @\placeholder{no-throw-sentinel-for}@<I> S>
-    requires default_initializable<iter_value_t<I>>
+    requires @\libconcept{default_initializable}@<iter_value_t<I>>
     I uninitialized_default_construct(I first, S last);
   template<@\placeholdernc{no-throw-forward-range}@ R>
-    requires default_initializable<range_value_t<R>>
+    requires @\libconcept{default_initializable}@<range_value_t<R>>
     borrowed_iterator_t<R> uninitialized_default_construct(R&& r);
 }
 \end{itemdecl}
@@ -10286,7 +10286,7 @@ return first;
 \begin{itemdecl}
 namespace ranges {
   template<@\placeholdernc{no-throw-forward-iterator}@ I>
-    requires default_initializable<iter_value_t<I>>
+    requires @\libconcept{default_initializable}@<iter_value_t<I>>
     I uninitialized_default_construct_n(I first, iter_difference_t<I> n);
 }
 \end{itemdecl}
@@ -10324,10 +10324,10 @@ for (; first != last; ++first)
 \begin{itemdecl}
 namespace ranges {
   template<@\placeholdernc{no-throw-forward-iterator}@ I, @\placeholder{no-throw-sentinel-for}@<I> S>
-    requires default_initializable<iter_value_t<I>>
+    requires @\libconcept{default_initializable}@<iter_value_t<I>>
     I uninitialized_value_construct(I first, S last);
   template<@\placeholdernc{no-throw-forward-range}@ R>
-    requires default_initializable<range_value_t<R>>
+    requires @\libconcept{default_initializable}@<range_value_t<R>>
     borrowed_iterator_t<R> uninitialized_value_construct(R&& r);
 }
 \end{itemdecl}
@@ -10365,7 +10365,7 @@ return first;
 \begin{itemdecl}
 namespace ranges {
   template<@\placeholdernc{no-throw-forward-iterator}@ I>
-    requires default_initializable<iter_value_t<I>>
+    requires @\libconcept{default_initializable}@<iter_value_t<I>>
     I uninitialized_value_construct_n(I first, iter_difference_t<I> n);
 }
 \end{itemdecl}
@@ -10411,13 +10411,13 @@ for (; first != last; ++result, (void) ++first)
 \indexlibraryglobal{uninitialized_copy}%
 \begin{itemdecl}
 namespace ranges {
-  template<input_iterator I, sentinel_for<I> S1,
+  template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S1,
            @\placeholdernc{no-throw-forward-iterator}@ O, @\placeholder{no-throw-sentinel-for}@<O> S2>
-    requires constructible_from<iter_value_t<O>, iter_reference_t<I>>
+    requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_reference_t<I>>
     uninitialized_copy_result<I, O>
       uninitialized_copy(I ifirst, S1 ilast, O ofirst, S2 olast);
   template<@\libconcept{input_range}@ IR, @\placeholdernc{no-throw-forward-range}@ OR>
-    requires constructible_from<range_value_t<OR>, range_reference_t<IR>>
+    requires @\libconcept{constructible_from}@<range_value_t<OR>, range_reference_t<IR>>
     uninitialized_copy_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
       uninitialized_copy(IR&& in_range, OR&& out_range);
 }
@@ -10467,8 +10467,8 @@ for ( ; n > 0; ++result, (void) ++first, --n)
 \indexlibraryglobal{uninitialized_copy_n}%
 \begin{itemdecl}
 namespace ranges {
-  template<input_iterator I, @\placeholdernc{no-throw-forward-iterator}@ O, @\placeholder{no-throw-sentinel-for}@<O> S>
-    requires constructible_from<iter_value_t<O>, iter_reference_t<I>>
+  template<@\libconcept{input_iterator}@ I, @\placeholdernc{no-throw-forward-iterator}@ O, @\placeholder{no-throw-sentinel-for}@<O> S>
+    requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_reference_t<I>>
     uninitialized_copy_n_result<I, O>
       uninitialized_copy_n(I ifirst, iter_difference_t<I> n, O ofirst, S olast);
 }
@@ -10518,13 +10518,13 @@ return result;
 \indexlibraryglobal{uninitialized_move}%
 \begin{itemdecl}
 namespace ranges {
-  template<input_iterator I, sentinel_for<I> S1,
+  template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S1,
            @\placeholdernc{no-throw-forward-iterator}@ O, @\placeholder{no-throw-sentinel-for}@<O> S2>
-    requires constructible_from<iter_value_t<O>, iter_rvalue_reference_t<I>>
+    requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_rvalue_reference_t<I>>
     uninitialized_move_result<I, O>
       uninitialized_move(I ifirst, S1 ilast, O ofirst, S2 olast);
   template<@\libconcept{input_range}@ IR, @\placeholdernc{no-throw-forward-range}@ OR>
-    requires constructible_from<range_value_t<OR>, range_rvalue_reference_t<IR>>
+    requires @\libconcept{constructible_from}@<range_value_t<OR>, range_rvalue_reference_t<IR>>
     uninitialized_move_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
       uninitialized_move(IR&& in_range, OR&& out_range);
 }
@@ -10578,8 +10578,8 @@ return {first, result};
 \indexlibraryglobal{uninitialized_move_n}%
 \begin{itemdecl}
 namespace ranges {
-  template<input_iterator I, @\placeholdernc{no-throw-forward-iterator}@ O, @\placeholder{no-throw-sentinel-for}@<O> S>
-    requires constructible_from<iter_value_t<O>, iter_rvalue_reference_t<I>>
+  template<@\libconcept{input_iterator}@ I, @\placeholdernc{no-throw-forward-iterator}@ O, @\placeholder{no-throw-sentinel-for}@<O> S>
+    requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_rvalue_reference_t<I>>
     uninitialized_move_n_result<I, O>
       uninitialized_move_n(I ifirst, iter_difference_t<I> n, O ofirst, S olast);
 }
@@ -10630,10 +10630,10 @@ for (; first != last; ++first)
 \begin{itemdecl}
 namespace ranges {
   template<@\placeholdernc{no-throw-forward-iterator}@ I, @\placeholder{no-throw-sentinel-for}@<I> S, class T>
-    requires constructible_from<iter_value_t<I>, const T&>
+    requires @\libconcept{constructible_from}@<iter_value_t<I>, const T&>
     I uninitialized_fill(I first, S last, const T& x);
   template<@\placeholdernc{no-throw-forward-range}@ R, class T>
-    requires constructible_from<range_value_t<R>, const T&>
+    requires @\libconcept{constructible_from}@<range_value_t<R>, const T&>
     borrowed_iterator_t<R> uninitialized_fill(R&& r, const T& x);
 }
 \end{itemdecl}
@@ -10671,7 +10671,7 @@ return first;
 \begin{itemdecl}
 namespace ranges {
   template<@\placeholdernc{no-throw-forward-iterator}@ I, class T>
-    requires constructible_from<iter_value_t<I>, const T&>
+    requires @\libconcept{constructible_from}@<iter_value_t<I>, const T&>
     I uninitialized_fill_n(I first, iter_difference_t<I> n, const T& x);
 }
 \end{itemdecl}
@@ -10719,7 +10719,7 @@ return ::new (@\placeholdernc{voidify}@(*location)) T(std::forward<Args>(args)..
 template<class T>
   constexpr void destroy_at(T* location);
 namespace ranges {
-  template<destructible T>
+  template<@\libconcept{destructible}@ T>
     constexpr void destroy_at(T* location) noexcept;
 }
 \end{itemdecl}
@@ -10755,10 +10755,10 @@ for (; first != last; ++first)
 \begin{itemdecl}
 namespace ranges {
   template<@\placeholdernc{no-throw-input-iterator}@ I, @\placeholder{no-throw-sentinel-for}@<I> S>
-    requires destructible<iter_value_t<I>>
+    requires @\libconcept{destructible}@<iter_value_t<I>>
     constexpr I destroy(I first, S last) noexcept;
   template<@\placeholdernc{no-throw-input-range}@ R>
-    requires destructible<range_value_t<R>>
+    requires @\libconcept{destructible}@<range_value_t<R>>
     constexpr borrowed_iterator_t<R> destroy(R&& r) noexcept;
 }
 \end{itemdecl}
@@ -10795,7 +10795,7 @@ return first;
 \begin{itemdecl}
 namespace ranges {
   template<@\placeholdernc{no-throw-input-iterator}@ I>
-    requires destructible<iter_value_t<I>>
+    requires @\libconcept{destructible}@<iter_value_t<I>>
     constexpr I destroy_n(I first, iter_difference_t<I> n) noexcept;
 }
 \end{itemdecl}

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -453,10 +453,10 @@ template<class T, class U>
       static_cast<common_type_t<T, U>>(declval<T>());
       static_cast<common_type_t<T, U>>(declval<U>());
     } &&
-    common_reference_with<
+    @\libconcept{common_reference_with}@<
       add_lvalue_reference_t<const T>,
       add_lvalue_reference_t<const U>> &&
-    common_reference_with<
+    @\libconcept{common_reference_with}@<
       add_lvalue_reference_t<common_type_t<T, U>>,
       common_reference_t<
         add_lvalue_reference_t<const T>,
@@ -494,9 +494,9 @@ Users can customize the behavior of \libconcept{common_with} by specializing the
 template<class T>
   concept @\deflibconcept{integral}@ = is_integral_v<T>;
 template<class T>
-  concept @\deflibconcept{signed_integral}@ = integral<T> && is_signed_v<T>;
+  concept @\deflibconcept{signed_integral}@ = @\libconcept{integral}@<T> && is_signed_v<T>;
 template<class T>
-  concept @\deflibconcept{unsigned_integral}@ = integral<T> && !signed_integral<T>;
+  concept @\deflibconcept{unsigned_integral}@ = @\libconcept{integral}@<T> && !@\libconcept{signed_integral}@<T>;
 template<class T>
   concept @\deflibconcept{floating_point}@ = is_floating_point_v<T>;
 \end{itemdecl}
@@ -521,7 +521,7 @@ not unsigned integer types\iref{basic.fundamental}; for example, \tcode{bool}.
 template<class LHS, class RHS>
   concept @\deflibconcept{assignable_from}@ =
     is_lvalue_reference_v<LHS> &&
-    common_reference_with<const remove_reference_t<LHS>&, const remove_reference_t<RHS>&> &&
+    @\libconcept{common_reference_with}@<const remove_reference_t<LHS>&, const remove_reference_t<RHS>&> &&
     requires(LHS lhs, RHS&& rhs) {
       { lhs = std::forward<RHS>(rhs) } -> @\libconcept{same_as}@<LHS>;
     };
@@ -673,7 +673,7 @@ template<class T>
 \begin{itemdecl}
 template<class T, class U>
   concept @\deflibconcept{swappable_with}@ =
-    common_reference_with<T, U> &&
+    @\libconcept{common_reference_with}@<T, U> &&
     requires(T&& t, U&& u) {
       ranges::swap(std::forward<T>(t), std::forward<T>(t));
       ranges::swap(std::forward<U>(u), std::forward<U>(u));
@@ -704,7 +704,7 @@ void value_swap(T&& t, U&& u) {
   ranges::swap(std::forward<T>(t), std::forward<U>(u));
 }
 
-template<std::swappable T>
+template<std::@\libconcept{swappable}@ T>
 void lv_swap(T& t1, T& t2) {
   ranges::swap(t1, t2);
 }
@@ -762,7 +762,7 @@ variable of a given type with a particular set of argument types.
 
 \begin{itemdecl}
 template<class T, class... Args>
-  concept @\deflibconcept{constructible_from}@ = destructible<T> && is_constructible_v<T, Args...>;
+  concept @\deflibconcept{constructible_from}@ = @\libconcept{destructible}@<T> && is_constructible_v<T, Args...>;
 \end{itemdecl}
 
 \rSec2[concept.default.init]{Concept \cname{default_initializable}}
@@ -772,7 +772,7 @@ template<class T>
   inline constexpr bool @\exposid{is-default-initializable}@ = @\seebelow@;  // \expos
 
 template<class T>
-  concept @\deflibconcept{default_initializable}@ = constructible_from<T> &&
+  concept @\deflibconcept{default_initializable}@ = @\libconcept{constructible_from}@<T> &&
                                   requires { T{}; } &&
                                   @\exposid{is-default-initializable}@<T>;
 \end{itemdecl}
@@ -794,7 +794,7 @@ Only the validity of the immediate context of the variable initialization is con
 
 \begin{itemdecl}
 template<class T>
-  concept @\deflibconcept{move_constructible}@ = constructible_from<T, T> && @\libconcept{convertible_to}@<T, T>;
+  concept @\deflibconcept{move_constructible}@ = @\libconcept{constructible_from}@<T, T> && @\libconcept{convertible_to}@<T, T>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -818,10 +818,10 @@ but unspecified\iref{lib.types.movedfrom}; otherwise, it is unchanged.
 \begin{itemdecl}
 template<class T>
   concept @\deflibconcept{copy_constructible}@ =
-    move_constructible<T> &&
-    constructible_from<T, T&> && @\libconcept{convertible_to}@<T&, T> &&
-    constructible_from<T, const T&> && @\libconcept{convertible_to}@<const T&, T> &&
-    constructible_from<T, const T> && @\libconcept{convertible_to}@<const T, T>;
+    @\libconcept{move_constructible}@<T> &&
+    @\libconcept{constructible_from}@<T, T&> && @\libconcept{convertible_to}@<T&, T> &&
+    @\libconcept{constructible_from}@<T, const T&> && @\libconcept{convertible_to}@<const T&, T> &&
+    @\libconcept{constructible_from}@<T, const T> && @\libconcept{convertible_to}@<const T, T>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1038,9 +1038,9 @@ implies that \tcode{==} is transitive and symmetric.
 \begin{itemdecl}
 template<class T, class U>
   concept @\deflibconcept{equality_comparable_with}@ =
-    equality_comparable<T> && equality_comparable<U> &&
-    common_reference_with<const remove_reference_t<T>&, const remove_reference_t<U>&> &&
-    equality_comparable<
+    @\libconcept{equality_comparable}@<T> && @\libconcept{equality_comparable}@<U> &&
+    @\libconcept{common_reference_with}@<const remove_reference_t<T>&, const remove_reference_t<U>&> &&
+    @\libconcept{equality_comparable}@<
       common_reference_t<
         const remove_reference_t<T>&,
         const remove_reference_t<U>&>> &&
@@ -1130,15 +1130,15 @@ value-oriented programming style on which the library is based.
 
 \begin{itemdecl}
 template<class T>
-  concept @\deflibconcept{movable}@ = is_object_v<T> && move_constructible<T> &&
-                    @\libconcept{assignable_from}@<T&, T> && swappable<T>;
+  concept @\deflibconcept{movable}@ = is_object_v<T> && @\libconcept{move_constructible}@<T> &&
+                    @\libconcept{assignable_from}@<T&, T> && @\libconcept{swappable}@<T>;
 template<class T>
   concept @\deflibconcept{copyable}@ = @\libconcept{copy_constructible}@<T> && @\libconcept{movable}@<T> && @\libconcept{assignable_from}@<T&, T&> &&
                      @\libconcept{assignable_from}@<T&, const T&> && @\libconcept{assignable_from}@<T&, const T>;
 template<class T>
-  concept @\deflibconcept{semiregular}@ = copyable<T> && default_initializable<T>;
+  concept @\deflibconcept{semiregular}@ = @\libconcept{copyable}@<T> && @\libconcept{default_initializable}@<T>;
 template<class T>
-  concept @\deflibconcept{regular}@ = semiregular<T> && equality_comparable<T>;
+  concept @\deflibconcept{regular}@ = @\libconcept{semiregular}@<T> && @\libconcept{equality_comparable}@<T>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1192,7 +1192,7 @@ equality-preserving\iref{concepts.equality}.
 
 \begin{itemdecl}
 template<class F, class... Args>
-  concept @\deflibconcept{regular_invocable}@ = invocable<F, Args...>;
+  concept @\deflibconcept{regular_invocable}@ = @\libconcept{invocable}@<F, Args...>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1230,15 +1230,15 @@ template<class F, class... Args>
 \begin{itemdecl}
 template<class R, class T, class U>
   concept @\deflibconcept{relation}@ =
-    predicate<R, T, T> && predicate<R, U, U> &&
-    predicate<R, T, U> && predicate<R, U, T>;
+    @\libconcept{predicate}@<R, T, T> && @\libconcept{predicate}@<R, U, U> &&
+    @\libconcept{predicate}@<R, T, U> && @\libconcept{predicate}@<R, U, T>;
 \end{itemdecl}
 
 \rSec2[concept.equiv]{Concept \cname{equivalence_relation}}
 
 \begin{itemdecl}
 template<class R, class T, class U>
-  concept @\deflibconcept{equivalence_relation}@ = relation<R, T, U>;
+  concept @\deflibconcept{equivalence_relation}@ = @\libconcept{relation}@<R, T, U>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1251,7 +1251,7 @@ it imposes an equivalence relation on its arguments.
 
 \begin{itemdecl}
 template<class R, class T, class U>
-  concept @\deflibconcept{strict_weak_order}@ = relation<R, T, U>;
+  concept @\deflibconcept{strict_weak_order}@ = @\libconcept{relation}@<R, T, U>;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -368,7 +368,7 @@ namespace std {
 
   // \ref{iterators.common}, common iterators
   template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
-    requires (!@\libconcept{same_as}@<I, S> && copyable<I>)
+    requires (!@\libconcept{same_as}@<I, S> && @\libconcept{copyable}@<I>)
       class common_iterator;
 
   template<class I, class S>
@@ -692,7 +692,7 @@ namespace std {
 
   template<class T>
     requires (!requires { typename T::difference_type; } &&
-              requires(const T& a, const T& b) { { a - b } -> integral; })
+              requires(const T& a, const T& b) { { a - b } -> @\libconcept{integral}@; })
   struct incrementable_traits<T> {
     using difference_type = make_signed_t<decltype(declval<T>() - declval<T>())>;
   };
@@ -804,15 +804,15 @@ on program-defined types.
 \begin{note}
 Some legacy output iterators define a nested type named \tcode{value_type}
 that is an alias for \tcode{void}.
-These types are not \tcode{indirectly_readable}
+These types are not \libconcept{indirectly_readable}
 and have no associated value types.
 \end{note}
 
 \pnum
 \begin{note}
-Smart pointers like \tcode{shared_ptr<int>} are \tcode{indirectly_readable} and
+Smart pointers like \tcode{shared_ptr<int>} are \libconcept{indirectly_readable} and
 have an associated value type, but a smart pointer like \tcode{shared_ptr<void>}
-is not \tcode{indirectly_readable} and has no associated value type.
+is not \libconcept{indirectly_readable} and has no associated value type.
 \end{note}
 
 \rSec3[iterator.traits]{Iterator traits}
@@ -879,7 +879,7 @@ concept @\defexposconcept{cpp17-input-iterator}@ =
                                 typename indirectly_readable_traits<I>::value_type&>;
     typename common_reference_t<decltype(*i++)&&,
                                 typename indirectly_readable_traits<I>::value_type&>;
-    requires signed_integral<typename incrementable_traits<I>::difference_type>;
+    requires @\libconcept{signed_integral}@<typename incrementable_traits<I>::difference_type>;
   };
 
 template<class I>
@@ -1144,7 +1144,7 @@ denoted by \tcode{E1} and \tcode{E2},
 the program is ill-formed, no diagnostic required.
 
 \item Otherwise, if the types of \tcode{E1} and \tcode{E2} each model
-\tcode{indirectly_readable}, and if the reference types of \tcode{E1} and \tcode{E2}
+\libconcept{indirectly_readable}, and if the reference types of \tcode{E1} and \tcode{E2}
 model \libconcept{swappable_with}\iref{concept.swappable},
 then \tcode{ranges::swap(*E1, *E2)}.
 
@@ -1224,12 +1224,12 @@ template<class In>
       typename iter_value_t<In>;
       typename iter_reference_t<In>;
       typename iter_rvalue_reference_t<In>;
-      { *in } -> same_as<iter_reference_t<In>>;
-      { ranges::iter_move(in) } -> same_as<iter_rvalue_reference_t<In>>;
+      { *in } -> @\libconcept{same_as}@<iter_reference_t<In>>;
+      { ranges::iter_move(in) } -> @\libconcept{same_as}@<iter_rvalue_reference_t<In>>;
     } &&
-    common_reference_with<iter_reference_t<In>&&, iter_value_t<In>&> &&
-    common_reference_with<iter_reference_t<In>&&, iter_rvalue_reference_t<In>&&> &&
-    common_reference_with<iter_rvalue_reference_t<In>&&, const iter_value_t<In>&>;
+    @\libconcept{common_reference_with}@<iter_reference_t<In>&&, iter_value_t<In>&> &&
+    @\libconcept{common_reference_with}@<iter_reference_t<In>&&, iter_rvalue_reference_t<In>&&> &&
+    @\libconcept{common_reference_with}@<iter_rvalue_reference_t<In>&&, const iter_value_t<In>&>;
 \end{codeblock}
 
 \begin{codeblock}
@@ -1291,7 +1291,7 @@ Assignment through the same value of the indirectly writable type happens only o
 
 \pnum
 \begin{note}
-\tcode{indirectly_writable} has the awkward \tcode{const_cast} expressions to reject
+\libconcept{indirectly_writable} has the awkward \tcode{const_cast} expressions to reject
 iterators with prvalue non-proxy reference types that permit rvalue
 assignment but do not also permit \tcode{const} rvalue assignment.
 Consequently, an iterator type \tcode{I} that returns \tcode{std::string}
@@ -1315,7 +1315,7 @@ template<class T>
 
 template<class I>
   concept @\deflibconcept{weakly_incrementable}@ =
-    default_initializable<I> && @\libconcept{movable}@<I> &&
+    @\libconcept{default_initializable}@<I> && @\libconcept{movable}@<I> &&
     requires(I i) {
       typename iter_difference_t<I>;
       requires @\exposid{is-signed-integer-like}@<iter_difference_t<I>>;
@@ -1474,7 +1474,7 @@ in the definition of \libconcept{weakly_incrementable}.
 \begin{codeblock}
 template<class I>
   concept @\deflibconcept{incrementable}@ =
-    regular<I> &&
+    @\libconcept{regular}@<I> &&
     @\libconcept{weakly_incrementable}@<I> &&
     requires(I i) {
       { i++ } -> @\libconcept{same_as}@<I>;
@@ -1553,7 +1553,7 @@ Let \tcode{s} and \tcode{i} be values of type \tcode{S} and
 \item If \tcode{bool(i != s)} then \tcode{i} is dereferenceable and
       \range{++i}{s} denotes a range.
 
-\item \tcode{assignable_from<I\&, S>} is either modeled or not satisfied.
+\item \tcode{\libconcept{assignable_from}<I\&, S>} is either modeled or not satisfied.
 \end{itemize}
 \end{itemdescr}
 
@@ -2325,7 +2325,7 @@ namespace std {
       @\libconcept{invocable}@<F&, iter_value_t<I>&> &&
       @\libconcept{invocable}@<F&, iter_reference_t<I>> &&
       @\libconcept{invocable}@<F&, iter_common_reference_t<I>> &&
-      common_reference_with<
+      @\libconcept{common_reference_with}@<
         invoke_result_t<F&, iter_value_t<I>&>,
         invoke_result_t<F&, iter_reference_t<I>>>;
 
@@ -2336,7 +2336,7 @@ namespace std {
       @\libconcept{regular_invocable}@<F&, iter_value_t<I>&> &&
       @\libconcept{regular_invocable}@<F&, iter_reference_t<I>> &&
       @\libconcept{regular_invocable}@<F&, iter_common_reference_t<I>> &&
-      common_reference_with<
+      @\libconcept{common_reference_with}@<
         invoke_result_t<F&, iter_value_t<I>&>,
         invoke_result_t<F&, iter_reference_t<I>>>;
 
@@ -4754,7 +4754,7 @@ namespace std {
     friend bool operator==(
       const common_iterator& x, const common_iterator<I2, S2>& y);
     template<class I2, @\libconcept{sentinel_for}@<I> S2>
-      requires @\libconcept{sentinel_for}@<S, I2> && equality_comparable_with<I, I2>
+      requires @\libconcept{sentinel_for}@<S, I2> && @\libconcept{equality_comparable_with}@<I, I2>
     friend bool operator==(
       const common_iterator& x, const common_iterator<I2, S2>& y);
 
@@ -5056,7 +5056,7 @@ where $i$ is \tcode{x.v_.index()} and $j$ is \tcode{y.v_.index()}.
 \indexlibrarymember{operator==}{common_iterator}%
 \begin{itemdecl}
 template<class I2, @\libconcept{sentinel_for}@<I> S2>
-  requires @\libconcept{sentinel_for}@<S, I2> && equality_comparable_with<I, I2>
+  requires @\libconcept{sentinel_for}@<S, I2> && @\libconcept{equality_comparable_with}@<I, I2>
 friend bool operator==(
   const common_iterator& x, const common_iterator<I2, S2>& y);
 \end{itemdecl}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -461,7 +461,7 @@ constexpr auto @\placeholdernc{synth-three-way}@ =
       { u < t } -> @\exposconcept{boolean-testable}@;
     }
   {
-    if constexpr (three_way_comparable_with<T, U>) {
+    if constexpr (@\libconcept{three_way_comparable_with}@<T, U>) {
       return t <=> u;
     } else {
       if (t < u) return weak_ordering::less;

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -264,7 +264,7 @@ namespace std::ranges {
 
   // \ref{range.common}, common view
   template<@\libconcept{view}@ V>
-    requires (!@\libconcept{common_range}@<V> && copyable<iterator_t<V>>)
+    requires (!@\libconcept{common_range}@<V> && @\libconcept{copyable}@<iterator_t<V>>)
   class common_view;
 
   namespace views { inline constexpr @\unspec@ common = @\unspec@; }
@@ -1172,11 +1172,11 @@ template<class T>
 \tcode{T} has \bigoh{1} destruction; and
 
 \item
-\tcode{copy_constructible<T>} is \tcode{false}, or
+\tcode{\libconcept{copy_constructible}<T>} is \tcode{false}, or
 \tcode{T} has \bigoh{1} copy construction; and
 
 \item
-\tcode{copyable<T>} is \tcode{false}, or
+\tcode{\libconcept{copyable}<T>} is \tcode{false}, or
 \tcode{T} has \bigoh{1} copy assignment.
 \end{itemize}
 
@@ -1205,7 +1205,7 @@ semantic, the two are differentiated with the help of \tcode{enable_view}.
 \indexlibraryglobal{enable_view}%
 \begin{itemdecl}
 template<class T>
-  inline constexpr bool enable_view = derived_from<T, view_base>;
+  inline constexpr bool enable_view = @\libconcept{derived_from}@<T, view_base>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1292,7 +1292,7 @@ The \libconcept{viewable_range} concept specifies the requirements of a
 \begin{itemdecl}
 template<class T>
   concept @\deflibconcept{viewable_range}@ =
-    @\libconcept{range}@<T> && (borrowed_range<T> || @\libconcept{view}@<remove_cvref_t<T>>);
+    @\libconcept{range}@<T> && (@\libconcept{borrowed_range}@<T> || @\libconcept{view}@<remove_cvref_t<T>>);
 \end{itemdecl}
 
 \rSec1[range.utility]{Range utilities}
@@ -1458,7 +1458,7 @@ iterator and a sentinel into a single object that models the
 namespace std::ranges {
   template<class From, class To>
     concept @\defexposconcept{convertible-to-non-slicing}@ =                    // \expos
-      convertible_to<From, To> &&
+      @\libconcept{convertible_to}@<From, To> &&
       !(is_pointer_v<decay_t<From>> &&
         is_pointer_v<decay_t<To>> &&
         @\exposconcept{not-same-as}@<remove_pointer_t<decay_t<From>>, remove_pointer_t<decay_t<To>>>);
@@ -1507,7 +1507,7 @@ namespace std::ranges {
                @\libconcept{convertible_to}@<sentinel_t<R>, S>
     constexpr subrange(R&& r) requires (!@\exposid{StoreSize}@ || @\libconcept{sized_range}@<R>);
 
-    template<borrowed_range R>
+    template<@\libconcept{borrowed_range}@ R>
       requires @\exposconcept{convertible-to-non-slicing}@<iterator_t<R>, I> &&
                @\libconcept{convertible_to}@<sentinel_t<R>, S>
     constexpr subrange(R&& r, @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>> n)
@@ -1519,8 +1519,8 @@ namespace std::ranges {
       requires @\exposconcept{pair-like-convertible-from}@<PairLike, const I&, const S&>
     constexpr operator PairLike() const;
 
-    constexpr I begin() const requires copyable<I>;
-    [[nodiscard]] constexpr I begin() requires (!copyable<I>);
+    constexpr I begin() const requires @\libconcept{copyable}@<I>;
+    [[nodiscard]] constexpr I begin() requires (!@\libconcept{copyable}@<I>);
     constexpr S end() const;
 
     constexpr bool empty() const;
@@ -1528,7 +1528,7 @@ namespace std::ranges {
       requires (K == subrange_kind::sized);
 
     [[nodiscard]] constexpr subrange next(iter_difference_t<I> n = 1) const &
-      requires forward_iterator<I>;
+      requires @\libconcept{forward_iterator}@<I>;
     [[nodiscard]] constexpr subrange next(iter_difference_t<I> n = 1) &&;
     [[nodiscard]] constexpr subrange prev(iter_difference_t<I> n = 1) const
       requires @\libconcept{bidirectional_iterator}@<I>;
@@ -1542,13 +1542,13 @@ namespace std::ranges {
     subrange(I, S, @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>>) ->
       subrange<I, S, subrange_kind::sized>;
 
-  template<borrowed_range R>
+  template<@\libconcept{borrowed_range}@ R>
     subrange(R&&) ->
       subrange<iterator_t<R>, sentinel_t<R>,
                (@\libconcept{sized_range}@<R> || @\libconcept{sized_sentinel_for}@<sentinel_t<R>, iterator_t<R>>)
                  ? subrange_kind::sized : subrange_kind::unsized>;
 
-  template<borrowed_range R>
+  template<@\libconcept{borrowed_range}@ R>
     subrange(R&&, @\placeholdernc{make-unsigned-like-t}@<range_difference_t<R>>) ->
       subrange<iterator_t<R>, sentinel_t<R>, subrange_kind::sized>;
 
@@ -1650,7 +1650,7 @@ Equivalent to: \tcode{return PairLike(\exposid{begin_}, \exposid{end_});}
 
 \indexlibrarymember{begin}{subrange}%
 \begin{itemdecl}
-constexpr I begin() const requires copyable<I>;
+constexpr I begin() const requires @\libconcept{copyable}@<I>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1661,7 +1661,7 @@ Equivalent to: \tcode{return \exposid{begin_};}
 
 \indexlibrarymember{begin}{subrange}%
 \begin{itemdecl}
-[[nodiscard]] constexpr I begin() requires (!copyable<I>);
+[[nodiscard]] constexpr I begin() requires (!@\libconcept{copyable}@<I>);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1710,7 +1710,7 @@ constexpr @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>> size() co
 \indexlibrarymember{next}{subrange}%
 \begin{itemdecl}
 [[nodiscard]] constexpr subrange next(iter_difference_t<I> n = 1) const &
-  requires forward_iterator<I>;
+  requires @\libconcept{forward_iterator}@<I>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2067,7 +2067,7 @@ namespace std::ranges {
       @\seebelow@;
 
   template<@\libconcept{weakly_incrementable}@ W, @\libconcept{semiregular}@ Bound = unreachable_sentinel_t>
-    requires @\exposconcept{weakly-equality-comparable-with}@<W, Bound> && semiregular<W>
+    requires @\exposconcept{weakly-equality-comparable-with}@<W, Bound> && @\libconcept{semiregular}@<W>
   class iota_view : public view_interface<iota_view<W, Bound>> {
   private:
     // \ref{range.iota.iterator}, class \tcode{iota_view::\exposid{iterator}}
@@ -2292,7 +2292,7 @@ else
 \remarks
 The expression in the \grammarterm{requires-clause} is equivalent to:
 \begin{codeblock}
-(@\libconcept{same_as}@<W, Bound> && @\exposconcept{advanceable}@<W>) || (integral<W> && integral<Bound>) ||
+(@\libconcept{same_as}@<W, Bound> && @\exposconcept{advanceable}@<W>) || (@\libconcept{integral}@<W> && @\libconcept{integral}@<Bound>) ||
   @\libconcept{sized_sentinel_for}@<Bound, W>
 \end{codeblock}
 \end{itemdescr}
@@ -2333,7 +2333,7 @@ namespace std::ranges {
       requires @\exposconcept{advanceable}@<W>;
 
     friend constexpr bool operator==(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires equality_comparable<W>;
+      requires @\libconcept{equality_comparable}@<W>;
 
     friend constexpr bool operator<(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
       requires @\libconcept{totally_ordered}@<W>;
@@ -2538,7 +2538,7 @@ Equivalent to: \tcode{return W(\exposid{value_} + n);}
 \indexlibrarymember{operator==}{iota_view::iterator}
 \begin{itemdecl}
 friend constexpr bool operator==(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires equality_comparable<W>;
+  requires @\libconcept{equality_comparable}@<W>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2765,8 +2765,8 @@ namespace std::ranges {
          is >> t;
       };
 
-  template<movable Val, class CharT, class Traits>
-    requires default_initializable<Val> &&
+  template<@\libconcept{movable}@ Val, class CharT, class Traits>
+    requires @\libconcept{default_initializable}@<Val> &&
              @\exposconcept{stream-extractable}@<Val, CharT, Traits>
   class basic_istream_view : public view_interface<basic_istream_view<Val, CharT, Traits>> {
   public:
@@ -2830,8 +2830,8 @@ Equivalent to: \tcode{return basic_istream_view<Val, CharT, Traits>\{s\};}
 \indexlibraryglobal{basic_istream_view::iterator}%
 \begin{codeblock}
 namespace std::ranges {
-  template<movable Val, class CharT, class Traits>
-    requires default_initializable<Val> &&
+  template<@\libconcept{movable}@ Val, class CharT, class Traits>
+    requires @\libconcept{default_initializable}@<Val> &&
              @\exposconcept{stream-extractable}@<Val, CharT, Traits>
   class basic_istream_view<Val, CharT, Traits>::@\exposid{iterator}@ {      // \expos
   public:
@@ -3191,7 +3191,7 @@ namespace std::ranges {
     filter_view() = default;
     constexpr filter_view(V base, Pred pred);
 
-    constexpr V base() const& requires copy_constructible<V> { return @\exposid{base_}@; }
+    constexpr V base() const& requires @\libconcept{copy_constructible}@<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
     constexpr const Pred& pred() const;
@@ -3277,7 +3277,7 @@ namespace std::ranges {
     constexpr @\exposid{iterator}@(filter_view& parent, iterator_t<V> current);
 
     constexpr iterator_t<V> base() const &
-      requires copyable<iterator_t<V>>;
+      requires @\libconcept{copyable}@<iterator_t<V>>;
     constexpr iterator_t<V> base() &&;
     constexpr range_reference_t<V> operator*() const;
     constexpr iterator_t<V> operator->() const
@@ -3291,7 +3291,7 @@ namespace std::ranges {
     constexpr @\exposid{iterator}@ operator--(int) requires @\libconcept{bidirectional_range}@<V>;
 
     friend constexpr bool operator==(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires equality_comparable<iterator_t<V>>;
+      requires @\libconcept{equality_comparable}@<iterator_t<V>>;
 
     friend constexpr range_rvalue_reference_t<V> iter_move(const @\exposid{iterator}@& i)
       noexcept(noexcept(ranges::iter_move(i.@\exposid{current_}@)));
@@ -3354,7 +3354,7 @@ Initializes \exposid{current_} with \tcode{std::move(current)} and
 \indexlibrarymember{base}{filter_view::iterator}%
 \begin{itemdecl}
 constexpr iterator_t<V> base() const &
-  requires copyable<iterator_t<V>>;
+  requires @\libconcept{copyable}@<iterator_t<V>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3476,7 +3476,7 @@ return tmp;
 \indexlibrarymember{operator==}{filter_view::iterator}%
 \begin{itemdecl}
 friend constexpr bool operator==(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires equality_comparable<iterator_t<V>>;
+  requires @\libconcept{equality_comparable}@<iterator_t<V>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3615,7 +3615,7 @@ namespace std::ranges {
     transform_view() = default;
     constexpr transform_view(V base, F fun);
 
-    constexpr V base() const& requires copy_constructible<V> { return @\exposid{base_}@; }
+    constexpr V base() const& requires @\libconcept{copy_constructible}@<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
     constexpr @\exposid{iterator}@<false> begin();
@@ -3773,7 +3773,7 @@ namespace std::ranges {
       requires Const && @\libconcept{convertible_to}@<iterator_t<V>, iterator_t<@\exposid{Base}@>>;
 
     constexpr iterator_t<@\exposid{Base}@> base() const &
-      requires copyable<iterator_t<@\exposid{Base}@>>;
+      requires @\libconcept{copyable}@<iterator_t<@\exposid{Base}@>>;
     constexpr iterator_t<@\exposid{Base}@> base() &&;
     constexpr decltype(auto) operator*() const
     { return invoke(*@\exposid{parent_}@->@\exposid{fun_}@, *@\exposid{current_}@); }
@@ -3901,7 +3901,7 @@ Initializes \exposid{current_} with \tcode{std::move(i.\exposid{current_})} and
 \indexlibrarymember{base}{transform_view::iterator}%
 \begin{itemdecl}
 constexpr iterator_t<@\exposid{Base}@> base() const &
-  requires copyable<iterator_t<@\exposid{Base}@>>;
+  requires @\libconcept{copyable}@<iterator_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4029,7 +4029,7 @@ return *this;
 \indexlibrarymember{operator==}{transform_view::iterator}%
 \begin{itemdecl}
 friend constexpr bool operator==(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires equality_comparable<iterator_t<@\exposid{Base}@>>;
+  requires @\libconcept{equality_comparable}@<iterator_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4339,7 +4339,7 @@ namespace std::ranges {
     take_view() = default;
     constexpr take_view(V base, range_difference_t<V> count);
 
-    constexpr V base() const& requires copy_constructible<V> { return @\exposid{base_}@; }
+    constexpr V base() const& requires @\libconcept{copy_constructible}@<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
     constexpr auto begin() requires (!@\exposconcept{simple-view}@<V>) {
@@ -4549,7 +4549,7 @@ namespace std::ranges {
     take_while_view() = default;
     constexpr take_while_view(V base, Pred pred);
 
-    constexpr V base() const& requires copy_constructible<V> { return @\exposid{base_}@; }
+    constexpr V base() const& requires @\libconcept{copy_constructible}@<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
     constexpr const Pred& pred() const;
@@ -4741,7 +4741,7 @@ namespace std::ranges {
     drop_view() = default;
     constexpr drop_view(V base, range_difference_t<V> count);
 
-    constexpr V base() const& requires copy_constructible<V> { return @\exposid{base_}@; }
+    constexpr V base() const& requires @\libconcept{copy_constructible}@<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
     constexpr auto begin()
@@ -4805,7 +4805,7 @@ constexpr auto begin()
   requires (!(@\exposconcept{simple-view}@<V> &&
               @\libconcept{random_access_range}@<const V> && @\libconcept{sized_range}@<const V>));
 constexpr auto begin() const
-  requires random_access_range<const V> && @\libconcept{sized_range}@<const V>;
+  requires @\libconcept{random_access_range}@<const V> && @\libconcept{sized_range}@<const V>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4870,7 +4870,7 @@ namespace std::ranges {
     drop_while_view() = default;
     constexpr drop_while_view(V base, Pred pred);
 
-    constexpr V base() const& requires copy_constructible<V> { return @\exposid{base_}@; }
+    constexpr V base() const& requires @\libconcept{copy_constructible}@<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
     constexpr const Pred& pred() const;
@@ -5340,8 +5340,8 @@ return tmp;
 \indexlibrarymember{operator==}{join_view::iterator}%
 \begin{itemdecl}
 friend constexpr bool operator==(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires @\exposid{ref-is-glvalue}@ && equality_comparable<iterator_t<@\exposid{Base}@>> &&
-           equality_comparable<iterator_t<range_reference_t<@\exposid{Base}@>>>;
+  requires @\exposid{ref-is-glvalue}@ && @\libconcept{equality_comparable}@<iterator_t<@\exposid{Base}@>> &&
+           @\libconcept{equality_comparable}@<iterator_t<range_reference_t<@\exposid{Base}@>>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5471,7 +5471,7 @@ namespace std::ranges {
 
   template<class R>
   concept @\defexposconcept{tiny-range}@ =                          // \expos
-    sized_range<R> &&
+    @\libconcept{sized_range}@<R> &&
     requires { typename @\exposid{require-constant}@<remove_reference_t<R>::size()>; } &&
     (remove_reference_t<R>::size() <= 1);
 
@@ -5483,7 +5483,7 @@ namespace std::ranges {
   private:
     V @\exposid{base_}@ = V();                              // \expos
     Pattern @\exposid{pattern_}@ = Pattern();               // \expos
-    iterator_t<V> @\exposid{current_}@ = iterator_t<V>();   // \expos, present only if \tcode{!forward_range<V>}
+    iterator_t<V> @\exposid{current_}@ = iterator_t<V>();   // \expos, present only if \tcode{!\libconcept{forward_range}<V>}
     // \ref{range.split.outer}, class template \tcode{split_view::\exposid{outer-iterator}}
     template<bool> struct @\exposid{outer-iterator}@;       // \expos
     // \ref{range.split.inner}, class template \tcode{split_view::\exposid{inner-iterator}}
@@ -5497,7 +5497,7 @@ namespace std::ranges {
                @\libconcept{constructible_from}@<Pattern, single_view<range_value_t<R>>>
     constexpr split_view(R&& r, range_value_t<R> e);
 
-    constexpr V base() const& requires copy_constructible<V> { return @\exposid{base_}@; }
+    constexpr V base() const& requires @\libconcept{copy_constructible}@<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
     constexpr auto begin() {
@@ -5743,8 +5743,8 @@ namespace std::ranges {
     value_type() = default;
     constexpr explicit value_type(@\exposid{outer-iterator}@ i);
 
-    constexpr @\exposid{inner-iterator}@<Const> begin() const requires copyable<@\exposid{outer-iterator}@>;
-    constexpr @\exposid{inner-iterator}@<Const> begin() requires (!copyable<@\exposid{outer-iterator}@>);
+    constexpr @\exposid{inner-iterator}@<Const> begin() const requires @\libconcept{copyable}@<@\exposid{outer-iterator}@>;
+    constexpr @\exposid{inner-iterator}@<Const> begin() requires (!@\libconcept{copyable}@<@\exposid{outer-iterator}@>);
     constexpr default_sentinel_t end() const;
   };
 }
@@ -5763,7 +5763,7 @@ Initializes \exposid{i_} with \tcode{std::move(i)}.
 
 \indexlibrarymember{begin}{split_view::\exposid{outer-iterator}::value_type}%
 \begin{itemdecl}
-constexpr @\exposid{inner-iterator}@<Const> begin() const requires copyable<@\exposid{outer-iterator}@>;
+constexpr @\exposid{inner-iterator}@<Const> begin() const requires @\libconcept{copyable}@<@\exposid{outer-iterator}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5774,7 +5774,7 @@ Equivalent to: \tcode{return \exposid{inner-iterator}<Const>\{\exposid{i_}\};}
 
 \indexlibrarymember{begin}{split_view::\exposid{outer-iterator}::value_type}%
 \begin{itemdecl}
-constexpr @\exposid{inner-iterator}@<Const> begin() requires (!copyable<@\exposid{outer-iterator}@>);
+constexpr @\exposid{inner-iterator}@<Const> begin() requires (!@\libconcept{copyable}@<@\exposid{outer-iterator}@>);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6078,10 +6078,10 @@ namespace std::ranges {
         return common_iterator<iterator_t<const V>, sentinel_t<const V>>(ranges::end(@\exposid{base_}@));
     }
 
-    constexpr auto size() requires sized_range<V> {
+    constexpr auto size() requires @\libconcept{sized_range}@<V> {
       return ranges::size(@\exposid{base_}@);
     }
-    constexpr auto size() const requires sized_range<const V> {
+    constexpr auto size() const requires @\libconcept{sized_range}@<const V> {
       return ranges::size(@\exposid{base_}@);
     }
   };
@@ -6322,7 +6322,7 @@ namespace std::ranges {
       typename tuple_size<T>::type;
       requires N < tuple_size_v<T>;
       typename tuple_element_t<N, T>;
-      { get<N>(t) } -> convertible_to<const tuple_element_t<N, T>&>;
+      { get<N>(t) } -> @\libconcept{convertible_to}@<const tuple_element_t<N, T>&>;
     };
 
   template<class T, size_t N>
@@ -6338,7 +6338,7 @@ namespace std::ranges {
     elements_view() = default;
     constexpr explicit elements_view(V base);
 
-    constexpr V base() const& requires copy_constructible<V> { return @\exposid{base_}@; }
+    constexpr V base() const& requires @\libconcept{copy_constructible}@<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
     constexpr auto begin() requires (!@\exposconcept{simple-view}@<V>)
@@ -6359,10 +6359,10 @@ namespace std::ranges {
     constexpr auto end() const requires @\libconcept{common_range}@<const V>
     { return @\exposid{iterator}@<true>{ranges::end(@\exposid{base_}@)}; }
 
-    constexpr auto size() requires sized_range<V>
+    constexpr auto size() requires @\libconcept{sized_range}@<V>
     { return ranges::size(@\exposid{base_}@); }
 
-    constexpr auto size() const requires sized_range<const V>
+    constexpr auto size() const requires @\libconcept{sized_range}@<const V>
     { return ranges::size(@\exposid{base_}@); }
 
   private:
@@ -6415,7 +6415,7 @@ namespace std::ranges {
       requires Const && @\libconcept{convertible_to}@<iterator_t<V>, iterator_t<@\exposid{Base}@>>;
 
     constexpr iterator_t<@\exposid{Base}@> base() const&
-      requires copyable<iterator_t<@\exposid{Base}@>>;
+      requires @\libconcept{copyable}@<iterator_t<@\exposid{Base}@>>;
     constexpr iterator_t<@\exposid{Base}@> base() &&;
 
     constexpr decltype(auto) operator*() const
@@ -6542,7 +6542,7 @@ Initializes \exposid{current_} with \tcode{std::move(i.\exposid{current_})}.
 \indexlibrarymember{base}{elements_view::iterator}%
 \begin{itemdecl}
 constexpr iterator_t<@\exposid{Base}@> base() const&
-  requires copyable<iterator_t<@\exposid{Base}@>>;
+  requires @\libconcept{copyable}@<iterator_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6670,7 +6670,7 @@ return *this;
 \indexlibrarymember{operator==}{elements_view::iterator}%
 \begin{itemdecl}
 friend constexpr bool operator==(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires equality_comparable<@\exposid{Base}@>;
+  requires @\libconcept{equality_comparable}@<@\exposid{Base}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6805,7 +6805,7 @@ namespace std::ranges {
     @\exposid{sentinel}@() = default;
     constexpr explicit @\exposid{sentinel}@(sentinel_t<@\exposid{Base}@> end);
     constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> other)
-      requires Const && convertible_to<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
+      requires Const && @\libconcept{convertible_to}@<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
 
     constexpr sentinel_t<@\exposid{Base}@> base() const;
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -4675,7 +4675,7 @@ This is \tcode{std::strong_ordering} if the expansion is empty.
 \end{note}
 \end{itemdescr}
 
-\rSec2[cmp.concept]{Concept \libconcept{three_way_comparable}}
+\rSec2[cmp.concept]{Concept \cname{three_way_comparable}}
 
 \begin{codeblock}
 template<class T, class Cat>
@@ -4723,7 +4723,6 @@ lvalues of types \tcode{const remove_reference_t<T>} and
   \tcode{bool(u <= t) == bool(t >= u)} is \tcode{true}.
 \end{itemize}
 
-\indexlibraryglobal{three_way_comparable}%
 \begin{codeblock}
 template<class T, class Cat = partial_ordering>
   concept @\deflibconcept{three_way_comparable}@ =
@@ -4759,7 +4758,6 @@ model \tcode{\libconcept{three_way_comparable}<T, Cat>} only if:
   \libconcept{totally_ordered}\iref{concept.totallyordered}.
 \end{itemize}
 
-\indexlibraryglobal{three_way_comparable_with}%
 \begin{codeblock}
 template<class T, class U, class Cat = partial_ordering>
   concept @\deflibconcept{three_way_comparable_with}@ =

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -3985,7 +3985,7 @@ namespace std {
     constexpr bool operator<=(const variant<Types...>&, const variant<Types...>&);
   template<class... Types>
     constexpr bool operator>=(const variant<Types...>&, const variant<Types...>&);
-  template<class... Types> requires (three_way_comparable<Types> && ...)
+  template<class... Types> requires (@\libconcept{three_way_comparable}@<Types> && ...)
     constexpr common_comparison_category_t<compare_three_way_result_t<Types>...>
       operator<=>(const variant<Types...>&, const variant<Types...>&);
 
@@ -5096,7 +5096,7 @@ otherwise \tcode{get<$i$>(v) >= get<$i$>(w)} with $i$ being \tcode{v.index()}.
 
 \indexlibrarymember{operator<=>}{variant}%
 \begin{itemdecl}
-template<class... Types> requires (three_way_comparable<Types> && ...)
+template<class... Types> requires (@\libconcept{three_way_comparable}@<Types> && ...)
   constexpr common_comparison_category_t<compare_three_way_result_t<Types>...>
     operator<=>(const variant<Types...>& v, const variant<Types...>& w);
 \end{itemdecl}
@@ -6878,14 +6878,14 @@ namespace std {
 
   namespace ranges {
     template<@\exposconcept{no-throw-forward-iterator}@ I, @\exposconcept{no-throw-sentinel-for}@<I> S>
-      requires default_initializable<iter_value_t<I>>
+      requires @\libconcept{default_initializable}@<iter_value_t<I>>
         I uninitialized_default_construct(I first, S last);
     template<@\exposconcept{no-throw-forward-range}@ R>
-      requires default_initializable<range_value_t<R>>
+      requires @\libconcept{default_initializable}@<range_value_t<R>>
         borrowed_iterator_t<R> uninitialized_default_construct(R&& r);
 
     template<@\exposconcept{no-throw-forward-iterator}@ I>
-      requires default_initializable<iter_value_t<I>>
+      requires @\libconcept{default_initializable}@<iter_value_t<I>>
         I uninitialized_default_construct_n(I first, iter_difference_t<I> n);
   }
 
@@ -6906,14 +6906,14 @@ namespace std {
 
   namespace ranges {
     template<@\exposconcept{no-throw-forward-iterator}@ I, @\exposconcept{no-throw-sentinel-for}@<I> S>
-      requires default_initializable<iter_value_t<I>>
+      requires @\libconcept{default_initializable}@<iter_value_t<I>>
         I uninitialized_value_construct(I first, S last);
     template<@\exposconcept{no-throw-forward-range}@ R>
-      requires default_initializable<range_value_t<R>>
+      requires @\libconcept{default_initializable}@<range_value_t<R>>
         borrowed_iterator_t<R> uninitialized_value_construct(R&& r);
 
     template<@\exposconcept{no-throw-forward-iterator}@ I>
-      requires default_initializable<iter_value_t<I>>
+      requires @\libconcept{default_initializable}@<iter_value_t<I>>
         I uninitialized_value_construct_n(I first, iter_difference_t<I> n);
   }
 
@@ -14173,7 +14173,7 @@ operator comparing pointers.
 \begin{itemdecl}
 struct ranges::equal_to {
   template<class T, class U>
-    requires equality_comparable_with<T, U> || @\placeholdernc{BUILTIN-PTR-CMP}@(T, ==, U)
+    requires @\libconcept{equality_comparable_with}@<T, U> || @\placeholdernc{BUILTIN-PTR-CMP}@(T, ==, U)
     constexpr bool operator()(T&& t, U&& u) const;
 
   using is_transparent = @\unspecnc@;
@@ -14208,7 +14208,7 @@ are equality-preserving\iref{concepts.equality}.
 \begin{itemdecl}
 struct ranges::not_equal_to {
   template<class T, class U>
-    requires equality_comparable_with<T, U> || @\placeholdernc{BUILTIN-PTR-CMP}@(T, ==, U)
+    requires @\libconcept{equality_comparable_with}@<T, U> || @\placeholdernc{BUILTIN-PTR-CMP}@(T, ==, U)
     constexpr bool operator()(T&& t, U&& u) const;
 
   using is_transparent = @\unspecnc@;


### PR DESCRIPTION
Resolves #4383.

No visible diff outside the index according to diffpdf.

Remaining question: Should these be dropped?
```
support.tex:\indexlibraryglobal{three_way_comparable}%
support.tex:\indexlibraryglobal{three_way_comparable_with}%
```