### PR TITLE
P2216R3 std::format improvements

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -40,6 +40,27 @@ auto c = L"a" U"b";             // was conditionally-supported; now ill-formed
 \end{codeblock}
 \end{example}
 
+\rSec2[diff.cpp20.utilities]{\ref{utilities}: general utilities library}
+
+\diffref{format}
+\change
+Signature changes: \tcode{format}, \tcode{format_to}, \tcode{vformat_to},
+\tcode{format_to_n}, \tcode{formatted_size}.
+Removal of \tcode{format_args_t}.
+\rationale
+Improve safety via compile-time format string checks,
+avoid unnecessary template instantiations.
+\effect
+Valid \CppXX{} code that
+contained errors in format strings or
+relied on previous format string signatures or
+\tcode{format_args_t} may become ill-formed.
+For example:
+\begin{codeblock}
+auto s = std::format("{:d}", "I am not a number");      // ill-formed,
+                                                        // previously threw \tcode{format_error}
+\end{codeblock}
+
 \rSec1[diff.cpp17]{\Cpp{} and ISO \CppXVII{}}
 
 \rSec2[diff.cpp17.general]{General}

--- a/source/support.tex
+++ b/source/support.tex
@@ -609,7 +609,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_exchange_function}@                 201304L // also in \libheader{utility}
 #define @\defnlibxname{cpp_lib_execution}@                         201902L // also in \libheader{execution}
 #define @\defnlibxname{cpp_lib_filesystem}@                        201703L // also in \libheader{filesystem}
-#define @\defnlibxname{cpp_lib_format}@                            201907L // also in \libheader{format}
+#define @\defnlibxname{cpp_lib_format}@                            202106L // also in \libheader{format}
 #define @\defnlibxname{cpp_lib_gcd_lcm}@                           201606L // also in \libheader{numeric}
 #define @\defnlibxname{cpp_lib_generic_associative_lookup}@        201304L // also in \libheader{map}, \libheader{set}
 #define @\defnlibxname{cpp_lib_generic_unordered_lookup}@          201811L

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -19640,18 +19640,26 @@ namespace std {
   using format_args = basic_format_args<format_context>;
   using wformat_args = basic_format_args<wformat_context>;
 
-  template<class Out, class charT>
-    using @\libglobal{format_args_t}@ = basic_format_args<basic_format_context<Out, charT>>;
+  // \ref{format.fmt.string}, class template \exposid{basic-format-string}
+  template<class charT, class... Args>
+    struct @\exposid{basic-format-string}@;                       // \expos
+
+  template<class... Args>
+    using @\exposid{format-string}@ =                             // \expos
+      @\exposid{basic-format-string}@<char, type_identity_t<Args>...>;
+  template<class... Args>
+    using @\exposid{wformat-string}@ =                            // \expos
+      @\exposid{basic-format-string}@<wchar_t, type_identity_t<Args>...>;
 
   // \ref{format.functions}, formatting functions
   template<class... Args>
-    string format(string_view fmt, const Args&... args);
+    string format(@\exposid{format-string}@<Args...> fmt, const Args&... args);
   template<class... Args>
-    wstring format(wstring_view fmt, const Args&... args);
+    wstring format(@\exposid{wformat-string}@<Args...> fmt, const Args&... args);
   template<class... Args>
-    string format(const locale& loc, string_view fmt, const Args&... args);
+    string format(const locale& loc, @\exposid{format-string}@<Args...> fmt, const Args&... args);
   template<class... Args>
-    wstring format(const locale& loc, wstring_view fmt, const Args&... args);
+    wstring format(const locale& loc, @\exposid{wformat-string}@<Args...> fmt, const Args&... args);
 
   string vformat(string_view fmt, format_args args);
   wstring vformat(wstring_view fmt, wformat_args args);
@@ -19659,26 +19667,22 @@ namespace std {
   wstring vformat(const locale& loc, wstring_view fmt, wformat_args args);
 
   template<class Out, class... Args>
-    Out format_to(Out out, string_view fmt, const Args&... args);
+    Out format_to(Out out, @\exposid{format-string}@<Args...> fmt, const Args&... args);
   template<class Out, class... Args>
-    Out format_to(Out out, wstring_view fmt, const Args&... args);
+    Out format_to(Out out, @\exposid{wformat-string}@<Args...> fmt, const Args&... args);
   template<class Out, class... Args>
-    Out format_to(Out out, const locale& loc, string_view fmt, const Args&... args);
+    Out format_to(Out out, const locale& loc, @\exposid{format-string}@<Args...> fmt, const Args&... args);
   template<class Out, class... Args>
-    Out format_to(Out out, const locale& loc, wstring_view fmt, const Args&... args);
+    Out format_to(Out out, const locale& loc, @\exposid{wformat-string}@<Args...> fmt, const Args&... args);
 
   template<class Out>
-    Out vformat_to(Out out, string_view fmt,
-                   format_args_t<type_identity_t<Out>, char> args);
+    Out vformat_to(Out out, string_view fmt, format_args, args);
   template<class Out>
-    Out vformat_to(Out out, wstring_view fmt,
-                   format_args_t<type_identity_t<Out>, wchar_t> args);
+    Out vformat_to(Out out, wstring_view fmt, wformat_args, args);
   template<class Out>
-    Out vformat_to(Out out, const locale& loc, string_view fmt,
-                   format_args_t<type_identity_t<Out>, char> args);
+    Out vformat_to(Out out, const locale& loc, string_view fmt, format_args args);
   template<class Out>
-    Out vformat_to(Out out, const locale& loc, wstring_view fmt,
-                   format_args_t<type_identity_t<Out>, wchar_t> args);
+    Out vformat_to(Out out, const locale& loc, wstring_view fmt, wformat_args args);
 
   template<class Out> struct format_to_n_result {
     Out out;
@@ -19686,27 +19690,27 @@ namespace std {
   };
   template<class Out, class... Args>
     format_to_n_result<Out> format_to_n(Out out, iter_difference_t<Out> n,
-                                        string_view fmt, const Args&... args);
+                                        @\exposid{format-string}@<Args...> fmt, const Args&... args);
   template<class Out, class... Args>
     format_to_n_result<Out> format_to_n(Out out, iter_difference_t<Out> n,
-                                        wstring_view fmt, const Args&... args);
+                                        @\exposid{wformat-string}@<Args...> fmt, const Args&... args);
   template<class Out, class... Args>
     format_to_n_result<Out> format_to_n(Out out, iter_difference_t<Out> n,
-                                        const locale& loc, string_view fmt,
+                                        const locale& loc, @\exposid{format-string}@<Args...> fmt,
                                         const Args&... args);
   template<class Out, class... Args>
     format_to_n_result<Out> format_to_n(Out out, iter_difference_t<Out> n,
-                                        const locale& loc, wstring_view fmt,
+                                        const locale& loc, @\exposid{wformat-string}@<Args...> fmt,
                                         const Args&... args);
 
   template<class... Args>
-    size_t formatted_size(string_view fmt, const Args&... args);
+    size_t formatted_size(@\exposid{format-string}@<Args...> fmt, const Args&... args);
   template<class... Args>
-    size_t formatted_size(wstring_view fmt, const Args&... args);
+    size_t formatted_size(@\exposid{wformat-string}@<Args...> fmt, const Args&... args);
   template<class... Args>
-    size_t formatted_size(const locale& loc, string_view fmt, const Args&... args);
+    size_t formatted_size(const locale& loc, @\exposid{format-string}@<Args...> fmt, const Args&... args);
   template<class... Args>
-    size_t formatted_size(const locale& loc, wstring_view fmt, const Args&... args);
+    size_t formatted_size(const locale& loc, @\exposid{wformat-string}@<Args...> fmt, const Args&... args);
 
   // \ref{format.formatter}, formatter
   template<class T, class charT = char> struct formatter;
@@ -19845,9 +19849,9 @@ mixture of automatic and manual indexing.
 string s0 = format("{} to {}",   "a", "b"); // OK, automatic indexing
 string s1 = format("{1} to {0}", "a", "b"); // OK, manual indexing
 string s2 = format("{0} to {}",  "a", "b"); // not a format string (mixing automatic and manual indexing),
-                                            // throws \tcode{format_error}
+                                            // ill-formed
 string s3 = format("{} to {1}",  "a", "b"); // not a format string (mixing automatic and manual indexing),
-                                            // throws \tcode{format_error}
+                                            // ill-formed
 \end{codeblock}
 \end{example}
 
@@ -20445,6 +20449,39 @@ They propagate exceptions thrown by operations of
 Failure to allocate storage is reported by
 throwing an exception as described in~\ref{res.on.exception.handling}.
 
+\rSec2[format.fmt.string]{Class template \exposid{basic-format-string}}
+
+\begin{codeblock}
+template<class charT, class... Args>
+struct @\exposid{basic-format-string}@ {            // \expos
+private:
+  basic_string_view<charT> @\exposid{str}@;         // \expos
+
+public:
+  template<class T> consteval @\exposid{basic-format-string}@(const T& s);
+};
+\end{codeblock}
+
+\begin{itemdecl}
+template<class T> consteval @\exposid{basic-format-string}@(const T& s);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{const T\&} models \tcode{\libconcept{convertible_to}<basic_string_view<charT>>}.
+
+\pnum
+\effects
+Direct-non-list-initializes \exposid{str} with \tcode{s}.
+
+\pnum
+\remarks
+A call to this function is not a core constant expression\iref{expr.const}
+unless there exist \tcode{args} of types \tcode{Args}
+such that \exposid{str} is a format string for \tcode{args}.
+\end{itemdescr}
+
 \rSec2[format.functions]{Formatting functions}
 
 \pnum
@@ -20456,7 +20493,7 @@ the same as in \ref{algorithms.requirements}.
 \indexlibraryglobal{format}%
 \begin{itemdecl}
 template<class... Args>
-  string format(string_view fmt, const Args&... args);
+  string format(@\exposid{format-string}@<Args...> fmt, const Args&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -20464,14 +20501,14 @@ template<class... Args>
 \effects
 Equivalent to:
 \begin{codeblock}
-return vformat(fmt, make_format_args(args...));
+return vformat(fmt.@\exposid{str}@, make_format_args(args...));
 \end{codeblock}
 \end{itemdescr}
 
 \indexlibraryglobal{format}%
 \begin{itemdecl}
 template<class... Args>
-  wstring format(wstring_view fmt, const Args&... args);
+  wstring format(@\exposid{wformat-string}@<Args...> fmt, const Args&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -20479,14 +20516,14 @@ template<class... Args>
 \effects
 Equivalent to:
 \begin{codeblock}
-return vformat(fmt, make_wformat_args(args...));
+return vformat(fmt.@\exposid{str}@, make_wformat_args(args...));
 \end{codeblock}
 \end{itemdescr}
 
 \indexlibraryglobal{format}%
 \begin{itemdecl}
 template<class... Args>
-  string format(const locale& loc, string_view fmt, const Args&... args);
+  string format(const locale& loc, @\exposid{format-string}@<Args...> fmt, const Args&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -20494,14 +20531,14 @@ template<class... Args>
 \effects
 Equivalent to:
 \begin{codeblock}
-return vformat(loc, fmt, make_format_args(args...));
+return vformat(loc, fmt.@\exposid{str}@, make_format_args(args...));
 \end{codeblock}
 \end{itemdescr}
 
 \indexlibraryglobal{format}%
 \begin{itemdecl}
 template<class... Args>
-  wstring format(const locale& loc, wstring_view fmt, const Args&... args);
+  wstring format(const locale& loc, @\exposid{wformat-string}@<Args...> fmt, const Args&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -20509,7 +20546,7 @@ template<class... Args>
 \effects
 Equivalent to:
 \begin{codeblock}
-return vformat(loc, fmt, make_wformat_args(args...));
+return vformat(loc, fmt.@\exposid{str}@, make_wformat_args(args...));
 \end{codeblock}
 \end{itemdescr}
 
@@ -20537,9 +20574,7 @@ As specified in~\ref{format.err.report}.
 \indexlibraryglobal{format_to}%
 \begin{itemdecl}
 template<class Out, class... Args>
-  Out format_to(Out out, string_view fmt, const Args&... args);
-template<class Out, class... Args>
-  Out format_to(Out out, wstring_view fmt, const Args&... args);
+  Out format_to(Out out, @\exposid{format-string}@<Args...> fmt, const Args&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -20547,17 +20582,14 @@ template<class Out, class... Args>
 \effects
 Equivalent to:
 \begin{codeblock}
-using context = basic_format_context<Out, decltype(fmt)::value_type>;
-return vformat_to(std::move(out), fmt, make_format_args<context>(args...));
+return vformat_to(out, fmt.@\exposid{str}@, make_format_args(args...));
 \end{codeblock}
 \end{itemdescr}
 
 \indexlibraryglobal{format_to}%
 \begin{itemdecl}
 template<class Out, class... Args>
-  Out format_to(Out out, const locale& loc, string_view fmt, const Args&... args);
-template<class Out, class... Args>
-  Out format_to(Out out, const locale& loc, wstring_view fmt, const Args&... args);
+  Out format_to(Out out, @\exposid{wformat-string}@<Args...> fmt, const Args&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -20565,25 +20597,50 @@ template<class Out, class... Args>
 \effects
 Equivalent to:
 \begin{codeblock}
-using context = basic_format_context<Out, decltype(fmt)::value_type>;
-return vformat_to(std::move(out), loc, fmt, make_format_args<context>(args...));
+return vformat_to(std::move(out), fmt.@\exposid{str}@, make_wformat_args(args...));
+\end{codeblock}
+\end{itemdescr}
+
+\indexlibraryglobal{format_to}%
+\begin{itemdecl}
+template<class Out, class... Args>
+  Out format_to(Out out, const locale& loc, @\exposid{format-string}@<Args...>  fmt, const Args&... args);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+return vformat_to(out, loc, fmt.@\exposid{str}@, make_format_args(args...));
+\end{codeblock}
+\end{itemdescr}
+
+\indexlibraryglobal{format_to}%
+\begin{itemdecl}
+template<class Out, class... Args>
+  Out format_to(Out out, const locale& loc, @\exposid{wformat-string}@<Args...> fmt, const Args&... args);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+return vformat_to(std::move(out), loc, fmt.@\exposid{str}@, make_wformat_args(args...));
 \end{codeblock}
 \end{itemdescr}
 
 \indexlibraryglobal{vformat_to}%
 \begin{itemdecl}
 template<class Out>
-  Out vformat_to(Out out, string_view fmt,
-                 format_args_t<type_identity_t<Out>, char> args);
+  Out vformat_to(Out out, string_view fmt, format_args args);
 template<class Out>
-  Out vformat_to(Out out, wstring_view fmt,
-                 format_args_t<type_identity_t<Out>, wchar_t> args);
+  Out vformat_to(Out out, wstring_view fmt, wformat_args args);
 template<class Out>
-  Out vformat_to(Out out, const locale& loc, string_view fmt,
-                 format_args_t<type_identity_t<Out>, char> args);
+  Out vformat_to(Out out, const locale& loc, string_view fmt, format_args args);
 template<class Out>
-  Out vformat_to(Out out, const locale& loc, wstring_view fmt,
-                 format_args_t<type_identity_t<Out>, wchar_t> args);
+  Out vformat_to(Out out, const locale& loc, wstring_view fmt, wformat_args args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -20622,17 +20679,17 @@ As specified in~\ref{format.err.report}.
 \begin{itemdecl}
 template<class Out, class... Args>
   format_to_n_result<Out> format_to_n(Out out, iter_difference_t<Out> n,
-                                      string_view fmt, const Args&... args);
+                                      @\exposid{format-string}@<Args...> fmt, const Args&... args);
 template<class Out, class... Args>
   format_to_n_result<Out> format_to_n(Out out, iter_difference_t<Out> n,
-                                      wstring_view fmt, const Args&... args);
+                                      @\exposid{wformat-string}@<Args...> fmt, const Args&... args);
 template<class Out, class... Args>
   format_to_n_result<Out> format_to_n(Out out, iter_difference_t<Out> n,
-                                      const locale& loc, string_view fmt,
+                                      const locale& loc, @\exposid{format-string}@<Args...> fmt,
                                       const Args&... args);
 template<class Out, class... Args>
   format_to_n_result<Out> format_to_n(Out out, iter_difference_t<Out> n,
-                                      const locale& loc, wstring_view fmt,
+                                      const locale& loc, @\exposid{wformat-string}@<Args...> fmt,
                                       const Args&... args);
 \end{itemdecl}
 
@@ -20640,7 +20697,7 @@ template<class Out, class... Args>
 \pnum
 Let
 \begin{itemize}
-\item \tcode{charT} be \tcode{decltype(fmt)::value_type},
+\item \tcode{charT} be \tcode{decltype(fmt.\exposid{str})::value_type},
 \item \tcode{N} be
 \tcode{formatted_size(fmt, args...)} for the functions without a \tcode{loc} parameter and
 \tcode{formatted_size(loc, fmt, args...)} for the functions with a \tcode{loc} parameter, and
@@ -20678,18 +20735,18 @@ As specified in~\ref{format.err.report}.
 \indexlibraryglobal{formatted_size}%
 \begin{itemdecl}
 template<class... Args>
-  size_t formatted_size(string_view fmt, const Args&... args);
+  size_t formatted_size(@\exposid{format-string}@<Args...> fmt, const Args&... args);
 template<class... Args>
-  size_t formatted_size(wstring_view fmt, const Args&... args);
+  size_t formatted_size(@\exposid{wformat-string}@<Args...> fmt, const Args&... args);
 template<class... Args>
-  size_t formatted_size(const locale& loc, string_view fmt, const Args&... args);
+  size_t formatted_size(const locale& loc, @\exposid{format-string}@<Args...> fmt, const Args&... args);
 template<class... Args>
-  size_t formatted_size(const locale& loc, wstring_view fmt, const Args&... args);
+  size_t formatted_size(const locale& loc, @\exposid{wformat-string}@<Args...> fmt, const Args&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-Let \tcode{charT} be \tcode{decltype(fmt)::value_type}.
+Let \tcode{charT} be \tcode{decltype(fmt.\exposid{str})::value_type}.
 
 \pnum
 \expects


### PR DESCRIPTION
 - Avoid redundantly presenting the definition of basic-format-string
   in the header synopsis.
 - Do not italicize basic-format-string's private exposition-only member,
   consistent with similar situations.

Fixes #4653
Fixes cplusplus/papers#919