### PR TITLE
[module.import]/3 remove redundant importing of interface partitions

### DIFF
--- a/source/modules.tex
+++ b/source/modules.tex
@@ -434,7 +434,7 @@ after the import declaration.
 \pnum
 A \grammarterm{module-import-declaration} that specifies
 a \grammarterm{module-name} \tcode{M}
-imports all module interface units of \tcode{M}.
+imports the primary interface unit of \tcode{M}.
 
 \pnum
 A \grammarterm{module-import-declaration} that specifies


### PR DESCRIPTION
https://eel.is/c++draft/module.import#7 already describes how importing a TU implicitly imports all TUs that are `export import`ed from the TU. https://eel.is/c++draft/module.unit#3.sentence-3 ensures that all interface partitions are transitively exported by the primary interface unit. Therefore, [module.import]/3 does not need to say that it imports "all module interface units of `M`" (unless the implication is that it also imports interface partitions that are not transitively exported by the PMI). I think it is simpler if [module.import]/3 only describes the "root" interface TU being imported with /7 handling the transitive importing of partitions. This also matches the wording used at https://eel.is/c++draft/module.unit#8 to describe the implicit `import M;` that occurs after `module M;`.