### PR TITLE
[expr.await] Remove hyphen from "re-thrown"

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4702,7 +4702,7 @@ Otherwise, \placeholder{await-suspend} is evaluated.
 If the evaluation of \placeholder{await-suspend}
 exits via an exception, the exception is caught,
 the coroutine is resumed, and the exception is immediately
-re-thrown\iref{except.throw}. Otherwise, control flow returns
+rethrown\iref{except.throw}. Otherwise, control flow returns
 to the current coroutine caller or resumer\iref{dcl.fct.def.coroutine}
 without exiting any scopes\iref{stmt.jump}.
 


### PR DESCRIPTION
Every other use of rethrow or rethrown is not hyphenated.