### PR TITLE
Spell "whitespace" consistently

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -150,7 +150,7 @@ Adjacent \grammarterm{string-literal}s are concatenated
 and a null character is appended to the result
 as specified in \ref{lex.string}.
 
-\item White-space characters separating tokens are no longer
+\item Whitespace characters separating tokens are no longer
 significant. Each preprocessing token is converted into a
 token\iref{lex.token}. The resulting tokens are syntactically and
 semantically analyzed and translated as a translation unit.
@@ -351,7 +351,7 @@ this consists of comments\iref{lex.comment}, or whitespace
 characters (space, horizontal tab, new-line, vertical tab, and
 form-feed), or both. As described in \ref{cpp}, in certain
 circumstances during translation phase 4, whitespace (or the absence
-thereof) serves as more than preprocessing token separation. White space
+thereof) serves as more than preprocessing token separation. Whitespace
 can appear within a preprocessing token only as part of a header name or
 between the quotation characters in a character literal or
 string literal.

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -3835,7 +3835,7 @@ the initial elements of the format pattern,
 at least one whitespace character is required.
 Where \tcode{money_base::none} appears
 in any of the initial elements of the format pattern,
-white space is allowed but not required.
+whitespace is allowed but not required.
 If \tcode{(str.flags() \& str.showbase)} is \tcode{false},
 the currency symbol is optional and
 is consumed only if other characters are needed to complete the format;
@@ -4144,7 +4144,7 @@ of \tcode{money_get<>} and \tcode{money_put<>}.
 The symbol \locgrammarterm{thousands-sep}
 is the character returned by \tcode{thousands_sep()}.
 The space character used is the value \tcode{ct.widen(' ')}.
-White space characters are those characters \tcode{c}
+Whitespace characters are those characters \tcode{c}
 for which \tcode{ci.is(space, c)} returns \tcode{true}.
 The number of digits required after the decimal point (if any)
 is exactly the value returned by \tcode{frac_digits()}.

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1314,7 +1314,7 @@ Let the \defn{stringizing argument} be the preprocessing token sequence
 for the corresponding argument with placemarker tokens removed.
 Each occurrence of whitespace between the stringizing argument's preprocessing
 tokens becomes a single space character in the character string literal.
-White space before the first preprocessing token and after the last
+Whitespace before the first preprocessing token and after the last
 preprocessing token comprising the stringizing argument is deleted.
 Otherwise, the original spelling of each preprocessing token in the
 stringizing argument is retained in the character string literal,


### PR DESCRIPTION
The wording refer to the set of whitespaces characters
as "whitespace", white-space" or "white space"

Unify by using "whitespace" consistently.

This doesn't address that we use "whitespace" and "whitespace characacters" inconsistently.