### PR TITLE
[range.elements.overview] Correct example

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -6303,7 +6303,7 @@ the expression \tcode{views::elements<N>(E)} is expression-equivalent to
 \begin{example}
 \begin{codeblock}
 auto historical_figures = map{
-  {"Lovelace"sv, 1815},
+  pair{"Lovelace"sv, 1815},
   {"Turing"sv, 1912},
   {"Babbage"sv, 1791},
   {"Hamilton"sv, 1936}


### PR DESCRIPTION
We need at least one element in the initializer list to actually have a type in order for deduction to work.

Examples 2 and 3 are also broken for other reasons, but those will be addressed via an LWG issue.
