### PR TITLE
[expr.mptr.oper] Clarify pointer-to-member operators.

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5883,16 +5883,15 @@ left-to-right.
 
 \pnum
 The binary operator \tcode{.*} binds its second operand, which shall be
-of type ``pointer to member of \tcode{T}'' to its first operand, which shall be
+of type ``pointer to member of class \tcode{T} of type \tcode{X}'' to its first operand, which shall be
 a glvalue
 of
 class \tcode{T} or of a class of which \tcode{T} is an unambiguous and
-accessible base class. The result is an object or a function of the type
-specified by the second operand.
+accessible base class. The result is an object or function of type \tcode{X}.
 
 \pnum
 The binary operator \tcode{->*} binds its second operand, which shall be
-of type ``pointer to member of \tcode{T}'' to its first operand, which shall be of
+of type ``pointer to member of class \tcode{T}'' to its first operand, which shall be of
 type ``pointer to \tcode{U}''
 where \tcode{U} is either \tcode{T} or
 a class of which \tcode{T}
@@ -5912,7 +5911,10 @@ Otherwise, the expression \tcode{E1} is sequenced before the expression \tcode{E
 The restrictions on cv-qualification, and the manner in which
 the cv-qualifiers of the operands are combined to produce the
 cv-qualifiers of the result, are the same as the rules for
-\tcode{E1.E2} given in~\ref{expr.ref}.
+\tcode{E1.EM} given in~\ref{expr.ref},
+where \tcode{EM} is an \grammarterm{identifier}
+naming a hypothetical non-static non-mutable member of class \tcode{T}
+declared with type \tcode{X}.
 \begin{note}
 It is not possible to use a pointer to member that refers to a
 \keyword{mutable} member to modify a const class object. For


### PR DESCRIPTION
Fixes #4703