### PR TITLE
[stdatomic.h.syn] Add missing atomic_fetch_xor/_explicit

### DIFF
--- a/source/atomics.tex
+++ b/source/atomics.tex
@@ -3804,6 +3804,8 @@ using std::@\libglobal{atomic_fetch_sub}@;                             // \seebe
 using std::@\libglobal{atomic_fetch_sub_explicit}@;                    // \seebelow
 using std::@\libglobal{atomic_fetch_or}@;                              // \seebelow
 using std::@\libglobal{atomic_fetch_or_explicit}@;                     // \seebelow
+using std::@\libglobal{atomic_fetch_xor}@;                             // \seebelow
+using std::@\libglobal{atomic_fetch_xor_explicit}@;                    // \seebelow
 using std::@\libglobal{atomic_fetch_and}@;                             // \seebelow
 using std::@\libglobal{atomic_fetch_and_explicit}@;                    // \seebelow
 using std::@\libglobal{atomic_flag_test_and_set}@;                     // \seebelow


### PR DESCRIPTION
This was accidentally omitted from P0943R6.