### PR TITLE
[expr.ref] specify the result of a reference member access expression CWG2614

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3475,7 +3475,8 @@ in~\ref{basic.type.qualifier}.
 
 \pnum
 If \tcode{E2} is declared to have type ``reference to \tcode{T}'', then
-\tcode{E1.E2} is an lvalue; the type of \tcode{E1.E2} is \tcode{T}.
+\tcode{E1.E2} is an lvalue of type \tcode{T}
+designating the object or function to which the reference is bound.
 Otherwise, one of the following rules applies.
 
 \begin{itemize}


### PR DESCRIPTION
I've completely ignored the [funny] decision that references bind to expressions.