### PR TITLE
[lib] Remove space between `requires` and parameter list

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -964,7 +964,7 @@ resolve to the corresponding built-in operators.
 \begin{itemdecl}
 template<class T>
   concept @\defexposconcept{boolean-testable}@ =                // \expos
-    @\exposconcept{boolean-testable-impl}@<T> && requires (T&& t) {
+    @\exposconcept{boolean-testable-impl}@<T> && requires(T&& t) {
       { !std::forward<T>(t) } -> @\exposconcept{boolean-testable-impl}@;
     };
 \end{itemdecl}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -3287,7 +3287,7 @@ return *--tmp;
 \begin{itemdecl}
 constexpr pointer operator->() const
   requires (is_pointer_v<Iterator> ||
-            requires (const Iterator i) { i.operator->(); });
+            requires(const Iterator i) { i.operator->(); });
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5002,7 +5002,7 @@ common_iterator tmp = *this;
 return tmp;
 \end{codeblock}
 Otherwise, if
-\tcode{requires (I\& i) \{ \{ *i++ \} -> \exposconceptnc{can-reference}; \}}
+\tcode{requires(I\& i) \{ \{ *i++ \} -> \exposconceptnc{can-reference}; \}}
 is \tcode{true} or
 \tcode{\libconceptx{constructible_\newline{}from}{constructible_from}<iter_value_t<I>, iter_reference_t<I>>}
 is \tcode{false},


### PR DESCRIPTION
Or
> [concept.booleantestable,reverse.iter.elem,common.iter.nav] Remove space between `requires` and parameter list