### PR TITLE
[func.require] Introduce labels 'term.perfect.forwarding.call.wrapper'

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2249,7 +2249,7 @@ template<template<class...> class C, class... Args>
 \pnum
 \returns
 A range adaptor closure object\iref{range.adaptor.object} \tcode{f}
-that is a perfect forwarding call wrapper\iref{func.require}
+that is a perfect forwarding call wrapper\iref{term.perfect.forwarding.call.wrapper}
 with the following properties:
 \begin{itemize}
 \item
@@ -3426,7 +3426,7 @@ R | C
 Given an additional range adaptor closure object \tcode{D},
 the expression \tcode{C | D} produces another range adaptor
 closure object \tcode{E}.
-\tcode{E} is a perfect forwarding call wrapper\iref{func.require}
+\tcode{E} is a perfect forwarding call wrapper\iref{term.perfect.forwarding.call.wrapper}
 with the following properties:
 \begin{itemize}
 \item
@@ -3500,7 +3500,7 @@ as specified in the rest of subclause~\ref{range.adaptors}, and
 let \tcode{BoundArgs} be a pack
 that denotes \tcode{decay_t<decltype((args))>...}.
 The expression \tcode{adaptor(args...)} produces a range adaptor closure object \tcode{f}
-that is a perfect forwarding call wrapper with the following properties:
+that is a perfect forwarding call wrapper\iref{term.perfect.forwarding.call.wrapper} with the following properties:
 \begin{itemize}
 \item
 Its target object is a copy of \tcode{adaptor}.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16461,8 +16461,8 @@ template<class... UnBoundArgs>
 \end{note}
 
 \pnum
-\indextext{call wrapper!perfect forwarding}%
-A \defn{perfect forwarding call wrapper} is
+\label{term.perfect.forwarding.call.wrapper}%
+A \defnadj{perfect forwarding}{call wrapper} is
 an argument forwarding call wrapper
 that forwards its state entities to the underlying call expression.
 This forwarding step delivers a state entity of type \tcode{T}
@@ -16483,6 +16483,7 @@ of the arguments of the call wrapper and its state entities
 with references as described in the corresponding forwarding steps.
 
 \pnum
+\label{term.simple.call.wrapper}%
 A \defn{simple call wrapper} is a perfect forwarding call wrapper that meets
 the \oldconcept{CopyConstructible} and \oldconcept{CopyAssignable} requirements
 and whose copy constructor, move constructor, and assignment operators
@@ -17901,7 +17902,7 @@ is \tcode{true}.
 
 \pnum
 \returns
-A perfect forwarding call wrapper \tcode{g}
+A perfect forwarding call wrapper\iref{term.perfect.forwarding.call.wrapper} \tcode{g}
 with call pattern \tcode{!invoke(fd, call_args...)}.
 
 \pnum
@@ -17960,7 +17961,7 @@ $\tcode{T}_i$ meets the \oldconcept{MoveConstructible} requirements.
 
 \pnum
 \returns
-A perfect forwarding call wrapper \tcode{g}
+A perfect forwarding call wrapper\iref{term.perfect.forwarding.call.wrapper} \tcode{g}
 with call pattern:
 \begin{itemize}
 \item
@@ -18199,7 +18200,7 @@ template<class R, class T> constexpr @\unspec@ mem_fn(R T::* pm) noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-A simple call wrapper\iref{func.def} \tcode{fn}
+A simple call wrapper\iref{term.simple.call.wrapper} \tcode{fn}
 with call pattern \tcode{invoke(pmd, call_args...)}, where
 \tcode{pmd} is the target object of \tcode{fn} of type \tcode{R T::*}
 direct-non-list-initialized with \tcode{pm}, and


### PR DESCRIPTION
and 'term.simple.call.wrapper' and refer to them.

@languagelawyer , what do you think?