### PR TITLE
[version.syn] Remove mention of nonexistent header `<priority_queue>`

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -605,7 +605,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_constexpr_vector}@                  201907L // also in \libheader{vector}
 #define @\defnlibxname{cpp_lib_containers_ranges}@                 202202L
   // also in \libheader{vector}, \libheader{list}, \libheader{forward_list}, \libheader{map}, \libheader{set}, \libheader{unordered_map}, \libheader{unordered_set},
-  // \libheader{deque}, \libheader{queue}, \libheader{priority_queue}, \libheader{stack}, \libheader{string}
+  // \libheader{deque}, \libheader{queue}, \libheader{stack}, \libheader{string}
 #define @\defnlibxname{cpp_lib_coroutine}@                         201902L // also in \libheader{coroutine}
 #define @\defnlibxname{cpp_lib_destroying_delete}@                 201806L // also in \libheader{new}
 #define @\defnlibxname{cpp_lib_enable_shared_from_this}@           201603L // also in \libheader{memory}


### PR DESCRIPTION
`std::priority_queue` is defined in `<queue>`.

The "Feature test macros" section in [P1206R7 Conversions from ranges to containers](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1206r7.pdf) does say that the macro `__cpp_lib_containers_ranges` is present in `<priority_queue>`, but I guess it's an error rather than a proposal to add this header.