### PR TITLE
[temp.dep.general] p2.1 lacks a trialing 'or'

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -4709,7 +4709,7 @@ is an \grammarterm{unqualified-id} and
 \begin{itemize}
 \item
 any of the expressions in the \grammarterm{expression-list} is a pack
-expansion\iref{temp.variadic},
+expansion\iref{temp.variadic}, or
 \item
 any of the expressions
 or \grammarterm{braced-init-list}{s}


### PR DESCRIPTION
[temp.dep.general]p2.1: http://eel.is/c++draft/temp.dep.general lacks a trailing or, which makes it a little bit confusing at the first sight.