### PR TITLE
P2251R1 Require span & basic_string_view to be Trivially Copyable

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10983,6 +10983,9 @@ namespace std {
 \end{codeblock}
 
 \pnum
+\tcode{span<ElementType, Extent>} is a trivially copyable type.
+
+\pnum
 \tcode{ElementType} is required to be
 a complete object type that is not an abstract class type.
 

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -4210,6 +4210,9 @@ returned from \tcode{str}'s member functions.
 The complexity of \tcode{basic_string_view} member functions is \bigoh{1}
 unless otherwise specified.
 
+\pnum
+\tcode{basic_string_view<charT,traits>} is a trivially copyable type.
+
 \rSec3[string.view.cons]{Construction and assignment}
 
 \indexlibraryctor{basic_string_view}%


### PR DESCRIPTION
Fixes #4985
Fixes cplusplus/papers#946