### PR TITLE
[range.chunk.outer.value] Fix unformatted dereference operator

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -11241,7 +11241,7 @@ constexpr @\exposid{inner-iterator}@ begin() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\exposid{inner-iterator}(*\exposid{parent_}).
+\tcode{\exposid{inner-iterator}(*\exposid{parent_})}.
 \end{itemdescr}
 
 \begin{itemdecl}


### PR DESCRIPTION
Before
<img width="775" alt="截圖 2022-03-04 下午7 16 27" src="https://user-images.githubusercontent.com/67143766/156757489-c68baed5-f168-4727-baf3-9d3d8b23f5cf.png">

After
![image](https://user-images.githubusercontent.com/67143766/156757395-97f36b6a-a4e1-460e-8fb6-22886088e4a8.png)
