### PR TITLE
[range.elements.sentinel] Correct return type of operator-

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -6853,7 +6853,7 @@ namespace std::ranges {
 
     template<bool OtherConst>
       requires @\libconcept{sized_sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>
-    friend constexpr range_difference_t<@\exposid{Base}@>
+    friend constexpr range_difference_t<@\exposid{maybe-const}@<OtherConst, V>>
       operator-(const @\exposid{iterator}@<OtherConst>& x, const @\exposid{sentinel}@& y);
 
     template<bool OtherConst>
@@ -6915,7 +6915,7 @@ Equivalent to: \tcode{return x.\exposid{current_} == y.\exposid{end_};}
 \begin{itemdecl}
 template<bool OtherConst>
   requires @\libconcept{sized_sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>
-friend constexpr range_difference_t<@\exposid{Base}@>
+friend constexpr range_difference_t<@\exposid{maybe-const}@<OtherConst, V>>
   operator-(const @\exposid{iterator}@<OtherConst>& x, const @\exposid{sentinel}@& y);
 \end{itemdecl}
 


### PR DESCRIPTION
This is a missed edit from [LWG3406](https://cplusplus.github.io/LWG/issue3406).