### PR TITLE
[stdatomic.h.syn] Fix missing \expos

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -3712,7 +3712,7 @@ The header \libheaderdef{stdatomic.h} provides the following definitions:
 
 \begin{codeblock}
 template<class T>
-  using @\exposid{std-atomic}@ = std::atomic<T>;        // exposition only
+  using @\exposid{std-atomic}@ = std::atomic<T>;        // \expos
 
 #define _Atomic(T) @\exposid{std-atomic}@<T>
 

--- a/tools/check-source.sh
+++ b/tools/check-source.sh
@@ -63,6 +63,10 @@ grep -n '\\opt[^{]' $texfiles |
 grep -n 'opt{}' *.tex |
     fail '\\opt used incorrectly' || failed=1
 
+# Use \expos insted of "exposition only"
+grep -n "// exposition only" $texfiles |
+    fail 'use \\expos instead' || failed=1
+
 # Use \notdef instead of "not defined".
 grep -n "// not defined" $texfiles |
     fail "use \\notdef instead" || failed=1


### PR DESCRIPTION
and augment the autmatic checks accordingly.