### PR TITLE
[vector.bool] Remove an extra close-paren.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -6225,7 +6225,7 @@ namespace std {
     constexpr vector(vector&& x);
     constexpr vector(const vector&, const Allocator&);
     constexpr vector(vector&&, const Allocator&);
-    constexpr vector(initializer_list<bool>, const Allocator& = Allocator()));
+    constexpr vector(initializer_list<bool>, const Allocator& = Allocator());
     constexpr ~vector();
     constexpr vector& operator=(const vector& x);
     constexpr vector& operator=(vector&& x);


### PR DESCRIPTION
In this vicinity I also noticed:

- The copy-constructor and assignment-operators for both flavors of `vector` give the rhs argument the name "`x`", which seems a bit silly; it _could_ go unnamed if we wanted.

- `vector<bool>`'s move-constructor is not declared `noexcept`. This was deliberate; I don't really know why, though. [N4258](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4258.pdf) made `vector<T>`'s move-ctor noexcept, and says briefly at the bottom: "No change in vector<bool>" (no rationale).

- The sequence containers and `set` declare constructors taking `initializer_list<T>`, whereas the maps and `unordered_{multi,}set` declare constructors taking `initializer_list<value_type>`. (This is almost entirely consistent with the hypothesis that for simplicity we use `T` wherever it's synonymous with `value_type`; except that `unordered_{multi,}set` breaks that rule.)