### PR TITLE
[stmt.return] Clarify flowing off the end of a function

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -849,7 +849,7 @@ a destructor, or
 a non-coroutine function with a \cv{}~\keyword{void} return type is
 equivalent to a \tcode{return} with no operand.
 Otherwise, flowing off the end of a function
-other than \tcode{main}\iref{basic.start.main} or a coroutine\iref{dcl.fct.def.coroutine}
+that is neither \tcode{main}\iref{basic.start.main} nor a coroutine\iref{dcl.fct.def.coroutine}
 results in undefined behavior.
 
 \pnum


### PR DESCRIPTION
Fixes #5215 