### PR TITLE
[range.filter.iterator] Add noexcept to base() functions

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -3469,7 +3469,7 @@ namespace std::ranges {
     @\exposid{iterator}@() requires @\libconcept{default_initializable}@<iterator_t<V>> = default;
     constexpr @\exposid{iterator}@(filter_view& parent, iterator_t<V> current);
 
-    constexpr const iterator_t<V>& base() const &;
+    constexpr const iterator_t<V>& base() const & noexcept;
     constexpr iterator_t<V> base() &&;
     constexpr range_reference_t<V> operator*() const;
     constexpr iterator_t<V> operator->() const
@@ -3546,7 +3546,7 @@ Initializes \exposid{current_} with \tcode{std::move(current)} and
 
 \indexlibrarymember{base}{filter_view::iterator}%
 \begin{itemdecl}
-constexpr const iterator_t<V>& base() const &;
+constexpr const iterator_t<V>& base() const & noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3967,7 +3967,7 @@ namespace std::ranges {
     constexpr @\exposid{iterator}@(@\exposid{iterator}@<!Const> i)
       requires Const && @\libconcept{convertible_to}@<iterator_t<V>, iterator_t<@\exposid{Base}@>>;
 
-    constexpr const iterator_t<@\exposid{Base}@>& base() const &;
+    constexpr const iterator_t<@\exposid{Base}@>& base() const & noexcept;
     constexpr iterator_t<@\exposid{Base}@> base() &&;
 
     constexpr decltype(auto) operator*() const {
@@ -4093,7 +4093,7 @@ Initializes \exposid{current_} with \tcode{std::move(i.\exposid{current_})} and
 
 \indexlibrarymember{base}{transform_view::iterator}%
 \begin{itemdecl}
-constexpr const iterator_t<@\exposid{Base}@>& base() const &;
+constexpr const iterator_t<@\exposid{Base}@>& base() const & noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6021,7 +6021,7 @@ namespace std::ranges {
     @\exposid{inner-iterator}@() = default;
     constexpr explicit @\exposid{inner-iterator}@(@\exposid{outer-iterator}@<Const> i);
 
-    constexpr const iterator_t<@\exposid{Base}@>& base() const &;
+    constexpr const iterator_t<@\exposid{Base}@>& base() const & noexcept;
     constexpr iterator_t<@\exposid{Base}@> base() &&;
 
     constexpr decltype(auto) operator*() const { return *@\exposid{i_}@.@\placeholder{current}@; }
@@ -6078,7 +6078,7 @@ Initializes \exposid{i_} with \tcode{std::move(i)}.
 
 \indexlibrarymember{base}{lazy_split_view::\exposid{inner-iterator}}%
 \begin{itemdecl}
-constexpr const iterator_t<@\exposid{Base}@>& base() const &;
+constexpr const iterator_t<@\exposid{Base}@>& base() const & noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6946,7 +6946,7 @@ namespace std::ranges {
     constexpr @\exposid{iterator}@(@\exposid{iterator}@<!Const> i)
       requires Const && @\libconcept{convertible_to}@<iterator_t<V>, iterator_t<@\exposid{Base}@>>;
 
-    constexpr const iterator_t<@\exposid{Base}@>& base() const&;
+    constexpr const iterator_t<@\exposid{Base}@>& base() const& noexcept;
     constexpr iterator_t<@\exposid{Base}@> base() &&;
 
     constexpr decltype(auto) operator*() const
@@ -7072,7 +7072,7 @@ Initializes \exposid{current_} with \tcode{std::move(i.\exposid{current_})}.
 
 \indexlibrarymember{base}{elements_view::iterator}%
 \begin{itemdecl}
-constexpr const iterator_t<@\exposid{Base}@>& base() const&;
+constexpr const iterator_t<@\exposid{Base}@>& base() const& noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
I want to know if this is an editorial issue? If it is worthy of being an LWG, I think I will submit it for it since LWG3391 can also add noexcept.