### PR TITLE
[ranges] Tweak use of braces and whitespace

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -85,7 +85,7 @@ namespace std::ranges {
   template<class T>
     inline constexpr bool enable_view = @\seebelow@;
 
-  struct view_base { };
+  struct view_base {};
 
   template<class T>
     concept view = @\seebelow@;
@@ -1638,8 +1638,7 @@ namespace std::ranges {
                @\libconcept{convertible_to}@<sentinel_t<R>, S>
     constexpr subrange(R&& r, @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>> n)
       requires (K == subrange_kind::sized)
-        : subrange{ranges::begin(r), ranges::end(r), n}
-    {}
+        : subrange{ranges::begin(r), ranges::end(r), n} {}
 
     template<@\exposconcept{different-from}@<subrange> PairLike>
       requires @\exposconcept{pair-like-convertible-from}@<PairLike, const I&, const S&>
@@ -1947,7 +1946,7 @@ the tag type \tcode{dangling} is returned instead of an iterator or subrange.
 namespace std::ranges {
   struct dangling {
     constexpr dangling() noexcept = default;
-    constexpr dangling(auto&&...) noexcept { }
+    constexpr dangling(auto&&...) noexcept {}
   };
 }
 \end{codeblock}
@@ -2968,8 +2967,7 @@ namespace std::ranges {
   public:
     constexpr explicit basic_istream_view(basic_istream<CharT, Traits>& stream);
 
-    constexpr auto begin()
-    {
+    constexpr auto begin() {
       *@\exposid{stream_}@ >> @\exposid{value_}@;
       return @\exposid{iterator}@{*this};
     }
@@ -3215,8 +3213,7 @@ constructor of \tcode{\exposid{copyable-box}<T>} is equivalent to:
 \begin{codeblock}
 constexpr @\exposid{copyable-box}@() noexcept(is_nothrow_default_constructible_v<T>)
     requires @\libconcept{default_initializable}@<T>
-  : @\exposid{copyable-box}@{in_place}
-{ }
+  : @\exposid{copyable-box}@{in_place} {}
 \end{codeblock}
 
 \item If \tcode{\libconcept{copyable}<T>} is not
@@ -3267,7 +3264,7 @@ with \tcode{is_object_v<T>}.
 \item
 The copy constructor is equivalent to:
 \begin{codeblock}
-constexpr @\exposid{non-propagating-cache}@(const @\exposid{non-propagating-cache}@&) noexcept { }
+constexpr @\exposid{non-propagating-cache}@(const @\exposid{non-propagating-cache}@&) noexcept {}
 \end{codeblock}
 \item
 The move constructor is equivalent to:
@@ -3394,6 +3391,7 @@ namespace std::ranges {
     constexpr auto data() const requires @\libconcept{contiguous_range}@<R>
     { return ranges::data(*@\exposid{r_}@); }
   };
+
   template<class R>
     ref_view(R&) -> ref_view<R>;
 }
@@ -3457,11 +3455,9 @@ namespace std::ranges {
     constexpr auto end() const requires @\libconcept{range}@<const R>
     { return ranges::end(@\exposid{r_}@); }
 
-    constexpr bool empty()
-      requires requires { ranges::empty(@\exposid{r_}@); }
+    constexpr bool empty() requires requires { ranges::empty(@\exposid{r_}@); }
     { return ranges::empty(@\exposid{r_}@); }
-    constexpr bool empty() const
-      requires requires { ranges::empty(@\exposid{r_}@); }
+    constexpr bool empty() const requires requires { ranges::empty(@\exposid{r_}@); }
     { return ranges::empty(@\exposid{r_}@); }
 
     constexpr auto size() requires @\libconcept{sized_range}@<R>
@@ -4696,26 +4692,28 @@ namespace std::ranges {
 
     constexpr auto begin() requires (!@\exposconcept{simple-view}@<V>) {
       if constexpr (@\libconcept{sized_range}@<V>) {
-        if constexpr (@\libconcept{random_access_range}@<V>)
+        if constexpr (@\libconcept{random_access_range}@<V>) {
           return ranges::begin(@\exposid{base_}@);
-        else {
+        } else {
           auto sz = range_difference_t<V>(size());
           return counted_iterator(ranges::begin(@\exposid{base_}@), sz);
         }
-      } else
+      } else {
         return counted_iterator(ranges::begin(@\exposid{base_}@), @\exposid{count_}@);
+      }
     }
 
     constexpr auto begin() const requires @\libconcept{range}@<const V> {
       if constexpr (@\libconcept{sized_range}@<const V>) {
-        if constexpr (@\libconcept{random_access_range}@<const V>)
+        if constexpr (@\libconcept{random_access_range}@<const V>) {
           return ranges::begin(@\exposid{base_}@);
-        else {
+        } else {
           auto sz = range_difference_t<const V>(size());
           return counted_iterator(ranges::begin(@\exposid{base_}@), sz);
         }
-      } else
+      } else {
         return counted_iterator(ranges::begin(@\exposid{base_}@), @\exposid{count_}@);
+      }
     }
 
     constexpr auto end() requires (!@\exposconcept{simple-view}@<V>) {
@@ -4724,8 +4722,9 @@ namespace std::ranges {
           return ranges::begin(@\exposid{base_}@) + range_difference_t<V>(size());
         else
           return default_sentinel;
-      } else
+      } else {
         return @\exposid{sentinel}@<false>{ranges::end(@\exposid{base_}@)};
+      }
     }
 
     constexpr auto end() const requires @\libconcept{range}@<const V> {
@@ -4734,8 +4733,9 @@ namespace std::ranges {
           return ranges::begin(@\exposid{base_}@) + range_difference_t<const V>(size());
         else
           return default_sentinel;
-      } else
+      } else {
         return @\exposid{sentinel}@<true>{ranges::end(@\exposid{base_}@)};
+      }
     }
 
     constexpr auto size() requires @\libconcept{sized_range}@<V> {
@@ -5120,29 +5120,24 @@ namespace std::ranges {
     constexpr auto begin() const
       requires @\libconcept{random_access_range}@<const V> && @\libconcept{sized_range}@<const V>;
 
-    constexpr auto end()
-      requires (!@\exposconcept{simple-view}@<V>)
+    constexpr auto end() requires (!@\exposconcept{simple-view}@<V>)
     { return ranges::end(@\exposid{base_}@); }
 
-    constexpr auto end() const
-      requires @\libconcept{range}@<const V>
+    constexpr auto end() const requires @\libconcept{range}@<const V>
     { return ranges::end(@\exposid{base_}@); }
 
-    constexpr auto size()
-      requires @\libconcept{sized_range}@<V>
-    {
+    constexpr auto size() requires @\libconcept{sized_range}@<V> {
       const auto s = ranges::size(@\exposid{base_}@);
       const auto c = static_cast<decltype(s)>(@\exposid{count_}@);
       return s < c ? 0 : s - c;
     }
 
-    constexpr auto size() const
-      requires @\libconcept{sized_range}@<const V>
-    {
+    constexpr auto size() const requires @\libconcept{sized_range}@<const V> {
       const auto s = ranges::size(@\exposid{base_}@);
       const auto c = static_cast<decltype(s)>(@\exposid{count_}@);
       return s < c ? 0 : s - c;
     }
+
   private:
     V @\exposid{base_}@ = V();                              // \expos
     range_difference_t<V> @\exposid{count_}@ = 0;           // \expos
@@ -5248,8 +5243,7 @@ namespace std::ranges {
 
     constexpr auto begin();
 
-    constexpr auto end()
-    { return ranges::end(@\exposid{base_}@); }
+    constexpr auto end() { return ranges::end(@\exposid{base_}@); }
 
   private:
     V @\exposid{base_}@ = V();                                      // \expos
@@ -5378,10 +5372,9 @@ namespace std::ranges {
     }
 
     constexpr auto begin() const
-    requires @\libconcept{input_range}@<const V> &&
-             is_reference_v<range_reference_t<const V>> {
-      return @\exposid{iterator}@<true>{*this, ranges::begin(@\exposid{base_}@)};
-    }
+      requires @\libconcept{input_range}@<const V> &&
+               is_reference_v<range_reference_t<const V>>
+    { return @\exposid{iterator}@<true>{*this, ranges::begin(@\exposid{base_}@)}; }
 
     constexpr auto end() {
       if constexpr (@\libconcept{forward_range}@<V> &&
@@ -5393,8 +5386,8 @@ namespace std::ranges {
     }
 
     constexpr auto end() const
-    requires @\libconcept{input_range}@<const V> &&
-             is_reference_v<range_reference_t<const V>> {
+      requires @\libconcept{input_range}@<const V> &&
+               is_reference_v<range_reference_t<const V>> {
       if constexpr (@\libconcept{forward_range}@<const V> &&
                     @\libconcept{forward_range}@<range_reference_t<const V>> &&
                     @\libconcept{common_range}@<const V> &&
@@ -5444,6 +5437,7 @@ namespace std::ranges {
     @\exposidnc{Parent}@* @\exposid{parent_}@  = nullptr;                                 // \expos
 
     constexpr void @\exposidnc{satisfy}@();                                   // \expos
+
   public:
     using iterator_concept  = @\seebelow@;
     using iterator_category = @\seebelow@;                        // not always present
@@ -5750,6 +5744,7 @@ namespace std::ranges {
     using @\exposid{Parent}@ = @\exposid{maybe-const}@<Const, join_view>;       // \expos
     using @\exposid{Base}@ = @\exposid{maybe-const}@<Const, V>;                 // \expos
     sentinel_t<@\exposid{Base}@> @\exposid{end_}@ = sentinel_t<@\exposid{Base}@>();         // \expos
+
   public:
     @\exposid{sentinel}@() = default;
 
@@ -5879,10 +5874,10 @@ namespace std::ranges {
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
     constexpr auto begin() {
-      if constexpr (@\libconcept{forward_range}@<V>)
+      if constexpr (@\libconcept{forward_range}@<V>) {
         return @\exposid{outer-iterator}@<@\exposconcept{simple-view}@<V> && @\exposconcept{simple-view}@<Pattern>>
           {*this, ranges::begin(@\exposid{base_}@)};
-      else {
+      } else {
         @\exposid{current_}@ = ranges::begin(@\exposid{base_}@);
         return @\exposid{outer-iterator}@<false>{*this};
       }
@@ -6900,6 +6895,7 @@ namespace std::ranges {
     constexpr auto size() requires @\libconcept{sized_range}@<V> {
       return ranges::size(@\exposid{base_}@);
     }
+
     constexpr auto size() const requires @\libconcept{sized_range}@<const V> {
       return ranges::size(@\exposid{base_}@);
     }
@@ -8419,9 +8415,7 @@ namespace std::ranges {
 
     constexpr explicit zip_transform_view(F fun, Views... views);
 
-    constexpr auto begin() {
-      return @\exposid{iterator}@<false>(*this, @\exposid{zip_}@.begin());
-    }
+    constexpr auto begin() { return @\exposid{iterator}@<false>(*this, @\exposid{zip_}@.begin()); }
 
     constexpr auto begin() const
       requires @\libconcept{range}@<const @\exposid{InnerView}@> &&


### PR DESCRIPTION
For example:
* Use braces symmetrically in if+else statements.
* Consistently spell empty blocks as "{}", on the same line.
* Indent required-clauses consistently.
* Avoid unnecessary line breaks.