### PR TITLE
[format] Use \exposid{,nc} for format-arg-store, not \placeholder

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -19728,13 +19728,13 @@ namespace std {
     decltype(auto) visit_format_arg(Visitor&& vis, basic_format_arg<Context> arg);
 
   // \ref{format.arg.store}, class template \exposid{format-arg-store}
-  template<class Context, class... Args> class @\placeholder{format-arg-store}@;       // \expos
+  template<class Context, class... Args> class @\exposidnc{format-arg-store}@;        // \expos
 
   template<class Context = format_context, class... Args>
-    @\placeholder{format-arg-store}@<Context, Args...>
+    @\exposid{format-arg-store}@<Context, Args...>
       make_format_args(const Args&... fmt_args);
   template<class... Args>
-    @\placeholder{format-arg-store}@<wformat_context, Args...>
+    @\exposid{format-arg-store}@<wformat_context, Args...>
       make_wformat_args(const Args&... args);
 
   // \ref{format.error}, class \tcode{format_error}
@@ -21557,8 +21557,8 @@ Equivalent to: \tcode{return visit(forward<Visitor>(vis), arg.value);}
 \begin{codeblock}
 namespace std {
   template<class Context, class... Args>
-  class @\exposid{format-arg-store}@ {                                      // \expos
-    array<basic_format_arg<Context>, sizeof...(Args)> @\exposid{args}@;     // \expos
+  class @\exposidnc{format-arg-store}@ {                                      // \expos
+    array<basic_format_arg<Context>, sizeof...(Args)> @\exposidnc{args}@;     // \expos
   };
 }
 \end{codeblock}
@@ -21569,7 +21569,7 @@ An instance of \exposid{format-arg-store} stores formatting arguments.
 \indexlibraryglobal{make_format_args}%
 \begin{itemdecl}
 template<class Context = format_context, class... Args>
-  @\placeholder{format-arg-store}@<Context, Args...> make_format_args(const Args&... fmt_args);
+  @\exposid{format-arg-store}@<Context, Args...> make_format_args(const Args&... fmt_args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -21590,7 +21590,7 @@ whose \exposid{args} data member is initialized with
 \indexlibraryglobal{make_wformat_args}%
 \begin{itemdecl}
 template<class... Args>
-  @\placeholder{format-arg-store}@<wformat_context, Args...> make_wformat_args(const Args&... args);
+  @\exposid{format-arg-store}@<wformat_context, Args...> make_wformat_args(const Args&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -21613,7 +21613,7 @@ namespace std {
     basic_format_args() noexcept;
 
     template<class... Args>
-      basic_format_args(const @\placeholder{format-arg-store}@<Context, Args...>& store) noexcept;
+      basic_format_args(const @\exposid{format-arg-store}@<Context, Args...>& store) noexcept;
 
     basic_format_arg<Context> get(size_t i) const noexcept;
   };
@@ -21645,7 +21645,7 @@ Initializes \tcode{size_} with \tcode{0}.
 \indexlibraryctor{basic_format_args}%
 \begin{itemdecl}
 template<class... Args>
-  basic_format_args(const @\placeholder{format-arg-store}@<Context, Args...>& store) noexcept;
+  basic_format_args(const @\exposid{format-arg-store}@<Context, Args...>& store) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Fixes #4698.