### PR TITLE
[dcl.init.ref] Avoid 'value of the expression'

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5475,8 +5475,8 @@ where ``\cvqual{cv1} \tcode{T1}'' is
 reference-compatible with ``\cvqual{cv3} \tcode{T3}'' (see~\ref{over.match.ref}),
 \end{itemize}
 then
-the value of the initializer expression in the first case and
-the result of the conversion in the second case
+the initializer expression in the first case and
+the converted expression in the second case
 is called the converted initializer.
 If the converted initializer is a prvalue,
 its type \tcode{T4} is adjusted to type ``\cvqual{cv1} \tcode{T4}''\iref{conv.qual}


### PR DESCRIPTION
when the properties of the expression are still relevant.

Fixes #4753