### PR TITLE
[range.split.iterator] Fix formatting of the 'Effects' clause

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -6374,7 +6374,7 @@ constexpr value_type operator*() const;
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to \tcode{return {\exposid{cur_}, \exposid{next_}.begin()};}
+Equivalent to \tcode{return \{\exposid{cur_}, \exposid{next_}.begin()\};}
 \end{itemdescr}
 
 \begin{itemdecl}


### PR DESCRIPTION
Before:
![upload](https://user-images.githubusercontent.com/8998201/123510769-e2f10800-d6af-11eb-9039-20a4e43b88b0.png)
After:
![upload](https://user-images.githubusercontent.com/8998201/123510779-f3a17e00-d6af-11eb-94b1-15bee5473376.png)
