### PR TITLE
[std] Use \Fundescx to avoid awkward mid-sentence colons.

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -115,7 +115,7 @@ the names of template parameters are used to express type requirements.
 \end{itemize}
 
 \pnum
-If an algorithm's \effects element specifies
+If an algorithm's \effectsx{} element specifies
 that a value pointed to by any iterator passed as an argument is modified,
 then that algorithm has an additional type requirement:
 The type of that argument shall meet

--- a/source/future.tex
+++ b/source/future.tex
@@ -1,7 +1,8 @@
 %!TEX root = std.tex
 \normannex{depr}{Compatibility features}
 
-\newcommand{\requires}{\Fundesc{Requires}}
+\newcommand{\requiresx}{\Fundescx{Requires}}
+\newcommand{\requires}{\Fundesc{\requiresx}}
 
 \rSec1[depr.general]{General}
 
@@ -403,14 +404,14 @@ the namespace \tcode{std}.
 
 \pnum
 In addition to the elements specified in \ref{structure.specifications},
-descriptions of function semantics may also contain a \requires element
+descriptions of function semantics may also contain a \requiresx{} element
 to denote the preconditions for calling a function.
 
 \pnum
 \indextext{restriction}%
-Violation of any preconditions specified in a function's \requires element
+Violation of any preconditions specified in a function's \requiresx{} element
 results in undefined behavior
-unless the function's \throws element
+unless the function's \throwsx{} element
 specifies throwing an exception when the precondition is violated.
 
 \rSec1[depr.relops]{Relational operators}%

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -15276,7 +15276,7 @@ as described in \ref{fs.class.directory.iterator.general}.
 \rSec3[fs.dir.entry.obs]{Observers}
 
 \pnum
-Unqualified function names in the \returns elements of the
+Unqualified function names in the \returnsx{} elements of the
 \tcode{directory_entry} observers described below refer to members of the
 \tcode{std::filesystem} namespace.
 

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -3564,7 +3564,7 @@ template<class Iterator1, @\libconcept{three_way_comparable_with}@<Iterator1> It
 
 \pnum
 \begin{note}
-The argument order in the \returns element is reversed
+The argument order in the \returnsx{} element is reversed
 because this is a reverse iterator.
 \end{note}
 \end{itemdescr}
@@ -5678,7 +5678,7 @@ Equivalent to: \tcode{return y.length <=> x.length;}
 
 \pnum
 \begin{note}
-The argument order in the \effects element is reversed
+The argument order in the \effectsx{} element is reversed
 because \tcode{length} counts down, not up.
 \end{note}
 \end{itemdescr}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -300,7 +300,7 @@ appropriate):
 \begin{footnote}
 To save space, elements that do not apply to a function are omitted.
 For example, if a function specifies no
-preconditions, there will be no \expects element.
+preconditions, there will be no \expectsx{} element.
 \end{footnote}
 
 \begin{itemize}
@@ -371,22 +371,22 @@ the error conditions for error codes reported by the function.
 \end{itemize}
 
 \pnum
-Whenever the \Fundescx{Effects} element specifies that the semantics of some function
+Whenever the \effectsx{} element specifies that the semantics of some function
 \tcode{F} are \term{Equivalent to} some code sequence, then the various elements are
 interpreted as follows.
-If \tcode{F}'s semantics specifies any \Fundescx{Constraints} or \Fundescx{Mandates} elements,
+If \tcode{F}'s semantics specifies any \constraintsx{} or \mandatesx{} elements,
 then those requirements are logically imposed prior to the \term{equivalent-to} semantics.
 Next, the semantics of the code sequence are determined by the
-\Fundescx{Constraints}, \Fundescx{Mandates}, \Fundescx{Preconditions}, \Fundescx{Effects},
-\Fundescx{Synchronization}, \Fundescx{Postconditions}, \Fundescx{Returns}, \Fundescx{Throws},
-\Fundescx{Complexity}, \Fundescx{Remarks}, and \Fundescx{Error conditions}
+\constraintsx{}, \mandatesx{}, \expectsx{}, \effectsx{},
+\syncx{}, \ensuresx{}, \returnsx{}, \throwsx{},
+\complexityx{}, \remarksx{}, and \errorsx{}
 specified for the function invocations contained in the code sequence.
-The value returned from \tcode{F} is specified by \tcode{F}'s \Fundescx{Returns} element,
-or if \tcode{F} has no \Fundescx{Returns} element,
+The value returned from \tcode{F} is specified by \tcode{F}'s \returnsx{} element,
+or if \tcode{F} has no \returnsx{} element,
 a non-\keyword{void} return from \tcode{F} is specified by the
 \tcode{return} statements\iref{stmt.return} in the code sequence.
-If \tcode{F}'s semantics contains a \Fundescx{Throws},
-\Fundescx{Postconditions}, or \Fundescx{Complexity} element,
+If \tcode{F}'s semantics contains a \throwsx{},
+\ensuresx{}, or \complexityx{} element,
 then that supersedes any occurrences of that element in the code sequence.
 
 \pnum
@@ -3153,8 +3153,8 @@ unless otherwise specified.
 Any of the functions defined in the \Cpp{} standard library
 \indextext{library!\Cpp{} standard}%
 can report a failure by throwing an exception of a type
-described in its \throws paragraph,
-or of a type derived from a type named in the \throws paragraph
+described in its \throwsx{} paragraph,
+or of a type derived from a type named in the \throwsx{} paragraph
 that would be caught by an exception handler for the base type.
 
 \pnum
@@ -3186,7 +3186,7 @@ non-throwing exception specification.
 Functions defined in the
 \Cpp{} standard library
 \indextext{specifications!\Cpp{}}%
-that do not have a \throws paragraph
+that do not have a \throwsx{} paragraph
 but do have a potentially-throwing exception specification
 may throw \impldef{exceptions thrown by standard library functions that have a
 potentially-throwing exception specification} exceptions.

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -320,30 +320,53 @@
 
 %% Library function descriptions
 \newcommand{\Fundescx}[1]{\textit{#1}}
-\newcommand{\Fundesc}[1]{\Fundescx{#1}:\space}
-\newcommand{\recommended}{\Fundesc{Recommended practice}}
-\newcommand{\required}{\Fundesc{Required behavior}}
-\newcommand{\constraints}{\Fundesc{Constraints}}
-\newcommand{\mandates}{\Fundesc{Mandates}}
-\newcommand{\expects}{\Fundesc{Preconditions}}
-\newcommand{\effects}{\Fundesc{Effects}}
-\newcommand{\ensures}{\Fundesc{Postconditions}}
-\newcommand{\returns}{\Fundesc{Returns}}
-\newcommand{\throws}{\Fundesc{Throws}}
-\newcommand{\default}{\Fundesc{Default behavior}}
-\newcommand{\complexity}{\Fundesc{Complexity}}
-\newcommand{\remarks}{\Fundesc{Remarks}}
-\newcommand{\errors}{\Fundesc{Error conditions}}
-\newcommand{\sync}{\Fundesc{Synchronization}}
-\newcommand{\implimits}{\Fundesc{Implementation limits}}
-\newcommand{\replaceable}{\Fundesc{Replaceable}}
-\newcommand{\returntype}{\Fundesc{Return type}}
-\newcommand{\cvalue}{\Fundesc{Value}}
-\newcommand{\ctype}{\Fundesc{Type}}
-\newcommand{\ctypes}{\Fundesc{Types}}
-\newcommand{\dtype}{\Fundesc{Default type}}
-\newcommand{\ctemplate}{\Fundesc{Class template}}
-\newcommand{\templalias}{\Fundesc{Alias template}}
+\newcommand{\Fundesc}[1]{#1:\space}
+\newcommand{\recommendedx}{\Fundescx{Recommended practice}}
+\newcommand{\recommended}{\Fundesc{\recommendedx}}
+\newcommand{\requiredx}{\Fundescx{Required behavior}}
+\newcommand{\required}{\Fundesc{\requiredx}}
+\newcommand{\constraintsx}{\Fundescx{Constraints}}
+\newcommand{\constraints}{\Fundesc{\constraintsx}}
+\newcommand{\mandatesx}{\Fundescx{Mandates}}
+\newcommand{\mandates}{\Fundesc{\mandatesx}}
+\newcommand{\expectsx}{\Fundescx{Preconditions}}
+\newcommand{\expects}{\Fundesc{\expectsx}}
+\newcommand{\effectsx}{\Fundescx{Effects}}
+\newcommand{\effects}{\Fundesc{\effectsx}}
+\newcommand{\ensuresx}{\Fundescx{Postconditions}}
+\newcommand{\ensures}{\Fundesc{\ensuresx}}
+\newcommand{\returnsx}{\Fundescx{Returns}}
+\newcommand{\returns}{\Fundesc{\returnsx}}
+\newcommand{\throwsx}{\Fundescx{Throws}}
+\newcommand{\throws}{\Fundesc{\throwsx}}
+\newcommand{\defaultx}{\Fundescx{Default behavior}}
+\newcommand{\default}{\Fundesc{\defaultx}}
+\newcommand{\complexityx}{\Fundescx{Complexity}}
+\newcommand{\complexity}{\Fundesc{\complexityx}}
+\newcommand{\remarksx}{\Fundescx{Remarks}}
+\newcommand{\remarks}{\Fundesc{\remarksx}}
+\newcommand{\errorsx}{\Fundescx{Error conditions}}
+\newcommand{\errors}{\Fundesc{\errorsx}}
+\newcommand{\syncx}{\Fundescx{Synchronization}}
+\newcommand{\sync}{\Fundesc{\syncx}}
+\newcommand{\implimitsx}{\Fundescx{Implementation limits}}
+\newcommand{\implimits}{\Fundesc{\implimitsx}}
+\newcommand{\replaceablex}{\Fundescx{Replaceable}}
+\newcommand{\replaceable}{\Fundesc{\replaceablex}}
+\newcommand{\returntypex}{\Fundescx{Return type}}
+\newcommand{\returntype}{\Fundesc{\returntypex}}
+\newcommand{\cvaluex}{\Fundescx{Value}}
+\newcommand{\cvalue}{\Fundesc{\cvaluex}}
+\newcommand{\ctypex}{\Fundescx{Type}}
+\newcommand{\ctype}{\Fundesc{\ctypex}}
+\newcommand{\ctypesx}{\Fundescx{Types}}
+\newcommand{\ctypes}{\Fundesc{\ctypesx}}
+\newcommand{\dtypex}{\Fundescx{Default type}}
+\newcommand{\dtype}{\Fundesc{\dtypex}}
+\newcommand{\ctemplatex}{\Fundescx{Class template}}
+\newcommand{\ctemplate}{\Fundesc{\ctemplatex}}
+\newcommand{\templaliasx}{\Fundescx{Alias template}}
+\newcommand{\templalias}{\Fundesc{\templaliasx}}
 
 %% Cross reference
 \newcommand{\xref}{\textsc{See also:}\space}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -1419,7 +1419,7 @@ Nothing.
 \pnum
 \remarks
 A function call expression
-that violates the precondition in the \expects element
+that violates the precondition in the \expectsx{} element
 is not a core constant expression\iref{expr.const}.
 \end{itemdescr}
 
@@ -10029,7 +10029,7 @@ for just those argument values
 for which:
 \begin{itemize}
   \item
-  the function description's \returns element
+  the function description's \returnsx{} element
   explicitly specifies a domain
   and those argument values fall
   outside the specified domain,

--- a/source/support.tex
+++ b/source/support.tex
@@ -2441,7 +2441,7 @@ The functions that have a \tcode{size} parameter
 forward their other parameters
 to the corresponding function without a \tcode{size} parameter.
 \begin{note}
-See the note in the above \replaceable paragraph.
+See the note in the above \replaceablex{} paragraph.
 \end{note}
 
 \pnum
@@ -3459,7 +3459,7 @@ constexpr source_location() noexcept;
 \begin{itemdescr}
 
 \pnum
-\Fundesc{Effects}
+\effects
 The data members are initialized with valid but unspecified values.
 \end{itemdescr}
 

--- a/source/time.tex
+++ b/source/time.tex
@@ -8754,7 +8754,7 @@ A \tcode{time_zone_link} specifies an alternative name for a \tcode{time_zone}.
 \pnum
 \throws
 If a \tcode{const time_zone*} cannot be found
-as described in the \returns element,
+as described in the \returnsx{} element,
 throws a \tcode{runtime_error}.
 \begin{note}
 On non-exceptional return, the return value is always a pointer to a valid \tcode{time_zone}.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -9239,7 +9239,7 @@ Where \tcode{UP} is \tcode{unique_ptr<U, E>}:
 \end{itemize}
 
 \begin{note}
-This replaces the \constraints specification of the primary template.
+This replaces the \constraintsx{} specification of the primary template.
 \end{note}
 \end{itemdescr}
 
@@ -9266,7 +9266,7 @@ Where \tcode{UP} is \tcode{unique_ptr<U, E>}:
 \end{itemize}
 
 \begin{note}
-This replaces the \constraints specification of the primary template.
+This replaces the \constraintsx{} specification of the primary template.
 \end{note}
 \end{itemdescr}
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22357/126887717-a6656998-0d27-48e9-bcf8-be6f2354f535.png)

There is precedent here, for example:

https://github.com/cplusplus/draft/blob/b4e36f7c5b7498a01b1d068afed0b90b0d46ab32/source/lib-intro.tex#L374-L378