### PR TITLE
[meta.rel] Avoid undefined term 'void types'

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -18680,8 +18680,8 @@ To test() {
 \end{codeblock}
 
 \begin{note}
-This requirement gives well-defined results for reference types, void
-types, array types, and function types.
+This requirement gives well-defined results for reference types,
+array types, function types, and \cv{}~\keyword{void}.
 \end{note}
 Access checking is performed
 in a context unrelated to \tcode{To} and \tcode{From}. Only the validity of


### PR DESCRIPTION
Partially addresses #3908