### PR TITLE
Add trailing semicolon to the example in expr.prim.id.general p5

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1370,7 +1370,7 @@ because such functions are never selected by overload resolution.
 \begin{codeblock}
 template<typename T> struct A {
   static void f(int) requires false;
-}
+};
 
 void g() {
   A<int>::f(0);                         // error: cannot call \tcode{f}


### PR DESCRIPTION
The semicolon is missing from the 'struct' definition, add it.