### PR TITLE
[macros] Use math font for ranges

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -476,7 +476,7 @@
 \newcommand{\defexposconceptnc}[1]{\ecname{#1}\indexconcept{\idxexposconcept{#1}|idxbfpage}\itcorr[-1]}  % macro length: 18
 
 %% Ranges
-\newcommand{\Range}[4]{\tcode{#1#3,\penalty2000{} #4#2}}
+\newcommand{\Range}[4]{\ensuremath{#1}\tcode{#3}, \penalty2000{} \tcode{#4}\ensuremath{#2}}
 \newcommand{\crange}[2]{\Range{[}{]}{#1}{#2}}
 \newcommand{\brange}[2]{\Range{(}{]}{#1}{#2}}
 \newcommand{\orange}[2]{\Range{(}{)}{#1}{#2}}

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -476,7 +476,7 @@
 \newcommand{\defexposconceptnc}[1]{\ecname{#1}\indexconcept{\idxexposconcept{#1}|idxbfpage}\itcorr[-1]}  % macro length: 18
 
 %% Ranges
-\newcommand{\Range}[4]{\ensuremath{#1}\tcode{#3}{,}\,\penalty2000{}\tcode{#4}\ensuremath{#2}}
+\newcommand{\Range}[4]{\ensuremath{#1}\tcode{#3}\ensuremath{,}\,\penalty2000{}\tcode{#4}\ensuremath{#2}}
 \newcommand{\crange}[2]{\Range{[}{]}{#1}{#2}}
 \newcommand{\brange}[2]{\Range{(}{]}{#1}{#2}}
 \newcommand{\orange}[2]{\Range{(}{)}{#1}{#2}}

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -476,7 +476,7 @@
 \newcommand{\defexposconceptnc}[1]{\ecname{#1}\indexconcept{\idxexposconcept{#1}|idxbfpage}\itcorr[-1]}  % macro length: 18
 
 %% Ranges
-\newcommand{\Range}[4]{\ensuremath{#1}\tcode{#3}, \penalty2000{} \tcode{#4}\ensuremath{#2}}
+\newcommand{\Range}[4]{\ensuremath{#1}\tcode{#3}{,}\,\penalty2000{}\tcode{#4}\ensuremath{#2}}
 \newcommand{\crange}[2]{\Range{[}{]}{#1}{#2}}
 \newcommand{\brange}[2]{\Range{(}{]}{#1}{#2}}
 \newcommand{\orange}[2]{\Range{(}{)}{#1}{#2}}


### PR DESCRIPTION
Fixes #2556

![ranges](https://user-images.githubusercontent.com/23412755/147134898-3a008191-6ba0-440e-8e6c-53b39a83fcbe.png)
