### PR TITLE
[temp.res] Move a note outside itemize environment

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -4446,6 +4446,7 @@ in the hypothetical instantiation
 is different from
 the interpretation of the corresponding construct
 in any actual instantiation of the template.
+\end{itemize}
 \begin{note}
 This can happen in situations including the following:
 \begin{itemize}
@@ -4478,7 +4479,6 @@ was not defined when the template was defined or it names an explicit
 specialization that was not declared when the template was defined.
 \end{itemize}
 \end{note}
-\end{itemize}
 
 Otherwise, no diagnostic shall be issued for a template
 for which a valid specialization can be generated.


### PR DESCRIPTION
Situations in the Note are not examples for the last list bullet exclusively (e.g. the first situation is an example for the next to the last normative bullet)
![image](https://user-images.githubusercontent.com/38548419/150654668-1bd83741-339c-4b1e-afe1-70d3ceb5d98e.png)