### PR TITLE
[support.c.headers.general] Do not use \libheader with placeholder.

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -5895,7 +5895,7 @@ should not use any of the C headers.
 \begin{note}
 The C headers either have no effect,
 such as \libheaderref{stdbool.h} and \libheaderref{stdalign.h}, or
-otherwise the corresponding header of the form \libheader{c\placeholder{name}}
+otherwise the corresponding header of the form \tcode{<c\placeholder{name}>}
 provides the same facilities and
 assuredly defines them in namespace \tcode{std}.
 \end{note}


### PR DESCRIPTION
So that we don't pollute the index of library headers.