### PR TITLE
[basic.string.general] Fix basic_string::npos

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -807,7 +807,7 @@ namespace std {
     using const_iterator         = @\impdefx{type of \tcode{basic_string::const_iterator}}@; // see \ref{container.requirements}
     using reverse_iterator       = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-    static const size_type npos  = -1;
+    static constexpr size_type npos = size_type(-1);
 
     // \ref{string.cons}, construct/copy/destroy
     constexpr basic_string() noexcept(noexcept(Allocator())) : basic_string(Allocator()) { }


### PR DESCRIPTION
Use constexpr and an explicit conversion to size_type,
for consistency with basic_string_view.

Requested by http://lists.isocpp.org/lib-ext/2021/09/19813.php