### PR TITLE
[format.syn] Remove extraneous commas in vformat_to declarations

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -19676,9 +19676,9 @@ namespace std {
     Out format_to(Out out, const locale& loc, @\exposid{wformat-string}@<Args...> fmt, const Args&... args);
 
   template<class Out>
-    Out vformat_to(Out out, string_view fmt, format_args, args);
+    Out vformat_to(Out out, string_view fmt, format_args args);
   template<class Out>
-    Out vformat_to(Out out, wstring_view fmt, wformat_args, args);
+    Out vformat_to(Out out, wstring_view fmt, wformat_args args);
   template<class Out>
     Out vformat_to(Out out, const locale& loc, string_view fmt, format_args args);
   template<class Out>


### PR DESCRIPTION
Fixes occurrences noted in #4680