### PR TITLE
[range.istream.view] Repeat default template argument in synopsis

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2856,7 +2856,7 @@ namespace std::ranges {
          is >> t;
       };
 
-  template<@\libconcept{movable}@ Val, class CharT, class Traits>
+  template<@\libconcept{movable}@ Val, class CharT, class Traits = char_traits<CharT>>
     requires @\libconcept{default_initializable}@<Val> &&
              @\exposconcept{stream-extractable}@<Val, CharT, Traits>
   class basic_istream_view : public view_interface<basic_istream_view<Val, CharT, Traits>> {


### PR DESCRIPTION
We usually repeat default template arguments in the class synopsis, e.g. `subrange` and `iota_view` do that.

But for `basic_istream_view` we only showed it in the `<ranges>` header synopsis, and not the class synopsis.