### PR TITLE
remove the condition to clarify the case that the parameter pack is n…

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -2816,8 +2816,7 @@ an \grammarterm{id-expression}
 a \grammarterm{typedef-name}
 (for a type template parameter pack declared without \tcode{template}), or
 a \grammarterm{template-name}
-(for a type template parameter pack declared with \tcode{template})
-if the pack was introduced by a pack expansion,
+(for a type template parameter pack declared with \tcode{template}),
 designating the $i^\text{th}$ corresponding type or value template argument;
 
 \item


### PR DESCRIPTION
I still think "if the pack was introduced by a pack expansion" should be removed for bullet 8.1. For example, `template<int...N> struct B{ B(){fun(N...);}};`, Isn't that each element instantiated in `N...` does designate the corresponding template argument? However, `int... N` is just a template parameter pack declaration instead of a pack expansion(where the template parameter pack `N` is introduced by the parameter pack declaration). If add the condition seems that the latter clause is not suitable for this case. For type template parameter pack, it is the same. `template<template<class T>... TMPL> struct C{using T =  U<TMPL....>;};`, `template<class...T> struct D{using T = tuple<T...>;}`, in all of these cases, the pack is introduced by the parameter pack declaration that is not a **pack expansion** itself, but each element actually does designate the ith template argument.