### PR TITLE
[concepts] rotates [concept.swappable] to the end of [concepts.lang]

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -205,17 +205,6 @@ namespace std {
   template<class LHS, class RHS>
     concept assignable_from = @\seebelow@;
 
-  // \ref{concept.swappable}, concept \libconcept{swappable}
-  namespace ranges {
-    inline namespace @\unspec@ {
-      inline constexpr @\unspec@ swap = @\unspec@;
-    }
-  }
-  template<class T>
-    concept swappable = @\seebelow@;
-  template<class T, class U>
-    concept swappable_with = @\seebelow@;
-
   // \ref{concept.destructible}, concept \libconcept{destructible}
   template<class T>
     concept destructible = @\seebelow@;
@@ -235,6 +224,17 @@ namespace std {
   // \ref{concept.copyconstructible}, concept \libconcept{copy_constructible}
   template<class T>
     concept copy_constructible = @\seebelow@;
+
+  // \ref{concept.swappable}, concept \libconcept{swappable}
+  namespace ranges {
+    inline namespace @\unspec@ {
+      inline constexpr @\unspec@ swap = @\unspec@;
+    }
+  }
+  template<class T>
+    concept swappable = @\seebelow@;
+  template<class T, class U>
+    concept swappable_with = @\seebelow@;
 
   // \ref{concepts.compare}, comparison concepts
   // \ref{concept.equalitycomparable}, concept \libconcept{equality_comparable}
@@ -566,6 +566,113 @@ of \tcode{=}.
 \end{note}
 \end{itemdescr}
 
+\rSec2[concept.destructible]{Concept \cname{destructible}}
+
+\pnum
+The \libconcept{destructible} concept specifies properties of all types,
+instances of which can be destroyed at the end of their lifetime, or reference
+types.
+
+\begin{itemdecl}
+template<class T>
+  concept @\deflibconcept{destructible}@ = is_nothrow_destructible_v<T>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\begin{note}
+Unlike the \oldconcept{Destructible} requirements~(\tref{cpp17.destructible}), this
+concept forbids destructors that are potentially throwing, even if a particular
+invocation of the destructor does not actually throw.
+\end{note}
+\end{itemdescr}
+
+\rSec2[concept.constructible]{Concept \cname{constructible_from}}
+
+\pnum
+The \libconcept{constructible_from} concept constrains the initialization of a
+variable of a given type with a particular set of argument types.
+
+\begin{itemdecl}
+template<class T, class... Args>
+  concept @\deflibconcept{constructible_from}@ = destructible<T> && is_constructible_v<T, Args...>;
+\end{itemdecl}
+
+\rSec2[concept.default.init]{Concept \cname{default_initializable}}
+
+\begin{itemdecl}
+template<class T>
+  inline constexpr bool @\exposid{is-default-initializable}@ = @\seebelow@;  // \expos
+
+template<class T>
+  concept @\deflibconcept{default_initializable}@ = constructible_from<T> &&
+                                  requires { T{}; } &&
+                                  @\exposid{is-default-initializable}@<T>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+For a type \tcode{T}, \tcode{\exposid{is-default-initializable}<T>} is \tcode{true}
+if and only if the variable definition
+\begin{codeblock}
+T t;
+\end{codeblock}
+is well-formed for some invented variable \tcode{t};
+otherwise it is \tcode{false}.
+Access checking is performed as if in a context unrelated to \tcode{T}.
+Only the validity of the immediate context of the variable initialization is considered.
+\end{itemdescr}
+
+\rSec2[concept.moveconstructible]{Concept \cname{move_constructible}}
+
+\begin{itemdecl}
+template<class T>
+  concept @\deflibconcept{move_constructible}@ = constructible_from<T, T> && @\libconcept{convertible_to}@<T, T>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+If \tcode{T} is an object type, then let \tcode{rv} be an rvalue of type
+\tcode{T} and \tcode{u2} a distinct object of type \tcode{T} equal to
+\tcode{rv}. \tcode{T} models \libconcept{move_constructible} only if
+
+\begin{itemize}
+\item After the definition \tcode{T u = rv;}, \tcode{u} is equal to \tcode{u2}.
+
+\item \tcode{T(rv)} is equal to \tcode{u2}.
+
+\item If \tcode{T} is not \tcode{const}, \tcode{rv}'s resulting state is valid
+but unspecified\iref{lib.types.movedfrom}; otherwise, it is unchanged.
+\end{itemize}
+\end{itemdescr}
+
+\rSec2[concept.copyconstructible]{Concept \cname{copy_constructible}}
+
+\begin{itemdecl}
+template<class T>
+  concept @\deflibconcept{copy_constructible}@ =
+    move_constructible<T> &&
+    constructible_from<T, T&> && @\libconcept{convertible_to}@<T&, T> &&
+    constructible_from<T, const T&> && @\libconcept{convertible_to}@<const T&, T> &&
+    constructible_from<T, const T> && @\libconcept{convertible_to}@<const T, T>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+If \tcode{T} is an object type, then let \tcode{v} be an lvalue of type
+(possibly \tcode{const}) \tcode{T} or an rvalue of type \tcode{const T}.
+\tcode{T} models \libconcept{copy_constructible} only if
+
+\begin{itemize}
+\item After the definition \tcode{T u = v;},
+\tcode{u} is equal to \tcode{v}\iref{concepts.equality} and
+\tcode{v} is not modified.
+
+\item \tcode{T(v)} is equal to \tcode{v} and does not modify \tcode{v}.
+\end{itemize}
+
+\end{itemdescr}
+
 \rSec2[concept.swappable]{Concept \cname{swappable}}
 
 \pnum
@@ -732,113 +839,6 @@ int main() {
 }
 \end{codeblock}
 \end{example}
-
-\rSec2[concept.destructible]{Concept \cname{destructible}}
-
-\pnum
-The \libconcept{destructible} concept specifies properties of all types,
-instances of which can be destroyed at the end of their lifetime, or reference
-types.
-
-\begin{itemdecl}
-template<class T>
-  concept @\deflibconcept{destructible}@ = is_nothrow_destructible_v<T>;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\begin{note}
-Unlike the \oldconcept{Destructible} requirements~(\tref{cpp17.destructible}), this
-concept forbids destructors that are potentially throwing, even if a particular
-invocation of the destructor does not actually throw.
-\end{note}
-\end{itemdescr}
-
-\rSec2[concept.constructible]{Concept \cname{constructible_from}}
-
-\pnum
-The \libconcept{constructible_from} concept constrains the initialization of a
-variable of a given type with a particular set of argument types.
-
-\begin{itemdecl}
-template<class T, class... Args>
-  concept @\deflibconcept{constructible_from}@ = destructible<T> && is_constructible_v<T, Args...>;
-\end{itemdecl}
-
-\rSec2[concept.default.init]{Concept \cname{default_initializable}}
-
-\begin{itemdecl}
-template<class T>
-  inline constexpr bool @\exposid{is-default-initializable}@ = @\seebelow@;  // \expos
-
-template<class T>
-  concept @\deflibconcept{default_initializable}@ = constructible_from<T> &&
-                                  requires { T{}; } &&
-                                  @\exposid{is-default-initializable}@<T>;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-For a type \tcode{T}, \tcode{\exposid{is-default-initializable}<T>} is \tcode{true}
-if and only if the variable definition
-\begin{codeblock}
-T t;
-\end{codeblock}
-is well-formed for some invented variable \tcode{t};
-otherwise it is \tcode{false}.
-Access checking is performed as if in a context unrelated to \tcode{T}.
-Only the validity of the immediate context of the variable initialization is considered.
-\end{itemdescr}
-
-\rSec2[concept.moveconstructible]{Concept \cname{move_constructible}}
-
-\begin{itemdecl}
-template<class T>
-  concept @\deflibconcept{move_constructible}@ = constructible_from<T, T> && @\libconcept{convertible_to}@<T, T>;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-If \tcode{T} is an object type, then let \tcode{rv} be an rvalue of type
-\tcode{T} and \tcode{u2} a distinct object of type \tcode{T} equal to
-\tcode{rv}. \tcode{T} models \libconcept{move_constructible} only if
-
-\begin{itemize}
-\item After the definition \tcode{T u = rv;}, \tcode{u} is equal to \tcode{u2}.
-
-\item \tcode{T(rv)} is equal to \tcode{u2}.
-
-\item If \tcode{T} is not \tcode{const}, \tcode{rv}'s resulting state is valid
-but unspecified\iref{lib.types.movedfrom}; otherwise, it is unchanged.
-\end{itemize}
-\end{itemdescr}
-
-\rSec2[concept.copyconstructible]{Concept \cname{copy_constructible}}
-
-\begin{itemdecl}
-template<class T>
-  concept @\deflibconcept{copy_constructible}@ =
-    move_constructible<T> &&
-    constructible_from<T, T&> && @\libconcept{convertible_to}@<T&, T> &&
-    constructible_from<T, const T&> && @\libconcept{convertible_to}@<const T&, T> &&
-    constructible_from<T, const T> && @\libconcept{convertible_to}@<const T, T>;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-If \tcode{T} is an object type, then let \tcode{v} be an lvalue of type
-(possibly \tcode{const}) \tcode{T} or an rvalue of type \tcode{const T}.
-\tcode{T} models \libconcept{copy_constructible} only if
-
-\begin{itemize}
-\item After the definition \tcode{T u = v;},
-\tcode{u} is equal to \tcode{v}\iref{concepts.equality} and
-\tcode{v} is not modified.
-
-\item \tcode{T(v)} is equal to \tcode{v} and does not modify \tcode{v}.
-\end{itemize}
-
-\end{itemdescr}
 
 \rSec1[concepts.compare]{Comparison concepts}
 


### PR DESCRIPTION
`ranges::swap` depends on `assignable_from` and `move_constructible`, so
it should be defined after them.