### PR TITLE
[macros] Allow \keyword and \grammarterm in section headings

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -559,7 +559,7 @@ struct S {
 \end{codeblock}
 \end{example}
 
-\rSec2[dcl.typedef]{The \tcode{typedef} specifier}%
+\rSec2[dcl.typedef]{The \keyword{typedef} specifier}%
 \indextext{specifier!\idxcode{typedef}}
 
 \pnum
@@ -698,14 +698,14 @@ typedef struct {
 \end{codeblock}
 \end{example}
 
-\rSec2[dcl.friend]{The \tcode{friend} specifier}%
+\rSec2[dcl.friend]{The \keyword{friend} specifier}%
 \indextext{specifier!\idxcode{friend}}
 
 \pnum
 The \keyword{friend} specifier is used to specify access to class members;
 see~\ref{class.friend}.
 
-\rSec2[dcl.constexpr]{The \tcode{constexpr} and \tcode{consteval} specifiers}%
+\rSec2[dcl.constexpr]{The \keyword{constexpr} and \keyword{consteval} specifiers}%
 \indextext{specifier!\idxcode{constexpr}}
 \indextext{specifier!\idxcode{consteval}}
 
@@ -953,7 +953,7 @@ constexpr pixel origin;                 // error: initializer missing
 \end{codeblock}
 \end{example}
 
-\rSec2[dcl.constinit]{The \tcode{constinit} specifier}
+\rSec2[dcl.constinit]{The \keyword{constinit} specifier}
 \indextext{specifier!\idxcode{constinit}}
 
 \pnum
@@ -982,7 +982,7 @@ constinit const char * d = f(false);    // error
 \end{codeblock}
 \end{example}
 
-\rSec2[dcl.inline]{The \tcode{inline} specifier}%
+\rSec2[dcl.inline]{The \keyword{inline} specifier}%
 \indextext{specifier!\idxcode{inline}}
 
 \pnum

--- a/source/front.tex
+++ b/source/front.tex
@@ -12,11 +12,19 @@
 \renewcommand\@pnumwidth{2.5em}
 \makeatother
 
+% Disable indexing within the table of contents
+\newcommand{\indexoff}[2][generalindex]{}
+\let\oindex\index
+\let\index\indexoff
+
 %% Include table of contents. Do not list "Contents"
 %% within it (per ISO request) but do include a
 %% bookmark for it in the PDF.
 \phantomsection
 \pdfbookmark{\contentsname}{toctarget}
 \hypertarget{toctarget}{\tableofcontents*}
+
+% Restore indexing
+\let\index\oindex
 
 \setcounter{tocdepth}{5}

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -224,8 +224,8 @@
 \newcommand{\term}[1]{\textit{#1}}
 \newcommand{\gterm}[1]{\GrammarStylex{#1}}
 \newcommand{\fakegrammarterm}[1]{\gterm{#1}}
-\newcommand{\keyword}[1]{\tcode{#1}\indextext{\idxcode{#1}!keyword}}        % macro length: 8
-\newcommand{\grammarterm}[1]{\indexgram{\idxgram{#1}}\gterm{#1}}
+\newcommand{\keyword}[1]{\texorpdfstring{\tcode{#1}\protect\indextext{\idxcode{#1}!keyword}}{#1}}                % macro length: 8
+\newcommand{\grammarterm}[1]{\texorpdfstring{\protect\indexgram{\idxgram{#1}}\gterm{#1}}{#1}}
 \newcommand{\grammartermnc}[1]{\indexgram{\idxgram{#1}}\gterm{#1\nocorr}}
 \newcommand{\regrammarterm}[1]{\textit{#1}}
 \newcommand{\placeholder}[1]{\textit{#1}}                                   % macro length: 12

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -231,7 +231,7 @@ each substatement of a \grammarterm{selection-statement}
 has a block scope\iref{basic.scope.block}.
 \end{note}
 
-\rSec2[stmt.if]{The \tcode{if} statement}%
+\rSec2[stmt.if]{The \keyword{if} statement}%
 \indextext{statement!\idxcode{if}}
 
 \pnum
@@ -376,7 +376,7 @@ but is equivalent to the consteval if statement
 \keyword{if} \keyword{consteval} statement$_2$ \keyword{else} compound-statement$_1$
 \end{ncsimplebnf}
 
-\rSec2[stmt.switch]{The \tcode{switch} statement}%
+\rSec2[stmt.switch]{The \keyword{switch} statement}%
 \indextext{statement!\idxcode{switch}}
 
 \pnum
@@ -518,7 +518,7 @@ while (--x >= 0) {
 Thus after the \keyword{while} statement, \tcode{i} is no longer in scope.
 \end{example}
 
-\rSec2[stmt.while]{The \tcode{while} statement}%
+\rSec2[stmt.while]{The \keyword{while} statement}%
 \indextext{statement!\idxcode{while}}
 
 \pnum
@@ -562,7 +562,7 @@ fails.
 \end{example}
 \end{note}
 
-\rSec2[stmt.do]{The \tcode{do} statement}%
+\rSec2[stmt.do]{The \keyword{do} statement}%
 \indextext{statement!\idxcode{do}}
 
 \pnum
@@ -614,7 +614,7 @@ A missing \grammarterm{condition}
 makes the implied \keyword{while} clause
 equivalent to \tcode{while(true)}.
 
-\rSec2[stmt.ranged]{The range-based \tcode{for} statement}%
+\rSec2[stmt.ranged]{The range-based \keyword{for} statement}%
 \indextext{statement!range based for@range based \tcode{for}}
 
 \pnum
@@ -736,7 +736,7 @@ destroying objects with automatic storage duration.
 A suspension of a coroutine\iref{expr.await} is not considered to be an exit from a scope.
 \end{note}
 
-\rSec2[stmt.break]{The \tcode{break} statement}%
+\rSec2[stmt.break]{The \keyword{break} statement}%
 \indextext{statement!\idxcode{break}}
 
 \pnum
@@ -748,7 +748,7 @@ termination of the smallest enclosing \grammarterm{iteration-statement} or
 \keyword{switch} statement; control passes to the statement following the
 terminated statement, if any.
 
-\rSec2[stmt.cont]{The \tcode{continue} statement}%
+\rSec2[stmt.cont]{The \keyword{continue} statement}%
 \indextext{statement!\idxcode{continue}}
 
 \pnum
@@ -795,7 +795,7 @@ for (;;) {
 a \keyword{continue} not contained in an enclosed iteration statement is
 equivalent to \tcode{goto} \exposid{contin}.
 
-\rSec2[stmt.return]{The \tcode{return} statement}%
+\rSec2[stmt.return]{The \keyword{return} statement}%
 \indextext{\idxcode{return}}%
 \indextext{function return|see{\tcode{return}}}%
 
@@ -856,7 +856,7 @@ by the operand of the \tcode{return} statement, which, in turn, is sequenced
 before the destruction of local variables\iref{stmt.jump} of the block
 enclosing the \tcode{return} statement.
 
-\rSec2[stmt.return.coroutine]{The \tcode{co_return} statement}%
+\rSec2[stmt.return.coroutine]{The \keyword{co_return} statement}%
 \indextext{\idxcode{co_return}}%
 \indextext{coroutine return|see{\tcode{co_return}}}%
 
@@ -907,7 +907,7 @@ is equivalent to a \keyword{co_return} with no operand;
 otherwise flowing off the end of a coroutine's \grammarterm{function-body}
 results in undefined behavior.
 
-\rSec2[stmt.goto]{The \tcode{goto} statement}%
+\rSec2[stmt.goto]{The \keyword{goto} statement}%
 \indextext{statement!\idxcode{goto}}
 
 \pnum


### PR DESCRIPTION
by disabling all indexing when typesetting the table-of-contents.