### PR TITLE
[class.mem.general] Add cross-reference for 'layout-compatible type'

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -782,7 +782,7 @@ The \defn{common initial sequence} of two standard-layout struct\iref{class.prop
 types is the longest sequence of non-static data
 members and bit-fields in declaration order, starting with the first
 such entity in each of the structs, such that corresponding entities
-have layout-compatible types,
+have layout-compatible types\iref{basic.types},
 either both entities are declared with
 the \tcode{no_unique_address} attribute\iref{dcl.attr.nouniqueaddr}
 or neither is,


### PR DESCRIPTION
Fixes #5216 