### PR TITLE
[func.wrap.func.general,func.wrap.move.class] Remove 'first-class' object

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16109,7 +16109,7 @@ namespace std {
 The \tcode{function} class template provides polymorphic wrappers that
 generalize the notion of a function pointer. Wrappers can store, copy,
 and call arbitrary callable objects\iref{func.def}, given a call
-signature\iref{func.def}, allowing functions to be first-class objects.
+signature\iref{func.def}.
 
 \pnum
 \indextext{callable type}%
@@ -16567,7 +16567,7 @@ namespace std {
 The \tcode{move_only_function} class template provides polymorphic wrappers
 that generalize the notion of a callable object\iref{func.def}.
 These wrappers can store, move, and call arbitrary callable objects,
-given a call signature, allowing functions to be first-class objects.
+given a call signature.
 
 \pnum
 \recommended


### PR DESCRIPTION
which is an undefined term.

Fixes #5034