### PR TITLE
[ranges] Rename 'not-same-as' to 'different-from'.

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1343,7 +1343,7 @@ template<class I>
     @\libconcept{input_iterator}@<I> && (is_pointer_v<I> || requires(I i) { i.operator->(); });
 
 template<class T, class U>
-  concept @\defexposconcept{not-same-as}@ =                         // \expos
+  concept @\defexposconcept{different-from}@                        // \expos
     !@\libconcept{same_as}@<remove_cvref_t<T>, remove_cvref_t<U>>;
 \end{codeblock}
 
@@ -1483,7 +1483,7 @@ namespace std::ranges {
       @\libconcept{convertible_to}@<From, To> &&
       !(is_pointer_v<decay_t<From>> &&
         is_pointer_v<decay_t<To>> &&
-        @\exposconcept{not-same-as}@<remove_pointer_t<decay_t<From>>, remove_pointer_t<decay_t<To>>>);
+        @\exposconcept{different-from}@<remove_pointer_t<decay_t<From>>, remove_pointer_t<decay_t<To>>>);
 
   template<class T>
     concept @\defexposconcept{pair-like}@ =                                     // \expos
@@ -1523,7 +1523,7 @@ namespace std::ranges {
                        @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>> n)
       requires (K == subrange_kind::sized);
 
-    template<@\exposconcept{not-same-as}@<subrange> R>
+    template<@\exposconcept{different-from}@<subrange> R>
       requires @\libconcept{borrowed_range}@<R> &&
                @\exposconcept{convertible-to-non-slicing}@<iterator_t<R>, I> &&
                @\libconcept{convertible_to}@<sentinel_t<R>, S>
@@ -1537,7 +1537,7 @@ namespace std::ranges {
         : subrange{ranges::begin(r), ranges::end(r), n}
     {}
 
-    template<@\exposconcept{not-same-as}@<subrange> PairLike>
+    template<@\exposconcept{different-from}@<subrange> PairLike>
       requires @\exposconcept{pair-like-convertible-from}@<PairLike, const I&, const S&>
     constexpr operator PairLike() const;
 
@@ -1637,7 +1637,7 @@ when it stores an iterator and sentinel that do not model
 
 \indexlibraryctor{subrange}%
 \begin{itemdecl}
-template<@\exposconcept{not-same-as}@<subrange> R>
+template<@\exposconcept{different-from}@<subrange> R>
   requires @\libconcept{borrowed_range}@<R> &&
            @\exposconcept{convertible-to-non-slicing}@<iterator_t<R>, I> &&
            @\libconcept{convertible_to}@<sentinel_t<R>, S>
@@ -1657,7 +1657,7 @@ Equivalent to:
 
 \indexlibrarymember{operator \placeholder{PairLike}}{subrange}%
 \begin{itemdecl}
-template<@\exposconcept{not-same-as}@<subrange> PairLike>
+template<@\exposconcept{different-from}@<subrange> PairLike>
   requires @\exposconcept{pair-like-convertible-from}@<PairLike, const I&, const S&>
 constexpr operator PairLike() const;
 \end{itemdecl}
@@ -3116,7 +3116,7 @@ namespace std::ranges {
   public:
     constexpr ref_view() noexcept = default;
 
-    template<@\exposconcept{not-same-as}@<ref_view> T>
+    template<@\exposconcept{different-from}@<ref_view> T>
       requires @\seebelow@
     constexpr ref_view(T&& t);
 
@@ -3142,7 +3142,7 @@ namespace std::ranges {
 
 \indexlibraryglobal{ref_view}%
 \begin{itemdecl}
-template<@\exposconcept{not-same-as}@<ref_view> T>
+template<@\exposconcept{different-from}@<ref_view> T>
   requires @\seebelow@
 constexpr ref_view(T&& t);
 \end{itemdecl}


### PR DESCRIPTION
Fixes #4606 