### PR TITLE
[time.syn] add constexpr to leap_second comparisons

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -772,27 +772,27 @@ namespace std {
     // \ref{time.zone.leap}, leap second support
     class leap_second;
 
-    bool operator==(const leap_second& x, const leap_second& y);
-    strong_ordering operator<=>(const leap_second& x, const leap_second& y);
+    constexpr bool operator==(const leap_second& x, const leap_second& y);
+    constexpr strong_ordering operator<=>(const leap_second& x, const leap_second& y);
 
     template<class Duration>
-      bool operator==(const leap_second& x, const sys_time<Duration>& y);
+      constexpr bool operator==(const leap_second& x, const sys_time<Duration>& y);
     template<class Duration>
-      bool operator< (const leap_second& x, const sys_time<Duration>& y);
+      constexpr bool operator< (const leap_second& x, const sys_time<Duration>& y);
     template<class Duration>
-      bool operator< (const sys_time<Duration>& x, const leap_second& y);
+      constexpr bool operator< (const sys_time<Duration>& x, const leap_second& y);
     template<class Duration>
-      bool operator> (const leap_second& x, const sys_time<Duration>& y);
+      constexpr bool operator> (const leap_second& x, const sys_time<Duration>& y);
     template<class Duration>
-      bool operator> (const sys_time<Duration>& x, const leap_second& y);
+      constexpr bool operator> (const sys_time<Duration>& x, const leap_second& y);
     template<class Duration>
-      bool operator<=(const leap_second& x, const sys_time<Duration>& y);
+      constexpr bool operator<=(const leap_second& x, const sys_time<Duration>& y);
     template<class Duration>
-      bool operator<=(const sys_time<Duration>& x, const leap_second& y);
+      constexpr bool operator<=(const sys_time<Duration>& x, const leap_second& y);
     template<class Duration>
-      bool operator>=(const leap_second& x, const sys_time<Duration>& y);
+      constexpr bool operator>=(const leap_second& x, const sys_time<Duration>& y);
     template<class Duration>
-      bool operator>=(const sys_time<Duration>& x, const leap_second& y);
+      constexpr bool operator>=(const sys_time<Duration>& x, const leap_second& y);
     template<class Duration>
       requires @\libconcept{three_way_comparable_with}@<sys_seconds, sys_time<Duration>>
       constexpr auto operator<=>(const leap_second& x, const sys_time<Duration>& y);


### PR DESCRIPTION
The comparison operators for `leap_second` are all specified as being `constexpr` in [[time.zone.leap.nonmembers]](http://eel.is/c++draft/time.zone.leap.nonmembers), but this specifier is missing in the corresponding section of [[time.syn]](http://eel.is/c++draft/time.syn). Although the current wording matches [P0355R7](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0355r7.html), I think this could qualify as an editorial issue. It's internally inconsistent and the intent seems clear, especially because these functions just call the corresponding `time_point` overrides, which are `constexpr` in both places. I'm happy to submit an LWG issue, however, if you feel differently.