### PR TITLE
[expr.prim.lambda.capture] Fix 'potentially references' for members

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2265,11 +2265,14 @@ an expression potentially references local entities as follows:
 \begin{itemize}
 \item
 An \grammarterm{id-expression} that names a local entity
-potentially references that entity;
-an \grammarterm{id-expression} that names
-one or more non-static class members
-and does not form a pointer to member\iref{expr.unary.op}
-potentially references \tcode{*\keyword{this}}.
+potentially references that entity.
+
+\item
+An \grammarterm{id-expression}
+that is not used to form a pointer to member\iref{expr.unary.op}
+potentially references \tcode{*\keyword{this}}
+if name lookup for its terminal name
+finds one or more non-static members of the current class. % TODO: \termref{current class}
 \begin{note}
 This occurs even if overload resolution
 selects a static member function for the \grammarterm{id-expression}.


### PR DESCRIPTION
This editorially limits capture of `*this` to only when a non-static member of the [current class](http://eel.is/c++draft/expr.prim.this#def:class,current) is found. Currently, naming a non-static member of any unrelated class potentially references `*this`.

I'd wait for #5210 to say `\termref{current class}`.

Fixes #5243