### PR TITLE
[expr.delete] Replace 'denote' with 'pointed to'

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5595,9 +5595,9 @@ is selected.
 \pnum
 For a single-object delete expression,
 the deleted object is
-the object denoted by the operand
-if its static type does not have a virtual destructor,
-and its most-derived object otherwise.
+the object $A$ pointed to by the operand
+if the static type of $A$ does not have a virtual destructor,
+and the most-derived object of $A$ otherwise.
 \begin{note}
 If the deallocation function is not a destroying operator delete
 and the deleted object is not the most derived object in the former case,


### PR DESCRIPTION
and clarify ambiguous antecedent for 'its'.

Fixes #4746