### PR TITLE
P1328R1 Making std::type_info::operator== constexpr

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -594,6 +594,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_constexpr_string}@                  201907L // also in \libheader{string}
 #define @\defnlibxname{cpp_lib_constexpr_string_view}@             201811L // also in \libheader{string_view}
 #define @\defnlibxname{cpp_lib_constexpr_tuple}@                   201811L // also in \libheader{tuple}
+#define @\defnlibxname{cpp_lib_constexpr_typeinfo}@                202106L // also in \libheader{typeinfo}
 #define @\defnlibxname{cpp_lib_constexpr_utility}@                 201811L // also in \libheader{utility}
 #define @\defnlibxname{cpp_lib_constexpr_vector}@                  201907L // also in \libheader{vector}
 #define @\defnlibxname{cpp_lib_coroutine}@                         201902L // also in \libheader{coroutine}
@@ -3112,7 +3113,7 @@ namespace std {
   class type_info {
   public:
     virtual ~type_info();
-    bool operator==(const type_info& rhs) const noexcept;
+    constexpr bool operator==(const type_info& rhs) const noexcept;
     bool before(const type_info& rhs) const noexcept;
     size_t hash_code() const noexcept;
     const char* name() const noexcept;
@@ -3135,7 +3136,7 @@ and may differ between programs.
 
 \indexlibrarymember{operator==}{type_info}%
 \begin{itemdecl}
-bool operator==(const type_info& rhs) const noexcept;
+constexpr bool operator==(const type_info& rhs) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Fixes  #4642
Fixes cplusplus/papers#70