### PR TITLE
[intro.abstract] Reference the sibling subclause

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -902,7 +902,7 @@ and behavior in these respects.
 \begin{footnote}
 This documentation also includes
 conditionally-supported constructs and locale-specific behavior.
-See~\ref{intro.compliance}.
+See~\ref{intro.compliance.general}.
 \end{footnote}
 Such documentation shall define the instance of the
 abstract machine that corresponds to that implementation (referred to as the


### PR DESCRIPTION
This is similar to #3192,
but recognizes that the sibling subclause
should be the destination of the reference,
which covers
conditionally-supported constructs and
locale-specific characteristics.