### PR TITLE
[associative.reqmts.general] Fix typo: 'kx', not 'rx'

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1723,7 +1723,7 @@ and \tcode{e} in \tcode{a};
 \tcode{kx} is a value such that
 \begin{itemize}
 \item
-\tcode{a} is partitioned with respect to \tcode{c(r, rx)} and \tcode{!c(kx, r)},
+\tcode{a} is partitioned with respect to \tcode{c(r, kx)} and \tcode{!c(kx, r)},
 with \tcode{c(r, kx)} implying \tcode{!c(kx, r)}, and
 \item
 \tcode{kx} is not convertible to


### PR DESCRIPTION
Fixes #5135