### PR TITLE
P0323R12 std::expected

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2480,7 +2480,6 @@ In namespace \tcode{std}, the following names are reserved for previous standard
 \item \indexlibraryzombie{uncaught_exception} \tcode{uncaught_exception},
 \item \indexlibraryzombie{undeclare_no_pointers} \tcode{undeclare_no_pointers},
 \item \indexlibraryzombie{undeclare_reachable} \tcode{undeclare_reachable},
-\item \indexlibraryzombie{unexpected} \tcode{unexpected},
 and
 \item \indexlibraryzombie{unexpected_handler} \tcode{unexpected_handler}.
 \end{itemize}

--- a/source/support.tex
+++ b/source/support.tex
@@ -610,6 +610,7 @@ the values of these macros with greater values.
   // \libheader{unordered_set}
 #define @\defnlibxname{cpp_lib_exchange_function}@                 201304L // also in \libheader{utility}
 #define @\defnlibxname{cpp_lib_execution}@                         201902L // also in \libheader{execution}
+#define @\defnlibxname{cpp_lib_expected}@                          202202L // also in \libheader{expected}
 #define @\defnlibxname{cpp_lib_filesystem}@                        201703L // also in \libheader{filesystem}
 #define @\defnlibxname{cpp_lib_format}@                            202110L // also in \libheader{format}
 #define @\defnlibxname{cpp_lib_gcd_lcm}@                           201606L // also in \libheader{numeric}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6470,7 +6470,7 @@ bool is_string(const any& operand) {
 \rSec2[expected.general]{In general}
 
 \pnum
-This subclause describes the class template \tcode{expected}
+Subclause \ref{expected} describes the class template \tcode{expected}
 that represents expected objects.
 An \tcode{expected<T, E>} object holds
 an object of type \tcode{T} or an object of type \tcode{unexpected<E>} and
@@ -6485,7 +6485,7 @@ namespace std {
   // \ref{expected.un.object}, class template \tcode{unexpected}
   template<class E> class unexpected;
 
-  // \ref{expected.bad}, class \tcode{bad_expected_access}
+  // \ref{expected.bad}, class template \tcode{bad_expected_access}
   template<class E> class bad_expected_access;
 
   // \ref{expected.bad.void}, specialization for \tcode{void}
@@ -6510,7 +6510,7 @@ namespace std {
 \rSec3[expected.un.general]{General}
 
 \pnum
-This subclause describes the class template \tcode{unexpected}
+Subclause \ref{expected.unexpected} describes the class template \tcode{unexpected}
 that represents unexpected objects stored in \tcode{expected} objects.
 
 \rSec3[expected.un.object]{Class template \tcode{unexpected}}
@@ -6595,7 +6595,7 @@ Any exception thrown by the initialization of \exposid{val}.
 \indexlibraryctor{unexpected}%
 \begin{itemdecl}
 template<class... Args>
-  constexpr explicit unexpected(in_place_t, Args&&...);
+  constexpr explicit unexpected(in_place_t, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6616,7 +6616,7 @@ Any exception thrown by the initialization of \exposid{val}.
 \indexlibraryctor{unexpected}%
 \begin{itemdecl}
 template<class U, class... Args>
-  constexpr explicit unexpected(in_place_t, initializer_list<U>, Args&&...);
+  constexpr explicit unexpected(in_place_t, initializer_list<U> il, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6627,7 +6627,7 @@ template<class U, class... Args>
 \pnum
 \effects
 Direct-non-list-initializes
-\exposid{val} with \tcode{std::forward<Args>(args)...}.
+\exposid{val} with \tcode{il, std::forward<Args>(args)...}.
 
 \pnum
 \throws
@@ -6874,7 +6874,7 @@ namespace std {
 
     // \ref{expected.object.swap}, swap
     constexpr void swap(expected&) noexcept(@\seebelow@);
-    friend constexpr void swap(expected&, expected&) noexcept(@\seebelow@);
+    friend constexpr void swap(expected& x, expected& y) noexcept(noexcept(x.swap(y)));
 
     // \ref{expected.object.obs}, observers
     constexpr const T* operator->() const noexcept;
@@ -6897,7 +6897,7 @@ namespace std {
     template<class U> constexpr T value_or(U&&) &&;
 
     // \ref{expected.object.eq}, equality operators
-    template<class T2, class E2>
+    template<class T2, class E2> requires (!is_void_v<T2>)
       friend constexpr bool operator==(const expected& x, const expected<T2, E2>& y);
     template<class T2>
       friend constexpr bool operator==(const expected&, const T2&);
@@ -7044,7 +7044,7 @@ Any exception thrown by the initialization of \exposid{val} or \exposid{unex}.
 
 \pnum
 \remarks
-The exception specification is
+The exception specification is equivalent to
 \tcode{is_nothrow_move_constructible_v<T> \&\&
 is_nothrow_move_constructible_v<E>}.
 
@@ -7185,7 +7185,7 @@ Let \tcode{GF} be \tcode{const G\&} for the first overload and
 
 \pnum
 \effects
-Direct-non-list-initializes \exposid{unex} with \tcode{std::forward<GF>(e.error())}.
+Direct-non-list-initializes \exposid{unex} with \tcode{std::forward<GF>(e.value())}.
 
 \pnum
 \ensures
@@ -7383,7 +7383,7 @@ This operator is defined as deleted unless:
 \item
 \tcode{is_copy_constructible_v<E>} is \tcode{true} and
 \item
-\tcode{is_nothrow_move_constructible_v<E> || is_nothrow_move_constructible_v<T>}
+\tcode{is_nothrow_move_constructible_v<T> || is_nothrow_move_constructible_v<E>}
 is \tcode{true}.
 \end{itemize}
 \end{itemdescr}
@@ -7434,7 +7434,7 @@ equivalent to: \tcode{has_val = rhs.has_value(); return *this;}
 
 \pnum
 \remarks
-The exception specification is
+The exception specification is equivalent to:
 \begin{codeblock}
 is_nothrow_move_assignable_v<T> && is_nothrow_move_constructible_v<T> &&
 is_nothrow_move_assignable_v<E> && is_nothrow_move_constructible_v<E>
@@ -7609,7 +7609,7 @@ See \tref{expected.object.swap}.
 \begin{floattable}{\tcode{swap(expected\&)} effects}{expected.object.swap}
 {lx{0.35\hsize}x{0.35\hsize}}
 \topline
-& \chdr{\tcode{this->has_value()}} & \rhdr{\tcode{!has_value()}} \\ \capsep
+& \chdr{\tcode{this->has_value()}} & \rhdr{\tcode{!this->has_value()}} \\ \capsep
 \lhdr{\tcode{rhs.has_value()}} &
   equivalent to: \tcode{using std::swap; swap(\exposid{val}, rhs.\exposid{val});} &
   calls \tcode{rhs.swap(*this)} \\
@@ -7654,7 +7654,7 @@ Any exception thrown by the expressions in the \Fundescx{Effects}.
 
 \pnum
 \remarks
-The exception specification is:
+The exception specification is equivalent to:
 \begin{codeblock}
 is_nothrow_move_constructible_v<T> && is_nothrow_swappable_v<T> &&
 is_nothrow_move_constructible_v<E> && is_nothrow_swappable_v<E>
@@ -7809,7 +7809,7 @@ template<class U> constexpr T value_or(U&& v) const&;
 \pnum
 \mandates
 \tcode{is_copy_constructible_v<T>} is \tcode{true} and
-\tcode{is_convertible<U, T>} is \tcode{true}.
+\tcode{is_convertible_v<U, T>} is \tcode{true}.
 
 \pnum
 \returns
@@ -7825,7 +7825,7 @@ template<class U> constexpr T value_or(U&& v) &&;
 \pnum
 \mandates
 \tcode{is_move_constructible_v<T>} is \tcode{true} and
-\tcode{is_convertible<U, T>} is \tcode{true}.
+\tcode{is_convertible_v<U, T>} is \tcode{true}.
 
 \pnum
 \returns
@@ -7855,7 +7855,7 @@ otherwise \tcode{x.error() == y.error()}.
 
 \indexlibrarymember{operator==}{expected}%
 \begin{itemdecl}
-template<class T2> constexpr bool operator==(const expected& x, const T2& v);
+template<class T2> friend constexpr bool operator==(const expected& x, const T2& v);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7874,7 +7874,7 @@ its result is convertible to \tcode{bool}.
 
 \indexlibrarymember{operator==}{expected}%
 \begin{itemdecl}
-template<class E2> constexpr bool operator==(const expected& x, const unexpected<E2>& e);
+template<class E2> friend constexpr bool operator==(const expected& x, const unexpected<E2>& e);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7938,7 +7938,7 @@ public:
 
   // \ref{expected.void.swap}, swap
   constexpr void swap(expected&) noexcept(@\seebelow@);
-  friend constexpr void swap(expected&, expected&) noexcept(@\seebelow@);
+  friend constexpr void swap(expected& x, expected& y) noexcept(noexcept(x.swap(y)));
 
   // \ref{expected.void.obs}, observers
   constexpr explicit operator bool() const noexcept;
@@ -8265,7 +8265,7 @@ Otherwise, equivalent to \tcode{\exposid{unex} = rhs.error()}.
 
 \pnum
 \remarks
-The exception specification is
+The exception specification is equivalent to
 \tcode{is_nothrow_move_constructible_v<E> \&\& is_nothrow_move_assignable_v<E>}.
 
 \pnum
@@ -8343,7 +8343,7 @@ See \tref{expected.void.swap}.
 \begin{floattable}{\tcode{swap(expected\&)} effects}{expected.void.swap}
 {lx{0.35\hsize}x{0.35\hsize}}
 \topline
-& \chdr{\tcode{this->has_value()}} & \rhdr{\tcode{!has_value()}} \\ \capsep
+& \chdr{\tcode{this->has_value()}} & \rhdr{\tcode{!this->has_value()}} \\ \capsep
 \lhdr{\tcode{rhs.has_value()}} &
   no effects &
   calls \tcode{rhs.swap(*this)} \\
@@ -8367,7 +8367,7 @@ Any exception thrown by the expressions in the \Fundescx{Effects}.
 
 \pnum
 \remarks
-The exception specification is
+The exception specification is equivalent to
 \tcode{is_nothrow_move_constructible_v<E> \&\& is_nothrow_swappable_v<E>}.
 \end{itemdescr}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16,6 +16,7 @@ These utilities are summarized in \tref{utilities.summary}.
 \ref{optional}              & Optional objects                  & \tcode{<optional>}    \\ \rowsep
 \ref{variant}               & Variants                          & \tcode{<variant>}     \\ \rowsep
 \ref{any}                   & Storage for any type              & \tcode{<any>}         \\ \rowsep
+\ref{expected}              & Expected objects                  & \tcode{<expected>}    \\ \rowsep
 \ref{bitset}                & Fixed-size sequences of bits      & \tcode{<bitset>}      \\ \rowsep
 \ref{memory}                & Memory                            & \tcode{<cstdlib>}, \tcode{<memory>} \\ \rowsep
 \ref{smartptr}              & Smart pointers                    & \tcode{<memory>}      \\ \rowsep
@@ -6461,6 +6462,2042 @@ bool is_string(const any& operand) {
 }
 \end{codeblock}
 \end{example}
+\end{itemdescr}
+
+\rSec1[expected]{Expected objects}
+\indexlibraryglobal{expected}%
+
+\rSec2[expected.general]{In general}
+
+\pnum
+This subclause describes the class template \tcode{expected}
+that represents expected objects.
+An \tcode{expected<T, E>} object holds
+an object of type \tcode{T} or an object of type \tcode{unexpected<E>} and
+manages the lifetime of the contained objects.
+
+\rSec2[expected.syn]{Header \tcode{<expected>} synopsis}
+
+\indexlibraryglobal{unexpect_t}%
+\indexlibraryglobal{unexpect}%
+\begin{codeblock}
+namespace std {
+  // \ref{expected.un.object}, class template \tcode{unexpected}
+  template<class E> class unexpected;
+
+  // \ref{expected.bad}, class \tcode{bad_expected_access}
+  template<class E> class bad_expected_access;
+
+  // \ref{expected.bad.void}, specialization for \tcode{void}
+  template<> class bad_expected_access<void>;
+
+  // in-place construction of unexpected values
+  struct unexpect_t {
+    explicit unexpect_t() = default;
+  };
+  inline constexpr unexpect_t unexpect{};
+
+  // \ref{expected.expected}, class template \tcode{expected}
+  template<class T, class E> class expected;
+
+  // \ref{expected.void}, partial specialization of \tcode{expected} for \tcode{void} types
+  template<class T, class E> requires is_void_v<T> class expected<T, E>;
+}
+\end{codeblock}
+
+\rSec2[expected.unexpected]{Unexpected objects}
+
+\rSec3[expected.un.general]{General}
+
+\pnum
+This subclause describes the class template \tcode{unexpected}
+that represents unexpected objects stored in \tcode{expected} objects.
+
+\rSec3[expected.un.object]{Class template \tcode{unexpected}}
+
+\rSec4[expected.un.object.general]{General}
+
+\indexlibraryglobal{unexpected}%
+\begin{codeblock}
+namespace std {
+  template<class E>
+  class unexpected {
+  public:
+    constexpr unexpected(const unexpected&) = default;
+    constexpr unexpected(unexpected&&) = default;
+    template<class... Args>
+      constexpr explicit unexpected(in_place_t, Args&&...);
+    template<class U, class... Args>
+      constexpr explicit unexpected(in_place_t, initializer_list<U>, Args&&...);
+    template<class Err = E>
+      constexpr explicit unexpected(Err&&);
+
+    constexpr unexpected& operator=(const unexpected&) = default;
+    constexpr unexpected& operator=(unexpected&&) = default;
+
+    constexpr const E& value() const& noexcept;
+    constexpr E& value() & noexcept;
+    constexpr const E&& value() const&& noexcept;
+    constexpr E&& value() && noexcept;
+
+    constexpr void swap(unexpected& other) noexcept(@\seebelow@);
+
+    template<class E2>
+      friend constexpr bool operator==(const unexpected&, const unexpected<E2>&);
+
+    friend constexpr void swap(unexpected& x, unexpected& y) noexcept(noexcept(x.swap(y)));
+
+  private:
+    E @\exposid{val}@;               // \expos
+  };
+
+  template<class E> unexpected(E) -> unexpected<E>;
+}
+\end{codeblock}
+
+\pnum
+A program that instantiates the definition of \tcode{unexpected} for
+a non-object type,
+an array type,
+a specialization of \tcode{unexpected}, or
+a cv-qualified type
+is ill-formed.
+
+\rSec4[expected.un.ctor]{Constructors}
+
+\indexlibraryctor{unexpected}%
+\begin{itemdecl}
+template<class Err = E>
+  constexpr explicit unexpected(Err&& e);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\begin{itemize}
+\item
+\tcode{is_same_v<remove_cvref_t<Err>, unexpected>} is \tcode{false}; and
+\item
+\tcode{is_same_v<remove_cvref_t<Err>, in_place_t>} is \tcode{false}; and
+\item
+\tcode{is_constructible_v<E, Err>} is \tcode{true}.
+\end{itemize}
+
+\pnum
+\effects
+Direct-non-list-initializes \exposid{val} with \tcode{std::forward<Err>(e)}.
+
+\pnum
+\throws
+Any exception thrown by the initialization of \exposid{val}.
+\end{itemdescr}
+
+\indexlibraryctor{unexpected}%
+\begin{itemdecl}
+template<class... Args>
+  constexpr explicit unexpected(in_place_t, Args&&...);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{is_constructible_v<E, Args...>} is \tcode{true}.
+
+\pnum
+\effects
+Direct-non-list-initializes
+\exposid{val} with \tcode{std::forward<Args>(args)...}.
+
+\pnum
+\throws
+Any exception thrown by the initialization of \exposid{val}.
+\end{itemdescr}
+
+\indexlibraryctor{unexpected}%
+\begin{itemdecl}
+template<class U, class... Args>
+  constexpr explicit unexpected(in_place_t, initializer_list<U>, Args&&...);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{is_constructible_v<E, initializer_list<U>\&, Args...>} is \tcode{true}.
+
+\pnum
+\effects
+Direct-non-list-initializes
+\exposid{val} with \tcode{std::forward<Args>(args)...}.
+
+\pnum
+\throws
+Any exception thrown by the initialization of \exposid{val}.
+\end{itemdescr}
+
+\rSec4[expected.un.obs]{Observers}
+
+\indexlibrarymember{value}{unexpected}%
+\begin{itemdecl}
+constexpr const E& value() const& noexcept;
+constexpr E& value() & noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\exposid{val}.
+\end{itemdescr}
+
+\indexlibrarymember{value}{unexpected}%
+\begin{itemdecl}
+constexpr E&& value() && noexcept;
+constexpr const E&& value() const&& noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{std::move(\exposid{val})}.
+\end{itemdescr}
+
+\rSec4[expected.un.swap]{Swap}
+
+\indexlibrarymember{swap}{unexpected}%
+\begin{itemdecl}
+constexpr void swap(unexpected& other) noexcept(is_nothrow_swappable_v<E>);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\mandates
+\tcode{is_swappable_v<E>} is \tcode{true}.
+
+\pnum
+\effects
+Equivalent to:
+\tcode{using std::swap; swap(\exposid{val}, other.\exposid{val});}
+\end{itemdescr}
+
+\begin{itemdecl}
+friend constexpr void swap(unexpected& x, unexpected& y) noexcept(noexcept(x.swap(y)));
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{is_swappable_v<E>} is \tcode{true}.
+
+\pnum
+\effects
+Equivalent to \tcode{x.swap(y)}.
+\end{itemdescr}
+
+\rSec4[expected.un.eq]{Equality operator}
+
+\indexlibrarymember{operator==}{unexpected}%
+\begin{itemdecl}
+template<class E2>
+  friend constexpr bool operator==(const unexpected& x, const unexpected<E2>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\mandates
+The expression \tcode{x.value() == y.value()} is well-formed and
+its result is convertible to \tcode{bool}.
+
+\pnum
+\returns
+\tcode{x.value() == y.value()}.
+\end{itemdescr}
+
+\rSec2[expected.bad]{Class template \tcode{bad_expected_access}}
+
+\indexlibraryglobal{bad_expected_access}%
+\begin{codeblock}
+namespace std {
+  template<class E>
+  class bad_expected_access : public bad_expected_access<void> {
+  public:
+    explicit bad_expected_access(E);
+    const char* what() const noexcept override;
+    E& error() & noexcept;
+    const E& error() const& noexcept;
+    E&& error() && noexcept;
+    const E&& error() const&& noexcept;
+  private:
+    E @\exposid{val}@;              // \expos
+  };
+}
+\end{codeblock}
+
+\pnum
+The class template \tcode{bad_expected_access}
+defines the type of objects thrown as exceptions to report the situation
+where an attempt is made to access the value of an \tcode{expected<T, E>} object
+for which \tcode{has_value()} is \tcode{false}.
+
+\indexlibraryctor{bad_expected_access}%
+\begin{itemdecl}
+explicit bad_expected_access(E e);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Initializes \exposid{val} with \tcode{std::move(e)}.
+\end{itemdescr}
+
+\indexlibrarymember{error}{bad_expected_access}%
+\begin{itemdecl}
+const E& error() const& noexcept;
+E& error() & noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\exposid{val}.
+\end{itemdescr}
+
+\indexlibrarymember{error}{bad_expected_access}%
+\begin{itemdecl}
+E&& error() && noexcept;
+const E&& error() const&& noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{std::move(\exposid{val})}.
+\end{itemdescr}
+
+\indexlibrarymember{what}{bad_expected_access}%
+\begin{itemdecl}
+const char* what() const noexcept override;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+An implementation-defined \ntbs.
+\end{itemdescr}
+
+\rSec2[expected.bad.void]{Class template specialization \tcode{bad_expected_access<void>}}
+
+\begin{codeblock}
+namespace std {
+  template<>
+  class bad_expected_access<void> : public exception {
+  protected:
+    bad_expected_access() noexcept;
+    bad_expected_access(const bad_expected_access&);
+    bad_expected_access(bad_expected_access&&);
+    bad_expected_access& operator=(const bad_expected_access&);
+    bad_expected_access& operator=(bad_expected_access&&);
+    ~bad_expected_access();
+  public:
+    const char* what() const noexcept override;
+  };
+}
+\end{codeblock}
+
+\indexlibrarymember{what}{bad_expected_access}%
+\begin{itemdecl}
+const char* what() const noexcept override;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+An implementation-defined \ntbs.
+\end{itemdescr}
+
+\rSec2[expected.expected]{Class template \tcode{expected}}
+
+\rSec3[expected.object.general]{General}
+
+\begin{codeblock}
+namespace std {
+  template<class T, class E>
+  class expected {
+  public:
+    using @\libmember{value_type}{expected}@ = T;
+    using @\libmember{error_type}{expected}@ = E;
+    using @\libmember{unexpected_type}{expected}@ = unexpected<E>;
+
+    template<class U>
+    using @\libmember{rebind}{expected}@ = expected<U, error_type>;
+
+    // \ref{expected.object.ctor}, constructors
+    constexpr expected();
+    constexpr explicit(@\seebelow@) expected(const expected&);
+    constexpr explicit(@\seebelow@) expected(expected&&) noexcept(@\seebelow@);
+    template<class U, class G>
+      constexpr explicit(@\seebelow@) expected(const expected<U, G>&);
+    template<class U, class G>
+      constexpr explicit(@\seebelow@) expected(expected<U, G>&&);
+
+    template<class U = T>
+      constexpr explicit(@\seebelow@) expected(U&& v);
+
+    template<class G>
+      constexpr expected(const unexpected<G>&);
+    template<class G>
+      constexpr expected(unexpected<G>&&);
+
+    template<class... Args>
+      constexpr explicit expected(in_place_t, Args&&...);
+    template<class U, class... Args>
+      constexpr explicit expected(in_place_t, initializer_list<U>, Args&&...);
+    template<class... Args>
+      constexpr explicit expected(unexpect_t, Args&&...);
+    template<class U, class... Args>
+      constexpr explicit expected(unexpect_t, initializer_list<U>, Args&&...);
+
+    // \ref{expected.object.dtor}, destructor
+    constexpr ~expected();
+
+    // \ref{expected.object.assign}, assignment
+    constexpr expected& operator=(const expected&);
+    constexpr expected& operator=(expected&&) noexcept(@\seebelow@);
+    template<class U = T> constexpr expected& operator=(U&&);
+    template<class G>
+      constexpr expected& operator=(const unexpected<G>&);
+    template<class G>
+      constexpr expected& operator=(unexpected<G>&&);
+
+    template<class... Args>
+      constexpr T& emplace(Args&&...) noexcept;
+    template<class U, class... Args>
+      constexpr T& emplace(initializer_list<U>, Args&&...) noexcept;
+
+    // \ref{expected.object.swap}, swap
+    constexpr void swap(expected&) noexcept(@\seebelow@);
+    friend constexpr void swap(expected&, expected&) noexcept(@\seebelow@);
+
+    // \ref{expected.object.obs}, observers
+    constexpr const T* operator->() const noexcept;
+    constexpr T* operator->() noexcept;
+    constexpr const T& operator*() const& noexcept;
+    constexpr T& operator*() & noexcept;
+    constexpr const T&& operator*() const&& noexcept;
+    constexpr T&& operator*() && noexcept;
+    constexpr explicit operator bool() const noexcept;
+    constexpr bool has_value() const noexcept;
+    constexpr const T& value() const&;
+    constexpr T& value() &;
+    constexpr const T&& value() const&&;
+    constexpr T&& value() &&;
+    constexpr const E& error() const&;
+    constexpr E& error() &;
+    constexpr const E&& error() const&&;
+    constexpr E&& error() &&;
+    template<class U> constexpr T value_or(U&&) const&;
+    template<class U> constexpr T value_or(U&&) &&;
+
+    // \ref{expected.object.eq}, equality operators
+    template<class T2, class E2>
+      friend constexpr bool operator==(const expected& x, const expected<T2, E2>& y);
+    template<class T2>
+      friend constexpr bool operator==(const expected&, const T2&);
+    template<class E2>
+      friend constexpr bool operator==(const expected&, const unexpected<E2>&);
+
+  private:
+    bool @\exposid{has_val}@;       // \expos
+    union {
+      T @\exposid{val}@;            // \expos
+      E @\exposid{unex}@;           // \expos
+    };
+  };
+}
+\end{codeblock}
+
+\pnum
+Any object of type \tcode{expected<T, E>} either
+contains a value of type \tcode{T} or
+a value of type \tcode{E} within its own storage.
+Implementations are not permitted to use additional storage,
+such as dynamic memory,
+to allocate the object of type \tcode{T} or the object of type E.
+These objects are allocated in a region of the \tcode{expected<T, E>} storage
+suitably aligned for the types \tcode{T} and \tcode{E}.
+Members \exposid{has_val}, \exposid{val}, and \exposid{unex}
+are provided for exposition only.
+\exposid{has_val} indicates whether the \tcode{expected<T, E>} object
+contains an object of type \tcode{T}.
+
+\pnum
+A program
+that instantiates the definition of template \tcode{expected<T, E>}
+for a reference type, a function type, or
+for possibly cv-qualified types \tcode{in_place_t}, \tcode{unexpect_t}, or
+a specialization of \tcode{unexpected} for the \tcode{T} parameter
+is ill-formed.
+A program that instantiates
+the definition of the template \tcode{expected<T, E>}
+with a type for the \tcode{E} parameter
+that is not a valid template argument for \tcode{unexpected} is ill-formed.
+
+\pnum
+When \tcode{T} is not \cv{} \tcode{void}, it shall meet
+the \oldconcept{Destructible} requirements (\tref{cpp17.destructible}).
+\tcode{E} shall meet
+the \oldconcept{Destructible} requirements.
+
+\rSec3[expected.object.ctor]{Constructors}
+
+\indexlibraryctor{expected}%
+\begin{itemdecl}
+constexpr expected();
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{is_default_constructible_v<T>} is \tcode{true}.
+
+\pnum
+\effects
+Value-initializes \exposid{val}.
+
+\pnum
+\ensures
+\tcode{has_value()} is \tcode{true}.
+
+\pnum
+\throws
+Any exception thrown by the initialization of \exposid{val}.
+\end{itemdescr}
+
+\indexlibraryctor{expected}%
+\begin{itemdecl}
+constexpr expected(const expected& rhs);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+If \tcode{rhs.has_value()} is \tcode{true},
+direct-non-list-initializes \exposid{val} with \tcode{*rhs}.
+Otherwise, direct-non-list-initializes \exposid{unex} with \tcode{rhs.error()}.
+
+\pnum
+\ensures
+\tcode{rhs.has_value() == this->has_value()}.
+
+\pnum
+\throws
+Any exception thrown by the initialization of \exposid{val} or \exposid{unex}.
+
+\pnum
+\remarks
+This constructor is defined as deleted unless
+\begin{itemize}
+\item
+\tcode{is_copy_constructible_v<T>} is \tcode{true} and
+\item
+\tcode{is_copy_constructible_v<E>} is \tcode{true}.
+\end{itemize}
+
+\pnum
+This constructor is trivial if
+\begin{itemize}
+\item
+\tcode{is_trivially_copy_constructible_v<T>} is \tcode{true} and
+\item
+\tcode{is_trivially_copy_constructible_v<E>} is \tcode{true}.
+\end{itemize}
+\end{itemdescr}
+
+\indexlibraryctor{expected}%
+\begin{itemdecl}
+constexpr expected(expected&& rhs) noexcept(@\seebelow@);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\begin{itemize}
+\item
+\tcode{is_move_constructible_v<T>} is \tcode{true} and
+\item
+\tcode{is_move_constructible_v<E>} is \tcode{true}.
+\end{itemize}
+
+\pnum
+\effects
+If \tcode{rhs.has_value()} is \tcode{true},
+direct-non-list-initializes \exposid{val} with \tcode{std::move(*rhs)}.
+Otherwise,
+direct-non-list-initializes \exposid{unex} with \tcode{std::move(rhs.error())}.
+
+\pnum
+\ensures
+\tcode{rhs.has_value()} is unchanged;
+\tcode{rhs.has_value() == this->has_value()} is \tcode{true}.
+
+\pnum
+\throws
+Any exception thrown by the initialization of \exposid{val} or \exposid{unex}.
+
+\pnum
+\remarks
+The exception specification is
+\tcode{is_nothrow_move_constructible_v<T> \&\&
+is_nothrow_move_constructible_v<E>}.
+
+\pnum
+This constructor is trivial if
+\begin{itemize}
+\item
+\tcode{is_trivially_move_constructible_v<T>} is \tcode{true} and
+\item
+\tcode{is_trivially_move_constructible_v<E>} is \tcode{true}.
+\end{itemize}
+\end{itemdescr}
+
+\indexlibraryctor{expected}%
+\begin{itemdecl}
+template<class U, class G>
+  constexpr explicit(@\seebelow@) expected(const expected<U, G>& rhs);
+template<class U, class G>
+  constexpr explicit(@\seebelow@) expected(expected<U, G>&& rhs);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let:
+\begin{itemize}
+\item
+\tcode{UF} be \tcode{const U\&} for the first overload and
+\tcode{U} for the second overload.
+\item
+\tcode{GF} be \tcode{const G\&} for the first overload and
+\tcode{G} for the second overload.
+\end{itemize}
+
+\pnum
+\constraints
+\begin{itemize}
+\item
+\tcode{is_constructible_v<T, UF>} is \tcode{true}; and
+\item
+\tcode{is_constructible_v<E, GF>} is \tcode{true}; and
+\item
+\tcode{is_constructible_v<T, expected<U, G>\&>} is \tcode{false}; and
+\item
+\tcode{is_constructible_v<T, expected<U, G>>} is \tcode{false}; and
+\item
+\tcode{is_constructible_v<T, const expected<U, G>\&>} is \tcode{false}; and
+\item
+\tcode{is_constructible_v<T, const expected<U, G>>} is \tcode{false}; and
+\item
+\tcode{is_convertible_v<expected<U, G>\&, T>} is \tcode{false}; and
+\item
+\tcode{is_convertible_v<expected<U, G>\&\&, T>} is \tcode{false}; and
+\item
+\tcode{is_convertible_v<const expected<U, G>\&, T>} is \tcode{false}; and
+\item
+\tcode{is_convertible_v<const expected<U, G>\&\&, T>} is \tcode{false}; and
+\item
+\tcode{is_constructible_v<unexpected<E>, expected<U, G>\&>} is \tcode{false}; and
+\item
+\tcode{is_constructible_v<unexpected<E>, expected<U, G>>} is \tcode{false}; and
+\item
+\tcode{is_constructible_v<unexpected<E>, const expected<U, G>\&>} is \tcode{false}; and
+\item
+\tcode{is_constructible_v<unexpected<E>, const expected<U, G>>} is \tcode{false}.
+\end{itemize}
+
+\pnum
+\effects
+If \tcode{rhs.has_value()},
+direct-non-list-initializes \exposid{val} with \tcode{std::forward<UF>(*rhs)}.
+Otherwise,
+direct-non-list-initializes \exposid{unex} with \tcode{std::forward<GF>(rhs.error())}.
+
+\pnum
+\ensures
+\tcode{rhs.has_value()} is unchanged;
+\tcode{rhs.has_value() == this->has_value()} is \tcode{true}.
+
+\pnum
+\throws
+Any exception thrown by the initialization of \exposid{val} or \exposid{unex}.
+
+\pnum
+\remarks
+The expression inside \tcode{explicit} is equivalent to
+\tcode{!is_convertible_v<UF, T> || !is_convertible_v<GF, E>}.
+\end{itemdescr}
+
+\indexlibraryctor{expected}%
+\begin{itemdecl}
+template<class U = T>
+  constexpr explicit(!is_convertible_v<U, T>) expected(U&& v);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\begin{itemize}
+\item
+\tcode{is_same_v<remove_cvref_t<U>, in_place_t>} is \tcode{false}; and
+\item
+\tcode{is_same_v<expected<T, E>, remove_cvref_t<U>>} is \tcode{false}; and
+\item
+\tcode{remove_cvref_t<U>} is not a specialization of \tcode{unexpected}; and
+\item
+\tcode{is_constructible_v<T, U>} is \tcode{true}.
+\end{itemize}
+
+\pnum
+\effects
+Direct-non-list-initializes \exposid{val} with \tcode{std::forward<U>(v)}.
+
+\pnum
+\ensures
+\tcode{has_value()} is \tcode{true}.
+
+\pnum
+\throws
+Any exception thrown by the initialization of \exposid{val}.
+\end{itemdescr}
+
+\indexlibraryctor{expected}%
+\begin{itemdecl}
+template<class G>
+  constexpr explicit(!is_convertible_v<const G&, E>) expected(const unexpected<G>& e);
+template<class G>
+  constexpr explicit(!is_convertible_v<G, E>) expected(unexpected<G>&& e);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{GF} be \tcode{const G\&} for the first overload and
+\tcode{G} for the second overload.
+
+\pnum
+\constraints
+\tcode{is_constructible_v<E, GF>} is \tcode{true}.
+
+\pnum
+\effects
+Direct-non-list-initializes \exposid{unex} with \tcode{std::forward<GF>(e.error())}.
+
+\pnum
+\ensures
+\tcode{has_value()} is \tcode{false}.
+
+\pnum
+\throws
+Any exception thrown by the initialization of \exposid{unex}.
+\end{itemdescr}
+
+\indexlibraryctor{expected}%
+\begin{itemdecl}
+template<class... Args>
+  constexpr explicit expected(in_place_t, Args&&... args);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{is_constructible_v<T, Args...>} is \tcode{true}.
+
+\pnum
+\effects
+Direct-non-list-initializes \exposid{val} with \tcode{std::forward<Args>(args)...}.
+
+\pnum
+\ensures
+\tcode{has_value()} is \tcode{true}.
+
+\pnum
+\throws
+Any exception thrown by the initialization of \exposid{val}.
+\end{itemdescr}
+
+\indexlibraryctor{expected}%
+\begin{itemdecl}
+template<class U, class... Args>
+  constexpr explicit expected(in_place_t, initializer_list<U> il, Args&&... args);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{is_constructible_v<T, initializer_list<U>\&, Args...>} is \tcode{true}.
+
+\pnum
+\effects
+Direct-non-list-initializes \exposid{val} with
+\tcode{il, std::forward<Args>(args)...}.
+
+\pnum
+\ensures
+\tcode{has_value()} is \tcode{true}.
+
+\pnum
+\throws
+Any exception thrown by the initialization of \exposid{val}.
+\end{itemdescr}
+
+\indexlibraryctor{expected}%
+\begin{itemdecl}
+template<class... Args>
+  constexpr explicit expected(unexpect_t, Args&&... args);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{is_constructible_v<E, Args...>} is \tcode{true}.
+
+\pnum
+\effects
+Direct-non-list-initializes \exposid{unex} with
+\tcode{std::forward<Args>(args)...}.
+
+\pnum
+\ensures
+\tcode{has_value()} is \tcode{false}.
+
+\pnum
+\throws
+Any exception thrown by the initialization of \exposid{unex}.
+\end{itemdescr}
+
+\indexlibraryctor{expected}%
+\begin{itemdecl}
+template<class U, class... Args>
+  constexpr explicit expected(unexpect_t, initializer_list<U> il, Args&&... args);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{is_constructible_v<E, initializer_list<U>\&, Args...>} is \tcode{true}.
+
+\pnum
+\effects
+Direct-non-list-initializes \exposid{unex} with
+\tcode{il, std::forward<Args>(args)...}.
+
+\pnum
+\ensures
+\tcode{has_value()} is \tcode{false}.
+
+\pnum
+\throws
+Any exception thrown by the initialization of \exposid{unex}.
+\end{itemdescr}
+
+\rSec3[expected.object.dtor]{Destructor}
+
+\indexlibrarydtor{expected}%
+\begin{itemdecl}
+constexpr ~expected();
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+If \tcode{has_value()} is \tcode{true}, destroys \exposid{val},
+otherwise destroys \exposid{unex}.
+
+\pnum
+\remarks
+If \tcode{is_trivially_destructible_v<T>} is \tcode{true}, and
+\tcode{is_trivially_destructible_v<E>} is \tcode{true},
+then this destructor is a trivial destructor.
+\end{itemdescr}
+
+\rSec3[expected.object.assign]{Assignment}
+
+\pnum
+This subclause makes use of the following exposition-only function:
+\begin{codeblock}
+template<class T, class U, class... Args>
+constexpr void @\exposid{reinit-expected}@(T& newval, U& oldval, Args&&... args) {  // \expos
+  if constexpr (is_nothrow_constructible_v<T, Args...>) {
+    destroy_at(addressof(oldval));
+    construct_at(addressof(newval), std::forward<Args>(args)...);
+  } else if constexpr (is_nothrow_move_constructible_v<T>) {
+    T tmp(std::forward<Args>(args)...);
+    destroy_at(addressof(oldval));
+    construct_at(addressof(newval), std::move(tmp));
+  } else {
+    U tmp(std::move(oldval));
+    destroy_at(addressof(oldval));
+    try {
+      construct_at(addressof(newval), std::forward<Args>(args)...);
+    } catch (...) {
+      construct_at(addressof(oldval), std::move(tmp));
+      throw;
+    }
+  }
+}
+\end{codeblock}
+
+\indexlibrarymember{operator=}{expected}%
+\begin{itemdecl}
+constexpr expected& operator=(const expected& rhs);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+\begin{itemize}
+\item
+If \tcode{this->has_value() \&\& rhs.has_value()} is \tcode{true},
+equivalent to \tcode{\exposid{val} = *rhs}.
+\item
+Otherwise, if \tcode{this->has_value()} is \tcode{true}, equivalent to:
+\begin{codeblock}
+@\exposid{reinit-expected}@(@\exposid{unex}@, @\exposid{val}@, rhs.error())
+\end{codeblock}
+\item
+Otherwise, if \tcode{rhs.has_value()} is \tcode{true}, equivalent to:
+\begin{codeblock}
+@\exposid{reinit-expected}@(@\exposid{val}@, @\exposid{unex}@, *rhs)
+\end{codeblock}
+\item
+Otherwise, equivalent to \tcode{\exposid{unex} = rhs.error()}.
+\end{itemize}
+Then, if no exception was thrown,
+equivalent to: \tcode{\exposid{has_val} = rhs.has_value(); return *this;}
+
+\pnum
+\remarks
+This operator is defined as deleted unless:
+\begin{itemize}
+\item
+\tcode{is_copy_assignable_v<T>} is \tcode{true} and
+\item
+\tcode{is_copy_constructible_v<T>} is \tcode{true} and
+\item
+\tcode{is_copy_assignable_v<E>} is \tcode{true} and
+\item
+\tcode{is_copy_constructible_v<E>} is \tcode{true} and
+\item
+\tcode{is_nothrow_move_constructible_v<E> || is_nothrow_move_constructible_v<T>}
+is \tcode{true}.
+\end{itemize}
+\end{itemdescr}
+
+\indexlibrarymember{operator=}{expected}%
+\begin{itemdecl}
+constexpr expected& operator=(expected&& rhs) noexcept(@\seebelow@);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\begin{itemize}
+\item
+\tcode{is_move_constructible_v<T>} is \tcode{true} and
+\item
+\tcode{is_move_assignable_v<T>} is \tcode{true} and
+\item
+\tcode{is_move_constructible_v<E>} is \tcode{true} and
+\item
+\tcode{is_move_assignable_v<E>} is \tcode{true} and
+\item
+\tcode{is_nothrow_move_constructible_v<T> || is_nothrow_move_constructible_v<E>}
+is \tcode{true}.
+\end{itemize}
+
+\pnum
+\effects
+\begin{itemize}
+\item
+If \tcode{this->has_value() \&\& rhs.has_value()} is \tcode{true},
+equivalent to \tcode{\exposid{val} = std::move(*rhs)}.
+\item
+Otherwise, if \tcode{this->has_value()} is \tcode{true}, equivalent to:
+\begin{codeblock}
+@\exposid{reinit-expected}@(@\exposid{unex}@, @\exposid{val}@, std::move(rhs.error()))
+\end{codeblock}
+\item
+Otherwise, if \tcode{rhs.has_value()} is \tcode{true}, equivalent to:
+\begin{codeblock}
+@\exposid{reinit-expected}@(@\exposid{val}@, @\exposid{unex}@, std::move(*rhs))
+\end{codeblock}
+\item
+Otherwise, equivalent to \tcode{\exposid{unex} = std::move(rhs.error())}.
+\end{itemize}
+Then, if no exception was thrown,
+equivalent to: \tcode{has_val = rhs.has_value(); return *this;}
+
+\pnum
+\remarks
+The exception specification is
+\begin{codeblock}
+is_nothrow_move_assignable_v<T> && is_nothrow_move_constructible_v<T> &&
+is_nothrow_move_assignable_v<E> && is_nothrow_move_constructible_v<E>
+\end{codeblock}
+\end{itemdescr}
+
+\indexlibrarymember{operator=}{expected}%
+\begin{itemdecl}
+template<class U = T>
+  constexpr expected& operator=(U&& v);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\begin{itemize}
+\item
+\tcode{is_same_v<expected, remove_cvref_t<U>>} is \tcode{false}; and
+\item
+\tcode{remove_cvref_t<U>} is not a specialization of \tcode{unexpected}; and
+\item
+\tcode{is_constructible_v<T, U>} is \tcode{true}; and
+\item
+\tcode{is_assignable_v<T\&, U>} is \tcode{true}; and
+\item
+\tcode{is_nothrow_constructible_v<T, U> || is_nothrow_move_constructible_v<T> ||\newline
+is_nothrow_move_constructible_v<E>}
+is \tcode{true}.
+\end{itemize}
+
+\pnum
+\effects
+\begin{itemize}
+\item
+If \tcode{has_value()} is \tcode{true},
+equivalent to: \tcode{\exposid{val} = std::forward<U>(v);}
+\item
+Otherwise, equivalent to:
+\begin{codeblock}
+@\exposid{reinit-expected}@(@\exposid{val}@, @\exposid{unex}@, std::forward<U>(v));
+@\exposid{has_val}@ = true;
+\end{codeblock}
+\end{itemize}
+
+\pnum
+\returns
+\tcode{*this}.
+\end{itemdescr}
+
+\indexlibrarymember{operator=}{expected}%
+\begin{itemdecl}
+template<class G>
+  constexpr expected& operator=(const unexpected<G>& e);
+template<class G>
+  constexpr expected& operator=(unexpected<G>&& e);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{GF} be \tcode{const G\&} for the first overload and
+\tcode{G} for the second overload.
+
+\pnum
+\constraints
+\begin{itemize}
+\item
+\tcode{is_constructible_v<E, GF>} is \tcode{true}; and
+\item
+\tcode{is_assignable_v<E\&, GF>} is \tcode{true}; and
+\item
+\tcode{is_nothrow_constructible_v<E, GF> || is_nothrow_move_constructible_v<T> ||\newline
+is_nothrow_move_constructible_v<E>} is \tcode{true}.
+\end{itemize}
+
+\pnum
+\effects
+\begin{itemize}
+\item
+If \tcode{has_value()} is \tcode{true}, equivalent to:
+\begin{codeblock}
+@\exposid{reinit-expected}@(@\exposid{unex}@, @\exposid{val}@, std::forward<GF>(e.value()));
+@\exposid{has_val}@ = false;
+\end{codeblock}
+\item
+Otherwise, equivalent to:
+\tcode{\exposid{unex} = std::forward<GF>(e.value());}
+\end{itemize}
+
+\pnum
+\returns
+\tcode{*this}.
+\end{itemdescr}
+
+\indexlibrarymember{emplace}{expected}%
+\begin{itemdecl}
+template<class... Args>
+  constexpr T& emplace(Args&&... args) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{is_nothrow_constructible_v<T, Args...>} is \tcode{true}.
+
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+if (has_value()) {
+  destroy_at(addressof(@\exposid{val}@));
+} else {
+  destroy_at(addressof(@\exposid{unex}@));
+  @\exposid{has_val}@ = true;
+}
+return *construct_at(addressof(@\exposid{val}@), std::forward<Args>(args)...);
+\end{codeblock}
+\end{itemdescr}
+
+\indexlibrarymember{emplace}{expected}%
+\begin{itemdecl}
+template<class U, class... Args>
+  constexpr T& emplace(initializer_list<U> il, Args&&... args) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{is_nothrow_constructible_v<T, initializer_list<U>\&, Args...>}
+is \tcode{true}.
+
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+if (has_value()) {
+  destroy_at(addressof(@\exposid{val}@));
+} else {
+  destroy_at(addressof(@\exposid{unex}@));
+  @\exposid{has_val}@ = true;
+}
+return *construct_at(addressof(@\exposid{val}@), il, std::forward<Args>(args)...);
+\end{codeblock}
+\end{itemdescr}
+
+\rSec3[expected.object.swap]{Swap}
+
+\indexlibrarymember{swap}{expected}%
+\begin{itemdecl}
+constexpr void swap(expected& rhs) noexcept(@\seebelow@);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\begin{itemize}
+\item
+\tcode{is_swappable_v<T>} is \tcode{true} and
+\item
+\tcode{is_swappable_v<E>} is \tcode{true} and
+\item
+\tcode{is_move_constructible_v<T> \&\& is_move_constructible_v<E>}
+is \tcode{true}, and
+\item
+\tcode{is_nothrow_move_constructible_v<T> || is_nothrow_move_constructible_v<E>}
+is \tcode{true}.
+\end{itemize}
+
+\pnum
+\effects
+See \tref{expected.object.swap}.
+
+\begin{floattable}{\tcode{swap(expected\&)} effects}{expected.object.swap}
+{lx{0.35\hsize}x{0.35\hsize}}
+\topline
+& \chdr{\tcode{this->has_value()}} & \rhdr{\tcode{!has_value()}} \\ \capsep
+\lhdr{\tcode{rhs.has_value()}} &
+  equivalent to: \tcode{using std::swap; swap(\exposid{val}, rhs.\exposid{val});} &
+  calls \tcode{rhs.swap(*this)} \\
+\lhdr{\tcode{!rhs.has_value()}} &
+  \seebelow &
+  equivalent to: \tcode{using std::swap; swap(\exposid{unex}, rhs.\exposid{unex});} \\
+\end{floattable}
+
+For the case where \tcode{rhs.value()} is \tcode{false} and
+\tcode{this->has_value()} is \tcode{true}, equivalent to:
+\begin{codeblock}
+if constexpr (is_nothrow_move_constructible_v<E>) {
+  E tmp(std::move(rhs.@\exposid{unex}@));
+  destroy_at(addressof(rhs.@\exposid{unex}@));
+  try {
+    construct_at(addressof(rhs.@\exposid{val}@), std::move(@\exposid{val}@));
+    destroy_at(addressof(@\exposid{val}@));
+    construct_at(addressof(@\exposid{unex}@), std::move(tmp));
+  } catch(...) {
+    construct_at(addressof(rhs.@\exposid{unex}@), std::move(tmp));
+    throw;
+  }
+} else {
+  T tmp(std::move(@\exposid{val}@));
+  destroy_at(addressof(@\exposid{val}@));
+  try {
+    construct_at(addressof(@\exposid{unex}@), std::move(rhs.@\exposid{unex}@));
+    destroy_at(addressof(rhs.@\exposid{unex}@));
+    construct_at(addressof(rhs.@\exposid{val}@), std::move(tmp));
+  } catch (...) {
+    construct_at(addressof(@\exposid{val}@), std::move(tmp));
+    throw;
+  }
+}
+@\exposid{has_val}@ = false;
+rhs.@\exposid{has_val}@ = true;
+\end{codeblock}
+
+\pnum
+\throws
+Any exception thrown by the expressions in the \Fundescx{Effects}.
+
+\pnum
+\remarks
+The exception specification is:
+\begin{codeblock}
+is_nothrow_move_constructible_v<T> && is_nothrow_swappable_v<T> &&
+is_nothrow_move_constructible_v<E> && is_nothrow_swappable_v<E>
+\end{codeblock}
+\end{itemdescr}
+
+\indexlibrarymember{swap}{expected}%
+\begin{itemdecl}
+friend constexpr void swap(expected& x, expected& y) noexcept(noexcept(x.swap(y)));
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to \tcode{x.swap(y)}.
+\end{itemdescr}
+
+\rSec3[expected.object.obs]{Observers}
+
+\indexlibrarymember{operator->}{expected}%
+\begin{itemdecl}
+constexpr const T* operator->() const noexcept;
+constexpr T* operator->() noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{has_value()} is \tcode{true}.
+
+\pnum
+\returns
+\tcode{addressof(\exposid{val})}.
+\end{itemdescr}
+
+\indexlibrarymember{operator*}{expected}%
+\begin{itemdecl}
+constexpr const T& operator*() const& noexcept;
+constexpr T& operator*() & noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{has_value()} is \tcode{true}.
+
+\pnum
+\returns
+\exposid{val}.
+\end{itemdescr}
+
+\indexlibrarymember{operator*}{expected}%
+\begin{itemdecl}
+constexpr T&& operator*() && noexcept;
+constexpr const T&& operator*() const&& noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{has_value()} is \tcode{true}.
+
+\pnum
+\returns
+\tcode{std::move(\exposid{val})}.
+\end{itemdescr}
+
+\indexlibrarymember{operator bool}{expected}%
+\indexlibrarymember{has_value}{expected}%
+\begin{itemdecl}
+constexpr explicit operator bool() const noexcept;
+constexpr bool has_value() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\exposid{has_val}.
+\end{itemdescr}
+
+\indexlibrarymember{value}{expected}%
+\begin{itemdecl}
+constexpr const T& value() const&;
+constexpr T& value() &;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\exposid{val}, if \tcode{has_value()} is \tcode{true}.
+
+\pnum
+\throws
+\tcode{bad_expected_access(error())} if \tcode{has_value()} is \tcode{false}.
+\end{itemdescr}
+
+\indexlibrarymember{value}{expected}%
+\begin{itemdecl}
+constexpr T&& value() &&;
+constexpr const T&& value() const&&;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{std::move(\exposid{val})}, if \tcode{has_value()} is \tcode{true}.
+
+\pnum
+\throws
+\tcode{bad_expected_access(std::move(error()))}
+if \tcode{has_value()} is \tcode{false}.
+\end{itemdescr}
+
+\indexlibrarymember{error}{expected}%
+\begin{itemdecl}
+constexpr const E& error() const& noexcept;
+constexpr E& error() & noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{has_value()} is \tcode{false}.
+
+\pnum
+\returns
+\exposid{unex}.
+\end{itemdescr}
+
+\indexlibrarymember{error}{expected}%
+\begin{itemdecl}
+constexpr E&& error() && noexcept;
+constexpr const E&& error() const&& noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{has_value()} is \tcode{false}.
+
+\pnum
+\returns
+\tcode{std::move(\exposid{unex})}.
+\end{itemdescr}
+
+\indexlibrarymember{value_or}{expected}%
+\begin{itemdecl}
+template<class U> constexpr T value_or(U&& v) const&;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\mandates
+\tcode{is_copy_constructible_v<T>} is \tcode{true} and
+\tcode{is_convertible<U, T>} is \tcode{true}.
+
+\pnum
+\returns
+\tcode{has_value() ? **this : static_cast<T>(std::forward<U>(v))}.
+\end{itemdescr}
+
+\indexlibrarymember{value_or}{expected}%
+\begin{itemdecl}
+template<class U> constexpr T value_or(U&& v) &&;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\mandates
+\tcode{is_move_constructible_v<T>} is \tcode{true} and
+\tcode{is_convertible<U, T>} is \tcode{true}.
+
+\pnum
+\returns
+\tcode{has_value() ? std::move(**this) : static_cast<T>(std::forward<U>(v))}.
+\end{itemdescr}
+
+\rSec3[expected.object.eq]{Equality operators}
+
+\indexlibrarymember{operator==}{expected}%
+\begin{itemdecl}
+template<class T2, class E2> requires (!is_void_v<T2>)
+  friend constexpr bool operator==(const expected& x, const expected<T2, E2>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\mandates
+The expressions \tcode{*x == *y} and \tcode{x.error() == y.error()}
+are well-formed and their results are convertible to \tcode{bool}.
+
+\pnum
+\returns
+If \tcode{x.has_value()} does not equal \tcode{y.has_value()}, \tcode{false};
+otherwise if \tcode{x.has_value()} is \tcode{true}, \tcode{*x == *y};
+otherwise \tcode{x.error() == y.error()}.
+\end{itemdescr}
+
+\indexlibrarymember{operator==}{expected}%
+\begin{itemdecl}
+template<class T2> constexpr bool operator==(const expected& x, const T2& v);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\mandates
+The expression \tcode{*x == v} is well-formed and
+its result is convertible to \tcode{bool}.
+\begin{note}
+\tcode{T1} need not be \oldconcept{EqualityComparable}.
+\end{note}
+
+\pnum
+\returns
+\tcode{x.has_value() \&\& static_cast<bool>(*x == v)}.
+\end{itemdescr}
+
+\indexlibrarymember{operator==}{expected}%
+\begin{itemdecl}
+template<class E2> constexpr bool operator==(const expected& x, const unexpected<E2>& e);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\mandates
+The expression \tcode{x.error() == e.value()} is well-formed and
+its result is convertible to \tcode{bool}.
+
+\pnum
+\returns
+\tcode{!x.has_value() \&\& static_cast<bool>(x.error() == e.value())}.
+\end{itemdescr}
+
+\rSec2[expected.void]{Partial specialization of \tcode{expected} for \tcode{void} types}
+
+\rSec3[expected.void.general]{General}
+
+\begin{codeblock}
+template<class T, class E> requires is_void_v<T>
+class expected<T, E> {
+public:
+  using @\libmember{value_type}{expected<void>}@ = T;
+  using @\libmember{error_type}{expected<void>}@ = E;
+  using @\libmember{unexpected_type}{expected<void>}@ = unexpected<E>;
+
+  template<class U>
+  using @\libmember{rebind}{expected<void>}@ = expected<U, error_type>;
+
+  // \ref{expected.void.ctor}, constructors
+  constexpr expected() noexcept;
+  constexpr explicit(@\seebelow@) expected(const expected&);
+  constexpr explicit(@\seebelow@) expected(expected&&) noexcept(@\seebelow@);
+  template<class U, class G>
+    constexpr explicit(@\seebelow@) expected(const expected<U, G>&);
+  template<class U, class G>
+    constexpr explicit(@\seebelow@) expected(expected<U, G>&&);
+
+  template<class G>
+    constexpr expected(const unexpected<G>&);
+  template<class G>
+    constexpr expected(unexpected<G>&&);
+
+  constexpr explicit expected(in_place_t) noexcept;
+  template<class... Args>
+    constexpr explicit expected(unexpect_t, Args&&...);
+  template<class U, class... Args>
+    constexpr explicit expected(unexpect_t, initializer_list<U>, Args&&...);
+
+
+  // \ref{expected.void.dtor}, destructor
+  constexpr ~expected();
+
+  // \ref{expected.void.assign}, assignment
+  constexpr expected& operator=(const expected&);
+  constexpr expected& operator=(expected&&) noexcept(@\seebelow@);
+  template<class G>
+    constexpr expected& operator=(const unexpected<G>&);
+  template<class G>
+    constexpr expected& operator=(unexpected<G>&&);
+  constexpr void emplace() noexcept;
+
+  // \ref{expected.void.swap}, swap
+  constexpr void swap(expected&) noexcept(@\seebelow@);
+  friend constexpr void swap(expected&, expected&) noexcept(@\seebelow@);
+
+  // \ref{expected.void.obs}, observers
+  constexpr explicit operator bool() const noexcept;
+  constexpr bool has_value() const noexcept;
+  constexpr void operator*() const noexcept;
+  constexpr void value() const&;
+  constexpr void value() &&;
+  constexpr const E& error() const&;
+  constexpr E& error() &;
+  constexpr const E&& error() const&&;
+  constexpr E&& error() &&;
+
+  // \ref{expected.void.eq}, equality operators
+  template<class T2, class E2> requires is_void_v<T2>
+    friend constexpr bool operator==(const expected& x, const expected<T2, E2>& y);
+  template<class E2>
+    friend constexpr bool operator==(const expected&, const unexpected<E2>&);
+
+private:
+  bool @\exposid{has_val}@;         // \expos
+  union {
+    E @\exposid{unex}@;             // \expos
+  };
+};
+\end{codeblock}
+
+\pnum
+\tcode{E} shall meet the requirements of
+\oldconcept{Destructible} (\tref{cpp17.destructible}).
+
+\rSec3[expected.void.ctor]{Constructors}
+
+\indexlibraryctor{expected<void>}%
+\begin{itemdecl}
+constexpr expected() noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ensures
+\tcode{has_value()} is \tcode{true}.
+\end{itemdescr}
+
+\indexlibraryctor{expected<void>}%
+\begin{itemdecl}
+constexpr expected(const expected& rhs);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+If \tcode{rhs.has_value()} is \tcode{false},
+direct-non-list-initializes \exposid{unex} with \tcode{rhs.error()}.
+
+\pnum
+\ensures
+\tcode{rhs.has_value() == this->has_value()}.
+
+\pnum
+\throws
+Any exception thrown by the initialization of \exposid{unex}.
+
+\pnum
+\remarks
+This constructor is defined as deleted
+unless \tcode{is_copy_constructible_v<E>} is \tcode{true}.
+
+\pnum
+This constructor is trivial
+if \tcode{is_trivially_copy_constructible_v<E>} is \tcode{true}.
+\end{itemdescr}
+
+\indexlibraryctor{expected<void>}%
+\begin{itemdecl}
+constexpr expected(expected&& rhs) noexcept(is_nothrow_move_constructible_v<E>);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{is_move_constructible_v<E>} is \tcode{true}.
+
+\pnum
+\effects
+If \tcode{rhs.has_value()} is \tcode{false},
+direct-non-list-initializes \exposid{unex} with \tcode{std::move(rhs.error())}.
+
+\pnum
+\ensures
+\tcode{rhs.has_value()} is unchanged;
+\tcode{rhs.has_value() == this->has_value()} is \tcode{true}.
+
+\pnum
+\throws
+Any exception thrown by the initialization of \exposid{unex}.
+
+\pnum
+\remarks
+This constructor is trivial
+if \tcode{is_trivially_move_constructible_v<E>} is \tcode{true}.
+\end{itemdescr}
+
+\indexlibraryctor{expected<void>}%
+\begin{itemdecl}
+template<class U, class G>
+  constexpr explicit(!is_convertible_v<const G&, E>) expected(const expected<U, G>& rhs);
+template<class U, class G>
+  constexpr explicit(!is_convertible_v<G, E>) expected(expected<U, G>&& rhs);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{GF} be \tcode{const G\&} for the first overload and
+\tcode{G} for the second overload.
+
+\pnum
+\constraints
+\begin{itemize}
+\item
+\tcode{is_void_v<U>} is \tcode{true}; and
+\item
+\tcode{is_constructible_v<E, GF>} is \tcode{true}; and
+\item
+\tcode{is_constructible_v<unexpected<E>, expected<U, G>\&>}
+is \tcode{false}; and
+\item
+\tcode{is_constructible_v<unexpected<E>, expected<U, G>>}
+is \tcode{false}; and
+\item
+\tcode{is_constructible_v<unexpected<E>, const expected<U, G>\&>}
+is \tcode{false}; and
+\item
+\tcode{is_constructible_v<unexpected<E>, const expected<U, G>>}
+is \tcode{false}.
+\end{itemize}
+
+\pnum
+\effects
+If \tcode{rhs.has_value()} is \tcode{false},
+direct-non-list-initializes \exposid{unex}
+with \tcode{std::forward<GF>(rhs.er\-ror())}.
+
+\pnum
+\ensures
+\tcode{rhs.has_value()} is unchanged;
+\tcode{rhs.has_value() == this->has_value()} is \tcode{true}.
+
+\pnum
+\throws
+Any exception thrown by the initialization of \exposid{unex}.
+\end{itemdescr}
+
+\indexlibraryctor{expected<void>}%
+\begin{itemdecl}
+template<class G>
+  constexpr explicit(!is_convertible_v<const G&, E>) expected(const unexpected<G>& e);
+template<class G>
+  constexpr explicit(!is_convertible_v<G, E>) expected(unexpected<G>&& e);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{GF} be \tcode{const G\&} for the first overload and
+\tcode{G} for the second overload.
+
+\pnum
+\constraints
+\tcode{is_constructible_v<E, GF>} is \tcode{true}.
+
+\pnum
+\effects
+Direct-non-list-initializes \exposid{unex}
+with \tcode{std::forward<GF>(e.value())}.
+
+\pnum
+\ensures
+\tcode{has_value()} is \tcode{false}.
+
+\pnum
+\throws
+Any exception thrown by the initialization of \exposid{unex}.
+\end{itemdescr}
+
+\indexlibraryctor{expected<void>}%
+\begin{itemdecl}
+constexpr explicit expected(in_place_t) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ensures
+\tcode{has_value()} is \tcode{true}.
+\end{itemdescr}
+
+\indexlibraryctor{expected<void>}%
+\begin{itemdecl}
+template<class... Args>
+  constexpr explicit expected(unexpect_t, Args&&... args);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{is_constructible_v<E, Args...>} is \tcode{true}.
+
+\pnum
+\effects
+Direct-non-list-initializes \exposid{unex}
+with \tcode{std::forward<Args>(args)...}.
+
+\pnum
+\ensures
+\tcode{has_value()} is \tcode{false}.
+
+\pnum
+\throws
+Any exception thrown by the initialization of \exposid{unex}.
+\end{itemdescr}
+
+\indexlibraryctor{expected<void>}%
+\begin{itemdecl}
+template<class U, class... Args>
+    constexpr explicit expected(unexpect_t, initializer_list<U> il, Args&&... args);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{is_constructible_v<E, initializer_list<U>\&, Args...>} is \tcode{true}.
+
+\pnum
+\effects
+Direct-non-list-initializes \exposid{unex}
+with \tcode{il, std::forward<Args>(args)...}.
+
+\pnum
+\ensures
+\tcode{has_value()} is \tcode{false}.
+
+\pnum
+\throws
+Any exception thrown by the initialization of \exposid{unex}.
+\end{itemdescr}
+
+\rSec3[expected.void.dtor]{Destructor}
+
+\indexlibrarydtor{expected<void>}%
+\begin{itemdecl}
+constexpr ~expected();
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+If \tcode{has_value()} is \tcode{false}, destroys \exposid{unex}.
+
+\pnum
+\remarks
+If \tcode{is_trivially_destructible_v<E>} is \tcode{true},
+then this destructor is a trivial destructor.
+\end{itemdescr}
+
+\rSec3[expected.void.assign]{Assignment}
+
+\indexlibrarymember{operator=}{expected<void>}%
+\begin{itemdecl}
+constexpr expected& operator=(const expected& rhs);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+\begin{itemize}
+\item
+If \tcode{this->has_value() \&\& rhs.has_value()} is \tcode{true}, no effects.
+\item
+Otherwise, if \tcode{this->has_value()} is \tcode{true},
+equivalent to: \tcode{construct_at(addressof(\exposid{unex}), rhs.\exposid{unex}); \exposid{has_val} = false;}
+\item
+Otherwise, if \tcode{rhs.has_value()} is \tcode{true},
+destroys \exposid{unex} and sets \exposid{has_val} to \tcode{true}.
+\item
+Otherwise, equivalent to \tcode{\exposid{unex} = rhs.error()}.
+\end{itemize}
+
+\pnum
+\returns
+\tcode{*this}.
+
+\pnum
+\remarks
+This operator is defined as deleted unless
+\tcode{is_copy_assignable_v<E>} is \tcode{true} and
+\tcode{is_copy_constructible_v<E>} is \tcode{true}.
+\end{itemdescr}
+
+\indexlibrarymember{operator=}{expected<void>}%
+\begin{itemdecl}
+constexpr expected& operator=(expected&& rhs) noexcept(@\seebelow@);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+\begin{itemize}
+\item
+If \tcode{this->has_value() \&\& rhs.has_value()} is \tcode{true}, no effects.
+\item
+Otherwise, if \tcode{this->has_value()} is \tcode{true}, equivalent to:
+\begin{codeblock}
+construct_at(addressof(@\exposid{unex}@), std::move(rhs.@\exposid{unex}@));
+@\exposid{has_val}@ = false;
+\end{codeblock}
+\item
+Otherwise, if \tcode{rhs.has_value()} is \tcode{true},
+destroys \exposid{unex} and sets \exposid{has_val} to \tcode{true}.
+\item
+Otherwise, equivalent to \tcode{\exposid{unex} = rhs.error()}.
+\end{itemize}
+
+\pnum
+\returns
+\tcode{*this}.
+
+\pnum
+\remarks
+The exception specification is
+\tcode{is_nothrow_move_constructible_v<E> \&\& is_nothrow_move_assignable_v<E>}.
+
+\pnum
+This operator is defined as deleted unless
+\tcode{is_move_constructible_v<E>} is \tcode{true} and
+\tcode{is_move_assignable_v<E>} is \tcode{true}.
+\end{itemdescr}
+
+\indexlibrarymember{operator=}{expected<void>}%
+\begin{itemdecl}
+template<class G>
+  constexpr expected& operator=(const unexpected<G>& e);
+template<class G>
+  constexpr expected& operator=(unexpected<G>&& e);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{GF} be \tcode{const G\&} for the first overload and
+\tcode{G} for the second overload.
+
+\pnum
+\constraints
+\tcode{is_constructible_v<E, GF>} is \tcode{true} and
+\tcode{is_assignable_v<E\&, GF>} is \tcode{true}.
+
+\pnum
+\effects
+\begin{itemize}
+\item
+If \tcode{has_value()} is \tcode{true}, equivalent to:
+\begin{codeblock}
+construct_at(addressof(@\exposid{unex}@), std::forward<GF>(e.value()));
+@\exposid{has_val}@ = false;
+\end{codeblock}
+\item
+Otherwise, equivalent to:
+\tcode{\exposid{unex} = std::forward<GF>(e.value());}
+\end{itemize}
+
+\pnum
+\returns
+\tcode{*this}.
+\end{itemdescr}
+
+\indexlibrarymember{emplace}{expected<void>}%
+\begin{itemdecl}
+constexpr void emplace() noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+If \tcode{has_value()} is \tcode{false},
+destroys \exposid{unex} and sets \exposid{has_val} to \tcode{true}.
+\end{itemdescr}
+
+\rSec3[expected.void.swap]{Swap}
+
+\indexlibrarymember{swap}{expected<void>}%
+\begin{itemdecl}
+constexpr void swap(expected& rhs) noexcept(@\seebelow@);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{is_swappable_v<E>} is \tcode{true} and
+\tcode{is_move_constructible_v<E>} is \tcode{true}.
+
+\pnum
+\effects
+See \tref{expected.void.swap}.
+
+\begin{floattable}{\tcode{swap(expected\&)} effects}{expected.void.swap}
+{lx{0.35\hsize}x{0.35\hsize}}
+\topline
+& \chdr{\tcode{this->has_value()}} & \rhdr{\tcode{!has_value()}} \\ \capsep
+\lhdr{\tcode{rhs.has_value()}} &
+  no effects &
+  calls \tcode{rhs.swap(*this)} \\
+\lhdr{\tcode{!rhs.has_value()}} &
+  \seebelow &
+  equivalent to: \tcode{using std::swap; swap(\exposid{unex}, rhs.\exposid{unex});} \\
+\end{floattable}
+
+For the case where \tcode{rhs.value()} is \tcode{false} and
+\tcode{this->has_value()} is \tcode{true}, equivalent to:
+\begin{codeblock}
+construct_at(addressof(@\exposid{unex}@), std::move(rhs.@\exposid{unex}@));
+destroy_at(addressof(rhs.@\exposid{unex}@));
+@\exposid{has_val}@ = false;
+rhs.@\exposid{has_val}@ = true;
+\end{codeblock}
+
+\pnum
+\throws
+Any exception thrown by the expressions in the \Fundescx{Effects}.
+
+\pnum
+\remarks
+The exception specification is
+\tcode{is_nothrow_move_constructible_v<E> \&\& is_nothrow_swappable_v<E>}.
+\end{itemdescr}
+
+\indexlibrarymember{swap}{expected<void>}%
+\begin{itemdecl}
+friend constexpr void swap(expected& x, expected& y) noexcept(noexcept(x.swap(y)));
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to \tcode{x.swap(y)}.
+\end{itemdescr}
+
+\rSec3[expected.void.obs]{Observers}
+
+\indexlibrarymember{operator bool}{expected<void>}%
+\indexlibrarymember{has_value}{expected<void>}%
+\begin{itemdecl}
+constexpr explicit operator bool() const noexcept;
+constexpr bool has_value() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\exposid{has_val}.
+\end{itemdescr}
+
+\indexlibrarymember{operator*}{expected<void>}%
+\begin{itemdecl}
+constexpr void operator*() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{has_value()} is \tcode{true}.
+\end{itemdescr}
+
+\indexlibrarymember{value}{expected}%
+\begin{itemdecl}
+constexpr void value() const&;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\throws
+\tcode{bad_expected_access(error())} if \tcode{has_value()} is \tcode{false}.
+\end{itemdescr}
+
+\indexlibrarymember{value}{expected<void>}%
+\begin{itemdecl}
+constexpr void value() &&;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\throws
+\tcode{bad_expected_access(std::move(error()))}
+if \tcode{has_value()} is \tcode{false}.
+\end{itemdescr}
+
+\indexlibrarymember{error}{expected<void>}%
+\begin{itemdecl}
+constexpr const E& error() const&;
+constexpr E& error() &;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{has_value()} is \tcode{false}.
+
+\pnum
+\returns
+\exposid{unex}.
+\end{itemdescr}
+
+\indexlibrarymember{error}{expected<void>}%
+\begin{itemdecl}
+constexpr E&& error() &&;
+constexpr const E&& error() const&&;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{has_value()} is \tcode{false}.
+
+\pnum
+\returns
+\tcode{std::move(\exposid{unex})}.
+\end{itemdescr}
+
+\rSec3[expected.void.eq]{Equality operators}
+
+\indexlibrarymember{operator==}{expected<void>}%
+\begin{itemdecl}
+template<class T2, class E2> requires is_void_v<T2>
+  friend constexpr bool operator==(const expected& x, const expected<T2, E2>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\mandates
+The expression \tcode{x.error() == y.error()} is well-formed and
+its result is convertible to \tcode{bool}.
+
+\pnum
+\returns
+If \tcode{x.has_value()} does not equal \tcode{y.has_value()}, \tcode{false};
+otherwise \tcode{x.has_value() || static_cast<bool>(x.error() == y.error())}.
+\end{itemdescr}
+
+\indexlibrarymember{operator==}{expected<void>}%
+\begin{itemdecl}
+template<class E2>
+  friend constexpr bool operator==(const expected& x, const unexpected<E2>& e);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\mandates
+The expression \tcode{x.error() == e.value()} is well-formed and
+its result is convertible to \tcode{bool}.
+
+\pnum
+\returns
+\tcode{!x.has_value() \&\& static_cast<bool>(x.error() == e.value())}.
 \end{itemdescr}
 
 \rSec1[bitset]{Bitsets}


### PR DESCRIPTION
- Introduce "General" subclauses to avoid hanging paragraphs.
- Introduce "Returns: *this" to avoid duplication.

Fixes #5261 
Fixes cplusplus/papers#254