### PR TITLE
[depr.default.allocator] Index allocator::is_always_equal here

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -1319,6 +1319,7 @@ int pcount() const;
 The following member is defined in addition to those
 specified in \ref{default.allocator}:
 
+\indexlibrarymember{is_always_equal}{allocator}%
 \begin{codeblock}
 namespace std {
   template<class T> class allocator {

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -8700,7 +8700,6 @@ allocator completeness requirements\iref{allocator.requirements.completeness}.
 \indexlibrarymember{size_type}{allocator}%
 \indexlibrarymember{difference_type}{allocator}%
 \indexlibrarymember{propagate_on_container_move_assignment}{allocator}%
-\indexlibrarymember{is_always_equal}{allocator}%
 \indexlibrarymember{operator=}{allocator}%
 \begin{codeblock}
 namespace std {


### PR DESCRIPTION
LWG3170 deprecated `allocator::is_always_equal`. We moved it to Annex D, but left this index entry behind.