### PR TITLE
[expr.type.conv] Move description of 'auto' deduction to [dcl.type.auto.deduct]

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1950,6 +1950,20 @@ a single \grammarterm{assignment-expression}
 and $E$ is the \grammarterm{assignment-expression}.
 \end{itemize}
 \item
+For an explicit type conversion\iref{expr.type.conv},
+\tcode{T} is the specified type, which shall be \keyword{auto}.
+\begin{itemize}
+\item
+If the initializer is a \grammarterm{braced-init-list},
+it shall consist of a single brace-enclosed \grammarterm{assignment-expression}
+and $E$ is the \grammarterm{assignment-expression}.
+\item
+If the initializer is a parenthesized \grammarterm{expression-list},
+the \grammarterm{expression-list} shall be
+a single \grammarterm{assignment-expression}
+and $E$ is the \grammarterm{assignment-expression}.
+\end{itemize}
+\item
 For a non-type template parameter declared with a type
 that contains a placeholder type,
 \tcode{T} is the declared type of the non-type template parameter

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3353,14 +3353,9 @@ it is replaced by the return type
 of the function selected by overload resolution
 for class template deduction\iref{over.match.class.deduct}
 for the remainder of this subclause.
-Otherwise, if the type is \tcode{auto},
-it is replaced by the type deduced for the variable \tcode{x}
-in the invented declaration\iref{dcl.spec.auto},
-which is never interpreted as a function declaration:
-\begin{codeblock}
-auto x @\placeholder{init}@;
-\end{codeblock}
-, where \placeholder{init} is the initializer.
+Otherwise, if the type contains a placeholder type,
+it is replaced by the type
+determined by placeholder type deduction\iref{dcl.type.auto.deduct}.
 \begin{example}
 \begin{codeblock}
 struct A {};


### PR DESCRIPTION
Fixes #4745.

See #5015 for discussion and suggestions.