### PR TITLE
[forward.list] Rename stable label from [forwardlist]

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -518,7 +518,7 @@ can simply be removed.
 
 \rSec2[diff.cpp17.containers]{\ref{containers}: containers library}
 
-\diffref{forwardlist,list}
+\diffref{forward.list,list}
 \change
 Return types of \tcode{remove}, \tcode{remove_if}, and \tcode{unique}
 changed from \tcode{void} to \tcode{container::size_type}.

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -3286,7 +3286,7 @@ namespace std {
 #include <initializer_list>     // see \ref{initializer.list.syn}
 
 namespace std {
-  // \ref{forwardlist}, class template \tcode{forward_list}
+  // \ref{forward.list}, class template \tcode{forward_list}
   template<class T, class Allocator = allocator<T>> class forward_list;
 
   template<class T, class Allocator>
@@ -4128,9 +4128,9 @@ return r;
 \end{codeblock}
 \end{itemdescr}
 
-\rSec2[forwardlist]{Class template \tcode{forward_list}}
+\rSec2[forward.list]{Class template \tcode{forward_list}}
 
-\rSec3[forwardlist.overview]{Overview}
+\rSec3[forward.list.overview]{Overview}
 
 \pnum
 A \tcode{forward_list} is a container that supports forward iterators and allows
@@ -4181,7 +4181,7 @@ namespace std {
     using iterator        = @\impdefx{type of \tcode{forward_list::iterator}}@; // see \ref{container.requirements}
     using const_iterator  = @\impdefx{type of \tcode{forward_list::const_iterator}}@; // see \ref{container.requirements}
 
-    // \ref{forwardlist.cons}, construct/copy/destroy
+    // \ref{forward.list.cons}, construct/copy/destroy
     forward_list() : forward_list(Allocator()) { }
     explicit forward_list(const Allocator&);
     explicit forward_list(size_type n, const Allocator& = Allocator());
@@ -4204,7 +4204,7 @@ namespace std {
     void assign(initializer_list<T>);
     allocator_type get_allocator() const noexcept;
 
-    // \ref{forwardlist.iter}, iterators
+    // \ref{forward.list.iter}, iterators
     iterator before_begin() noexcept;
     const_iterator before_begin() const noexcept;
     iterator begin() noexcept;
@@ -4220,11 +4220,11 @@ namespace std {
     [[nodiscard]] bool empty() const noexcept;
     size_type max_size() const noexcept;
 
-    // \ref{forwardlist.access}, element access
+    // \ref{forward.list.access}, element access
     reference front();
     const_reference front() const;
 
-    // \ref{forwardlist.modifiers}, modifiers
+    // \ref{forward.list.modifiers}, modifiers
     template<class... Args> reference emplace_front(Args&&... args);
     void push_front(const T& x);
     void push_front(T&& x);
@@ -4248,7 +4248,7 @@ namespace std {
     void resize(size_type sz, const value_type& c);
     void clear() noexcept;
 
-    // \ref{forwardlist.ops}, \tcode{forward_list} operations
+    // \ref{forward.list.ops}, \tcode{forward_list} operations
     void splice_after(const_iterator position, forward_list& x);
     void splice_after(const_iterator position, forward_list&& x);
     void splice_after(const_iterator position, forward_list& x, const_iterator i);
@@ -4288,7 +4288,7 @@ allocator completeness requirements\iref{allocator.requirements.completeness}.
 \tcode{T} shall be complete before any member of the resulting specialization
 of \tcode{forward_list} is referenced.
 
-\rSec3[forwardlist.cons]{Constructors, copy, and assignment}
+\rSec3[forward.list.cons]{Constructors, copy, and assignment}
 
 \indexlibraryctor{forward_list}%
 \begin{itemdecl}
@@ -4360,7 +4360,7 @@ Constructs a \tcode{forward_list} object equal to the range \range{first}{last}.
 Linear in \tcode{distance(first, last)}.
 \end{itemdescr}
 
-\rSec3[forwardlist.iter]{Iterators}
+\rSec3[forward.list.iter]{Iterators}
 
 \indexlibrarymember{before_begin}{forward_list}%
 \indexlibrarymember{cbefore_begin}{forward_list}%
@@ -4386,7 +4386,7 @@ returned by \tcode{begin()}.
 \tcode{before_begin() == end()} shall equal \tcode{false}.
 \end{itemdescr}
 
-\rSec3[forwardlist.access]{Element access}
+\rSec3[forward.list.access]{Element access}
 
 \indexlibrarymember{front}{forward_list}%
 \begin{itemdecl}
@@ -4400,7 +4400,7 @@ const_reference front() const;
 \tcode{*begin()}
 \end{itemdescr}
 
-\rSec3[forwardlist.modifiers]{Modifiers}
+\rSec3[forward.list.modifiers]{Modifiers}
 
 \pnum
 None of the overloads of \tcode{insert_after} shall affect the validity of iterators and
@@ -4644,7 +4644,7 @@ Erases all elements in the range \range{begin()}{end()}.
 Does not invalidate past-the-end iterators.
 \end{itemdescr}
 
-\rSec3[forwardlist.ops]{Operations}
+\rSec3[forward.list.ops]{Operations}
 
 \pnum
 In this subclause,

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -44,5 +44,13 @@
 \movedxref{temp.class.order}{temp.spec.partial.order}
 \movedxref{temp.class.spec.mfunc}{temp.spec.partial.member}
 
+\movedxref{forwardlist}{forward.list}
+\movedxref{forwardlist.overview}{forward.list.overview}
+\movedxref{forwardlist.cons}{forward.list.cons}
+\movedxref{forwardlist.iter}{forward.list.iter}
+\movedxref{forwardlist.access}{forward.list.access}
+\movedxref{forwardlist.modifiers}{forward.list.modifiers}
+\movedxref{forwardlist.ops}{forward.list.ops}
+
 % Deprecated features.
 %\deprxref{old.label}  (if moved to depr.old.label, otherwise use \movedxref)


### PR DESCRIPTION
This makes the labels consistent.

Fixes #4302