### PR TITLE
[unique.ptr.single] Remove redundant preconditions after 079f7d3b02d

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -8761,9 +8761,6 @@ unique_ptr(unique_ptr&& u) noexcept;
 If \tcode{D} is not a reference type,
 \tcode{D} meets the \oldconcept{MoveConstructible}
 requirements (\tref{cpp17.moveconstructible}).
-Construction
-of the deleter from an rvalue of type \tcode{D} does not
-throw an exception.
 
 \pnum
 \effects
@@ -8871,9 +8868,7 @@ If \tcode{D} is not a reference type, \tcode{D} meets the
 \oldconcept{MoveAssignable} requirements (\tref{cpp17.moveassignable}) and assignment
 of the deleter from an rvalue of type \tcode{D} does not throw an exception.
 Otherwise, \tcode{D} is a reference type;
-\tcode{remove_reference_t<D>} meets the \oldconcept{CopyAssignable}
-requirements and assignment of the deleter from an
-lvalue of type \tcode{D} does not throw an exception.
+\tcode{remove_reference_t<D>} meets the \oldconcept{CopyAssignable} requirements.
 
 \pnum
 \effects


### PR DESCRIPTION
Resolves #4872.