### PR TITLE
[util.smartptr.atomic.general] Fix xref

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -2734,7 +2734,7 @@ Equivalent to: \tcode{return fetch_sub(1) - 1;}
 
 \pnum
 The library provides partial specializations of the \tcode{atomic} template
-for shared-ownership smart pointers\iref{smartptr}.
+for shared-ownership smart pointers\iref{util.sharedptr}.
 \begin{note}
 The partial specializations are declared in header \libheaderref{memory}.
 \end{note}


### PR DESCRIPTION
This should refer to the shared_ptr subclause, not its parent.