### PR TITLE
Clarify definition of "variable"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -92,8 +92,11 @@ by a \grammarterm{typedef-name} introduced by a declaration specifying $E$.
 \pnum
 A \defn{variable} is introduced by the
 declaration of
-a reference other than a non-static data member or of
-an object. The variable's name, if any, denotes the reference or object.
+an object or reference, other than a non-static data member.
+The variable's name, if any, denotes the reference or object.
+\begin{note}
+A declaration of a non-static data member of object type is not a declaration of an object.
+\end{note}
 
 \pnum
 A \defnadj{local}{entity} is a variable with


### PR DESCRIPTION
In the current definition, the special exception for non-static data members is only stated for references, which gives the misleading impression that non-reference non-static data member declarations are variable declarations. By re-wording the definition, we can make it clear that a non-static data member declaration is never a variable declaration.