### PR TITLE
[basic.stc.static] Rephrase the definition of 'static storage duration'

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3696,10 +3696,17 @@ causes a system-generated runtime fault.
 
 \pnum
 \indextext{storage duration!static}%
-All variables which do not have dynamic storage duration, do not have thread
-storage duration, and are not local
-have \defn{static storage duration}. The
-storage for these entities lasts for the duration of the
+All variables which
+\begin{itemize}
+\item
+do not have thread storage duration and
+\item
+belong to a namespace scope\iref{basic.scope.namespace} or
+are first declared with
+the \keyword{static} or \keyword{extern} keywords\iref{dcl.stc}
+\end{itemize}
+have \defn{static storage duration}.
+The storage for these entities lasts for the duration of the
 program~(\ref{basic.start.static}, \ref{basic.start.term}).
 
 \pnum
@@ -3709,18 +3716,17 @@ appears to be unused, except that a class object or its copy/move may be
 eliminated as specified in~\ref{class.copy.elision}.
 
 \pnum
+\begin{note}
 \indextext{object!local static@local \tcode{static}}%
 The keyword \keyword{static} can be used to declare
-a block variable\iref{basic.scope.block} with static storage duration.
-\begin{note}
+a block variable\iref{basic.scope.block} with static storage duration;
 \ref{stmt.dcl} and \ref{basic.start.term} describe the
 initialization and destruction of such variables.
-\end{note}
-
-\pnum
 \indextext{member!class static@class \tcode{static}}%
-The keyword \keyword{static} applied to a class data member in a class
-definition gives the data member static storage duration.
+The keyword \keyword{static} applied to
+a class data member in a class definition
+gives the data member static storage duration\iref{class.static.data}.
+\end{note}
 
 \rSec3[basic.stc.thread]{Thread storage duration}
 


### PR DESCRIPTION
This clarifies and centralizes the definition and
also avoids the undefined term 'local variable'.

Fixes #4567