### PR TITLE
[container.requirements] Use bulleted lists to introduce identifiers

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -72,13 +72,21 @@ aligned buffers and call \tcode{construct} to place the element into the buffer.
 \pnum
 In Tables~\ref{tab:container.req},
 \ref{tab:container.rev.req}, and
-\ref{tab:container.opt}
+\ref{tab:container.opt},
+\begin{itemize}
+\item
 \tcode{X} denotes a container class containing objects of type \tcode{T},
+\item
 \tcode{a} and \tcode{b} denote values of type \tcode{X},
+\item
 \tcode{i} and \tcode{j} denote values of type (possibly const) \tcode{X::iterator},
+\item
 \tcode{u} denotes an identifier,
+\item
 \tcode{r} denotes a non-const value of type \tcode{X}, and
+\item
 \tcode{rv} denotes a non-const rvalue of type \tcode{X}.
+\end{itemize}
 
 \begin{libreqtab5}
 {Container requirements}
@@ -610,12 +618,22 @@ but specialized allocators can choose a different definition.
 \end{note}
 
 \pnum
-In \tref{container.alloc.req}, \tcode{X} denotes an allocator-aware container class
-with a \tcode{value_type} of \tcode{T} using allocator of type \tcode{A}, \tcode{u} denotes a
-variable,
+In \tref{container.alloc.req},
+\begin{itemize}
+\item
+\tcode{X} denotes an allocator-aware container class
+with a \tcode{value_type} of \tcode{T} using allocator of type \tcode{A},
+\item
+\tcode{u} denotes a variable,
+\item
 \tcode{a} and \tcode{b} denote non-const lvalues of type \tcode{X},
-\tcode{t} denotes an lvalue or a const rvalue of type \tcode{X}, \tcode{rv} denotes a
-non-const rvalue of type \tcode{X}, and \tcode{m} is a value of type \tcode{A}.
+\item
+\tcode{t} denotes an lvalue or a const rvalue of type \tcode{X},
+\item
+\tcode{rv} denotes a non-const rvalue of type \tcode{X}, and
+\item
+\tcode{m} is a value of type \tcode{A}.
+\end{itemize}
 
 \begin{libreqtab4a}
 {Allocator-aware container requirements}
@@ -794,32 +812,43 @@ leave a comment to explain if you choose from the rest!
 \pnum
 In Tables~\ref{tab:container.seq.req}
 and \ref{tab:container.seq.opt},
+\begin{itemize}
+\item
 \tcode{X} denotes a sequence container class,
+\item
 \tcode{a} denotes a value of type \tcode{X} containing elements of type \tcode{T},
+\item
 \tcode{u} denotes the name of a variable being declared,
+\item
 \tcode{A} denotes \tcode{X::allocator_type} if
 the \grammarterm{qualified-id} \tcode{X::allocator_type} is valid and denotes a
 type\iref{temp.deduct} and
 \tcode{allocator<T>} if it doesn't,
+\item
 \tcode{i} and \tcode{j}
 denote iterators that meet the \oldconcept{InputIterator} requirements
 and refer to elements implicitly convertible to \tcode{value_type},
-\tcode{[i, j)}
-denotes a valid range,
+\item
+\tcode{[i, j)} denotes a valid range,
+\item
 \tcode{il} designates an object of type \tcode{initializer_list<value_type>},
-\tcode{n}
-denotes a value of type \tcode{X::size_type},
-\tcode{p} denotes a valid constant iterator to
-\tcode{a}, \tcode{q}
-denotes a valid dereferenceable constant iterator to
-\tcode{a}, \tcode{[q1, q2)}
-denotes a valid range of constant iterators in
-\tcode{a}, \tcode{t}
-denotes an lvalue or a const rvalue of
-\tcode{X::value_type}, and \tcode{rv} denotes
-a non-const rvalue of \tcode{X::value_type}.
+\item
+\tcode{n} denotes a value of type \tcode{X::size_type},
+\item
+\tcode{p} denotes a valid constant iterator to \tcode{a},
+\item
+\tcode{q} denotes a valid dereferenceable constant iterator to \tcode{a},
+\item
+\tcode{[q1, q2)} denotes a valid range of constant iterators in \tcode{a},
+\item
+\tcode{t} denotes an lvalue or a const rvalue of \tcode{X::value_type}, and
+\item
+\tcode{rv} denotes a non-const rvalue of \tcode{X::value_type}.
+\item
 \tcode{Args} denotes a template parameter pack;
+\item
 \tcode{args} denotes a function parameter pack with the pattern \tcode{Args\&\&}.
+\end{itemize}
 
 \pnum
 The complexities of the expressions are sequence dependent.
@@ -1632,44 +1661,69 @@ are required to be \oldconcept{CopyAssignable} even though the associated
 
 \pnum
 In \tref{container.assoc.req},
+\begin{itemize}
+\item
 \tcode{X} denotes an associative container class,
+\item
 \tcode{a} denotes a value of type \tcode{X},
+\item
 \tcode{a2} denotes a value of a type with nodes compatible with type
 \tcode{X} (\tref{container.node.compat}),
+\item
 \tcode{b} denotes a possibly \tcode{const} value of type \tcode{X},
+\item
 \tcode{u} denotes the name of a variable being declared,
+\item
 \tcode{a_uniq} denotes a value of type \tcode{X}
 when \tcode{X} supports unique keys,
+\item
 \tcode{a_eq} denotes a value of type \tcode{X}
 when \tcode{X} supports multiple keys,
+\item
 \tcode{a_tran} denotes a possibly \tcode{const} value of type \tcode{X}
 when the \grammarterm{qualified-id}
-\tcode{X::key_compare::is_transparent} is valid
+\tcode{X::key_compare::is_transpa\-rent} is valid
 and denotes a type\iref{temp.deduct},
+\item
 \tcode{i} and \tcode{j}
 meet the \oldconcept{InputIterator} requirements and refer to elements
 implicitly convertible to
-\tcode{value_type}, \range{i}{j}
-denotes a valid range,
+\tcode{value_type},
+\item
+\range{i}{j} denotes a valid range,
+\item
 \tcode{p} denotes a valid constant iterator to \tcode{a},
+\item
 \tcode{q} denotes a valid dereferenceable constant iterator to \tcode{a},
+\item
 \tcode{r} denotes a valid dereferenceable iterator to \tcode{a},
+\item
 \tcode{[q1, q2)} denotes a valid range of constant iterators in \tcode{a},
+\item
 \tcode{il} designates an object of type \tcode{initializer_list<value_type>},
+\item
 \tcode{t} denotes a value of type \tcode{X::value_type},
-\tcode{k} denotes a value of type \tcode{X::key_type}
-and \tcode{c} denotes a possibly \tcode{const} value of type \tcode{X::key_compare};
+\item
+\tcode{k} denotes a value of type \tcode{X::key_type}, and
+\item
+\tcode{c} denotes a possibly \tcode{const} value of type \tcode{X::key_compare};
+\item
 \tcode{kl} is a value such that \tcode{a} is partitioned\iref{alg.sorting}
 with respect to \tcode{c(r, kl)}, with \tcode{r} the key value of \tcode{e}
 and \tcode{e} in \tcode{a};
+\item
 \tcode{ku} is a value such that \tcode{a} is partitioned with respect to
 \tcode{!c(ku, r)};
+\item
 \tcode{ke} is a value such that \tcode{a} is partitioned with respect to
 \tcode{c(r, ke)} and \tcode{!c(ke, r)}, with \tcode{c(r, ke)} implying
 \tcode{!c(ke, r)}.
+\item
 \tcode{A} denotes the storage allocator used by \tcode{X}, if any, or \tcode{allocator<X::value_type>} otherwise,
+\item
 \tcode{m} denotes an allocator of a type convertible to \tcode{A},
 and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
+\end{itemize}
 
 % Local command to index names as members of all ordered containers.
 \newcommand{\indexordmem}[1]{%
@@ -2317,45 +2371,67 @@ are sometimes required to be \oldconcept{CopyAssignable} even though the associa
 \indextext{unordered associative containers!unique keys}%
 \indextext{unordered associative containers!equivalent keys}%
 \indextext{requirements!container}%
-In \tref{container.hash.req}:
+In \tref{container.hash.req},
 \begin{itemize}
-\item \tcode{X} denotes an unordered associative container class,
-\item \tcode{a} denotes a value of type \tcode{X},
-\item \tcode{a2} denotes a value of a type with nodes compatible
+\item
+\tcode{X} denotes an unordered associative container class,
+\item
+\tcode{a} denotes a value of type \tcode{X},
+\item
+\tcode{a2} denotes a value of a type with nodes compatible
   with type \tcode{X} (\tref{container.node.compat}),
-\item \tcode{b} denotes a possibly const value of type \tcode{X},
-\item \tcode{a_uniq} denotes a value of type \tcode{X}
+\item
+\tcode{b} denotes a possibly const value of type \tcode{X},
+\item
+\tcode{a_uniq} denotes a value of type \tcode{X}
   when \tcode{X} supports unique keys,
-\item \tcode{a_eq} denotes a value of type \tcode{X}
+\item
+\tcode{a_eq} denotes a value of type \tcode{X}
   when \tcode{X} supports equivalent keys,
-\item \tcode{a_tran} denotes a possibly const value of type \tcode{X}
+\item
+\tcode{a_tran} denotes a possibly const value of type \tcode{X}
   when the \grammarterm{qualified-id}s
   \tcode{X::key_equal::is_transparent} and
   \tcode{X::hasher::is_transparent}
   are both valid and denote types\iref{temp.deduct},
-\item \tcode{i} and \tcode{j} denote input iterators
+\item
+\tcode{i} and \tcode{j} denote input iterators
   that refer to \tcode{value_type},
-\item \tcode{[i, j)} denotes a valid range,
-\item \tcode{p} and \tcode{q2} denote valid constant iterators to \tcode{a},
-\item \tcode{q} and \tcode{q1} denote
+\item
+\tcode{[i, j)} denotes a valid range,
+\item
+\tcode{p} and \tcode{q2} denote valid constant iterators to \tcode{a},
+\item
+\tcode{q} and \tcode{q1} denote
   valid dereferenceable constant iterators to \tcode{a},
-\item \tcode{r} denotes a valid dereferenceable iterator to \tcode{a},
-\item \tcode{[q1, q2)} denotes a valid range in \tcode{a},
-\item \tcode{il} denotes a value of type \tcode{initializer_list<value_type>},
-\item \tcode{t} denotes a value of type \tcode{X::value_type},
-\item \tcode{k} denotes a value of type \tcode{key_type},
-\item \tcode{hf} denotes a possibly const value of type \tcode{hasher},
-\item \tcode{eq} denotes a possibly const value of type \tcode{key_equal},
-\item \tcode{ke} is a value such that
+\item
+\tcode{r} denotes a valid dereferenceable iterator to \tcode{a},
+\item
+\tcode{[q1, q2)} denotes a valid range in \tcode{a},
+\item
+\tcode{il} denotes a value of type \tcode{initializer_list<value_type>},
+\item
+\tcode{t} denotes a value of type \tcode{X::value_type},
+\item
+\tcode{k} denotes a value of type \tcode{key_type},
+\item
+\tcode{hf} denotes a possibly const value of type \tcode{hasher},
+\item
+\tcode{eq} denotes a possibly const value of type \tcode{key_equal},
+\item
+\tcode{ke} is a value such that
   \begin{itemize}
   \item \tcode{eq(r1, ke) == eq(ke, r1)}
   \item \tcode{hf(r1) == hf(ke)} if \tcode{eq(r1, ke)} is \tcode{true}, and
   \item \tcode{(eq(r1, ke) \&\& eq(r1, r2)) == eq(r2, ke)}
   \end{itemize}
   where \tcode{r1} and \tcode{r2} are keys of elements in \tcode{a_tran},
-\item \tcode{n} denotes a value of type \tcode{size_type},
-\item \tcode{z} denotes a value of type \tcode{float}, and
-\item \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
+\item
+\tcode{n} denotes a value of type \tcode{size_type},
+\item
+\tcode{z} denotes a value of type \tcode{float}, and
+\item
+\tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \end{itemize}
 
 % Local command to index names as members of all unordered containers.


### PR DESCRIPTION
This is a first step towards dissolving the container requirements tables. This step is clearly editorial.