### PR TITLE
[macros] Preserve straight apostrophes in code.

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -500,7 +500,7 @@
 \newcommand{\CodeBlockSetup}{%
 \lstset{escapechar=@, aboveskip=\parskip, belowskip=0pt,
         midpenalty=500, endpenalty=-50,
-        emptylinepenalty=-250, semicolonpenalty=0}%
+        emptylinepenalty=-250, semicolonpenalty=0,upquote=true}%
 \renewcommand{\tcode}[1]{\textup{\CodeStylex{##1}}}
 \renewcommand{\term}[1]{\textit{##1}}%
 \renewcommand{\grammarterm}[1]{\gterm{##1}}%


### PR DESCRIPTION
Apostrophes are code and should not be turned into typographic single quotes.

Please let me know if there's an appetite for this change. I think it's altogether fitting to have codeblocks show actual code, but I'd like to hear other opinions.

The effect is pervasive, here's a random example screenshot:

![image](https://user-images.githubusercontent.com/6378233/136223846-abd42d4b-6c72-4a80-be81-019bb40db019.png)
