### PR TITLE
[range.join.view] remove duplicative condition in end() const

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -5211,7 +5211,6 @@ namespace std::ranges {
     requires @\libconcept{input_range}@<const V> &&
              is_reference_v<range_reference_t<const V>> {
       if constexpr (@\libconcept{forward_range}@<const V> &&
-                    is_reference_v<range_reference_t<const V>> &&
                     @\libconcept{forward_range}@<range_reference_t<const V>> &&
                     @\libconcept{common_range}@<const V> &&
                     @\libconcept{common_range}@<range_reference_t<const V>>)


### PR DESCRIPTION
This function is constrained on `is_reference_v<range_reference_t<const V>>` already so checking it again in the `if constexpr` has no effect.