### PR TITLE
[dcl.init.aggr] An initializer list is brace-enclosed

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4735,14 +4735,15 @@ The \defnx{explicitly initialized elements}{explicitly initialized elements!aggr
 of the aggregate are determined as follows:
 \begin{itemize}
 \item
-If the initializer list is a \grammarterm{designated-initializer-list},
+If the initializer list is
+a brace-enclosed \grammarterm{designated-initializer-list},
 the aggregate shall be of class type,
 the \grammarterm{identifier} in each \grammarterm{designator}
 shall name a direct non-static data member of the class, and
 the explicitly initialized elements of the aggregate
 are the elements that are, or contain, those members.
 \item
-If the initializer list is an \grammarterm{initializer-list},
+If the initializer list is a brace-enclosed \grammarterm{initializer-list},
 the explicitly initialized elements of the aggregate
 are the first $n$ elements of the aggregate,
 where $n$ is the number of elements in the initializer list.
@@ -4756,7 +4757,8 @@ For each explicitly initialized element:
 \begin{itemize}
 \item
 If the element is an anonymous union member and
-the initializer list is a \grammarterm{designated-initializer-list},
+the initializer list is
+a brace-enclosed \grammarterm{designated-initializer-list},
 the element is initialized by the
 \grammarterm{designated-initializer-list} \tcode{\{ }\placeholder{D}\tcode{ \}},
 where \placeholder{D} is the \grammarterm{designated-initializer-clause}


### PR DESCRIPTION
Do not claim that a designated-initializer-list or
an initializer-list is an initializer list.

Fixes #4571