### PR TITLE
[tuple.elem] Replace "member variables" with "data members"

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2209,7 +2209,7 @@ the return type is \tcode{X\&}, not \tcode{const X\&}.
 However, if the element type is a non-reference type \tcode{T},
 the return type is \tcode{const T\&}.
 This is consistent with how constness is defined to work
-for member variables of reference type.
+for non-static data members of reference type.
 \end{note}
 \end{itemdescr}
 


### PR DESCRIPTION
While I use both terms — data members and member variables — I don't think "member variable" is a defined term in the Standard.