### PR TITLE
Less redundant 'typename' in type-id-only contexts

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -4256,7 +4256,7 @@ protected:
   typedef T TT;
 };
 
-template <class U, class V = typename U::TT>
+template <class U, class V = U::TT>
 class D : public U { };
 
 D <C<B> >* d;       // access error, \tcode{C::TT} is protected

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -3355,7 +3355,7 @@ The following exposition-only alias template may appear in deduction guides for 
 
 \begin{codeblock}
 template<class InputIterator>
-  using @\placeholdernc{iter-value-type}@ = typename iterator_traits<InputIterator>::value_type;  // \expos
+  using @\placeholdernc{iter-value-type}@ = iterator_traits<InputIterator>::value_type;  // \expos
 \end{codeblock}
 
 \rSec2[array.syn]{Header \tcode{<array>} synopsis}
@@ -3905,8 +3905,8 @@ namespace std {
     // types
     using value_type             = T;
     using allocator_type         = Allocator;
-    using pointer                = typename allocator_traits<Allocator>::pointer;
-    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using pointer                = allocator_traits<Allocator>::pointer;
+    using const_pointer          = allocator_traits<Allocator>::const_pointer;
     using reference              = value_type&;
     using const_reference        = const value_type&;
     using size_type              = @\impdefx{type of \tcode{deque::size_type}}@; // see \ref{container.requirements}
@@ -4332,8 +4332,8 @@ namespace std {
     // types
     using value_type      = T;
     using allocator_type  = Allocator;
-    using pointer         = typename allocator_traits<Allocator>::pointer;
-    using const_pointer   = typename allocator_traits<Allocator>::const_pointer;
+    using pointer         = allocator_traits<Allocator>::pointer;
+    using const_pointer   = allocator_traits<Allocator>::const_pointer;
     using reference       = value_type&;
     using const_reference = const value_type&;
     using size_type       = @\impdefx{type of \tcode{forward_list::size_type}}@; // see \ref{container.requirements}
@@ -5133,8 +5133,8 @@ namespace std {
     // types
     using value_type             = T;
     using allocator_type         = Allocator;
-    using pointer                = typename allocator_traits<Allocator>::pointer;
-    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using pointer                = allocator_traits<Allocator>::pointer;
+    using const_pointer          = allocator_traits<Allocator>::const_pointer;
     using reference              = value_type&;
     using const_reference        = const value_type&;
     using size_type              = @\impdefx{type of \tcode{list::size_type}}@; // see \ref{container.requirements}
@@ -5841,8 +5841,8 @@ namespace std {
     // types
     using value_type             = T;
     using allocator_type         = Allocator;
-    using pointer                = typename allocator_traits<Allocator>::pointer;
-    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using pointer                = allocator_traits<Allocator>::pointer;
+    using const_pointer          = allocator_traits<Allocator>::const_pointer;
     using reference              = value_type&;
     using const_reference        = const value_type&;
     using size_type              = @\impdefx{type of \tcode{vector::size_type}}@; // see \ref{container.requirements}
@@ -6548,13 +6548,13 @@ The following exposition-only alias templates may appear in deduction guides for
 \begin{codeblock}
 template<class InputIterator>
   using @\placeholder{iter-value-type}@ =
-    typename iterator_traits<InputIterator>::value_type;                // \expos
+    iterator_traits<InputIterator>::value_type;                         // \expos
 template<class InputIterator>
   using @\placeholder{iter-key-type}@ = remove_const_t<
     typename iterator_traits<InputIterator>::value_type::first_type>;   // \expos
 template<class InputIterator>
   using @\placeholder{iter-mapped-type}@ =
-    typename iterator_traits<InputIterator>::value_type::second_type;   // \expos
+    iterator_traits<InputIterator>::value_type::second_type;            // \expos
 template<class InputIterator>
   using @\placeholder{iter-to-alloc-type}@ = pair<
     add_const_t<typename iterator_traits<InputIterator>::value_type::first_type>,
@@ -6740,8 +6740,8 @@ namespace std {
     using value_type             = pair<const Key, T>;
     using key_compare            = Compare;
     using allocator_type         = Allocator;
-    using pointer                = typename allocator_traits<Allocator>::pointer;
-    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using pointer                = allocator_traits<Allocator>::pointer;
+    using const_pointer          = allocator_traits<Allocator>::const_pointer;
     using reference              = value_type&;
     using const_reference        = const value_type&;
     using size_type              = @\impdefx{type of \tcode{map::size_type}}@; // see \ref{container.requirements}
@@ -7288,8 +7288,8 @@ namespace std {
     using value_type             = pair<const Key, T>;
     using key_compare            = Compare;
     using allocator_type         = Allocator;
-    using pointer                = typename allocator_traits<Allocator>::pointer;
-    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using pointer                = allocator_traits<Allocator>::pointer;
+    using const_pointer          = allocator_traits<Allocator>::const_pointer;
     using reference              = value_type&;
     using const_reference        = const value_type&;
     using size_type              = @\impdefx{type of \tcode{multimap::size_type}}@; // see \ref{container.requirements}
@@ -7604,8 +7604,8 @@ namespace std {
     using value_type             = Key;
     using value_compare          = Compare;
     using allocator_type         = Allocator;
-    using pointer                = typename allocator_traits<Allocator>::pointer;
-    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using pointer                = allocator_traits<Allocator>::pointer;
+    using const_pointer          = allocator_traits<Allocator>::const_pointer;
     using reference              = value_type&;
     using const_reference        = const value_type&;
     using size_type              = @\impdefx{type of \tcode{set::size_type}}@; // see \ref{container.requirements}
@@ -7881,8 +7881,8 @@ namespace std {
     using value_type             = Key;
     using value_compare          = Compare;
     using allocator_type         = Allocator;
-    using pointer                = typename allocator_traits<Allocator>::pointer;
-    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using pointer                = allocator_traits<Allocator>::pointer;
+    using const_pointer          = allocator_traits<Allocator>::const_pointer;
     using reference              = value_type&;
     using const_reference        = const value_type&;
     using size_type              = @\impdefx{type of \tcode{multiset::size_type}}@; // see \ref{container.requirements}
@@ -8296,8 +8296,8 @@ namespace std {
     using hasher               = Hash;
     using key_equal            = Pred;
     using allocator_type       = Allocator;
-    using pointer              = typename allocator_traits<Allocator>::pointer;
-    using const_pointer        = typename allocator_traits<Allocator>::const_pointer;
+    using pointer              = allocator_traits<Allocator>::pointer;
+    using const_pointer        = allocator_traits<Allocator>::const_pointer;
     using reference            = value_type&;
     using const_reference      = const value_type&;
     using size_type            = @\impdefx{type of \tcode{unordered_map::size_type}}@; // see \ref{container.requirements}
@@ -8894,8 +8894,8 @@ namespace std {
     using hasher               = Hash;
     using key_equal            = Pred;
     using allocator_type       = Allocator;
-    using pointer              = typename allocator_traits<Allocator>::pointer;
-    using const_pointer        = typename allocator_traits<Allocator>::const_pointer;
+    using pointer              = allocator_traits<Allocator>::pointer;
+    using const_pointer        = allocator_traits<Allocator>::const_pointer;
     using reference            = value_type&;
     using const_reference      = const value_type&;
     using size_type            = @\impdefx{type of \tcode{unordered_multimap::size_type}}@; // see \ref{container.requirements}
@@ -9262,8 +9262,8 @@ namespace std {
     using hasher               = Hash;
     using key_equal            = Pred;
     using allocator_type       = Allocator;
-    using pointer              = typename allocator_traits<Allocator>::pointer;
-    using const_pointer        = typename allocator_traits<Allocator>::const_pointer;
+    using pointer              = allocator_traits<Allocator>::pointer;
+    using const_pointer        = allocator_traits<Allocator>::const_pointer;
     using reference            = value_type&;
     using const_reference      = const value_type&;
     using size_type            = @\impdefx{type of \tcode{unordered_set::size_type}}@; // see \ref{container.requirements}
@@ -9590,8 +9590,8 @@ namespace std {
     using hasher               = Hash;
     using key_equal            = Pred;
     using allocator_type       = Allocator;
-    using pointer              = typename allocator_traits<Allocator>::pointer;
-    using const_pointer        = typename allocator_traits<Allocator>::const_pointer;
+    using pointer              = allocator_traits<Allocator>::pointer;
+    using const_pointer        = allocator_traits<Allocator>::const_pointer;
     using reference            = value_type&;
     using const_reference      = const value_type&;
     using size_type            = @\impdefx{type of \tcode{unordered_multiset::size_type}}@; // see \ref{container.requirements}
@@ -10016,10 +10016,10 @@ namespace std {
   template<class T, class Container = deque<T>>
   class queue {
   public:
-    using value_type      = typename Container::value_type;
-    using reference       = typename Container::reference;
-    using const_reference = typename Container::const_reference;
-    using size_type       = typename Container::size_type;
+    using value_type      = Container::value_type;
+    using reference       = Container::reference;
+    using const_reference = Container::const_reference;
+    using size_type       = Container::size_type;
     using container_type  =          Container;
 
   protected:
@@ -10327,10 +10327,10 @@ namespace std {
            class Compare = less<typename Container::value_type>>
   class priority_queue {
   public:
-    using value_type      = typename Container::value_type;
-    using reference       = typename Container::reference;
-    using const_reference = typename Container::const_reference;
-    using size_type       = typename Container::size_type;
+    using value_type      = Container::value_type;
+    using reference       = Container::reference;
+    using const_reference = Container::const_reference;
+    using size_type       = Container::size_type;
     using container_type  = Container;
     using value_compare   = Compare;
 
@@ -10745,10 +10745,10 @@ namespace std {
   template<class T, class Container = deque<T>>
   class stack {
   public:
-    using value_type      = typename Container::value_type;
-    using reference       = typename Container::reference;
-    using const_reference = typename Container::const_reference;
-    using size_type       = typename Container::size_type;
+    using value_type      = Container::value_type;
+    using reference       = Container::reference;
+    using const_reference = Container::const_reference;
+    using size_type       = Container::size_type;
     using container_type  = Container;
 
   protected:

--- a/source/future.tex
+++ b/source/future.tex
@@ -2065,8 +2065,8 @@ namespace std {
     public:
       using byte_string = basic_string<char, char_traits<char>, ByteAlloc>;
       using wide_string = basic_string<Elem, char_traits<Elem>, WideAlloc>;
-      using state_type  = typename Codecvt::state_type;
-      using int_type    = typename wide_string::traits_type::int_type;
+      using state_type  = Codecvt::state_type;
+      using int_type    = wide_string::traits_type::int_type;
 
       wstring_convert() : wstring_convert(new Codecvt) {}
       explicit wstring_convert(Codecvt* pcvt);
@@ -2186,7 +2186,7 @@ Otherwise, the member function throws an object of class \tcode{range_error}.
 
 \indexlibrarymember{int_type}{wstring_convert}%
 \begin{itemdecl}
-using int_type = typename wide_string::traits_type::int_type;
+using int_type = wide_string::traits_type::int_type;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2207,7 +2207,7 @@ state_type state() const;
 
 \indexlibrarymember{state_type}{wstring_convert}%
 \begin{itemdecl}
-using state_type = typename Codecvt::state_type;
+using state_type = Codecvt::state_type;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2318,7 +2318,7 @@ namespace std {
   template<class Codecvt, class Elem = wchar_t, class Tr = char_traits<Elem>>
     class wbuffer_convert : public basic_streambuf<Elem, Tr> {
     public:
-      using state_type = typename Codecvt::state_type;
+      using state_type = Codecvt::state_type;
 
       wbuffer_convert() : wbuffer_convert(nullptr) {}
       explicit wbuffer_convert(streambuf* bytebuf,
@@ -2401,7 +2401,7 @@ The previous value of \tcode{bufptr}.
 
 \indexlibrarymember{state_type}{wbuffer_convert}%
 \begin{itemdecl}
-using state_type = typename Codecvt::state_type;
+using state_type = Codecvt::state_type;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -1793,9 +1793,9 @@ namespace std {
   class basic_ios : public ios_base {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     // \ref{iostate.flags}, flags functions
@@ -2978,9 +2978,9 @@ namespace std {
   class basic_streambuf {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     virtual ~basic_streambuf();
@@ -4228,9 +4228,9 @@ namespace std {
   public:
     // types (inherited from \tcode{basic_ios}\iref{ios})
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     // \ref{istream.cons}, constructor/destructor
@@ -5698,9 +5698,9 @@ namespace std {
       public basic_ostream<charT, traits> {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     // \ref{iostream.cons}, constructor
@@ -5823,9 +5823,9 @@ namespace std {
   public:
     // types (inherited from \tcode{basic_ios}\iref{ios})
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     // \ref{ostream.cons}, constructor/destructor
@@ -7553,9 +7553,9 @@ namespace std {
   class basic_stringbuf : public basic_streambuf<charT, traits> {
   public:
     using char_type      = charT;
-    using int_type       = typename traits::int_type;
-    using pos_type       = typename traits::pos_type;
-    using off_type       = typename traits::off_type;
+    using int_type       = traits::int_type;
+    using pos_type       = traits::pos_type;
+    using off_type       = traits::off_type;
     using traits_type    = traits;
     using allocator_type = Allocator;
 
@@ -8352,9 +8352,9 @@ namespace std {
   class basic_istringstream : public basic_istream<charT, traits> {
   public:
     using char_type      = charT;
-    using int_type       = typename traits::int_type;
-    using pos_type       = typename traits::pos_type;
-    using off_type       = typename traits::off_type;
+    using int_type       = traits::int_type;
+    using pos_type       = traits::pos_type;
+    using off_type       = traits::off_type;
     using traits_type    = traits;
     using allocator_type = Allocator;
 
@@ -8667,9 +8667,9 @@ namespace std {
   class basic_ostringstream : public basic_ostream<charT, traits> {
   public:
     using char_type      = charT;
-    using int_type       = typename traits::int_type;
-    using pos_type       = typename traits::pos_type;
-    using off_type       = typename traits::off_type;
+    using int_type       = traits::int_type;
+    using pos_type       = traits::pos_type;
+    using off_type       = traits::off_type;
     using traits_type    = traits;
     using allocator_type = Allocator;
 
@@ -8987,9 +8987,9 @@ namespace std {
   class basic_stringstream : public basic_iostream<charT, traits> {
   public:
     using char_type      = charT;
-    using int_type       = typename traits::int_type;
-    using pos_type       = typename traits::pos_type;
-    using off_type       = typename traits::off_type;
+    using int_type       = traits::int_type;
+    using pos_type       = traits::pos_type;
+    using off_type       = traits::off_type;
     using traits_type    = traits;
     using allocator_type = Allocator;
 
@@ -9369,9 +9369,9 @@ namespace std {
     : public basic_streambuf<charT, traits> {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     // \ref{spanbuf.ctor}, constructors
@@ -9698,9 +9698,9 @@ namespace std {
     : public basic_istream<charT, traits> {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     // \ref{ispanstream.ctor}, constructors
@@ -9889,9 +9889,9 @@ namespace std {
     : public basic_ostream<charT, traits> {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     // \ref{ospanstream.ctor}, constructors
@@ -10030,9 +10030,9 @@ namespace std {
     : public basic_iostream<charT, traits> {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     // \ref{spanstream.ctor}, constructors
@@ -10252,9 +10252,9 @@ namespace std {
   class basic_filebuf : public basic_streambuf<charT, traits> {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     // \ref{filebuf.cons}, constructors/destructor
@@ -11018,9 +11018,9 @@ namespace std {
   class basic_ifstream : public basic_istream<charT, traits> {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     // \ref{ifstream.cons}, constructors
@@ -11263,9 +11263,9 @@ namespace std {
   class basic_ofstream : public basic_ostream<charT, traits> {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     // \ref{ofstream.cons}, constructors
@@ -11506,9 +11506,9 @@ namespace std {
   class basic_fstream : public basic_iostream<charT, traits> {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     // \ref{fstream.cons}, constructors
@@ -11807,9 +11807,9 @@ namespace std {
   class basic_syncbuf : public basic_streambuf<charT, traits> {
   public:
     using char_type      = charT;
-    using int_type       = typename traits::int_type;
-    using pos_type       = typename traits::pos_type;
-    using off_type       = typename traits::off_type;
+    using int_type       = traits::int_type;
+    using pos_type       = traits::pos_type;
+    using off_type       = traits::off_type;
     using traits_type    = traits;
     using allocator_type = Allocator;
 
@@ -12120,9 +12120,9 @@ namespace std {
   class basic_osyncstream : public basic_ostream<charT, traits> {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     using allocator_type = Allocator;

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -5245,12 +5245,12 @@ namespace std {
   class counted_iterator {
   public:
     using iterator_type = I;
-    using value_type = iter_value_t<I>;                // present only
+    using value_type = iter_value_t<I>;                         // present only
                         // if \tcode{I} models \libconcept{indirectly_readable}
     using difference_type = iter_difference_t<I>;
-    using iterator_concept = I::iterator_concept;      // present only
+    using iterator_concept = I::iterator_concept;               // present only
                         // if the \grammarterm{qualified-id} \tcode{I::iterator_concept} is valid and denotes a type
-    using iterator_category = I::iterator_category;    // present only
+    using iterator_category = I::iterator_category;             // present only
                         // if the \grammarterm{qualified-id} \tcode{I::iterator_category} is valid and denotes a type
     constexpr counted_iterator() requires @\libconcept{default_initializable}@<I> = default;
     constexpr counted_iterator(I x, iter_difference_t<I> n);

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -690,7 +690,7 @@ namespace std {
   template<class T>
     requires requires { typename T::difference_type; }
   struct incrementable_traits<T> {
-    using difference_type = typename T::difference_type;
+    using difference_type = T::difference_type;
   };
 
   template<class T>
@@ -935,11 +935,11 @@ then
 \tcode{iterator_traits<I>}
 has the following publicly accessible members:
 \begin{codeblock}
-using iterator_category = typename I::iterator_category;
-using value_type        = typename I::value_type;
-using difference_type   = typename I::difference_type;
+using iterator_category = I::iterator_category;
+using value_type        = I::value_type;
+using difference_type   = I::difference_type;
 using pointer           = @\seebelow@;
-using reference         = typename I::reference;
+using reference         = I::reference;
 \end{codeblock}
 If the \grammarterm{qualified-id} \tcode{I::pointer} is valid and
 denotes a type, then \tcode{iterator_traits<I>::pointer} names that type;
@@ -953,8 +953,8 @@ Otherwise, if \tcode{I} satisfies the exposition-only concept
 publicly accessible members:
 \begin{codeblock}
 using iterator_category = @\seebelow@;
-using value_type        = typename indirectly_readable_traits<I>::value_type;
-using difference_type   = typename incrementable_traits<I>::difference_type;
+using value_type        = indirectly_readable_traits<I>::value_type;
+using difference_type   = incrementable_traits<I>::difference_type;
 using pointer           = @\seebelow@;
 using reference         = @\seebelow@;
 \end{codeblock}
@@ -3141,7 +3141,7 @@ namespace std {
     using iterator_category = @\seebelow@;
     using value_type        = iter_value_t<Iterator>;
     using difference_type   = iter_difference_t<Iterator>;
-    using pointer           = typename iterator_traits<Iterator>::pointer;
+    using pointer           = iterator_traits<Iterator>::pointer;
     using reference         = iter_reference_t<Iterator>;
 
     constexpr reverse_iterator();
@@ -5245,12 +5245,12 @@ namespace std {
   class counted_iterator {
   public:
     using iterator_type = I;
-    using value_type = iter_value_t<I>;                         // present only
+    using value_type = iter_value_t<I>;                // present only
                         // if \tcode{I} models \libconcept{indirectly_readable}
     using difference_type = iter_difference_t<I>;
-    using iterator_concept = typename I::iterator_concept;      // present only
+    using iterator_concept = I::iterator_concept;      // present only
                         // if the \grammarterm{qualified-id} \tcode{I::iterator_concept} is valid and denotes a type
-    using iterator_category = typename I::iterator_category;    // present only
+    using iterator_category = I::iterator_category;    // present only
                         // if the \grammarterm{qualified-id} \tcode{I::iterator_category} is valid and denotes a type
     constexpr counted_iterator() requires @\libconcept{default_initializable}@<I> = default;
     constexpr counted_iterator(I x, iter_difference_t<I> n);
@@ -6216,12 +6216,12 @@ namespace std {
   public:
     using iterator_category = input_iterator_tag;
     using value_type        = charT;
-    using difference_type   = typename traits::off_type;
+    using difference_type   = traits::off_type;
     using pointer           = @\unspec@;
     using reference         = charT;
     using char_type         = charT;
     using traits_type       = traits;
-    using int_type          = typename traits::int_type;
+    using int_type          = traits::int_type;
     using streambuf_type    = basic_streambuf<charT,traits>;
     using istream_type      = basic_istream<charT,traits>;
 

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -1304,7 +1304,7 @@ namespace std {
   template<class charT>
     class ctype_byname : public ctype<charT> {
     public:
-      using mask = typename ctype<charT>::mask;
+      using mask = ctype<charT>::mask;
       explicit ctype_byname(const char*, size_t refs = 0);
       explicit ctype_byname(const string&, size_t refs = 0);
 

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -3567,7 +3567,7 @@ namespace std {
   class discard_block_engine {
   public:
     // types
-    using result_type = typename Engine::result_type;
+    using result_type = Engine::result_type;
 
     // engine characteristics
     static constexpr size_t block_size = p;
@@ -3818,7 +3818,7 @@ namespace std {
   class shuffle_order_engine {
   public:
     // types
-    using result_type = typename Engine::result_type;
+    using result_type = Engine::result_type;
 
     // engine characteristics
     static constexpr size_t table_size = k;

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -6202,7 +6202,7 @@ namespace std::ranges {
     bool @\exposid{incremented_}@ = false;                              // \expos
 
   public:
-    using iterator_concept  = typename @\exposid{outer-iterator}@<Const>::iterator_concept;
+    using iterator_concept  = @\exposid{outer-iterator}@<Const>::iterator_concept;
 
     using iterator_category = @\seebelownc@;                    // present only if \exposid{Base}
                                                             // models \libconcept{forward_range}
@@ -8500,7 +8500,7 @@ namespace std::ranges {
 
   public:
     using iterator_category = @\seebelownc@;                        // not always present
-    using iterator_concept  = typename @\exposid{ziperator}@<Const>::iterator_concept;
+    using iterator_concept  = @\exposid{ziperator}@<Const>::iterator_concept;
     using value_type =
       remove_cvref_t<invoke_result_t<@\exposid{maybe-const}@<Const, F>&,
                                      range_reference_t<@\exposid{maybe-const}@<Const, Views>>...>>;
@@ -9671,7 +9671,7 @@ namespace std::ranges {
 
   public:
     using iterator_category = @\seebelow@;
-    using iterator_concept  = typename @\exposid{inner-iterator}@<Const>::iterator_concept;
+    using iterator_concept  = @\exposid{inner-iterator}@<Const>::iterator_concept;
     using value_type =
       remove_cvref_t<invoke_result_t<@\exposid{maybe-const}@<Const, F>&,
                                      @\exposid{REPEAT}@(range_reference_t<@\exposid{Base}@>, N)...>>;

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -407,7 +407,7 @@ namespace std {
 
   // \ref{re.regiter}, class template \tcode{regex_iterator}
   template<class BidirectionalIterator,
-            class charT = typename iterator_traits<BidirectionalIterator>::value_type,
+            class charT = iterator_traits<BidirectionalIterator>::value_type,
             class traits = regex_traits<charT>>
     class regex_iterator;
 
@@ -418,7 +418,7 @@ namespace std {
 
   // \ref{re.tokiter}, class template \tcode{regex_token_iterator}
   template<class BidirectionalIterator,
-            class charT = typename iterator_traits<BidirectionalIterator>::value_type,
+            class charT = iterator_traits<BidirectionalIterator>::value_type,
             class traits = regex_traits<charT>>
     class regex_token_iterator;
 
@@ -1195,9 +1195,9 @@ namespace std {
       // types
       using value_type  =          charT;
       using traits_type =          traits;
-      using string_type = typename traits::string_type;
+      using string_type = traits::string_type;
       using flag_type   =          regex_constants::syntax_option_type;
-      using locale_type = typename traits::locale_type;
+      using locale_type = traits::locale_type;
 
       // \ref{re.synopt}, constants
       static constexpr flag_type icase = regex_constants::icase;
@@ -1696,10 +1696,8 @@ namespace std {
   template<class BidirectionalIterator>
     class sub_match : public pair<BidirectionalIterator, BidirectionalIterator> {
     public:
-      using value_type      =
-              typename iterator_traits<BidirectionalIterator>::value_type;
-      using difference_type =
-              typename iterator_traits<BidirectionalIterator>::difference_type;
+      using value_type      = iterator_traits<BidirectionalIterator>::value_type;
+      using difference_type = iterator_traits<BidirectionalIterator>::difference_type;
       using iterator        = BidirectionalIterator;
       using string_type     = basic_string<value_type>;
 
@@ -2000,7 +1998,7 @@ namespace std {
       using iterator        = const_iterator;
       using difference_type =
               typename iterator_traits<BidirectionalIterator>::difference_type;
-      using size_type       = typename allocator_traits<Allocator>::size_type;
+      using size_type       = allocator_traits<Allocator>::size_type;
       using allocator_type  = Allocator;
       using char_type       =
               typename iterator_traits<BidirectionalIterator>::value_type;
@@ -3054,7 +3052,7 @@ the same arguments.
 \begin{codeblock}
 namespace std {
   template<class BidirectionalIterator,
-            class charT = typename iterator_traits<BidirectionalIterator>::value_type,
+            class charT = iterator_traits<BidirectionalIterator>::value_type,
             class traits = regex_traits<charT>>
     class regex_iterator {
     public:
@@ -3323,7 +3321,7 @@ equal when they are constructed from the same arguments.
 \begin{codeblock}
 namespace std {
   template<class BidirectionalIterator,
-            class charT = typename iterator_traits<BidirectionalIterator>::value_type,
+            class charT = iterator_traits<BidirectionalIterator>::value_type,
             class traits = regex_traits<charT>>
     class regex_token_iterator {
     public:

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -797,10 +797,10 @@ namespace std {
     using traits_type            = traits;
     using value_type             = charT;
     using allocator_type         = Allocator;
-    using size_type              = typename allocator_traits<Allocator>::size_type;
-    using difference_type        = typename allocator_traits<Allocator>::difference_type;
-    using pointer                = typename allocator_traits<Allocator>::pointer;
-    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using size_type              = allocator_traits<Allocator>::size_type;
+    using difference_type        = allocator_traits<Allocator>::difference_type;
+    using pointer                = allocator_traits<Allocator>::pointer;
+    using const_pointer          = allocator_traits<Allocator>::const_pointer;
     using reference              = value_type&;
     using const_reference        = const value_type&;
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -4185,7 +4185,7 @@ namespace std {
     using type = @\seebelow@;
   };
   template<class... Ts>
-    using common_comparison_category_t = typename common_comparison_category<Ts...>::type;
+    using common_comparison_category_t = common_comparison_category<Ts...>::type;
 
   // \ref{cmp.concept}, concept \libconcept{three_way_comparable}
   template<class T, class Cat = partial_ordering>
@@ -4197,7 +4197,7 @@ namespace std {
   template<class T, class U = T> struct compare_three_way_result;
 
   template<class T, class U = T>
-    using compare_three_way_result_t = typename compare_three_way_result<T, U>::type;
+    using compare_three_way_result_t = compare_three_way_result<T, U>::type;
 
   // \ref{comparisons.three.way}, class \tcode{compare_three_way}
   struct compare_three_way;
@@ -5120,7 +5120,7 @@ then \tcode{coroutine_traits<R, ArgTypes...>} has the following publicly
 accessible member:
 
 \begin{codeblock}
-using promise_type = typename R::promise_type;
+using promise_type = R::promise_type;
 \end{codeblock}
 
 Otherwise, \tcode{coroutine_traits<R, ArgTypes...>} has no members.

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -4097,7 +4097,7 @@ specialization shall not directly or indirectly make use of that specialization.
 \begin{example}
 \begin{codeblock}
 template <class T> struct A;
-template <class T> using B = typename A<T>::U;
+template <class T> using B = A<T>::U;
 template <class T> struct A {
   typedef B<T> U;
 };
@@ -7071,7 +7071,7 @@ template <C T> typename Z<T>::xx f(void *, T);          // \#1
 template <class T> void f(int, T);                      // \#2
 struct A {} a;
 struct ZZ {
-  template <class T, class = typename Z<T>::xx> operator T *();
+  template <class T, class = Z<T>::xx> operator T *();
   operator int();
 };
 int main() {
@@ -7110,7 +7110,7 @@ if the substitution results in an invalid type or expression.
 \end{note}
 \begin{example}
 \begin{codeblock}
-template <class T> struct A { using X = typename T::X; };
+template <class T> struct A { using X = T::X; };
 template <class T> typename T::X f(typename A<T>::X);
 template <class T> void f(...) { }
 template <class T> auto g(typename A<T>::X) -> typename T::X;

--- a/source/time.tex
+++ b/source/time.tex
@@ -70,7 +70,7 @@ namespace std::chrono {
   template<class Rep, class Period = ratio<1>> class duration;
 
   // \ref{time.point}, class template \tcode{time_point}
-  template<class Clock, class Duration = typename Clock::duration> class time_point;
+  template<class Clock, class Duration = Clock::duration> class time_point;
 }
 
 namespace std {
@@ -1222,7 +1222,7 @@ namespace std::chrono {
   class duration {
   public:
     using rep    = Rep;
-    using period = typename Period::type;
+    using period = Period::type;
 
   private:
     rep rep_;       // \expos
@@ -1810,24 +1810,24 @@ ToDuration::rep, Rep, intmax_t>::type}.
 \begin{itemize}
 \item If \tcode{CF::num == 1} and \tcode{CF::den == 1}, returns
 \begin{codeblock}
-ToDuration(static_cast<typename ToDuration::rep>(d.count()))
+ToDuration(static_cast<ToDuration::rep>(d.count()))
 \end{codeblock}
 
 \item otherwise, if \tcode{CF::num != 1} and \tcode{CF::den == 1}, returns
 \begin{codeblock}
-ToDuration(static_cast<typename ToDuration::rep>(
+ToDuration(static_cast<ToDuration::rep>(
   static_cast<CR>(d.count()) * static_cast<CR>(CF::num)))
 \end{codeblock}
 
 \item otherwise, if \tcode{CF::num == 1} and \tcode{CF::den != 1}, returns
 \begin{codeblock}
-ToDuration(static_cast<typename ToDuration::rep>(
+ToDuration(static_cast<ToDuration::rep>(
   static_cast<CR>(d.count()) / static_cast<CR>(CF::den)))
 \end{codeblock}
 
 \item otherwise, returns
 \begin{codeblock}
-ToDuration(static_cast<typename ToDuration::rep>(
+ToDuration(static_cast<ToDuration::rep>(
   static_cast<CR>(d.count()) * static_cast<CR>(CF::num) / static_cast<CR>(CF::den)))
 \end{codeblock}
 \end{itemize}
@@ -2189,13 +2189,13 @@ that value will be assigned to \tcode{*offset} if \tcode{offset} is non-null.
 \indexlibraryglobal{time_point}%
 \begin{codeblock}
 namespace std::chrono {
-  template<class Clock, class Duration = typename Clock::duration>
+  template<class Clock, class Duration = Clock::duration>
   class time_point {
   public:
     using clock    = Clock;
     using duration = Duration;
-    using rep      = typename duration::rep;
-    using period   = typename duration::period;
+    using rep      = duration::rep;
+    using period   = duration::period;
 
   private:
     duration d_;                                                // \expos

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1412,7 +1412,7 @@ namespace std {
     struct tuple_element<I, tuple<Types...>>;
 
   template<size_t I, class T>
-    using @\libglobal{tuple_element_t}@ = typename tuple_element<I, T>::type;
+    using @\libglobal{tuple_element_t}@ = tuple_element<I, T>::type;
 
   // \ref{tuple.elem}, element access
   template<size_t I, class... Types>
@@ -4465,7 +4465,7 @@ namespace std {
   template<size_t I, class T> struct variant_alternative;       // \notdef
   template<size_t I, class T> struct variant_alternative<I, const T>;
   template<size_t I, class T>
-    using @\libglobal{variant_alternative_t}@ = typename variant_alternative<I, T>::type;
+    using @\libglobal{variant_alternative_t}@ = variant_alternative<I, T>::type;
 
   template<size_t I, class... Types>
     struct variant_alternative<I, variant<Types...>>;
@@ -8400,7 +8400,7 @@ namespace std {
   template<class Alloc> struct allocator_traits {
     using allocator_type     = Alloc;
 
-    using value_type         = typename Alloc::value_type;
+    using value_type         = Alloc::value_type;
 
     using pointer            = @\seebelow@;
     using const_pointer      = @\seebelow@;
@@ -10140,7 +10140,7 @@ template<class T, class D>
 \pnum
 \returns
 \begin{codeblock}
-compare_three_way()(x.get(), static_cast<typename unique_ptr<T, D>::pointer>(nullptr)).
+compare_three_way()(x.get(), static_cast<unique_ptr<T, D>::pointer>(nullptr)).
 \end{codeblock}
 \end{itemdescr}
 
@@ -11320,7 +11320,7 @@ template<class T>
 \pnum
 \returns
 \begin{codeblock}
-compare_three_way()(a.get(), static_cast<typename shared_ptr<T>::element_type*>(nullptr).
+compare_three_way()(a.get(), static_cast<shared_ptr<T>::element_type*>(nullptr).
 \end{codeblock}
 \end{itemdescr}
 
@@ -11356,7 +11356,7 @@ The expression \tcode{static_cast<T*>((U*)nullptr)} is well-formed.
 \pnum
 \returns
 \begin{codeblock}
-shared_ptr<T>(@\placeholder{R}@, static_cast<typename shared_ptr<T>::element_type*>(r.get()))
+shared_ptr<T>(@\placeholder{R}@, static_cast<shared_ptr<T>::element_type*>(r.get()))
 \end{codeblock}
 where \tcode{\placeholder{R}} is \tcode{r} for the first overload, and
 \tcode{std::move(r)} for the second.
@@ -11382,16 +11382,16 @@ template<class T, class U>
 \pnum
 \mandates
 The expression \tcode{dynamic_cast<T*>((U*)nullptr)} is well-formed.
-The expression \tcode{dynamic_cast<typename shared_ptr<T>::element_type*>(r.get())} is well-formed.
+The expression \tcode{dynamic_cast<shared_ptr<T>::element_type*>(r.get())} is well-formed.
 
 \pnum
 \expects
-The expression \tcode{dynamic_cast<typename shared_ptr<T>::element_type*>(r.get())} has well-defined behavior.
+The expression \tcode{dynamic_cast<shared_ptr<T>::element_type*>(r.get())} has well-defined behavior.
 
 \pnum
 \returns
 \begin{itemize}
-\item When \tcode{dynamic_cast<typename shared_ptr<T>::element_type*>(r.get())}
+\item When \tcode{dynamic_cast<shared_ptr<T>::element_type*>(r.get())}
   returns a non-null value \tcode{p},
   \tcode{shared_ptr<T>(\placeholder{R}, p)},
   where \tcode{\placeholder{R}} is \tcode{r} for the first overload, and
@@ -11423,7 +11423,7 @@ The expression \tcode{const_cast<T*>((U*)nullptr)} is well-formed.
 \pnum
 \returns
 \begin{codeblock}
-shared_ptr<T>(@\placeholder{R}@, const_cast<typename shared_ptr<T>::element_type*>(r.get()))
+shared_ptr<T>(@\placeholder{R}@, const_cast<shared_ptr<T>::element_type*>(r.get()))
 \end{codeblock}
 where \tcode{\placeholder{R}} is \tcode{r} for the first overload, and
 \tcode{std::move(r)} for the second.
@@ -11452,7 +11452,7 @@ The expression \tcode{reinterpret_cast<T*>((U*)nullptr)} is well-formed.
 \pnum
 \returns
 \begin{codeblock}
-shared_ptr<T>(@\placeholder{R}@, reinterpret_cast<typename shared_ptr<T>::element_type*>(r.get()))
+shared_ptr<T>(@\placeholder{R}@, reinterpret_cast<shared_ptr<T>::element_type*>(r.get()))
 \end{codeblock}
 where \tcode{\placeholder{R}} is \tcode{r} for the first overload, and
 \tcode{std::move(r)} for the second.
@@ -13599,13 +13599,13 @@ namespace std {
     using outer_allocator_type = OuterAlloc;
     using inner_allocator_type = @\seebelow@;
 
-    using value_type           = typename OuterTraits::value_type;
-    using size_type            = typename OuterTraits::size_type;
-    using difference_type      = typename OuterTraits::difference_type;
-    using pointer              = typename OuterTraits::pointer;
-    using const_pointer        = typename OuterTraits::const_pointer;
-    using void_pointer         = typename OuterTraits::void_pointer;
-    using const_void_pointer   = typename OuterTraits::const_void_pointer;
+    using value_type           = OuterTraits::value_type;
+    using size_type            = OuterTraits::size_type;
+    using difference_type      = OuterTraits::difference_type;
+    using pointer              = OuterTraits::pointer;
+    using const_pointer        = OuterTraits::const_pointer;
+    using void_pointer         = OuterTraits::void_pointer;
+    using const_void_pointer   = OuterTraits::const_void_pointer;
 
     using propagate_on_container_copy_assignment = @\seebelow@;
     using propagate_on_container_move_assignment = @\seebelow@;
@@ -17455,17 +17455,17 @@ namespace std {
   template<class T> struct add_cv;
 
   template<class T>
-    using @\libglobal{remove_const_t}@    = typename remove_const<T>::type;
+    using @\libglobal{remove_const_t}@    = remove_const<T>::type;
   template<class T>
-    using @\libglobal{remove_volatile_t}@ = typename remove_volatile<T>::type;
+    using @\libglobal{remove_volatile_t}@ = remove_volatile<T>::type;
   template<class T>
-    using @\libglobal{remove_cv_t}@       = typename remove_cv<T>::type;
+    using @\libglobal{remove_cv_t}@       = remove_cv<T>::type;
   template<class T>
-    using @\libglobal{add_const_t}@       = typename add_const<T>::type;
+    using @\libglobal{add_const_t}@       = add_const<T>::type;
   template<class T>
-    using @\libglobal{add_volatile_t}@    = typename add_volatile<T>::type;
+    using @\libglobal{add_volatile_t}@    = add_volatile<T>::type;
   template<class T>
-    using @\libglobal{add_cv_t}@          = typename add_cv<T>::type;
+    using @\libglobal{add_cv_t}@          = add_cv<T>::type;
 
   // \ref{meta.trans.ref}, reference modifications
   template<class T> struct remove_reference;
@@ -17473,38 +17473,38 @@ namespace std {
   template<class T> struct add_rvalue_reference;
 
   template<class T>
-    using @\libglobal{remove_reference_t}@     = typename remove_reference<T>::type;
+    using @\libglobal{remove_reference_t}@     = remove_reference<T>::type;
   template<class T>
-    using @\libglobal{add_lvalue_reference_t}@ = typename add_lvalue_reference<T>::type;
+    using @\libglobal{add_lvalue_reference_t}@ = add_lvalue_reference<T>::type;
   template<class T>
-    using @\libglobal{add_rvalue_reference_t}@ = typename add_rvalue_reference<T>::type;
+    using @\libglobal{add_rvalue_reference_t}@ = add_rvalue_reference<T>::type;
 
   // \ref{meta.trans.sign}, sign modifications
   template<class T> struct make_signed;
   template<class T> struct make_unsigned;
 
   template<class T>
-    using @\libglobal{make_signed_t}@   = typename make_signed<T>::type;
+    using @\libglobal{make_signed_t}@   = make_signed<T>::type;
   template<class T>
-    using @\libglobal{make_unsigned_t}@ = typename make_unsigned<T>::type;
+    using @\libglobal{make_unsigned_t}@ = make_unsigned<T>::type;
 
   // \ref{meta.trans.arr}, array modifications
   template<class T> struct remove_extent;
   template<class T> struct remove_all_extents;
 
   template<class T>
-    using @\libglobal{remove_extent_t}@      = typename remove_extent<T>::type;
+    using @\libglobal{remove_extent_t}@      = remove_extent<T>::type;
   template<class T>
-    using @\libglobal{remove_all_extents_t}@ = typename remove_all_extents<T>::type;
+    using @\libglobal{remove_all_extents_t}@ = remove_all_extents<T>::type;
 
   // \ref{meta.trans.ptr}, pointer modifications
   template<class T> struct remove_pointer;
   template<class T> struct add_pointer;
 
   template<class T>
-    using @\libglobal{remove_pointer_t}@ = typename remove_pointer<T>::type;
+    using @\libglobal{remove_pointer_t}@ = remove_pointer<T>::type;
   template<class T>
-    using @\libglobal{add_pointer_t}@    = typename add_pointer<T>::type;
+    using @\libglobal{add_pointer_t}@    = add_pointer<T>::type;
 
   // \ref{meta.trans.other}, other transformations
   template<class T> struct type_identity;
@@ -17525,31 +17525,31 @@ namespace std {
   template<class T> struct unwrap_ref_decay;
 
   template<class T>
-    using @\libglobal{type_identity_t}@    = typename type_identity<T>::type;
+    using @\libglobal{type_identity_t}@    = type_identity<T>::type;
   template<size_t Len, size_t Align = @\textit{default-alignment}@> // see \ref{meta.trans.other}
-    using @\libglobal{aligned_storage_t}@  = typename aligned_storage<Len, Align>::type;
+    using @\libglobal{aligned_storage_t}@  = aligned_storage<Len, Align>::type;
   template<size_t Len, class... Types>
-    using @\libglobal{aligned_union_t}@    = typename aligned_union<Len, Types...>::type;
+    using @\libglobal{aligned_union_t}@    = aligned_union<Len, Types...>::type;
   template<class T>
-    using @\libglobal{remove_cvref_t}@     = typename remove_cvref<T>::type;
+    using @\libglobal{remove_cvref_t}@     = remove_cvref<T>::type;
   template<class T>
-    using @\libglobal{decay_t}@            = typename decay<T>::type;
+    using @\libglobal{decay_t}@            = decay<T>::type;
   template<bool b, class T = void>
-    using @\libglobal{enable_if_t}@        = typename enable_if<b, T>::type;
+    using @\libglobal{enable_if_t}@        = enable_if<b, T>::type;
   template<bool b, class T, class F>
-    using @\libglobal{conditional_t}@      = typename conditional<b, T, F>::type;
+    using @\libglobal{conditional_t}@      = conditional<b, T, F>::type;
   template<class... T>
-    using @\libglobal{common_type_t}@      = typename common_type<T...>::type;
+    using @\libglobal{common_type_t}@      = common_type<T...>::type;
   template<class... T>
-    using @\libglobal{common_reference_t}@ = typename common_reference<T...>::type;
+    using @\libglobal{common_reference_t}@ = common_reference<T...>::type;
   template<class T>
-    using @\libglobal{underlying_type_t}@  = typename underlying_type<T>::type;
+    using @\libglobal{underlying_type_t}@  = underlying_type<T>::type;
   template<class Fn, class... ArgTypes>
-    using @\libglobal{invoke_result_t}@    = typename invoke_result<Fn, ArgTypes...>::type;
+    using @\libglobal{invoke_result_t}@    = invoke_result<Fn, ArgTypes...>::type;
   template<class T>
-    using unwrap_reference_t = typename unwrap_reference<T>::type;
+    using unwrap_reference_t = unwrap_reference<T>::type;
   template<class T>
-    using unwrap_ref_decay_t = typename unwrap_ref_decay<T>::type;
+    using unwrap_ref_decay_t = unwrap_ref_decay<T>::type;
   template<class...>
     using @\libglobal{void_t}@             = void;
 
@@ -21938,7 +21938,7 @@ namespace std {
   class basic_format_parse_context {
   public:
     using char_type = charT;
-    using const_iterator = typename basic_string_view<charT>::const_iterator;
+    using const_iterator = basic_string_view<charT>::const_iterator;
     using iterator = const_iterator;
 
   private:
@@ -22231,7 +22231,7 @@ namespace std {
     class handle;
 
   private:
-    using char_type = typename Context::char_type;                              // \expos
+    using char_type = Context::char_type;                                       // \expos
 
     variant<monostate, bool, char_type,
             int, unsigned int, long long int, unsigned long long int,


### PR DESCRIPTION
- default argument of a _type-parameter_ of a template cleared
- _defining-type-id_ cleared
- _type-id_ of a `static_cast`, `const_cast`, `reinterpret_cast`, or `dynamic_cast` cleared
- _trailing-return-type_ no instance
- _new-type-id_ probably no instance

~~I'm not very sure about the `static_cast<T::type*>` ones.~~

Closes: #3637