### PR TITLE
[dcl.typedef] Add explanation for lookup failure in example

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -621,7 +621,8 @@ particular, it does not define a new type.
 using handler_t = void (*)(int);
 extern handler_t ignore;
 extern void (*ignore)(int);         // redeclare \tcode{ignore}
-using cell = pair<void*, cell*>;    // error
+template<class T> struct P { };
+using cell = P<cell*>;              // error: \tcode{cell} not found\iref{basic.scope.pdecl}
 \end{codeblock}
 \end{example}
 The \grammarterm{defining-type-specifier-seq}


### PR DESCRIPTION
Fixes #5107