### PR TITLE
[expr.sizeof] Clarify sizeof(array)

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3219,6 +3219,8 @@ it has zero size.
 Otherwise, the circumstances under which the object has zero size
 are \impldef{which non-standard-layout objects
 containing no data are considered empty}.
+
+\pnum
 \indextext{most derived object!bit-field}%
 Unless it is a bit-field\iref{class.bit},
 an object with nonzero size
@@ -3228,6 +3230,12 @@ by any of its subobjects.
 An object of trivially copyable or
 standard-layout type\iref{basic.types.general} shall occupy contiguous bytes of
 storage.
+An object of array type shall not occupy any byte
+that is not occupied by any of its subobjects.
+\begin{note}
+This implies that \tcode{sizeof(T[n])}
+has the same value as \tcode{n * sizeof(T)}.
+\end{note}
 
 \pnum
 \indextext{most derived object!bit-field}%

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4784,10 +4784,8 @@ other than \tcode{char}, \tcode{signed char}, and \tcode{unsigned char}}.
 \begin{note}
 In particular, the values of \tcode{\keyword{sizeof}(\keyword{bool})}, \tcode{\keyword{sizeof}(\keyword{char16_t})},
 \tcode{\keyword{sizeof}(\keyword{char32_t})}, and \tcode{\keyword{sizeof}(\keyword{wchar_t})} are
-implementation-defined.
-\begin{footnote}
+implementation-defined;
 \tcode{\keyword{sizeof}(\keyword{bool})} is not required to be \tcode{1}.
-\end{footnote}
 \end{note}
 \begin{note}
 See~\ref{intro.memory} for the definition of byte

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4803,7 +4803,7 @@ When applied to a class, the result is the number of bytes in an object
 of that class including any padding required for placing objects of that
 type in an array.
 The result of applying \keyword{sizeof} to a
-potentially-overlapping subobject is
+potentially-overlapping subobject\iref{intro.object} is
 the size of the type, not the size of the subobject.
 \begin{footnote}
 The actual size of a potentially-overlapping subobject
@@ -4812,9 +4812,10 @@ applying \keyword{sizeof} to the subobject, due to virtual base classes
 and less strict padding requirements on potentially-overlapping subobjects.
 \end{footnote}
 \indextext{array!\idxcode{sizeof}}%
-When applied to an array, the result is the total number of bytes in the
-array. This implies that the size of an array of $n$ elements is
-$n$ times the size of an element.
+\begin{note}
+When applied to an array of $n$ elements,
+the result is $n$ times the size of an element.
+\end{note}
 
 \pnum
 The lvalue-to-rvalue\iref{conv.lval},


### PR DESCRIPTION
Fixes #4794