### PR TITLE
[basic.scope.block] Fix regression introduced by P1787R6 CWG2502

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1190,7 +1190,8 @@ If a declaration whose target scope is the block scope $S$ of a
 \grammarterm{compound-statement} of a \grammarterm{lambda-expression},
 \grammarterm{function-body}, or \grammarterm{function-try-block},
 \item
-substatement of a selection or iteration statement, or
+substatement of a selection or iteration statement
+that is not itself a selection or iteration statement, or
 \item
 \grammarterm{handler} of a \grammarterm{function-try-block}
 \end{itemize}


### PR DESCRIPTION
"if (int a = 1) if (int a = 1) ..." is intended to be valid.

Fixes #4841

http://lists.isocpp.org/core/2021/08/11372.php