### PR TITLE
[stmt.pre] Excise undefined term 'contained'

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -41,13 +41,13 @@ The optional \grammarterm{attribute-specifier-seq} appertains to the respective 
 A \defn{substatement} of a \grammarterm{statement} is one of the following:
 \begin{itemize}
 \item
-  for a \grammarterm{labeled-statement}, its contained \grammarterm{statement},
+  for a \grammarterm{labeled-statement}, its \grammarterm{statement},
 \item
   for a \grammarterm{compound-statement}, any \grammarterm{statement} of its \grammarterm{statement-seq},
 \item
   for a \grammarterm{selection-statement}, any of its \grammarterm{statement}{s} (but not its \grammarterm{init-statement}), or
 \item
-  for an \grammarterm{iteration-statement}, its contained \grammarterm{statement} (but not an \grammarterm{init-statement}).
+  for an \grammarterm{iteration-statement}, its \grammarterm{statement} (but not an \grammarterm{init-statement}).
 \end{itemize}
 \begin{note}
 The \grammarterm{compound-statement} of a \grammarterm{lambda-expression}


### PR DESCRIPTION
Using "contained" in some, but not all cases of decomposing the grammar is inconsistent and not helpful.

Fixes #4468