### PR TITLE
[basic.lval] Replace the misused term ‘classifications’ by ‘categories’

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -158,7 +158,7 @@ or an expression that has type \cv{}~\keyword{void}.
 \end{itemize}
 
 \pnum
-Every expression belongs to exactly one of the fundamental classifications in this
+Every expression belongs to exactly one of the fundamental categories in this
 taxonomy: lvalue, xvalue, or prvalue. This property of an expression is called
 its \defn{value category}.
 \begin{note}
@@ -178,7 +178,7 @@ because they could appear on the left- and right-hand side of an assignment
 glvalues are ``generalized'' lvalues,
 prvalues are ``pure'' rvalues,
 and xvalues are ``eXpiring'' lvalues.
-Despite their names, these terms classify expressions, not values.
+Despite their names, these terms categorize expressions, not values.
 \end{note}
 
 \pnum


### PR DESCRIPTION
A single classification/categorization is a set of classes/categories.