### PR TITLE
[iterator.operations] clarify preconditions on std::distance

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2806,10 +2806,10 @@ template<class InputIterator>
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{last} is reachable from \tcode{first}, or
-\tcode{InputIterator} meets
-the \oldconcept{RandomAccessIterator} requirements and
-\tcode{first} is reachable from \tcode{last}.
+If \tcode{InputIterator} meets the \oldconcept{RandomAccessIterator} requirements,
+\tcode{first} is reachable from \tcode{last}; otherwise,
+\tcode{last} is reachable from \tcode{first}.
+
 
 \pnum
 \effects


### PR DESCRIPTION
The prior wording implied that the two sides of the "or" were independent, so as long as `last` was reachable from `first`, `first` didn't need to be reachable from `last` even if passing a `RandomAccessIterator`. It seems clear that it is really trying to express two different possible preconditions depending on whether a `RandomAccessIterator` is passed or not. I used the same phrasing as in the "Effects:" clause to separate the cases.

Alternatively, this precondition seems redundant with http://eel.is/c++draft/iterators#iterator.requirements.general-12, so maybe it should just be removed? This seems to be the only function in [iterators], [ranges], and [algorithms] that has an explicit precondition that iterators passed to it are reachable.