### PR TITLE
[fstream.syn] Fix grammar

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -10215,7 +10215,7 @@ object converts those multibyte sequences into wide character sequences.
 
 \pnum
 In subclause~\ref{file.streams}, member functions taking arguments of \tcode{const filesystem::path::value_type*}
-are only be provided on systems where \tcode{filesystem::path::value_type}\iref{fs.class.path} is not \tcode{char}.
+are only provided on systems where \tcode{filesystem::path::value_type}\iref{fs.class.path} is not \tcode{char}.
 \begin{note}
 These functions enable class \tcode{path} support for systems with a wide native path character type, such as \keyword{wchar_t}.
 \end{note}


### PR DESCRIPTION
"are only be provided" is not a valid english verb phrase. I'm not sure if the intent was "are only provided" or "are only to be provided", but I think the first more closely adheres to our style of making existential statements about library implementations.