### PR TITLE
[lib] Add 'namespace std' wrappings around class definitions

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -3010,7 +3010,8 @@ is $\mathsf{GA}(\state{x}{i}) = \state{x}{i+1}$.
 \indexlibraryglobal{linear_congruential_engine}%
 \indexlibrarymember{result_type}{linear_congruential_engine}%
 \begin{codeblock}
-template<class UIntType, UIntType a, UIntType c, UIntType m>
+namespace std {
+  template<class UIntType, UIntType a, UIntType c, UIntType m>
   class linear_congruential_engine {
   public:
     // types
@@ -3047,6 +3048,7 @@ template<class UIntType, UIntType a, UIntType c, UIntType m>
       friend basic_istream<charT, traits>&
         operator>>(basic_istream<charT, traits>& is, linear_congruential_engine& x);
   };
+}
 \end{codeblock}
 
 \pnum
@@ -3176,10 +3178,11 @@ The generation algorithm
 \indexlibraryglobal{mersenne_twister_engine}%
 \indexlibrarymember{result_type}{mersenne_twister_engine}%
 \begin{codeblock}
-template<class UIntType, size_t w, size_t n, size_t m, size_t r,
-         UIntType a, size_t u, UIntType d, size_t s,
-         UIntType b, size_t t,
-         UIntType c, size_t l, UIntType f>
+namespace std {
+  template<class UIntType, size_t w, size_t n, size_t m, size_t r,
+           UIntType a, size_t u, UIntType d, size_t s,
+           UIntType b, size_t t,
+           UIntType c, size_t l, UIntType f>
   class mersenne_twister_engine {
   public:
     // types
@@ -3225,6 +3228,7 @@ template<class UIntType, size_t w, size_t n, size_t m, size_t r,
       friend basic_istream<charT, traits>&
         operator>>(basic_istream<charT, traits>& is, mersenne_twister_engine& x);
   };
+}
 \end{codeblock}
 
 \pnum
@@ -3352,7 +3356,8 @@ of advancing the engine's state as described above.
 \indexlibraryglobal{subtract_with_carry_engine}%
 \indexlibrarymember{result_type}{subtract_with_carry_engine}%
 \begin{codeblock}
-template<class UIntType, size_t w, size_t s, size_t r>
+namespace std {
+  template<class UIntType, size_t w, size_t s, size_t r>
   class subtract_with_carry_engine {
   public:
     // types
@@ -3389,6 +3394,7 @@ template<class UIntType, size_t w, size_t s, size_t r>
       friend basic_istream<charT, traits>&
         operator>>(basic_istream<charT, traits>& is, subtract_with_carry_engine& x);
   };
+}
 \end{codeblock}
 
 \pnum
@@ -3556,7 +3562,8 @@ yields the value returned by the last invocation of \tcode{e()}
 \indexlibraryglobal{discard_block_engine}%
 \indexlibrarymember{result_type}{discard_block_engine}%
 \begin{codeblock}
-template<class Engine, size_t p, size_t r>
+namespace std {
+  template<class Engine, size_t p, size_t r>
   class discard_block_engine {
   public:
     // types
@@ -3600,6 +3607,7 @@ template<class Engine, size_t p, size_t r>
     Engine e;   // \expos
     size_t n;   // \expos
   };
+}
 \end{codeblock}
 
 \pnum
@@ -3805,7 +3813,8 @@ yields the last value of \tcode{Y}
 \indexlibraryglobal{shuffle_order_engine}%
 \indexlibrarymember{result_type}{shuffle_order_engine}%
 \begin{codeblock}
-template<class Engine, size_t k>
+namespace std {
+  template<class Engine, size_t k>
   class shuffle_order_engine {
   public:
     // types
@@ -3849,6 +3858,7 @@ template<class Engine, size_t k>
     result_type V[k];   // \expos
     result_type Y;      // \expos
   };
+}
 \end{codeblock}
 
 \pnum
@@ -4085,29 +4095,31 @@ the implementation may employ a random number engine.
 \indexlibraryglobal{random_device}%
 \indexlibrarymember{result_type}{random_device}%
 \begin{codeblock}
-class random_device {
-public:
-  // types
-  using result_type = unsigned int;
+namespace std {
+  class random_device {
+  public:
+    // types
+    using result_type = unsigned int;
 
-  // generator characteristics
-  static constexpr result_type min() { return numeric_limits<result_type>::min(); }
-  static constexpr result_type max() { return numeric_limits<result_type>::max(); }
+    // generator characteristics
+    static constexpr result_type min() { return numeric_limits<result_type>::min(); }
+    static constexpr result_type max() { return numeric_limits<result_type>::max(); }
 
-  // constructors
-  random_device() : random_device(@\textit{implementation-defined}@) {}
-  explicit random_device(const string& token);
+    // constructors
+    random_device() : random_device(@\textit{implementation-defined}@) {}
+    explicit random_device(const string& token);
 
-  // generating functions
-  result_type operator()();
+    // generating functions
+    result_type operator()();
 
-  // property functions
-  double entropy() const noexcept;
+    // property functions
+    double entropy() const noexcept;
 
-  @\textit{// no copy functions}@
-  random_device(const random_device&) = delete;
-  void operator=(const random_device&) = delete;
-};
+    @\textit{// no copy functions}@
+    random_device(const random_device&) = delete;
+    void operator=(const random_device&) = delete;
+  };
+}
 \end{codeblock}
 
 
@@ -4202,34 +4214,36 @@ A value of an \impldef{exception type when \tcode{random_device::operator()} fai
 \indexlibraryglobal{seed_seq}%
 \indexlibrarymember{result_type}{seed_seq}%
 \begin{codeblock}
-class seed_seq {
-public:
-  // types
-  using result_type = uint_least32_t;
+namespace std {
+  class seed_seq {
+  public:
+    // types
+    using result_type = uint_least32_t;
 
-  // constructors
-  seed_seq() noexcept;
-  template<class T>
-    seed_seq(initializer_list<T> il);
-  template<class InputIterator>
-    seed_seq(InputIterator begin, InputIterator end);
+    // constructors
+    seed_seq() noexcept;
+    template<class T>
+      seed_seq(initializer_list<T> il);
+    template<class InputIterator>
+      seed_seq(InputIterator begin, InputIterator end);
 
-  // generating functions
-  template<class RandomAccessIterator>
-    void generate(RandomAccessIterator begin, RandomAccessIterator end);
+    // generating functions
+    template<class RandomAccessIterator>
+      void generate(RandomAccessIterator begin, RandomAccessIterator end);
 
-  // property functions
-  size_t size() const noexcept;
-  template<class OutputIterator>
-    void param(OutputIterator dest) const;
+    // property functions
+    size_t size() const noexcept;
+    template<class OutputIterator>
+      void param(OutputIterator dest) const;
 
-  // no copy functions
-  seed_seq(const seed_seq&) = delete;
-  void operator=(const seed_seq&) = delete;
+    // no copy functions
+    seed_seq(const seed_seq&) = delete;
+    void operator=(const seed_seq&) = delete;
 
-private:
-  vector<result_type> v;        // \expos
-};
+  private:
+    vector<result_type> v;      // \expos
+  };
+}
 \end{codeblock}
 
 
@@ -4574,7 +4588,8 @@ the constant discrete probability function%
 \indexlibraryglobal{uniform_int_distribution}%
 \indexlibrarymember{result_type}{uniform_int_distribution}%
 \begin{codeblock}
-template<class IntType = int>
+namespace std {
+  template<class IntType = int>
   class uniform_int_distribution {
   public:
     // types
@@ -4612,6 +4627,7 @@ template<class IntType = int>
       friend basic_istream<charT, traits>&
         operator>>(basic_istream<charT, traits>& is, uniform_int_distribution& x);
   };
+}
 \end{codeblock}
 
 
@@ -4675,7 +4691,8 @@ This implies that $p(x\,|\,a,b)$ is undefined when \tcode{a == b}.
 \indexlibraryglobal{uniform_real_distribution}%
 \indexlibrarymember{result_type}{uniform_real_distribution}%
 \begin{codeblock}
-template<class RealType = double>
+namespace std {
+  template<class RealType = double>
   class uniform_real_distribution {
   public:
     // types
@@ -4714,6 +4731,7 @@ template<class RealType = double>
       friend basic_istream<charT, traits>&
         operator>>(basic_istream<charT, traits>& is, uniform_real_distribution& x);
   };
+}
 \end{codeblock}
 
 
@@ -4792,42 +4810,44 @@ the discrete probability function
 \indexlibraryglobal{bernoulli_distribution}%
 \indexlibrarymember{result_type}{bernoulli_distribution}%
 \begin{codeblock}
-class bernoulli_distribution {
-public:
-  // types
-  using result_type = bool;
-  using param_type  = @\unspec@;
+namespace std {
+  class bernoulli_distribution {
+  public:
+    // types
+    using result_type = bool;
+    using param_type  = @\unspec@;
 
-  // constructors and reset functions
-  bernoulli_distribution() : bernoulli_distribution(0.5) {}
-  explicit bernoulli_distribution(double p);
-  explicit bernoulli_distribution(const param_type& parm);
-  void reset();
+    // constructors and reset functions
+    bernoulli_distribution() : bernoulli_distribution(0.5) {}
+    explicit bernoulli_distribution(double p);
+    explicit bernoulli_distribution(const param_type& parm);
+    void reset();
 
-  // equality operators
-  friend bool operator==(const bernoulli_distribution& x, const bernoulli_distribution& y);
+    // equality operators
+    friend bool operator==(const bernoulli_distribution& x, const bernoulli_distribution& y);
 
-  // generating functions
-  template<class URBG>
-    result_type operator()(URBG& g);
-  template<class URBG>
-    result_type operator()(URBG& g, const param_type& parm);
+    // generating functions
+    template<class URBG>
+      result_type operator()(URBG& g);
+    template<class URBG>
+      result_type operator()(URBG& g, const param_type& parm);
 
-  // property functions
-  double p() const;
-  param_type param() const;
-  void param(const param_type& parm);
-  result_type min() const;
-  result_type max() const;
+    // property functions
+    double p() const;
+    param_type param() const;
+    void param(const param_type& parm);
+    result_type min() const;
+    result_type max() const;
 
-  // inserters and extractors
-  template<class charT, class traits>
-    friend basic_ostream<charT, traits>&
-      operator<<(basic_ostream<charT, traits>& os, const bernoulli_distribution& x);
-  template<class charT, class traits>
-    friend basic_istream<charT, traits>&
-      operator>>(basic_istream<charT, traits>& is, bernoulli_distribution& x);
-};
+    // inserters and extractors
+    template<class charT, class traits>
+      friend basic_ostream<charT, traits>&
+        operator<<(basic_ostream<charT, traits>& os, const bernoulli_distribution& x);
+    template<class charT, class traits>
+      friend basic_istream<charT, traits>&
+        operator>>(basic_istream<charT, traits>& is, bernoulli_distribution& x);
+  };
+}
 \end{codeblock}
 
 
@@ -4875,7 +4895,8 @@ the discrete probability function%
 \indexlibraryglobal{binomial_distribution}%
 \indexlibrarymember{result_type}{binomial_distribution}%
 \begin{codeblock}
-template<class IntType = int>
+namespace std {
+  template<class IntType = int>
   class binomial_distribution {
   public:
     // types
@@ -4913,6 +4934,7 @@ template<class IntType = int>
       friend basic_istream<charT, traits>&
         operator>>(basic_istream<charT, traits>& is, binomial_distribution& x);
   };
+}
 \end{codeblock}
 
 
@@ -4971,7 +4993,8 @@ the discrete probability function
 \indexlibraryglobal{geometric_distribution}%
 \indexlibrarymember{result_type}{geometric_distribution}%
 \begin{codeblock}
-template<class IntType = int>
+namespace std {
+  template<class IntType = int>
   class geometric_distribution {
   public:
     // types
@@ -5008,6 +5031,7 @@ template<class IntType = int>
       friend basic_istream<charT, traits>&
         operator>>(basic_istream<charT, traits>& is, geometric_distribution& x);
   };
+}
 \end{codeblock}
 
 
@@ -5059,7 +5083,8 @@ This implies that $P(i\,|\,k,p)$ is undefined when \tcode{p == 1}.
 \indexlibraryglobal{negative_binomial_distribution}%
 \indexlibrarymember{result_type}{negative_binomial_distribution}%
 \begin{codeblock}
-template<class IntType = int>
+namespace std {
+  template<class IntType = int>
   class negative_binomial_distribution {
   public:
     // types
@@ -5098,6 +5123,7 @@ template<class IntType = int>
       friend basic_istream<charT, traits>&
         operator>>(basic_istream<charT, traits>& is, negative_binomial_distribution& x);
   };
+}
 \end{codeblock}
 
 
@@ -5257,7 +5283,8 @@ the probability density function%
 \indexlibraryglobal{exponential_distribution}%
 \indexlibrarymember{result_type}{exponential_distribution}%
 \begin{codeblock}
-template<class RealType = double>
+namespace std {
+  template<class RealType = double>
   class exponential_distribution {
   public:
     // types
@@ -5294,6 +5321,7 @@ template<class RealType = double>
       friend basic_istream<charT, traits>&
         operator>>(basic_istream<charT, traits>& is, exponential_distribution& x);
   };
+}
 \end{codeblock}
 
 
@@ -5342,7 +5370,8 @@ the probability density function%
 \indexlibraryglobal{gamma_distribution}%
 \indexlibrarymember{result_type}{gamma_distribution}%
 \begin{codeblock}
-template<class RealType = double>
+namespace std {
+  template<class RealType = double>
   class gamma_distribution {
   public:
     // types
@@ -5380,6 +5409,7 @@ template<class RealType = double>
       friend basic_istream<charT, traits>&
         operator>>(basic_istream<charT, traits>& is, gamma_distribution& x);
   };
+}
 \end{codeblock}
 
 
@@ -5443,7 +5473,8 @@ the probability density function%
 \indexlibraryglobal{weibull_distribution}%
 \indexlibrarymember{result_type}{weibull_distribution}%
 \begin{codeblock}
-template<class RealType = double>
+namespace std {
+  template<class RealType = double>
   class weibull_distribution {
   public:
     // types
@@ -5481,6 +5512,7 @@ template<class RealType = double>
       friend basic_istream<charT, traits>&
         operator>>(basic_istream<charT, traits>& is, weibull_distribution& x);
   };
+}
 \end{codeblock}
 
 \indexlibraryctor{weibull_distribution}%
@@ -5552,7 +5584,8 @@ The distribution corresponding to
 \indexlibraryglobal{extreme_value_distribution}%
 \indexlibrarymember{result_type}{extreme_value_distribution}%
 \begin{codeblock}
-template<class RealType = double>
+namespace std {
+  template<class RealType = double>
   class extreme_value_distribution {
   public:
     // types
@@ -5591,6 +5624,7 @@ template<class RealType = double>
       friend basic_istream<charT, traits>&
         operator>>(basic_istream<charT, traits>& is, extreme_value_distribution& x);
   };
+}
 \end{codeblock}
 
 
@@ -5676,7 +5710,8 @@ and \term{standard deviation}.
 \indexlibraryglobal{normal_distribution}%
 \indexlibrarymember{result_type}{normal_distribution}%
 \begin{codeblock}
-template<class RealType = double>
+namespace std {
+  template<class RealType = double>
   class normal_distribution {
   public:
     // types
@@ -5714,6 +5749,7 @@ template<class RealType = double>
       friend basic_istream<charT, traits>&
         operator>>(basic_istream<charT, traits>& is, normal_distribution& x);
   };
+}
 \end{codeblock}
 
 
@@ -5776,7 +5812,8 @@ the probability density function%
 \indexlibraryglobal{lognormal_distribution}%
 \indexlibrarymember{result_type}{lognormal_distribution}%
 \begin{codeblock}
-template<class RealType = double>
+namespace std {
+  template<class RealType = double>
   class lognormal_distribution {
   public:
     // types
@@ -5814,6 +5851,7 @@ template<class RealType = double>
       friend basic_istream<charT, traits>&
         operator>>(basic_istream<charT, traits>& is, lognormal_distribution& x);
   };
+}
 \end{codeblock}
 
 
@@ -5874,7 +5912,8 @@ the probability density function%
 \indexlibraryglobal{chi_squared_distribution}%
 \indexlibrarymember{result_type}{chi_squared_distribution}%
 \begin{codeblock}
-template<class RealType = double>
+namespace std {
+  template<class RealType = double>
   class chi_squared_distribution {
   public:
     // types
@@ -5911,6 +5950,7 @@ template<class RealType = double>
       friend basic_istream<charT, traits>&
         operator>>(basic_istream<charT, traits>& is, chi_squared_distribution& x);
   };
+}
 \end{codeblock}
 
 
@@ -5958,7 +5998,8 @@ the probability density function%
 \indexlibraryglobal{cauchy_distribution}%
 \indexlibrarymember{result_type}{cauchy_distribution}%
 \begin{codeblock}
-template<class RealType = double>
+namespace std {
+  template<class RealType = double>
   class cauchy_distribution {
   public:
     // types
@@ -5996,6 +6037,7 @@ template<class RealType = double>
       friend basic_istream<charT, traits>&
         operator>>(basic_istream<charT, traits>& is, cauchy_distribution& x);
   };
+}
 \end{codeblock}
 
 
@@ -6060,7 +6102,8 @@ the probability density function%
 \indexlibraryglobal{fisher_f_distribution}%
 \indexlibrarymember{result_type}{fisher_distribution}%
 \begin{codeblock}
-template<class RealType = double>
+namespace std {
+  template<class RealType = double>
   class fisher_f_distribution {
   public:
     // types
@@ -6098,6 +6141,7 @@ template<class RealType = double>
       friend basic_istream<charT, traits>&
         operator>>(basic_istream<charT, traits>& is, fisher_f_distribution& x);
   };
+}
 \end{codeblock}
 
 
@@ -6161,7 +6205,8 @@ the probability density function%
 \indexlibraryglobal{student_t_distribution}%
 \indexlibrarymember{result_type}{student_t_distribution}%
 \begin{codeblock}
-template<class RealType = double>
+namespace std {
+  template<class RealType = double>
   class student_t_distribution {
   public:
     // types
@@ -6198,6 +6243,7 @@ template<class RealType = double>
       friend basic_istream<charT, traits>&
         operator>>(basic_istream<charT, traits>& is, student_t_distribution& x);
   };
+}
 \end{codeblock}
 
 
@@ -6269,7 +6315,8 @@ $0 < S = w_0 + \dotsb + w_{n - 1}$.
 \indexlibraryglobal{discrete_distribution}%
 \indexlibrarymember{result_type}{discrete_distribution}%
 \begin{codeblock}
-template<class IntType = int>
+namespace std {
+  template<class IntType = int>
   class discrete_distribution {
   public:
     // types
@@ -6310,6 +6357,7 @@ template<class IntType = int>
       friend basic_istream<charT, traits>&
         operator>>(basic_istream<charT, traits>& is, discrete_distribution& x);
   };
+}
 \end{codeblock}
 
 \indexlibraryctor{discrete_distribution}
@@ -6451,7 +6499,8 @@ Moreover, the following relation shall hold:
 \indexlibraryglobal{piecewise_constant_distribution}%
 \indexlibrarymember{result_type}{piecewise_constant_distribution}%
 \begin{codeblock}
-template<class RealType = double>
+namespace std {
+  template<class RealType = double>
   class piecewise_constant_distribution {
   public:
     // types
@@ -6497,6 +6546,7 @@ template<class RealType = double>
       friend basic_istream<charT, traits>&
         operator>>(basic_istream<charT, traits>& is, piecewise_constant_distribution& x);
   };
+}
 \end{codeblock}
 
 
@@ -6685,7 +6735,8 @@ Moreover, the following relation shall hold:
 \indexlibraryglobal{piecewise_linear_distribution}%
 \indexlibrarymember{result_type}{piecewise_linear_distribution}%
 \begin{codeblock}
-template<class RealType = double>
+namespace std {
+  template<class RealType = double>
   class piecewise_linear_distribution {
   public:
     // types
@@ -6730,6 +6781,7 @@ template<class RealType = double>
       friend basic_istream<charT, traits>&
         operator>>(basic_istream<charT, traits>& is, piecewise_linear_distribution& x);
   };
+}
 \end{codeblock}
 
 \indexlibraryctor{piecewise_linear_distribution}

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -810,11 +810,13 @@ expression matches the specified character sequence.  \\
 \rSec1[re.badexp]{Class \tcode{regex_error}}
 \indexlibraryglobal{regex_error}%
 \begin{codeblock}
-class regex_error : public runtime_error {
-public:
-  explicit regex_error(regex_constants::error_type ecode);
-  regex_constants::error_type code() const;
-};
+namespace std {
+  class regex_error : public runtime_error {
+  public:
+    explicit regex_error(regex_constants::error_type ecode);
+    regex_constants::error_type code() const;
+  };
+}
 \end{codeblock}
 
 \pnum

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -3936,11 +3936,13 @@ Type \tcode{nullopt_t} shall not have a default constructor or an initializer-li
 \rSec2[optional.bad.access]{Class \tcode{bad_optional_access}}
 
 \begin{codeblock}
-class bad_optional_access : public exception {
-public:
-  // see \ref{exception} for the specification of the special member functions
-  const char* what() const noexcept override;
-};
+namespace std {
+  class bad_optional_access : public exception {
+  public:
+    // see \ref{exception} for the specification of the special member functions
+    const char* what() const noexcept override;
+  };
+}
 \end{codeblock}
 
 \pnum
@@ -5782,11 +5784,13 @@ The exception specification is equivalent to \tcode{noexcept(v.swap(w))}.
 \indexlibraryglobal{bad_variant_access}%
 
 \begin{codeblock}
-class bad_variant_access : public exception {
-public:
-  // see \ref{exception} for the specification of the special member functions
-  const char* what() const noexcept override;
-};
+namespace std {
+  class bad_variant_access : public exception {
+  public:
+    // see \ref{exception} for the specification of the special member functions
+    const char* what() const noexcept override;
+  };
+}
 \end{codeblock}
 
 \pnum
@@ -5881,11 +5885,13 @@ namespace std {
 
 \indexlibraryglobal{bad_any_cast}%
 \begin{codeblock}
-class bad_any_cast : public bad_cast {
-public:
-  // see \ref{exception} for the specification of the special member functions
-  const char* what() const noexcept override;
-};
+namespace std {
+  class bad_any_cast : public bad_cast {
+  public:
+    // see \ref{exception} for the specification of the special member functions
+    const char* what() const noexcept override;
+  };
+}
 \end{codeblock}
 
 \pnum

--- a/tools/check-source.sh
+++ b/tools/check-source.sh
@@ -108,6 +108,14 @@ grep -Hne '^\\\(change\|rationale\|effect\|difficulty\|howwide\)\s.\+$' compatib
 grep -ne 'template\s<class' $texlib |
     fail 'space between "template" and "<class"' || failed=1
 
+# "Class" heading without namespace
+for f in $texlib; do
+    sed -n '/rSec[0-9].*{Class/,/\\end{codeblock}/{/\\begin{example}/,/\\end{example}/b;/\\begin{codeblock}/,/\(^namespace\)\|\(\\end{codeblock}\)/{s/template<[^>]*>//;/\(class\|struct\)[A-Za-z0-9_: ]*{/{=;p;};};}' $f |
+    # prefix output with filename and line
+    sed '/^[0-9]\+$/{N;s/\n/:/;}' | sed "s/.*/$f:&/"
+done |
+    fail 'No namespace around class definition' || failed=1
+
 # \begin{example/note} with non-whitespace in front on the same line.
 grep -ne '^.*[^ ]\s*\\\(begin\|end\){\(example\|note\)}' $texfiles |
     fail "non-whitespace before note/example begins" || failed=1


### PR DESCRIPTION
Those were missing in a few places, notably [rand].

Also add an automated check.

Fixes #1168