### PR TITLE
[basic] Reference [basic.types.general] where appropriate

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -318,7 +318,7 @@ A class name can also be implicitly declared by an
 \indextext{type!incomplete}%
 In the definition of an object,
 the type of that object shall not be
-an incomplete type\iref{basic.types},
+an incomplete type\iref{basic.types.general},
 an abstract class type\iref{class.abstract}, or
 a (possibly multi-dimensional) array thereof.
 
@@ -2972,7 +2972,7 @@ contiguous bytes. Every byte has a unique address.
 \pnum
 \begin{note}
 The representation of types is described
-in~\ref{basic.types}.
+in~\ref{basic.types.general}.
 \end{note}
 
 \pnum
@@ -3192,7 +3192,7 @@ shall occupy one or more bytes of storage,
 including every byte that is occupied in full or in part
 by any of its subobjects.
 An object of trivially copyable or
-standard-layout type\iref{basic.types} shall occupy contiguous bytes of
+standard-layout type\iref{basic.types.general} shall occupy contiguous bytes of
 storage.
 
 \pnum
@@ -3233,7 +3233,7 @@ Some operations are described as
 within a specified region of storage.
 For each operation that is specified as implicitly creating objects,
 that operation implicitly creates and starts the lifetime of
-zero or more objects of implicit-lifetime types\iref{basic.types}
+zero or more objects of implicit-lifetime types\iref{basic.types.general}
 in its specified region of storage
 if doing so would result in the program having defined behavior.
 If no such set of objects would give the program defined behavior,
@@ -4801,7 +4801,7 @@ The width of each signed integer type
 shall not be less than the values specified in \tref{basic.fundamental.width}.
 The value representation of a signed or unsigned integer type
 comprises $N$ bits, where N is the respective width.
-Each set of values for any padding bits\iref{basic.types}
+Each set of values for any padding bits\iref{basic.types.general}
 in the object representation are
 alternative representations of the value specified by the value representation.
 \begin{note}
@@ -4864,7 +4864,7 @@ This requirement does not hold for other types.
 \end{note}
 \begin{note}
 A bit-field of narrow character type whose width is larger than
-the width of that type has padding bits; see \ref{basic.types}.
+the width of that type has padding bits; see \ref{basic.types.general}.
 \end{note}
 
 \pnum


### PR DESCRIPTION
All these references are for terms defined in the subclause.