### PR TITLE
[range.utility.conv.general] Add missing template parameter to container_inserter

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2101,8 +2101,8 @@ constexpr bool @\exposid{container-insertable}@ =          // \expos
 \pnum
 Let \exposid{container-inserter} be defined as follows:
 \begin{codeblock}
-template<typename Ref>
-auto @\exposid{container-inserter}@(C& c) {                // \expos
+template<class Ref, class Container>
+auto @\exposid{container-inserter}@(Container& c) {                // \expos
   if constexpr (requires { c.push_back(declval<Ref>()); })
     return back_inserter(c);
   else


### PR DESCRIPTION
Also, I strongly doubt that this should be a `constexpr` function, if so I'd be happy to add an LWG (if that can't be as an edit fixed) for it.