### PR TITLE
[dcl.init.general] break p7 into three paragraphs

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4368,6 +4368,7 @@ Otherwise,
 no initialization is performed.
 \end{itemize}
 
+\pnum
 A class type \tcode{T} is \defn{const-default-constructible} if
 default-initialization of \tcode{T} would invoke
 a user-provided constructor of \tcode{T} (not inherited from a base class)


### PR DESCRIPTION
Is [dcl.init.general] p7 really supposed to be all one paragraph, with bullet numbers continuing between two separate lists, or should there be a `\pnum` after each list? Or just after the first list, giving two paragraphs?