### PR TITLE
[pairs.pair] Use T1/T2, not first_type/second_type

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -765,8 +765,8 @@ constexpr explicit(@\seebelow@) pair();
 \pnum
 \constraints
 \begin{itemize}
-\item \tcode{is_default_constructible_v<first_type>} is \tcode{true} and
-\item \tcode{is_default_constructible_v<second_type>} is \tcode{true}.
+\item \tcode{is_default_constructible_v<T1>} is \tcode{true} and
+\item \tcode{is_default_constructible_v<T2>} is \tcode{true}.
 \end{itemize}
 
 \pnum
@@ -776,11 +776,11 @@ Value-initializes \tcode{first} and \tcode{second}.
 \pnum
 \remarks
 The expression inside \keyword{explicit} evaluates to \tcode{true}
-if and only if either \tcode{first_type} or
-\tcode{second_type} is not implicitly default-constructible.
+if and only if either \tcode{T1} or
+\tcode{T2} is not implicitly default-constructible.
 \begin{note}
 This behavior can be implemented with a trait that checks
-whether a \tcode{const first_type\&} or a \tcode{const second_type\&}
+whether a \tcode{const T1\&} or a \tcode{const T2\&}
 can be initialized with \tcode{\{\}}.
 \end{note}
 \end{itemdescr}
@@ -794,8 +794,8 @@ constexpr explicit(@\seebelow@) pair(const T1& x, const T2& y);
 \pnum
 \constraints
 \begin{itemize}
-\item \tcode{is_copy_constructible_v<first_type>} is \tcode{true} and
-\item \tcode{is_copy_constructible_v<second_type>} is \tcode{true}.
+\item \tcode{is_copy_constructible_v<T1>} is \tcode{true} and
+\item \tcode{is_copy_constructible_v<T2>} is \tcode{true}.
 \end{itemize}
 
 \pnum
@@ -806,8 +806,7 @@ Initializes \tcode{first} with \tcode{x} and \tcode{second} with \tcode{y}.
 \remarks
 The expression inside \keyword{explicit} is equivalent to:
 \begin{codeblock}
-!is_convertible_v<const first_type&, first_type> ||
-  !is_convertible_v<const second_type&, second_type>
+!is_convertible_v<const T1&, T1> || !is_convertible_v<const T2&, T2>
 \end{codeblock}
 \end{itemdescr}
 
@@ -820,8 +819,8 @@ template<class U1 = T1, class U2 = T2> constexpr explicit(@\seebelow@) pair(U1&&
 \pnum
 \constraints
 \begin{itemize}
-\item \tcode{is_constructible_v<first_type, U1>} is \tcode{true} and
-\item \tcode{is_constructible_v<second_type, U2>} is \tcode{true}.
+\item \tcode{is_constructible_v<T1, U1>} is \tcode{true} and
+\item \tcode{is_constructible_v<T2, U2>} is \tcode{true}.
 \end{itemize}
 
 \pnum
@@ -834,7 +833,7 @@ with \tcode{std::forward<U2>(y)}.
 \remarks
 The expression inside \keyword{explicit} is equivalent to:
 \begin{codeblock}
-!is_convertible_v<U1, first_type> || !is_convertible_v<U2, second_type>
+!is_convertible_v<U1, T1> || !is_convertible_v<U2, T2>
 \end{codeblock}
 \end{itemdescr}
 
@@ -854,10 +853,10 @@ Let \tcode{\exposid{FWD}(u)} be \tcode{static_cast<decltype(u)>(u)}.
 \constraints
 \begin{itemize}
 \item
-\tcode{is_constructible_v<first_type, decltype(get<0>(\exposid{FWD}(p)))>}
+\tcode{is_constructible_v<T1, decltype(get<0>(\exposid{FWD}(p)))>}
 is \tcode{true} and
 \item
-\tcode{is_constructible_v<second_type, decltype(get<1>(\exposid{FWD}(p)))>}
+\tcode{is_constructible_v<T2, decltype(get<1>(\exposid{FWD}(p)))>}
 is \tcode{true}.
 \end{itemize}
 
@@ -870,8 +869,8 @@ Initializes \tcode{first} with \tcode{get<0>(\exposid{FWD}(p))} and
 \remarks
 The expression inside \keyword{explicit} is equivalent to:
 \begin{codeblock}
-!is_convertible_v<decltype(get<0>(@\exposid{FWD}@(p))), first_type> ||
-!is_convertible_v<decltype(get<1>(@\exposid{FWD}@(p))), second_type>
+!is_convertible_v<decltype(get<0>(@\exposid{FWD}@(p))), T1> ||
+!is_convertible_v<decltype(get<1>(@\exposid{FWD}@(p))), T2>
 \end{codeblock}
 \end{itemdescr}
 
@@ -886,8 +885,8 @@ template<class... Args1, class... Args2>
 \pnum
 \mandates
 \begin{itemize}
-\item \tcode{is_constructible_v<first_type, Args1...>} is \tcode{true} and
-\item \tcode{is_constructible_v<second_type, Args2...>} is \tcode{true}.
+\item \tcode{is_constructible_v<T1, Args1...>} is \tcode{true} and
+\item \tcode{is_constructible_v<T2, Args2...>} is \tcode{true}.
 \end{itemize}
 
 \pnum
@@ -919,8 +918,8 @@ Assigns \tcode{p.first} to \tcode{first} and \tcode{p.second} to \tcode{second}.
 \pnum
 \remarks
 This operator is defined as deleted unless
-\tcode{is_copy_assignable_v<first_type>} is \tcode{true} and
-\tcode{is_copy_assignable_v<second_type>} is \tcode{true}.
+\tcode{is_copy_assignable_v<T1>} is \tcode{true} and
+\tcode{is_copy_assignable_v<T2>} is \tcode{true}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{pair}%
@@ -933,9 +932,9 @@ constexpr const pair& operator=(const pair& p) const;
 \constraints
 \begin{itemize}
 \item
-\tcode{is_copy_assignable<const first_type>} is \tcode{true} and
+\tcode{is_copy_assignable<const T1>} is \tcode{true} and
 \item
-\tcode{is_copy_assignable<const second_type>} is \tcode{true}.
+\tcode{is_copy_assignable<const T2>} is \tcode{true}.
 \end{itemize}
 
 \pnum
@@ -956,8 +955,8 @@ template<class U1, class U2> constexpr pair& operator=(const pair<U1, U2>& p);
 \pnum
 \constraints
 \begin{itemize}
-\item \tcode{is_assignable_v<first_type\&, const U1\&>} is \tcode{true} and
-\item \tcode{is_assignable_v<second_type\&, const U2\&>} is \tcode{true}.
+\item \tcode{is_assignable_v<T1\&, const U1\&>} is \tcode{true} and
+\item \tcode{is_assignable_v<T2\&, const U2\&>} is \tcode{true}.
 \end{itemize}
 
 \pnum
@@ -979,9 +978,9 @@ template<class U1, class U2> constexpr const pair& operator=(const pair<U1, U2>&
 \constraints
 \begin{itemize}
 \item
-\tcode{is_assignable_v<const first_type\&, const U1\&>} is \tcode{true}, and
+\tcode{is_assignable_v<const T1\&, const U1\&>} is \tcode{true}, and
 \item
-\tcode{is_assignable_v<const second_type\&, const U2\&>} is \tcode{true}.
+\tcode{is_assignable_v<const T2\&, const U2\&>} is \tcode{true}.
 \end{itemize}
 
 \pnum
@@ -1002,14 +1001,14 @@ constexpr pair& operator=(pair&& p) noexcept(@\seebelow@);
 \pnum
 \constraints
 \begin{itemize}
-\item \tcode{is_move_assignable_v<first_type>} is \tcode{true} and
-\item \tcode{is_move_assignable_v<second_type>} is \tcode{true}.
+\item \tcode{is_move_assignable_v<T1>} is \tcode{true} and
+\item \tcode{is_move_assignable_v<T2>} is \tcode{true}.
 \end{itemize}
 
 \pnum
 \effects
-Assigns to \tcode{first} with \tcode{std::forward<first_type>(p.first)}
-and to \tcode{second} with\\ \tcode{std::forward<second_type>(p.second)}.
+Assigns to \tcode{first} with \tcode{std::forward<T1>(p.first)}
+and to \tcode{second} with \tcode{std::forward<T2>(\brk{}p.second)}.
 
 \pnum
 \returns
@@ -1033,15 +1032,15 @@ constexpr const pair& operator=(pair&& p) const;
 \constraints
 \begin{itemize}
 \item
-\tcode{is_assignable<const first_type\&, first_type>} is \tcode{true} and
+\tcode{is_assignable<const T1\&, T1>} is \tcode{true} and
 \item
-\tcode{is_assignable<const second_type\&, second_type>} is \tcode{true}.
+\tcode{is_assignable<const T2\&, T2>} is \tcode{true}.
 \end{itemize}
 
 \pnum
 \effects
-Assigns \tcode{std::forward<first_type>(p.first)} to \tcode{first} and
-\tcode{std::forward<second_type>(\brk{}p.second)} to \tcode{second}.
+Assigns \tcode{std::forward<T1>(p.first)} to \tcode{first} and
+\tcode{std::forward<T2>(p.second)} to \tcode{second}.
 
 \pnum
 \returns
@@ -1057,8 +1056,8 @@ template<class U1, class U2> constexpr pair& operator=(pair<U1, U2>&& p);
 \pnum
 \constraints
 \begin{itemize}
-\item \tcode{is_assignable_v<first_type\&, U1>} is \tcode{true} and
-\item \tcode{is_assignable_v<second_type\&, U2>} is \tcode{true}.
+\item \tcode{is_assignable_v<T1\&, U1>} is \tcode{true} and
+\item \tcode{is_assignable_v<T2\&, U2>} is \tcode{true}.
 \end{itemize}
 
 \pnum
@@ -1081,9 +1080,9 @@ template<class U1, class U2> constexpr const pair& operator=(pair<U1, U2>&& p) c
 \constraints
 \begin{itemize}
 \item
-\tcode{is_assignable_v<const first_type\&, U1>} is \tcode{true}, and
+\tcode{is_assignable_v<const T1\&, U1>} is \tcode{true}, and
 \item
-\tcode{is_assignable_v<const second_type\&, U2>} is \tcode{true}.
+\tcode{is_assignable_v<const T2\&, U2>} is \tcode{true}.
 \end{itemize}
 
 \effects
@@ -1131,10 +1130,10 @@ Swaps
 The exception specification is equivalent to:
 \begin{itemize}
 \item
-\tcode{is_nothrow_swappable_v<first_type> \&\& is_nothrow_swappable_v<second_type>}
-for the\newline first overload, and
+\tcode{is_nothrow_swappable_v<T1> \&\& is_nothrow_swappable_v<T2>}
+for the first overload, and
 \item
-\tcode{is_nothrow_swappable_v<const first_type> \&\& is_nothrow_swappable_v<const\newline second_type>}
+\tcode{is_nothrow_swappable_v<const T1> \&\& is_nothrow_swappable_v<const T2>}
 for the second overload.
 \end{itemize}
 \end{itemdescr}


### PR DESCRIPTION
Fixes #5028 