### PR TITLE
P2273R3 Making std::unique_ptr constexpr

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -594,7 +594,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_constexpr_dynamic_alloc}@           201907L // also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_constexpr_functional}@              201907L // also in \libheader{functional}
 #define @\defnlibxname{cpp_lib_constexpr_iterator}@                201811L // also in \libheader{iterator}
-#define @\defnlibxname{cpp_lib_constexpr_memory}@                  201811L // also in \libheader{memory}
+#define @\defnlibxname{cpp_lib_constexpr_memory}@                  202202L // also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_constexpr_numeric}@                 201911L // also in \libheader{numeric}
 #define @\defnlibxname{cpp_lib_constexpr_string}@                  201907L // also in \libheader{string}
 #define @\defnlibxname{cpp_lib_constexpr_string_view}@             201811L // also in \libheader{string_view}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -9771,24 +9771,24 @@ namespace std {
   template<class T, class D> class unique_ptr<T[], D>;
 
   template<class T, class... Args>
-    unique_ptr<T> make_unique(Args&&... args);                                  // \tcode{T} is not array
+    constexpr unique_ptr<T> make_unique(Args&&... args);                        // \tcode{T} is not array
   template<class T>
-    unique_ptr<T> make_unique(size_t n);                                        // \tcode{T} is \tcode{U[]}
+    constexpr unique_ptr<T> make_unique(size_t n);                              // \tcode{T} is \tcode{U[]}
   template<class T, class... Args>
     @\unspecnc@ make_unique(Args&&...) = delete;                                // \tcode{T} is \tcode{U[N]}
 
   template<class T>
-    unique_ptr<T> make_unique_for_overwrite();                                  // \tcode{T} is not array
+    constexpr unique_ptr<T> make_unique_for_overwrite();                        // \tcode{T} is not array
   template<class T>
-    unique_ptr<T> make_unique_for_overwrite(size_t n);                          // \tcode{T} is \tcode{U[]}
+    constexpr unique_ptr<T> make_unique_for_overwrite(size_t n);                // \tcode{T} is \tcode{U[]}
   template<class T, class... Args>
     @\unspecnc@ make_unique_for_overwrite(Args&&...) = delete;                  // \tcode{T} is \tcode{U[N]}
 
   template<class T, class D>
-    void swap(unique_ptr<T, D>& x, unique_ptr<T, D>& y) noexcept;
+    constexpr void swap(unique_ptr<T, D>& x, unique_ptr<T, D>& y) noexcept;
 
   template<class T1, class D1, class T2, class D2>
-    bool operator==(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
+    constexpr bool operator==(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
   template<class T1, class D1, class T2, class D2>
     bool operator<(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
   template<class T1, class D1, class T2, class D2>
@@ -9805,26 +9805,26 @@ namespace std {
       operator<=>(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
 
   template<class T, class D>
-    bool operator==(const unique_ptr<T, D>& x, nullptr_t) noexcept;
+    constexpr bool operator==(const unique_ptr<T, D>& x, nullptr_t) noexcept;
   template<class T, class D>
-    bool operator<(const unique_ptr<T, D>& x, nullptr_t);
+    constexpr bool operator<(const unique_ptr<T, D>& x, nullptr_t);
   template<class T, class D>
-    bool operator<(nullptr_t, const unique_ptr<T, D>& y);
+    constexpr bool operator<(nullptr_t, const unique_ptr<T, D>& y);
   template<class T, class D>
-    bool operator>(const unique_ptr<T, D>& x, nullptr_t);
+    constexpr bool operator>(const unique_ptr<T, D>& x, nullptr_t);
   template<class T, class D>
-    bool operator>(nullptr_t, const unique_ptr<T, D>& y);
+    constexpr bool operator>(nullptr_t, const unique_ptr<T, D>& y);
   template<class T, class D>
-    bool operator<=(const unique_ptr<T, D>& x, nullptr_t);
+    constexpr bool operator<=(const unique_ptr<T, D>& x, nullptr_t);
   template<class T, class D>
-    bool operator<=(nullptr_t, const unique_ptr<T, D>& y);
+    constexpr bool operator<=(nullptr_t, const unique_ptr<T, D>& y);
   template<class T, class D>
-    bool operator>=(const unique_ptr<T, D>& x, nullptr_t);
+    constexpr bool operator>=(const unique_ptr<T, D>& x, nullptr_t);
   template<class T, class D>
-    bool operator>=(nullptr_t, const unique_ptr<T, D>& y);
+    constexpr bool operator>=(nullptr_t, const unique_ptr<T, D>& y);
   template<class T, class D>
     requires @\libconcept{three_way_comparable}@<typename unique_ptr<T, D>::pointer>
-    compare_three_way_result_t<typename unique_ptr<T, D>::pointer>
+    constexpr compare_three_way_result_t<typename unique_ptr<T, D>::pointer>
       operator<=>(const unique_ptr<T, D>& x, nullptr_t);
 
   template<class E, class T, class Y, class D>
@@ -11154,15 +11154,15 @@ an incomplete type.
 namespace std {
   template<class T> struct default_delete {
     constexpr default_delete() noexcept = default;
-    template<class U> default_delete(const default_delete<U>&) noexcept;
-    void operator()(T*) const;
+    template<class U> constexpr default_delete(const default_delete<U>&) noexcept;
+    constexpr void operator()(T*) const;
   };
 }
 \end{codeblock}
 
 \indexlibraryctor{default_delete}%
 \begin{itemdecl}
-template<class U> default_delete(const default_delete<U>& other) noexcept;
+template<class U> constexpr default_delete(const default_delete<U>& other) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11178,7 +11178,7 @@ from another \tcode{default_delete<U>} object.
 
 \indexlibrarymember{operator()}{default_delete}%
 \begin{itemdecl}
-void operator()(T* ptr) const;
+constexpr void operator()(T* ptr) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11197,15 +11197,15 @@ Calls \keyword{delete} on \tcode{ptr}.
 namespace std {
   template<class T> struct default_delete<T[]> {
     constexpr default_delete() noexcept = default;
-    template<class U> default_delete(const default_delete<U[]>&) noexcept;
-    template<class U> void operator()(U* ptr) const;
+    template<class U> constexpr default_delete(const default_delete<U[]>&) noexcept;
+    template<class U> constexpr void operator()(U* ptr) const;
   };
 }
 \end{codeblock}
 
 \indexlibraryctor{default_delete}
 \begin{itemdecl}
-template<class U> default_delete(const default_delete<U[]>& other) noexcept;
+template<class U> constexpr default_delete(const default_delete<U[]>& other) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11220,7 +11220,7 @@ Constructs a \tcode{default_delete} object from another \tcode{default_delete<U[
 
 \indexlibrarymember{operator()}{default_delete}%
 \begin{itemdecl}
-template<class U> void operator()(U* ptr) const;
+template<class U> constexpr void operator()(U* ptr) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11252,35 +11252,35 @@ namespace std {
 
     // \ref{unique.ptr.single.ctor}, constructors
     constexpr unique_ptr() noexcept;
-    explicit unique_ptr(type_identity_t<pointer> p) noexcept;
-    unique_ptr(type_identity_t<pointer> p, @\seebelow@ d1) noexcept;
-    unique_ptr(type_identity_t<pointer> p, @\seebelow@ d2) noexcept;
-    unique_ptr(unique_ptr&& u) noexcept;
+    constexpr explicit unique_ptr(type_identity_t<pointer> p) noexcept;
+    constexpr unique_ptr(type_identity_t<pointer> p, @\seebelow@ d1) noexcept;
+    constexpr unique_ptr(type_identity_t<pointer> p, @\seebelow@ d2) noexcept;
+    constexpr unique_ptr(unique_ptr&& u) noexcept;
     constexpr unique_ptr(nullptr_t) noexcept;
     template<class U, class E>
-      unique_ptr(unique_ptr<U, E>&& u) noexcept;
+      constexpr unique_ptr(unique_ptr<U, E>&& u) noexcept;
 
     // \ref{unique.ptr.single.dtor}, destructor
-    ~unique_ptr();
+    constexpr ~unique_ptr();
 
     // \ref{unique.ptr.single.asgn}, assignment
-    unique_ptr& operator=(unique_ptr&& u) noexcept;
+    constexpr unique_ptr& operator=(unique_ptr&& u) noexcept;
     template<class U, class E>
-      unique_ptr& operator=(unique_ptr<U, E>&& u) noexcept;
-    unique_ptr& operator=(nullptr_t) noexcept;
+      constexpr unique_ptr& operator=(unique_ptr<U, E>&& u) noexcept;
+    constexpr unique_ptr& operator=(nullptr_t) noexcept;
 
     // \ref{unique.ptr.single.observers}, observers
-    add_lvalue_reference_t<T> operator*() const noexcept(@\seebelow@);
-    pointer operator->() const noexcept;
-    pointer get() const noexcept;
-    deleter_type& get_deleter() noexcept;
-    const deleter_type& get_deleter() const noexcept;
-    explicit operator bool() const noexcept;
+    constexpr add_lvalue_reference_t<T> operator*() const noexcept(@\seebelow@);
+    constexpr pointer operator->() const noexcept;
+    constexpr pointer get() const noexcept;
+    constexpr deleter_type& get_deleter() noexcept;
+    constexpr const deleter_type& get_deleter() const noexcept;
+    constexpr explicit operator bool() const noexcept;
 
     // \ref{unique.ptr.single.modifiers}, modifiers
-    pointer release() noexcept;
-    void reset(pointer p = pointer()) noexcept;
-    void swap(unique_ptr& u) noexcept;
+    constexpr pointer release() noexcept;
+    constexpr void reset(pointer p = pointer()) noexcept;
+    constexpr void swap(unique_ptr& u) noexcept;
 
     // disable copy from lvalue
     unique_ptr(const unique_ptr&) = delete;
@@ -11353,7 +11353,7 @@ returns a reference to the stored deleter.
 
 \indexlibraryctor{unique_ptr}%
 \begin{itemdecl}
-explicit unique_ptr(type_identity_t<pointer> p) noexcept;
+constexpr explicit unique_ptr(type_identity_t<pointer> p) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11381,8 +11381,8 @@ returns a reference to the stored deleter.
 
 \indexlibraryctor{unique_ptr}%
 \begin{itemdecl}
-unique_ptr(type_identity_t<pointer> p, const D& d) noexcept;
-unique_ptr(type_identity_t<pointer> p, remove_reference_t<D>&& d) noexcept;
+constexpr unique_ptr(type_identity_t<pointer> p, const D& d) noexcept;
+constexpr unique_ptr(type_identity_t<pointer> p, remove_reference_t<D>&& d) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11432,7 +11432,7 @@ unique_ptr<int, const D&> p4(new int, D()); // error: rvalue deleter object comb
 
 \indexlibraryctor{unique_ptr}%
 \begin{itemdecl}
-unique_ptr(unique_ptr&& u) noexcept;
+constexpr unique_ptr(unique_ptr&& u) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11473,7 +11473,7 @@ the same lvalue deleter.
 
 \indexlibraryctor{unique_ptr}%
 \begin{itemdecl}
-template<class U, class E> unique_ptr(unique_ptr<U, E>&& u) noexcept;
+template<class U, class E> constexpr unique_ptr(unique_ptr<U, E>&& u) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11519,7 +11519,7 @@ to the stored deleter that was constructed from
 
 \indexlibrarydtor{unique_ptr}%
 \begin{itemdecl}
-~unique_ptr();
+constexpr ~unique_ptr();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11541,7 +11541,7 @@ Otherwise \tcode{get_deleter()(get())}.
 
 \indexlibrarymember{operator=}{unique_ptr}%
 \begin{itemdecl}
-unique_ptr& operator=(unique_ptr&& u) noexcept;
+constexpr unique_ptr& operator=(unique_ptr&& u) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11577,7 +11577,7 @@ otherwise \tcode{u.get()} is unchanged.
 
 \indexlibrarymember{operator=}{unique_ptr}%
 \begin{itemdecl}
-template<class U, class E> unique_ptr& operator=(unique_ptr<U, E>&& u) noexcept;
+template<class U, class E> constexpr unique_ptr& operator=(unique_ptr<U, E>&& u) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11614,7 +11614,7 @@ Calls \tcode{reset(u.release())} followed by
 
 \indexlibrarymember{operator=}{unique_ptr}%
 \begin{itemdecl}
-unique_ptr& operator=(nullptr_t) noexcept;
+constexpr unique_ptr& operator=(nullptr_t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11635,7 +11635,7 @@ As if by \tcode{reset()}.
 
 \indexlibrarymember{operator*}{unique_ptr}%
 \begin{itemdecl}
-add_lvalue_reference_t<T> operator*() const noexcept(noexcept(*declval<pointer>()));
+constexpr add_lvalue_reference_t<T> operator*() const noexcept(noexcept(*declval<pointer>()));
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11651,7 +11651,7 @@ add_lvalue_reference_t<T> operator*() const noexcept(noexcept(*declval<pointer>(
 
 \indexlibrarymember{operator->}{unique_ptr}%
 \begin{itemdecl}
-pointer operator->() const noexcept;
+constexpr pointer operator->() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11671,7 +11671,7 @@ The use of this function typically requires that \tcode{T} be a complete type.
 
 \indexlibrarymember{get}{unique_ptr}%
 \begin{itemdecl}
-pointer get() const noexcept;
+constexpr pointer get() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11682,8 +11682,8 @@ The stored pointer.
 
 \indexlibrarymember{get_deleter}{unique_ptr}%
 \begin{itemdecl}
-deleter_type& get_deleter() noexcept;
-const deleter_type& get_deleter() const noexcept;
+constexpr deleter_type& get_deleter() noexcept;
+constexpr const deleter_type& get_deleter() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11694,7 +11694,7 @@ A reference to the stored deleter.
 
 \indexlibrarymember{operator bool}{unique_ptr}%
 \begin{itemdecl}
-explicit operator bool() const noexcept;
+constexpr explicit operator bool() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11707,7 +11707,7 @@ explicit operator bool() const noexcept;
 
 \indexlibrarymember{release}{unique_ptr}%
 \begin{itemdecl}
-pointer release() noexcept;
+constexpr pointer release() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11723,7 +11723,7 @@ the call to \tcode{release}.
 
 \indexlibrarymember{reset}{unique_ptr}%
 \begin{itemdecl}
-void reset(pointer p = pointer()) noexcept;
+constexpr void reset(pointer p = pointer()) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11753,7 +11753,7 @@ destroys \tcode{*this} since \tcode{this->get()} is no longer a valid expression
 
 \indexlibrarymember{swap}{unique_ptr}%
 \begin{itemdecl}
-void swap(unique_ptr& u) noexcept;
+constexpr void swap(unique_ptr& u) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11783,35 +11783,35 @@ namespace std {
 
     // \ref{unique.ptr.runtime.ctor}, constructors
     constexpr unique_ptr() noexcept;
-    template<class U> explicit unique_ptr(U p) noexcept;
-    template<class U> unique_ptr(U p, @\seebelow@ d) noexcept;
-    template<class U> unique_ptr(U p, @\seebelow@ d) noexcept;
-    unique_ptr(unique_ptr&& u) noexcept;
+    template<class U> constexpr explicit unique_ptr(U p) noexcept;
+    template<class U> constexpr unique_ptr(U p, @\seebelow@ d) noexcept;
+    template<class U> constexpr unique_ptr(U p, @\seebelow@ d) noexcept;
+    constexpr unique_ptr(unique_ptr&& u) noexcept;
     template<class U, class E>
-      unique_ptr(unique_ptr<U, E>&& u) noexcept;
+      constexpr unique_ptr(unique_ptr<U, E>&& u) noexcept;
     constexpr unique_ptr(nullptr_t) noexcept;
 
     // destructor
-    ~unique_ptr();
+    constexpr ~unique_ptr();
 
     // assignment
-    unique_ptr& operator=(unique_ptr&& u) noexcept;
+    constexpr unique_ptr& operator=(unique_ptr&& u) noexcept;
     template<class U, class E>
-      unique_ptr& operator=(unique_ptr<U, E>&& u) noexcept;
-    unique_ptr& operator=(nullptr_t) noexcept;
+      constexpr unique_ptr& operator=(unique_ptr<U, E>&& u) noexcept;
+    constexpr unique_ptr& operator=(nullptr_t) noexcept;
 
     // \ref{unique.ptr.runtime.observers}, observers
-    T& operator[](size_t i) const;
-    pointer get() const noexcept;
-    deleter_type& get_deleter() noexcept;
-    const deleter_type& get_deleter() const noexcept;
-    explicit operator bool() const noexcept;
+    constexpr T& operator[](size_t i) const;
+    constexpr pointer get() const noexcept;
+    constexpr deleter_type& get_deleter() noexcept;
+    constexpr const deleter_type& get_deleter() const noexcept;
+    constexpr explicit operator bool() const noexcept;
 
     // \ref{unique.ptr.runtime.modifiers}, modifiers
-    pointer release() noexcept;
-    template<class U> void reset(U p) noexcept;
-    void reset(nullptr_t = nullptr) noexcept;
-    void swap(unique_ptr& u) noexcept;
+    constexpr pointer release() noexcept;
+    template<class U> constexpr void reset(U p) noexcept;
+    constexpr void reset(nullptr_t = nullptr) noexcept;
+    constexpr void swap(unique_ptr& u) noexcept;
 
     // disable copy from lvalue
     unique_ptr(const unique_ptr&) = delete;
@@ -11853,7 +11853,7 @@ The template argument \tcode{T} shall be a complete type.
 
 \indexlibraryctor{unique_ptr}%
 \begin{itemdecl}
-template<class U> explicit unique_ptr(U p) noexcept;
+template<class U> constexpr explicit unique_ptr(U p) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11874,8 +11874,8 @@ takes a single parameter of type \tcode{pointer}.
 
 \indexlibraryctor{unique_ptr}%
 \begin{itemdecl}
-template<class U> unique_ptr(U p, @\seebelow@ d) noexcept;
-template<class U> unique_ptr(U p, @\seebelow@ d) noexcept;
+template<class U> constexpr unique_ptr(U p, @\seebelow@ d) noexcept;
+template<class U> constexpr unique_ptr(U p, @\seebelow@ d) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11897,7 +11897,7 @@ take a parameter of type \tcode{pointer} and a second parameter.
 
 \indexlibraryctor{unique_ptr}%
 \begin{itemdecl}
-template<class U, class E> unique_ptr(unique_ptr<U, E>&& u) noexcept;
+template<class U, class E> constexpr unique_ptr(unique_ptr<U, E>&& u) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11925,7 +11925,7 @@ This replaces the \constraints specification of the primary template.
 
 \indexlibrarymember{operator=}{unique_ptr}%
 \begin{itemdecl}
-template<class U, class E> unique_ptr& operator=(unique_ptr<U, E>&& u) noexcept;
+template<class U, class E> constexpr unique_ptr& operator=(unique_ptr<U, E>&& u) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11952,7 +11952,7 @@ This replaces the \constraints specification of the primary template.
 
 \indexlibrarymember{operator[]}{unique_ptr}%
 \begin{itemdecl}
-T& operator[](size_t i) const;
+constexpr T& operator[](size_t i) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11971,7 +11971,7 @@ the stored pointer points.
 
 \indexlibrarymember{reset}{unique_ptr}%
 \begin{itemdecl}
-void reset(nullptr_t p = nullptr) noexcept;
+constexpr void reset(nullptr_t p = nullptr) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11982,7 +11982,7 @@ Equivalent to \tcode{reset(pointer())}.
 
 \indexlibrarymember{reset}{unique_ptr}%
 \begin{itemdecl}
-template<class U> void reset(U p) noexcept;
+constexpr template<class U> void reset(U p) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -12004,7 +12004,7 @@ the \tcode{reset} member of the primary template.
 
 \indexlibraryglobal{make_unique}%
 \begin{itemdecl}
-template<class T, class... Args> unique_ptr<T> make_unique(Args&&... args);
+template<class T, class... Args> constexpr unique_ptr<T> make_unique(Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -12020,7 +12020,7 @@ template<class T, class... Args> unique_ptr<T> make_unique(Args&&... args);
 
 \indexlibraryglobal{make_unique}%
 \begin{itemdecl}
-template<class T> unique_ptr<T> make_unique(size_t n);
+template<class T> constexpr unique_ptr<T> make_unique(size_t n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -12048,7 +12048,7 @@ template<class T, class... Args> @\unspec@ make_unique(Args&&...) = delete;
 
 \indexlibraryglobal{make_unique}%
 \begin{itemdecl}
-template<class T> unique_ptr<T> make_unique_for_overwrite();
+template<class T> constexpr unique_ptr<T> make_unique_for_overwrite();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -12063,7 +12063,7 @@ template<class T> unique_ptr<T> make_unique_for_overwrite();
 
 \indexlibraryglobal{make_unique}%
 \begin{itemdecl}
-template<class T> unique_ptr<T> make_unique_for_overwrite(size_t n);
+template<class T> constexpr unique_ptr<T> make_unique_for_overwrite(size_t n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -12091,7 +12091,7 @@ template<class T, class... Args> @\unspec@ make_unique_for_overwrite(Args&&...) 
 
 \indexlibrary{\idxcode{swap(unique_ptr\&, unique_ptr\&)}}%
 \begin{itemdecl}
-template<class T, class D> void swap(unique_ptr<T, D>& x, unique_ptr<T, D>& y) noexcept;
+template<class T, class D> constexpr void swap(unique_ptr<T, D>& x, unique_ptr<T, D>& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -12107,7 +12107,7 @@ Calls \tcode{x.swap(y)}.
 \indexlibrarymember{operator==}{unique_ptr}%
 \begin{itemdecl}
 template<class T1, class D1, class T2, class D2>
-  bool operator==(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
+  constexpr bool operator==(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -12203,7 +12203,7 @@ template<class T1, class D1, class T2, class D2>
 \indexlibrarymember{operator==}{unique_ptr}%
 \begin{itemdecl}
 template<class T, class D>
-  bool operator==(const unique_ptr<T, D>& x, nullptr_t) noexcept;
+  constexpr bool operator==(const unique_ptr<T, D>& x, nullptr_t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -12215,9 +12215,9 @@ template<class T, class D>
 \indexlibrarymember{operator<}{unique_ptr}%
 \begin{itemdecl}
 template<class T, class D>
-  bool operator<(const unique_ptr<T, D>& x, nullptr_t);
+  constexpr bool operator<(const unique_ptr<T, D>& x, nullptr_t);
 template<class T, class D>
-  bool operator<(nullptr_t, const unique_ptr<T, D>& x);
+  constexpr bool operator<(nullptr_t, const unique_ptr<T, D>& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -12242,9 +12242,9 @@ less<unique_ptr<T, D>::pointer>()(nullptr, x.get())
 \indexlibrarymember{operator>}{unique_ptr}%
 \begin{itemdecl}
 template<class T, class D>
-  bool operator>(const unique_ptr<T, D>& x, nullptr_t);
+  constexpr bool operator>(const unique_ptr<T, D>& x, nullptr_t);
 template<class T, class D>
-  bool operator>(nullptr_t, const unique_ptr<T, D>& x);
+  constexpr bool operator>(nullptr_t, const unique_ptr<T, D>& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -12257,9 +12257,9 @@ The second function template returns \tcode{x < nullptr}.
 \indexlibrarymember{operator<=}{unique_ptr}%
 \begin{itemdecl}
 template<class T, class D>
-  bool operator<=(const unique_ptr<T, D>& x, nullptr_t);
+  constexpr bool operator<=(const unique_ptr<T, D>& x, nullptr_t);
 template<class T, class D>
-  bool operator<=(nullptr_t, const unique_ptr<T, D>& x);
+  constexpr bool operator<=(nullptr_t, const unique_ptr<T, D>& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -12272,9 +12272,9 @@ The second function template returns \tcode{!(x < nullptr)}.
 \indexlibrarymember{operator>=}{unique_ptr}%
 \begin{itemdecl}
 template<class T, class D>
-  bool operator>=(const unique_ptr<T, D>& x, nullptr_t);
+  constexpr bool operator>=(const unique_ptr<T, D>& x, nullptr_t);
 template<class T, class D>
-  bool operator>=(nullptr_t, const unique_ptr<T, D>& x);
+  constexpr bool operator>=(nullptr_t, const unique_ptr<T, D>& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -12288,7 +12288,7 @@ The second function template returns \tcode{!(nullptr < x)}.
 \begin{itemdecl}
 template<class T, class D>
   requires @\libconcept{three_way_comparable}@<typename unique_ptr<T, D>::pointer>
-  compare_three_way_result_t<typename unique_ptr<T, D>::pointer>
+  constexpr compare_three_way_result_t<typename unique_ptr<T, D>::pointer>
     operator<=>(const unique_ptr<T, D>& x, nullptr_t);
 \end{itemdecl}
 


### PR DESCRIPTION
- Fix position of 'constexpr' operator<=>(nullptr_t)

Fixes #5267
Fixes cplusplus/papers#961