### PR TITLE
[intro.object]/1 Turn non-normative wording into a Note; remove incorrect wording.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3023,13 +3023,12 @@ name\iref{basic.pre}. An object has a storage
 duration\iref{basic.stc} which influences its
 lifetime\iref{basic.life}. An object has a
 type\iref{basic.types}.
+\begin{note}
 Some objects are
 polymorphic\iref{class.virtual}; the implementation
 generates information associated with each such object that makes it
-possible to determine that object's type during program execution. For
-other objects, the interpretation of the values found therein is
-determined by the type of the \grammarterm{expression}{s}\iref{expr.compound}
-used to access them.
+possible to determine that object's type during program execution.
+\end{note}
 
 \pnum
 \indextext{subobject}%


### PR DESCRIPTION
The last sentence looks just wrong: the type of the expression doesn't affect the value of the objects.
The second to last sentence doesn't look normative, it looks like a typical implementation strategy description.

Fixes #2308