### PR TITLE
[container.requirements] Improve punctuation of list items.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1718,16 +1718,16 @@ and \tcode{e} in \tcode{a};
 \item
 \tcode{ke} is a value such that \tcode{a} is partitioned with respect to
 \tcode{c(r, ke)} and \tcode{!c(ke, r)}, with \tcode{c(r, ke)} implying
-\tcode{!c(ke, r)}.
+\tcode{!c(ke, r)};
 \item
 \tcode{kx} is a value such that
 \begin{itemize}
 \item
 \tcode{a} is partitioned with respect to \tcode{c(r, rx)} and \tcode{!c(kx, r)},
-with \tcode{c(r, kx)} implying \tcode{!c(kx, r)}
+with \tcode{c(r, kx)} implying \tcode{!c(kx, r)}, and
 \item
 \tcode{kx} is not convertible to
-either \tcode{iterator} or \tcode{const_iterator},
+either \tcode{iterator} or \tcode{const_iterator}; and
 \end{itemize}
 \item
 \tcode{A} denotes the storage allocator used by \tcode{X}, if any, or \tcode{allocator<X::value_type>} otherwise,
@@ -2453,9 +2453,9 @@ In \tref{container.hash.req},
 \item
 \tcode{ke} is a value such that
   \begin{itemize}
-  \item \tcode{eq(r1, ke) == eq(ke, r1)}
+  \item \tcode{eq(r1, ke) == eq(ke, r1)},
   \item \tcode{hf(r1) == hf(ke)} if \tcode{eq(r1, ke)} is \tcode{true}, and
-  \item \tcode{(eq(r1, ke) \&\& eq(r1, r2)) == eq(r2, ke)}
+  \item \tcode{(eq(r1, ke) \&\& eq(r1, r2)) == eq(r2, ke)},
   \end{itemize}
   where \tcode{r1} and \tcode{r2} are keys of elements in \tcode{a_tran},
 \item
@@ -2465,7 +2465,7 @@ In \tref{container.hash.req},
   \item \tcode{hf(r1) == hf(kx)} if \tcode{eq(r1, kx)} is \tcode{true},
   \item \tcode{(eq(r1, kx) \&\& eq(r1, r2)) == eq(r2, kx)}, and
   \item \tcode{kx} is not convertible to
-    either \tcode{iterator} or \tcode{const_iterator}
+    either \tcode{iterator} or \tcode{const_iterator},
   \end{itemize}
   where \tcode{r1} and \tcode{r2} are keys of elements in \tcode{a_tran},
 \item


### PR DESCRIPTION
It is still odd to have semicolons in the middle of the first list,
but at least this change makes the overall punctuation somewhat more correct.