### PR TITLE
[lex.string] Replace string-literal with a string literal object in a note

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1839,7 +1839,7 @@ nonoverlapping objects) and whether successive evaluations of a
 unspecified.
 \begin{note}
 \indextext{literal!string!undefined change to}%
-The effect of attempting to modify a \grammarterm{string-literal} is undefined.
+The effect of attempting to modify a string literal object is undefined.
 \end{note}
 
 \pnum


### PR DESCRIPTION
I think syntactic construct `string-literal` couldn't be modified, unlike its resulting object.