### PR TITLE
[std] Replace vestigial parenthesized \ref with \iref

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3990,7 +3990,7 @@ optionally, a parameter of type \tcode{std::size_t},
 The global \tcode{\keyword{operator} \keyword{delete}(\keyword{void}*, std::size_t)}
 precludes use of an
 allocation function \tcode{\keyword{void} \keyword{operator} \keyword{new}(std::size_t, std::size_t)} as a placement
-allocation function~(\ref{diff.cpp11.basic}).
+allocation function\iref{diff.cpp11.basic}.
 \end{footnote}
 then
 \item

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3815,7 +3815,7 @@ The \keyword{virtual} specifier implies membership, so a virtual function
 cannot be a non-member\iref{dcl.fct.spec} function. Nor can a virtual
 function be a static member, since a virtual function call relies on a
 specific object for determining which function to invoke. A virtual
-function declared in one class can be declared a friend~(\ref{class.friend}) in
+function declared in one class can be declared a friend\iref{class.friend} in
 another class.
 \end{note}
 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -662,7 +662,7 @@ type, the conversion copy-initializes the result object from
 the glvalue.
 
 \item Otherwise, if the object to which the glvalue refers contains an invalid
-pointer value~(\ref{basic.stc.dynamic.deallocation}), the behavior is
+pointer value\iref{basic.stc.dynamic.deallocation}, the behavior is
 \impldef{lvalue-to-rvalue conversion of an invalid pointer value}.
 
 \item Otherwise, the object indicated by the glvalue is read\iref{defns.access},
@@ -2749,7 +2749,7 @@ template<typename T> using Ref = T&;
 
 template<typename T> concept C = requires {
   typename T::inner;    // required nested member name
-  typename S<T>;        // required valid~(\ref{temp.names}) \grammarterm{template-id};
+  typename S<T>;        // required valid\iref{temp.names} \grammarterm{template-id};
                         // fails if \tcode{T::type} does not exist as a type to which \tcode{0} can be implicitly converted
   typename Ref<T>;      // required alias template substitution, fails if \tcode{T} is void
 };

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2312,13 +2312,13 @@ the following expressions are valid as shown in \tref{randomaccessiterator}.
 
 \pnum
 There are several concepts that group requirements of algorithms that
-take callable objects~(\ref{func.def}) as arguments.
+take callable objects\iref{func.def} as arguments.
 
 \rSec3[indirectcallable.indirectinvocable]{Indirect callables}
 
 \pnum
 The indirect callable concepts are used to constrain those algorithms
-that accept callable objects~(\ref{func.def}) as arguments.
+that accept callable objects\iref{func.def} as arguments.
 
 \begin{codeblock}
 namespace std {
@@ -2832,7 +2832,7 @@ The function call expression at \tcode{\#1} invokes \tcode{std::ranges::distance
 not \tcode{std::distance}, despite that
 (a) the iterator type returned from \tcode{begin(vec)} and \tcode{end(vec)}
 may be associated with namespace \tcode{std} and
-(b) \tcode{std::distance} is more specialized~(\ref{temp.func.order}) than
+(b) \tcode{std::distance} is more specialized\iref{temp.func.order} than
 \tcode{std::ranges::distance} since the former requires its first two parameters
 to have the same type.
 \end{example}

--- a/source/modules.tex
+++ b/source/modules.tex
@@ -937,7 +937,7 @@ the instantiation context of \tcode{foo<int, X>} comprises
 \item the point at the end of translation unit \#2, and
 \item the point of the call to \tcode{f(0)},
 \end{itemize}
-so the definition of \tcode{X} is reachable (\ref{module.reach}).
+so the definition of \tcode{X} is reachable\iref{module.reach}.
 
 It is unspecified whether the call to \tcode{g(0)} is valid:
 the instantiation context of \tcode{bar<int, X>} comprises
@@ -960,7 +960,7 @@ from a point $P$ if
 $U$ is a module interface unit on which the translation unit containing $P$
 has an interface dependency, or
 the translation unit containing $P$ imports $U$,
-in either case prior to $P$ (\ref{module.import}).
+in either case prior to $P$\iref{module.import}.
 \begin{note}
 While module interface units are reachable even when they are only
 transitively imported via a non-exported import declaration,

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -9875,7 +9875,7 @@ namespace std {
 The contents and meaning of the header \libheader{cmath}
 are the same as the C standard library header \libheader{math.h},
 with the addition of
-a three-dimensional hypotenuse function~(\ref{c.math.hypot3}),
+a three-dimensional hypotenuse function\iref{c.math.hypot3},
 a linear interpolation function\iref{c.math.lerp}, and
 the mathematical special functions described in \ref{sf.cmath}.
 \begin{note}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3050,7 +3050,7 @@ in either case with a \grammarterm{nested-name-specifier}
 ending with a \grammarterm{simple-template-id}, \placeholder{C},
 whose \grammarterm{template-name} names a class template.
 The template parameters of the template friend declaration
-shall be deducible from \placeholder{C}~(\ref{temp.deduct.type}).
+shall be deducible from \placeholder{C}\iref{temp.deduct.type}.
 In this case,
 a member of a specialization \placeholder{S} of the class template
 is a friend of the class granting friendship

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -513,7 +513,7 @@ namespace std {
 The class \tcode{stop_token} provides an interface for querying whether
 a stop request has been made (\tcode{stop_requested})
 or can ever be made (\tcode{stop_possible})
-using an associated \tcode{stop_source} object (\ref{stopsource}).
+using an associated \tcode{stop_source} object\iref{stopsource}.
 A \tcode{stop_token} can also be passed to a
 \tcode{stop_callback}\iref{stopcallback} constructor
 to register a callback to be called when a stop request has been made
@@ -708,7 +708,7 @@ Equivalent to: \tcode{x.swap(y)}.
 \indexlibraryglobal{stop_source}%
 The class \tcode{stop_source} implements the semantics of making a stop request.
 A stop request made on a \tcode{stop_source} object is visible to all
-associated \tcode{stop_source} and \tcode{stop_token} (\ref{stoptoken}) objects.
+associated \tcode{stop_source} and \tcode{stop_token}\iref{stoptoken} objects.
 Once a stop request has been made it cannot be withdrawn
 (a subsequent stop request has no effect).
 

--- a/tools/check-source.sh
+++ b/tools/check-source.sh
@@ -127,6 +127,10 @@ grep -n "&[ 0-9a-z_]\+) = delete" $texfiles |
 grep -n '^\\rSec.\[[^]]*[^-a-z.0-9][^]]*\]{' $texfiles |
     fail 'bad character in label' || failed=1
 
+# Use of parenthesized \ref
+grep -n '[ ~](\\ref{[.a-z0-9]*})' $texfiles |
+    fail 'replace \\ref with \\iref' || failed=1
+
 # "shall", "may", or "should" inside a note
 for f in $texfiles; do
     sed -n '/begin{\(note\|footnote\)}/,/end{\(note\|footnote\)}/{/\(shall\|may\|should\)[^a-zA-Z]/{=;p;};}' $f |


### PR DESCRIPTION
Also add an automated check.

(No visual diff in the resulting PDF.)