### PR TITLE
[Editorial] Add whitespace.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -6604,7 +6604,7 @@ that allows the programmer to avoid deadlocks.
 #include "a.h"
 #include "b.h"
 B b;
-A::A(){
+A::A() {
   b.Use();
 }
 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1690,7 +1690,7 @@ type specified by the
 \tcode{return} statements as described in~\ref{dcl.spec.auto}.
 \begin{example}
 \begin{codeblock}
-auto x1 = [](int i){ return i; };       // OK: return type is \tcode{int}
+auto x1 = [](int i) { return i; };      // OK: return type is \tcode{int}
 auto x2 = []{ return { 1, 2 }; };       // error: deducing return type from \grammarterm{braced-init-list}
 int j;
 auto x3 = []()->auto&& { return j; };   // OK: return type is \tcode{int\&}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -586,14 +586,14 @@ constexpr @\placeholder{bitmask}{}@ operator|(@\placeholder{bitmask}{}@ X, @\pla
   return static_cast<@\placeholder{bitmask}{}@>(
     static_cast<int_type>(X) | static_cast<int_type>(Y));
 }
-constexpr @\placeholder{bitmask}{}@ operator^(@\placeholder{bitmask}{}@ X, @\placeholder{bitmask}{}@ Y){
+constexpr @\placeholder{bitmask}{}@ operator^(@\placeholder{bitmask}{}@ X, @\placeholder{bitmask}{}@ Y) {
   return static_cast<@\placeholder{bitmask}{}@>(
     static_cast<int_type>(X) ^ static_cast<int_type>(Y));
 }
-constexpr @\placeholder{bitmask}{}@ operator~(@\placeholder{bitmask}{}@ X){
+constexpr @\placeholder{bitmask}{}@ operator~(@\placeholder{bitmask}{}@ X) {
   return static_cast<@\placeholder{bitmask}{}@>(~static_cast<int_type>(X));
 }
-@\placeholder{bitmask}{}@& operator&=(@\placeholder{bitmask}{}@& X, @\placeholder{bitmask}{}@ Y){
+@\placeholder{bitmask}{}@& operator&=(@\placeholder{bitmask}{}@& X, @\placeholder{bitmask}{}@ Y) {
   X = X & Y; return X;
 }
 @\placeholder{bitmask}{}@& operator|=(@\placeholder{bitmask}{}@& X, @\placeholder{bitmask}{}@ Y) {

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2955,7 +2955,7 @@ semantics.
 \begin{example}
 \begin{codeblock}
 vector<int> ints{0,1,2,3,4,5};
-auto even = [](int i){ return 0 == i % 2; };
+auto even = [](int i) { return 0 == i % 2; };
 auto square = [](int i) { return i * i; };
 for (int i : ints | views::filter(even) | views::transform(square)) {
   cout << i << ' '; // prints: 0 4 16

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -1039,7 +1039,7 @@ struct T1 {
   int operator=(int x) { return x; }
   T1(int) { }
 };
-struct T2 { T2(int){ } };
+struct T2 { T2(int) { } };
 int a, (*(*b)(T2))(int), c, d;
 
 void f() {

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -2615,8 +2615,8 @@ the same type\iref{class.conv.fct}.
 struct A {
   template <class T> operator T*();
 };
-template <class T> A::operator T*(){ return 0; }
-template <> A::operator char*(){ return 0; }        // specialization
+template <class T> A::operator T*() { return 0; }
+template <> A::operator char*() { return 0; }       // specialization
 template A::operator void*();                       // explicit instantiation
 
 int main() {
@@ -3020,7 +3020,7 @@ template are friends of the class or class template granting friendship.
 \begin{codeblock}
 class A {
   template<class T> friend class B;                 // OK
-  template<class T> friend void f(T){ @\commentellip@ }   // OK
+  template<class T> friend void f(T) { @\commentellip@ }  // OK
 };
 \end{codeblock}
 \end{example}
@@ -7195,7 +7195,7 @@ j(0);               // deduction fails on \#1, calls \#2
 \begin{codeblock}
 struct X { };
 struct Y {
-  Y(X){}
+  Y(X) {}
 };
 
 template <class T> auto f(T t1, T t2) -> decltype(t1 + t2);     // \#1
@@ -7246,9 +7246,9 @@ the specified member is not a non-type where a non-type is required.
 \begin{codeblock}
 template <int I> struct X { };
 template <template <class T> class> struct Z { };
-template <class T> void f(typename T::Y*){}
-template <class T> void g(X<T::N>*){}
-template <class T> void h(Z<T::TT>*){}
+template <class T> void f(typename T::Y*) {}
+template <class T> void g(X<T::N>*) {}
+template <class T> void h(Z<T::TT>*) {}
 struct A {};
 struct B { int Y; };
 struct C {
@@ -8187,7 +8187,7 @@ a derived class type of the corresponding function parameter type:
 template <class T> struct B { };
 template <class T> struct D : public B<T> {};
 struct D2 : public B<int> {};
-template <class T> void f(B<T>&){}
+template <class T> void f(B<T>&) {}
 void t() {
   D<int> d;
   D2     d2;


### PR DESCRIPTION
Change all occuances of '){' to ') {'. This was noticed due to the
differences in [bitmask.types].