### PR TITLE
[lib] Rename exposition-only 'no-throw-' concepts

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -10247,7 +10247,7 @@ exposition-only concepts:
 
 \begin{itemdecl}
 template<class I>
-concept @\defexposconcept{no-throw-input-iterator}@ = // \expos
+concept @\defexposconcept{nothrow-input-iterator}@ = // \expos
   @\libconcept{input_iterator}@<I> &&
   is_lvalue_reference_v<iter_reference_t<I>> &&
   @\libconcept{same_as}@<remove_cvref_t<iter_reference_t<I>>, iter_value_t<I>>;
@@ -10255,7 +10255,7 @@ concept @\defexposconcept{no-throw-input-iterator}@ = // \expos
 
 \begin{itemdescr}
 \pnum
-A type \tcode{I} models \tcode{\placeholder{no-throw-input-iterator}} only if
+A type \tcode{I} models \tcode{\placeholder{nothrow-input-iterator}} only if
 no exceptions are thrown from increment,
 copy construction, move construction,
 copy assignment, move assignment,
@@ -10270,12 +10270,12 @@ operations to throw exceptions.
 
 \begin{itemdecl}
 template<class S, class I>
-concept @\defexposconcept{no-throw-sentinel-for}@ = @\libconcept{sentinel_for}@<S, I>; // \expos
+concept @\defexposconcept{nothrow-sentinel-for}@ = @\libconcept{sentinel_for}@<S, I>; // \expos
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-Types \tcode{S} and \tcode{I} model \tcode{\placeholder{no-throw-sentinel-for}}
+Types \tcode{S} and \tcode{I} model \tcode{\placeholder{nothrow-sentinel-for}}
 only if no exceptions are thrown from copy construction, move construction,
 copy assignment, move assignment, or comparisons between
 valid values of type \tcode{I} and \tcode{S}.
@@ -10289,25 +10289,25 @@ operations to throw exceptions.
 
 \begin{itemdecl}
 template<class R>
-concept @\defexposconcept{no-throw-input-range}@ = // \expos
+concept @\defexposconcept{nothrow-input-range}@ = // \expos
   range<R> &&
-  @\placeholder{no-throw-input-iterator}@<iterator_t<R>> &&
-  @\placeholder{no-throw-sentinel-for}@<sentinel_t<R>, iterator_t<R>>;
+  @\placeholder{nothrow-input-iterator}@<iterator_t<R>> &&
+  @\placeholder{nothrow-sentinel-for}@<sentinel_t<R>, iterator_t<R>>;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-A type \tcode{R} models \tcode{\placeholder{no-throw-input-range}} only if
+A type \tcode{R} models \tcode{\placeholder{nothrow-input-range}} only if
 no exceptions are thrown from calls to \tcode{ranges::begin} and
 \tcode{ranges::end} on an object of type \tcode{R}.
 \end{itemdescr}
 
 \begin{itemdecl}
 template<class I>
-concept @\defexposconcept{no-throw-forward-iterator}@ = // \expos
-  @\placeholder{no-throw-input-iterator}@<I> &&
+concept @\defexposconcept{nothrow-forward-iterator}@ = // \expos
+  @\placeholder{nothrow-input-iterator}@<I> &&
   @\libconcept{forward_iterator}@<I> &&
-  @\placeholder{no-throw-sentinel-for}@<I, I>;
+  @\placeholder{nothrow-sentinel-for}@<I, I>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10320,9 +10320,9 @@ operations to throw exceptions.
 
 \begin{itemdecl}
 template<class R>
-concept @\defexposconcept{no-throw-forward-range}@ = // \expos
-  @\placeholder{no-throw-input-range}@<R> &&
-  @\placeholder{no-throw-forward-iterator}@<iterator_t<R>>;
+concept @\defexposconcept{nothrow-forward-range}@ = // \expos
+  @\placeholder{nothrow-input-range}@<R> &&
+  @\placeholder{nothrow-forward-iterator}@<iterator_t<R>>;
 \end{itemdecl}
 
 \rSec2[uninitialized.construct.default]{\tcode{uninitialized_default_construct}}
@@ -10347,10 +10347,10 @@ for (; first != last; ++first)
 \indexlibraryglobal{uninitialized_default_construct}%
 \begin{itemdecl}
 namespace ranges {
-  template<@\placeholdernc{no-throw-forward-iterator}@ I, @\placeholder{no-throw-sentinel-for}@<I> S>
+  template<@\placeholdernc{nothrow-forward-iterator}@ I, @\placeholder{nothrow-sentinel-for}@<I> S>
     requires @\libconcept{default_initializable}@<iter_value_t<I>>
     I uninitialized_default_construct(I first, S last);
-  template<@\placeholdernc{no-throw-forward-range}@ R>
+  template<@\placeholdernc{nothrow-forward-range}@ R>
     requires @\libconcept{default_initializable}@<range_value_t<R>>
     borrowed_iterator_t<R> uninitialized_default_construct(R&& r);
 }
@@ -10388,7 +10388,7 @@ return first;
 \indexlibraryglobal{uninitialized_default_construct_n}%
 \begin{itemdecl}
 namespace ranges {
-  template<@\placeholdernc{no-throw-forward-iterator}@ I>
+  template<@\placeholdernc{nothrow-forward-iterator}@ I>
     requires @\libconcept{default_initializable}@<iter_value_t<I>>
     I uninitialized_default_construct_n(I first, iter_difference_t<I> n);
 }
@@ -10426,10 +10426,10 @@ for (; first != last; ++first)
 \indexlibraryglobal{uninitialized_value_construct}%
 \begin{itemdecl}
 namespace ranges {
-  template<@\placeholdernc{no-throw-forward-iterator}@ I, @\placeholder{no-throw-sentinel-for}@<I> S>
+  template<@\placeholdernc{nothrow-forward-iterator}@ I, @\placeholder{nothrow-sentinel-for}@<I> S>
     requires @\libconcept{default_initializable}@<iter_value_t<I>>
     I uninitialized_value_construct(I first, S last);
-  template<@\placeholdernc{no-throw-forward-range}@ R>
+  template<@\placeholdernc{nothrow-forward-range}@ R>
     requires @\libconcept{default_initializable}@<range_value_t<R>>
     borrowed_iterator_t<R> uninitialized_value_construct(R&& r);
 }
@@ -10467,7 +10467,7 @@ return first;
 \indexlibraryglobal{uninitialized_value_construct_n}%
 \begin{itemdecl}
 namespace ranges {
-  template<@\placeholdernc{no-throw-forward-iterator}@ I>
+  template<@\placeholdernc{nothrow-forward-iterator}@ I>
     requires @\libconcept{default_initializable}@<iter_value_t<I>>
     I uninitialized_value_construct_n(I first, iter_difference_t<I> n);
 }
@@ -10515,11 +10515,11 @@ for (; first != last; ++result, (void) ++first)
 \begin{itemdecl}
 namespace ranges {
   template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S1,
-           @\placeholdernc{no-throw-forward-iterator}@ O, @\placeholder{no-throw-sentinel-for}@<O> S2>
+           @\placeholdernc{nothrow-forward-iterator}@ O, @\placeholder{nothrow-sentinel-for}@<O> S2>
     requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_reference_t<I>>
     uninitialized_copy_result<I, O>
       uninitialized_copy(I ifirst, S1 ilast, O ofirst, S2 olast);
-  template<@\libconcept{input_range}@ IR, @\placeholdernc{no-throw-forward-range}@ OR>
+  template<@\libconcept{input_range}@ IR, @\placeholdernc{nothrow-forward-range}@ OR>
     requires @\libconcept{constructible_from}@<range_value_t<OR>, range_reference_t<IR>>
     uninitialized_copy_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
       uninitialized_copy(IR&& in_range, OR&& out_range);
@@ -10570,7 +10570,7 @@ for ( ; n > 0; ++result, (void) ++first, --n)
 \indexlibraryglobal{uninitialized_copy_n}%
 \begin{itemdecl}
 namespace ranges {
-  template<@\libconcept{input_iterator}@ I, @\placeholdernc{no-throw-forward-iterator}@ O, @\placeholder{no-throw-sentinel-for}@<O> S>
+  template<@\libconcept{input_iterator}@ I, @\placeholdernc{nothrow-forward-iterator}@ O, @\placeholder{nothrow-sentinel-for}@<O> S>
     requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_reference_t<I>>
     uninitialized_copy_n_result<I, O>
       uninitialized_copy_n(I ifirst, iter_difference_t<I> n, O ofirst, S olast);
@@ -10622,11 +10622,11 @@ return result;
 \begin{itemdecl}
 namespace ranges {
   template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S1,
-           @\placeholdernc{no-throw-forward-iterator}@ O, @\placeholder{no-throw-sentinel-for}@<O> S2>
+           @\placeholdernc{nothrow-forward-iterator}@ O, @\placeholder{nothrow-sentinel-for}@<O> S2>
     requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_rvalue_reference_t<I>>
     uninitialized_move_result<I, O>
       uninitialized_move(I ifirst, S1 ilast, O ofirst, S2 olast);
-  template<@\libconcept{input_range}@ IR, @\placeholdernc{no-throw-forward-range}@ OR>
+  template<@\libconcept{input_range}@ IR, @\placeholdernc{nothrow-forward-range}@ OR>
     requires @\libconcept{constructible_from}@<range_value_t<OR>, range_rvalue_reference_t<IR>>
     uninitialized_move_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
       uninitialized_move(IR&& in_range, OR&& out_range);
@@ -10681,7 +10681,7 @@ return {first, result};
 \indexlibraryglobal{uninitialized_move_n}%
 \begin{itemdecl}
 namespace ranges {
-  template<@\libconcept{input_iterator}@ I, @\placeholdernc{no-throw-forward-iterator}@ O, @\placeholder{no-throw-sentinel-for}@<O> S>
+  template<@\libconcept{input_iterator}@ I, @\placeholdernc{nothrow-forward-iterator}@ O, @\placeholder{nothrow-sentinel-for}@<O> S>
     requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_rvalue_reference_t<I>>
     uninitialized_move_n_result<I, O>
       uninitialized_move_n(I ifirst, iter_difference_t<I> n, O ofirst, S olast);
@@ -10732,10 +10732,10 @@ for (; first != last; ++first)
 \indexlibraryglobal{uninitialized_fill}%
 \begin{itemdecl}
 namespace ranges {
-  template<@\placeholdernc{no-throw-forward-iterator}@ I, @\placeholder{no-throw-sentinel-for}@<I> S, class T>
+  template<@\placeholdernc{nothrow-forward-iterator}@ I, @\placeholder{nothrow-sentinel-for}@<I> S, class T>
     requires @\libconcept{constructible_from}@<iter_value_t<I>, const T&>
     I uninitialized_fill(I first, S last, const T& x);
-  template<@\placeholdernc{no-throw-forward-range}@ R, class T>
+  template<@\placeholdernc{nothrow-forward-range}@ R, class T>
     requires @\libconcept{constructible_from}@<range_value_t<R>, const T&>
     borrowed_iterator_t<R> uninitialized_fill(R&& r, const T& x);
 }
@@ -10773,7 +10773,7 @@ return first;
 \indexlibraryglobal{uninitialized_fill_n}%
 \begin{itemdecl}
 namespace ranges {
-  template<@\placeholdernc{no-throw-forward-iterator}@ I, class T>
+  template<@\placeholdernc{nothrow-forward-iterator}@ I, class T>
     requires @\libconcept{constructible_from}@<iter_value_t<I>, const T&>
     I uninitialized_fill_n(I first, iter_difference_t<I> n, const T& x);
 }
@@ -10857,10 +10857,10 @@ for (; first != last; ++first)
 \indexlibraryglobal{destroy}%
 \begin{itemdecl}
 namespace ranges {
-  template<@\placeholdernc{no-throw-input-iterator}@ I, @\placeholder{no-throw-sentinel-for}@<I> S>
+  template<@\placeholdernc{nothrow-input-iterator}@ I, @\placeholder{nothrow-sentinel-for}@<I> S>
     requires @\libconcept{destructible}@<iter_value_t<I>>
     constexpr I destroy(I first, S last) noexcept;
-  template<@\placeholdernc{no-throw-input-range}@ R>
+  template<@\placeholdernc{nothrow-input-range}@ R>
     requires @\libconcept{destructible}@<range_value_t<R>>
     constexpr borrowed_iterator_t<R> destroy(R&& r) noexcept;
 }
@@ -10897,7 +10897,7 @@ return first;
 \indexlibraryglobal{destroy_n}%
 \begin{itemdecl}
 namespace ranges {
-  template<@\placeholdernc{no-throw-input-iterator}@ I>
+  template<@\placeholdernc{nothrow-input-iterator}@ I>
     requires @\libconcept{destructible}@<iter_value_t<I>>
     constexpr I destroy_n(I first, iter_difference_t<I> n) noexcept;
 }

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6919,15 +6919,15 @@ namespace std {
   // \ref{specialized.algorithms}, specialized algorithms
   // \ref{special.mem.concepts}, special memory concepts
   template<class I>
-    concept @\exposconcept{no-throw-input-iterator}@ = @\seebelow@;    // \expos
+    concept @\exposconcept{nothrow-input-iterator}@ = @\seebelow@;    // \expos
   template<class I>
-    concept @\exposconcept{no-throw-forward-iterator}@ = @\seebelow@;  // \expos
+    concept @\exposconcept{nothrow-forward-iterator}@ = @\seebelow@;  // \expos
   template<class S, class I>
-    concept @\exposconcept{no-throw-sentinel-for}@ = @\seebelow@;      // \expos
+    concept @\exposconcept{nothrow-sentinel-for}@ = @\seebelow@;      // \expos
   template<class R>
-    concept @\exposconcept{no-throw-input-range}@ = @\seebelow@;       // \expos
+    concept @\exposconcept{nothrow-input-range}@ = @\seebelow@;       // \expos
   template<class R>
-    concept @\exposconcept{no-throw-forward-range}@ = @\seebelow@;     // \expos
+    concept @\exposconcept{nothrow-forward-range}@ = @\seebelow@;     // \expos
 
   template<class NoThrowForwardIterator>
     void uninitialized_default_construct(NoThrowForwardIterator first,
@@ -6945,14 +6945,14 @@ namespace std {
                                         NoThrowForwardIterator first, Size n);
 
   namespace ranges {
-    template<@\exposconcept{no-throw-forward-iterator}@ I, @\exposconcept{no-throw-sentinel-for}@<I> S>
+    template<@\exposconcept{nothrow-forward-iterator}@ I, @\exposconcept{nothrow-sentinel-for}@<I> S>
       requires @\libconcept{default_initializable}@<iter_value_t<I>>
         I uninitialized_default_construct(I first, S last);
-    template<@\exposconcept{no-throw-forward-range}@ R>
+    template<@\exposconcept{nothrow-forward-range}@ R>
       requires @\libconcept{default_initializable}@<range_value_t<R>>
         borrowed_iterator_t<R> uninitialized_default_construct(R&& r);
 
-    template<@\exposconcept{no-throw-forward-iterator}@ I>
+    template<@\exposconcept{nothrow-forward-iterator}@ I>
       requires @\libconcept{default_initializable}@<iter_value_t<I>>
         I uninitialized_default_construct_n(I first, iter_difference_t<I> n);
   }
@@ -6973,14 +6973,14 @@ namespace std {
                                       NoThrowForwardIterator first, Size n);
 
   namespace ranges {
-    template<@\exposconcept{no-throw-forward-iterator}@ I, @\exposconcept{no-throw-sentinel-for}@<I> S>
+    template<@\exposconcept{nothrow-forward-iterator}@ I, @\exposconcept{nothrow-sentinel-for}@<I> S>
       requires @\libconcept{default_initializable}@<iter_value_t<I>>
         I uninitialized_value_construct(I first, S last);
-    template<@\exposconcept{no-throw-forward-range}@ R>
+    template<@\exposconcept{nothrow-forward-range}@ R>
       requires @\libconcept{default_initializable}@<range_value_t<R>>
         borrowed_iterator_t<R> uninitialized_value_construct(R&& r);
 
-    template<@\exposconcept{no-throw-forward-iterator}@ I>
+    template<@\exposconcept{nothrow-forward-iterator}@ I>
       requires @\libconcept{default_initializable}@<iter_value_t<I>>
         I uninitialized_value_construct_n(I first, iter_difference_t<I> n);
   }
@@ -7005,18 +7005,18 @@ namespace std {
     template<class I, class O>
       using uninitialized_copy_result = in_out_result<I, O>;
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S1,
-             @\exposconcept{no-throw-forward-iterator}@ O, @\exposconcept{no-throw-sentinel-for}@<O> S2>
+             @\exposconcept{nothrow-forward-iterator}@ O, @\exposconcept{nothrow-sentinel-for}@<O> S2>
       requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_reference_t<I>>
         uninitialized_copy_result<I, O>
           uninitialized_copy(I ifirst, S1 ilast, O ofirst, S2 olast);
-    template<@\libconcept{input_range}@ IR, @\exposconcept{no-throw-forward-range}@ OR>
+    template<@\libconcept{input_range}@ IR, @\exposconcept{nothrow-forward-range}@ OR>
       requires @\libconcept{constructible_from}@<range_value_t<OR>, range_reference_t<IR>>
         uninitialized_copy_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
           uninitialized_copy(IR&& in_range, OR&& out_range);
 
     template<class I, class O>
       using uninitialized_copy_n_result = in_out_result<I, O>;
-    template<@\libconcept{input_iterator}@ I, @\exposconcept{no-throw-forward-iterator}@ O, @\exposconcept{no-throw-sentinel-for}@<O> S>
+    template<@\libconcept{input_iterator}@ I, @\exposconcept{nothrow-forward-iterator}@ O, @\exposconcept{nothrow-sentinel-for}@<O> S>
       requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_reference_t<I>>
         uninitialized_copy_n_result<I, O>
           uninitialized_copy_n(I ifirst, iter_difference_t<I> n, O ofirst, S olast);
@@ -7042,11 +7042,11 @@ namespace std {
     template<class I, class O>
       using uninitialized_move_result = in_out_result<I, O>;
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S1,
-             @\exposconcept{no-throw-forward-iterator}@ O, @\exposconcept{no-throw-sentinel-for}@<O> S2>
+             @\exposconcept{nothrow-forward-iterator}@ O, @\exposconcept{nothrow-sentinel-for}@<O> S2>
       requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_rvalue_reference_t<I>>
         uninitialized_move_result<I, O>
           uninitialized_move(I ifirst, S1 ilast, O ofirst, S2 olast);
-    template<@\libconcept{input_range}@ IR, @\exposconcept{no-throw-forward-range}@ OR>
+    template<@\libconcept{input_range}@ IR, @\exposconcept{nothrow-forward-range}@ OR>
       requires @\libconcept{constructible_from}@<range_value_t<OR>, range_rvalue_reference_t<IR>>
         uninitialized_move_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
           uninitialized_move(IR&& in_range, OR&& out_range);
@@ -7054,7 +7054,7 @@ namespace std {
     template<class I, class O>
       using uninitialized_move_n_result = in_out_result<I, O>;
     template<@\libconcept{input_iterator}@ I,
-             @\exposconcept{no-throw-forward-iterator}@ O, @\exposconcept{no-throw-sentinel-for}@<O> S>
+             @\exposconcept{nothrow-forward-iterator}@ O, @\exposconcept{nothrow-sentinel-for}@<O> S>
       requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_rvalue_reference_t<I>>
         uninitialized_move_n_result<I, O>
           uninitialized_move_n(I ifirst, iter_difference_t<I> n, O ofirst, S olast);
@@ -7076,14 +7076,14 @@ namespace std {
                            NoThrowForwardIterator first, Size n, const T& x);
 
   namespace ranges {
-    template<@\exposconcept{no-throw-forward-iterator}@ I, @\exposconcept{no-throw-sentinel-for}@<I> S, class T>
+    template<@\exposconcept{nothrow-forward-iterator}@ I, @\exposconcept{nothrow-sentinel-for}@<I> S, class T>
       requires @\libconcept{constructible_from}@<iter_value_t<I>, const T&>
         I uninitialized_fill(I first, S last, const T& x);
-    template<@\exposconcept{no-throw-forward-range}@ R, class T>
+    template<@\exposconcept{nothrow-forward-range}@ R, class T>
       requires @\libconcept{constructible_from}@<range_value_t<R>, const T&>
         borrowed_iterator_t<R> uninitialized_fill(R&& r, const T& x);
 
-    template<@\exposconcept{no-throw-forward-iterator}@ I, class T>
+    template<@\exposconcept{nothrow-forward-iterator}@ I, class T>
       requires @\libconcept{constructible_from}@<iter_value_t<I>, const T&>
         I uninitialized_fill_n(I first, iter_difference_t<I> n, const T& x);
   }
@@ -7115,14 +7115,14 @@ namespace std {
     template<@\libconcept{destructible}@ T>
       constexpr void destroy_at(T* location) noexcept;
 
-    template<@\exposconcept{no-throw-input-iterator}@ I, @\exposconcept{no-throw-sentinel-for}@<I> S>
+    template<@\exposconcept{nothrow-input-iterator}@ I, @\exposconcept{nothrow-sentinel-for}@<I> S>
       requires @\libconcept{destructible}@<iter_value_t<I>>
         constexpr I destroy(I first, S last) noexcept;
-    template<@\exposconcept{no-throw-input-range}@ R>
+    template<@\exposconcept{nothrow-input-range}@ R>
       requires @\libconcept{destructible}@<range_value_t<R>>
         constexpr borrowed_iterator_t<R> destroy(R&& r) noexcept;
 
-    template<@\exposconcept{no-throw-input-iterator}@ I>
+    template<@\exposconcept{nothrow-input-iterator}@ I>
       requires @\libconcept{destructible}@<iter_value_t<I>>
         constexpr I destroy_n(I first, iter_difference_t<I> n) noexcept;
   }


### PR DESCRIPTION
to 'nothrow-', for consistency with nothrow_constructible

Fixes #4101