### PR TITLE
[expr.new] Clarify result type and value category

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4931,28 +4931,6 @@ argument and returning \tcode{int}).
 \end{note}
 
 \pnum
-\indextext{storage duration!dynamic}%
-Objects created by a \grammarterm{new-expression} have dynamic storage
-duration\iref{basic.stc.dynamic}.
-\begin{note}
-\indextext{\idxcode{new}!scoping and}%
-The lifetime of such an object is not necessarily restricted to the
-scope in which it is created.
-\end{note}
-When the allocated object is not an array, the result of the \grammarterm{new-expression}
-is a pointer to the object created.
-
-\pnum
-\indextext{array!\idxcode{new}}%
-When the allocated object is an array (that is, the
-\grammarterm{noptr-new-declarator} syntax is used or the
-\grammarterm{new-type-id} or \grammarterm{type-id} denotes an array type), the
-\grammarterm{new-expression} yields a pointer to the initial element (if
-any) of the array.
-\begin{note}
-Both \tcode{\keyword{new} \keyword{int}} and \tcode{\keyword{new} \keyword{int}[10]} have type \tcode{\keyword{int}*} and
-the type of \tcode{\keyword{new} \keyword{int}[i][10]} is \tcode{\keyword{int} (*)[10]}
-\end{note}
 The \grammarterm{attribute-specifier-seq} in a \grammarterm{noptr-new-declarator} appertains
 to the associated array type.
 
@@ -5032,6 +5010,32 @@ exception of a type that would match a handler\iref{except.handle} of type
 \end{itemize}
 When the value of the \grammarterm{expression} is zero, the allocation
 function is called to allocate an array with no elements.
+
+\pnum
+\indextext{storage duration!dynamic}%
+Objects created by a \grammarterm{new-expression} have dynamic storage
+duration\iref{basic.stc.dynamic}.
+\begin{note}
+\indextext{\idxcode{new}!scoping and}%
+The lifetime of such an object is not necessarily restricted to the
+scope in which it is created.
+\end{note}
+
+\pnum
+\indextext{array!\idxcode{new}}%
+When the allocated type is ``array of \tcode{N} \tcode{T}''
+(that is, the \grammarterm{noptr-new-declarator} syntax is used or the
+\grammarterm{new-type-id} or \grammarterm{type-id} denotes an array type),
+the \grammarterm{new-expression} yields a prvalue of type ``pointer to \tcode{T}''
+that points to the initial element (if any) of the array.
+Otherwise, let \tcode{T} be the allocated type;
+the \grammarterm{new-expression}
+is a prvalue of type ``pointer to T''
+that points to the object created.
+\begin{note}
+Both \tcode{\keyword{new} \keyword{int}} and \tcode{\keyword{new} \keyword{int}[10]} have type \tcode{\keyword{int}*} and
+the type of \tcode{\keyword{new} \keyword{int}[i][10]} is \tcode{\keyword{int} (*)[10]}.
+\end{note}
 
 \pnum
 A \grammarterm{new-expression} may obtain storage for the object by calling an


### PR DESCRIPTION
Also move the relevant text to after the syntactic constraints.

Fixes #4752.