### PR TITLE
P1147R1 Printing volatile Pointers

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -5854,6 +5854,7 @@ namespace std {
     basic_ostream& operator<<(long double f);
 
     basic_ostream& operator<<(const void* p);
+    basic_ostream& operator<<(const volatile void* p);
     basic_ostream& operator<<(nullptr_t);
     basic_ostream& operator<<(basic_streambuf<char_type, traits>* sb);
 
@@ -6417,6 +6418,17 @@ which may throw an exception, and returns.
 \pnum
 \returns
 \tcode{*this}.
+\end{itemdescr}
+
+\indexlibrarymember{operator<<}{basic_ostream}%
+\begin{itemdecl}
+basic_ostream& operator<<(const volatile void* p);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return operator<<(const_cast<const void*>(p));}
 \end{itemdescr}
 
 \rSec4[ostream.inserters]{\tcode{basic_ostream::operator<<}}


### PR DESCRIPTION
Moved to [ostream.inserters.arithmetic] and renamed the parameter
from 'val' to 'p' for consistency with the 'const void*' overload.

Fixes #4981
Fixes cplusplus/papers#320