### PR TITLE
[lib] Add missing \pnum before descriptive elements

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -518,6 +518,7 @@ a.max_size()
 \returns
 \tcode{distance(begin(), end())} for the largest possible container.
 
+\pnum
 \complexity
 Constant.
 \end{itemdescr}
@@ -3311,6 +3312,7 @@ if the insertion failed, \tcode{inserted} is \tcode{false},
 \tcode{node} has the previous value of \tcode{nh}, and
 \tcode{position} points to an element with a key equivalent to \tcode{nh.key()}.
 
+\pnum
 \complexity
 Logarithmic.
 \end{itemdescr}
@@ -3562,6 +3564,7 @@ a.erase(q)
 \effects
 Erases the element pointed to by \tcode{q}.
 
+\pnum
 \returns
 An iterator pointing to the element immediately following \tcode{q}
 prior to the element being erased.
@@ -4383,6 +4386,7 @@ X a;
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
 \expects
 \tcode{hasher} and \tcode{key_equal} meet
 the \oldconcept{DefaultConstructible} requirements.
@@ -5073,6 +5077,7 @@ in containers with equivalent keys.
 The iterator \tcode{q} is a hint pointing to where the search should start.
 Implementations are permitted to ignore the hint.
 
+\pnum
 \ensures
 \tcode{nh} is empty if insertion succeeds, unchanged if insertion fails.
 
@@ -5147,6 +5152,7 @@ a.extract(q)
 \effects
 Removes the element pointed to by \tcode{q}.
 
+\pnum
 \returns
 A \tcode{node_type} owning that element.
 
@@ -11732,6 +11738,7 @@ template<class M>
 \mandates
 \tcode{is_assignable_v<mapped_type\&, M\&\&>} is \tcode{true}.
 
+\pnum
 \expects
 \tcode{value_type} is \oldconcept{Emplace\-Constructible} into \tcode{unordered_map}
 from \tcode{std::move(k)}, \tcode{std::\brk{}forward<M>(obj)}.

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -15290,6 +15290,7 @@ Equivalent to \tcode{pathobject.replace_filename(p)},
 then \tcode{refresh()} or \tcode{refresh(ec)}, respectively.
 If an error occurs, the values of any cached attributes are unspecified.
 
+\pnum
 \throws
 As specified in~\ref{fs.err.report}.
 \end{itemdescr}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -7393,6 +7393,7 @@ valarray(const T* p, size_t n);
 \expects
 \range{p}{p + n} is a valid range.
 
+\pnum
 \effects
 Constructs a \tcode{valarray} that has length \tcode{n}.
 The values of the elements of the array are initialized with the

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -9267,6 +9267,7 @@ constexpr auto size() const requires @\libconcept{sized_range}@<const V>;
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
 \effects
 Equivalent to:
 \begin{codeblock}

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -134,31 +134,31 @@ shall exit via an exception.
 \tcode{X::state_type}   &                       &
 (described in~\ref{char.traits.typedefs})   &   compile-time    \\ \rowsep
 \tcode{X::eq(c,d)}      &   \tcode{bool}        &
-\returns
+ \returns
 whether \tcode{c} is to be treated as equal to \tcode{d}.   &   constant    \\ \rowsep
 \tcode{X::lt(c,d)}      &   \tcode{bool}        &
-\returns
+ \returns
 whether \tcode{c} is to be treated as less than \tcode{d}.  &   constant    \\ \rowsep
 \tcode{X::compare(p,q,n)}   &   \tcode{int}     &
-\returns
+ \returns
 \tcode{0} if for each \tcode{i} in \tcode{[0,n)}, \tcode{X::eq(p[i],q[i])}
 is \tcode{true}; else, a negative value if, for some \tcode{j} in \tcode{[0,n)},
 \tcode{X::lt(p[j],q[j])} is \tcode{true} and for each \tcode{i} in \tcode{[0,j)}
 \tcode{X::eq(p[i],q[i])} is \tcode{true}; else a positive value.            &   linear      \\ \rowsep
 \tcode{X::length(p)}    &   \tcode{size_t}     &
-\returns
+ \returns
 the smallest \tcode{i} such that \tcode{X::eq(p[i],charT())} is \tcode{true}.  &   linear  \\ \rowsep
 \tcode{X::find(p,n,c)}  &   \tcode{const X::char_type*} &
-\returns
+ \returns
 the smallest \tcode{q} in \tcode{[p,p+n)} such that
 \tcode{X::eq(*q,c)} is \tcode{true}, zero otherwise.                        &   linear      \\ \rowsep
 \tcode{X::move(s,p,n)}  &   \tcode{X::char_type*}   &
 for each \tcode{i} in \tcode{[0,n)}, performs \tcode{X::assign(s[i],p[i])}.
 Copies correctly even where the ranges \tcode{[p,p+n)} and \tcode{[s,s+n)} overlap.\br \returns \tcode{s}.    &   linear  \\ \rowsep
 \tcode{X::copy(s,p,n)}  &   \tcode{X::char_type*}   &
-\expects
+ \expects
 \tcode{p} not in \tcode{[s,s+n)}.\par
-\returns
+ \returns
 \tcode{s}.\br
 for each \tcode{i} in
 \tcode{[0,n)}, performs \tcode{X::assign(s[i],p[i])}.               &   linear      \\ \rowsep
@@ -167,30 +167,30 @@ assigns \tcode{r=d}.                            &   constant        \\ \rowsep
 \tcode{X::assign\-(s,n,c)}  &   \tcode{X::char_type*}   &
 for each \tcode{i} in \tcode{[0,n)}, performs
 \tcode{X::assign(s[i],c)}.\br
-\returns
+ \returns
 \tcode{s}.                       &   linear      \\ \rowsep
 \tcode{X::not_eof(e)}   &   \tcode{int_type}        &
-\returns
+ \returns
 \tcode{e} if \tcode{X::eq_int_type(e,X::eof())} is \tcode{false},
 otherwise a value \tcode{f} such that
 \tcode{X::eq_int_type(f,X::eof())} is \tcode{false}.                       &   constant    \\ \rowsep
 \tcode{X::to_char_type\-(e)}    &   \tcode{X::char_type}    &
-\returns
+ \returns
 if for some \tcode{c}, \tcode{X::eq_int_type(e,X::to_int_type(c))}
 is \tcode{true}, \tcode{c}; else some unspecified value.                    &   constant    \\ \rowsep
 \tcode{X::to_int_type\-(c)} &   \tcode{X::int_type} &
-\returns
+ \returns
 some value \tcode{e}, constrained by the definitions of
 \tcode{to_char_type} and \tcode{eq_int_type}.                  &   constant    \\ \rowsep
 \tcode{X::eq_int_type\-(e,f)}   &   \tcode{bool}            &
-\returns
+ \returns
 for all \tcode{c} and \tcode{d}, \tcode{X::eq(c,d)} is equal to
 \tcode{X::eq_int_type(X::to_int_type(c), X::to_int_type(d))}; otherwise, yields \tcode{true}
 if \tcode{e} and \tcode{f} are both copies of \tcode{X::eof()}; otherwise, yields \tcode{false} if
 one of \tcode{e} and \tcode{f} is a copy of \tcode{X::eof()} and the other is not; otherwise
 the value is unspecified.                                           &   constant    \\ \rowsep
 \tcode{X::eof()}                &   \tcode{X::int_type} &
-\returns
+ \returns
 a value \tcode{e} such that \tcode{X::eq_int_type(e,X::to_int_type(c))}
 is \tcode{false} for all values \tcode{c}.                                  &   constant    \\
 \end{libreqtab4d}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1138,6 +1138,7 @@ template<class U1, class U2> constexpr const pair& operator=(pair<U1, U2>&& p) c
 \tcode{is_assignable_v<const T2\&, U2>} is \tcode{true}.
 \end{itemize}
 
+\pnum
 \effects
 Assigns \tcode{std::forward<U1>(p.first)} to \tcode{first} and
 \tcode{std::forward<U2>(u.second)} to \tcode{second}.
@@ -18981,6 +18982,7 @@ move_only_function& operator=(nullptr_t) noexcept;
 \effects
 Destroys the target object of \tcode{*this}, if any.
 
+\pnum
 \returns
 \tcode{*this}.
 \end{itemdescr}

--- a/tools/check-source.sh
+++ b/tools/check-source.sh
@@ -198,9 +198,7 @@ done | fail 'subclause without siblings' || failed=1
 
 # Library descriptive macros not immediately preceded by \pnum.
 for f in $texlibdesc; do
-    sed -n '/^\\pnum/{h;:x;n;/^\\index/b x;/^\\\(constraints\|mandates\|expects\|effects\|sync\|ensures\|returns\|throws\|complexity\|remarks\|errors\)/{x;/\n/{x;=;p;};d;};/^\\pnum/D;H;b x;}' $f |
-    # prefix output with filename and line
-    sed '/^[0-9]\+$/{N;s/\n/:/;}' | sed "s/.*/$f:&/"
+    awk '/^\\pnum/ { seenpnum=1; next } /^\\index/ { next } /^\\(constraints|mandates|expects|effects|sync|ensures|returns|throws|complexity|remarks|errors)/ { if(seenpnum == 0) { print FILENAME ":" FNR ":" $0 } } { seenpnum=0 }' $f
 done |
     fail '\\pnum missing' || failed=1
 


### PR DESCRIPTION
Also fix the ineffective check script by rewriting the
check in straightforward awk.