### PR TITLE
[forward] Fix typo in example 2 in paragraph 6

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -362,7 +362,7 @@ struct A {
 void g() {
   A a;
   shared_ptr<A> sp1 = factory<A>(a);                // ``\tcode{a}\!'' binds to \tcode{A(const A\&)}
-  shared_ptr<A> sp1 = factory<A>(std::move(a));     // ``\tcode{a}\!'' binds to \tcode{A(A\&\&)}
+  shared_ptr<A> sp2 = factory<A>(std::move(a));     // ``\tcode{a}\!'' binds to \tcode{A(A\&\&)}
 }
 \end{codeblock}
 In the first call to \tcode{factory},


### PR DESCRIPTION
Duplicate declaration of `sp1`. Change it to `sp2` just as that in example 1 above.