### PR TITLE
[ranges.syn] Don't constrain specializations of enable_borrowed_range

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -127,7 +127,7 @@ namespace std::ranges {
     requires (K == subrange_kind::sized || !@\libconcept{sized_sentinel_for}@<S, I>)
   class subrange;
 
-  template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S, subrange_kind K>
+  template<class I, class S, subrange_kind K>
     inline constexpr bool enable_borrowed_range<subrange<I, S, K>> = true;
 
   // \ref{range.dangling}, dangling iterator handling
@@ -168,7 +168,7 @@ namespace std::ranges {
     requires @\exposconcept{weakly-equality-comparable-with}@<W, Bound> && @\libconcept{semiregular}@<W>
   class iota_view;
 
-  template<@\libconcept{weakly_incrementable}@ W, @\libconcept{semiregular}@ Bound>
+  template<class W, class Bound>
     inline constexpr bool enable_borrowed_range<iota_view<W, Bound>> = true;
 
   namespace views { inline constexpr @\unspec@ iota = @\unspec@; }


### PR DESCRIPTION
These constraints redundantly repeat the constraints from the template we're partially specializing for. This isn't incorrect, but it is unnecessary, adds opportunities for editorial errors, and is inconsistent with how other partial specializations of templates for constrained types are specified.

EDIT: To be perfectly clear, removing these constraints has no normative effect. One cannot so much as form the template-id `meow<T, U>` if `T` and `U` don't satisfy the constraints of `meow`. So if a partial specialization matches the pattern `meow<T, U>`, we know a priori that the constraints of `meow` are satisfied by `T` and `U`. The only possible results of duplicating the constraints are that an implementation may waste compiletime rechecking them, and WG21 will waste time keeping them in sync. Witness the recent fiasco that resulted from changing the constraints on `iota_view` and failing to propagate that change to the four necessary places (https://github.com/microsoft/STL/pull/1693#discussion_r582175402) for reference; we have enough required duplication without adding optional duplication =). 