### PR TITLE
[dcl.init.aggr] Insert paragraph break to avoid bad \item numbering

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4891,6 +4891,8 @@ that member is initialized from its default member initializer;
 otherwise, the first member of the union (if any)
 is copy-initialized from an empty initializer list.
 \end{itemize}
+
+\pnum
 \begin{example}
 \begin{codeblock}
 struct S { int a; const char* b; int c; int d = b[a]; };


### PR DESCRIPTION
Fixes #4891