### PR TITLE
[func.memfn] Correct target object by fixing typo

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16013,7 +16013,7 @@ with call pattern \tcode{invoke(pmd, call_args...)}, where
 \tcode{pmd} is the target object of \tcode{fn} of type \tcode{R T::*}
 direct-non-list-initialized with \tcode{pm}, and
 \tcode{call_args} is an argument pack
-used in a function call expression\iref{expr.call} of \tcode{pm}.
+used in a function call expression\iref{expr.call} of \tcode{fn}.
 \end{itemdescr}
 \indextext{function object!\idxcode{mem_fn}|)}
 


### PR DESCRIPTION
Pointer to member has no function call expression (only pointer to member expression has). `call_args` should mean the args passed to the call wrapper.