### PR TITLE
[std] Replace 'OK:' in code comments with 'OK,'

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -950,7 +950,7 @@ typedef int Int;
 enum E : int { a };
 void f(int);                    // \#1
 void f(Int) {}                  // defines \#1
-void f(E) {}                    // OK: another overload
+void f(E) {}                    // OK, another overload
 
 struct X {
   static void f();
@@ -960,7 +960,7 @@ struct X {
   void g() &;                   // error: redeclaration
 
   void h(this X&, int);
-  void h(int) &&;               // OK: another overload
+  void h(int) &&;               // OK, another overload
   void j(this const X&);
   void j() const&;              // error: redeclaration
   void k();
@@ -993,9 +993,9 @@ void f() {
 enum { f };             // error: different entity for \tcode{::f}
 namespace A {}
 namespace B = A;
-namespace B = A;        // OK: no effect
-namespace B = B;        // OK: no effect
-namespace A = B;        // OK: no effect
+namespace B = A;        // OK, no effect
+namespace B = B;        // OK, no effect
+namespace A = B;        // OK, no effect
 namespace B {}          // error: different entity for \tcode{B}
 \end{codeblock}
 \end{example}
@@ -1452,7 +1452,7 @@ export import Q;
 
 \begin{codeblocktu}{Translation unit \#3}
 import R;
-int main() { return sq(9); }    // OK: \tcode{sq} from module \tcode{Q}
+int main() { return sq(9); }    // OK, \tcode{sq} from module \tcode{Q}
 \end{codeblocktu}
 \end{example}
 \end{note}
@@ -1616,9 +1616,9 @@ struct C : A, virtual V { };
 struct D : B, C { };
 
 void f(D* pd) {
-  pd->v++;          // OK: only one \tcode{v} (virtual)
-  pd->s++;          // OK: only one \tcode{s} (static)
-  int i = pd->e;    // OK: only one \tcode{e} (enumerator)
+  pd->v++;          // OK, only one \tcode{v} (virtual)
+  pd->s++;          // OK, only one \tcode{s} (static)
+  int i = pd->e;    // OK, only one \tcode{e} (enumerator)
   pd->a++;          // error: ambiguous: two \tcode{a}{s} in \tcode{D}
 }
 \end{codeblock}
@@ -1658,8 +1658,8 @@ are hidden by those in \tcode{B}, but the names declared in the
 right-hand instance of \tcode{W} are not hidden at all.
 \begin{codeblock}
 void D::glorp() {
-  x++;              // OK: \tcode{B::x} hides \tcode{V::x}
-  f();              // OK: \tcode{B::f()} hides \tcode{V::f()}
+  x++;              // OK, \tcode{B::x} hides \tcode{V::x}
+  f();              // OK, \tcode{B::f()} hides \tcode{V::f()}
   y++;              // error: \tcode{B::y} and \tcode{C}'s \tcode{W::y}
   g();              // error: \tcode{B::g()} and \tcode{C}'s \tcode{W::g()}
 }
@@ -1685,7 +1685,7 @@ void g() {
   D d;
   B* pb = &d;
   A* pa = &d;       // error: ambiguous: \tcode{C}'s \tcode{A} or \tcode{B}'s \tcode{A}?
-  V* pv = &d;       // OK: only one \tcode{V} subobject
+  V* pv = &d;       // OK, only one \tcode{V} subobject
 }
 \end{codeblock}
 \end{example}
@@ -1886,7 +1886,7 @@ namespace N {
 
 void g() {
   N::S s;
-  f(s);             // OK: calls \tcode{N::f}
+  f(s);             // OK, calls \tcode{N::f}
   (f)(s);           // error: \tcode{N::f} not considered; parentheses prevent argument-dependent lookup
 }
 \end{codeblock}
@@ -1913,8 +1913,8 @@ namespace N {
   template <class T> int h(T);
 }
 
-int x = f<N::A>(N::A());        // OK: lookup of \tcode{f} finds nothing, \tcode{f} treated as template name
-int y = g<N::A>(N::A());        // OK: lookup of \tcode{g} finds a function, \tcode{g} treated as template name
+int x = f<N::A>(N::A());        // OK, lookup of \tcode{f} finds nothing, \tcode{f} treated as template name
+int y = g<N::A>(N::A());        // OK, lookup of \tcode{g} finds a function, \tcode{g} treated as template name
 int z = h<N::A>(N::A());        // error: \tcode{h<} does not begin a \grammarterm{template-id}
 \end{codeblock}
 
@@ -2086,9 +2086,9 @@ namespace NS {
 NS::T parm;
 void g(NS::T, float);
 int main() {
-  f(parm);                      // OK: calls \tcode{NS::f}
+  f(parm);                      // OK, calls \tcode{NS::f}
   extern void g(NS::T, float);
-  g(parm, 1);                   // OK: calls \tcode{g(NS::T, float)}
+  g(parm, 1);                   // OK, calls \tcode{g(NS::T, float)}
 }
 \end{codeblock}
 \end{example}
@@ -2215,8 +2215,8 @@ template<int> using X = A;
 template<class T>
 void g(T *p) {                  // as instantiated for \tcode{g<A>}:
   p->X<0>::f();                 // error: \tcode{A::X} not found in \tcode{((p->X) < 0) > ::f()}
-  p->template X<0>::f();        // OK: \tcode{::X} found in definition context
-  p->B::f();                    // OK: non-type \tcode{A::B} ignored
+  p->template X<0>::f();        // OK, \tcode{::X} found in definition context
+  p->B::f();                    // OK, non-type \tcode{A::B} ignored
   p->template C<0>::f();        // error: \tcode{A::C} is not a template
   p->template D<0>::f();        // error: \tcode{A::D<0>} is not a class type
   p->T::f();                    // error: \tcode{A::T} is not a class type
@@ -2405,7 +2405,7 @@ namespace BC {
 
 void f()
 {
-  BC::a++;          // OK: \tcode{S} is $\{ \tcode{A::a}, \tcode{A::a} \}$
+  BC::a++;          // OK, \tcode{S} is $\{ \tcode{A::a}, \tcode{A::a} \}$
 }
 
 namespace D {
@@ -2419,7 +2419,7 @@ namespace BD {
 
 void g()
 {
-  BD::a++;          // OK: \tcode{S} is $\{ \tcode{A::a}, \tcode{A::a} \}$
+  BD::a++;          // OK, \tcode{S} is $\{ \tcode{A::a}, \tcode{A::a} \}$
 }
 \end{codeblock}
 \end{example}
@@ -2445,10 +2445,10 @@ namespace B {
 
 void f()
 {
-  A::a++;           // OK: \tcode{a} declared directly in \tcode{A}, \tcode{S} is $\{ \tcode{A::a} \}$
-  B::a++;           // OK: both \tcode{A} and \tcode{B} searched (once), \tcode{S} is $\{ \tcode{A::a} \}$
-  A::b++;           // OK: both \tcode{A} and \tcode{B} searched (once), \tcode{S} is $\{ \tcode{B::b} \}$
-  B::b++;           // OK: \tcode{b} declared directly in \tcode{B}, \tcode{S} is $\{ \tcode{B::b} \}$
+  A::a++;           // OK, \tcode{a} declared directly in \tcode{A}, \tcode{S} is $\{ \tcode{A::a} \}$
+  B::a++;           // OK, both \tcode{A} and \tcode{B} searched (once), \tcode{S} is $\{ \tcode{A::a} \}$
+  A::b++;           // OK, both \tcode{A} and \tcode{B} searched (once), \tcode{S} is $\{ \tcode{B::b} \}$
+  B::b++;           // OK, \tcode{b} declared directly in \tcode{B}, \tcode{S} is $\{ \tcode{B::b} \}$
 }
 \end{codeblock}
 \end{example}
@@ -2509,31 +2509,31 @@ the \grammarterm{elaborated-type-specifier} is ill-formed.
 \begin{example}
 \begin{codeblock}
 struct Node {
-  struct Node* Next;            // OK: Refers to injected-class-name \tcode{Node}
-  struct Data* Data;            // OK: Declares type \tcode{Data} at global scope and member \tcode{Data}
+  struct Node* Next;            // OK, refers to injected-class-name \tcode{Node}
+  struct Data* Data;            // OK, declares type \tcode{Data} at global scope and member \tcode{Data}
 };
 
 struct Data {
-  struct Node* Node;            // OK: Refers to \tcode{Node} at global scope
+  struct Node* Node;            // OK, refers to \tcode{Node} at global scope
   friend struct ::Glob;         // error: \tcode{Glob} is not declared, cannot introduce a qualified type\iref{dcl.type.elab}
-  friend struct Glob;           // OK: Refers to (as yet) undeclared \tcode{Glob} at global scope.
+  friend struct Glob;           // OK, refers to (as yet) undeclared \tcode{Glob} at global scope.
   @\commentellip@
 };
 
 struct Base {
-  struct Data;                  // OK: Declares nested \tcode{Data}
-  struct ::Data*     thatData;  // OK: Refers to \tcode{::Data}
-  struct Base::Data* thisData;  // OK: Refers to nested \tcode{Data}
-  friend class ::Data;          // OK: global \tcode{Data} is a friend
-  friend class Data;            // OK: nested \tcode{Data} is a friend
+  struct Data;                  // OK, declares nested \tcode{Data}
+  struct ::Data*     thatData;  // OK, refers to \tcode{::Data}
+  struct Base::Data* thisData;  // OK, refers to nested \tcode{Data}
+  friend class ::Data;          // OK, global \tcode{Data} is a friend
+  friend class Data;            // OK, nested \tcode{Data} is a friend
   struct Data { @\commentellip@ };    // Defines nested \tcode{Data}
 };
 
-struct Data;                    // OK: Redeclares \tcode{Data} at global scope
+struct Data;                    // OK, redeclares \tcode{Data} at global scope
 struct ::Data;                  // error: cannot introduce a qualified type\iref{dcl.type.elab}
 struct Base::Data;              // error: cannot introduce a qualified type\iref{dcl.type.elab}
 struct Base::Datum;             // error: \tcode{Datum} undefined
-struct Base::Data* pBase;       // OK: refers to nested \tcode{Data}
+struct Base::Data* pBase;       // OK, refers to nested \tcode{Data}
 \end{codeblock}
 \end{example}
 \indextext{lookup!elaborated type specifier|)}%
@@ -2739,7 +2739,7 @@ int g();            // \#2, attached to the global module
 module;
 #include "decls.h"
 export module M;
-export using ::f;   // OK: does not declare an entity, exports \#1
+export using ::f;   // OK, does not declare an entity, exports \#1
 int g();            // error: matches \#2, but attached to \tcode{M}
 export int h();     // \#3
 export int k();     // \#4
@@ -2799,7 +2799,7 @@ No diagnostic is required if neither declaration is reachable from the other.
 \begin{codeblock}
 int f(int x, int x);    // error: different entities for \tcode{x}
 void g();               // \#1
-void g(int);            // OK: different entity from \#1
+void g(int);            // OK, different entity from \#1
 int g();                // error: same entity as \#1 with different type
 void h();               // \#2
 namespace h {}          // error: same entity as \#2, but not a function
@@ -3458,8 +3458,8 @@ void g() {
   void* p = std::malloc(sizeof(D1) + sizeof(D2));
   B* pb = new (p) D1;
   pb->mutate();
-  *pb;              // OK: \tcode{pb} points to valid memory
-  void* q = pb;     // OK: \tcode{pb} points to valid memory
+  *pb;              // OK, \tcode{pb} points to valid memory
+  void* q = pb;     // OK, \tcode{pb} points to valid memory
   pb->f();          // undefined behavior: lifetime of \tcode{*pb} has ended
 }
 \end{codeblock}
@@ -4651,7 +4651,7 @@ UNKA** arrpp;
 void foo() {
   xp++;                         // error: \tcode{X} is incomplete
   arrp++;                       // error: incomplete type
-  arrpp++;                      // OK: sizeof \tcode{UNKA*} is known
+  arrpp++;                      // OK, sizeof \tcode{UNKA*} is known
 }
 
 struct X { int i; };            // now \tcode{X} is a complete type
@@ -4661,7 +4661,7 @@ X x;
 void bar() {
   xp = &x;                      // OK; type is ``pointer to \tcode{X}''
   arrp = &arr;                  // OK; qualification conversion\iref{conv.qual}
-  xp++;                         // OK:  \tcode{X} is complete
+  xp++;                         // OK, \tcode{X} is complete
   arrp++;                       // error: \tcode{UNKA} can't be completed
 }
 \end{codeblock}

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -128,12 +128,12 @@ interpreted as a \grammarterm{class-virt-specifier}.
 \begin{example}
 \begin{codeblock}
 struct A;
-struct A final {};      // OK: definition of \tcode{struct A},
+struct A final {};      // OK, definition of \tcode{struct A},
                         // not value-initialization of variable \tcode{final}
 
 struct X {
  struct C { constexpr operator int() { return 5; } };
- struct B final : C{};  // OK: definition of nested class \tcode{B},
+ struct B final : C{};  // OK, definition of nested class \tcode{B},
                         // not declaration of a bit-field member \tcode{final}
 };
 \end{codeblock}
@@ -619,8 +619,8 @@ a \grammarterm{brace-or-equal-initializer}.
 \begin{codeblock}
 struct S {
   using T = void();
-  T * p = 0;        // OK: \grammarterm{brace-or-equal-initializer}
-  virtual T f = 0;  // OK: \grammarterm{pure-specifier}
+  T * p = 0;        // OK, \grammarterm{brace-or-equal-initializer}
+  virtual T f = 0;  // OK, \grammarterm{pure-specifier}
 };
 \end{codeblock}
 \end{example}
@@ -2396,7 +2396,7 @@ struct Y {
 
 Y a;
 int b = a;          // error: no viable conversion (\tcode{a.operator X().operator int()} not considered)
-int c = X(a);       // OK: \tcode{a.operator X().operator int()}
+int c = X(a);       // OK, \tcode{a.operator X().operator int()}
 \end{codeblock}
 \end{example}
 
@@ -2446,15 +2446,15 @@ struct Z {
   explicit Z(int, int);
 };
 
-Z a;                            // OK: default-initialization performed
-Z b{};                          // OK: direct initialization syntax used
+Z a;                            // OK, default-initialization performed
+Z b{};                          // OK, direct initialization syntax used
 Z c = {};                       // error: copy-list-initialization
 Z a1 = 1;                       // error: no implicit conversion
-Z a3 = Z(1);                    // OK: direct initialization syntax used
-Z a2(1);                        // OK: direct initialization syntax used
-Z* p = new Z(1);                // OK: direct initialization syntax used
-Z a4 = (Z)1;                    // OK: explicit cast used
-Z a5 = static_cast<Z>(1);       // OK: explicit cast used
+Z a3 = Z(1);                    // OK, direct initialization syntax used
+Z a2(1);                        // OK, direct initialization syntax used
+Z* p = new Z(1);                // OK, direct initialization syntax used
+Z a4 = (Z)1;                    // OK, explicit cast used
+Z a5 = static_cast<Z>(1);       // OK, explicit cast used
 Z a6 = { 3, 4 };                // error: no implicit conversion
 \end{codeblock}
 \end{example}
@@ -2539,9 +2539,9 @@ struct Z {
 };
 
 void h(Z z) {
-  Y y1(z);          // OK: direct-initialization
+  Y y1(z);          // OK, direct-initialization
   Y y2 = z;         // error: no conversion function candidate for copy-initialization
-  Y y3 = (Y)z;      // OK: cast notation
+  Y y3 = (Y)z;      // OK, cast notation
 }
 
 void g(X a, X b) {
@@ -2648,7 +2648,7 @@ struct process {
 process& g();
 
 void f() {
-  process::reschedule();        // OK: no object necessary
+  process::reschedule();        // OK, no object necessary
   g().reschedule();             // \tcode{g()} is called
 }
 \end{codeblock}
@@ -2887,14 +2887,14 @@ struct enclose {
 
   struct inner {
     void f(int i) {
-      int a = sizeof(x);        // OK: operand of sizeof is an unevaluated operand
+      int a = sizeof(x);        // OK, operand of sizeof is an unevaluated operand
       x = i;                    // error: assign to \tcode{enclose::x}
-      s = i;                    // OK: assign to \tcode{enclose::s}
-      ::x = i;                  // OK: assign to global \tcode{x}
-      y = i;                    // OK: assign to global \tcode{y}
+      s = i;                    // OK, assign to \tcode{enclose::s}
+      ::x = i;                  // OK, assign to global \tcode{x}
+      y = i;                    // OK, assign to global \tcode{y}
     }
     void g(enclose* p, int i) {
-      p->x = i;                 // OK: assign to \tcode{enclose::x}
+      p->x = i;                 // OK, assign to \tcode{enclose::x}
     }
   };
 };
@@ -3069,9 +3069,9 @@ struct B { A a; };
 union C { B b; int k; };
 int f() {
   C c;                  // does not start lifetime of any union member
-  c.b.a.y[3] = 4;       // OK: $S($\tcode{c.b.a.y[3]}$)$ contains \tcode{c.b} and \tcode{c.b.a.y};
+  c.b.a.y[3] = 4;       // OK, $S($\tcode{c.b.a.y[3]}$)$ contains \tcode{c.b} and \tcode{c.b.a.y};
                         // creates objects to hold union members \tcode{c.b} and \tcode{c.b.a.y}
-  return c.b.a.y[3];    // OK: \tcode{c.b.a.y} refers to newly created object (see \ref{basic.life})
+  return c.b.a.y[3];    // OK, \tcode{c.b.a.y} refers to newly created object (see \ref{basic.life})
 }
 
 struct X { const int a; int b; };
@@ -3079,7 +3079,7 @@ union Y { X x; int k; };
 void g() {
   Y y = { { 1, 2 } };   // OK, \tcode{y.x} is active union member\iref{class.mem}
   int n = y.x.a;
-  y.k = 4;              // OK: ends lifetime of \tcode{y.x}, \tcode{y.k} is active member of union
+  y.k = 4;              // OK, ends lifetime of \tcode{y.x}, \tcode{y.k} is active member of union
   y.x.b = n;            // undefined behavior: \tcode{y.x.b} modified outside its lifetime,
                         // $S($\tcode{y.x.b}$)$ is empty because \tcode{X}'s default constructor is deleted,
                         // so union member \tcode{y.x}'s lifetime does not implicitly start
@@ -3228,7 +3228,7 @@ void f() {
     int h() { return s; }       // OK
     int k() { return ::x; }     // OK
     int l() { return q(); }     // OK
-    int m() { return N; }       // OK: not an odr-use
+    int m() { return N; }       // OK, not an odr-use
     int* n() { return &N; }     // error: odr-use of non-odr-usable variable \tcode{N}
     int p() { return y; }       // error: odr-use of non-odr-usable structured binding \tcode{y}
   };
@@ -3656,7 +3656,7 @@ void foo() {
 struct A { virtual void f(); };
 struct B : A { };
 struct C : A { void f(); };
-struct D : B, C { };            // OK: \tcode{A::f} and \tcode{C::f} are the final overriders
+struct D : B, C { };            // OK, \tcode{A::f} and \tcode{C::f} are the final overriders
                                 // for the \tcode{B} and \tcode{C} subobjects, respectively
 \end{codeblock}
 \end{example}
@@ -3787,7 +3787,7 @@ struct Derived : public Base {
     void vf1();     // virtual and overrides \tcode{Base::vf1()}
     void vf2(int);  // not virtual, hides \tcode{Base::vf2()}
     char vf3();     // error: invalid difference in return type only
-    D*   vf4();     // OK: returns pointer to derived class
+    D*   vf4();     // OK, returns pointer to derived class
     A*   vf5();     // error: returns pointer to incomplete class
     void f();
 };
@@ -4459,7 +4459,7 @@ void DD::f() {
   ::B::si = 3;                  // OK
   ::B* bp1 = this;              // error: \tcode{B} is a private base class
   ::B* bp2 = (::B*)this;        // OK with cast
-  bp2->mi = 3;                  // OK: access through a pointer to \tcode{B}.
+  bp2->mi = 3;                  // OK, access through a pointer to \tcode{B}.
 }
 \end{codeblock}
 \end{note}
@@ -4632,7 +4632,7 @@ private:
 };
 class B : public A { };
 void f(B* p) {
-  p->i = 1;         // OK: \tcode{B*} can be implicitly converted to \tcode{A*}, and \tcode{f} has access to \tcode{i} in \tcode{A}
+  p->i = 1;         // OK, \tcode{B*} can be implicitly converted to \tcode{A*}, and \tcode{f} has access to \tcode{i} in \tcode{A}
 }
 \end{codeblock}
 \end{example}
@@ -4699,10 +4699,10 @@ class A {
   friend class X;
 };
 
-struct X : A::B {               // OK: \tcode{A::B} accessible to friend
-  A::B mx;                      // OK: \tcode{A::B} accessible to member of friend
+struct X : A::B {               // OK, \tcode{A::B} accessible to friend
+  A::B mx;                      // OK, \tcode{A::B} accessible to member of friend
   class Y {
-    A::B my;                    // OK: \tcode{A::B} accessible to nested member of friend
+    A::B my;                    // OK, \tcode{A::B} accessible to nested member of friend
   };
 };
 \end{codeblock}
@@ -4749,13 +4749,13 @@ class C;
 typedef C Ct;
 
 class X1 {
-  friend C;                     // OK: \tcode{class C} is a friend
+  friend C;                     // OK, \tcode{class C} is a friend
 };
 
 class X2 {
-  friend Ct;                    // OK: \tcode{class C} is a friend
+  friend Ct;                    // OK, \tcode{class C} is a friend
   friend D;                     // error: \tcode{D} not found
-  friend class D;               // OK: elaborated-type-specifier declares new class
+  friend class D;               // OK, elaborated-type-specifier declares new class
 };
 
 template <typename T> class R {
@@ -4763,7 +4763,7 @@ template <typename T> class R {
 };
 
 R<C> rc;                        // \tcode{class C} is a friend of \tcode{R<C>}
-R<int> Ri;                      // OK: \tcode{"friend int;"} is ignored
+R<int> Ri;                      // OK, \tcode{"friend int;"} is ignored
 \end{codeblock}
 \end{example}
 
@@ -5008,7 +5008,7 @@ void f() {
   B* pb = &d;
   D* pd = &d;
 
-  pb->f();                      // OK: \tcode{B::f()} is public, \tcode{D::f()} is invoked
+  pb->f();                      // OK, \tcode{B::f()} is public, \tcode{D::f()} is invoked
   pd->f();                      // error: \tcode{D::f()} is private
 }
 \end{codeblock}
@@ -5063,10 +5063,10 @@ class E {
   class B { };
 
   class I {
-    B b;                        // OK: \tcode{E::I} can access \tcode{E::B}
+    B b;                        // OK, \tcode{E::I} can access \tcode{E::B}
     int y;
     void f(E* p, int i) {
-      p->x = i;                 // OK: \tcode{E::I} can access \tcode{E::x}
+      p->x = i;                 // OK, \tcode{E::I} can access \tcode{E::x}
     }
   };
 
@@ -5459,10 +5459,10 @@ struct B {
 
 struct C {
   C() { }               // initializes members as follows:
-  A a;                  // OK: calls \tcode{A::A()}
+  A a;                  // OK, calls \tcode{A::A()}
   const B b;            // error: \tcode{B} has no default constructor
-  int i;                // OK: \tcode{i} has indeterminate value
-  int j = 5;            // OK: \tcode{j} has the value \tcode{5}
+  int i;                // OK, \tcode{i} has indeterminate value
+  int j = 5;            // OK, \tcode{j} has the value \tcode{5}
 };
 \end{codeblock}
 \end{example}
@@ -5732,7 +5732,7 @@ struct D1 : B1 {
 };
 
 void test() {
-  D1 d(2, 3, 4);    // OK: \tcode{B1} is initialized by calling \tcode{B1(2, 3, 4)},
+  D1 d(2, 3, 4);    // OK, \tcode{B1} is initialized by calling \tcode{B1(2, 3, 4)},
                     // then \tcode{d.x} is default-initialized (no initialization is performed),
                     // then \tcode{d.y} is initialized by calling \tcode{get()}
   D1 e;             // error: \tcode{D1} has a deleted default constructor
@@ -5749,7 +5749,7 @@ struct W { W(int); };
 struct X : virtual W { using W::W; X() = delete; };
 struct Y : X { using X::X; };
 struct Z : Y, virtual W { using Y::Y; };
-Z z(0);             // OK: initialization of \tcode{Y} does not invoke default constructor of \tcode{X}
+Z z(0);             // OK, initialization of \tcode{Y} does not invoke default constructor of \tcode{X}
 
 template<class T> struct Log : T {
   using T::T;       // inherits all constructors from class \tcode{T}
@@ -5786,14 +5786,14 @@ struct D2 : V1, V2 {
 };
 
 D1 d1(0);           // error: ambiguous
-D2 d2(0);           // OK: initializes virtual \tcode{B} base class, which initializes the \tcode{A} base class
+D2 d2(0);           // OK, initializes virtual \tcode{B} base class, which initializes the \tcode{A} base class
                     // then initializes the \tcode{V1} and \tcode{V2} base classes as if by a defaulted default constructor
 
 struct M { M(); M(int); };
 struct N : M { using M::M; };
 struct O : M {};
 struct P : N, O { using N::N; using O::O; };
-P p(0);             // OK: use \tcode{M(0)} to initialize \tcode{N}{'s} base class,
+P p(0);             // OK, use \tcode{M(0)} to initialize \tcode{N}{'s} base class,
                     // use \tcode{M()} to initialize \tcode{O}{'s} base class
 \end{codeblock}
 \end{example}
@@ -6240,11 +6240,11 @@ private:
 Thing f(bool b) {
   Thing t;
   if (b)
-    throw t;            // OK: \tcode{Thing(Thing\&\&)} used (or elided) to throw \tcode{t}
-  return t;             // OK: \tcode{Thing(Thing\&\&)} used (or elided) to return \tcode{t}
+    throw t;            // OK, \tcode{Thing(Thing\&\&)} used (or elided) to throw \tcode{t}
+  return t;             // OK, \tcode{Thing(Thing\&\&)} used (or elided) to return \tcode{t}
 }
 
-Thing t2 = f(false);    // OK: no extra copy/move performed, \tcode{t2} constructed by call to \tcode{f}
+Thing t2 = f(false);    // OK, no extra copy/move performed, \tcode{t2} constructed by call to \tcode{f}
 
 struct Weird {
   Weird();
@@ -6253,7 +6253,7 @@ struct Weird {
 
 Weird g() {
   Weird w;
-  return w;             // OK: first overload resolution fails, second overload resolution selects \tcode{Weird(Weird\&)}
+  return w;             // OK, first overload resolution fails, second overload resolution selects \tcode{Weird(Weird\&)}
 }
 \end{codeblock}
 \end{example}

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1990,9 +1990,9 @@ Syntactic transformation. The fix is to add a cast:
 \begin{codeblock}
 char* p = "abc";                // valid in C, invalid in \Cpp{}
 void f(char*) {
-  char* p = (char*)"abc";       // OK: cast added
+  char* p = (char*)"abc";       // OK, cast added
   f(p);
-  f((char*)"def");              // OK: cast added
+  f((char*)"def");              // OK, cast added
 }
 \end{codeblock}
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -729,23 +729,23 @@ Function parameters cannot be declared \keyword{constexpr}.
 \end{note}
 \begin{example}
 \begin{codeblock}
-constexpr void square(int &x);  // OK: declaration
-constexpr int bufsz = 1024;     // OK: definition
+constexpr void square(int &x);  // OK, declaration
+constexpr int bufsz = 1024;     // OK, definition
 constexpr struct pixel {        // error: \tcode{pixel} is a type
   int x;
   int y;
-  constexpr pixel(int);         // OK: declaration
+  constexpr pixel(int);         // OK, declaration
 };
 constexpr pixel::pixel(int a)
-  : x(a), y(x)                  // OK: definition
+  : x(a), y(x)                  // OK, definition
   { square(x); }
 constexpr pixel small(2);       // error: \tcode{square} not defined, so \tcode{small(2)}
                                 // not constant\iref{expr.const} so \keyword{constexpr} not satisfied
 
-constexpr void square(int &x) { // OK: definition
+constexpr void square(int &x) { // OK, definition
   x *= x;
 }
-constexpr pixel large(4);       // OK: \tcode{square} defined
+constexpr pixel large(4);       // OK, \tcode{square} defined
 int next(constexpr int x) {     // error: not for parameters
      return x + 1;
 }
@@ -1208,7 +1208,7 @@ ci = 4;                                 // error: attempt to modify \keyword{con
 
 int i = 2;                              // not cv-qualified
 const int* cip;                         // pointer to \tcode{const int}
-cip = &i;                               // OK: cv-qualified access path to unqualified
+cip = &i;                               // OK, cv-qualified access path to unqualified
 *cip = 4;                               // error: attempt to modify through ptr to \keyword{const}
 
 int* ip;
@@ -1634,7 +1634,7 @@ template<class T> auto f(T)     // \#1
 template<class T> auto f(T)     // \#2
   -> void;
 auto g() -> void {
-  f(42);                        // OK: calls \#2. (\#1 is not a viable candidate: type deduction
+  f(42);                        // OK, calls \#2. (\#1 is not a viable candidate: type deduction
                                 // fails\iref{temp.deduct} because \tcode{A<int>::\~{}A()} is implicitly used in its
                                 // \grammarterm{decltype-specifier})
 }
@@ -1714,13 +1714,13 @@ be followed by a non-empty
 \grammarterm{initializer}.
 \begin{example}
 \begin{codeblock}
-auto x = 5;                     // OK: \tcode{x} has type \tcode{int}
-const auto *v = &x, u = 6;      // OK: \tcode{v} has type \tcode{const int*}, \tcode{u} has type \tcode{const int}
-static auto y = 0.0;            // OK: \tcode{y} has type \tcode{double}
+auto x = 5;                     // OK, \tcode{x} has type \tcode{int}
+const auto *v = &x, u = 6;      // OK, \tcode{v} has type \tcode{const int*}, \tcode{u} has type \tcode{const int}
+static auto y = 0.0;            // OK, \tcode{y} has type \tcode{double}
 auto int r;                     // error: \keyword{auto} is not a \grammarterm{storage-class-specifier}
-auto f() -> int;                // OK: \tcode{f} returns \tcode{int}
-auto g() { return 0.0; }        // OK: \tcode{g} returns \tcode{double}
-auto h();                       // OK: \tcode{h}'s return type will be deduced when it is defined
+auto f() -> int;                // OK, \tcode{f} returns \tcode{int}
+auto g() { return 0.0; }        // OK, \tcode{g} returns \tcode{double}
+auto h();                       // OK, \tcode{h}'s return type will be deduced when it is defined
 \end{codeblock}
 \end{example}
 The \keyword{auto} \grammarterm{type-specifier}
@@ -1754,7 +1754,7 @@ same in each deduction, the program is ill-formed.
 
 \begin{example}
 \begin{codeblock}
-auto x = 5, *y = &x;            // OK: \keyword{auto} is \tcode{int}
+auto x = 5, *y = &x;            // OK, \keyword{auto} is \tcode{int}
 auto a = 5, b = { 1, 2 };       // error: different types for \keyword{auto}
 \end{codeblock}
 \end{example}
@@ -2193,8 +2193,8 @@ auto i = 1, j = 2.0;    // error: deduced types for \tcode{i} and \tcode{j} do n
 \end{codeblock}
 as opposed to
 \begin{codeblock}
-auto i = 1;             // OK: \tcode{i} deduced to have type \tcode{int}
-auto j = 2.0;           // OK: \tcode{j} deduced to have type \tcode{double}
+auto i = 1;             // OK, \tcode{i} deduced to have type \tcode{int}
+auto j = 2.0;           // OK, \tcode{j} deduced to have type \tcode{double}
 \end{codeblock}
 \end{note}
 
@@ -2585,7 +2585,7 @@ namespace N {
   }
   using P::f,P::g;
 }
-template<> void N::f(int*) {}           // OK: \#2 is not nominable
+template<> void N::f(int*) {}           // OK, \#2 is not nominable
 template void N::g(int);                // error: lookup is ambiguous
 \end{codeblock}
 \end{example}
@@ -3254,8 +3254,8 @@ struct S {
   static int y[10];
 };
 
-int x[];                // OK: bound is 10
-int S::y[];             // OK: bound is 10
+int x[];                // OK, bound is 10
+int S::y[];             // OK, bound is 10
 
 void f() {
   extern int x[];
@@ -3549,12 +3549,12 @@ For example, \tcode{int(*)(const int p, decltype(p)*)} and
 \begin{codeblock}
 void f(char*);                  // \#1
 void f(char[]) {}               // defines \#1
-void f(const char*) {}          // OK: another overload
+void f(const char*) {}          // OK, another overload
 void f(char *const) {}          // error: redefines \#1
 
 void g(char(*)[2]);             // \#2
 void g(char[3][2]) {}           // defines \#2
-void g(char[3][3]) {}           // OK: another overload
+void g(char[3][3]) {}           // OK, another overload
 
 void h(int x(const int));       // \#3
 void h(int (*)(int)) {}         // defines \#3
@@ -3665,7 +3665,7 @@ cv-qualified type; there are no cv-qualified function types.
 \begin{codeblock}
 typedef void F();
 struct S {
-  const F f;        // OK: equivalent to: \tcode{void f();}
+  const F f;        // OK, equivalent to: \tcode{void f();}
 };
 \end{codeblock}
 \end{example}
@@ -3722,9 +3722,9 @@ used to define a function\iref{dcl.fct.def}.
 \begin{example}
 \begin{codeblock}
 typedef void F();
-F  fv;              // OK: equivalent to \tcode{void fv();}
+F  fv;              // OK, equivalent to \tcode{void fv();}
 F  fv { }           // error
-void fv() { }       // OK: definition of \tcode{fv}
+void fv() { }       // OK, definition of \tcode{fv}
 \end{codeblock}
 \end{example}
 
@@ -5769,7 +5769,7 @@ struct S2 {
 };
 S2 s21 = { 1, 2, 3.0 };             // OK
 S2 s22 { 1.0, 2, 3 };               // error: narrowing
-S2 s23 { };                         // OK: default to 0,0,0
+S2 s23 { };                         // OK, default to 0,0,0
 \end{codeblock}
 \end{example}
 
@@ -5816,9 +5816,9 @@ struct S {
   S();                              // \#2
   // ...
 };
-S s1 = { 1, 2, 3.0 };               // OK: invoke \#1
+S s1 = { 1, 2, 3.0 };               // OK, invoke \#1
 S s2 { 1.0, 2, 3 };                 // error: narrowing
-S s3 { };                           // OK: invoke \#2
+S s3 { };                           // OK, invoke \#2
 \end{codeblock}
 \end{example}
 
@@ -5886,12 +5886,12 @@ struct S {
   S(const std::string&);            // \#2
   // ...
 };
-const S& r1 = { 1, 2, 3.0 };        // OK: invoke \#1
-const S& r2 { "Spinach" };          // OK: invoke \#2
+const S& r1 = { 1, 2, 3.0 };        // OK, invoke \#1
+const S& r2 { "Spinach" };          // OK, invoke \#2
 S& r3 = { 1, 2, 3 };                // error: initializer is not an lvalue
 const int& i1 = { 1 };              // OK
 const int& i2 = { 1.1 };            // error: narrowing
-const int (&iar)[2] = { 1, 2 };     // OK: \tcode{iar} is bound to temporary array
+const int (&iar)[2] = { 1, 2 };     // OK, \tcode{iar} is bound to temporary array
 
 struct A { } a;
 struct B { explicit B(const A&); };
@@ -6049,18 +6049,18 @@ const int z = 99;
 char c1 = x;                    // OK, though it potentially narrows (in this case, it does narrow)
 char c2{x};                     // error: potentially narrows
 char c3{y};                     // error: narrows (assuming \tcode{char} is 8 bits)
-char c4{z};                     // OK: no narrowing needed
-unsigned char uc1 = {5};        // OK: no narrowing needed
+char c4{z};                     // OK, no narrowing needed
+unsigned char uc1 = {5};        // OK, no narrowing needed
 unsigned char uc2 = {-1};       // error: narrows
 unsigned int ui1 = {-1};        // error: narrows
 signed int si1 =
   { (unsigned int)-1 };         // error: narrows
 int ii = {2.0};                 // error: narrows
 float f1 { x };                 // error: potentially narrows
-float f2 { 7 };                 // OK: 7 can be exactly represented as a \tcode{float}
+float f2 { 7 };                 // OK, 7 can be exactly represented as a \tcode{float}
 bool b = {"meow"};              // error: narrows
 int f(int);
-int a[] = { 2, f(2), f(2.0) };  // OK: the \tcode{double}-to-\tcode{int} conversion is not at the top level
+int a[] = { 2, f(2), f(2.0) };  // OK, the \tcode{double}-to-\tcode{int} conversion is not at the top level
 \end{codeblock}
 \end{example}
 \indextext{initialization!list-initialization|)}%
@@ -6256,9 +6256,9 @@ struct S {
   ~S() noexcept(false) = default;       // OK, despite mismatched exception specification
 private:
   int i;
-  S(S&);                                // OK: private copy constructor
+  S(S&);                                // OK, private copy constructor
 };
-S::S(S&) = default;                     // OK: defines copy constructor
+S::S(S&) = default;                     // OK, defines copy constructor
 
 struct T {
   T();
@@ -7097,7 +7097,7 @@ distinct types, objects of type \tcode{color} can be assigned only
 values of type \tcode{color}.
 \begin{codeblock}
 color c = 1;                    // error: type mismatch, no conversion from \tcode{int} to \tcode{color}
-int i = yellow;                 // OK: \tcode{yellow} converted to integral value \tcode{1}, integral promotion
+int i = yellow;                 // OK, \tcode{yellow} converted to integral value \tcode{1}, integral promotion
 \end{codeblock}
 Note that this implicit \keyword{enum} to \tcode{int}
 conversion is not provided for a scoped enumeration:
@@ -7603,8 +7603,8 @@ using namespace B;
 
 void f() {
   X(1);             // error: name \tcode{X} found in two namespaces
-  g();              // OK: name \tcode{g} refers to the same entity
-  h();              // OK: overload resolution selects \tcode{A::h}
+  g();              // OK, name \tcode{g} refers to the same entity
+  h();              // OK, overload resolution selects \tcode{A::h}
 }
 \end{codeblock}
 \end{note}
@@ -7635,7 +7635,7 @@ namespace D {
 }
 using namespace D;
 
-int d1;             // OK: no conflict with \tcode{D::d1}
+int d1;             // OK, no conflict with \tcode{D::d1}
 
 namespace E {
   int e;
@@ -7652,10 +7652,10 @@ void f() {
   d1++;             // error: ambiguous \tcode{::d1} or \tcode{D::d1}?
   ::d1++;           // OK
   D::d1++;          // OK
-  d2++;             // OK: \tcode{D::d2}
-  e++;              // OK: \tcode{E::e}
+  d2++;             // OK, \tcode{D::d2}
+  e++;              // OK, \tcode{E::e}
   f(1);             // error: ambiguous: \tcode{D::f(int)} or \tcode{E::f(int)}?
-  f('a');           // OK: \tcode{D::f(char)}
+  f('a');           // OK, \tcode{D::f(char)}
 }
 \end{codeblock}
 \end{example}
@@ -7762,9 +7762,9 @@ struct C {
 };
 
 struct D : B {
-  using B::f;                   // OK: \tcode{B} is a base of \tcode{D}
-  using B::e;                   // OK: \tcode{e} is an enumerator of base \tcode{B}
-  using B::x;                   // OK: \tcode{x} is a union member of base \tcode{B}
+  using B::f;                   // OK, \tcode{B} is a base of \tcode{D}
+  using B::e;                   // OK, \tcode{e} is an enumerator of base \tcode{B}
+  using B::x;                   // OK, \tcode{x} is a union member of base \tcode{B}
   using C::f;                   // error: \tcode{C} isn't a base of \tcode{D}
   void f(int) { f('c'); }       // calls \tcode{B::f(char)}
   void g(int) { g('c'); }       // recursively calls \tcode{D::g(int)}
@@ -7773,7 +7773,7 @@ template <typename... bases>
 struct X : bases... {
   using bases::f...;
 };
-X<B, C> x;                      // OK: \tcode{B::f} and \tcode{C::f} named
+X<B, C> x;                      // OK, \tcode{B::f} and \tcode{C::f} named
 \end{codeblock}
 \end{example}
 
@@ -7894,17 +7894,17 @@ namespace B {
   struct x { };
   void f(int);
   void f(double);
-  void g(char);                         // OK: hides \tcode{struct g}
+  void g(char);                         // OK, hides \tcode{struct g}
 }
 
 void func() {
   int i;
   using B::i;                           // error: conflicts
   void f(char);
-  using B::f;                           // OK: each \tcode{f} is a function
+  using B::f;                           // OK, each \tcode{f} is a function
   using A::f;                           // OK, but interferes with \tcode{B::f(int)}
   f(1);                                 // error: ambiguous
-  static_cast<int(*)(int)>(f)(1);       // OK: calls \tcode{A::f}
+  static_cast<int(*)(int)>(f)(1);       // OK, calls \tcode{A::f}
   f(3.5);                               // calls \tcode{B::f(double)}
   using B::g;
   g('a');                               // calls \tcode{B::g(char)}
@@ -7913,7 +7913,7 @@ void func() {
   void h();
   using A::h;                           // error: conflicts
   using B::x;
-  using A::x;                           // OK: hides \tcode{struct B::x}
+  using A::x;                           // OK, hides \tcode{struct B::x}
   x = 99;                               // assigns to \tcode{A::x}
   struct x x1;                          // \tcode{x1} has class type \tcode{B::x}
 }
@@ -7938,13 +7938,13 @@ struct B {
 
 struct D : B {
   using B::f;
-  void f(int);      // OK: \tcode{D::f(int)} overrides \tcode{B::f(int)};
+  void f(int);      // OK, \tcode{D::f(int)} overrides \tcode{B::f(int)};
 
   using B::g;
   void g(char);     // OK
 
   using B::h;
-  void h(int);      // OK: \tcode{D::h(int)} hides \tcode{B::h(int)}
+  void h(int);      // OK, \tcode{D::h(int)} hides \tcode{B::h(int)}
 };
 
 void k(D* p)
@@ -7972,7 +7972,7 @@ D1 d1(0);           // error: ambiguous
 struct D2 : B1, B2 {
   using B1::B1;
   using B2::B2;
-  D2(int);          // OK: \tcode{D2::D2(int)} hides \tcode{B1::B1(int)} and \tcode{B2::B2(int)}
+  D2(int);          // OK, \tcode{D2::D2(int)} hides \tcode{B1::B1(int)} and \tcode{B2::B2(int)}
 };
 D2 d2(0);           // calls \tcode{D2::D2(int)}
 \end{codeblock}
@@ -8191,15 +8191,15 @@ extern "C" {
 }
 
 extern "C" void f5() {
-  extern void f4();             // OK: Name linkage (internal) and function type linkage (C language linkage)
+  extern void f4();             // OK, name linkage (internal) and function type linkage (C language linkage)
                                 // obtained from previous declaration.
 }
 
-extern void f4();               // OK: Name linkage (internal) and function type linkage (C language linkage)
+extern void f4();               // OK, name linkage (internal) and function type linkage (C language linkage)
                                 // obtained from previous declaration.
 
 void f6() {
-  extern void f4();             // OK: Name linkage (internal) and function type linkage (C language linkage)
+  extern void f4();             // OK, name linkage (internal) and function type linkage (C language linkage)
                                 // obtained from previous declaration.
 }
 \end{codeblock}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1254,7 +1254,7 @@ The expression \keyword{this} shall not appear in any other context.
 \begin{codeblock}
 class Outer {
   int a[sizeof(*this)];                 // error: not inside a member function
-  unsigned int sz = sizeof(*this);      // OK: in default member initializer
+  unsigned int sz = sizeof(*this);      // OK, in default member initializer
 
   void f() {
     int b[sizeof(*this)];               // OK
@@ -1734,10 +1734,10 @@ type specified by the
 \tcode{return} statements as described in~\ref{dcl.spec.auto}.
 \begin{example}
 \begin{codeblock}
-auto x1 = [](int i) { return i; };      // OK: return type is \tcode{int}
+auto x1 = [](int i) { return i; };      // OK, return type is \tcode{int}
 auto x2 = []{ return { 1, 2 }; };       // error: deducing return type from \grammarterm{braced-init-list}
 int j;
-auto x3 = []()->auto&& { return j; };   // OK: return type is \tcode{int\&}
+auto x3 = []()->auto&& { return j; };   // OK, return type is \tcode{int\&}
 \end{codeblock}
 \end{example}
 
@@ -1748,8 +1748,8 @@ has any generic parameter type placeholders\iref{dcl.spec.auto}, or
 if the lambda has a \grammarterm{template-parameter-list}.
 \begin{example}
 \begin{codeblock}
-int i = [](int i, auto a) { return i; }(3, 4);                  // OK: a generic lambda
-int j = []<class T>(T t, int i) { return i; }(3, 4);            // OK: a generic lambda
+int i = [](int i, auto a) { return i; }(3, 4);                  // OK, a generic lambda
+int j = []<class T>(T t, int i) { return i; }(3, 4);            // OK, a generic lambda
 \end{codeblock}
 \end{example}
 
@@ -1812,7 +1812,7 @@ auto glambda = [](auto a, auto&& b) { return a < b; };
 bool b = glambda(3, 3.14);                                      // OK
 
 auto vglambda = [](auto printer) {
-  return [=](auto&& ... ts) {                                   // OK: \tcode{ts} is a function parameter pack
+  return [=](auto&& ... ts) {                                   // OK, \tcode{ts} is a function parameter pack
     printer(std::forward<decltype(ts)>(ts)...);
 
     return [=]() {
@@ -1822,13 +1822,13 @@ auto vglambda = [](auto printer) {
 };
 auto p = vglambda( [](auto v1, auto v2, auto v3)
                    { std::cout << v1 << v2 << v3; } );
-auto q = p(1, 'a', 3.14);                                       // OK: outputs \tcode{1a3.14}
-q();                                                            // OK: outputs \tcode{1a3.14}
+auto q = p(1, 'a', 3.14);                                       // OK, outputs \tcode{1a3.14}
+q();                                                            // OK, outputs \tcode{1a3.14}
 
-auto fact = [](this auto self, int n) -> int {                  // OK: explicit object parameter
+auto fact = [](this auto self, int n) -> int {                  // OK, explicit object parameter
   return (n <= 1) ? 1 : n * self(n-1);
 };
-std::cout << fact(5);                                           // OK: outputs 120
+std::cout << fact(5);                                           // OK, outputs 120
 \end{codeblock}
 \end{example}
 
@@ -2020,7 +2020,7 @@ auto glambda = [](auto a) { return a; };
 f1(glambda);                    // OK
 f2(glambda);                    // error: ID is not convertible
 g(glambda);                     // error: ambiguous
-h(glambda);                     // OK: calls \#3 since it is convertible from ID
+h(glambda);                     // OK, calls \#3 since it is convertible from ID
 int& (*fpi)(int*) = [](auto* a) -> auto& { return *a; };        // OK
 \end{codeblock}
 \end{example}
@@ -2042,8 +2042,8 @@ the return type and parameter types of the pointer to function.
 \begin{example}
 \begin{codeblock}
 auto GL = [](auto a) { std::cout << a; return a; };
-int (*GL_int)(int) = GL;        // OK: through conversion function template
-GL_int(3);                      // OK: same as \tcode{GL(3)}
+int (*GL_int)(int) = GL;        // OK, through conversion function template
+GL_int(3);                      // OK, same as \tcode{GL(3)}
 \end{codeblock}
 \end{example}
 
@@ -2297,16 +2297,16 @@ void f(const int&, const int (&)[1]);       // \#2
 void test() {
   const int x = 17;
   auto g = [](auto a) {
-    f(x);                       // OK: calls \#1, does not capture \tcode{x}
+    f(x);                       // OK, calls \#1, does not capture \tcode{x}
   };
 
   auto g1 = [=](auto a) {
-    f(x);                       // OK: calls \#1, captures \tcode{x}
+    f(x);                       // OK, calls \#1, captures \tcode{x}
   };
 
   auto g2 = [=](auto a) {
     int selector[sizeof(a) == 1 ? 1 : 2]{};
-    f(x, selector);             // OK: captures \tcode{x}, can call \#1 or \#2
+    f(x, selector);             // OK, captures \tcode{x}, can call \#1 or \#2
   };
 
   auto g3 = [=](auto a) {
@@ -2353,8 +2353,8 @@ void f1(int i) {
   auto m1 = [=]{
     int const M = 30;
     auto m2 = [i]{
-      int x[N][M];              // OK: \tcode{N} and \tcode{M} are not odr-used
-      x[0][0] = i;              // OK: \tcode{i} is explicitly captured by \tcode{m2} and implicitly captured by \tcode{m1}
+      int x[N][M];              // OK, \tcode{N} and \tcode{M} are not odr-used
+      x[0][0] = i;              // OK, \tcode{i} is explicitly captured by \tcode{m2} and implicitly captured by \tcode{m1}
     };
   };
   struct s1 {
@@ -2365,10 +2365,10 @@ void f1(int i) {
       auto m3 = [this,m] {
         auto m4 = [&,j] {       // error: \tcode{j} not odr-usable due to intervening lambda \tcode{m3}
           int x = n;            // error: \tcode{n} is odr-used but not odr-usable due to intervening lambda \tcode{m3}
-          x += m;               // OK: \tcode{m} implicitly captured by \tcode{m4} and explicitly captured by \tcode{m3}
+          x += m;               // OK, \tcode{m} implicitly captured by \tcode{m4} and explicitly captured by \tcode{m3}
           x += i;               // error: \tcode{i} is odr-used but not odr-usable
                                 // due to intervening function and class scopes
-          x += f;               // OK: \keyword{this} captured implicitly by \tcode{m4} and explicitly by \tcode{m3}
+          x += f;               // OK, \keyword{this} captured implicitly by \tcode{m4} and explicitly by \tcode{m3}
         };
       };
     }
@@ -2461,8 +2461,8 @@ void f(const int*);
 void g() {
   const int N = 10;
   [=] {
-    int arr[N];     // OK: not an odr-use, refers to automatic variable
-    f(&N);          // OK: causes \tcode{N} to be captured; \tcode{\&N} points to
+    int arr[N];     // OK, not an odr-use, refers to automatic variable
+    f(&N);          // OK, causes \tcode{N} to be captured; \tcode{\&N} points to
                     // the corresponding member of the closure type
   };
 }
@@ -7379,7 +7379,7 @@ struct A {
   constexpr A(bool b) : m(b?42:x) { }
   int m;
 };
-constexpr int v = A(true).m;        // OK: constructor call initializes \tcode{m} with the value \tcode{42}
+constexpr int v = A(true).m;        // OK, constructor call initializes \tcode{m} with the value \tcode{42}
 
 constexpr int w = A(false).m;       // error: initializer for \tcode{m} is \tcode{x}, which is non-constant
 
@@ -7389,7 +7389,7 @@ constexpr int f1(int k) {
   return x;
 }
 constexpr int f2(int k) {
-  int x = k;                        // OK: not required to be a constant expression
+  int x = k;                        // OK, not required to be a constant expression
                                     // because \tcode{x} is not \keyword{constexpr}
   return x;
 }
@@ -7403,10 +7403,10 @@ constexpr int g(int k) {
   return x;
 }
 constexpr int h(int k) {
-  int x = incr(k);                  // OK: \tcode{incr(k)} is not required to be a core constant expression
+  int x = incr(k);                  // OK, \tcode{incr(k)} is not required to be a core constant expression
   return x;
 }
-constexpr int y = h(1);             // OK: initializes \tcode{y} with the value \tcode{2}
+constexpr int y = h(1);             // OK, initializes \tcode{y} with the value \tcode{2}
                                     // \tcode{h(1)} is a core constant expression because
                                     // the lifetime of \tcode{k} begins inside \tcode{h(1)}
 \end{codeblock}

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -2152,7 +2152,7 @@ and that suffix is applied to the result of the concatenation.
 \begin{example}
 \begin{codeblock}
 int main() {
-  L"A" "B" "C"_x;   // OK: same as \tcode{L"ABC"_x}
+  L"A" "B" "C"_x;   // OK, same as \tcode{L"ABC"_x}
   "P"_x "Q" "R"_y;  // error: two different \grammarterm{ud-suffix}{es}
 }
 \end{codeblock}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1625,7 +1625,7 @@ is performed in an appropriate context under the various conditions as follows:
 template<class T, class U>
 void value_swap(T&& t, U&& u) {
   using std::swap;
-  swap(std::forward<T>(t), std::forward<U>(u)); // OK: uses ``swappable with'' conditions
+  swap(std::forward<T>(t), std::forward<U>(u)); // OK, uses ``swappable with'' conditions
                                                 // for rvalues and lvalues
 }
 
@@ -1633,7 +1633,7 @@ void value_swap(T&& t, U&& u) {
 template<class T>
 void lv_swap(T& t1, T& t2) {
   using std::swap;
-  swap(t1, t2);                                 // OK: uses swappable conditions for lvalues of type \tcode{T}
+  swap(t1, t2);                                 // OK, uses swappable conditions for lvalues of type \tcode{T}
 }
 
 namespace N {
@@ -1642,7 +1642,7 @@ namespace N {
   Proxy proxy(A& a) { return Proxy{ &a }; }
 
   void swap(A& x, Proxy p) {
-    std::swap(x.m, p.a->m);                     // OK: uses context equivalent to swappable
+    std::swap(x.m, p.a->m);                     // OK, uses context equivalent to swappable
                                                 // conditions for fundamental types
   }
   void swap(Proxy p, A& x) { swap(x, p); }      // satisfy symmetry constraint

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -936,7 +936,7 @@ A a;
 
 void B::f() {
   operator+ (a,a);              // error: global operator hidden by member
-  a + a;                        // OK: calls global \tcode{\keyword{operator}+}
+  a + a;                        // OK, calls global \tcode{\keyword{operator}+}
 }
 \end{codeblock}
 \end{note}
@@ -2274,9 +2274,9 @@ the context of a call to an initializer-list constructor.
 \begin{example}
 \begin{codeblock}
 void f(std::initializer_list<int>);
-f( {} );                        // OK: \tcode{f(initializer_list<int>)} identity conversion
-f( {1,2,3} );                   // OK: \tcode{f(initializer_list<int>)} identity conversion
-f( {'a','b'} );                 // OK: \tcode{f(initializer_list<int>)} integral promotion
+f( {} );                        // OK, \tcode{f(initializer_list<int>)} identity conversion
+f( {1,2,3} );                   // OK, \tcode{f(initializer_list<int>)} identity conversion
+f( {'a','b'} );                 // OK, \tcode{f(initializer_list<int>)} integral promotion
 f( {1.0} );                     // error: narrowing
 
 struct A {
@@ -2291,7 +2291,7 @@ g({ "foo", "bar" });            // OK, uses \#3
 
 typedef int IA[3];
 void h(const IA&);
-h({ 1, 2, 3 });                 // OK: identity conversion
+h({ 1, 2, 3 });                 // OK, identity conversion
 \end{codeblock}
 \end{example}
 
@@ -2333,13 +2333,13 @@ struct A {
   A(std::initializer_list<int>);
 };
 void f(A);
-f( {'a', 'b'} );        // OK: \tcode{f(A(std::initializer_list<int>))} user-defined conversion
+f( {'a', 'b'} );        // OK, \tcode{f(A(std::initializer_list<int>))} user-defined conversion
 
 struct B {
   B(int, double);
 };
 void g(B);
-g( {'a', 'b'} );        // OK: \tcode{g(B(int, double))} user-defined conversion
+g( {'a', 'b'} );        // OK, \tcode{g(B(int, double))} user-defined conversion
 g( {1.0, 1.0} );        // error: narrowing
 
 void f(B);
@@ -2349,13 +2349,13 @@ struct C {
   C(std::string);
 };
 void h(C);
-h({"foo"});             // OK: \tcode{h(C(std::string("foo")))}
+h({"foo"});             // OK, \tcode{h(C(std::string("foo")))}
 
 struct D {
   D(A, C);
 };
 void i(D);
-i({ {1,2}, {"bar"} });  // OK: \tcode{i(D(A(std::initializer_list<int>\{1,2\}), C(std::string("bar"))))}
+i({ {1,2}, {"bar"} });  // OK, \tcode{i(D(A(std::initializer_list<int>\{1,2\}), C(std::string("bar"))))}
 \end{codeblock}
 \end{example}
 
@@ -2373,7 +2373,7 @@ struct A {
 };
 
 void f(A);
-f( {'a', 'b'} );        // OK: \tcode{f(A(int,double))} user-defined conversion
+f( {'a', 'b'} );        // OK, \tcode{f(A(int,double))} user-defined conversion
 f( {1.0} );             // error: narrowing
 \end{codeblock}
 \end{example}
@@ -2392,7 +2392,7 @@ struct A {
 };
 
 void f(const A&);
-f( {'a', 'b'} );        // OK: \tcode{f(A(int,double))} user-defined conversion
+f( {'a', 'b'} );        // OK, \tcode{f(A(int,double))} user-defined conversion
 f( {1.0} );             // error: narrowing
 
 void g(const double &);
@@ -2409,7 +2409,7 @@ the parameter type;
 \begin{example}
 \begin{codeblock}
 void f(int);
-f( {'a'} );             // OK: same conversion as \tcode{char} to \tcode{int}
+f( {'a'} );             // OK, same conversion as \tcode{char} to \tcode{int}
 f( {1.0} );             // error: narrowing
 \end{codeblock}
 \end{example}
@@ -2419,7 +2419,7 @@ is the identity conversion.
 \begin{example}
 \begin{codeblock}
 void f(int);
-f( { } );               // OK: identity conversion
+f( { } );               // OK, identity conversion
 \end{codeblock}
 \end{example}
 \end{itemize}
@@ -3846,11 +3846,11 @@ taken, etc.
 \begin{codeblock}
 void operator "" _km(long double);                  // OK
 string operator "" _i18n(const char*, std::size_t); // OK
-template <char...> double operator "" _\u03C0();    // OK: UCN for lowercase pi
+template <char...> double operator "" _\u03C0();    // OK, UCN for lowercase pi
 float operator ""_e(const char*);                   // OK
 float operator ""E(const char*);                    // ill-formed, no diagnostic required:
                                                     // reserved literal suffix~(\ref{usrlit.suffix}, \ref{lex.ext})
-double operator""_Bq(long double);                  // OK: does not use the reserved \grammarterm{identifier} \tcode{_Bq}\iref{lex.name}
+double operator""_Bq(long double);                  // OK, does not use the reserved \grammarterm{identifier} \tcode{_Bq}\iref{lex.name}
 double operator"" _Bq(long double);                 // ill-formed, no diagnostic required:
                                                     // uses the reserved \grammarterm{identifier} \tcode{_Bq}\iref{lex.name}
 float operator " " B(const char*);                  // error: non-empty \grammarterm{string-literal}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -428,8 +428,8 @@ template<const X& x, int i, A a> void f() {
   &i;                           // error: address of non-reference template-parameter
   &a;                           // OK
   int& ri = i;                  // error: attempt to bind non-const reference to temporary
-  const int& cri = i;           // OK: const reference binds to temporary
-  const A& ra = a;              // OK: const reference binds to a template parameter object
+  const int& cri = i;           // OK, const reference binds to temporary
+  const A& ra = a;              // OK, const reference binds to a template parameter object
 }
 \end{codeblock}
 \end{example}
@@ -733,9 +733,9 @@ struct X {
 };
 template<class T> void f(T* p) {
   T* p1 = p->alloc<200>();              // error: \tcode{<} means less than
-  T* p2 = p->template alloc<200>();     // OK: \tcode{<} starts template argument list
+  T* p2 = p->template alloc<200>();     // OK, \tcode{<} starts template argument list
   T::adjust<100>();                     // error: \tcode{<} means less than
-  T::template adjust<100>();            // OK: \tcode{<} starts template argument list
+  T::template adjust<100>();            // OK, \tcode{<} starts template argument list
 }
 \end{codeblock}
 \end{example}
@@ -812,7 +812,7 @@ template <class T> struct A {
 
 template <class T> void f(T t) {
   A<T> a;
-  a.template f<>(t);                    // OK: calls template
+  a.template f<>(t);                    // OK, calls template
   a.template f(t);                      // error: not a \grammarterm{template-id}
 }
 
@@ -1031,9 +1031,9 @@ template<class T> class X {
 class Y {
 private:
   struct S { @\commentellip@ };
-  X<S> x;           // OK: \tcode{S} is accessible
+  X<S> x;           // OK, \tcode{S} is accessible
                     // \tcode{X<Y::S>} has a static member of type \tcode{Y::S}
-                    // OK: even though \tcode{Y::S} is private
+                    // OK, even though \tcode{Y::S} is private
 };
 
 X<Y::S> y;          // error: \tcode{S} not accessible
@@ -1072,10 +1072,10 @@ brackets shall still be used as the
 \begin{example}
 \begin{codeblock}
 template<class T = char> class String;
-String<>* p;                    // OK: \tcode{String<char>}
+String<>* p;                    // OK, \tcode{String<char>}
 String* q;                      // syntax error
 template<class ... Elements> class Tuple;
-Tuple<>* t;                     // OK: \tcode{Elements} is empty
+Tuple<>* t;                     // OK, \tcode{Elements} is empty
 Tuple* u;                       // syntax error
 \end{codeblock}
 \end{example}
@@ -1090,8 +1090,8 @@ template<class T> struct A {
   ~A();
 };
 void f(A<int>* p, A<int>* q) {
-  p->A<int>::~A();              // OK: destructor call
-  q->A<int>::~A<int>();         // OK: destructor call
+  p->A<int>::~A();              // OK, destructor call
+  q->A<int>::~A<int>();         // OK, destructor call
 }
 \end{codeblock}
 \end{example}
@@ -1387,8 +1387,8 @@ template <int N> struct C;
 template <class T1, int N> struct D;
 template <class T1, class T2, int N = 17> struct E;
 
-eval<A<int>> eA;                // OK: matches partial specialization of \tcode{eval}
-eval<B<int, float>> eB;         // OK: matches partial specialization of \tcode{eval}
+eval<A<int>> eA;                // OK, matches partial specialization of \tcode{eval}
+eval<B<int, float>> eB;         // OK, matches partial specialization of \tcode{eval}
 eval<C<17>> eC;                 // error: \tcode{C} does not match \tcode{TT} in partial specialization
 eval<D<int, 17>> eD;            // error: \tcode{D} does not match \tcode{TT} in partial specialization
 eval<E<int, float>> eE;         // error: \tcode{E} does not match \tcode{TT} in partial specialization
@@ -1539,7 +1539,7 @@ template<typename T>
 
 void f(int);
 
-f('a'); // OK: calls \tcode{f(int)}
+f('a'); // OK, calls \tcode{f(int)}
 \end{codeblock}
 In the satisfaction of the associated constraints\iref{temp.constr.decl}
 of \tcode{f}, the constraint \tcode{sizeof(char) > 1} is not satisfied;
@@ -2285,7 +2285,7 @@ template<C T> struct S {
   template<D U> struct Inner;
 };
 
-template<C A> void S<A>::f() { }        // OK: \grammarterm{template-head}{s} match
+template<C A> void S<A>::f() { }        // OK, \grammarterm{template-head}{s} match
 template<typename T> void S<T>::g() { } // error: no matching declaration for \tcode{S<T>}
 
 template<typename T> requires C<T>      // ill-formed, no diagnostic required: \grammarterm{template-head}{s} are
@@ -2444,9 +2444,9 @@ For example,
 template<class T> struct A {
   class B;
 };
-A<int>::B* b1;                          // OK: requires \tcode{A} to be defined but not \tcode{A::B}
+A<int>::B* b1;                          // OK, requires \tcode{A} to be defined but not \tcode{A::B}
 template<class T> class A<T>::B { };
-A<int>::B  b2;                          // OK: requires \tcode{A::B} to be defined
+A<int>::B  b2;                          // OK, requires \tcode{A::B} to be defined
 \end{codeblock}
 \end{note}
 
@@ -2483,7 +2483,7 @@ template <class T> struct A {
   static int i[];
 };
 template <class T> int A<T>::i[4];      // 4 elements
-template <> int A<int>::i[] = { 1 };    // OK: 1 element
+template <> int A<int>::i[] = { 1 };    // OK, 1 element
 \end{codeblock}
 \end{example}
 
@@ -2789,11 +2789,11 @@ typedef zip<short>::with<unsigned short, unsigned>::type T2;
     // error: different number of arguments specified for \tcode{Args1} and \tcode{Args2}
 
 template<class ... Args>
-  void g(Args ... args) {                   // OK: \tcode{Args} is expanded by the function parameter pack \tcode{args}
-    f(const_cast<const Args*>(&args)...);   // OK: ``\tcode{Args}'' and ``\tcode{args}'' are expanded
+  void g(Args ... args) {                   // OK, \tcode{Args} is expanded by the function parameter pack \tcode{args}
+    f(const_cast<const Args*>(&args)...);   // OK, ``\tcode{Args}'' and ``\tcode{args}'' are expanded
     f(5 ...);                               // error: pattern does not contain any packs
     f(args);                                // error: pack ``\tcode{args}'' is not expanded
-    f(h(args ...) + args ...);              // OK: first ``\tcode{args}'' expanded within \tcode{h},
+    f(h(args ...) + args ...);              // OK, first ``\tcode{args}'' expanded within \tcode{h},
                                             // second ``\tcode{args}'' expanded within \tcode{f}
   }
 \end{codeblock}
@@ -2925,7 +2925,7 @@ template<class... T> void f(T... values) {
   X<T...> x(values...);
 }
 
-template void f<>();    // OK: \tcode{X<>} has no base classes
+template void f<>();    // OK, \tcode{X<>} has no base classes
                         // \tcode{x} is a variable of type \tcode{X<>} that is value-initialized
 \end{codeblock}
 \end{example}
@@ -3609,7 +3609,7 @@ them.
 
 \begin{codeblock}
 template<class T> void f();
-template<int I> void f();       // OK: overloads the first template
+template<int I> void f();       // OK, overloads the first template
                                 // distinguishable with an explicit template argument list
 \end{codeblock}
 \end{note}
@@ -3959,8 +3959,8 @@ template<class T, class... U> void g(T*, U...);         // \#3
 template<class T            > void g(T);                // \#4
 
 void h(int i) {
-  f(&i);                                                // OK: calls \#2
-  g(&i);                                                // OK: calls \#3
+  f(&i);                                                // OK, calls \#2
+  g(&i);                                                // OK, calls \#3
 }
 \end{codeblock}
 \end{example}
@@ -4030,7 +4030,7 @@ void f(C auto &, auto &) = delete;
 template <C Q> void f(Q &, C auto &);
 
 void g(struct A *ap, struct B *bp) {
-  f(*ap, *bp);                  // OK: Can use different methods to produce template parameters
+  f(*ap, *bp);                  // OK, can use different methods to produce template parameters
 }
 
 template <typename T, typename U> struct X {};
@@ -4039,7 +4039,7 @@ template <typename T, C U, typename V> bool operator==(X<T, U>, V) = delete;
 template <C T, C U, C V>               bool operator==(T, X<U, V>);
 
 void h() {
-  X<void *, int>{} == 0;        // OK: Correspondence of [\tcode{T}, \tcode{U}, \tcode{V}] and [\tcode{U}, \tcode{V}, \tcode{T}]
+  X<void *, int>{} == 0;        // OK, correspondence of [\tcode{T}, \tcode{U}, \tcode{V}] and [\tcode{U}, \tcode{V}, \tcode{T}]
 }
 \end{codeblock}
 \end{example}
@@ -4083,7 +4083,7 @@ f(v);               // error: \tcode{Vec} not deduced
 
 template<template<class,class> class TT>
   void g(TT<int, Alloc<int>>);
-g(v);               // OK: \tcode{TT} = \tcode{vector}
+g(v);               // OK, \tcode{TT} = \tcode{vector}
 \end{codeblock}
 
 \end{example}
@@ -4221,7 +4221,7 @@ template<class B, class T>
 struct D : B {
   T get() { return operator T(); }      // \grammarterm{conversion-function-id} is dependent
 };
-int f(D<A, int> d) { return d.get(); }  // OK: lookup finds A::operator int
+int f(D<A, int> d) { return d.get(); }  // OK, lookup finds A::operator int
 \end{codeblock}
 \end{example}
 \begin{example}
@@ -4313,7 +4313,7 @@ template<class T> void f(T t) {
 void foo() {
   A a;
   B b;
-  f(b);             // OK: \tcode{T::X} refers to \tcode{B::X}
+  f(b);             // OK, \tcode{T::X} refers to \tcode{B::X}
   f(a);             // error: \tcode{T::X} refers to the data member \tcode{A::X} not the struct \tcode{A::X}
 }
 \end{codeblock}
@@ -4578,7 +4578,7 @@ template <class T> struct Derived: public Base<T> {
 };
 
 template<class T, template<class> class U = T::Base> struct Third { };
-Third<Derived<int> > t;                 // OK: default argument uses injected-class-name as a template
+Third<Derived<int> > t;                 // OK, default argument uses injected-class-name as a template
 \end{codeblock}
 \end{example}
 
@@ -4631,7 +4631,7 @@ template<class T, int i> class Y {
   void f() {
     char T;                             // error: \grammarterm{template-parameter} hidden
   }
-  friend void T();                      // OK: no name bound
+  friend void T();                      // OK, no name bound
 };
 
 template<class X> class X;              // error: hidden by \grammarterm{template-parameter}
@@ -4974,7 +4974,7 @@ struct C : A, T {
 };
 
 template int C<B>::f();         // error: finds both \tcode{A::m} and \tcode{B::m}
-template int C<B>::g();         // OK: transformation to class member access syntax
+template int C<B>::g();         // OK, transformation to class member access syntax
                                 // does not occur in the template definition context; see~\ref{class.mfct.non-static}
 \end{codeblock}
 \end{example}
@@ -5451,7 +5451,7 @@ module;
 export module M;
 import F;
 void g(X x) {
-  f(x);             // OK: instantiates \tcode{f} from \tcode{F},
+  f(x);             // OK, instantiates \tcode{f} from \tcode{F},
                     // \tcode{operator+} is visible in instantiation context
 }
 \end{codeblocktu}
@@ -5795,7 +5795,7 @@ template<class T, class U>
 struct Outer {
   template<class X, class Y> struct Inner;
   template<class Y> struct Inner<T, Y>;         // \#1a
-  template<class Y> struct Inner<T, Y> { };     // \#1b; OK: valid redeclaration of \#1a
+  template<class Y> struct Inner<T, Y> { };     // \#1b; OK, valid redeclaration of \#1a
   template<class Y> struct Inner<U, Y> { };     // \#2
 };
 
@@ -6383,7 +6383,7 @@ template<> class X<int> { @\commentellip@ };          // error: \tcode{X} not a 
 
 template<class T> class X;
 
-template<> class X<char*> { @\commentellip@ };        // OK: \tcode{X} is a template
+template<> class X<char*> { @\commentellip@ };        // OK, \tcode{X} is a template
 \end{codeblock}
 \end{example}
 
@@ -6488,7 +6488,7 @@ void f(Array<String>& v) {
 }
 
 template<> void sort<String>(Array<String>& v);     // error: specialization after use of primary template
-template<> void sort<>(Array<char*>& v);            // OK: \tcode{sort<char*>} not yet used
+template<> void sort<>(Array<char*>& v);            // OK, \tcode{sort<char*>} not yet used
 template<class T> struct A {
   enum E : T;
   enum class S : T;
@@ -6538,7 +6538,7 @@ classes\iref{basic.types}.
 template<class T> class X;                      // \tcode{X} is a class template
 template<> class X<int>;
 
-X<int>* p;                                      // OK: pointer to declared class \tcode{X<int>}
+X<int>* p;                                      // OK, pointer to declared class \tcode{X<int>}
 X<int> x;                                       // error: object of incomplete class \tcode{X<int>}
 \end{codeblock}
 \end{example}
@@ -6587,8 +6587,8 @@ is independent of those properties of the template.
 template<class T> void f(T) { @\commentellip@ }
 template<class T> inline T g(T) { @\commentellip@ }
 
-template<> inline void f<>(int) { @\commentellip@ }   // OK: inline
-template<> int g<>(int) { @\commentellip@ }           // OK: not inline
+template<> inline void f<>(int) { @\commentellip@ }   // OK, inline
+template<> int g<>(int) { @\commentellip@ }           // OK, not inline
 \end{codeblock}
 \end{example}
 
@@ -8150,8 +8150,8 @@ struct B : A { @\commentellip@ };
 void g(A a, B b) {
   f(a,b);           // error: \tcode{T} deduced as both \tcode{A} and \tcode{B}
   f(b,a);           // error: \tcode{T} deduced as both \tcode{A} and \tcode{B}
-  f(a,a);           // OK: \tcode{T} is \tcode{A}
-  f(b,b);           // OK: \tcode{T} is \tcode{B}
+  f(a,a);           // OK, \tcode{T} is \tcode{A}
+  f(b,b);           // OK, \tcode{T} is \tcode{B}
 }
 \end{codeblock}
 
@@ -8168,7 +8168,7 @@ char g2( int, float, float);
 int g3( int, char, float);
 
 void r() {
-  f(g1);            // OK: \tcode{T} is \tcode{int} and \tcode{U} is \tcode{float}
+  f(g1);            // OK, \tcode{T} is \tcode{int} and \tcode{U} is \tcode{float}
   f(g2);            // error: \tcode{T} deduced as both \tcode{char} and \tcode{int}
   f(g3);            // error: \tcode{U} deduced as both \tcode{char} and \tcode{float}
 }
@@ -8430,7 +8430,7 @@ using V = S<int[42]>::Q;        // OK; \tcode{T} was deduced as \tcode{std::size
 template<class T, T i> void f(int (&a)[i]);
 int v[10];
 void g() {
-  f(v);                         // OK: \tcode{T} is \tcode{std::size_t}
+  f(v);                         // OK, \tcode{T} is \tcode{std::size_t}
 }
 \end{codeblock}
 \end{example}
@@ -8446,11 +8446,11 @@ template<int i> void f3(int (&a)[i][20]);
 
 void g() {
   int v[10][20];
-  f1(v);                        // OK: \tcode{i} deduced as \tcode{20}
+  f1(v);                        // OK, \tcode{i} deduced as \tcode{20}
   f1<20>(v);                    // OK
   f2(v);                        // error: cannot deduce template-argument \tcode{i}
   f2<10>(v);                    // OK
-  f3(v);                        // OK: \tcode{i} deduced as \tcode{10}
+  f3(v);                        // OK, \tcode{i} deduced as \tcode{10}
 }
 \end{codeblock}
 \end{note}
@@ -8530,7 +8530,7 @@ template<const short cs> class B { };
 template<short s> void g(B<s>);
 void k2() {
   B<1> b;
-  g(b);             // OK: cv-qualifiers are ignored on template parameter types
+  g(b);             // OK, cv-qualifiers are ignored on template parameter types
 }
 \end{codeblock}
 \end{example}
@@ -8552,7 +8552,7 @@ void h(int,int,int);
 void h(char,int);
 int m() {
   f(&g);            // error: ambiguous
-  f(&h);            // OK: void \tcode{h(char,int)} is a unique match
+  f(&h);            // OK, void \tcode{h(char,int)} is a unique match
   f(&foo);          // error: type deduction fails because \tcode{foo} is a template
 }
 \end{codeblock}
@@ -8566,9 +8566,9 @@ cannot be deduced from the type of a function default argument.
 \begin{codeblock}
 template <class T> void f(T = 5, T = 7);
 void g() {
-  f(1);             // OK: call \tcode{f<int>(1,7)}
+  f(1);             // OK, calls \tcode{f<int>(1,7)}
   f();              // error: cannot deduce \tcode{T}
-  f<int>();         // OK: call \tcode{f<int>(5,7)}
+  f<int>();         // OK, calls \tcode{f<int>(5,7)}
 }
 \end{codeblock}
 \end{example}


### PR DESCRIPTION
In contrast to errors, which use a colon, an OK comment
is not followed by any unique reason why the code is
well-formed, but by a subjective highlighting of a fact.