### PR TITLE
[intro.object,lex.ccon] Use \Cpp{} macros

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3323,7 +3323,7 @@ named \tcode{\keyword{operator} \keyword{new}} or \tcode{\keyword{operator} \key
 implicitly creates objects in the returned region of storage and
 returns a pointer to a suitable created object.
 \begin{note}
-Some functions in the C++ standard library implicitly create objects
+Some functions in the \Cpp{} standard library implicitly create objects
 (\ref{allocator.traits.members}, \ref{c.malloc}, \ref{cstring.syn}, \ref{bit.cast}).
 \end{note}
 \indextext{object model|)}

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1485,7 +1485,7 @@ The character specified by a \grammarterm{simple-escape-sequence}
 is specified in \tref{lex.ccon.esc}.
 \begin{note}
 Using an escape sequence for a question mark
-is supported for compatibility with ISO C++ 2014 and ISO C.
+is supported for compatibility with ISO \CppXIV{} and ISO C.
 \end{note}
 
 \begin{floattable}{Simple escape sequences}{lex.ccon.esc}

--- a/tools/check-source.sh
+++ b/tools/check-source.sh
@@ -67,6 +67,10 @@ grep -n 'opt{}' *.tex |
 grep -n "// not defined" $texfiles |
     fail "use \\notdef instead" || failed=1
 
+# Use \Cpp{} instead of C++
+grep -n '^[^%]*[^{"]C++[^"}]' $texfiles |
+    fail 'use \Cpp{} instead' || failed=1
+
 # Library element introducer followed by stuff.
 grep -ne '^\\\(constraints\|mandates\|expects\|effects\|sync\|ensures\|returns\|throws\|complexity\|remarks\|errors\).\+$' $texlibdesc |
     fail 'stuff after library element' || failed=1


### PR DESCRIPTION
and augment the automatic checks to flag literal 'C++'.