### PR TITLE
[except.throw,except.handle] Move lvalue specification for copies

### DIFF
--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -260,9 +260,6 @@ Throwing an exception
 copy-initializes~(\ref{dcl.init}, \ref{class.copy.ctor}) a temporary object,
 called the
 \defnx{exception object}{exception handling!exception object}.
-An lvalue denoting the temporary is used to initialize the
-variable declared in the matching
-\grammarterm{handler}\iref{except.handle}.
 If the type of the exception object would be
 an incomplete type,
 an abstract class type\iref{class.abstract},
@@ -655,11 +652,12 @@ The variable declared by the \grammarterm{exception-declaration}, of type
 of type \tcode{E}, as follows:
 \begin{itemize}
 \item
-if \tcode{T} is a base class of \tcode{E}, the variable is
-copy-initialized\iref{dcl.init} from the corresponding base class subobject
+if \tcode{T} is a base class of \tcode{E},
+the variable is copy-initialized\iref{dcl.init}
+from an lvalue of type \tcode{T} designating the corresponding base class subobject
 of the exception object;
 \item otherwise, the variable is copy-initialized\iref{dcl.init}
-from the exception object.
+from an lvalue of type \tcode{E} designating the exception object.
 \end{itemize}
 
 The lifetime of the variable ends


### PR DESCRIPTION
Fixes #5091