### PR TITLE
[expr.static.cast] static_cast of pointer to derived class only handles base class subobjects

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3887,7 +3887,7 @@ to ``pointer to \tcode{B}'' exists\iref{conv.ptr}, the program is ill-formed.
 The null pointer value\iref{basic.compound} is converted
 to the null pointer value of the destination type. If the prvalue of type
 ``pointer to \cvqual{cv1} \tcode{B}'' points to a \tcode{B} that is
-actually a subobject of an object of type \tcode{D}, the resulting
+actually a base class subobject of an object of type \tcode{D}, the resulting
 pointer points to the enclosing object of type \tcode{D}. Otherwise, the
 behavior is undefined.
 


### PR DESCRIPTION
`static_cast` from `base*` to `derived*` only handles the case where the `base` is a base class subobject of a `derived`, not when `base` is a member subobject. This brings the pointer wording in line with the reference wording:
> If the object of type “cv1 B” is actually a base class subobject of an object of type D, the result refers to the enclosing object of type D.