### PR TITLE
[c.mb.wcs] mbrtoc8 stores code units, not characters

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -5783,9 +5783,9 @@ that corresponds to the U+0000 Unicode character
 (which is the value stored).
 \item between \tcode{1} and \tcode{n} (inclusive),
 if the next n or fewer bytes complete a valid multibyte character
-(which is the value stored);
+(whose first (or only) code unit is stored);
 the value returned is the number of bytes that complete the multibyte character.
-\item \tcode{(size_t)(-3)}, if the next character
+\item \tcode{(size_t)(-3)}, if the next code unit
 resulting from a previous call has been stored
 (no bytes from the input have been consumed by this call).
 \item \tcode{(size_t)(-2)}, if the next \tcode{n} bytes


### PR DESCRIPTION
Fixes #5001