### PR TITLE
[basic.lval] Remove an incorrect statement that assignment expects PR-value right operands

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -165,7 +165,7 @@ its \defn{value category}.
 The discussion of each built-in operator in
 \ref{expr.compound} indicates the category of the value it yields and the value categories
 of the operands it expects. For example, the built-in assignment operators expect that
-the left operand is an lvalue and that the right operand is a prvalue and yield an
+the left operand is an lvalue and yield an
 lvalue as the result. User-defined operators are functions, and the categories of
 values they expect and yield are determined by their parameter and return types.
 \end{note}


### PR DESCRIPTION
This is a perfectly valid assignment with an L-value right operand:

```c++
int x{3}, y;
y = x;
```