### PR TITLE
Introduce term.* labels for [basic.types.general] terms

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -1918,7 +1918,7 @@ The result of the comparison.
 \begin{note}
 For example, the effect of
 \tcode{compare_exchange_strong}
-on objects without padding bits\iref{basic.types} is
+on objects without padding bits\iref{term.padding.bits} is
 \begin{codeblock}
 if (memcmp(this, &expected, sizeof(*this)) == 0)
   memcpy(this, &desired, sizeof(*this));

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4689,6 +4689,7 @@ a function type, not a reference type, and not \cv{}~\keyword{void}.
 \indextext{class!trivial}%
 \indextext{class!trivially copyable}%
 \indextext{class!standard-layout}%
+\label{term.scalar.type}%
 Arithmetic types\iref{basic.fundamental}, enumeration types,
 pointer types, pointer-to-member types\iref{basic.compound},
 \tcode{std::nullptr_t},

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4684,6 +4684,7 @@ contexts incomplete types are prohibited.
 \end{note}
 
 \pnum
+\label{term.object.type}%
 An \defn{object type} is a (possibly cv-qualified) type that is not
 a function type, not a reference type, and not \cv{}~\keyword{void}.
 

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4706,7 +4706,9 @@ types are collectively called \defnadjx{trivially copyable}{types}{type}.
 Scalar types, trivial class types\iref{class.prop},
 arrays of such types and cv-qualified versions of these
 types are collectively called
-\defnadjx{trivial}{types}{type}. Scalar types, standard-layout class
+\defnadjx{trivial}{types}{type}.
+\label{term.standard.layout.type}%
+Scalar types, standard-layout class
 types\iref{class.prop}, arrays of such types and
 cv-qualified versions of these types
 are collectively called \defnadjx{standard-layout}{types}{type}.

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4751,9 +4751,9 @@ will be usable in a constant expression.
 \end{note}
 
 \pnum
-\indextext{layout-compatible type}%
+\label{term.layout.compatible.type}%
 Two types \cvqual{cv1} \tcode{T1} and \cvqual{cv2} \tcode{T2} are
-\defn{layout-compatible} types
+\defnadjx{layout-compatible}{types}{type}
 if \tcode{T1} and \tcode{T2} are the same type,
 layout-compatible enumerations\iref{dcl.enum}, or
 layout-compatible standard-layout class types\iref{class.mem}.

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -318,7 +318,7 @@ A class name can also be implicitly declared by an
 \indextext{type!incomplete}%
 In the definition of an object,
 the type of that object shall not be
-an incomplete type\iref{basic.types.general},
+an incomplete type\iref{term.incomplete.type},
 an abstract class type\iref{class.abstract}, or
 a (possibly multi-dimensional) array thereof.
 
@@ -4625,8 +4625,9 @@ bound or of incomplete element type, is an
 The size and layout of an instance of an incompletely-defined
 object type is unknown.
 \end{footnote}
+\label{term.incomplete.type}%
 Incompletely-defined object types and \cv{}~\keyword{void} are
-\defnx{incomplete types}{type!incomplete}\iref{basic.fundamental}.
+\defnadjx{incomplete}{types}{type}\iref{basic.fundamental}.
 \begin{note}
 Objects cannot be defined to have an incomplete type\iref{basic.def}.
 \end{note}

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4603,6 +4603,7 @@ by the object of type \tcode{T}, where \placeholder{N} equals
 The \defnx{value representation}{representation!value}
 of an object of type \tcode{T} is the set of bits
 that participate in representing a value of type \tcode{T}.
+\label{term.padding.bits}%
 Bits in the object representation that are not part of the value representation
 are \defn{padding bits}.
 For trivially copyable types, the value representation is

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4703,6 +4703,7 @@ types are collectively called
 Scalar types, trivially copyable class types\iref{class.prop},
 arrays of such types, and cv-qualified versions of these
 types are collectively called \defnadjx{trivially copyable}{types}{type}.
+\label{term.trivial.type}%
 Scalar types, trivial class types\iref{class.prop},
 arrays of such types and cv-qualified versions of these
 types are collectively called

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4595,6 +4595,7 @@ std::memcpy(t1p, t2p, sizeof(T));
 \indextext{object!byte copying and|)}
 
 \pnum
+\label{term.object.representation}%
 The \defnx{object representation}{representation!object}
 of an object of type \tcode{T} is the
 sequence of \placeholder{N} \tcode{\keyword{unsigned} \keyword{char}} objects taken up

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4695,6 +4695,7 @@ and
 cv-qualified\iref{basic.type.qualifier} versions of these
 types are collectively called
 \defnadjx{scalar}{types}{type}.
+\label{term.trivially.copyable.type}%
 Scalar types, trivially copyable class types\iref{class.prop},
 arrays of such types, and cv-qualified versions of these
 types are collectively called \defnadjx{trivially copyable}{types}{type}.

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4717,6 +4717,7 @@ array types, and cv-qualified versions of these types
 are collectively called \defnadjx{implicit-lifetime}{types}{type}.
 
 \pnum
+\label{term.literal.type}%
 A type is a \defnadj{literal}{type} if it is:
 \begin{itemize}
 \item \cv{}~\keyword{void}; or

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -602,7 +602,7 @@ the \grammarterm{member-specification} of the enclosing class.
 
 \pnum
 A class is considered a completely-defined object
-type\iref{basic.types} (or complete type) at the closing \tcode{\}} of
+type\iref{term.incomplete.type} (or complete type) at the closing \tcode{\}} of
 the \grammarterm{class-specifier}.
 The class is regarded as complete within its complete-class contexts;
 otherwise it is regarded as incomplete within its own class
@@ -689,7 +689,7 @@ function\iref{class.virtual}.
 \pnum
 \indextext{class object!member}%
 The type of a non-static data member shall not be an
-incomplete type\iref{basic.types},
+incomplete type\iref{term.incomplete.type},
 an abstract class type\iref{class.abstract},
 or a (possibly multi-dimensional) array thereof.
 \begin{note}

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -812,7 +812,7 @@ both classes\iref{basic.types}.
 Two standard-layout unions are layout-compatible if they
 have the same number of non-static data members and corresponding
 non-static data members (in any order) have layout-compatible
-types\iref{basic.types}.
+types\iref{term.layout.compatible.type}.
 
 \pnum
 In a standard-layout union with an active member\iref{class.union}

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -2823,7 +2823,7 @@ is called the \defn{width} of the bit-field.
 If the width of a bit-field is larger than
 the width of the bit-field's type
 (or, in case of an enumeration type, of its underlying type),
-the extra bits are padding bits\iref{basic.types}.
+the extra bits are padding bits\iref{term.padding.bits}.
 \indextext{allocation!implementation-defined bit-field}%
 Allocation of bit-fields within a class object is
 \impldef{allocation of bit-fields within a class object}.

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1659,7 +1659,7 @@ the implicitly-defined copy/move constructor (see~\ref{class.base.init}).
 
 \pnum
 The implicitly-defined copy/move constructor for a union
-\tcode{X} copies the object representation\iref{basic.types} of \tcode{X}.
+\tcode{X} copies the object representation\iref{term.object.representation} of \tcode{X}.
 For each object nested within\iref{intro.object}
 the object that is the source of the copy,
 a corresponding object $o$ nested within the destination
@@ -1984,7 +1984,7 @@ is assigned twice by the implicitly-defined copy/move assignment operator for
 
 \pnum
 The implicitly-defined copy assignment operator for a
-union \tcode{X} copies the object representation\iref{basic.types} of \tcode{X}.
+union \tcode{X} copies the object representation\iref{term.object.representation} of \tcode{X}.
 If the source and destination of the assignment are not the same object, then
 for each object nested within\iref{intro.object}
 the object that is the source of the copy,

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -637,7 +637,7 @@ template<class T>
   \tcode{S} is an expression that exchanges the denoted values.
   \tcode{S} is a constant expression if
   \begin{itemize}
-  \item \tcode{T} is a literal type\iref{basic.types},
+  \item \tcode{T} is a literal type\iref{term.literal.type},
   \item both \tcode{E1 = std::move(E2)} and \tcode{E2 = std::move(E1)} are
     constant subexpressions\iref{defns.const.subexpr}, and
   \item the full-expressions of the initializers in the declarations

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -14429,7 +14429,8 @@ namespace std {
 \end{codeblock}
 
 \pnum
-\tcode{span<ElementType, Extent>} is a trivially copyable type\iref{basic.types.general}.
+\tcode{span<ElementType, Extent>} is
+a trivially copyable type\iref{term.trivially.copyable.type}.
 
 \pnum
 \tcode{ElementType} is required to be

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4383,7 +4383,7 @@ to a pointer type results in a null pointer value.
 if
 \tcode{T}
 is a (possibly cv-qualified) non-union class type,
-its padding bits\iref{basic.types} are initialized to zero bits and
+its padding bits\iref{term.padding.bits} are initialized to zero bits and
 each non-static data member,
 each non-virtual base class subobject, and,
 if the object is not a base class subobject,
@@ -4394,7 +4394,7 @@ is zero-initialized;
 if
 \tcode{T}
 is a (possibly cv-qualified) union type,
-its padding bits\iref{basic.types} are initialized to zero bits and
+its padding bits\iref{term.padding.bits} are initialized to zero bits and
 the
 object's first non-static named
 data member

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4367,7 +4367,7 @@ means:
 \item
 if
 \tcode{T}
-is a scalar type\iref{basic.types}, the
+is a scalar type\iref{term.scalar.type}, the
 object
 is initialized to the value obtained by converting the integer literal \tcode{0}
 (zero) to

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2863,7 +2863,7 @@ template<typename T> concept C = requires {
 
 \pnum
 A \grammarterm{type-requirement} that names a class template specialization
-does not require that type to be complete\iref{basic.types}.
+does not require that type to be complete\iref{term.incomplete.type}.
 
 \rSec3[expr.prim.req.compound]{Compound requirements}
 \indextext{requirement!compound}%
@@ -4952,9 +4952,9 @@ The \grammarterm{new-expression} attempts to create an object of the
 \grammarterm{type-id}\iref{dcl.name} or \grammarterm{new-type-id} to which
 it is applied. The type of that object is the \defnadj{allocated}{type}.
 \indextext{type!incomplete}%
-This type shall be a complete object type, but not an abstract class
-type or array
-thereof~(\ref{intro.object}, \ref{basic.types}, \ref{class.abstract}).
+This type shall be a complete object type\iref{term.incomplete.type},
+but not an abstract class type\iref{class.abstract} or array
+thereof\iref{intro.object}.
 \begin{note}
 Because references are not objects, references cannot be created by
 \grammarterm{new-expression}{s}.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4826,7 +4826,7 @@ implementation-defined.
 \end{note}
 \begin{note}
 See~\ref{intro.memory} for the definition of byte
-and~\ref{basic.types} for the definition of object representation.
+and~\ref{term.object.representation} for the definition of object representation.
 \end{note}
 
 \pnum

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1836,7 +1836,7 @@ allocators.
 {allocator.req.var}
 \topline
 \lhdr{Variable} &   \rhdr{Definition}   \\  \capsep
-\tcode{T, U, C}    &   any \cv-unqualified object type\iref{basic.types}       \\ \rowsep
+\tcode{T, U, C}    &   any \cv-unqualified object type\iref{term.object.type}       \\ \rowsep
 \tcode{X}       &   an allocator class for type \tcode{T}   \\ \rowsep
 \tcode{Y}       &   the corresponding allocator class for type \tcode{U}    \\ \rowsep
 \tcode{XX}      &   the type \tcode{allocator_traits<X>}    \\ \rowsep

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2807,7 +2807,7 @@ in the applicable
 \required
 paragraph.
 \item
-If an incomplete type\iref{basic.types} is used as a template
+If an incomplete type\iref{term.incomplete.type} is used as a template
 argument when instantiating a template component or evaluating a concept, unless specifically
 allowed for that component.
 \end{itemize}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -197,7 +197,7 @@ for any type other than \tcode{float}, \tcode{double}, or \tcode{long double} is
 The specializations
 \tcode{complex<float>},
 \tcode{complex<double>}, and
-\tcode{complex<long double>} are literal types\iref{basic.types}.
+\tcode{complex<long double>} are literal types\iref{term.literal.type}.
 
 \pnum
 If the result of a function is not mathematically defined or not in

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -5,7 +5,7 @@
 
 \pnum
 This Clause describes components for manipulating sequences of
-any non-array trivial standard-layout\iref{basic.types} type.
+any non-array trivial standard-layout\iref{term.standard.layout.type} type.
 Such types are called \defnx{char-like types}{char-like type},
 and objects of
 char-like types are called \defnx{char-like objects}{char-like object} or

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -4368,7 +4368,8 @@ The complexity of \tcode{basic_string_view} member functions is \bigoh{1}
 unless otherwise specified.
 
 \pnum
-\tcode{basic_string_view<charT, traits>} is a trivially copyable type\iref{basic.types.general}.
+\tcode{basic_string_view<charT, traits>} is
+a trivially copyable type\iref{term.trivially.copyable.type}.
 
 \rSec3[string.view.cons]{Construction and assignment}
 

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1157,7 +1157,7 @@ void f() {
 \end{codeblock}
 \end{example}
 \begin{note}
-A template type argument can be an incomplete type\iref{basic.types}.
+A template type argument can be an incomplete type\iref{term.incomplete.type}.
 \end{note}
 
 \rSec2[temp.arg.nontype]{Template non-type arguments}
@@ -5724,7 +5724,7 @@ void g(D<int>* p, D<char>* pp, D<double>* ppp) {
 If the template selected for the specialization\iref{temp.spec.partial.match}
 has been declared, but not defined,
 at the point of instantiation\iref{temp.point},
-the instantiation yields an incomplete class type\iref{basic.types}.
+the instantiation yields an incomplete class type\iref{term.incomplete.type}.
 \begin{example}
 \begin{codeblock}
 template<class T> class X;

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -20205,7 +20205,7 @@ the cv-qualification is subject to adjustment\iref{expr.type}.
 \indexlibraryglobal{is_standard_layout}%
 \tcode{template<class T>}\br
  \tcode{struct is_standard_layout;}                 &
- \tcode{T} is a standard-layout type\iref{basic.types}   &
+ \tcode{T} is a standard-layout type\iref{term.standard.layout.type}   &
  \tcode{remove_all_extents_t<T>} shall be a complete
  type or \cv{}~\keyword{void}.                \\ \rowsep
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -20114,7 +20114,7 @@ For any given type \tcode{T}, the result of applying one of these templates to
 \indexlibraryglobal{is_scalar}%
 \tcode{template<class T>}\br
  \tcode{struct is_scalar;}              &
- \tcode{T} is a scalar type\iref{basic.types}                         &   \\ \rowsep
+ \tcode{T} is a scalar type\iref{term.scalar.type}                       &   \\ \rowsep
 \indexlibraryglobal{is_compound}%
 \tcode{template<class T>}\br
  \tcode{struct is_compound;}            &

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16160,7 +16160,7 @@ a.outer_allocator() == b.outer_allocator() && a.inner_allocator() == b.inner_all
 
 \pnum
 A \defnx{function object type}{function object!type} is an object
-type\iref{basic.types} that can be the type of the
+type\iref{term.object.type} that can be the type of the
 \grammarterm{postfix-expression} in a function call
 (\ref{expr.call}, \ref{over.match.call}).
 \begin{footnote}
@@ -20110,7 +20110,7 @@ For any given type \tcode{T}, the result of applying one of these templates to
 \indexlibraryglobal{is_object}%
 \tcode{template<class T>}\br
  \tcode{struct is_object;}              &
- \tcode{T} is an object type\iref{basic.types}                            &   \\ \rowsep
+ \tcode{T} is an object type\iref{term.object.type}                    &   \\ \rowsep
 \indexlibraryglobal{is_scalar}%
 \tcode{template<class T>}\br
  \tcode{struct is_scalar;}              &

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -10917,7 +10917,7 @@ deallocation call shall happen before the next allocation (if any) in this order
 \begin{itemdescr}
 \pnum
 \mandates
-\tcode{T} is not an incomplete type\iref{basic.types}.
+\tcode{T} is not an incomplete type\iref{term.incomplete.type}.
 
 \pnum
 \returns
@@ -10947,7 +10947,7 @@ but not that of any of the array elements.
 \begin{itemdescr}
 \pnum
 \mandates
-\tcode{T} is not an incomplete type\iref{basic.types}.
+\tcode{T} is not an incomplete type\iref{term.incomplete.type}.
 
 \pnum
 \returns

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -20145,7 +20145,7 @@ the argument is a complete type.
 \pnum
 For the purpose of defining the templates in this subclause,
 a function call expression \tcode{declval<T>()} for any type \tcode{T}
-is considered to be a trivial~(\ref{basic.types}, \ref{special}) function call
+is considered to be a trivial~(\ref{term.trivial.type}, \ref{special}) function call
 that is not an odr-use\iref{term.odr.use} of \tcode{declval}
 in the context of the corresponding definition
 notwithstanding the restrictions of~\ref{declval}.
@@ -20191,7 +20191,7 @@ the cv-qualification is subject to adjustment\iref{expr.type}.
 \indexlibraryglobal{is_trivial}%
 \tcode{template<class T>}\br
  \tcode{struct is_trivial;}                 &
- \tcode{T} is a trivial type\iref{basic.types}     &
+ \tcode{T} is a trivial type\iref{term.trivial.type}     &
  \tcode{remove_all_extents_t<T>} shall be a complete
  type or \cv{}~\keyword{void}.                \\ \rowsep
 
@@ -20405,7 +20405,7 @@ The compilation of the
   \tcode{is_constructible_v<T,}\br
   \tcode{Args...>} is \tcode{true} and the variable
   definition for \tcode{is_constructible}, as defined below, is known to call
-  no operation that is not trivial~(\ref{basic.types}, \ref{special}). &
+  no operation that is not trivial~(\ref{term.trivial.type}, \ref{special}). &
   \tcode{T} and all types in the template parameter pack \tcode{Args} shall be complete types,
   \cv{}~\keyword{void}, or arrays of unknown bound. \\ \rowsep
 
@@ -20440,7 +20440,7 @@ The compilation of the
   \tcode{struct is_trivially_assignable;} &
   \tcode{is_assignable_v<T, U>} is \tcode{true} and the assignment, as defined by
   \tcode{is_assignable}, is known to call no operation that is not trivial
- ~(\ref{basic.types}, \ref{special}). &
+ ~(\ref{term.trivial.type}, \ref{special}). &
   \tcode{T} and \tcode{U} shall be complete types, \cv{}~\keyword{void},
   or arrays of unknown bound. \\ \rowsep
 
@@ -20875,7 +20875,7 @@ Base classes that are private, protected, or ambiguous
 \pnum
 For the purpose of defining the templates in this subclause,
 a function call expression \tcode{declval<T>()} for any type \tcode{T}
-is considered to be a trivial~(\ref{basic.types}, \ref{special}) function call
+is considered to be a trivial~(\ref{term.trivial.type}, \ref{special}) function call
 that is not an odr-use\iref{term.odr.use} of \tcode{declval}
 in the context of the corresponding definition
 notwithstanding the restrictions of~\ref{declval}.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -8764,7 +8764,7 @@ constexpr bitset(unsigned long long val) noexcept;
 Initializes the first \tcode{M} bit positions to the corresponding bit
 values in \tcode{val}.
 \tcode{M} is the smaller of \tcode{N} and the number of bits in the value
-representation\iref{basic.types} of \tcode{unsigned long long}.
+representation\iref{term.object.representation} of \tcode{unsigned long long}.
 If \tcode{M < N}, the remaining bit positions are initialized to zero.
 \end{itemdescr}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16581,7 +16581,8 @@ namespace std {
 around a reference to an object or function of type \tcode{T}.
 
 \pnum
-\tcode{reference_wrapper<T>} is a trivially copyable type\iref{basic.types}.
+\tcode{reference_wrapper<T>} is
+a trivially copyable type\iref{term.trivially.copyable.type}.
 
 \pnum
 The template parameter \tcode{T} of \tcode{reference_wrapper}
@@ -20197,7 +20198,7 @@ the cv-qualification is subject to adjustment\iref{expr.type}.
 \indexlibraryglobal{is_trivially_copyable}%
 \tcode{template<class T>}\br
  \tcode{struct is_trivially_copyable;}      &
- \tcode{T} is a trivially copyable type\iref{basic.types} &
+ \tcode{T} is a trivially copyable type\iref{term.trivially.copyable.type} &
  \tcode{remove_all_extents_t<T>} shall be a complete type or
  \cv{}~\keyword{void}.                               \\ \rowsep
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -20813,7 +20813,7 @@ Base classes that are private, protected, or ambiguous
 \indexlibraryglobal{is_layout_compatible}%
 \tcode{template<class T, class U>}\br
  \tcode{struct is_layout_compatible;}                 &
- \tcode{T} and \tcode{U} are layout-compatible\iref{basic.types}    &
+ \tcode{T} and \tcode{U} are layout-compatible\iref{term.layout.compatible.type}    &
  \tcode{T} and \tcode{U} shall be complete types,
  \cv{}~\keyword{void},
  or arrays of unknown bound.                \\ \rowsep


### PR DESCRIPTION
For ease of review, these are all separate commits.
Feel free to squash on merge.

Fixes #4630 