### PR TITLE
[defns.access] [basic.lval] Clarify what and how can be accessed

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -319,7 +319,9 @@ for a union of type \tcode{U} with a glvalue argument
 that does not denote an object of type \cv{}~\keyword{U} within its lifetime,
 the behavior is undefined.
 \begin{note}
-Unlike in C, \Cpp{} has no accesses of class type.
+In C, an entire object of structure type can be accessed, e.g. using assignment.
+By contrast, \Cpp{} has no notion of accessing an object of class type
+through an lvalue of class type.
 \end{note}
 
 \rSec2[expr.type]{Type}

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -137,7 +137,7 @@ defined.
 read or modify the value of an object
 
 \begin{defnote}
-Only objects of scalar type can be accessed.
+Only glvalues of scalar type can be used to access objects.
 Reads of scalar objects are described in \ref{conv.lval} and
 modifications of scalar objects are described in
 \ref{expr.ass}, \ref{expr.post.incr}, and \ref{expr.pre.incr}.

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -139,7 +139,7 @@ read or modify the value of an object
 \begin{defnote}
 Only objects of scalar type can be accessed.
 Reads of scalar objects are described in \ref{conv.lval} and
-modifications of scalar objects are describred in
+modifications of scalar objects are described in
 \ref{expr.ass}, \ref{expr.post.incr}, and \ref{expr.pre.incr}.
 Attempts to read or modify an object of class type
 typically invoke a constructor\iref{class.ctor}


### PR DESCRIPTION
```c++
struct S { int i; } s;
auto u = (unsigned&)s; // accesses s, which is an object of class type
```
So the Notes are not accurate enough.