### PR TITLE
P2242R3  Non-literal variables (and labels and gotos) in constexpr functions

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -783,21 +783,7 @@ it shall not be a coroutine\iref{dcl.fct.def.coroutine};
 
 \item
 if the function is a constructor or destructor,
-its class shall not have any virtual base classes;
-
-\item
-its \grammarterm{function-body} shall not enclose\iref{stmt.pre}
-\begin{itemize}
-\item a \tcode{goto} statement,
-\item a label with an \grammarterm{identifier}\iref{stmt.label},
-\item a definition of a variable
-of non-literal type or
-of static or thread storage duration.
-\end{itemize}
-\begin{note}
-A \grammarterm{function-body} that is \tcode{= delete} or \tcode{= default}
-encloses none of the above.
-\end{note}
+its class shall not have any virtual base classes.
 \end{itemize}
 
 \begin{example}
@@ -811,9 +797,12 @@ constexpr int abs(int x) {
     x = -x;
   return x;                     // OK
 }
-constexpr int first(int n) {
-  static int value = n;         // error: variable has static storage duration
-  return value;
+constexpr int constant_non_42(int n) {  // OK
+  if (n == 42) {
+    static int value = n;
+    return value;
+  }
+  return n;
 }
 constexpr int uninit() {
   struct { int a; } s;
@@ -892,6 +881,12 @@ struct D : B {
   constexpr D() : B(global) { }         // ill-formed, no diagnostic required
                                         // lvalue-to-rvalue conversion on non-constant \tcode{global}
 };
+
+constexpr int f(int x) {
+  static int n = x;
+  return n + x;                         // ill-formed, no diagnostic required
+                                        // all calls reach the static variable declaration
+}
 \end{codeblock}
 \end{example}
 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -7090,6 +7090,12 @@ function\iref{dcl.constexpr} that is being evaluated as part
 of $E$;
 
 \item
+a control flow that passes through
+a declaration of a variable with
+static\iref{basic.stc.static} or
+thread\iref{basic.stc.thread} storage duration;
+
+\item
 an invocation of a non-constexpr function;
 \begin{footnote}
 Overload resolution\iref{over.match}
@@ -7263,10 +7269,13 @@ a \keyword{dynamic_cast}\iref{expr.dynamic.cast} or \keyword{typeid}\iref{expr.t
 that would throw an exception;
 
 \item
-an \grammarterm{asm-declaration}\iref{dcl.asm}; or
+an \grammarterm{asm-declaration}\iref{dcl.asm};
 
 \item
-an invocation of the \tcode{va_arg} macro\iref{cstdarg.syn}.
+an invocation of the \tcode{va_arg} macro\iref{cstdarg.syn}; or
+
+\item
+a \keyword{goto} statement\iref{stmt.goto}.
 \end{itemize}
 
 If $E$ satisfies the constraints of a core constant expression, but

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1765,7 +1765,7 @@ an \impldef{text of \mname{TIME} when time of translation is not available} vali
 \defnxname{cpp_char8_t}                           & \tcode{201811L} \\ \rowsep
 \defnxname{cpp_concepts}                          & \tcode{201907L} \\ \rowsep
 \defnxname{cpp_conditional_explicit}              & \tcode{201806L} \\ \rowsep
-\defnxname{cpp_constexpr}                         & \tcode{201907L} \\ \rowsep
+\defnxname{cpp_constexpr}                         & \tcode{202110L} \\ \rowsep
 \defnxname{cpp_constexpr_dynamic_alloc}           & \tcode{201907L} \\ \rowsep
 \defnxname{cpp_constexpr_in_decltype}             & \tcode{201711L} \\ \rowsep
 \defnxname{cpp_consteval}                         & \tcode{201811L} \\ \rowsep


### PR DESCRIPTION
Fixes #4963
Fixes cplusplus/papers#941