### PR TITLE
[namespace.def.general] Clarify inline namespaces

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -7220,7 +7220,7 @@ appertains to the namespace being defined or extended.
 
 \pnum
 Members of an inline namespace can be used in most respects as though they were members
-of the enclosing namespace. Specifically, the inline namespace and its enclosing
+of the innermost enclosing namespace. Specifically, the inline namespace and its enclosing
 namespace are both added to the set of associated namespaces used in
 argument-dependent lookup\iref{basic.lookup.argdep} whenever one of them is,
 and a \grammarterm{using-directive}\iref{namespace.udir} that names the inline


### PR DESCRIPTION
Highlight 'innermost enclosing' namespace, and remove
unneeded mechanism of inserting a using-directive.

Fixes #4556