### PR TITLE
[lib] Use 'tm', not 'struct tm'

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4171,8 +4171,8 @@ namespace std {
   @\unspec@ setw(int n);
   template<class moneyT> @\unspec@ get_money(moneyT& mon, bool intl = false);
   template<class moneyT> @\unspec@ put_money(const moneyT& mon, bool intl = false);
-  template<class charT> @\unspec@ get_time(struct tm* tmb, const charT* fmt);
-  template<class charT> @\unspec@ put_time(const struct tm* tmb, const charT* fmt);
+  template<class charT> @\unspec@ get_time(tm* tmb, const charT* fmt);
+  template<class charT> @\unspec@ put_time(const tm* tmb, const charT* fmt);
 
   template<class charT>
     @\unspec@ quoted(const charT* s, charT delim = charT('"'), charT escape = charT('\\'));
@@ -7275,13 +7275,13 @@ The expression \tcode{out << put_money(mon, intl)} has type
 
 \indexlibraryglobal{get_time}%
 \begin{itemdecl}
-template<class charT> @\unspec@ get_time(struct tm* tmb, const charT* fmt);
+template<class charT> @\unspec@ get_time(tm* tmb, const charT* fmt);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \expects
-The argument \tcode{tmb} is a valid pointer to an object of type \tcode{struct tm},
+The argument \tcode{tmb} is a valid pointer to an object of type \tcode{tm},
 and \range{fmt}{fmt + char_traits<charT>::length(fmt)} is a valid range.
 
 \pnum
@@ -7293,7 +7293,7 @@ defined as:
 
 \begin{codeblock}
 template<class charT, class traits>
-void f(basic_ios<charT, traits>& str, struct tm* tmb, const charT* fmt) {
+void f(basic_ios<charT, traits>& str, tm* tmb, const charT* fmt) {
   using Iter    = istreambuf_iterator<charT, traits>;
   using TimeGet = time_get<charT, Iter>;
 
@@ -7314,13 +7314,13 @@ The expression \tcode{in >> get_time(tmb, fmt)} has type
 
 \indexlibraryglobal{put_time}%
 \begin{itemdecl}
-template<class charT> @\unspec@ put_time(const struct tm* tmb, const charT* fmt);
+template<class charT> @\unspec@ put_time(const tm* tmb, const charT* fmt);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \expects
-The argument \tcode{tmb} is a valid pointer to an object of type \tcode{struct tm},
+The argument \tcode{tmb} is a valid pointer to an object of type \tcode{tm},
 and \range{fmt}{fmt + char_traits<charT>::length(fmt)} is a valid range.
 
 \pnum
@@ -7332,7 +7332,7 @@ where the function \tcode{f} is defined as:
 
 \begin{codeblock}
 template<class charT, class traits>
-void f(basic_ios<charT, traits>& str, const struct tm* tmb, const charT* fmt) {
+void f(basic_ios<charT, traits>& str, const tm* tmb, const charT* fmt) {
   using Iter    = ostreambuf_iterator<charT, traits>;
   using TimePut = time_put<charT, Iter>;
 

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -108,7 +108,7 @@ The header \libheader{locale}
 defines classes and declares functions
 that encapsulate and manipulate the information peculiar to a locale.
 \begin{footnote}
-In this subclause, the type name \tcode{struct tm}
+In this subclause, the type name \tcode{tm}
 is an incomplete type that is defined in \libheaderref{ctime}.
 \end{footnote}
 
@@ -3191,12 +3191,12 @@ namespace std {
 
 \pnum
 \tcode{time_get} is used to parse a character sequence,
-extracting components of a time or date into a \tcode{struct tm} object.
+extracting components of a time or date into a \tcode{tm} object.
 Each \tcode{get} member parses a format as produced by a corresponding format specifier to
 \tcode{time_put<>::put}.
 If the sequence being parsed matches the correct format, the corresponding
 members of the
-\tcode{struct tm}
+\tcode{tm}
 argument are set to the values used to produce the sequence; otherwise
 either an error is reported or unspecified values are assigned.
 \begin{footnote}
@@ -3401,7 +3401,7 @@ iter_type do_get_time(iter_type s, iter_type end, ios_base& str,
 \pnum
 \effects
 Reads characters starting at \tcode{s}
-until it has extracted those \tcode{struct tm} members, and
+until it has extracted those \tcode{tm} members, and
 remaining format characters,
 used by \tcode{time_put<>::put}
 to produce the format specified by \tcode{"\%H:\%M:\%S"},
@@ -3423,7 +3423,7 @@ iter_type do_get_date(iter_type s, iter_type end, ios_base& str,
 \pnum
 \effects
 Reads characters starting at \tcode{s}
-until it has extracted those \tcode{struct tm} members and
+until it has extracted those \tcode{tm} members and
 remaining format characters
 used by \tcode{time_put<>::put}
 to produce one of the following formats,
@@ -3467,7 +3467,7 @@ until it has extracted the (perhaps abbreviated) name of a weekday or month.
 If it finds an abbreviation
 that is followed by characters that can match a full name,
 it continues reading until it matches the full name or fails.
-It sets the appropriate \tcode{struct tm} member accordingly.
+It sets the appropriate \tcode{tm} member accordingly.
 
 \pnum
 \returns
@@ -3513,7 +3513,7 @@ iter_type do_get(iter_type s, iter_type end, ios_base& f,
 \effects
 The function starts by evaluating \tcode{err = ios_base::goodbit}.
 It then reads characters starting at \tcode{s} until it encounters an error, or
-until it has extracted and assigned those \tcode{struct tm} members, and
+until it has extracted and assigned those \tcode{tm} members, and
 any remaining format characters,
 corresponding to a conversion directive appropriate for
 the ISO/IEC 9945 function \tcode{strptime},
@@ -3531,9 +3531,9 @@ For complex conversion directives
 such as \tcode{\%c}, \tcode{\%x}, or \tcode{\%X}, or
 directives that involve the optional modifiers \tcode{E} or \tcode{O},
 when the function is unable to unambiguously determine
-some or all \tcode{struct tm} members from the input sequence \range{s}{end},
+some or all \tcode{tm} members from the input sequence \range{s}{end},
 it evaluates \tcode{err |= ios_base::eofbit}.
-In such cases the values of those \tcode{struct tm} members are unspecified
+In such cases the values of those \tcode{tm} members are unspecified
 and may be outside their valid range.
 
 \pnum
@@ -3545,7 +3545,7 @@ a valid input sequence for the given \tcode{format} and \tcode{modifier}.
 \pnum
 \remarks
 It is unspecified whether multiple calls to \tcode{do_get()}
-with the address of the same \tcode{struct tm} object
+with the address of the same \tcode{tm} object
 will update the current contents of the object or simply overwrite its members.
 Portable programs should zero out the object before invoking the function.
 \end{itemdescr}

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -5470,7 +5470,7 @@ namespace std {
   wchar_t* wmemchr(wchar_t* s, wchar_t c, size_t n);            // see \ref{library.c}
   size_t wcslen(const wchar_t* s);
   wchar_t* wmemset(wchar_t* s, wchar_t c, size_t n);
-  size_t wcsftime(wchar_t* s, size_t maxsize, const wchar_t* format, const struct tm* timeptr);
+  size_t wcsftime(wchar_t* s, size_t maxsize, const wchar_t* format, const tm* timeptr);
   wint_t btowc(int c);
   int wctob(wint_t c);
 

--- a/source/time.tex
+++ b/source/time.tex
@@ -11425,14 +11425,14 @@ namespace std {
 
   clock_t clock();
   double difftime(time_t time1, time_t time0);
-  time_t mktime(struct tm* timeptr);
+  time_t mktime(tm* timeptr);
   time_t time(time_t* timer);
   int timespec_get(timespec* ts, int base);
-  char* asctime(const struct tm* timeptr);
+  char* asctime(const tm* timeptr);
   char* ctime(const time_t* timer);
-  struct tm* gmtime(const time_t* timer);
-  struct tm* localtime(const time_t* timer);
-  size_t strftime(char* s, size_t maxsize, const char* format, const struct tm* timeptr);
+  tm* gmtime(const time_t* timer);
+  tm* localtime(const time_t* timer);
+  size_t strftime(char* s, size_t maxsize, const char* format, const tm* timeptr);
 }
 \end{codeblock}
 


### PR DESCRIPTION
Using the elaborated-type-specifier implies that this type
is declared in namespace 'std', which might not be true.

Fixes #4338