### PR TITLE
[range.access] Fix cross-references for 'array'

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3175,6 +3175,7 @@ the type of the \grammarterm{declarator-id} in \tcode{D} is
 
 \pnum
 \indextext{declaration!array}%
+\label{term.array.type}%
 A type of the form ``array of \tcode{N} \tcode{U}'' or
 ``array of unknown bound of \tcode{U}'' is an \defn{array type}.
 The optional \grammarterm{attribute-specifier-seq}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -465,7 +465,7 @@ Then:
   \tcode{ranges::begin(E)} is ill-formed.
 
 \item
-  Otherwise, if \tcode{T} is an array type\iref{basic.compound} and
+  Otherwise, if \tcode{T} is an array type\iref{term.array.type} and
   \tcode{remove_all_extents_t<T>} is an incomplete type,
   \tcode{ranges::begin(E)} is ill-formed with no diagnostic required.
 
@@ -531,7 +531,7 @@ Then:
   \tcode{ranges::end(E)} is ill-formed.
 
 \item
-  Otherwise, if \tcode{T} is an array type\iref{basic.compound} and
+  Otherwise, if \tcode{T} is an array type\iref{term.array.type} and
   \tcode{remove_all_extents_t<T>} is an incomplete type,
   \tcode{ranges::end(E)} is ill-formed with no diagnostic required.
 
@@ -644,7 +644,7 @@ Then:
   \tcode{ranges::rbegin(E)} is ill-formed.
 
 \item
-  Otherwise, if \tcode{T} is an array type\iref{basic.compound} and
+  Otherwise, if \tcode{T} is an array type\iref{term.array.type} and
   \tcode{remove_all_extents_t<T>} is an incomplete type,
   \tcode{ranges::rbegin(E)} is ill-formed with no diagnostic required.
 
@@ -713,7 +713,7 @@ Then:
   \tcode{ranges::rend(E)} is ill-formed.
 
 \item
-  Otherwise, if \tcode{T} is an array type\iref{basic.compound} and
+  Otherwise, if \tcode{T} is an array type\iref{term.array.type} and
   \tcode{remove_all_extents_t<T>} is an incomplete type,
   \tcode{ranges::rend(E)} is ill-formed with no diagnostic required.
 
@@ -821,7 +821,7 @@ Then:
 
 \begin{itemize}
 \item
-  If \tcode{T} is an array of unknown bound\iref{dcl.array},
+  If \tcode{T} is an array of unknown bound\iref{term.array.type},
   \tcode{ranges::size(E)} is ill-formed.
 
 \item
@@ -912,7 +912,7 @@ Then:
 
 \begin{itemize}
 \item
-  If \tcode{T} is an array of unknown bound\iref{basic.compound},
+  If \tcode{T} is an array of unknown bound\iref{term.array.type},
   \tcode{ranges::empty(E)} is ill-formed.
 
 \item
@@ -968,7 +968,7 @@ Then:
   \tcode{ranges::data(E)} is ill-formed.
 
 \item
-  Otherwise, if \tcode{T} is an array type\iref{basic.compound} and
+  Otherwise, if \tcode{T} is an array type\iref{term.array.type} and
   \tcode{remove_all_extents_t<T>} is an incomplete type,
   \tcode{ranges::data(E)} is ill-formed with no diagnostic required.
 


### PR DESCRIPTION
Also introduce a label 'term.array.type' in [dcl.array}.

Fixes #5146