### PR TITLE
[input.output] Fix headings of 'assign and swap' subclauses

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4291,7 +4291,7 @@ namespace std {
     basic_istream(const basic_istream&) = delete;
     basic_istream(basic_istream&& rhs);
 
-    // \ref{istream.assign}, assign and swap
+    // \ref{istream.assign}, assignment and swap
     basic_istream& operator=(const basic_istream&) = delete;
     basic_istream& operator=(basic_istream&& rhs);
     void swap(basic_istream& rhs);
@@ -5714,7 +5714,7 @@ namespace std {
     basic_iostream(const basic_iostream&) = delete;
     basic_iostream(basic_iostream&& rhs);
 
-    // \ref{iostream.assign}, assign and swap
+    // \ref{iostream.assign}, assignment and swap
     basic_iostream& operator=(const basic_iostream&) = delete;
     basic_iostream& operator=(basic_iostream&& rhs);
     void swap(basic_iostream& rhs);
@@ -5874,7 +5874,7 @@ namespace std {
     basic_ostream(const basic_ostream&) = delete;
     basic_ostream(basic_ostream&& rhs);
 
-    // \ref{ostream.assign}, assign and swap
+    // \ref{ostream.assign}, assignment and swap
     basic_ostream& operator=(const basic_ostream&) = delete;
     basic_ostream& operator=(basic_ostream&& rhs);
     void swap(basic_ostream& rhs);
@@ -7587,7 +7587,7 @@ namespace std {
     basic_stringbuf(basic_stringbuf&& rhs);
     basic_stringbuf(basic_stringbuf&& rhs, const Allocator& a);
 
-    // \ref{stringbuf.assign}, assign and swap
+    // \ref{stringbuf.assign}, assignment and swap
     basic_stringbuf& operator=(const basic_stringbuf&) = delete;
     basic_stringbuf& operator=(basic_stringbuf&& rhs);
     void swap(basic_stringbuf& rhs) noexcept(@\seebelow@);
@@ -8383,9 +8383,10 @@ namespace std {
     basic_istringstream(const basic_istringstream&) = delete;
     basic_istringstream(basic_istringstream&& rhs);
 
-    // \ref{istringstream.assign}, assign and swap
     basic_istringstream& operator=(const basic_istringstream&) = delete;
     basic_istringstream& operator=(basic_istringstream&& rhs);
+
+    // \ref{istringstream.swap}, swap
     void swap(basic_istringstream& rhs);
 
     // \ref{istringstream.members}, members
@@ -8532,7 +8533,7 @@ Then calls \tcode{basic_istream<charT, traits>::set_rdbuf(addressof(sb))}
 to install the contained \tcode{basic_stringbuf}.
 \end{itemdescr}
 
-\rSec3[istringstream.assign]{Assignment and swap}
+\rSec3[istringstream.swap]{Swap}
 
 \indexlibrarymember{swap}{basic_istringstream}%
 \begin{itemdecl}
@@ -8697,9 +8698,10 @@ namespace std {
     basic_ostringstream(const basic_ostringstream&) = delete;
     basic_ostringstream(basic_ostringstream&& rhs);
 
-    // \ref{ostringstream.assign}, assign and swap
     basic_ostringstream& operator=(const basic_ostringstream&) = delete;
     basic_ostringstream& operator=(basic_ostringstream&& rhs);
+
+    // \ref{ostringstream.swap}, swap
     void swap(basic_ostringstream& rhs);
 
     // \ref{ostringstream.members}, members
@@ -8851,7 +8853,7 @@ Then calls \tcode{basic_ostream<charT, traits>::set_rdbuf(addressof(sb))}
 to install the contained \tcode{basic_stringbuf}.
 \end{itemdescr}
 
-\rSec3[ostringstream.assign]{Assignment and swap}
+\rSec3[ostringstream.swap]{Swap}
 
 \indexlibrarymember{swap}{basic_ostringstream}%
 \begin{itemdecl}
@@ -9016,9 +9018,10 @@ namespace std {
     basic_stringstream(const basic_stringstream&) = delete;
     basic_stringstream(basic_stringstream&& rhs);
 
-    // \ref{stringstream.assign}, assign and swap
     basic_stringstream& operator=(const basic_stringstream&) = delete;
     basic_stringstream& operator=(basic_stringstream&& rhs);
+
+    // \ref{stringstream.swap}, swap
     void swap(basic_stringstream& rhs);
 
     // \ref{stringstream.members}, members
@@ -9175,7 +9178,7 @@ Then calls \tcode{basic_istream<charT, traits>::set_rdbuf(addressof(sb))}
 to install the contained \tcode{basic_stringbuf}.
 \end{itemdescr}
 
-\rSec3[stringstream.assign]{Assignment and swap}
+\rSec3[stringstream.swap]{Swap}
 
 \indexlibrarymember{swap}{basic_stringstream}%
 \begin{itemdecl}
@@ -9707,9 +9710,10 @@ namespace std {
     basic_ispanstream(basic_ispanstream&& rhs);
     template<class ROS> explicit basic_ispanstream(ROS&& s);
 
-    // \ref{ispanstream.assign}, assignment and swap
     basic_ispanstream& operator=(const basic_ispanstream&) = delete;
     basic_ispanstream& operator=(basic_ispanstream&& rhs);
+
+    // \ref{ispanstream.swap}, swap
     void swap(basic_ispanstream& rhs);
 
     // \ref{ispanstream.members}, member functions
@@ -9786,7 +9790,7 @@ basic_ispanstream(std::span<charT>(const_cast<charT*>(sp.data()), sp.size()))
 \end{codeblock}
 \end{itemdescr}
 
-\rSec3[ispanstream.assign]{Assignment and swap}
+\rSec3[ispanstream.swap]{Swap}
 
 \indexlibrarymember{swap}{basic_ispanstream}%
 \begin{itemdecl}
@@ -9896,9 +9900,10 @@ namespace std {
     basic_ospanstream(const basic_ospanstream&) = delete;
     basic_ospanstream(basic_ospanstream&& rhs);
 
-    // \ref{ospanstream.assign}, assignment and swap
     basic_ospanstream& operator=(const basic_ospanstream&) = delete;
     basic_ospanstream& operator=(basic_ospanstream&& rhs);
+
+    // \ref{ospanstream.swap}, swap
     void swap(basic_ospanstream& rhs);
 
     // \ref{ospanstream.members}, member functions
@@ -9946,7 +9951,7 @@ Next, \tcode{basic_ostream<charT, traits>::set_rdbuf(addressof(sb))}
 is called to install the contained \tcode{basic_spanbuf}.
 \end{itemdescr}
 
-\rSec3[ospanstream.assign]{Assignment and swap}
+\rSec3[ospanstream.swap]{Swap}
 
 \indexlibrarymember{swap}{basic_ospanstream}%
 \begin{itemdecl}
@@ -10036,9 +10041,10 @@ namespace std {
     basic_spanstream(const basic_spanstream&) = delete;
     basic_spanstream(basic_spanstream&& rhs);
 
-    // \ref{spanstream.assign}, assignment and swap
     basic_spanstream& operator=(const basic_spanstream&) = delete;
     basic_spanstream& operator=(basic_spanstream&& rhs);
+
+    // \ref{spanstream.swap}, swap
     void swap(basic_spanstream& rhs);
 
     // \ref{spanstream.members}, members
@@ -10086,7 +10092,7 @@ Next, \tcode{basic_iostream<charT, traits>::set_rdbuf(addressof(sb))}
 is called to install the contained \tcode{basic_spanbuf}.
 \end{itemdescr}
 
-\rSec3[spanstream.assign]{Assignment and swap}
+\rSec3[spanstream.swap]{Swap}
 
 \indexlibrarymember{swap}{basic_spanstream}%
 \begin{itemdecl}
@@ -10257,7 +10263,7 @@ namespace std {
     basic_filebuf(basic_filebuf&& rhs);
     virtual ~basic_filebuf();
 
-    // \ref{filebuf.assign}, assign and swap
+    // \ref{filebuf.assign}, assignment and swap
     basic_filebuf& operator=(const basic_filebuf&) = delete;
     basic_filebuf& operator=(basic_filebuf&& rhs);
     void swap(basic_filebuf& rhs);
@@ -10447,8 +10453,7 @@ and \tcode{rhs}.
 \indexlibrarymember{swap}{basic_filebuf}%
 \begin{itemdecl}
 template<class charT, class traits>
-  void swap(basic_filebuf<charT, traits>& x,
-            basic_filebuf<charT, traits>& y);
+  void swap(basic_filebuf<charT, traits>& x, basic_filebuf<charT, traits>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11031,9 +11036,10 @@ namespace std {
     basic_ifstream(const basic_ifstream&) = delete;
     basic_ifstream(basic_ifstream&& rhs);
 
-    // \ref{ifstream.assign}, assign and swap
     basic_ifstream& operator=(const basic_ifstream&) = delete;
     basic_ifstream& operator=(basic_ifstream&& rhs);
+
+    // \ref{ifstream.swap}, swap
     void swap(basic_ifstream& rhs);
 
     // \ref{ifstream.members}, members
@@ -11144,7 +11150,7 @@ Then calls \tcode{basic_istream<charT, traits>::set_rdbuf(\brk{}addressof(sb))}
 to install the contained \tcode{basic_filebuf}.
 \end{itemdescr}
 
-\rSec3[ifstream.assign]{Assignment and swap}
+\rSec3[ifstream.swap]{Swap}
 
 \indexlibrarymember{swap}{basic_ifstream}%
 \begin{itemdecl}
@@ -11163,8 +11169,7 @@ and \tcode{rhs} by calling
 \indexlibrarymember{swap}{basic_ifstream}%
 \begin{itemdecl}
 template<class charT, class traits>
-  void swap(basic_ifstream<charT, traits>& x,
-            basic_ifstream<charT, traits>& y);
+  void swap(basic_ifstream<charT, traits>& x, basic_ifstream<charT, traits>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11276,9 +11281,10 @@ namespace std {
     basic_ofstream(const basic_ofstream&) = delete;
     basic_ofstream(basic_ofstream&& rhs);
 
-    // \ref{ofstream.assign}, assign and swap
     basic_ofstream& operator=(const basic_ofstream&) = delete;
     basic_ofstream& operator=(basic_ofstream&& rhs);
+
+    // \ref{ofstream.swap}, swap
     void swap(basic_ofstream& rhs);
 
     // \ref{ofstream.members}, members
@@ -11389,7 +11395,7 @@ Then calls \tcode{basic_ostream<charT, traits>::set_rdbuf(\brk{}addressof(sb))}
 to install the contained \tcode{basic_filebuf}.
 \end{itemdescr}
 
-\rSec3[ofstream.assign]{Assignment and swap}
+\rSec3[ofstream.swap]{Swap}
 
 \indexlibrarymember{swap}{basic_ofstream}%
 \begin{itemdecl}
@@ -11408,8 +11414,7 @@ and \tcode{rhs} by calling
 \indexlibrarymember{swap}{basic_ofstream}%
 \begin{itemdecl}
 template<class charT, class traits>
-  void swap(basic_ofstream<charT, traits>& x,
-            basic_ofstream<charT, traits>& y);
+  void swap(basic_ofstream<charT, traits>& x, basic_ofstream<charT, traits>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11522,9 +11527,10 @@ namespace std {
     basic_fstream(const basic_fstream&) = delete;
     basic_fstream(basic_fstream&& rhs);
 
-    // \ref{fstream.assign}, assign and swap
     basic_fstream& operator=(const basic_fstream&) = delete;
     basic_fstream& operator=(basic_fstream&& rhs);
+
+    // \ref{fstream.swap}, swap
     void swap(basic_fstream& rhs);
 
     // \ref{fstream.members}, members
@@ -11645,7 +11651,7 @@ Then calls \tcode{basic_istream<charT, traits>::set_rdbuf(\brk{}addressof(sb))}
 to install the contained \tcode{basic_filebuf}.
 \end{itemdescr}
 
-\rSec3[fstream.assign]{Assignment and swap}
+\rSec3[fstream.swap]{Swap}
 
 \indexlibrarymember{swap}{basic_fstream}%
 \begin{itemdecl}

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -82,5 +82,12 @@
 \movedxref{depr.stdbool.h.syn}{stdbool.h.syn}
 \movedxref{depr.tgmath.h.syn}{tgmath.h.syn}
 
+\movedxref{istringstream.assign}{istringstream.swap}
+\movedxref{ostringstream.assign}{ostringstream.swap}
+\movedxref{stringstream.assign}{stringstream.swap}
+\movedxref{ifstream.assign}{ifstream.swap}
+\movedxref{ofstream.assign}{ofstream.swap}
+\movedxref{fstream.assign}{fstream.swap}
+
 % Deprecated features.
 %\deprxref{old.label}  (if moved to depr.old.label, otherwise use \movedxref)


### PR DESCRIPTION
Fixes #4700 