### PR TITLE
[range.prim.data] Use ranges::begin(t) not ranges::begin(E)

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -919,7 +919,7 @@ Then:
   is a valid expression whose type models
   \libconcept{contiguous_iterator},
   \tcode{ranges::data(E)} is expression-equivalent to
-  \tcode{to_address(ranges::begin(E))}.
+  \tcode{to_address(ranges::begin(t))}.
 
 \item
   Otherwise, \tcode{ranges::data(E)} is ill-formed.


### PR DESCRIPTION
This is consistent with the typo fixes for ranges::size done in
aa9c660a835540117123617a13b0ba1ab6dd801e as part of #3752.