### PR TITLE
[class.base.init] Clarify implicitly-defined copy/move constructors

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -5388,8 +5388,9 @@ struct A {
 \end{example}
 
 \pnum
-In a non-delegating constructor, if
-a given potentially constructed subobject is not designated by a
+In a non-delegating constructor
+other than an implicitly-defined copy/move constructor\iref{class.copy.ctor},
+if a given potentially constructed subobject is not designated by a
 \grammarterm{mem-initializer-id}
 (including the case where there is no
 \grammarterm{mem-initializer-list}


### PR DESCRIPTION
Those do not have a (grammatical) mem-initializer-list,
yet they ignore default member initializers.

Fixes #4916