### PR TITLE
[dcl.fct.def.coroutine] Limit 'this' to implicit object member functions

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6468,7 +6468,7 @@ $\tcode{p}_{i+1}$ denotes the $i^\text{th}$ non-object function parameter
 for a non-static member function, and
 $\tcode{p}_i$ denotes
 the $i^\text{th}$ function parameter otherwise.
-For a non-static member function,
+For an implicit object member function,
 $\tcode{q}_1$ is an lvalue that denotes \tcode{*this};
 any other $\tcode{q}_i$ is an lvalue
 that denotes the parameter copy corresponding to $\tcode{p}_i$,


### PR DESCRIPTION
After P0847R7, a non-static member function may be an explicit
object member function, which does not have a this pointer.

Fixes #5085