### PR TITLE
P1413R3 Deprecate std::aligned_storage and std::aligned_union

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -1369,6 +1369,14 @@ has the following addition:
 namespace std {
   template<class T> struct is_pod;
   template<class T> inline constexpr bool is_pod_v = is_pod<T>::value;
+  template<size_t Len, size_t Align = @\exposid{default-alignment}@> // \seebelow
+    struct aligned_storage;
+  template<size_t Len, size_t Align = @\exposid{default-alignment}@> // \seebelow
+    using @\libglobal{aligned_storage_t}@ = typename aligned_storage<Len, Align>::type;
+  template<size_t Len, class... Types>
+    struct aligned_union;
+  template<size_t Len, class... Types>
+    using @\libglobal{aligned_union_t}@ = typename aligned_union<Len, Types...>::type;
 }
 \end{codeblock}
 
@@ -1401,6 +1409,74 @@ or a cv-qualified version of one of these types.
 \begin{note}
 It is unspecified whether a closure type\iref{expr.prim.lambda.closure} is a POD type.
 \end{note}
+\end{itemdescr}
+
+\indexlibraryglobal{aligned_storage}%
+\begin{itemdecl}
+template<size_t Len, size_t Align = @\exposid{default-alignment}@>
+  struct aligned_storage;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+The value of \exposid{default-alignment} is the most
+stringent alignment requirement for any object type whose size
+is no greater than \tcode{Len}\iref{basic.types}.
+
+\pnum
+\mandates
+\tcode{Len} is not zero.
+\tcode{Align} is equal to \tcode{alignof(T)} for some type \tcode{T} or
+to \exposid{default-alignment}.
+
+\pnum
+The member typedef \tcode{type} is a trivial standard-layout type
+suitable for use as uninitialized storage for any object
+whose size is at most \tcode{Len} and
+whose alignment is a divisor of \tcode{Align}.
+
+\pnum
+\begin{note}
+Uses of \tcode{aligned_storage<Len, Align>::type} can be replaced
+by an array \tcode{std::byte[Len]} declared with \tcode{alignas(Align)}.
+\end{note}
+
+\pnum
+\begin{note}
+A typical implementation would define \tcode{aligned_storage} as:
+\begin{codeblock}
+template<size_t Len, size_t Alignment>
+struct aligned_storage {
+  typedef struct {
+    alignas(Alignment) unsigned char __data[Len];
+  } type;
+};
+\end{codeblock}
+\end{note}
+
+\end{itemdescr}
+
+\indexlibraryglobal{aligned_union}%
+\begin{itemdecl}
+template<size_t Len, class... Types>
+  struct aligned_union;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\mandates
+At least one type is provided.
+Each type in the template parameter pack \tcode{Types}
+is a complete object type.
+
+\pnum
+The member typedef \tcode{type} is a trivial standard-layout type
+suitable for use as uninitialized storage for any object
+whose type is listed in \tcode{Types};
+its size shall be at least \tcode{Len}.
+The static member \tcode{alignment_value}
+is an integral constant of type \tcode{size_t}
+whose value is the strictest alignment of all types listed in \tcode{Types}.
 \end{itemdescr}
 
 \rSec1[depr.tuple]{Tuple}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -19635,9 +19635,6 @@ namespace std {
 
   // \ref{meta.trans.other}, other transformations
   template<class T> struct type_identity;
-  template<size_t Len, size_t Align = @\textit{default-alignment}@> // see \ref{meta.trans.other}
-    struct aligned_storage;
-  template<size_t Len, class... Types> struct aligned_union;
   template<class T> struct remove_cvref;
   template<class T> struct decay;
   template<bool, class T = void> struct enable_if;
@@ -19653,10 +19650,6 @@ namespace std {
 
   template<class T>
     using @\libglobal{type_identity_t}@    = typename type_identity<T>::type;
-  template<size_t Len, size_t Align = @\textit{default-alignment}@> // see \ref{meta.trans.other}
-    using @\libglobal{aligned_storage_t}@  = typename aligned_storage<Len, Align>::type;
-  template<size_t Len, class... Types>
-    using @\libglobal{aligned_union_t}@    = typename aligned_union<Len, Types...>::type;
   template<class T>
     using @\libglobal{remove_cvref_t}@     = typename remove_cvref<T>::type;
   template<class T>
@@ -21095,36 +21088,6 @@ assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
  &
  The member typedef \tcode{type} names the type \tcode{T}. \\ \rowsep
 
-\indexlibraryglobal{aligned_storage}%
-\tcode{template<size_t Len,\br
- size_t Align\br
- = \textit{default-alignment}>\br
- struct aligned_storage;}
- &
- The value of \textit{default-alignment} shall be the most
- stringent alignment requirement for any object type whose size
- is no greater than \tcode{Len}\iref{basic.types}.
- The member typedef \tcode{type} shall be a trivial standard-layout type
- suitable for use as uninitialized storage for any object whose size
- is at most \tcode{Len} and whose alignment is a divisor of \tcode{Align}.\br
- \mandates \tcode{Len} is not zero. \tcode{Align} is equal to
- \tcode{alignof(T)} for some type \tcode{T} or to \textit{default-alignment}.\\ \rowsep
-
-\indexlibraryglobal{aligned_union}%
-\tcode{template<size_t Len,\br
-  class... Types>\br
-  struct aligned_union;}
-  &
-  The member typedef \tcode{type} shall be a trivial standard-layout type suitable for use as
-  uninitialized storage for any object whose type is listed in \tcode{Types};
-  its size shall be at least \tcode{Len}. The static member \tcode{alignment_value}
-  shall be an integral constant of type \tcode{size_t} whose value is the
-  strictest alignment of all types listed in \tcode{Types}.\br
- \mandates At least one type is provided.
-  Each type in the template parameter pack \tcode{Types}
-  is a complete object type.
-  \\ \rowsep
-
 \indexlibraryglobal{remove_cvref}%
 \tcode{template<class T>\br struct remove_cvref;}
  &
@@ -21234,21 +21197,6 @@ argument passing.
  The member typedef \tcode{type} of \tcode{unwrap_ref_decay<T>}
  denotes the type \tcode{unwrap_reference_t<decay_t<T>>}.\\
 \end{libreqtab2a}
-
-\indexlibraryglobal{aligned_storage}%
-\pnum
-\begin{note}
-A typical implementation would define \tcode{aligned_storage} as:
-
-\begin{codeblock}
-template<size_t Len, size_t Alignment>
-struct aligned_storage {
-  typedef struct {
-    alignas(Alignment) unsigned char __data[Len];
-  } type;
-};
-\end{codeblock}
-\end{note}
 
 \pnum
 In addition to being available via inclusion


### PR DESCRIPTION
- Replace 'shall be' with 'is'.

Fixes #5265
Fixes cplusplus/papers#197