### PR TITLE
[derivation] Remove 'basic integral type' from footnote

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -3143,12 +3143,12 @@ Every base class not specified as
 \item
 Unless explicitly stated otherwise, types with distinct names shall be distinct
 types.
-\begin{footnote}
+\begin{note}
 There is an implicit exception to this rule for types that are
-described as synonyms for basic integral types, such as
+described as synonyms~(\ref{dcl.typedef}, \ref{namespace.udecl}), such as
 \tcode{size_t}\iref{support.types} and
 \tcode{streamoff}\iref{stream.types}.
-\end{footnote}
+\end{note}
 \end{itemize}
 
 \pnum


### PR DESCRIPTION
Also switch footnote to note.

Partially addresses #5240