### PR TITLE
[std] Use \keyword for coroutine keywords

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6186,7 +6186,7 @@ In the following copy-initialization contexts,
 a move operation is first considered before attempting a copy operation:
 \begin{itemize}
 \item If the \grammarterm{expression} in a \tcode{return}\iref{stmt.return} or
-\tcode{co_return}\iref{stmt.return.coroutine} statement
+\keyword{co_return}\iref{stmt.return.coroutine} statement
 is a (possibly parenthesized) \grammarterm{id-expression}
 that names an implicitly movable entity declared in the body
 or \grammarterm{parameter-declaration-clause} of the innermost enclosing

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -131,7 +131,7 @@ declare immediate functions\iref{dcl.constexpr}.
 The \keyword{constinit} keyword is added to
 prevent unintended dynamic initialization\iref{dcl.constinit}.
 \item
-The \tcode{co_await}, \tcode{co_yield}, and \tcode{co_return} keywords are added
+The \keyword{co_await}, \keyword{co_yield}, and \keyword{co_return} keywords are added
 to enable the definition of coroutines \iref{dcl.fct.def.coroutine}.
 \item
 The \tcode{requires} keyword is added
@@ -144,7 +144,7 @@ Valid \CppXVII{} code using
 \tcode{concept},
 \keyword{consteval},
 \keyword{constinit},
-\tcode{co_await}, \tcode{co_yield}, \tcode{co_return},
+\keyword{co_await}, \keyword{co_yield}, \keyword{co_return},
 or \tcode{requires}
 as an identifier is not valid in this revision of \Cpp{}.
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6461,7 +6461,7 @@ in the scope of the promise type each find any declarations,
 the program is ill-formed.
 \begin{note}
 If \tcode{return_void} is found, flowing off
-the end of a coroutine is equivalent to a \tcode{co_return} with no operand.
+the end of a coroutine is equivalent to a \keyword{co_return} with no operand.
 Otherwise, flowing off the end of a coroutine
 results in undefined behavior\iref{stmt.return.coroutine}.
 \end{note}
@@ -6619,7 +6619,7 @@ If the evaluation of the expression
 the coroutine is considered suspended at the final suspend point.
 
 \pnum
-The expression \tcode{co_await} \tcode{\exposid{promise}.final_suspend()}
+The expression \keyword{co_await} \tcode{\exposid{promise}.final_suspend()}
 shall not be potentially-throwing\iref{except.spec}.
 
 \rSec1[dcl.struct.bind]{Structured binding declarations}%

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4473,7 +4473,7 @@ For postfix increment and decrement, see~\ref{expr.post.incr}.
 \indextext{\idxcode{co_await}}%
 
 \pnum
-The \tcode{co_await} expression is used to suspend evaluation of a
+The \keyword{co_await} expression is used to suspend evaluation of a
 coroutine\iref{dcl.fct.def.coroutine} while awaiting completion of
 the computation represented by the operand expression.
 

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3037,7 +3037,7 @@ found in the rest of \ref{over.oper} do not apply to them unless explicitly
 stated in~\ref{basic.stc.dynamic}.
 
 \pnum
-The \tcode{co_await} operator is described completely in~\ref{expr.await}.
+The \keyword{co_await} operator is described completely in~\ref{expr.await}.
 The attributes and restrictions
 found in the rest of \ref{over.oper} do not apply to it unless explicitly
 stated in~\ref{expr.await}.

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -866,7 +866,7 @@ enclosing the \tcode{return} statement.
 
 \pnum
 A coroutine returns to its caller or resumer\iref{dcl.fct.def.coroutine}
-by the \tcode{co_return} statement or when suspended\iref{expr.await}.
+by the \keyword{co_return} statement or when suspended\iref{expr.await}.
 A coroutine shall not enclose
 a \tcode{return} statement\iref{stmt.return}.
 \begin{note}
@@ -875,11 +875,11 @@ is enclosed by a discarded statement\iref{stmt.if}.
 \end{note}
 
 \pnum
-The \grammarterm{expr-or-braced-init-list} of a \tcode{co_return} statement is
+The \grammarterm{expr-or-braced-init-list} of a \keyword{co_return} statement is
 called its operand.
 Let \placeholder{p} be an lvalue naming the coroutine
 promise object\iref{dcl.fct.def.coroutine}.
-A \tcode{co_return} statement is equivalent to:
+A \keyword{co_return} statement is equivalent to:
 \begin{ncsimplebnf}
 \terminal{\{} S\terminal{;} \terminal{goto} \exposid{final-suspend}\terminal{;} \terminal{\}}
 \end{ncsimplebnf}
@@ -902,7 +902,7 @@ shall be a prvalue of type \keyword{void}.
 \pnum
 If \placeholder{p}\tcode{.return_void()} is a valid expression,
 flowing off the end of a coroutine's \grammarterm{function-body}
-is equivalent to a \tcode{co_return} with no operand;
+is equivalent to a \keyword{co_return} with no operand;
 otherwise flowing off the end of a coroutine's \grammarterm{function-body}
 results in undefined behavior.
 


### PR DESCRIPTION
No visual diff, except for (intentional) additional index entries.