### PR TITLE
[alg.c.library,c.math.fpclass,cmath.syn] Use \xrefc macro

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -10968,5 +10968,4 @@ These functions have the semantics specified in the C standard library.
 Any exception thrown by \tcode{compar}\iref{res.on.exception.handling}.
 \end{itemdescr}
 
-\xref
-ISO C 7.22.5.
+\xrefc{7.22.5}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -9949,8 +9949,7 @@ have type \tcode{float}.
 \tcode{abs} is exempted from these rules in order to stay compatible with C.
 \end{note}
 
-\xref
-ISO C 7.12
+\xrefc{7.12}
 
 \rSec2[c.math.abs]{Absolute values}
 
@@ -10047,8 +10046,7 @@ The classification / comparison functions behave the same as the C macros with t
 corresponding names defined in the C standard library.
 Each function is overloaded for the three floating-point types.
 
-\xref
-ISO C 7.12.3, 7.12.4
+\xrefc{7.12.3, 7.12.4}
 
 \rSec2[sf.cmath]{Mathematical special functions}%
 

--- a/tools/check-source.sh
+++ b/tools/check-source.sh
@@ -81,6 +81,10 @@ grep -n 'ucode{[^}]*[^0-9a-f}][^}]*}' $texfiles |
 grep -n 'unicode{[^}]*[^0-9a-f}][^}]*}' $texfiles |
     fail 'use lowercase hex digits inside \\unicode' || failed=1
 
+# Use \xrefc instead of "ISO C x.y.z"
+grep -n "^ISO C [0-9]*\." $texfiles |
+    fail 'use \\xrefc instead' || failed=1
+
 # Library element introducer followed by stuff.
 grep -ne '^\\\(constraints\|mandates\|expects\|effects\|sync\|ensures\|returns\|throws\|complexity\|remarks\|errors\).\+$' $texlibdesc |
     fail 'stuff after library element' || failed=1


### PR DESCRIPTION
and augment the automatic checks to flag literal 'ISO C'.