### PR TITLE
[stmt.dcl] Clarify 'active' variables

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -942,14 +942,14 @@ after which it resumes its force.
 A variable with automatic storage duration\iref{basic.stc.auto}
 is \defnx{active}{variable!active} everywhere in the scope to which it belongs
 after its \grammarterm{init-declarator}.
-
-\pnum
 \indextext{initialization!jump past}%
 \indextext{\idxcode{goto}!initialization and}%
 Upon each transfer of control (including sequential execution of statements)
 within a function from point $P$ to point $Q$,
-all variables that are active at $P$ and not at $Q$ are destroyed in the reverse order of their construction.
-Then, all variables that are active at $Q$ but not at $P$ are initialized in declaration order;
+all variables with automatic storage duration
+that are active at $P$ and not at $Q$ are destroyed in the reverse order of their construction.
+Then, all variables with automatic storage duration
+that are active at $Q$ but not at $P$ are initialized in declaration order;
 unless all such variables have vacuous initialization\iref{basic.life},
 the transfer of control shall not be a jump.
 \begin{footnote}


### PR DESCRIPTION
They necessarily have automatic storage duration.

Fixes #4741