### PR TITLE
[iterator.operations, range.iter.op.distance] Reword "get to".

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2763,11 +2763,9 @@ the \oldconcept{RandomAccessIterator} requirements and
 \pnum
 \effects
 If \tcode{InputIterator} meets the \oldconcept{RandomAccessIterator} requirements,
-returns \tcode{(last - first)}; otherwise, returns
-the number of increments needed to get from
-\tcode{first}
-to
-\tcode{last}.
+returns \tcode{(last - first)}; otherwise, increments
+\tcode{first} until \tcode{last} is reached and returns
+the number of increments.
 \end{itemdescr}
 
 \indexlibraryglobal{next}%
@@ -2952,10 +2950,9 @@ template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<
 \effects
 If \tcode{S} and \tcode{I} model \tcode{\libconcept{sized_sentinel_for}<S, I>},
 returns \tcode{(last - first)};
-otherwise, returns the number of increments needed to get from
-\tcode{first}
-to
-\tcode{last}.
+otherwise, increments
+\tcode{first} until \tcode{last} is reached and returns
+the number of increments.
 \end{itemdescr}
 
 \indexlibraryglobal{distance}%


### PR DESCRIPTION
It was previously not explicitly stated that input iterators would
actually be incremented (which invalidates copies). The new wording is
more explicit about how the distance is measured, and in doing so
calls out more explicitly that input iterators are indeed incremented.

Fixes #2807.
Fixes #2813.

This is an alternative approach to #2813, as suggested by @jensmaurer in the comments.

@jwakely, @CaseyCarter, I'd welcome your review on this!