### PR TITLE
[temp.deduct.general] Clarify explicit-specifier and exception specifications CWG2618

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -7100,8 +7100,11 @@ of template argument deduction when any template arguments that were deduced or
 obtained from default arguments are substituted.
 
 \pnum
-The substitution occurs in all types and expressions that are used in the function
-type and in template parameter declarations. The expressions include not only
+The substitution occurs in all types and expressions that are used
+in the function type outside of the exception specification,
+in template parameter declarations, and
+in the \grammarterm{explicit-specifier}.
+The expressions include not only
 constant expressions such as those that appear in array bounds or as nontype
 template arguments but also general expressions (i.e., non-constant expressions)
 inside \tcode{sizeof}, \keyword{decltype}, and other contexts that allow non-constant
@@ -7145,9 +7148,9 @@ diagnostic is required, the program is still ill-formed. Access checking is done
 as part of the substitution
 process.
 \end{note}
-Only invalid types and expressions in the immediate context of
-the function type,
-its template parameter types,
+Invalid types and expressions only in the immediate context of
+the function's type outside of the exception specification,
+its template parameters,
 and its \grammarterm{explicit-specifier}
 can result in a deduction failure.
 \begin{note}


### PR DESCRIPTION
Fixes #5129 