### PR TITLE
[variant.variant],[variant.ctor] - clarifying the meaning of Ti

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -4110,7 +4110,7 @@ A program that instantiates the definition of \tcode{variant} with
 no template arguments is ill-formed.
 
 \pnum
-In the descriptions that follow, let $i$ be in the range \range{0}{sizeof...(Types)},
+In the descriptions of \ref{variant}, let $i$ be in the range \range{0}{sizeof...(Types)},
 and $\tcode{T}_i$ be the $i^\text{th}$ type in \tcode{Types}.
 
 \rSec3[variant.ctor]{Constructors}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -4880,7 +4880,7 @@ $\tcode{I} < \tcode{sizeof...(Types)}$.
 
 \pnum
 \ctype
-The type in \tcode{Types} with index \tcode{I}.
+The $\tcode{I}^\text{th}$ element of \tcode{Types}, where indexing is zero-based.
 \end{itemdescr}
 
 \rSec2[variant.get]{Value access}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -4109,11 +4109,11 @@ the \oldconcept{Destructible} requirements (\tref{cpp17.destructible}).
 A program that instantiates the definition of \tcode{variant} with
 no template arguments is ill-formed.
 
-\rSec3[variant.ctor]{Constructors}
-
 \pnum
 In the descriptions that follow, let $i$ be in the range \range{0}{sizeof...(Types)},
 and $\tcode{T}_i$ be the $i^\text{th}$ type in \tcode{Types}.
+
+\rSec3[variant.ctor]{Constructors}
 
 \indexlibraryctor{variant}%
 \begin{itemdecl}
@@ -4880,7 +4880,7 @@ $\tcode{I} < \tcode{sizeof...(Types)}$.
 
 \pnum
 \ctype
-The type $\tcode{T}_I$.
+The type in \tcode{Types} with index \tcode{I}.
 \end{itemdescr}
 
 \rSec2[variant.get]{Value access}


### PR DESCRIPTION
We preface some of the sections with "In the descriptions that follow, let i be in the range [0, sizeof...(Types)), and Ti be the ith type in Types.", but we do not do this for all the sections that use Ti. Similarly, there is another place where we use TI, but do not elaborate on what it means.