### PR TITLE
[range.drop.view] Fix tabs inserted as part of LWG3482

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -4741,7 +4741,7 @@ namespace std::ranges {
 
     constexpr auto begin()
       requires (!(@\exposconcept{simple-view}@<V> &&
-		  @\libconcept{random_access_range}@<const V> && @\libconcept{sized_range}@<const V>));
+                  @\libconcept{random_access_range}@<const V> && @\libconcept{sized_range}@<const V>));
     constexpr auto begin() const
       requires @\libconcept{random_access_range}@<const V> && @\libconcept{sized_range}@<const V>;
 
@@ -4798,7 +4798,7 @@ Initializes \exposid{base_} with \tcode{std::move(base)} and
 \begin{itemdecl}
 constexpr auto begin()
   requires (!(@\exposconcept{simple-view}@<V> &&
-	      @\libconcept{random_access_range}@<const V> && @\libconcept{sized_range}@<const V>));
+              @\libconcept{random_access_range}@<const V> && @\libconcept{sized_range}@<const V>));
 constexpr auto begin() const
   requires random_access_range<const V> && @\libconcept{sized_range}@<const V>;
 \end{itemdecl}


### PR DESCRIPTION
Tab characters were accidently added in LWG3482 and merged into master as part of 2020-11 LWG Motion 3.