### PR TITLE
[diff.stmt] Properly refer to function return types

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2261,7 +2261,7 @@ Besides,
 promising to return a value of a given type, and then not returning
 such a value, has always been recognized to be a questionable
 practice, tolerated only because very-old C had no distinction between
-void  functions and  int  functions.
+functions with \keyword{void} and \keyword{int} return types.
 \effect
 Deletion of semantically well-defined feature.
 \difficulty


### PR DESCRIPTION
Also annotate the 'void' and 'int' keywords.

Partially addresses #3908.