### PR TITLE
missing to_underlying in index

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -574,6 +574,7 @@ These function templates cannot be used to compare
 
 \rSec2[utility.underlying]{Function template \tcode{to_underlying}}
 
+\indexlibraryglobal{to_underlying}%
 \begin{itemdecl}
 template<class T>
   constexpr underlying_type_t<T> to_underlying(T value) noexcept;


### PR DESCRIPTION
During writing P2351 I noticed missing to_underlying in library index.