### PR TITLE
[format.arg] Fix return type of visit_format_arg

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -19186,7 +19186,7 @@ namespace std {
   template<class Context> class basic_format_arg;
 
   template<class Visitor, class Context>
-    @\seebelow@ visit_format_arg(Visitor&& vis, basic_format_arg<Context> arg);
+    decltype(auto) visit_format_arg(Visitor&& vis, basic_format_arg<Context> arg);
 
   // \ref{format.arg.store}, class template \exposid{format-arg-store}
   template<class Context, class... Args> struct @\placeholder{format-arg-store}@;      // \expos
@@ -20950,7 +20950,7 @@ Equivalent to: \tcode{format_(parse_ctx, format_ctx, ptr_);}
 \indexlibraryglobal{visit_format_arg}%
 \begin{itemdecl}
 template<class Visitor, class Context>
-  @\seebelow@ visit_format_arg(Visitor&& vis, basic_format_arg<Context> arg);
+  decltype(auto) visit_format_arg(Visitor&& vis, basic_format_arg<Context> arg);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
It was specified as 'see below', pointing nowhere.
Use 'decltype(auto)', congruent with the Effects item.

http://lists.isocpp.org/lib/2021/02/18545.php