### PR TITLE
Fix inconsistency in class grammar vs text

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -36,7 +36,7 @@ make a \grammarterm{class-name}. An object of a class consists of a
 
 \begin{bnf}
 \nontermdef{class-head}\br
-    class-key \opt{attribute-specifier-seq} class-head-name \opt{class-virt-specifier} \opt{base-clause}\br
+    class-key \opt{attribute-specifier-seq} \opt{class-head-name} \opt{class-virt-specifier} \opt{base-clause}\br
     class-key \opt{attribute-specifier-seq} \opt{base-clause}
 \end{bnf}
 


### PR DESCRIPTION
Changed grammar specification of class to indicate that the class-head-name is optional.  The text of the standard specifically explains that an anonymous class is created by not specifying a class-head-name.

g++ and clang++ both support omission of class-head-name per the text.