### PR TITLE
[basic.lookup.unqual] Clarify conversion-function-id components lookup

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1777,13 +1777,15 @@ Unless otherwise specified,
 such a name undergoes unqualified name lookup from the point where it appears.
 
 \pnum
-An unqualified name that is a component name\iref{expr.prim.id.unqual} of
+Lookup for an unqualified name $U$
+that is a component name\iref{expr.prim.id.unqual} of
 a \grammarterm{type-specifier} or \grammarterm{ptr-operator} of
-a \grammarterm{conversion-type-id} is looked up in the same fashion
-as the \grammarterm{conversion-function-id} in which it appears.
-If that lookup finds nothing, it undergoes unqualified name lookup;
-in each case, only names
-that denote types or templates whose specializations are types are considered.
+a \grammarterm{conversion-type-id} $T$ considers only names
+that denote types or templates whose specializations are types.
+If $T$ appears in a \grammarterm{conversion-function-id} that is a qualified name
+whose lookup context\iref{basic.lookup.qual} is a class $S$,
+lookup for $U$ performs a search in the scope associated with $S$;
+if that lookup finds nothing, $U$ undergoes unqualified name lookup.
 \begin{example}
 \begin{codeblock}
 struct T1 { struct U { int i; }; };


### PR DESCRIPTION
What does `looked up in the same fashion as the \grammarterm{conversion-function-id}` mean when the `\grammarterm{conversion-function-id}` is not looked up? Like in declarations.
```c++
struct S
{
  using T = int;
  operator T(); // `operator T` is not looked up. What does it mean for T?
};

S::operator T() // same here
{ return {}; }
```