### PR TITLE
[stacktrace.entry.query] Fix description of `source_line`

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -21319,7 +21319,7 @@ returns the actual line number.
 \pnum
 \throws
 \tcode{bad_alloc} if memory for
-the internal data structures or the resulting string cannot be allocated.
+the internal data structures cannot be allocated.
 \end{itemdescr}
 
 \rSec3[stacktrace.entry.cmp]{Comparison}


### PR DESCRIPTION
Unlike `description` and `source_file`, this function does not return a string.

This appears to be a mistake made when [P0881R7](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p0881r7.html) was applied.