### PR TITLE
[temp.param] Delete outdated wording at p15

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -558,17 +558,6 @@ template<class... T, class U> void g() { }      // error
 \end{codeblock}
 \end{example}
 
-\pnum
-A \grammarterm{template-parameter}
-shall not be given default arguments by two different declarations
-if one is reachable from the other.
-\begin{example}
-\begin{codeblock}
-template<class T = int> class X;
-template<class T = int> class X { @\commentellip@ };  // error
-\end{codeblock}
-\end{example}
-
 \indextext{\idxcode{<}!template and}%
 \pnum
 When parsing a


### PR DESCRIPTION
The wording at [temp.param]/15 says:
> A template-parameter shall not be given default arguments by two
> different declarations if one is reachable from the other.

But it is conflicted with [basic.def.odr]/13:
> There can be more than one definition of a
> ...
> 	default template argument
> ...
> in a program provided that each definition appears in a different
> translation unit and the definitions satisfy the [same-meaning
> criteria of the ODR].

[temp.param] should be deleted otherwise we couldn't modularize a real
project. 

Here is an reduced example:

```C++
// templ.h
template<class T = int> class X{}
// foo.cppm
module;
#include "templ.h"
export module foo;
// decls to make 'X' not discard.
//bar.cpp
import foo;
#include "templ.h"
```

The example above here should be able to be accepted.