### PR TITLE
[basic.def.odr] Introduce label 'term.odr.use' and refer to it

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -426,6 +426,7 @@ This covers
 \end{itemize}
 
 \pnum
+\label{term.odr.use}%
 A variable is named by an expression
 if the expression is an \grammarterm{id-expression} that denotes it.
 A variable \tcode{x} whose name appears as a
@@ -2854,7 +2855,7 @@ friend declarations in a class definition, and
 \item
 any reference to a non-volatile const object or reference
 with internal or no linkage initialized with a constant expression
-that is not an odr-use\iref{basic.def.odr},
+that is not an odr-use\iref{term.odr.use},
 \end{itemize}
 or defines a constexpr variable initialized to a TU-local value (defined below).
 \begin{note}
@@ -6540,7 +6541,7 @@ ordered variables concurrently with another sequence.
 \pnum
 \indextext{non-initialization odr-use|see{odr-use, non-initialization}}%
 A \defnx{non-initialization odr-use}{odr-use!non-initialization}
-is an odr-use\iref{basic.def.odr} not caused directly or indirectly by
+is an odr-use\iref{term.odr.use} not caused directly or indirectly by
 the initialization of a non-block static or thread storage duration variable.
 
 \pnum
@@ -6557,7 +6558,7 @@ defined in the same translation unit as the variable to be initialized.
 A non-block variable with static storage duration
 having initialization
 with side effects is initialized in this case,
-even if it is not itself odr-used~(\ref{basic.def.odr}, \ref{basic.stc.static}).
+even if it is not itself odr-used~(\ref{term.odr.use}, \ref{basic.stc.static}).
 \end{footnote}
 It is \impldef{threads and program points at which deferred dynamic initialization is performed}
 in which threads and at which points in the program such deferred dynamic initialization occurs.

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1030,7 +1030,7 @@ and prospective destructors\iref{class.dtor} are
 The implementation will implicitly declare these member functions for some class
 types when the program does not explicitly declare them.
 The implementation will implicitly define them
-if they are odr-used\iref{basic.def.odr} or
+if they are odr-used\iref{term.odr.use} or
 needed for constant evaluation\iref{expr.const}.
 \end{note}
 An implicitly-declared special member function is declared at the closing
@@ -1303,7 +1303,7 @@ A default constructor
 that is defaulted and not defined as deleted
 is
 \defnx{implicitly defined}{constructor!implicitly defined}
-when it is odr-used\iref{basic.def.odr}
+when it is odr-used\iref{term.odr.use}
 to create an object of its class type\iref{intro.object},
 when it is needed for constant evaluation\iref{expr.const}, or
 when it is explicitly defaulted after its first declaration.
@@ -1611,12 +1611,12 @@ A copy/move constructor
 that is defaulted and not defined as deleted
 is
 \term{implicitly defined}
-when it is odr-used\iref{basic.def.odr},
+when it is odr-used\iref{term.odr.use},
 when it is needed for constant evaluation\iref{expr.const}, or
 when it is explicitly defaulted after its first declaration.
 \begin{note}
 The copy/move constructor is implicitly defined even if the implementation elided
-its odr-use~(\ref{basic.def.odr}, \ref{class.temporary}).
+its odr-use~(\ref{term.odr.use}, \ref{class.temporary}).
 \end{note}
 If the implicitly-defined constructor would satisfy the requirements of a
 constexpr constructor\iref{dcl.constexpr}, the implicitly-defined
@@ -1912,7 +1912,7 @@ A copy/move assignment operator for a class \tcode{X}
 that is defaulted and not defined as deleted
 is
 \term{implicitly defined}
-when it is odr-used\iref{basic.def.odr}
+when it is odr-used\iref{term.odr.use}
 (e.g., when it is selected by overload resolution
 to assign to an object of its class type),
 when it is needed for constant evaluation\iref{expr.const}, or
@@ -2070,7 +2070,7 @@ also known as the \defnadj{selected}{destructor}.
 The program is ill-formed if overload resolution fails.
 Destructor selection does not constitute
 a reference to,
-or odr-use\iref{basic.def.odr} of,
+or odr-use\iref{term.odr.use} of,
 the selected destructor,
 and in particular,
 the selected destructor may be deleted\iref{dcl.fct.def.delete}.
@@ -2140,7 +2140,7 @@ A destructor
 that is defaulted and not defined as deleted
 is
 \defnx{implicitly defined}{destructor!implicitly defined}
-when it is odr-used\iref{basic.def.odr}
+when it is odr-used\iref{term.odr.use}
 or when it is explicitly defaulted after its first declaration.
 
 \pnum
@@ -2747,7 +2747,7 @@ its declaration in the class definition can specify a
 \grammarterm{initializer-clause} that is an \grammarterm{assignment-expression}
 is a constant expression\iref{expr.const}.
 The member shall still be defined in a namespace scope if
-it is odr-used\iref{basic.def.odr} in the program and the
+it is odr-used\iref{term.odr.use} in the program and the
 namespace scope definition shall not contain an \grammarterm{initializer}.
 The declaration of an inline static data member (which is a definition)
 may specify a \grammarterm{brace-or-equal-initializer}. If the
@@ -2759,7 +2759,7 @@ static data members shall not specify a \grammarterm{brace-or-equal-initializer}
 \pnum
 \begin{note}
 There is exactly one definition of a static data member
-that is odr-used\iref{basic.def.odr} in a valid program.
+that is odr-used\iref{term.odr.use} in a valid program.
 \end{note}
 
 \pnum
@@ -3205,7 +3205,7 @@ A class can be declared within a function definition; such a class is
 called a \defnadj{local}{class}.
 \begin{note}
 A declaration in a local class
-cannot odr-use\iref{basic.def.odr}
+cannot odr-use\iref{term.odr.use}
 a local entity
 from an
 enclosing scope.

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4124,7 +4124,7 @@ void C::g(int i = 88, int j) {} // in this translation unit, \tcode{C::g} can be
 
 \pnum
 \begin{note}
-A local variable cannot be odr-used\iref{basic.def.odr}
+A local variable cannot be odr-used\iref{term.odr.use}
 in a default argument.
 \end{note}
 \begin{example}
@@ -6180,7 +6180,7 @@ distinct from that of any other object in the program.
 Implementations are
 permitted to provide additional predefined variables with names that are reserved to the
 implementation\iref{lex.name}. If a predefined variable is not
-odr-used\iref{basic.def.odr}, its string value need not be present in the program image.
+odr-used\iref{term.odr.use}, its string value need not be present in the program image.
 \end{footnote}
 \begin{example}
 \begin{codeblock}
@@ -6340,7 +6340,7 @@ implicitly or explicitly and forming a pointer or pointer-to-member to the
 function. It applies even for references in expressions that are not
 potentially-evaluated. For an overload set, only the
 function selected by overload resolution is referenced. The implicit
-odr-use\iref{basic.def.odr} of a virtual function does not, by itself,
+odr-use\iref{term.odr.use} of a virtual function does not, by itself,
 constitute a reference.
 \end{note}
 

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -943,7 +943,7 @@ An exception specification is considered to be \defnx{needed}{needed!exception s
 \item in an expression, the function is selected by
 overload resolution~(\ref{over.match}, \ref{over.over});
 
-\item the function is odr-used\iref{basic.def.odr} or, if it appears in an
+\item the function is odr-used\iref{term.odr.use} or, if it appears in an
 unevaluated operand, would be odr-used if the expression were
 potentially-evaluated;
 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2338,7 +2338,7 @@ void f(int n) {
 
 \pnum
 An entity is \defn{captured} if it is captured explicitly or implicitly. An entity
-captured by a \grammarterm{lambda-expression} is odr-used\iref{basic.def.odr} by
+captured by a \grammarterm{lambda-expression} is odr-used\iref{term.odr.use} by
 the \grammarterm{lambda-expression}.
 \begin{note}
 As a consequence, if a \grammarterm{lambda-expression}
@@ -2443,7 +2443,7 @@ A member of an anonymous union shall not be captured by copy.
 
 \pnum
 Every \grammarterm{id-expression} within the \grammarterm{compound-statement} of a
-\grammarterm{lambda-expression} that is an odr-use\iref{basic.def.odr} of an
+\grammarterm{lambda-expression} that is an odr-use\iref{term.odr.use} of an
 entity captured by copy is transformed into an access to the corresponding unnamed data
 member of the closure type.
 \begin{note}
@@ -7265,7 +7265,7 @@ in a \grammarterm{lambda-expression},
 a reference to \keyword{this} or to a variable with
 automatic storage duration defined outside that
 \grammarterm{lambda-expression}, where
-the reference would be an odr-use~(\ref{basic.def.odr}, \ref{expr.prim.lambda});
+the reference would be an odr-use~(\ref{term.odr.use}, \ref{expr.prim.lambda});
 \begin{example}
 \begin{codeblock}
 void g() {

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -268,7 +268,7 @@ if constexpr (sizeof(int[2])) {}        // OK, narrowing allowed
 \end{codeblock}
 \end{example}
 \begin{note}
-Odr-uses\iref{basic.def.odr} in a discarded statement do not require
+Odr-uses\iref{term.odr.use} in a discarded statement do not require
 an entity to be defined.
 \end{note}
 A \keyword{case} or \keyword{default} label appearing within such an

--- a/source/support.tex
+++ b/source/support.tex
@@ -5858,7 +5858,7 @@ control entering a \grammarterm{try-block} or \grammarterm{function-try-block};
 initialization of a variable with static storage duration
 requiring dynamic initialization~(\ref{basic.start.dynamic}, \ref{stmt.dcl})
 \begin{footnote}
-Such initialization can occur because it is the first odr-use\iref{basic.def.odr} of that variable.
+Such initialization can occur because it is the first odr-use\iref{term.odr.use} of that variable.
 \end{footnote}
 ; or
 

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3557,7 +3557,7 @@ declarations of non-template functions do not merely guide
 overload resolution of
 function template specializations
 with the same name.
-If such a non-template function is odr-used\iref{basic.def.odr} in a program, it must be defined;
+If such a non-template function is odr-used\iref{term.odr.use} in a program, it must be defined;
 it will not be implicitly instantiated using the function template definition.
 \end{footnote}
 
@@ -5847,7 +5847,7 @@ An inline function
 that is the subject of an explicit instantiation declaration
 is not a declared specialization;
 the intent is that it still be implicitly instantiated
-when odr-used\iref{basic.def.odr}
+when odr-used\iref{term.odr.use}
 so that the body can be considered for inlining,
 but that no out-of-line copy of it be generated in the translation unit.
 \end{note}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -442,7 +442,7 @@ template<class T> add_rvalue_reference_t<T> declval() noexcept;    // as unevalu
 \begin{itemdescr}
 \pnum
 \mandates
-This function is not odr-used\iref{basic.def.odr}.
+This function is not odr-used\iref{term.odr.use}.
 
 \pnum
 \remarks
@@ -17949,7 +17949,7 @@ the argument is a complete type.
 For the purpose of defining the templates in this subclause,
 a function call expression \tcode{declval<T>()} for any type \tcode{T}
 is considered to be a trivial~(\ref{basic.types}, \ref{special}) function call
-that is not an odr-use\iref{basic.def.odr} of \tcode{declval}
+that is not an odr-use\iref{term.odr.use} of \tcode{declval}
 in the context of the corresponding definition
 notwithstanding the restrictions of~\ref{declval}.
 
@@ -18642,7 +18642,7 @@ Base classes that are private, protected, or ambiguous
 For the purpose of defining the templates in this subclause,
 a function call expression \tcode{declval<T>()} for any type \tcode{T}
 is considered to be a trivial~(\ref{basic.types}, \ref{special}) function call
-that is not an odr-use\iref{basic.def.odr} of \tcode{declval}
+that is not an odr-use\iref{term.odr.use} of \tcode{declval}
 in the context of the corresponding definition
 notwithstanding the restrictions of~\ref{declval}.
 


### PR DESCRIPTION
instead of referring to 'basic.def.odr'.  The latter breaks if we
ever move the definition of 'odr-use', e.g. to a subclause.

This new "term.x" convention is also documented in the wiki now.
Partially addresses #4937