### PR TITLE
Fixes misapplied resolution of LWG3539

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -21502,7 +21502,7 @@ template<class Out, class... Args>
 \effects
 Equivalent to:
 \begin{codeblock}
-return vformat_to(out, fmt.@\exposid{str}@, make_format_args(args...));
+return vformat_to(std::move(out), fmt.@\exposid{str}@, make_format_args(args...));
 \end{codeblock}
 \end{itemdescr}
 
@@ -21532,7 +21532,7 @@ template<class Out, class... Args>
 \effects
 Equivalent to:
 \begin{codeblock}
-return vformat_to(out, loc, fmt.@\exposid{str}@, make_format_args(args...));
+return vformat_to(std::move(out), loc, fmt.@\exposid{str}@, make_format_args(args...));
 \end{codeblock}
 \end{itemdescr}
 


### PR DESCRIPTION
LWG3539 has the following resolution

template<class Out, class... Args>
  Out format_to(Out out, string_view fmt, const Args&... args);
template<class Out, class... Args>
  Out format_to(Out out, wstring_view fmt, const Args&... args);

    -8- Effects: Equivalent to:

        using context = basic_format_context<Out, decltype(fmt)::value_type>;
        return vformat_to(<add>std::move(</add>out<add>)</add>, fmt, make_format_args<context>(args...));

template<class Out, class... Args>
  Out format_to(Out out, const locale& loc, string_view fmt, const Args&... args);
template<class Out, class... Args>
  Out format_to(Out out, const locale& loc, wstring_view fmt, const Args&... args);

    -9- Effects: Equivalent to:

        using context = basic_format_context<Out, decltype(fmt)::value_type>;
        return vformat_to(<add>std::move(</add>out<add>)</add>, loc, fmt, make_format_args<context>(args...));

In the current Standard every overload has its own Effects paragraph.
The proposed resolution is only applied to the wstring_view overloads.

This seems to a be mistake. This patch applies the resolution to the
string_view overloads; currently named format-string.