### PR TITLE
P2162R2 Inheriting from std::variant

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -693,7 +693,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_uncaught_exceptions}@               201411L // also in \libheader{exception}
 #define @\defnlibxname{cpp_lib_unordered_map_try_emplace}@         201411L // also in \libheader{unordered_map}
 #define @\defnlibxname{cpp_lib_unwrap_ref}@                        201811L // also in \libheader{type_traits}
-#define @\defnlibxname{cpp_lib_variant}@                           201606L // also in \libheader{variant}
+#define @\defnlibxname{cpp_lib_variant}@                           202102L // also in \libheader{variant}
 #define @\defnlibxname{cpp_lib_void_t}@                            201411L // also in \libheader{type_traits}
 \end{codeblock}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -5129,41 +5129,67 @@ template<class R, class Visitor, class... Variants>
 
 \begin{itemdescr}
 \pnum
-Let $n$ be \tcode{sizeof...(Variants)}. Let \tcode{m} be a pack of $n$
-values of type \tcode{size_t}. Such a pack is called valid if $0 \leq
-\tcode{m}_i < \tcode{variant_size_v<remove_reference_t<Variants}_i\tcode{>>}$ for
-all $0 \leq i < n$. For each valid pack $\tcode{m}$, let $e(\tcode{m})$
-denote the expression:
+Let \exposid{as-variant} denote the following exposition-only function templates:
 \begin{codeblock}
-@\placeholder{INVOKE}@(std::forward<Visitor>(vis), get<m>(std::forward<Variants>(vars))...) // see \ref{func.require}
+template<class... Ts>
+  auto&& @\exposid{as-variant}@(variant<Ts...>& var) { return var; }
+template<class... Ts>
+  auto&& @\exposid{as-variant}@(const variant<Ts...>& var) { return var; }
+template<class... Ts>
+  auto&& @\exposid{as-variant}@(variant<Ts...>&& var) { return std::move(var); }
+template<class... Ts>
+  auto&& @\exposid{as-variant}@(const variant<Ts...>&& var) { return std::move(var); }
+\end{codeblock}
+Let $n$ be \tcode{sizeof...(Variants)}.
+For each $0 \leq i < n$, let
+$\tcode{V}_i$ denote the type\newline
+\tcode{decltype(\exposid{as-variant}(\tcode{std::forward<$\tcode{Variants}_i$>($\tcode{vars}_i$)}))}.
+
+\pnum
+\constraints
+$\tcode{V}_i$ is a valid type for all $0 \leq i < n$.
+
+\pnum
+Let \tcode{V} denote the pack of types $\tcode{V}_i$.
+
+\pnum
+Let $m$ be a pack of $n$ values of type \tcode{size_t}.
+Such a pack is valid if\newline
+$0 \leq m_i < \tcode{variant_size_v<remove_reference_t<V}_i\tcode{>>}$
+for all $0 \leq i < n$.
+For each valid pack $m$, let $e(m)$ denote the expression:
+\begin{codeblock}
+@\placeholder{INVOKE}@(std::forward<Visitor>(vis), get<@$m$@>(std::forward<V>(vars))...)  // see \ref{func.require}
 \end{codeblock}
 for the first form and
 \begin{codeblock}
-@\placeholder{INVOKE}@<R>(std::forward<Visitor>(vis), get<m>(std::forward<Variants>(vars))...) // see \ref{func.require}
+@\placeholder{INVOKE}@<R>(std::forward<Visitor>(vis), get<@$m$@>(std::forward<V>(vars))...)  // see \ref{func.require}
 \end{codeblock}
 for the second form.
 
 \pnum
 \mandates
-For each valid pack \tcode{m}, $e(\tcode{m})$ is a valid expression.
+For each valid pack $m$, $e(m)$ is a valid expression.
 All such expressions are of the same type and value category.
 
 \pnum
 \returns
-$e(\tcode{m})$, where \tcode{m} is the pack for which
-$\tcode{m}_i$ is \tcode{vars$_i$.index()} for all $0 \leq i < n$.
-The return type is $\tcode{decltype(}e(\tcode{m})\tcode{)}$
+$e(m)$, where $m$ is the pack for which
+$m_i$ is \tcode{\exposid{as-variant}(vars$_i$).index()} for all $0 \leq i < n$.
+The return type is $\tcode{decltype(}e(m)\tcode{)}$
 for the first form.
 
 \pnum
 \throws
-\tcode{bad_variant_access} if any \tcode{variant} in \tcode{vars} is \tcode{valueless_by_exception()}.
+\tcode{bad_variant_access} if
+\tcode{(\exposid{as-variant}(vars).valueless_by_exception() || ...)}
+is \tcode{true}.
 
 \pnum
 \complexity
 For $n \leq 1$, the invocation of the callable object is
 implemented in constant time, i.e., for $n = 1$, it does not depend on
-the number of alternative types of $\tcode{Variants}_0$.
+the number of alternative types of $\tcode{V}_0$.
 For $n > 1$, the invocation of the callable object has
 no complexity requirements.
 \end{itemdescr}


### PR DESCRIPTION
Also fixes LWG3052.

 - Introduced new type meta-variable FV_i to handle overfull lines.

Fixes #4509
Fixes cplusplus/papers#873