### PR TITLE
[allocator.adaptor.members] Fix select_on_container_copy_construction

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16126,10 +16126,12 @@ scoped_allocator_adaptor select_on_container_copy_construction() const;
 \begin{itemdescr}
 \pnum
 \returns
-A new \tcode{scoped_allocator_adaptor} object where each allocator \tcode{A} in the
-adaptor is initialized from the result of calling
-\tcode{allocator_traits<A>::select_on_container_copy_construction()} on the
-corresponding allocator in \tcode{*this}.
+A new \tcode{scoped_allocator_adaptor} object
+where each allocator \tcode{a1} within the adaptor
+is initialized with
+\tcode{allocator_traits<A1>::select_on_container_copy_construction(a2)},
+where \tcode{A1} is the type of \tcode{a1} and
+\tcode{a2} is the corresponding allocator in \tcode{*this}.
 \end{itemdescr}
 
 \rSec2[scoped.adaptor.operators]{Operators}


### PR DESCRIPTION
The description was confusing objects and types.

Fixes #518