### PR TITLE
[range.iota.iterator,range.iota.sentinel] Fix markup around \libconcept

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2304,7 +2304,7 @@ The expression in the \grammarterm{requires-clause} is equivalent to:
 \begin{codeblock}
 namespace std::ranges {
   template<@\libconcept{weakly_incrementable}@ W, @\libconcept{semiregular}@ Bound>
-    requires @\exposconcept{weakly-equality-comparable-with}@<W, Bound> && \libconcept{semiregular}<W>
+    requires @\exposconcept{weakly-equality-comparable-with}@<W, Bound> && @\libconcept{semiregular}@<W>
   struct iota_view<W, Bound>::@\exposid{iterator}@ {
   private:
     W @\exposid{value_}@ = W();             // \expos
@@ -2675,7 +2675,7 @@ if constexpr (@\exposid{is-integer-like}@<W>) {
 \begin{codeblock}
 namespace std::ranges {
   template<@\libconcept{weakly_incrementable}@ W, @\libconcept{semiregular}@ Bound>
-    requires @\exposconcept{weakly-equality-comparable-with}@<W, Bound> && \libconcept{semiregular}<W>
+    requires @\exposconcept{weakly-equality-comparable-with}@<W, Bound> && @\libconcept{semiregular}@<W>
   struct iota_view<W, Bound>::@\exposid{sentinel}@ {
   private:
     Bound @\exposid{bound_}@ = Bound();     // \expos


### PR DESCRIPTION
...so it doesn't appear in the rendered text.