### PR TITLE
[time.format] Avoid non-sentence in bulleted list

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -10491,7 +10491,7 @@ are copied unchanged to the output.
 
 \pnum
 A \defnadj{formatting}{locale} is an instance of \tcode{locale}
-used by a formatting function, that is determined as follows:
+used by a formatting function, defined as
 \begin{itemize}
 \item
 the \tcode{"C"} locale if the \tcode{L} option


### PR DESCRIPTION
Fixes #5036 