### PR TITLE
[over.match.best] Define 'worst conversion sequence'

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1811,6 +1811,14 @@ void use() {
 \end{codeblock}
 \end{example}
 
+\pnum
+Given a set of implicit conversion sequences,
+a \defnadj{worst}{conversion sequence} $S$ in the set
+is a conversion sequence
+such that $S$ is not a better conversion sequence
+than any other conversion sequence in the set and
+at least one other conversion sequence is a better conversion sequence than $S$.
+
 \rSec3[over.best.ics]{Implicit conversion sequences}%
 
 \rSec4[over.best.ics.general]{General}%
@@ -2232,7 +2240,7 @@ sequence is the identity conversion.
 Otherwise, if the parameter type is \tcode{std::initializer_list<X>}
 and all the elements
 of the initializer list can be implicitly converted to \tcode{X}, the implicit
-conversion sequence is the worst conversion necessary to convert an element of
+conversion sequence is the worst conversion sequence\iref{over.match.best.general} necessary to convert an element of
 the list to \tcode{X}, or if the initializer list has no elements, the identity
 conversion. This conversion can be a user-defined conversion even in
 the context of a call to an initializer-list constructor.


### PR DESCRIPTION
Fixes #4809.

DO NOT MERGE; this is obviously insufficient and incorrect.