### PR TITLE
[module.interface] Add adjective 'exported' to dangling prons

### DIFF
--- a/source/modules.tex
+++ b/source/modules.tex
@@ -266,7 +266,7 @@ export using namespace N;       // error: does not declare a name
 \end{example}
 
 \pnum
-If the declaration is a \grammarterm{using-declaration}\iref{namespace.udecl}
+If an exported declaration is a \grammarterm{using-declaration}\iref{namespace.udecl}
 and is not within a header unit,
 all entities to which all of the
 \grammarterm{using-declarator}{s} ultimately refer (if any)


### PR DESCRIPTION
Although we could infer the declaration should refer to 'exported declaration' from the context in the previous paragraph, they are two paragraphs and split by a relatively long example. So I am confused at the first sight. I think it would be helpful to add the adjective.