### PR TITLE
[basic.start.main] remove redundant phrase

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -6386,7 +6386,7 @@ Terminating the program
 without leaving the current block (e.g., by calling the function
 \tcode{std::exit(int)}\iref{support.start.term}) does not destroy any
 objects with automatic storage duration\iref{class.dtor}. If
-\tcode{std::exit} is called to end a program during the destruction of
+\tcode{std::exit} is called during the destruction of
 an object with static or thread storage duration, the program has undefined
 behavior.
 

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -6386,7 +6386,7 @@ Terminating the program
 without leaving the current block (e.g., by calling the function
 \tcode{std::exit(int)}\iref{support.start.term}) does not destroy any
 objects with automatic storage duration\iref{class.dtor}. If
-\tcode{std::exit} is called during the destruction of
+\tcode{std::exit} is invoked during the destruction of
 an object with static or thread storage duration, the program has undefined
 behavior.
 


### PR DESCRIPTION
If "to end the program" is merely describing what `std::exit` does, it's redundant; if it is read as expressing purpose or intent, it's incorrect - whether a program has UB cannot depend on the programmer's intent.