### PR TITLE
[expr.await] Clarify rethrowing exceptions from await-suspend

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4597,7 +4597,8 @@ without exiting any scopes\iref{stmt.jump}.
 
 \item
 If the result of \placeholder{await-ready} is \tcode{true},
-or when the coroutine is resumed,
+or when the coroutine is resumed
+other than by rethrowing an exception from \placeholder{await-suspend},
 the \placeholder{await-resume} expression is evaluated, and
 its result is the result of the \grammarterm{await-expression}.
 \end{itemize}


### PR DESCRIPTION
Fixes #4568