### PR TITLE
[class.copy.elision] No implicit moves for reference return types

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6192,7 +6192,8 @@ an rvalue reference to a non-volatile object type.
 In the following copy-initialization contexts,
 a move operation is first considered before attempting a copy operation:
 \begin{itemize}
-\item If the \grammarterm{expression} in a \tcode{return}\iref{stmt.return} or
+\item If the \grammarterm{expression}
+in a \keyword{return}\iref{stmt.return} or
 \keyword{co_return}\iref{stmt.return.coroutine} statement
 is a (possibly parenthesized) \grammarterm{id-expression}
 that names an implicitly movable entity declared in the body

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6198,7 +6198,8 @@ in a \keyword{return}\iref{stmt.return} or
 is a (possibly parenthesized) \grammarterm{id-expression}
 that names an implicitly movable entity declared in the body
 or \grammarterm{parameter-declaration-clause} of the innermost enclosing
-function or \grammarterm{lambda-expression}, or
+function or \grammarterm{lambda-expression},
+in either case having a non-reference return type, or
 
 \item if the operand of a \grammarterm{throw-expression}\iref{expr.throw}
 is a (possibly parenthesized) \grammarterm{id-expression}


### PR DESCRIPTION
Fixes #4839