### PR TITLE
[range.slide.iterator] Remove `@` in `\tcode`

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -12355,7 +12355,7 @@ constexpr auto operator[](difference_type n) const
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return views::counted(\exposid{current_} + n, @\exposid{n_}@);}
+Equivalent to: \tcode{return views::counted(\exposid{current_} + n, \exposid{n_});}
 \end{itemdescr}
 
 \begin{itemdecl}


### PR DESCRIPTION
Without this patch:
![upload](https://user-images.githubusercontent.com/8998201/154896005-6cef0ee2-7e18-425c-99a5-64815554308a.png)
