### PR TITLE
[lex.string,dcl.init.string] Use 'code unit' for initialization from a string-literal

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5367,12 +5367,11 @@ UTF-16 string literal,
 UTF-32 string literal, or
 wide string literal,
 respectively, or by an appropriately-typed \grammarterm{string-literal} enclosed in
-braces\iref{lex.string}.
+braces.
 \indextext{initialization!character array}%
-Successive
-characters of the
-value of the \grammarterm{string-literal}
-initialize the elements of the array.
+The elements of the array are initialized
+with successive values of the sequence of code unit values
+represented by the \grammarterm{string-literal}\iref{lex.string}.
 \begin{example}
 \begin{codeblock}
 char msg[] = "Syntax error on line %s\n";

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1881,9 +1881,11 @@ The effect of attempting to modify a string literal object is undefined.
 \indextext{\idxcode{0}|seealso{zero, null}}%
 \indextext{\idxcode{0}!string terminator}%
 \indextext{\idxcode{0}!null character|see {character, null}}%
-String literal objects are initialized with
+A string literal object is initialized with
 the sequence of code unit values
-corresponding to the \grammarterm{string-literal}'s sequence of
+represented by the \grammarterm{string-literal}.
+A \grammarterm{string-literal} represents
+a sequence of code unit values corresponding to the sequence of
 \grammarterm{s-char}s (originally from non-raw string literals) and
 \grammarterm{r-char}s (originally from raw string literals),
 plus a terminating \unicode{0000}{null} character,


### PR DESCRIPTION
[lex.string] defines a sequence of code unit values
for a string-literal.  Use that sequence for the
initialization of an array by a string-literal.

Fixes #5103