### PR TITLE
[thread] Rename to 'Concurrency support library'

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -1,5 +1,5 @@
 %!TEX root = std.tex
-\rSec0[thread]{Thread support library}
+\rSec0[thread]{Concurrency support library}
 
 \rSec1[thread.general]{General}
 


### PR DESCRIPTION
Missed update with commit d74c2170a9f4c928519461d7742293af2d141852.

See #5313