### PR TITLE
[basic.string.general], [string.view.template.general] remove constexpr

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -824,7 +824,7 @@ namespace std {
       constexpr explicit basic_string(const T& t, const Allocator& a = Allocator());
     constexpr basic_string(const charT* s, size_type n, const Allocator& a = Allocator());
     constexpr basic_string(const charT* s, const Allocator& a = Allocator());
-    constexpr basic_string(nullptr_t) = delete;
+    basic_string(nullptr_t) = delete;
     constexpr basic_string(size_type n, charT c, const Allocator& a = Allocator());
     template<class InputIterator>
       constexpr basic_string(InputIterator begin, InputIterator end,
@@ -841,7 +841,7 @@ namespace std {
     template<class T>
       constexpr basic_string& operator=(const T& t);
     constexpr basic_string& operator=(const charT* s);
-    constexpr basic_string& operator=(nullptr_t) = delete;
+    basic_string& operator=(nullptr_t) = delete;
     constexpr basic_string& operator=(charT c);
     constexpr basic_string& operator=(initializer_list<charT>);
 
@@ -4090,7 +4090,7 @@ Because \tcode{basic_string_view} refers to a constant sequence, \tcode{iterator
     constexpr basic_string_view(const basic_string_view&) noexcept = default;
     constexpr basic_string_view& operator=(const basic_string_view&) noexcept = default;
     constexpr basic_string_view(const charT* str);
-    constexpr basic_string_view(nullptr_t) = delete;
+    basic_string_view(nullptr_t) = delete;
     constexpr basic_string_view(const charT* str, size_type len);
     template<class It, class End>
       constexpr basic_string_view(It begin, End end);


### PR DESCRIPTION
There is no reason to declare a deleted function constexpr.