### PR TITLE
[dcl.spec.auto.general] The placeholder type -> A placeholder type

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1694,7 +1694,7 @@ the lambda is a generic lambda\iref{expr.prim.lambda}.
 \end{note}
 
 \pnum
-The placeholder type can appear with a function declarator in the
+A placeholder type can appear with a function declarator in the
 \grammarterm{decl-specifier-seq}, \grammarterm{type-specifier-seq},
 \grammarterm{conversion-function-id}, or \grammarterm{trailing-return-type},
 in any context where such a declarator is valid. If the function declarator


### PR DESCRIPTION
"The placeholder type" gives the wrong impression that we're talking about the case from the previous paragraph. We're not; this is parallel to the previous paragraph so should use parallel wording.