### PR TITLE
[meta.member] Clarify is_corresponding_member semantics

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -18582,7 +18582,7 @@ template<class S1, class S2, class M1, class M2>
 \pnum
 \returns
 \tcode{true} if and only if
- \tcode{S1} and \tcode{S2} are standard-layout types,
+ \tcode{S1} and \tcode{S2} are standard-layout struct\iref{class.prop} types,
  \tcode{M1} and \tcode{M2} are object types,
  \tcode{m1} and \tcode{m2} are not null,
  and \tcode{m1} and \tcode{m2} point to corresponding members of


### PR DESCRIPTION
The definition of 'common initial sequence' in [class.mem] only applies
to standard-layout struct types, which excludes unions. There is no
reason to define is_corresponding_member in terms of standard-layout
types (which includes unions and scalars and arrays of such types) when
the common initial sequence is only meaningful for standard-layout
structs.