### PR TITLE
[iostream.format] Use the injected-class-name throughout

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4241,53 +4241,50 @@ namespace std {
     class sentry;
 
     // \ref{istream.formatted}, formatted input
-    basic_istream<charT, traits>&
-      operator>>(basic_istream<charT, traits>& (*pf)(basic_istream<charT, traits>&));
-    basic_istream<charT, traits>&
-      operator>>(basic_ios<charT, traits>& (*pf)(basic_ios<charT, traits>&));
-    basic_istream<charT, traits>&
-      operator>>(ios_base& (*pf)(ios_base&));
+    basic_istream& operator>>(basic_istream& (*pf)(basic_istream&));
+    basic_istream& operator>>(basic_ios<charT, traits>& (*pf)(basic_ios<charT, traits>&));
+    basic_istream& operator>>(ios_base& (*pf)(ios_base&));
 
-    basic_istream<charT, traits>& operator>>(bool& n);
-    basic_istream<charT, traits>& operator>>(short& n);
-    basic_istream<charT, traits>& operator>>(unsigned short& n);
-    basic_istream<charT, traits>& operator>>(int& n);
-    basic_istream<charT, traits>& operator>>(unsigned int& n);
-    basic_istream<charT, traits>& operator>>(long& n);
-    basic_istream<charT, traits>& operator>>(unsigned long& n);
-    basic_istream<charT, traits>& operator>>(long long& n);
-    basic_istream<charT, traits>& operator>>(unsigned long long& n);
-    basic_istream<charT, traits>& operator>>(float& f);
-    basic_istream<charT, traits>& operator>>(double& f);
-    basic_istream<charT, traits>& operator>>(long double& f);
+    basic_istream& operator>>(bool& n);
+    basic_istream& operator>>(short& n);
+    basic_istream& operator>>(unsigned short& n);
+    basic_istream& operator>>(int& n);
+    basic_istream& operator>>(unsigned int& n);
+    basic_istream& operator>>(long& n);
+    basic_istream& operator>>(unsigned long& n);
+    basic_istream& operator>>(long long& n);
+    basic_istream& operator>>(unsigned long long& n);
+    basic_istream& operator>>(float& f);
+    basic_istream& operator>>(double& f);
+    basic_istream& operator>>(long double& f);
 
-    basic_istream<charT, traits>& operator>>(void*& p);
-    basic_istream<charT, traits>& operator>>(basic_streambuf<char_type, traits>* sb);
+    basic_istream& operator>>(void*& p);
+    basic_istream& operator>>(basic_streambuf<char_type, traits>* sb);
 
     // \ref{istream.unformatted}, unformatted input
     streamsize gcount() const;
     int_type get();
-    basic_istream<charT, traits>& get(char_type& c);
-    basic_istream<charT, traits>& get(char_type* s, streamsize n);
-    basic_istream<charT, traits>& get(char_type* s, streamsize n, char_type delim);
-    basic_istream<charT, traits>& get(basic_streambuf<char_type, traits>& sb);
-    basic_istream<charT, traits>& get(basic_streambuf<char_type, traits>& sb, char_type delim);
+    basic_istream& get(char_type& c);
+    basic_istream& get(char_type* s, streamsize n);
+    basic_istream& get(char_type* s, streamsize n, char_type delim);
+    basic_istream& get(basic_streambuf<char_type, traits>& sb);
+    basic_istream& get(basic_streambuf<char_type, traits>& sb, char_type delim);
 
-    basic_istream<charT, traits>& getline(char_type* s, streamsize n);
-    basic_istream<charT, traits>& getline(char_type* s, streamsize n, char_type delim);
+    basic_istream& getline(char_type* s, streamsize n);
+    basic_istream& getline(char_type* s, streamsize n, char_type delim);
 
-    basic_istream<charT, traits>& ignore(streamsize n = 1, int_type delim = traits::eof());
-    int_type                      peek();
-    basic_istream<charT, traits>& read    (char_type* s, streamsize n);
-    streamsize                    readsome(char_type* s, streamsize n);
+    basic_istream& ignore(streamsize n = 1, int_type delim = traits::eof());
+    int_type       peek();
+    basic_istream& read    (char_type* s, streamsize n);
+    streamsize     readsome(char_type* s, streamsize n);
 
-    basic_istream<charT, traits>& putback(char_type c);
-    basic_istream<charT, traits>& unget();
+    basic_istream& putback(char_type c);
+    basic_istream& unget();
     int sync();
 
     pos_type tellg();
-    basic_istream<charT, traits>& seekg(pos_type);
-    basic_istream<charT, traits>& seekg(off_type, ios_base::seekdir);
+    basic_istream& seekg(pos_type);
+    basic_istream& seekg(off_type, ios_base::seekdir);
 
   protected:
     // \ref{istream.cons}, copy/move constructor
@@ -4451,11 +4448,11 @@ Exchanges the values returned by \tcode{gcount()} and
 \indexlibrarymember{sentry}{basic_istream}%
 \begin{codeblock}
 namespace std {
-  template<class charT, class traits = char_traits<charT>>
+  template<class charT, class traits>
   class basic_istream<charT, traits>::sentry {
     bool ok_;                   // \expos
   public:
-    explicit sentry(basic_istream<charT, traits>& is, bool noskipws = false);
+    explicit sentry(basic_istream& is, bool noskipws = false);
     ~sentry();
     explicit operator bool() const { return ok_; }
     sentry(const sentry&) = delete;
@@ -4475,7 +4472,7 @@ operations.
 \indexlibraryctor{sentry}%
 \indexlibraryctor{basic_istream::sentry}%
 \begin{itemdecl}
-explicit sentry(basic_istream<charT, traits>& is, bool noskipws = false);
+explicit sentry(basic_istream& is, bool noskipws = false);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4534,7 +4531,7 @@ the function calls
 \remarks
 The constructor
 \begin{codeblock}
-explicit sentry(basic_istream<charT, traits>& is, bool noskipws = false)
+explicit sentry(basic_istream& is, bool noskipws = false)
 \end{codeblock}
 uses the currently imbued locale in \tcode{is},
 to determine whether the next input character is
@@ -4637,17 +4634,17 @@ If no exception has been thrown, it returns
 
 \indexlibrarymember{operator>>}{basic_istream}%
 \begin{itemdecl}
-operator>>(unsigned short& val);
-operator>>(unsigned int& val);
-operator>>(long& val);
-operator>>(unsigned long& val);
-operator>>(long long& val);
-operator>>(unsigned long long& val);
-operator>>(float& val);
-operator>>(double& val);
-operator>>(long double& val);
-operator>>(bool& val);
-operator>>(void*& val);
+basic_istream& operator>>(unsigned short& val);
+basic_istream& operator>>(unsigned int& val);
+basic_istream& operator>>(long& val);
+basic_istream& operator>>(unsigned long& val);
+basic_istream& operator>>(long long& val);
+basic_istream& operator>>(unsigned long long& val);
+basic_istream& operator>>(float& val);
+basic_istream& operator>>(double& val);
+basic_istream& operator>>(long double& val);
+basic_istream& operator>>(bool& val);
+basic_istream& operator>>(void*& val);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4686,7 +4683,7 @@ so that it does not need to depend directly on
 
 \indexlibrarymember{operator>>}{basic_istream}%
 \begin{itemdecl}
-operator>>(short& val);
+basic_istream& operator>>(short& val);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4712,7 +4709,7 @@ setstate(err);
 
 \indexlibrarymember{operator>>}{basic_istream}%
 \begin{itemdecl}
-operator>>(int& val);
+basic_istream& operator>>(int& val);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4740,8 +4737,7 @@ setstate(err);
 
 \indexlibrarymember{operator>>}{basic_istream}%
 \begin{itemdecl}
-basic_istream<charT, traits>&
-  operator>>(basic_istream<charT, traits>& (*pf)(basic_istream<charT, traits>&));
+basic_istream& operator>>(basic_istream& (*pf)(basic_istream&));
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4763,8 +4759,7 @@ See, for example, the function signature
 
 \indexlibrarymember{operator>>}{basic_istream}%
 \begin{itemdecl}
-basic_istream<charT, traits>&
-  operator>>(basic_ios<charT, traits>& (*pf)(basic_ios<charT, traits>&));
+basic_istream& operator>>(basic_ios<charT, traits>& (*pf)(basic_ios<charT, traits>&));
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4782,7 +4777,7 @@ This extractor does not behave as a formatted input function
 
 \indexlibrarymember{operator>>}{basic_istream}%
 \begin{itemdecl}
-basic_istream<charT, traits>& operator>>(ios_base& (*pf)(ios_base&));
+basic_istream& operator>>(ios_base& (*pf)(ios_base&));
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4889,7 +4884,7 @@ Otherwise, the function calls
 
 \indexlibrarymember{operator>>}{basic_istream}%
 \begin{itemdecl}
-basic_istream<charT, traits>& operator>>(basic_streambuf<charT, traits>* sb);
+basic_istream& operator>>(basic_streambuf<charT, traits>* sb);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5032,7 +5027,7 @@ otherwise
 
 \indexlibrarymember{get}{basic_istream}%
 \begin{itemdecl}
-basic_istream<charT, traits>& get(char_type& c);
+basic_istream& get(char_type& c);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5061,7 +5056,7 @@ Otherwise, the function calls
 
 \indexlibrarymember{get}{basic_istream}%
 \begin{itemdecl}
-basic_istream<charT, traits>& get(char_type* s, streamsize n, char_type delim);
+basic_istream& get(char_type* s, streamsize n, char_type delim);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5110,7 +5105,7 @@ into the next successive location of the array.
 
 \indexlibrarymember{get}{basic_istream}%
 \begin{itemdecl}
-basic_istream<charT, traits>& get(char_type* s, streamsize n);
+basic_istream& get(char_type* s, streamsize n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5126,7 +5121,7 @@ Value returned by the call.
 
 \indexlibrarymember{get}{basic_istream}%
 \begin{itemdecl}
-basic_istream<charT, traits>& get(basic_streambuf<char_type, traits>& sb, char_type delim);
+basic_istream& get(basic_streambuf<char_type, traits>& sb, char_type delim);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5167,7 +5162,7 @@ which may throw
 
 \indexlibrarymember{get}{basic_istream}%
 \begin{itemdecl}
-basic_istream<charT, traits>& get(basic_streambuf<char_type, traits>& sb);
+basic_istream& get(basic_streambuf<char_type, traits>& sb);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5183,7 +5178,7 @@ Value returned by the call.
 
 \indexlibrarymember{getline}{basic_istream}%
 \begin{itemdecl}
-basic_istream<charT, traits>& getline(char_type* s, streamsize n, char_type delim);
+basic_istream& getline(char_type* s, streamsize n, char_type delim);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5288,7 +5283,7 @@ int main() {
 
 \indexlibrarymember{getline}{basic_istream}%
 \begin{itemdecl}
-basic_istream<charT, traits>& getline(char_type* s, streamsize n);
+basic_istream& getline(char_type* s, streamsize n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5299,7 +5294,7 @@ basic_istream<charT, traits>& getline(char_type* s, streamsize n);
 
 \indexlibrarymember{ignore}{basic_istream}%
 \begin{itemdecl}
-basic_istream<charT, traits>& ignore(streamsize n = 1, int_type delim = traits::eof());
+basic_istream& ignore(streamsize n = 1, int_type delim = traits::eof());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5362,7 +5357,7 @@ Otherwise, returns
 
 \indexlibrarymember{read}{basic_istream}%
 \begin{itemdecl}
-basic_istream<charT, traits>& read(char_type* s, streamsize n);
+basic_istream& read(char_type* s, streamsize n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5447,7 +5442,7 @@ The number of characters extracted.
 
 \indexlibrarymember{putback}{basic_istream}%
 \begin{itemdecl}
-basic_istream<charT, traits>& putback(char_type c);
+basic_istream& putback(char_type c);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5489,7 +5484,7 @@ is 0.
 
 \indexlibrarymember{unget}{basic_istream}%
 \begin{itemdecl}
-basic_istream<charT, traits>& unget();
+basic_istream& unget();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5583,7 +5578,7 @@ Otherwise, returns
 
 \indexlibrarymember{seekg}{basic_istream}%
 \begin{itemdecl}
-basic_istream<charT, traits>& seekg(pos_type pos);
+basic_istream& seekg(pos_type pos);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5611,7 +5606,7 @@ In case of failure, the function calls
 
 \indexlibrarymember{seekg}{basic_istream}%
 \begin{itemdecl}
-basic_istream<charT, traits>& seekg(off_type off, ios_base::seekdir dir);
+basic_istream& seekg(off_type off, ios_base::seekdir dir);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5841,40 +5836,37 @@ namespace std {
     class sentry;
 
     // \ref{ostream.formatted}, formatted output
-    basic_ostream<charT, traits>&
-      operator<<(basic_ostream<charT, traits>& (*pf)(basic_ostream<charT, traits>&));
-    basic_ostream<charT, traits>&
-      operator<<(basic_ios<charT, traits>& (*pf)(basic_ios<charT, traits>&));
-    basic_ostream<charT, traits>&
-      operator<<(ios_base& (*pf)(ios_base&));
+    basic_ostream& operator<<(basic_ostream& (*pf)(basic_ostream&));
+    basic_ostream& operator<<(basic_ios<charT, traits>& (*pf)(basic_ios<charT, traits>&));
+    basic_ostream& operator<<(ios_base& (*pf)(ios_base&));
 
-    basic_ostream<charT, traits>& operator<<(bool n);
-    basic_ostream<charT, traits>& operator<<(short n);
-    basic_ostream<charT, traits>& operator<<(unsigned short n);
-    basic_ostream<charT, traits>& operator<<(int n);
-    basic_ostream<charT, traits>& operator<<(unsigned int n);
-    basic_ostream<charT, traits>& operator<<(long n);
-    basic_ostream<charT, traits>& operator<<(unsigned long n);
-    basic_ostream<charT, traits>& operator<<(long long n);
-    basic_ostream<charT, traits>& operator<<(unsigned long long n);
-    basic_ostream<charT, traits>& operator<<(float f);
-    basic_ostream<charT, traits>& operator<<(double f);
-    basic_ostream<charT, traits>& operator<<(long double f);
+    basic_ostream& operator<<(bool n);
+    basic_ostream& operator<<(short n);
+    basic_ostream& operator<<(unsigned short n);
+    basic_ostream& operator<<(int n);
+    basic_ostream& operator<<(unsigned int n);
+    basic_ostream& operator<<(long n);
+    basic_ostream& operator<<(unsigned long n);
+    basic_ostream& operator<<(long long n);
+    basic_ostream& operator<<(unsigned long long n);
+    basic_ostream& operator<<(float f);
+    basic_ostream& operator<<(double f);
+    basic_ostream& operator<<(long double f);
 
-    basic_ostream<charT, traits>& operator<<(const void* p);
-    basic_ostream<charT, traits>& operator<<(nullptr_t);
-    basic_ostream<charT, traits>& operator<<(basic_streambuf<char_type, traits>* sb);
+    basic_ostream& operator<<(const void* p);
+    basic_ostream& operator<<(nullptr_t);
+    basic_ostream& operator<<(basic_streambuf<char_type, traits>* sb);
 
     // \ref{ostream.unformatted}, unformatted output
-    basic_ostream<charT, traits>& put(char_type c);
-    basic_ostream<charT, traits>& write(const char_type* s, streamsize n);
+    basic_ostream& put(char_type c);
+    basic_ostream& write(const char_type* s, streamsize n);
 
-    basic_ostream<charT, traits>& flush();
+    basic_ostream& flush();
 
     // \ref{ostream.seeks}, seeks
     pos_type tellp();
-    basic_ostream<charT, traits>& seekp(pos_type);
-    basic_ostream<charT, traits>& seekp(off_type, ios_base::seekdir);
+    basic_ostream& seekp(pos_type);
+    basic_ostream& seekp(off_type, ios_base::seekdir);
 
   protected:
     // \ref{ostream.cons}, copy/move constructor
@@ -6084,11 +6076,11 @@ Calls \tcode{basic_ios<charT, traits>::swap(rhs)}.
 \indexlibrarymember{sentry}{basic_ostream}%
 \begin{codeblock}
 namespace std {
-  template<class charT, class traits = char_traits<charT>>
+  template<class charT, class traits>
   class basic_ostream<charT, traits>::sentry {
     bool ok_;       // \expos
   public:
-    explicit sentry(basic_ostream<charT, traits>& os);
+    explicit sentry(basic_ostream& os);
     ~sentry();
     explicit operator bool() const { return ok_; }
 
@@ -6106,7 +6098,7 @@ operations.
 
 \indexlibraryctor{basic_ostream::sentry}%
 \begin{itemdecl}
-explicit sentry(basic_ostream<charT, traits>& os);
+explicit sentry(basic_ostream& os);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6202,7 +6194,7 @@ Otherwise, returns
 
 \indexlibrarymember{seekp}{basic_ostream}%
 \begin{itemdecl}
-basic_ostream<charT, traits>& seekp(pos_type pos);
+basic_ostream& seekp(pos_type pos);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6224,7 +6216,7 @@ In case of failure, the function calls
 
 \indexlibrarymember{seekp}{basic_ostream}%
 \begin{itemdecl}
-basic_ostream<charT, traits>& seekp(off_type off, ios_base::seekdir dir);
+basic_ostream& seekp(off_type off, ios_base::seekdir dir);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6303,19 +6295,19 @@ character sequence.
 
 \indexlibrarymember{operator<<}{basic_ostream}%
 \begin{itemdecl}
-operator<<(bool val);
-operator<<(short val);
-operator<<(unsigned short val);
-operator<<(int val);
-operator<<(unsigned int val);
-operator<<(long val);
-operator<<(unsigned long val);
-operator<<(long long val);
-operator<<(unsigned long long val);
-operator<<(float val);
-operator<<(double val);
-operator<<(long double val);
-operator<<(const void* val);
+basic_ostream& operator<<(bool val);
+basic_ostream& operator<<(short val);
+basic_ostream& operator<<(unsigned short val);
+basic_ostream& operator<<(int val);
+basic_ostream& operator<<(unsigned int val);
+basic_ostream& operator<<(long val);
+basic_ostream& operator<<(unsigned long val);
+basic_ostream& operator<<(long long val);
+basic_ostream& operator<<(unsigned long long val);
+basic_ostream& operator<<(float val);
+basic_ostream& operator<<(double val);
+basic_ostream& operator<<(long double val);
+basic_ostream& operator<<(const void* val);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6431,8 +6423,7 @@ which may throw an exception, and returns.
 
 \indexlibrarymember{operator<<}{basic_ostream}%
 \begin{itemdecl}
-basic_ostream<charT, traits>&
-  operator<<(basic_ostream<charT, traits>& (*pf)(basic_ostream<charT, traits>&));
+basic_ostream& operator<<(basic_ostream& (*pf)(basic_ostream&));
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6454,8 +6445,7 @@ See, for example, the function signature
 
 \indexlibrarymember{operator<<}{basic_ostream}%
 \begin{itemdecl}
-basic_ostream<charT, traits>&
-  operator<<(basic_ios<charT, traits>& (*pf)(basic_ios<charT, traits>&));
+basic_ostream& operator<<(basic_ios<charT, traits>& (*pf)(basic_ios<charT, traits>&));
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6478,7 +6468,7 @@ See, for example, the function signature
 
 \indexlibrarymember{operator<<}{basic_ostream}%
 \begin{itemdecl}
-basic_ostream<charT, traits>& operator<<(ios_base& (*pf)(ios_base&));
+basic_ostream& operator<<(ios_base& (*pf)(ios_base&));
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6496,7 +6486,7 @@ behave as a formatted output function (as described in~\ref{ostream.formatted.re
 
 \indexlibrarymember{operator<<}{basic_ostream}%
 \begin{itemdecl}
-basic_ostream<charT, traits>& operator<<(basic_streambuf<charT, traits>* sb);
+basic_ostream& operator<<(basic_streambuf<charT, traits>* sb);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6547,7 +6537,7 @@ the caught exception is rethrown.
 
 \indexlibrarymember{operator<<}{basic_ostream}%
 \begin{itemdecl}
-basic_ostream<charT, traits>& operator<<(nullptr_t);
+basic_ostream& operator<<(nullptr_t);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6691,7 +6681,7 @@ specified for the unformatted output function.
 
 \indexlibrarymember{put}{basic_ostream}%
 \begin{itemdecl}
-basic_ostream<charT, traits>& put(char_type c);
+basic_ostream& put(char_type c);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Also remove ill-formed default template arguments in the definition
of sentry and spell out the return type of arithmetic inserters and
extractors.