### PR TITLE
[stmt.return,dcl.fct.def.coroutine] Avoid use of 'glvalue result'

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6466,7 +6466,7 @@ results in undefined behavior\iref{stmt.return.coroutine}.
 \pnum
 The expression \tcode{\exposid{promise}.get_return_object()} is used
 to initialize
-the glvalue result or prvalue result object of a call to a coroutine.
+the returned reference or prvalue result object of a call to a coroutine.
 The call to \tcode{get_return_object}
 is sequenced before
 the call to \tcode{initial_suspend}

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -815,7 +815,8 @@ A \tcode{return} statement with any other operand shall be used only
 in a function whose return type is not \cv{}~\keyword{void};
 \indextext{conversion!return type}%
 the \tcode{return} statement initializes the
-glvalue result or prvalue result object of the (explicit or implicit) function call
+returned reference or prvalue result object
+of the (explicit or implicit) function call
 by copy-initialization\iref{dcl.init} from the operand.
 \begin{note}
 A \tcode{return} statement can involve


### PR DESCRIPTION
Also fixes CWG2495.

Fixes #4724

As discussed in the CWG teleconference 2021-08-09.

Needs CWG review.