### PR TITLE
[range.view] Move note outside of list.

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1258,11 +1258,7 @@ is no more complex than destruction followed by move construction; and
 \item
 if $N$ copies and/or moves are made from an object of type \tcode{T}
 that contained $M$ elements,
-then those $N$ objects have \bigoh{N+M} destruction
-\begin{note}
-This implies that a moved-from object of type \tcode{T} has \bigoh{1} destruction
-\end{note}%
-; and
+then those $N$ objects have \bigoh{N+M} destruction; and
 
 \item
 \tcode{\libconcept{copy_constructible}<T>} is \tcode{false}, or
@@ -1273,6 +1269,12 @@ This implies that a moved-from object of type \tcode{T} has \bigoh{1} destructio
 copy assignment of an object of type \tcode{T}
 is no more complex than destruction followed by copy construction.
 \end{itemize}
+
+\pnum
+\begin{note}
+The constraints on copying and moving imply that
+a moved-from object of type \tcode{T} has \bigoh{1} destruction.
+\end{note}
 
 \pnum
 \begin{example}


### PR DESCRIPTION
Also replace "and/or" by just "/", which already means "and/or".