### PR TITLE
[dcl.init.general] Fix misapplied term 'block variable'

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4252,8 +4252,9 @@ and~\ref{stmt.dcl}.
 \end{note}
 
 \pnum
-A declaration of a block variable with linkage
-that has an \grammarterm{initializer} is ill-formed.
+A declaration $D$ of a variable with linkage
+shall not have an \grammarterm{initializer}
+if $D$ inhabits a block scope.
 
 \pnum
 \indextext{initialization!default}%


### PR DESCRIPTION
Block-scope externs are in view here, but those are not
block variables, because their target scope is an
enclosing namespace scope.

Fixes #4478