### PR TITLE
[basic.types.general] Do not mention pointers

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4595,10 +4595,10 @@ std::memcpy(&obj, buf, N);      // at this point, each subobject of \tcode{obj} 
 \end{example}
 
 \pnum
-For any trivially copyable type \tcode{T}, if two pointers to \tcode{T} point to
-distinct \tcode{T} objects \tcode{obj1} and \tcode{obj2}, where neither
-\tcode{obj1} nor \tcode{obj2} is a potentially-overlapping subobject, if the underlying
-bytes\iref{intro.memory} making up
+For two distinct objects \tcode{obj1} and \tcode{obj2}
+of trivially copyable type \tcode{T},
+where neither \tcode{obj1} nor \tcode{obj2} is a potentially-overlapping subobject,
+if the underlying bytes\iref{intro.memory} making up
 \tcode{obj1} are copied into \tcode{obj2},
 \begin{footnote}
 By using, for example,


### PR DESCRIPTION
It is unclear why having pointers to `T` is a precondition, since it doesn't seem that these pointers are used normatively.

Not sure should I write «For any distinct objects», «For two distinct objects» or «For any two distinct objects».