### PR TITLE
[ranges.syn] Add primary templates for tuple-like protocol

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -316,6 +316,9 @@ namespace std::ranges {
 namespace std {
   namespace views = ranges::views;
 
+  template<class T> struct tuple_size;
+  template<size_t I, class T> struct tuple_element;
+
   template<class I, class S, ranges::subrange_kind K>
   struct tuple_size<ranges::subrange<I, S, K>>
     : integral_constant<size_t, 2> {};


### PR DESCRIPTION
The primary templates tuple_size and tuple_element
are partially specialized, and should be declared
before doing so.

Fixes #4572