### PR TITLE
Fix order of std-format-spec field descriptions.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -14266,6 +14266,26 @@ In addition, for \tcode{g} and \tcode{G} conversions,
 trailing zeros are not removed from the result.
 
 \pnum
+A zero (\tcode{0}) character
+preceding the \fmtgrammarterm{width} field
+pads the field with leading zeros (following any indication of sign or base)
+to the field width,
+except when applied to an infinity or NaN.
+This option is only valid for
+arithmetic types other than \tcode{charT} and \tcode{bool}
+or when an integer presentation type is specified.
+If the \tcode{0} character and an \fmtgrammarterm{align} option both appear,
+the \tcode{0} character is ignored.
+\begin{example}
+\begin{codeblock}
+char c = 120;
+string s1 = format("{:+06d}", c);       // value of \tcode{s1} is \tcode{"+00120"}
+string s2 = format("{:#06x}", 0xa);     // value of \tcode{s2} is \tcode{"0x000a"}
+string s3 = format("{:<06}", -42);      // value of \tcode{s3} is \tcode{"-42\ \ \ "} (\tcode{0} is ignored because of \tcode{<} alignment)
+\end{codeblock}
+\end{example}
+
+\pnum
 If \tcode{\{ \opt{\fmtgrammarterm{arg-id}} \}} is used in
 a \fmtgrammarterm{width} or \fmtgrammarterm{precision},
 the value of the corresponding formatting argument is used in its place.
@@ -14335,26 +14355,6 @@ The estimated width of other code points is 1.
 
 \pnum
 For a string in a non-Unicode encoding, the width of a string is unspecified.
-
-\pnum
-A zero (\tcode{0}) character
-preceding the \fmtgrammarterm{width} field
-pads the field with leading zeros (following any indication of sign or base)
-to the field width,
-except when applied to an infinity or NaN.
-This option is only valid for
-arithmetic types other than \tcode{charT} and \tcode{bool}
-or when an integer presentation type is specified.
-If the \tcode{0} character and an \fmtgrammarterm{align} option both appear,
-the \tcode{0} character is ignored.
-\begin{example}
-\begin{codeblock}
-char c = 120;
-string s1 = format("{:+06d}", c);       // value of \tcode{s1} is \tcode{"+00120"}
-string s2 = format("{:#06x}", 0xa);     // value of \tcode{s2} is \tcode{"0x000a"}
-string s3 = format("{:<06}", -42);      // value of \tcode{s3} is \tcode{"-42\ \ \ "} (\tcode{0} is ignored because of \tcode{<} alignment)
-\end{codeblock}
-\end{example}
 
 \pnum
 % FIXME: What if it's an arg-id?


### PR DESCRIPTION
Moves the wording describing the zero-padding before the description of
the width; matching the order of the fields in the std-format-spec.

The swapped order was introduced in the initial <format> paper
  P0645R10 Text formatting
Since both fields had one paragraph description it wasn't too noticeable.
  P1868R2 🦄 width: clarifying units of width and precision in std::format
expanded the wording of the width. Now it's not so easy to find the
description of the zero-padding field.