### PR TITLE
[temp.expl.spec] Use 'reachable from', not 'declared before'

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6462,7 +6462,8 @@ template<class U> void A<short>::C<U>::f() { @\commentellip@ }    // error: \tco
 
 \pnum
 If a template, a member template or a member of a class template is explicitly
-specialized then that specialization shall be declared before the first use of
+specialized, a declaration of that specialization shall be reachable from
+every use of
 that specialization that would cause an implicit instantiation to take place,
 in every translation unit in which such a use occurs;
 no diagnostic is required.


### PR DESCRIPTION
With modules, 'declared before' no longer makes sense.

Fixes #4479