### PR TITLE
[std] Fix bad \grammarterms

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3613,7 +3613,7 @@ If a virtual member function $F$ is declared in a class $B$, and,
 in a class $D$ derived (directly or indirectly) from $B$,
 a declaration of a member function $G$
 corresponds\iref{basic.scope.scope} to a declaration of $F$,
-ignoring \grammarterm{trailing requires-clause}s,
+ignoring trailing \grammarterm{requires-clause}s,
 \indextext{override|see{function, virtual, override}}%
 then $G$ \defnx{overrides}{function!virtual!override}
 \begin{footnote}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1450,7 +1450,7 @@ If the \grammarterm{unqualified-id} appears
 in a \grammarterm{lambda-expression} at program point $P$ and
 the entity is a local entity\iref{basic.pre} or a variable declared by
 an \grammarterm{init-capture}\iref{expr.prim.lambda.capture},
-then let $S$ be the \grammarterm{compound-expression} of
+then let $S$ be the \grammarterm{compound-statement} of
 the innermost enclosing \grammarterm{lambda-expression} of $P$.
 If naming the entity from outside of an unevaluated operand within $S$
 would refer to an entity

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3655,7 +3655,7 @@ if two function definitions containing the expressions
 would satisfy the one-definition rule,
 except that the tokens used to name types and declarations may differ
 as long as they name the same entities, and
-the tokens used to form \grammarterm{concept-id}s may differ
+the tokens used to form concept-ids\iref{temp.names} may differ
 as long as the two \grammarterm{template-id}{s} are the same\iref{temp.type}.
 \begin{note}
 For instance, \tcode{A<42>} and \tcode{A<40+2>} name the same type.

--- a/tools/check-output.sh
+++ b/tools/check-output.sh
@@ -34,6 +34,13 @@ grep -o '\\see{[^}]*}' < std-generalindex.ind |
     done | fail || failed=1
 rm -f tmp.txt
 
+# Find grammar index entries missing a definition
+cat std-grammarindex.ind |
+    awk 'BEGIN { def=1 } /^  .item/ { if (def==0) { gsub("[{},]", "", item); print item } item=$NF; def=0; next } /hyperindexformat/ { def=1 }' |
+    grep -v -- '-keyword$' |    # xxx-keyword is special
+    sed 's/^\(.*\)$/grammar non-terminal \1 has no definition/' |
+    fail || failed=1
+
 # Cross references since the previous standard.
 function indexentries() { sed 's,\\glossaryentry{\(.*\)@.*,\1,' "$1" | LANG=C sort; }
 function removals() { diff -u "$1" "$2" | grep '^-' | grep -v '^---' | sed 's/^-//'; }


### PR DESCRIPTION
Also adds a check. This essentially flags typos inside `\grammarterm`.