### PR TITLE
move_only_function takes one signature

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -14129,7 +14129,7 @@ namespace std {
     bool operator==(const function<R(ArgTypes...)>&, nullptr_t) noexcept;
 
   // \ref{func.wrap.move}, move only wrapper
-  template<class... S> class move_only_function;        // \notdef
+  template<class S> class move_only_function;        // \notdef
   template<class R, class... ArgTypes>
     class move_only_function<R(ArgTypes...) @\cv{}@ @\placeholder{ref}@ noexcept(@\placeholder{noex}@)>; // \seebelow
 
@@ -16527,7 +16527,7 @@ otherwise, let \placeholder{inv-quals} be \cv{} \placeholder{ref}.
 \indexlibraryglobal{move_only_function}%
 \begin{codeblock}
 namespace std {
-  template<class... S> class move_only_function;                // \notdef
+  template<class S> class move_only_function;                // \notdef
 
   template<class R, class... ArgTypes>
   class move_only_function<R(ArgTypes...) @\cv{}@ @\placeholder{ref}@ noexcept(@\placeholder{noex}@)> {


### PR DESCRIPTION
The pack (`Args...`) in the specializations does not need the main template to be variadic. A signature is just one type parameter.