### PR TITLE
[move.iterator] Use the template parameter directly in declaration of base()

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -4158,8 +4158,8 @@ namespace std {
     template<class U> constexpr move_iterator(const move_iterator<U>& u);
     template<class U> constexpr move_iterator& operator=(const move_iterator<U>& u);
 
-    constexpr const iterator_type& base() const & noexcept;
-    constexpr iterator_type base() &&;
+    constexpr const Iterator& base() const & noexcept;
+    constexpr Iterator base() &&;
     constexpr reference operator*() const;
 
     constexpr move_iterator& operator++();


### PR DESCRIPTION
Every other place (including the itemdecl for these overloads) uses `Iterator` directly.