### PR TITLE
Better string splitting example

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -6192,10 +6192,8 @@ the expression \tcode{views::split(E, F)} is expression-equivalent to
 \begin{example}
 \begin{codeblock}
 string str{"the quick brown fox"};
-for (span<char const> word : split(str, ' ')) {
-  for (char ch : word)
-    cout << ch;
-  cout << '*';
+for (string_view word : split(str, ' ')) {
+  cout << word << '*';
 }
 // The above prints: the*quick*brown*fox*
 \end{codeblock}


### PR DESCRIPTION
With the adoption of P1989, string_view is constructible from
subrange, we can use that to provide a good example of
string splitting.