### PR TITLE
Update Getting Started on Arch Linux

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,6 @@ Getting Started on Arch Linux
 
 Install the following packages:
 
-   latex-mk from the Arch User Repository.
    pacman -S texlive-latexextra
 
 -----------------------------


### PR DESCRIPTION
`texlive-latexextra` depends on `texlive-core` which now includes `latexmk`.