### PR TITLE
[class.virtual] Explicit object member functions cannot be virtual CWG2553

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3881,6 +3881,21 @@ struct A {
 \end{example}
 
 \pnum
+A virtual function shall not be an explicit object member
+function\iref{dcl.fct}.
+\begin{example}
+\begin{codeblock}
+struct B {
+  virtual void g();             // \#1
+};
+struct D : B {
+  virtual void f(this D&);      // error: explicit object member function cannot be virtual
+  void g(this D&);              // overrides \#1; error: explicit object member function cannot be virtual
+};
+\end{codeblock}
+\end{example}
+
+\pnum
 The \grammarterm{ref-qualifier}, or lack thereof, of an overriding function
 shall be the same as that of the overridden function.
 

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -2997,6 +2997,10 @@ void f(int i) {
 \end{note}
 
 \pnum
+An allocation or deallocation function for a class
+shall not have an explicit object parameter\iref{dcl.fct}.
+
+\pnum
 Access to the deallocation function is checked statically,
 even if a different one is actually executed.
 \begin{example}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3894,7 +3894,7 @@ a \grammarterm{lambda-declarator}\iref{expr.prim.lambda}.
 A \grammarterm{member-declarator} with an explicit-object-parameter-declaration
 shall not include
 a \grammarterm{ref-qualifier} or a \grammarterm{cv-qualifier-seq} and
-shall not be declared \keyword{static} or \keyword{virtual}.
+shall not be declared \keyword{static}.
 \begin{example}
 \begin{codeblock}
 struct C {


### PR DESCRIPTION
including when overriding a virtual function.
Remove a prohibition focusing on 'declared virtual'
from [dcl.fct].

Fixes #5144