### PR TITLE
[conv.general] Fix index redirect for contextual conversion to bool.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -483,7 +483,7 @@ The glvalue expression is evaluated and its value is discarded.
 \rSec2[conv.general]{General}
 
 \indextext{implicit conversion|see{conversion, implicit}}
-\indextext{contextually converted to bool|see{conversion, contextual}}
+\indextext{contextually converted to \tcode{bool}|see{conversion, contextual to \tcode{bool}}}
 \indextext{rvalue!lvalue conversion to|see{conversion, lvalue-to-rvalue}}%
 
 \pnum


### PR DESCRIPTION
Here's the entry being redirected to:

https://github.com/cplusplus/draft/blob/fb3bea889899c5ea5c0f70b12fc72129f7d1692a/source/expressions.tex#L552