### PR TITLE
[dcl.meaning.general] Improve clarity of presentation

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2460,6 +2460,8 @@ void h(int *(C[10]));           // \tcode{void h(int *(*_fp)(C _parm[10]));}
 \indextext{declaration!type}%
 A declarator contains exactly one \grammarterm{declarator-id};
 it names the entity that is declared.
+The terminal name of the \grammarterm{declarator-id} is not looked up
+except as specified below.
 If the \grammarterm{unqualified-id} occurring in a \grammarterm{declarator-id}
 is a \grammarterm{template-id},
 the declarator shall appear in the \grammarterm{declaration} of a
@@ -2484,8 +2486,9 @@ the \grammarterm{declarator-id} of the \grammarterm{declarator} is
 a \grammarterm{qualified-id} or a \grammarterm{template-id}:
 \begin{itemize}
   \item
+The terminal name of the \grammarterm{declarator-id} is looked up.
 If the friend declaration is not a template declaration,
-then in the lookup for the terminal name of $E$:
+then in this name lookup:
 \begin{itemize}
     \item
 if the \grammarterm{unqualified-id} in $E$ is a \grammarterm{template-id},
@@ -2507,8 +2510,8 @@ they shall all have the same target scope, and
 the target scope of the \grammarterm{declarator} is that scope.
 \end{itemize}
 \item
-Otherwise, the terminal name of $E$ is not looked up.
-The declaration's target scope is the innermost enclosing namespace scope.
+Otherwise,
+the declaration's target scope is the innermost enclosing namespace scope.
 If the declaration is contained by a block scope,
 the declaration shall correspond to a declaration
 that inhabits the innermost block scope.
@@ -2533,11 +2536,12 @@ Then:
 If the \grammarterm{declarator} declares
 an explicit instantiation or a partial or explicit specialization,
 the \grammarterm{declarator} does not bind a name.
-If such a \grammarterm{declarator} declares a class member,
-the terminal name of the \grammarterm{declarator-id} is not looked up;
-otherwise, only those lookup results that are nominable in $S$
+If such a \grammarterm{declarator} does not declare a class member,
+the terminal name of the \grammarterm{declarator-id} is looked up,
+and only those lookup results that are nominable in $S$
 are considered when identifying
-any function template specialization being declared\iref{temp.deduct.decl}.
+any function or variable template specialization
+being declared\iref{temp.deduct.decl}.
 \begin{example}
 \begin{codeblock}
 namespace N {
@@ -2557,8 +2561,7 @@ template void N::g(int);                // error: lookup is ambiguous
 \end{example}
 \item
 Otherwise,
-the terminal name of the \grammarterm{declarator-id} is not looked up.
-If it is a qualified name,
+if the terminal name of the \grammarterm{declarator-id} is a qualified name,
 the \grammarterm{declarator} shall correspond to
 one or more declarations nominable in $S$;
 all the declarations shall have the same target scope and

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2508,14 +2508,14 @@ the target scope of the \grammarterm{declarator} is that scope.
 \end{itemize}
 \item
 Otherwise, the terminal name of $E$ is not looked up.
-The declaration's target scope is the innermost enclosing namespace scope;
-if the declaration is contained by a block scope,
+The declaration's target scope is the innermost enclosing namespace scope.
+If the declaration is contained by a block scope,
 the declaration shall correspond to a declaration
 that inhabits the innermost block scope.
 \end{itemize}
 
 \pnum
-Otherwise:
+If the declaration is not a friend declaration:
 \begin{itemize}
 \item
 If the \grammarterm{id-expression} in
@@ -2526,11 +2526,14 @@ the declaration shall inhabit a namespace scope.
 \item
 Otherwise, let $S$ be the entity associated with the scope inhabited by
 the \grammarterm{declarator}.
+\end{itemize}
+Then:
+\begin{itemize}
 \item
 If the \grammarterm{declarator} declares
 an explicit instantiation or a partial or explicit specialization,
 the \grammarterm{declarator} does not bind a name.
-If it declares a class member,
+If such a \grammarterm{declarator} declares a class member,
 the terminal name of the \grammarterm{declarator-id} is not looked up;
 otherwise, only those lookup results that are nominable in $S$
 are considered when identifying
@@ -2578,11 +2581,13 @@ namespace R {
 }
 \end{codeblock}
 \end{example}
-\item
+\end{itemize}
+
+\pnum
 If the declaration inhabits a block scope $S$ and
 declares a function\iref{dcl.fct} or uses the \keyword{extern} specifier,
-the declaration shall not be attached to a named module\iref{module.unit};
-its target scope is the innermost enclosing namespace scope,
+the declaration shall not be attached to a named module\iref{module.unit}.
+Its target scope is the innermost enclosing namespace scope,
 but the name is bound in $S$.
 \begin{example}
 \begin{codeblock}
@@ -2604,7 +2609,6 @@ void q() { @\commentellip@ }          // some other, unrelated \tcode{q}
 void X::r() { @\commentellip@ }       // error: \tcode{r} cannot be declared by \grammarterm{qualified-id}
 \end{codeblock}
 \end{example}
-\end{itemize}
 
 \pnum
 A


### PR DESCRIPTION
[dcl.meaning.general] is hard to read currently, mostly due to a dense nesting of "if" / "otherwise" clauses where it's not always clear which wording is in the scope of which "if"s, and what each "otherwise" binds to. This PR attempts to clean this up a bit.

In passing, I also fixed an issue where we use the same name `S` for two different purposes in the same scope, and front-loaded the "declarator-id is normally not looked up" rule so that the special cases where lookup does happen are more obvious.

@opensdh Your review in particular would be appreciated.