### PR TITLE
[actions] Update dependencies cache before installing

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: check-source
         run: ../tools/check-source.sh
+      - name: update-apt-cache
+        run: sudo apt-get update
       - name: install
         run: sudo apt-get install latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended lmodern
       - name: make


### PR DESCRIPTION
because Ubuntu 20.04 can otherwise no longer install ghostscript,
which is needed for LaTeX.
