### PR TITLE
[locale.time.get] Replace 'ISO/IEC 9945' with 'POSIX'

### DIFF
--- a/source/locales.tex
+++ b/source/locales.tex
@@ -3345,7 +3345,7 @@ The next element of \tcode{fmt} is equal to \tcode{'\%'},
 optionally followed by a modifier character,
 followed by a conversion specifier character, \tcode{format},
 together forming a conversion specification
-valid for the ISO/IEC 9945 function \tcode{strptime}.
+valid for the POSIX function \tcode{strptime}.
 If the number of elements in the range \range{fmt}{fmtend}
 is not sufficient to unambiguously determine
 whether the conversion specification is complete and valid,
@@ -3535,7 +3535,7 @@ It then reads characters starting at \tcode{s} until it encounters an error, or
 until it has extracted and assigned those \tcode{tm} members, and
 any remaining format characters,
 corresponding to a conversion directive appropriate for
-the ISO/IEC 9945 function \tcode{strptime},
+the POSIX function \tcode{strptime},
 formed by concatenating \tcode{'\%'},
 the \tcode{modifier} character, when non-NUL, and
 the \tcode{format} character.

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -3534,7 +3534,7 @@ The function starts by evaluating \tcode{err = ios_base::goodbit}.
 It then reads characters starting at \tcode{s} until it encounters an error, or
 until it has extracted and assigned those \tcode{tm} members, and
 any remaining format characters,
-corresponding to a conversion directive appropriate for
+corresponding to a conversion specification appropriate for
 the POSIX function \tcode{strptime},
 formed by concatenating \tcode{'\%'},
 the \tcode{modifier} character, when non-NUL, and
@@ -3546,9 +3546,9 @@ When \tcode{s == end} evaluates to \tcode{true} after reading a character
 the function evaluates \tcode{err |= ios_base::eofbit}.
 
 \pnum
-For complex conversion directives
+For complex conversion specifications
 such as \tcode{\%c}, \tcode{\%x}, or \tcode{\%X}, or
-directives that involve the optional modifiers \tcode{E} or \tcode{O},
+conversion specifications that involve the optional modifiers \tcode{E} or \tcode{O},
 when the function is unable to unambiguously determine
 some or all \tcode{tm} members from the input sequence \range{s}{end},
 it evaluates \tcode{err |= ios_base::eofbit}.


### PR DESCRIPTION
We introduce POSIX as an alias for ISO/IEC 9945, and we use 'POSIX'
everywhere else.