### PR TITLE
[core] Replace 'enumerated type' with 'enumeration'

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5065,9 +5065,8 @@ on the access to these entities\iref{class.access};
 different types at different times, \ref{class.union};
 
 \item
-\defnx{enumerations}{\idxcode{enum}}, which comprise a set of named constant values.
-Each distinct enumeration constitutes a different
-\defnadj{enumerated}{type}, \ref{dcl.enum};
+\defnx{enumerations}{\idxcode{enum}},
+which comprise a set of named constant values, \ref{dcl.enum};
 
 \item
 \indextext{member pointer to|see{pointer to member}}%

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -766,7 +766,7 @@ names\iref{class.ctor}
 \item every member template of class \tcode{T};
 
 \item every enumerator of every member of class \tcode{T} that is an
-unscoped enumerated type; and
+unscoped enumeration type; and
 
 \item every member of every anonymous union that is a member of class
 \tcode{T}.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -876,7 +876,7 @@ to a prvalue of type \keyword{int} if \keyword{int} can represent all the
 values of the bit-field; otherwise, it can be converted to
 \tcode{\keyword{unsigned} \keyword{int}} if \tcode{\keyword{unsigned} \keyword{int}} can represent all the
 values of the bit-field. If the bit-field is larger yet, no integral
-promotion applies to it. If the bit-field has an enumerated type, it is
+promotion applies to it. If the bit-field has enumeration type, it is
 treated as any other value of that type for promotion purposes.
 
 \pnum
@@ -1127,7 +1127,7 @@ converted to \keyword{float}.
 performed on both operands.
 \begin{footnote}
 As a consequence, operands of type \keyword{bool}, \keyword{char8_t}, \keyword{char16_t},
-\keyword{char32_t}, \keyword{wchar_t}, or an enumerated type are converted
+\keyword{char32_t}, \keyword{wchar_t}, or of enumeration type are converted
 to some integral type.
 \end{footnote}
 Then the following rules shall be applied to the promoted operands:

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -523,7 +523,7 @@ that takes a callback parameter with C language linkage.
 
 \pnum
 Several types defined in \ref{input.output} are
-\defnx{enumerated types}{type!enumerated}.
+\defnadjx{enumerated}{types}{type}.
 Each enumerated type may be implemented as an enumeration or as a synonym for
 an enumeration.
 \begin{footnote}


### PR DESCRIPTION
The term "enumerated type" is defined in [enumerated.types]
for use in the standard library, and is not synonymous with
"enumeration type".

Fixes #3977