### PR TITLE
[range.split.inner] Clarify paragraph 1

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -5866,7 +5866,7 @@ namespace std::ranges {
 \end{codeblock}
 
 \pnum
-If \tcode{Base} does not model \libconcept{forward_range}
+If \exposid{Base} does not model \libconcept{forward_range}
 there is no member \tcode{iterator_category}.
 Otherwise, the \grammarterm{typedef-name} \tcode{iterator_category} denotes:
 \begin{itemize}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -5866,7 +5866,9 @@ namespace std::ranges {
 \end{codeblock}
 
 \pnum
-When present, the \grammarterm{typedef-name} \tcode{iterator_category} denotes:
+If \tcode{Base} does not model \libconcept{forward_range}
+there is no member \tcode{iterator_category}.
+Otherwise, the \grammarterm{typedef-name} \tcode{iterator_category} denotes:
 \begin{itemize}
 \item
 \tcode{forward_iterator_tag} if

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -5866,7 +5866,7 @@ namespace std::ranges {
 \end{codeblock}
 
 \pnum
-The \grammarterm{typedef-name} \tcode{iterator_category} denotes:
+When present, the \grammarterm{typedef-name} \tcode{iterator_category} denotes:
 \begin{itemize}
 \item
 \tcode{forward_iterator_tag} if


### PR DESCRIPTION
... to avoid confusion about what it means for a name that is not present to denote a type.