### PR TITLE
[ranges] Use views::meow in examples instead of meow_view

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1925,7 +1925,7 @@ a particular type.
 \pnum
 \begin{example}
 \begin{codeblock}
-empty_view<int> e;
+auto e = views::empty<int>;
 static_assert(ranges::empty(e));
 static_assert(0 == e.size());
 \end{codeblock}
@@ -1968,8 +1968,7 @@ Given a subexpression \tcode{E}, the expression
 \pnum
 \begin{example}
 \begin{codeblock}
-single_view s{4};
-for (int i : s)
+for (int i : views::single(4))
   cout << i;        // prints \tcode{4}
 \end{codeblock}
 \end{example}
@@ -2106,7 +2105,7 @@ are expression-equivalent to
 \pnum
 \begin{example}
 \begin{codeblock}
-for (int i : iota_view{1, 10})
+for (int i : views::iota(1, 10))
   cout << i << ' '; // prints: 1 2 3 4 5 6 7 8 9
 \end{codeblock}
 \end{example}
@@ -3350,7 +3349,7 @@ the expression \tcode{views::filter(E, P)} is expression-equivalent to
 \begin{example}
 \begin{codeblock}
 vector<int> is{ 0, 1, 2, 3, 4, 5, 6 };
-filter_view evens{is, [](int i) { return 0 == i % 2; }};
+auto evens = views::filter(is, [](int i) { return 0 == i % 2; });
 for (int i : evens)
   cout << i << ' '; // prints: 0 2 4 6
 \end{codeblock}
@@ -3771,7 +3770,7 @@ Given subexpressions \tcode{E} and \tcode{F}, the expression
 \begin{example}
 \begin{codeblock}
 vector<int> is{ 0, 1, 2, 3, 4 };
-transform_view squares{is, [](int i) { return i * i; }};
+auto squares = views::transform(is, [](int i) { return i * i; });
 for (int i : squares)
   cout << i << ' '; // prints: 0 1 4 9 16
 \end{codeblock}
@@ -4482,8 +4481,7 @@ Otherwise, \tcode{ranges::take_view\{E, F\}}.
 \begin{example}
 \begin{codeblock}
 vector<int> is{0,1,2,3,4,5,6,7,8,9};
-take_view few{is, 5};
-for (int i : few)
+for (int i : is | views::take(5))
   cout << i << ' '; // prints: 0 1 2 3 4
 \end{codeblock}
 \end{example}
@@ -4891,8 +4889,7 @@ Otherwise, \tcode{ranges::drop_view\{E, F\}}.
 \begin{example}
 \begin{codeblock}
 auto ints = views::iota(0) | views::take(10);
-auto latter_half = drop_view{ints, 5};
-for (auto i : latter_half) {
+for (auto i : ints | views::drop(5)) {
   cout << i << ' ';                             // prints \tcode{5 6 7 8 9}
 }
 \end{codeblock}
@@ -5020,7 +5017,7 @@ is expression-equivalent to \tcode{drop_while_view\{E, F\}}.
 \begin{codeblock}
 constexpr auto source = "  \t   \t   \t   hello there";
 auto is_invisible = [](const auto x) { return x == ' ' || x == '\t'; };
-auto skip_ws = drop_while_view{source, is_invisible};
+auto skip_ws = views::drop_while(source, is_invisible);
 for (auto c : skip_ws) {
   cout << c;                                    // prints \tcode{hello there} with no leading space
 }
@@ -5133,8 +5130,7 @@ Given a subexpression \tcode{E}, the expression
 \begin{example}
 \begin{codeblock}
 vector<string> ss{"hello", " ", "world", "!"};
-join_view greeting{ss};
-for (char ch : greeting)
+for (char ch : ss | views::join)
   cout << ch;                                   // prints: \tcode{hello world!}
 \end{codeblock}
 \end{example}
@@ -5619,8 +5615,7 @@ the expression \tcode{views::lazy_split(E, F)} is expression-equivalent to
 \begin{example}
 \begin{codeblock}
 string str{"the quick brown fox"};
-lazy_split_view sentence{str, ' '};
-for (auto word : sentence) {
+for (auto word : str | views::lazy_split(' ')) {
   for (char ch : word)
     cout << ch;
   cout << '*';
@@ -6525,7 +6520,7 @@ size_t count(ForwardIterator first, ForwardIterator last);
 
 template<@\libconcept{forward_range}@ R>
 void my_algo(R&& r) {
-  auto&& common = common_view{r};
+  auto&& common = views::common(r);
   auto cnt = count(common.begin(), common.end());
   // ...
 }
@@ -6650,8 +6645,7 @@ subrange<I, I, K>(E.end().base(), E.begin().base())
 \begin{example}
 \begin{codeblock}
 vector<int> is {0,1,2,3,4};
-reverse_view rv {is};
-for (int i : rv)
+for (int i : is | views::reverse)
   cout << i << ' '; // prints: 4 3 2 1 0
 \end{codeblock}
 \end{example}
@@ -6795,7 +6789,7 @@ is useful for extracting keys from associative containers.
 
 \begin{example}
 \begin{codeblock}
-auto names = keys_view{historical_figures};
+auto names = historical_figures | views::keys;
 for (auto&& name : names) {
   cout << name << ' ';          // prints \tcode{Babbage Hamilton Lovelace Turing }
 }
@@ -6809,7 +6803,7 @@ is useful for extracting values from associative containers.
 \begin{example}
 \begin{codeblock}
 auto is_even = [](const auto x) { return x % 2 == 0; };
-cout << ranges::count_if(values_view{historical_figures}, is_even);     // prints \tcode{2}
+cout << ranges::count_if(historical_figures | views::values, is_even);  // prints \tcode{2}
 \end{codeblock}
 \end{example}
 


### PR DESCRIPTION
During reflector discussion of [LWG3563](https://wg21.link/LWG3563), LWG expressed a preference for examples to use the `views::meow` objects whenever applicable, instead of `meow_view`s directly.