### PR TITLE
[dcl.init.general] Mention scalar type explicitly for default-initialization

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4364,7 +4364,9 @@ If
 is an array type, each element is default-initialized.
 
 \item
-Otherwise,
+If
+\tcode{T}
+is a scalar type\iref{basic.types},
 no initialization is performed.
 \end{itemize}
 


### PR DESCRIPTION
Like it is already the case for zero-initialization.