### PR TITLE
[stmt.return,class.{ctor,dtor}] Clarify no return operand

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1208,12 +1208,13 @@ They come into effect when the constructor for the
 most derived object\iref{intro.object} ends.
 
 \pnum
-\indextext{restriction!constructor}%
-A
-\tcode{return}
-statement in the body of a constructor shall not specify a return value.
 \indextext{constructor!address of}%
 The address of a constructor shall not be taken.
+\indextext{restriction!constructor}%
+\begin{note}
+A \tcode{return} statement in the body of a constructor
+cannot specify a return value\iref{stmt.return}.
+\end{note}
 
 \pnum
 A constructor shall not be a coroutine.
@@ -2071,8 +2072,13 @@ and in particular,
 the selected destructor may be deleted\iref{dcl.fct.def.delete}.
 
 \pnum
-\indextext{restriction!destructor}%
+\indextext{destructor!address of}%
 The address of a destructor shall not be taken.
+\indextext{restriction!destructor}%
+\begin{note}
+A \tcode{return} statement in the body of a destructor
+cannot specify a return value\iref{stmt.return}.
+\end{note}
 \indextext{\idxcode{const}!destructor and}%
 \indextext{\idxcode{volatile}!destructor and}%
 A destructor can be invoked for a

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -811,14 +811,17 @@ destructor\iref{class.dtor}.
 \indextext{\idxcode{return}!constructor and}%
 \indextext{\idxcode{return}!constructor and}%
 A \tcode{return} statement with an operand of type \keyword{void} shall be used only
-in a function whose return type is \cv{}~\keyword{void}.
+in a function that has a \cv{}~\keyword{void} return type.
 A \tcode{return} statement with any other operand shall be used only
-in a function whose return type is not \cv{}~\keyword{void};
+in a function that has a return type other than \cv{}~\keyword{void};
 \indextext{conversion!return type}%
 the \tcode{return} statement initializes the
 returned reference or prvalue result object
 of the (explicit or implicit) function call
 by copy-initialization\iref{dcl.init} from the operand.
+\begin{note}
+A constructor or destructor does not have a return type.
+\end{note}
 \begin{note}
 A \tcode{return} statement can involve
 an invocation of a constructor to perform a copy or move of the operand


### PR DESCRIPTION
Highlight that constructors and destructors do not have a
return type and thus a return statement within a constructor
or destructor cannot have an operand.

Supersedes #3647