### PR TITLE
[tuple.apply] Move exposition-only functions to namespace std

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2015,10 +2015,12 @@ template<class F, class Tuple>
 \effects
 Given the exposition-only function:
 \begin{codeblock}
-template<class F, class Tuple, size_t... I>
-constexpr decltype(auto) @\placeholdernc{apply-impl}@(F&& f, Tuple&& t, index_sequence<I...>) {
+namespace std {
+  template<class F, class Tuple, size_t... I>
+  constexpr decltype(auto) @\placeholdernc{apply-impl}@(F&& f, Tuple&& t, index_sequence<I...>) {
                                                                         // \expos
-  return @\placeholdernc{INVOKE}@(std::forward<F>(f), std::get<I>(std::forward<Tuple>(t))...);  // see \ref{func.require}
+    return @\placeholdernc{INVOKE}@(std::forward<F>(f), get<I>(std::forward<Tuple>(t))...);     // see \ref{func.require}
+  }
 }
 \end{codeblock}
 Equivalent to:
@@ -2039,10 +2041,12 @@ template<class T, class Tuple>
 \effects
 Given the exposition-only function:
 \begin{codeblock}
-template<class T, class Tuple, size_t... I>
-  requires is_constructible_v<T, decltype(get<I>(declval<Tuple>()))...>
-constexpr T @\placeholdernc{make-from-tuple-impl}@(Tuple&& t, index_sequence<I...>) {     // \expos
-  return T(get<I>(std::forward<Tuple>(t))...);
+namespace std {
+  template<class T, class Tuple, size_t... I>
+    requires is_constructible_v<T, decltype(get<I>(declval<Tuple>()))...>
+  constexpr T @\placeholdernc{make-from-tuple-impl}@(Tuple&& t, index_sequence<I...>) {   // \expos
+    return T(get<I>(std::forward<Tuple>(t))...);
+  }
 }
 \end{codeblock}
 Equivalent to:


### PR DESCRIPTION
and remove superfluous std:: qualification.

Fixes #4948