### PR TITLE
[lib] Drop 'inline' from 'inline constexpr' variable templates.

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -775,7 +775,7 @@ template<class T, class... Args>
 
 \begin{itemdecl}
 template<class T>
-  inline constexpr bool @\exposid{is-default-initializable}@ = @\seebelow@;  // \expos
+  constexpr bool @\exposid{is-default-initializable}@ = @\seebelow@;         // \expos
 
 template<class T>
   concept @\deflibconcept{default_initializable}@ = @\libconcept{constructible_from}@<T> &&

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -6118,7 +6118,7 @@ namespace std {
     class vector<bool, Allocator>;
 
   template<class T>
-    inline constexpr bool @\exposid{is-vector-bool-reference}@ = @\seebelow@;   // \expos
+    constexpr bool @\exposid{is-vector-bool-reference}@ = @\seebelow@;          // \expos
 
   // hash support
   template<class T> struct hash;
@@ -9346,7 +9346,7 @@ The specialization is enabled\iref{unord.hash}.
 \indexlibrary{is-vector-bool-reference@\exposid{is-vector-bool-reference}}%
 \begin{itemdecl}
 template<class T>
-  inline constexpr bool @\exposid{is-vector-bool-reference}@ = @\seebelow@;
+  constexpr bool @\exposid{is-vector-bool-reference}@ = @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -17520,9 +17520,9 @@ namespace std {
     class span;
 
   template<class ElementType, size_t Extent>
-    inline constexpr bool ranges::enable_view<span<ElementType, Extent>> = true;
+    constexpr bool ranges::enable_view<span<ElementType, Extent>> = true;
   template<class ElementType, size_t Extent>
-    inline constexpr bool ranges::enable_borrowed_range<span<ElementType, Extent>> = true;
+    constexpr bool ranges::enable_borrowed_range<span<ElementType, Extent>> = true;
 
   // \ref{span.objectrep}, views of object representation
   template<class ElementType, size_t Extent>

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -816,9 +816,9 @@ namespace std {
 
   // \ref{syserr}, system error support
   template<class T>
-    inline constexpr bool is_error_code_enum_v = is_error_code_enum<T>::value;
+    constexpr bool is_error_code_enum_v = is_error_code_enum<T>::value;
   template<class T>
-    inline constexpr bool is_error_condition_enum_v = is_error_condition_enum<T>::value;
+    constexpr bool is_error_condition_enum_v = is_error_condition_enum<T>::value;
 }
 \end{codeblock}
 

--- a/source/future.tex
+++ b/source/future.tex
@@ -1368,7 +1368,7 @@ has the following addition:
 \begin{codeblock}
 namespace std {
   template<class T> struct is_pod;
-  template<class T> inline constexpr bool is_pod_v = is_pod<T>::value;
+  template<class T> constexpr bool is_pod_v = is_pod<T>::value;
   template<size_t Len, size_t Align = @\exposid{default-alignment}@> // \seebelow
     struct aligned_storage;
   template<size_t Len, size_t Align = @\exposid{default-alignment}@> // \seebelow

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -110,7 +110,7 @@ namespace std {
 
   // \ref{iterator.concept.sizedsentinel}, concept \libconcept{sized_sentinel_for}
   template<class S, class I>
-    inline constexpr bool disable_sized_sentinel_for = false;                       // freestanding
+    constexpr bool disable_sized_sentinel_for = false;                              // freestanding
 
   template<class S, class I>
     concept sized_sentinel_for = @\seebelow@;                                         // freestanding
@@ -317,7 +317,7 @@ namespace std {
 
   template<class Iterator1, class Iterator2>
       requires (!@\libconcept{sized_sentinel_for}@<Iterator1, Iterator2>)
-    inline constexpr bool disable_sized_sentinel_for<reverse_iterator<Iterator1>,   // freestanding
+    constexpr bool disable_sized_sentinel_for<reverse_iterator<Iterator1>,          // freestanding
                                                      reverse_iterator<Iterator2>> = true;
 
   // \ref{insert.iterators}, insert iterators
@@ -404,8 +404,8 @@ namespace std {
 
   template<class Iterator1, class Iterator2>
       requires (!@\libconcept{sized_sentinel_for}@<Iterator1, Iterator2>)
-    inline constexpr bool disable_sized_sentinel_for<move_iterator<Iterator1>,      // freestanding
-                                                     move_iterator<Iterator2>> = true;
+    constexpr bool disable_sized_sentinel_for<move_iterator<Iterator1>,             // freestanding
+                                              move_iterator<Iterator2>> = true;
 
   template<@\libconcept{semiregular}@ S> class move_sentinel;                                      // freestanding
 
@@ -1366,10 +1366,10 @@ nor is the type required to be \libconcept{equality_comparable}.
 
 \begin{codeblock}
 template<class T>
-  inline constexpr bool @\exposid{is-integer-like}@ = @\seebelow@; @\itcorr[-2]@           // \expos
+  constexpr bool @\exposid{is-integer-like}@ = @\seebelow@; @\itcorr[-2]@                  // \expos
 
 template<class T>
-  inline constexpr bool @\exposid{is-signed-integer-like}@ = @\seebelow@; @\itcorr[-2]@    // \expos
+  constexpr bool @\exposid{is-signed-integer-like}@ = @\seebelow@; @\itcorr[-2]@           // \expos
 
 template<class I>
   concept @\deflibconcept{weakly_incrementable}@ =
@@ -1700,7 +1700,7 @@ necessary to make \tcode{bool(i == s)} be \tcode{true}.
 \indexlibraryglobal{disable_sized_sentinel_for}%
 \begin{itemdecl}
 template<class S, class I>
-  inline constexpr bool disable_sized_sentinel_for = false;
+  constexpr bool disable_sized_sentinel_for = false;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -114,7 +114,7 @@ namespace std {
 
   // \ref{allocator.uses.trait}, \tcode{uses_allocator}
   template<class T, class Alloc>
-    inline constexpr bool @\libglobal{uses_allocator_v}@ = uses_allocator<T, Alloc>::value;       // freestanding
+    constexpr bool @\libglobal{uses_allocator_v}@ = uses_allocator<T, Alloc>::value;              // freestanding
 
   // \ref{allocator.uses.construction}, uses-allocator construction
   template<class T, class Alloc, class... Args>

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -378,198 +378,198 @@ namespace std {
 
   // \ref{meta.unary.cat}, primary type categories
   template<class T>
-    inline constexpr bool @\libglobal{is_void_v}@ = is_void<T>::value;
+    constexpr bool @\libglobal{is_void_v}@ = is_void<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_null_pointer_v}@ = is_null_pointer<T>::value;
+    constexpr bool @\libglobal{is_null_pointer_v}@ = is_null_pointer<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_integral_v}@ = is_integral<T>::value;
+    constexpr bool @\libglobal{is_integral_v}@ = is_integral<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_floating_point_v}@ = is_floating_point<T>::value;
+    constexpr bool @\libglobal{is_floating_point_v}@ = is_floating_point<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_array_v}@ = is_array<T>::value;
+    constexpr bool @\libglobal{is_array_v}@ = is_array<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_pointer_v}@ = is_pointer<T>::value;
+    constexpr bool @\libglobal{is_pointer_v}@ = is_pointer<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_lvalue_reference_v}@ = is_lvalue_reference<T>::value;
+    constexpr bool @\libglobal{is_lvalue_reference_v}@ = is_lvalue_reference<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_rvalue_reference_v}@ = is_rvalue_reference<T>::value;
+    constexpr bool @\libglobal{is_rvalue_reference_v}@ = is_rvalue_reference<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_member_object_pointer_v}@ = is_member_object_pointer<T>::value;
+    constexpr bool @\libglobal{is_member_object_pointer_v}@ = is_member_object_pointer<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_member_function_pointer_v}@ = is_member_function_pointer<T>::value;
+    constexpr bool @\libglobal{is_member_function_pointer_v}@ = is_member_function_pointer<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_enum_v}@ = is_enum<T>::value;
+    constexpr bool @\libglobal{is_enum_v}@ = is_enum<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_union_v}@ = is_union<T>::value;
+    constexpr bool @\libglobal{is_union_v}@ = is_union<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_class_v}@ = is_class<T>::value;
+    constexpr bool @\libglobal{is_class_v}@ = is_class<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_function_v}@ = is_function<T>::value;
+    constexpr bool @\libglobal{is_function_v}@ = is_function<T>::value;
 
   // \ref{meta.unary.comp}, composite type categories
   template<class T>
-    inline constexpr bool @\libglobal{is_reference_v}@ = is_reference<T>::value;
+    constexpr bool @\libglobal{is_reference_v}@ = is_reference<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_arithmetic_v}@ = is_arithmetic<T>::value;
+    constexpr bool @\libglobal{is_arithmetic_v}@ = is_arithmetic<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_fundamental_v}@ = is_fundamental<T>::value;
+    constexpr bool @\libglobal{is_fundamental_v}@ = is_fundamental<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_object_v}@ = is_object<T>::value;
+    constexpr bool @\libglobal{is_object_v}@ = is_object<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_scalar_v}@ = is_scalar<T>::value;
+    constexpr bool @\libglobal{is_scalar_v}@ = is_scalar<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_compound_v}@ = is_compound<T>::value;
+    constexpr bool @\libglobal{is_compound_v}@ = is_compound<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_member_pointer_v}@ = is_member_pointer<T>::value;
+    constexpr bool @\libglobal{is_member_pointer_v}@ = is_member_pointer<T>::value;
 
   // \ref{meta.unary.prop}, type properties
   template<class T>
-    inline constexpr bool @\libglobal{is_const_v}@ = is_const<T>::value;
+    constexpr bool @\libglobal{is_const_v}@ = is_const<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_volatile_v}@ = is_volatile<T>::value;
+    constexpr bool @\libglobal{is_volatile_v}@ = is_volatile<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_trivial_v}@ = is_trivial<T>::value;
+    constexpr bool @\libglobal{is_trivial_v}@ = is_trivial<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_trivially_copyable_v}@ = is_trivially_copyable<T>::value;
+    constexpr bool @\libglobal{is_trivially_copyable_v}@ = is_trivially_copyable<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_standard_layout_v}@ = is_standard_layout<T>::value;
+    constexpr bool @\libglobal{is_standard_layout_v}@ = is_standard_layout<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_empty_v}@ = is_empty<T>::value;
+    constexpr bool @\libglobal{is_empty_v}@ = is_empty<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_polymorphic_v}@ = is_polymorphic<T>::value;
+    constexpr bool @\libglobal{is_polymorphic_v}@ = is_polymorphic<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_abstract_v}@ = is_abstract<T>::value;
+    constexpr bool @\libglobal{is_abstract_v}@ = is_abstract<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_final_v}@ = is_final<T>::value;
+    constexpr bool @\libglobal{is_final_v}@ = is_final<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_aggregate_v}@ = is_aggregate<T>::value;
+    constexpr bool @\libglobal{is_aggregate_v}@ = is_aggregate<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_signed_v}@ = is_signed<T>::value;
+    constexpr bool @\libglobal{is_signed_v}@ = is_signed<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_unsigned_v}@ = is_unsigned<T>::value;
+    constexpr bool @\libglobal{is_unsigned_v}@ = is_unsigned<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_bounded_array_v}@ = is_bounded_array<T>::value;
+    constexpr bool @\libglobal{is_bounded_array_v}@ = is_bounded_array<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_unbounded_array_v}@ = is_unbounded_array<T>::value;
+    constexpr bool @\libglobal{is_unbounded_array_v}@ = is_unbounded_array<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_scoped_enum_v}@ = is_scoped_enum<T>::value;
+    constexpr bool @\libglobal{is_scoped_enum_v}@ = is_scoped_enum<T>::value;
   template<class T, class... Args>
-    inline constexpr bool @\libglobal{is_constructible_v}@ = is_constructible<T, Args...>::value;
+    constexpr bool @\libglobal{is_constructible_v}@ = is_constructible<T, Args...>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_default_constructible_v}@ = is_default_constructible<T>::value;
+    constexpr bool @\libglobal{is_default_constructible_v}@ = is_default_constructible<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_copy_constructible_v}@ = is_copy_constructible<T>::value;
+    constexpr bool @\libglobal{is_copy_constructible_v}@ = is_copy_constructible<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_move_constructible_v}@ = is_move_constructible<T>::value;
+    constexpr bool @\libglobal{is_move_constructible_v}@ = is_move_constructible<T>::value;
   template<class T, class U>
-    inline constexpr bool @\libglobal{is_assignable_v}@ = is_assignable<T, U>::value;
+    constexpr bool @\libglobal{is_assignable_v}@ = is_assignable<T, U>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_copy_assignable_v}@ = is_copy_assignable<T>::value;
+    constexpr bool @\libglobal{is_copy_assignable_v}@ = is_copy_assignable<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_move_assignable_v}@ = is_move_assignable<T>::value;
+    constexpr bool @\libglobal{is_move_assignable_v}@ = is_move_assignable<T>::value;
   template<class T, class U>
-    inline constexpr bool @\libglobal{is_swappable_with_v}@ = is_swappable_with<T, U>::value;
+    constexpr bool @\libglobal{is_swappable_with_v}@ = is_swappable_with<T, U>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_swappable_v}@ = is_swappable<T>::value;
+    constexpr bool @\libglobal{is_swappable_v}@ = is_swappable<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_destructible_v}@ = is_destructible<T>::value;
+    constexpr bool @\libglobal{is_destructible_v}@ = is_destructible<T>::value;
   template<class T, class... Args>
-    inline constexpr bool is_trivially_constructible_v
+    constexpr bool is_trivially_constructible_v
       = is_trivially_constructible<T, Args...>::value;
   template<class T>
-    inline constexpr bool is_trivially_default_constructible_v
+    constexpr bool is_trivially_default_constructible_v
       = is_trivially_default_constructible<T>::value;
   template<class T>
-    inline constexpr bool is_trivially_copy_constructible_v
+    constexpr bool is_trivially_copy_constructible_v
       = is_trivially_copy_constructible<T>::value;
   template<class T>
-    inline constexpr bool is_trivially_move_constructible_v
+    constexpr bool is_trivially_move_constructible_v
       = is_trivially_move_constructible<T>::value;
   template<class T, class U>
-    inline constexpr bool @\libglobal{is_trivially_assignable_v}@ = is_trivially_assignable<T, U>::value;
+    constexpr bool @\libglobal{is_trivially_assignable_v}@ = is_trivially_assignable<T, U>::value;
   template<class T>
-    inline constexpr bool is_trivially_copy_assignable_v
+    constexpr bool is_trivially_copy_assignable_v
       = is_trivially_copy_assignable<T>::value;
   template<class T>
-    inline constexpr bool is_trivially_move_assignable_v
+    constexpr bool is_trivially_move_assignable_v
       = is_trivially_move_assignable<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_trivially_destructible_v}@ = is_trivially_destructible<T>::value;
+    constexpr bool @\libglobal{is_trivially_destructible_v}@ = is_trivially_destructible<T>::value;
   template<class T, class... Args>
-    inline constexpr bool is_nothrow_constructible_v
+    constexpr bool is_nothrow_constructible_v
       = is_nothrow_constructible<T, Args...>::value;
   template<class T>
-    inline constexpr bool is_nothrow_default_constructible_v
+    constexpr bool is_nothrow_default_constructible_v
       = is_nothrow_default_constructible<T>::value;
   template<class T>
-    inline constexpr bool is_nothrow_copy_constructible_v
+    constexpr bool is_nothrow_copy_constructible_v
       = is_nothrow_copy_constructible<T>::value;
   template<class T>
-    inline constexpr bool is_nothrow_move_constructible_v
+    constexpr bool is_nothrow_move_constructible_v
       = is_nothrow_move_constructible<T>::value;
   template<class T, class U>
-    inline constexpr bool @\libglobal{is_nothrow_assignable_v}@ = is_nothrow_assignable<T, U>::value;
+    constexpr bool @\libglobal{is_nothrow_assignable_v}@ = is_nothrow_assignable<T, U>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_nothrow_copy_assignable_v}@ = is_nothrow_copy_assignable<T>::value;
+    constexpr bool @\libglobal{is_nothrow_copy_assignable_v}@ = is_nothrow_copy_assignable<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_nothrow_move_assignable_v}@ = is_nothrow_move_assignable<T>::value;
+    constexpr bool @\libglobal{is_nothrow_move_assignable_v}@ = is_nothrow_move_assignable<T>::value;
   template<class T, class U>
-    inline constexpr bool @\libglobal{is_nothrow_swappable_with_v}@ = is_nothrow_swappable_with<T, U>::value;
+    constexpr bool @\libglobal{is_nothrow_swappable_with_v}@ = is_nothrow_swappable_with<T, U>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_nothrow_swappable_v}@ = is_nothrow_swappable<T>::value;
+    constexpr bool @\libglobal{is_nothrow_swappable_v}@ = is_nothrow_swappable<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{is_nothrow_destructible_v}@ = is_nothrow_destructible<T>::value;
+    constexpr bool @\libglobal{is_nothrow_destructible_v}@ = is_nothrow_destructible<T>::value;
   template<class T>
-    inline constexpr bool @\libglobal{has_virtual_destructor_v}@ = has_virtual_destructor<T>::value;
+    constexpr bool @\libglobal{has_virtual_destructor_v}@ = has_virtual_destructor<T>::value;
   template<class T>
-    inline constexpr bool has_unique_object_representations_v
+    constexpr bool has_unique_object_representations_v
       = has_unique_object_representations<T>::value;
   template<class T, class U>
-    inline constexpr bool @\libglobal{reference_constructs_from_temporary_v}@
+    constexpr bool @\libglobal{reference_constructs_from_temporary_v}@
       = reference_constructs_from_temporary<T, U>::value;
   template<class T, class U>
-    inline constexpr bool @\libglobal{reference_converts_from_temporary_v}@
+    constexpr bool @\libglobal{reference_converts_from_temporary_v}@
       = reference_converts_from_temporary<T, U>::value;
 
   // \ref{meta.unary.prop.query}, type property queries
   template<class T>
-    inline constexpr size_t @\libglobal{alignment_of_v}@ = alignment_of<T>::value;
+    constexpr size_t @\libglobal{alignment_of_v}@ = alignment_of<T>::value;
   template<class T>
-    inline constexpr size_t @\libglobal{rank_v}@ = rank<T>::value;
+    constexpr size_t @\libglobal{rank_v}@ = rank<T>::value;
   template<class T, unsigned I = 0>
-    inline constexpr size_t @\libglobal{extent_v}@ = extent<T, I>::value;
+    constexpr size_t @\libglobal{extent_v}@ = extent<T, I>::value;
 
   // \ref{meta.rel}, type relations
   template<class T, class U>
-    inline constexpr bool @\libglobal{is_same_v}@ = is_same<T, U>::value;
+    constexpr bool @\libglobal{is_same_v}@ = is_same<T, U>::value;
   template<class Base, class Derived>
-    inline constexpr bool @\libglobal{is_base_of_v}@ = is_base_of<Base, Derived>::value;
+    constexpr bool @\libglobal{is_base_of_v}@ = is_base_of<Base, Derived>::value;
   template<class From, class To>
-    inline constexpr bool @\libglobal{is_convertible_v}@ = is_convertible<From, To>::value;
+    constexpr bool @\libglobal{is_convertible_v}@ = is_convertible<From, To>::value;
   template<class From, class To>
-    inline constexpr bool @\libglobal{is_nothrow_convertible_v}@ = is_nothrow_convertible<From, To>::value;
+    constexpr bool @\libglobal{is_nothrow_convertible_v}@ = is_nothrow_convertible<From, To>::value;
   template<class T, class U>
-    inline constexpr bool @\libglobal{is_layout_compatible_v}@ = is_layout_compatible<T, U>::value;
+    constexpr bool @\libglobal{is_layout_compatible_v}@ = is_layout_compatible<T, U>::value;
   template<class Base, class Derived>
-    inline constexpr bool is_pointer_interconvertible_base_of_v
+    constexpr bool is_pointer_interconvertible_base_of_v
       = is_pointer_interconvertible_base_of<Base, Derived>::value;
   template<class Fn, class... ArgTypes>
-    inline constexpr bool @\libglobal{is_invocable_v}@ = is_invocable<Fn, ArgTypes...>::value;
+    constexpr bool @\libglobal{is_invocable_v}@ = is_invocable<Fn, ArgTypes...>::value;
   template<class R, class Fn, class... ArgTypes>
-    inline constexpr bool @\libglobal{is_invocable_r_v}@ = is_invocable_r<R, Fn, ArgTypes...>::value;
+    constexpr bool @\libglobal{is_invocable_r_v}@ = is_invocable_r<R, Fn, ArgTypes...>::value;
   template<class Fn, class... ArgTypes>
-    inline constexpr bool @\libglobal{is_nothrow_invocable_v}@ = is_nothrow_invocable<Fn, ArgTypes...>::value;
+    constexpr bool @\libglobal{is_nothrow_invocable_v}@ = is_nothrow_invocable<Fn, ArgTypes...>::value;
   template<class R, class Fn, class... ArgTypes>
-    inline constexpr bool is_nothrow_invocable_r_v
+    constexpr bool is_nothrow_invocable_r_v
       = is_nothrow_invocable_r<R, Fn, ArgTypes...>::value;
 
   // \ref{meta.logical}, logical operator traits
   template<class... B>
-    inline constexpr bool @\libglobal{conjunction_v}@ = conjunction<B...>::value;
+    constexpr bool @\libglobal{conjunction_v}@ = conjunction<B...>::value;
   template<class... B>
-    inline constexpr bool @\libglobal{disjunction_v}@ = disjunction<B...>::value;
+    constexpr bool @\libglobal{disjunction_v}@ = disjunction<B...>::value;
   template<class B>
-    inline constexpr bool @\libglobal{negation_v}@ = negation<B>::value;
+    constexpr bool @\libglobal{negation_v}@ = negation<B>::value;
 
   // \ref{meta.member}, member relationships
   template<class S, class M>
@@ -2433,17 +2433,17 @@ namespace std {
   template<class R1, class R2> struct ratio_greater_equal;
 
   template<class R1, class R2>
-    inline constexpr bool @\libglobal{ratio_equal_v}@ = ratio_equal<R1, R2>::value;
+    constexpr bool @\libglobal{ratio_equal_v}@ = ratio_equal<R1, R2>::value;
   template<class R1, class R2>
-    inline constexpr bool @\libglobal{ratio_not_equal_v}@ = ratio_not_equal<R1, R2>::value;
+    constexpr bool @\libglobal{ratio_not_equal_v}@ = ratio_not_equal<R1, R2>::value;
   template<class R1, class R2>
-    inline constexpr bool @\libglobal{ratio_less_v}@ = ratio_less<R1, R2>::value;
+    constexpr bool @\libglobal{ratio_less_v}@ = ratio_less<R1, R2>::value;
   template<class R1, class R2>
-    inline constexpr bool @\libglobal{ratio_less_equal_v}@ = ratio_less_equal<R1, R2>::value;
+    constexpr bool @\libglobal{ratio_less_equal_v}@ = ratio_less_equal<R1, R2>::value;
   template<class R1, class R2>
-    inline constexpr bool @\libglobal{ratio_greater_v}@ = ratio_greater<R1, R2>::value;
+    constexpr bool @\libglobal{ratio_greater_v}@ = ratio_greater<R1, R2>::value;
   template<class R1, class R2>
-    inline constexpr bool @\libglobal{ratio_greater_equal_v}@ = ratio_greater_equal<R1, R2>::value;
+    constexpr bool @\libglobal{ratio_greater_equal_v}@ = ratio_greater_equal<R1, R2>::value;
 
   // \ref{ratio.si}, convenience SI typedefs
   using @\libglobal{yocto}@ = ratio<1, 1'000'000'000'000'000'000'000'000>;  // see below

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -10301,33 +10301,33 @@ See also \ref{sf.cmath.cyl.neumann}.
 \indexheader{numbers}%
 \begin{codeblock}
 namespace std::numbers {
-  template<class T> inline constexpr T e_v          = @\unspec@;
-  template<class T> inline constexpr T log2e_v      = @\unspec@;
-  template<class T> inline constexpr T log10e_v     = @\unspec@;
-  template<class T> inline constexpr T pi_v         = @\unspec@;
-  template<class T> inline constexpr T inv_pi_v     = @\unspec@;
-  template<class T> inline constexpr T inv_sqrtpi_v = @\unspec@;
-  template<class T> inline constexpr T ln2_v        = @\unspec@;
-  template<class T> inline constexpr T ln10_v       = @\unspec@;
-  template<class T> inline constexpr T sqrt2_v      = @\unspec@;
-  template<class T> inline constexpr T sqrt3_v      = @\unspec@;
-  template<class T> inline constexpr T inv_sqrt3_v  = @\unspec@;
-  template<class T> inline constexpr T egamma_v     = @\unspec@;
-  template<class T> inline constexpr T phi_v        = @\unspec@;
+  template<class T> constexpr T e_v          = @\unspec@;
+  template<class T> constexpr T log2e_v      = @\unspec@;
+  template<class T> constexpr T log10e_v     = @\unspec@;
+  template<class T> constexpr T pi_v         = @\unspec@;
+  template<class T> constexpr T inv_pi_v     = @\unspec@;
+  template<class T> constexpr T inv_sqrtpi_v = @\unspec@;
+  template<class T> constexpr T ln2_v        = @\unspec@;
+  template<class T> constexpr T ln10_v       = @\unspec@;
+  template<class T> constexpr T sqrt2_v      = @\unspec@;
+  template<class T> constexpr T sqrt3_v      = @\unspec@;
+  template<class T> constexpr T inv_sqrt3_v  = @\unspec@;
+  template<class T> constexpr T egamma_v     = @\unspec@;
+  template<class T> constexpr T phi_v        = @\unspec@;
 
-  template<@\libconcept{floating_point}@ T> inline constexpr T e_v<T>          = @\seebelow@;
-  template<@\libconcept{floating_point}@ T> inline constexpr T log2e_v<T>      = @\seebelow@;
-  template<@\libconcept{floating_point}@ T> inline constexpr T log10e_v<T>     = @\seebelow@;
-  template<@\libconcept{floating_point}@ T> inline constexpr T pi_v<T>         = @\seebelow@;
-  template<@\libconcept{floating_point}@ T> inline constexpr T inv_pi_v<T>     = @\seebelow@;
-  template<@\libconcept{floating_point}@ T> inline constexpr T inv_sqrtpi_v<T> = @\seebelow@;
-  template<@\libconcept{floating_point}@ T> inline constexpr T ln2_v<T>        = @\seebelow@;
-  template<@\libconcept{floating_point}@ T> inline constexpr T ln10_v<T>       = @\seebelow@;
-  template<@\libconcept{floating_point}@ T> inline constexpr T sqrt2_v<T>      = @\seebelow@;
-  template<@\libconcept{floating_point}@ T> inline constexpr T sqrt3_v<T>      = @\seebelow@;
-  template<@\libconcept{floating_point}@ T> inline constexpr T inv_sqrt3_v<T>  = @\seebelow@;
-  template<@\libconcept{floating_point}@ T> inline constexpr T egamma_v<T>     = @\seebelow@;
-  template<@\libconcept{floating_point}@ T> inline constexpr T phi_v<T>        = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> constexpr T e_v<T>          = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> constexpr T log2e_v<T>      = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> constexpr T log10e_v<T>     = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> constexpr T pi_v<T>         = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> constexpr T inv_pi_v<T>     = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> constexpr T inv_sqrtpi_v<T> = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> constexpr T ln2_v<T>        = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> constexpr T ln10_v<T>       = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> constexpr T sqrt2_v<T>      = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> constexpr T sqrt3_v<T>      = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> constexpr T inv_sqrt3_v<T>  = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> constexpr T egamma_v<T>     = @\seebelow@;
+  template<@\libconcept{floating_point}@ T> constexpr T phi_v<T>        = @\seebelow@;
 
   inline constexpr double e          = e_v<double>;
   inline constexpr double log2e      = log2e_v<double>;

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -55,7 +55,7 @@ namespace std::ranges {
     concept range = @\seebelow@;                                                      // freestanding
 
   template<class T>
-    inline constexpr bool enable_borrowed_range = false;                            // freestanding
+    constexpr bool enable_borrowed_range = false;                                   // freestanding
 
   template<class T>
     concept borrowed_range = @\seebelow@;                                             // freestanding
@@ -83,14 +83,14 @@ namespace std::ranges {
 
   // \ref{range.sized}, sized ranges
   template<class>
-    inline constexpr bool disable_sized_range = false;                              // freestanding
+    constexpr bool disable_sized_range = false;                                     // freestanding
 
   template<class T>
     concept sized_range = @\seebelow@;                                                // freestanding
 
   // \ref{range.view}, views
   template<class T>
-    inline constexpr bool enable_view = @\seebelow@;                                  // freestanding
+    constexpr bool enable_view = @\seebelow@;                                         // freestanding
 
   struct view_base {};                                                              // freestanding
 
@@ -138,7 +138,7 @@ namespace std::ranges {
   class subrange;                                                                   // freestanding
 
   template<class I, class S, subrange_kind K>
-    inline constexpr bool enable_borrowed_range<subrange<I, S, K>> = true;          // freestanding
+    constexpr bool enable_borrowed_range<subrange<I, S, K>> = true;                 // freestanding
 
   template<size_t N, class I, class S, subrange_kind K>
     requires ((N == 0 && @\libconcept{copyable}@<I>) || N == 1)
@@ -183,11 +183,11 @@ namespace std::ranges {
   class empty_view;                                                                 // freestanding
 
   template<class T>
-    inline constexpr bool enable_borrowed_range<empty_view<T>> = true;              // freestanding
+    constexpr bool enable_borrowed_range<empty_view<T>> = true;                     // freestanding
 
   namespace views {
     template<class T>
-      inline constexpr empty_view<T> @\libmember{empty}{views}@{};                                       // freestanding
+      constexpr empty_view<T> @\libmember{empty}{views}@{};                                              // freestanding
   }
 
   // \ref{range.single}, single view
@@ -206,7 +206,7 @@ namespace std::ranges {
   class iota_view;                                                                  // freestanding
 
   template<class W, class Bound>
-    inline constexpr bool enable_borrowed_range<iota_view<W, Bound>> = true;        // freestanding
+    constexpr bool enable_borrowed_range<iota_view<W, Bound>> = true;               // freestanding
 
   namespace views { inline constexpr @\unspecnc@ iota = @\unspecnc@; }              // freestanding
 
@@ -227,7 +227,7 @@ namespace std::ranges {
   template<class Val>
     using wistream_view = basic_istream_view<Val, wchar_t>;
 
-  namespace views { template<class T> inline constexpr @\unspecnc@ istream = @\unspecnc@; }
+  namespace views { template<class T> constexpr @\unspecnc@ istream = @\unspecnc@; }
 
   // \ref{range.adaptor.object}, range adaptor objects
   template<class D>
@@ -248,7 +248,7 @@ namespace std::ranges {
   class ref_view;                                                                   // freestanding
 
   template<class T>
-    inline constexpr bool enable_borrowed_range<ref_view<T>> = true;                // freestanding
+    constexpr bool enable_borrowed_range<ref_view<T>> = true;                       // freestanding
 
   // \ref{range.owning.view}, owning view
   template<@\libconcept{range}@ R>
@@ -256,7 +256,7 @@ namespace std::ranges {
   class owning_view;                                                                // freestanding
 
   template<class T>
-    inline constexpr bool enable_borrowed_range<owning_view<T>> =                   // freestanding
+    constexpr bool enable_borrowed_range<owning_view<T>> =                          // freestanding
       enable_borrowed_range<T>;
 
   // \ref{range.as.rvalue}, as rvalue view
@@ -265,7 +265,7 @@ namespace std::ranges {
   class as_rvalue_view;                                                             // freestanding
 
   template<class T>
-    inline constexpr bool enable_borrowed_range<as_rvalue_view<T>> =                // freestanding
+    constexpr bool enable_borrowed_range<as_rvalue_view<T>> =                       // freestanding
       enable_borrowed_range<T>;
 
   namespace views { inline constexpr @\unspecnc@ as_rvalue = @\unspecnc@; }         // freestanding
@@ -290,7 +290,7 @@ namespace std::ranges {
   template<@\libconcept{view}@> class take_view;                                                   // freestanding
 
   template<class T>
-    inline constexpr bool enable_borrowed_range<take_view<T>> =                     // freestanding
+    constexpr bool enable_borrowed_range<take_view<T>> =                            // freestanding
       enable_borrowed_range<T>;
 
   namespace views { inline constexpr @\unspecnc@ take = @\unspecnc@; }              // freestanding
@@ -308,7 +308,7 @@ namespace std::ranges {
     class drop_view;                                                                // freestanding
 
   template<class T>
-    inline constexpr bool enable_borrowed_range<drop_view<T>> =                     // freestanding
+    constexpr bool enable_borrowed_range<drop_view<T>> =                            // freestanding
       enable_borrowed_range<T>;
 
   namespace views { inline constexpr @\unspecnc@ drop = @\unspecnc@; }              // freestanding
@@ -320,7 +320,7 @@ namespace std::ranges {
     class drop_while_view;                                                          // freestanding
 
   template<class T, class Pred>
-    inline constexpr bool enable_borrowed_range<drop_while_view<T, Pred>> =         // freestanding
+    constexpr bool enable_borrowed_range<drop_while_view<T, Pred>> =                // freestanding
       enable_borrowed_range<T>;
 
   namespace views { inline constexpr @\unspecnc@ drop_while = @\unspecnc@; }        // freestanding
@@ -374,7 +374,7 @@ namespace std::ranges {
   class common_view;                                                                // freestanding
 
   template<class T>
-    inline constexpr bool enable_borrowed_range<common_view<T>> =                   // freestanding
+    constexpr bool enable_borrowed_range<common_view<T>> =                          // freestanding
       enable_borrowed_range<T>;
 
   namespace views { inline constexpr @\unspecnc@ common = @\unspecnc@; }            // freestanding
@@ -385,7 +385,7 @@ namespace std::ranges {
   class reverse_view;                                                               // freestanding
 
   template<class T>
-    inline constexpr bool enable_borrowed_range<reverse_view<T>> =                  // freestanding
+    constexpr bool enable_borrowed_range<reverse_view<T>> =                         // freestanding
       enable_borrowed_range<T>;
 
   namespace views { inline constexpr @\unspecnc@ reverse = @\unspecnc@; }           // freestanding
@@ -405,7 +405,7 @@ namespace std::ranges {
   class as_const_view;                                                              // freestanding
 
   template<class T>
-    inline constexpr bool enable_borrowed_range<as_const_view<T>> =                 // freestanding
+    constexpr bool enable_borrowed_range<as_const_view<T>> =                        // freestanding
       enable_borrowed_range<T>;
 
   namespace views { inline constexpr @\unspecnc@ as_const = @\unspecnc@; }          // freestanding
@@ -416,7 +416,7 @@ namespace std::ranges {
   class elements_view;                                                              // freestanding
 
   template<class T, size_t N>
-    inline constexpr bool enable_borrowed_range<elements_view<T, N>> =              // freestanding
+    constexpr bool enable_borrowed_range<elements_view<T, N>> =                     // freestanding
       enable_borrowed_range<T>;
 
   template<class R>
@@ -426,7 +426,7 @@ namespace std::ranges {
 
   namespace views {
     template<size_t N>
-      inline constexpr @\unspecnc@ elements = @\unspecnc@;                          // freestanding
+      constexpr @\unspecnc@ elements = @\unspecnc@;                                 // freestanding
     inline constexpr auto @\libmember{keys}{views}@ = elements<0>;                                       // freestanding
     inline constexpr auto @\libmember{values}{views}@ = elements<1>;                                     // freestanding
   }
@@ -437,7 +437,7 @@ namespace std::ranges {
   class zip_view;                                                                   // freestanding
 
   template<class... Views>
-    inline constexpr bool enable_borrowed_range<zip_view<Views...>> =               // freestanding
+    constexpr bool enable_borrowed_range<zip_view<Views...>> =                      // freestanding
       (enable_borrowed_range<Views> && ...);
 
   namespace views { inline constexpr @\unspecnc@ zip = @\unspecnc@; }               // freestanding
@@ -457,7 +457,7 @@ namespace std::ranges {
   class adjacent_view;                                                              // freestanding
 
   template<class V, size_t N>
-    inline constexpr bool enable_borrowed_range<adjacent_view<V, N>> =              // freestanding
+    constexpr bool enable_borrowed_range<adjacent_view<V, N>> =                     // freestanding
       enable_borrowed_range<V>;
 
   namespace views {
@@ -487,7 +487,7 @@ namespace std::ranges {
   class chunk_view<V>;                                                              // freestanding
 
   template<class V>
-    inline constexpr bool enable_borrowed_range<chunk_view<V>> =                    // freestanding
+    constexpr bool enable_borrowed_range<chunk_view<V>> =                           // freestanding
       @\libconcept{forward_range}@<V> && enable_borrowed_range<V>;
 
   namespace views { inline constexpr @\unspecnc@ chunk = @\unspecnc@; }             // freestanding
@@ -498,7 +498,7 @@ namespace std::ranges {
   class slide_view;                                                                 // freestanding
 
   template<class V>
-    inline constexpr bool enable_borrowed_range<slide_view<V>> =
+    constexpr bool enable_borrowed_range<slide_view<V>> =
       enable_borrowed_range<V>;                                                     // freestanding
 
   namespace views { inline constexpr @\unspecnc@ slide = @\unspecnc@; }             // freestanding
@@ -516,7 +516,7 @@ namespace std::ranges {
   class stride_view;                                                                // freestanding
 
   template<class V>
-    inline constexpr bool enable_borrowed_range<stride_view<V>> =                   // freestanding
+    constexpr bool enable_borrowed_range<stride_view<V>> =                          // freestanding
       enable_borrowed_range<V>;
 
   namespace views { inline constexpr @\unspecnc@ stride = @\unspecnc@; }            // freestanding
@@ -1319,7 +1319,7 @@ return iterators obtained from it without danger of dangling.
 \indexlibraryglobal{enable_borrowed_range}%
 \begin{itemdecl}
 template<class>
-  inline constexpr bool enable_borrowed_range = false;
+  constexpr bool enable_borrowed_range = false;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1386,7 +1386,7 @@ only if evaluated before the first call to \tcode{ranges::begin(t)}.
 \indexlibraryglobal{disable_sized_range}%
 \begin{itemdecl}
 template<class>
-  inline constexpr bool disable_sized_range = false;
+  constexpr bool disable_sized_range = false;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1478,9 +1478,9 @@ semantic, the two are differentiated with the help of \tcode{enable_view}.
 \indexlibraryglobal{enable_view}%
 \begin{itemdecl}
 template<class T>
-  inline constexpr bool @\exposidnc{is-derived-from-view-interface}@ = @\seebelownc@;     // \expos
+  constexpr bool @\exposidnc{is-derived-from-view-interface}@ = @\seebelownc@;            // \expos
 template<class T>
-  inline constexpr bool enable_view =
+  constexpr bool enable_view =
     @\libconcept{derived_from}@<T, view_base> || @\exposid{is-derived-from-view-interface}@<T>;
 \end{itemdecl}
 

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -541,9 +541,9 @@ namespace std {
   class basic_string_view;
 
   template<class charT, class traits>
-    inline constexpr bool ranges::enable_view<basic_string_view<charT, traits>> = true;
+    constexpr bool ranges::enable_view<basic_string_view<charT, traits>> = true;
   template<class charT, class traits>
-    inline constexpr bool ranges::enable_borrowed_range<basic_string_view<charT, traits>> = true;
+    constexpr bool ranges::enable_borrowed_range<basic_string_view<charT, traits>> = true;
 
   // \ref{string.view.comparison}, non-member comparison functions
   template<class charT, class traits>

--- a/source/time.tex
+++ b/source/time.tex
@@ -88,12 +88,12 @@ namespace std::chrono {
   // \ref{time.traits}, customization traits
   template<class Rep> struct treat_as_floating_point;
   template<class Rep>
-    inline constexpr bool treat_as_floating_point_v = treat_as_floating_point<Rep>::value;
+    constexpr bool treat_as_floating_point_v = treat_as_floating_point<Rep>::value;
 
   template<class Rep> struct duration_values;
 
   template<class T> struct is_clock;
-  template<class T> inline constexpr bool is_clock_v = is_clock<T>::value;
+  template<class T> constexpr bool is_clock_v = is_clock<T>::value;
 
   // \ref{time.duration.nonmember}, \tcode{duration} arithmetic
   template<class Rep1, class Period1, class Rep2, class Period2>

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -207,13 +207,13 @@ namespace std {
     struct in_place_type_t {
       explicit in_place_type_t() = default;
     };
-  template<class T> inline constexpr in_place_type_t<T> in_place_type{};
+  template<class T> constexpr in_place_type_t<T> in_place_type{};
 
   template<size_t I>
     struct in_place_index_t {
       explicit in_place_index_t() = default;
     };
-  template<size_t I> inline constexpr in_place_index_t<I> in_place_index{};
+  template<size_t I> constexpr in_place_index_t<I> in_place_index{};
 }
 \end{codeblock}
 
@@ -1584,7 +1584,7 @@ namespace std {
 
   // \ref{tuple.helper}, tuple helper classes
   template<class T>
-    inline constexpr size_t @\libglobal{tuple_size_v}@ = tuple_size<T>::value;
+    constexpr size_t @\libglobal{tuple_size_v}@ = tuple_size<T>::value;
 }
 \end{codeblock}
 
@@ -4857,7 +4857,7 @@ namespace std {
   template<class T> struct variant_size;                        // \notdef
   template<class T> struct variant_size<const T>;
   template<class T>
-    inline constexpr size_t @\libglobal{variant_size_v}@ = variant_size<T>::value;
+    constexpr size_t @\libglobal{variant_size_v}@ = variant_size<T>::value;
 
   template<class... Types>
     struct variant_size<variant<Types...>>;
@@ -10493,11 +10493,11 @@ namespace std {
   // \ref{func.bind}, bind
   template<class T> struct is_bind_expression;                                      // freestanding
   template<class T>
-    inline constexpr bool @\libglobal{is_bind_expression_v}@ =                                    // freestanding
+    constexpr bool @\libglobal{is_bind_expression_v}@ =                                           // freestanding
       is_bind_expression<T>::value;
   template<class T> struct is_placeholder;                                          // freestanding
   template<class T>
-    inline constexpr int @\libglobal{is_placeholder_v}@ =                                         // freestanding
+    constexpr int @\libglobal{is_placeholder_v}@ =                                                // freestanding
       is_placeholder<T>::value;
 
   template<class F, class... BoundArgs>
@@ -13926,7 +13926,7 @@ parameters for efficient execution.
 namespace std {
   // \ref{execpol.type}, execution policy type trait
   template<class T> struct is_execution_policy;
-  template<class T> inline constexpr bool @\libglobal{is_execution_policy_v}@ = is_execution_policy<T>::value;
+  template<class T> constexpr bool @\libglobal{is_execution_policy_v}@ = is_execution_policy<T>::value;
 }
 
 namespace std::execution {


### PR DESCRIPTION
Since CWG2387, constexpr variable templates have external linkage.

Fixes #4601

@zygoloid, since const(expr) variable templates now have external linkage, it seems the "inline" is now redundant. What do you think?