### PR TITLE
[spanbuf.virtuals] Add missing "override"

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -9665,7 +9665,7 @@ return seekoff(off_type(sp), ios_base::beg, which);
 
 \indexlibrarymember{setbuf}{basic_spanbuf}%
 \begin{itemdecl}
-basic_streambuf<charT, traits>* setbuf(charT* s, streamsize n);
+basic_streambuf<charT, traits>* setbuf(charT* s, streamsize n) override;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
... to the declaration of `setbuf` to agree with the class synopsis.