### PR TITLE
[except.ctor] Remove false claim about automatic objects

### DIFF
--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -369,7 +369,7 @@ If a destructor directly invoked by stack unwinding exits via an exception,
 \indextext{unwinding!stack}%
 As control passes from the point where an exception is thrown
 to a handler,
-objects with automatic storage duration are destroyed by a process,
+objects are destroyed by a process,
 specified in this subclause, called \defn{stack unwinding}.
 
 \pnum


### PR DESCRIPTION
CWG1774 clarified that partially-constructed objects may not be of
automatic storage duration. CWG2256 re-introduced that false
claim.

Fixes #4548