### PR TITLE
[expected.unexpected] Rearrange std::unexpected

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6541,12 +6541,12 @@ namespace std {
   public:
     constexpr unexpected(const unexpected&) = default;
     constexpr unexpected(unexpected&&) = default;
+    template<class Err = E>
+      constexpr explicit unexpected(Err&&);
     template<class... Args>
       constexpr explicit unexpected(in_place_t, Args&&...);
     template<class U, class... Args>
       constexpr explicit unexpected(in_place_t, initializer_list<U>, Args&&...);
-    template<class Err = E>
-      constexpr explicit unexpected(Err&&);
 
     constexpr unexpected& operator=(const unexpected&) = default;
     constexpr unexpected& operator=(unexpected&&) = default;

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6498,7 +6498,7 @@ manages the lifetime of the contained objects.
 \indexlibraryglobal{unexpect}%
 \begin{codeblock}
 namespace std {
-  // \ref{expected.un.object}, class template \tcode{unexpected}
+  // \ref{expected.unexpected}, class template \tcode{unexpected}
   template<class E> class unexpected;
 
   // \ref{expected.bad}, class template \tcode{bad_expected_access}
@@ -6521,17 +6521,13 @@ namespace std {
 }
 \end{codeblock}
 
-\rSec2[expected.unexpected]{Unexpected objects}
+\rSec2[expected.unexpected]{Class template \tcode{unexpected}}
 
 \rSec3[expected.un.general]{General}
 
 \pnum
 Subclause \ref{expected.unexpected} describes the class template \tcode{unexpected}
 that represents unexpected objects stored in \tcode{expected} objects.
-
-\rSec3[expected.un.object]{Class template \tcode{unexpected}}
-
-\rSec4[expected.un.object.general]{General}
 
 \indexlibraryglobal{unexpected}%
 \begin{codeblock}
@@ -6579,7 +6575,7 @@ a specialization of \tcode{unexpected}, or
 a cv-qualified type
 is ill-formed.
 
-\rSec4[expected.un.ctor]{Constructors}
+\rSec3[expected.un.ctor]{Constructors}
 
 \indexlibraryctor{unexpected}%
 \begin{itemdecl}
@@ -6650,7 +6646,7 @@ Direct-non-list-initializes
 Any exception thrown by the initialization of \exposid{val}.
 \end{itemdescr}
 
-\rSec4[expected.un.obs]{Observers}
+\rSec3[expected.un.obs]{Observers}
 
 \indexlibrarymember{value}{unexpected}%
 \begin{itemdecl}
@@ -6676,7 +6672,7 @@ constexpr const E&& value() const && noexcept;
 \tcode{std::move(\exposid{val})}.
 \end{itemdescr}
 
-\rSec4[expected.un.swap]{Swap}
+\rSec3[expected.un.swap]{Swap}
 
 \indexlibrarymember{swap}{unexpected}%
 \begin{itemdecl}
@@ -6708,7 +6704,7 @@ friend constexpr void swap(unexpected& x, unexpected& y) noexcept(noexcept(x.swa
 Equivalent to \tcode{x.swap(y)}.
 \end{itemdescr}
 
-\rSec4[expected.un.eq]{Equality operator}
+\rSec3[expected.un.eq]{Equality operator}
 
 \indexlibrarymember{operator==}{unexpected}%
 \begin{itemdecl}


### PR DESCRIPTION
Some minor improvements to the `std::unexpected` spec.

This is the TOC before:

![before](https://user-images.githubusercontent.com/1254480/159890768-1c96a3a3-b4dd-420c-9f1b-20c3bcd13f24.png)

And after:

![after](https://user-images.githubusercontent.com/1254480/159890506-298bdf36-aadb-44ca-80e6-4cb22f89c97f.png)

In the second image every "Class template foo" under 22.8 is at the same level, without the pointless "Unexpected objects" subclause, and without two "General" subclauses for one simple class template.

The other commit just reorders the `std::unexpected` synopsis to match the order of the detailed descriptions, and the order of corresponding constructors in the `std::expected` and `std::expected<cv void, E>` synopses and details descriptions.