### PR TITLE
[dcl.fct.def.coroutine] Initializer of a non-block variable is also a resumer CWG2613

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6554,7 +6554,8 @@ A suspended coroutine can be resumed to continue execution by invoking
 a resumption member function\iref{coroutine.handle.resumption}
 of a coroutine handle\iref{coroutine.handle}
 that refers to the coroutine.
-The function or the initializer of a non-block variable\iref{basic.start.dynamic}
+The function or the initializer of a non-block variable
+with static or thread storage duration\iref{basic.start.dynamic}
 that invokes a resumption member function is called the \defnx{resumer}{coroutine!resumer}.
 Invoking a resumption member function for a coroutine
 that is not suspended results in undefined behavior.

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6555,7 +6555,7 @@ a resumption member function\iref{coroutine.handle.resumption}
 of a coroutine handle\iref{coroutine.handle}
 that refers to the coroutine.
 The function or the initializer of a non-block variable
-that invoked a resumption member function is called the \defnx{resumer}{coroutine!resumer}.
+that invokes a resumption member function is called the \defnx{resumer}{coroutine!resumer}.
 Invoking a resumption member function for a coroutine
 that is not suspended results in undefined behavior.
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6554,7 +6554,7 @@ A suspended coroutine can be resumed to continue execution by invoking
 a resumption member function\iref{coroutine.handle.resumption}
 of a coroutine handle\iref{coroutine.handle}
 that refers to the coroutine.
-The function or the initializer of a non-block variable
+The function or the initializer of a non-block variable\iref{basic.start.dynamic}
 that invokes a resumption member function is called the \defnx{resumer}{coroutine!resumer}.
 Invoking a resumption member function for a coroutine
 that is not suspended results in undefined behavior.

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6554,8 +6554,8 @@ A suspended coroutine can be resumed to continue execution by invoking
 a resumption member function\iref{coroutine.handle.resumption}
 of a coroutine handle\iref{coroutine.handle}
 that refers to the coroutine.
-The function that invoked a resumption member function is
-called the \defnx{resumer}{coroutine!resumer}.
+The function or the initializer of a non-block variable
+that invoked a resumption member function is called the \defnx{resumer}{coroutine!resumer}.
 Invoking a resumption member function for a coroutine
 that is not suspended results in undefined behavior.
 


### PR DESCRIPTION
Fixes #5295 