### PR TITLE
[class.access.base] No cv-qualification for access to inherited members

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -4894,20 +4894,6 @@ void f(B* p) {
 \end{example}
 \end{itemize}
 
-\pnum
-If a class member access operator, including an implicit
-``\tcode{this->}'',
-is used to access a non-static data member or non-static
-member function, the reference is ill-formed if the
-left operand (considered as a pointer in the
-``\tcode{.}''
-operator case) cannot be implicitly converted to a
-pointer to the designating class of the right operand.
-\begin{note}
-This requirement is in addition to the requirement that
-the member be accessible as designated.
-\end{note}
-
 \rSec2[class.friend]{Friends}%
 \indextext{friend function!access and}%
 \indextext{access control!friend function}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4339,6 +4339,16 @@ Otherwise, the program is ill-formed.
 \end{itemize}
 
 \pnum
+Let \tcode{C} be the cv-unqualified version of the type of \tcode{E1}.
+The program is ill-formed if a prvalue of type ``pointer to \tcode{C}''
+cannot be implicitly converted to a pointer to
+the designating class\iref{class.access.base} of the right operand.
+\begin{note}
+This requirement is in addition to the requirement that
+the member be accessible as designated.
+\end{note}
+
+\pnum
 If \tcode{E2} designates a non-static member
 (possibly after overload resolution),
 the program is ill-formed if the class of which \tcode{E2} designates


### PR DESCRIPTION
Fixes #4952
~The pointed-to designating class type should be identically cv-qualified.~
The class type of the left operand and the designating class of the member should be considered cv-unqualified for the purpose of accessibility.