### PR TITLE
[range.nonprop.cache] Clarify that emplace-deref does not require materialization of the result of *i before the initialization

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -3216,6 +3216,10 @@ template<class I>
  \mandates
 The declaration \tcode{T t(*i);} is well-formed
 for some invented variable \tcode{t}.
+\begin{note}
+When \tcode{*i} is a prvalue of type \cv{} \tcode{T},
+\tcode{is_constructible_v<T, decltype(*i)>} can be \tcode{false}.
+\end{note}
 
  \effects
 Calls \tcode{reset()}.

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -3217,8 +3217,8 @@ template<class I>
 The declaration \tcode{T t(*i);} is well-formed
 for some invented variable \tcode{t}.
 \begin{note}
-When \tcode{*i} is a prvalue of type \cv{} \tcode{T},
-\tcode{is_constructible_v<T, decltype(*i)>} can be \tcode{false}.
+If \tcode{*i} is a prvalue of type \cv{} \tcode{T},
+there is no requirement that it is movable\iref{dcl.init.general}.
 \end{note}
 
  \effects


### PR DESCRIPTION
Based on empirical evidence, the existing wording is too subtle, so this adds a note to make the implication more obvious.