### PR TITLE
[time.clock.cast.sys],[time.clock.cast.utc] Use Duration2 for clarity.

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -3717,8 +3717,8 @@ template<class Duration>
 
 \pnum
 \mandates
-\tcode{SourceClock::to_sys(t)} returns a \tcode{sys_time<Duration>},
-where \tcode{Duration} is a valid \tcode{chrono::duration} specialization.
+\tcode{SourceClock::to_sys(t)} returns a \tcode{sys_time<Duration2>},
+where \tcode{Duration2} is a valid \tcode{chrono::duration} specialization.
 
 \pnum
 \returns
@@ -3748,8 +3748,8 @@ template<class Duration>
 
 \pnum
 \mandates
-\tcode{DestClock::from_sys(t)} returns a \tcode{time_point<DestClock, Duration>},
-where \tcode{Duration} is a valid \tcode{chrono::duration} specialization.
+\tcode{DestClock::from_sys(t)} returns a \tcode{time_point<DestClock, Duration2>},
+where \tcode{Duration2} is a valid \tcode{chrono::duration} specialization.
 
 \pnum
 \returns
@@ -3781,8 +3781,8 @@ template<class Duration>
 
 \pnum
 \mandates
-\tcode{SourceClock::to_utc(t)}  returns a \tcode{utc_time<Duration>},
-where \tcode{Duration} is a valid \tcode{chrono::duration} specialization.
+\tcode{SourceClock::to_utc(t)}  returns a \tcode{utc_time<Duration2>},
+where \tcode{Duration2} is a valid \tcode{chrono::duration} specialization.
 
 \pnum
 \returns
@@ -3812,8 +3812,8 @@ template<class Duration>
 
 \pnum
 \mandates
-\tcode{DestClock::from_utc(t)} returns a \tcode{time_point<DestClock, Duration>},
-where \tcode{Duration} is a valid \tcode{chrono::duration} specialization.
+\tcode{DestClock::from_utc(t)} returns a \tcode{time_point<DestClock, Duration2>},
+where \tcode{Duration2} is a valid \tcode{chrono::duration} specialization.
 
 \pnum
 \returns

--- a/source/time.tex
+++ b/source/time.tex
@@ -3749,7 +3749,7 @@ template<class Duration>
 \pnum
 \mandates
 \tcode{DestClock::from_sys(t)} returns a \tcode{time_point<DestClock, Duration2>},
-where \tcode{Duration2} is a valid \tcode{chrono::duration} specialization.
+where \tcode{Dura\-tion2} is a valid \tcode{chrono::duration} specialization.
 
 \pnum
 \returns
@@ -3813,7 +3813,7 @@ template<class Duration>
 \pnum
 \mandates
 \tcode{DestClock::from_utc(t)} returns a \tcode{time_point<DestClock, Duration2>},
-where \tcode{Duration2} is a valid \tcode{chrono::duration} specialization.
+where \tcode{Dura\-tion2} is a valid \tcode{chrono::duration} specialization.
 
 \pnum
 \returns


### PR DESCRIPTION
Fixes #4564.