### PR TITLE
P2071R2 Named universal character escapes

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -289,6 +289,25 @@ The \grammarterm{universal-character-name} construct provides a way to name
 other characters.
 
 \begin{bnf}
+\nontermdef{n-char} \textnormal{one of}\br
+    \terminal{A B C D E F G H I J K L M N O P Q R S T U V W X Y Z}\br
+    \terminal{0 1 2 3 4 5 6 7 8 9}\br
+    \textnormal{\unicode{002d}{hyphen-minus}}\br
+    \textnormal{\unicode{0020}{space}}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{n-char-sequence}\br
+    n-char\br
+    n-char-sequence n-char
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{named-universal-character}\br
+    \terminal{\textbackslash N\{} n-char-sequence \terminal{\}}
+\end{bnf}
+
+\begin{bnf}
 \nontermdef{hex-quad}\br
     hexadecimal-digit hexadecimal-digit hexadecimal-digit hexadecimal-digit
 \end{bnf}
@@ -296,15 +315,138 @@ other characters.
 \begin{bnf}
 \nontermdef{universal-character-name}\br
     \terminal{\textbackslash u} hex-quad\br
-    \terminal{\textbackslash U} hex-quad hex-quad
+    \terminal{\textbackslash U} hex-quad hex-quad\br
+    named-universal-character
 \end{bnf}
 
+\pnum
 A \grammarterm{universal-character-name}
+of the form \textbackslash u \grammarterm{hex-quad} or \textbackslash U
+\grammarterm{hex-quad} \grammarterm{hex-quad}
 designates the character in the translation character set
 whose UCS scalar value is the hexadecimal number represented by
 the sequence of \grammarterm{hexadecimal-digit}s
 in the \grammarterm{universal-character-name}.
 The program is ill-formed if that number is not a UCS scalar value.
+
+\pnum
+A \grammarterm{universal-character-name} that is a
+\grammarterm{named-universal-character} designates the
+character named by its \grammarterm{n-char-sequence}. A character is so named if the
+\grammarterm{n-char-sequence} is equal to
+\begin{itemize}
+\item the associated character name or associated character name alias specified in
+ ISO/IEC 10646 subclause ``Code charts and lists of character names'' or
+\item the control code alias given in \tref{lex.charset.aliases}.
+\begin{note}
+The aliases in \tref{lex.charset.aliases} are provided for control characters
+which otherwise have no associated character name or character name alias.
+These names are derived from the Unicode Character Database's \tcode{NameAliases.txt}.
+For historical reasons, control characters are formally unnamed.
+\end{note}
+\end{itemize}
+
+
+\begin{note}
+None of the associated character names, associated character name aliases, or
+control code aliases have leading or trailing spaces.
+\end{note}
+
+\begin{LongTable}{Control Code Aliases}{lex.charset.aliases}{ll}
+\\ \topline
+\lhdr{Code point} & \rhdr{Control code alias} \\ \capsep
+\endfirsthead
+\continuedcaption \\
+\hline
+\lhdr{Code point} & \rhdr{Control code alias} \\ \capsep
+\endhead
+\ucode{0000} & \tcode{NULL} \\ \rowsep
+\ucode{0001} & \tcode{START OF HEADING} \\ \rowsep
+\ucode{0002} & \tcode{START OF TEXT} \\ \rowsep
+\ucode{0003} & \tcode{END OF TEXT} \\ \rowsep
+\ucode{0004} & \tcode{END OF TRANSMISSION} \\ \rowsep
+\ucode{0005} & \tcode{ENQUIRY} \\ \rowsep
+\ucode{0006} & \tcode{ACKNOWLEDGE} \\ \rowsep
+\ucode{0007} & \tcode{ALERT} \\ \rowsep
+\ucode{0008} & \tcode{BACKSPACE} \\ \rowsep
+\ucode{0009} & \tcode{CHARACTER TABULATION} \\
+             & \tcode{HORIZONTAL TABULATION} \\ \rowsep
+\ucode{000a} & \tcode{LINE FEED} \\
+             & \tcode{NEW LINE} \\
+             & \tcode{END OF LINE} \\ \rowsep
+\ucode{000b} & \tcode{LINE TABULATION} \\
+             & \tcode{VERTICAL TABULATION} \\ \rowsep
+\ucode{000c} & \tcode{FORM FEED} \\ \rowsep
+\ucode{000d} & \tcode{CARRIAGE RETURN} \\ \rowsep
+\ucode{000e} & \tcode{SHIFT OUT} \\
+             & \tcode{LOCKING-SHIFT ONE} \\ \rowsep
+\ucode{000f} & \tcode{SHIFT IN} \\
+             & \tcode{LOCKING-SHIFT ZERO} \\ \rowsep
+\ucode{0010} & \tcode{DATA LINK ESCAPE} \\ \rowsep
+\ucode{0011} & \tcode{DEVICE CONTROL ONE} \\ \rowsep
+\ucode{0012} & \tcode{DEVICE CONTROL TWO} \\ \rowsep
+\ucode{0013} & \tcode{DEVICE CONTROL THREE} \\ \rowsep
+\ucode{0014} & \tcode{DEVICE CONTROL FOUR} \\ \rowsep
+\ucode{0015} & \tcode{NEGATIVE ACKNOWLEDGE} \\ \rowsep
+\ucode{0016} & \tcode{SYNCHRONOUS IDLE} \\ \rowsep
+\ucode{0017} & \tcode{END OF TRANSMISSION BLOCK} \\ \rowsep
+\ucode{0018} & \tcode{CANCEL} \\ \rowsep
+\ucode{0019} & \tcode{END OF MEDIUM} \\ \rowsep
+\ucode{001a} & \tcode{SUBSTITUTE} \\ \rowsep
+\ucode{001b} & \tcode{ESCAPE} \\ \rowsep
+\ucode{001c} & \tcode{INFORMATION SEPARATOR FOUR} \\
+             & \tcode{FILE SEPARATOR} \\ \rowsep
+\ucode{001d} & \tcode{INFORMATION SEPARATOR THREE} \\
+             & \tcode{GROUP SEPARATOR} \\ \rowsep
+\ucode{001e} & \tcode{INFORMATION SEPARATOR TWO} \\
+             & \tcode{RECORD SEPARATOR} \\ \rowsep
+\ucode{001f} & \tcode{INFORMATION SEPARATOR ON} \\
+             & \tcode{UNIT SEPARATOR} \\ \rowsep
+\ucode{007f} & \tcode{DELETE} \\ \rowsep
+\ucode{0082} & \tcode{BREAK PERMITTED HERE} \\ \rowsep
+\ucode{0083} & \tcode{NO BREAK HERE} \\ \rowsep
+\ucode{0084} & \tcode{INDEX} \\ \rowsep
+\ucode{0085} & \tcode{NEXT LINE} \\ \rowsep
+\ucode{0086} & \tcode{START OF SELECTED AREA} \\ \rowsep
+\ucode{0087} & \tcode{END OF SELECTED AREA} \\ \rowsep
+\ucode{0088} & \tcode{CHARACTER TABULATION SET} \\
+             & \tcode{HORIZONTAL TABULATION SET} \\ \rowsep
+\ucode{0089} & \tcode{CHARACTER TABULATION WITH JUSTIFICATION} \\
+             & \tcode{HORIZONTAL TABULATION WITH JUSTIFICATION} \\ \rowsep
+\ucode{008a} & \tcode{LINE TABULATION SET} \\
+             & \tcode{VERTICAL TABULATION SET} \\ \rowsep
+\ucode{008b} & \tcode{PARTIAL LINE FORWARD} \\
+             & \tcode{PARTIAL LINE DOWN} \\ \rowsep
+\ucode{008c} & \tcode{PARTIAL LINE BACKWARD} \\
+             & \tcode{PARTIAL LINE UP} \\ \rowsep
+\ucode{008d} & \tcode{REVERSE LINE FEED} \\
+             & \tcode{REVERSE INDEX} \\ \rowsep
+\ucode{008e} & \tcode{SINGLE SHIFT TWO} \\
+             & \tcode{SINGLE-SHIFT-2} \\ \rowsep
+\ucode{008f} & \tcode{SINGLE SHIFT THREE} \\
+             & \tcode{SINGLE-SHIFT-3} \\ \rowsep
+\ucode{0090} & \tcode{DEVICE CONTROL STRING} \\ \rowsep
+\ucode{0091} & \tcode{PRIVATE USE ONE} \\
+             & \tcode{PRIVATE USE-1} \\ \rowsep
+\ucode{0092} & \tcode{PRIVATE USE TWO} \\
+             & \tcode{PRIVATE USE-2} \\ \rowsep
+\ucode{0093} & \tcode{SET TRANSMIT STATE} \\ \rowsep
+\ucode{0094} & \tcode{CANCEL CHARACTER} \\ \rowsep
+\ucode{0095} & \tcode{MESSAGE WAITING} \\ \rowsep
+\ucode{0096} & \tcode{START OF GUARDED AREA} \\
+             & \tcode{START OF PROTECTED AREA} \\ \rowsep
+\ucode{0097} & \tcode{END OF GUARDED AREA} \\
+             & \tcode{END OF PROTECTED AREA} \\ \rowsep
+\ucode{0098} & \tcode{START OF STRING} \\ \rowsep
+\ucode{009a} & \tcode{SINGLE CHARACTER INTRODUCER} \\ \rowsep
+\ucode{009b} & \tcode{CONTROL SEQUENCE INTRODUCER} \\ \rowsep
+\ucode{009c} & \tcode{STRING TERMINATOR} \\ \rowsep
+\ucode{009d} & \tcode{OPERATING SYSTEM COMMAND} \\ \rowsep
+\ucode{009e} & \tcode{PRIVACY MESSAGE} \\ \rowsep
+\ucode{009f} & \tcode{APPLICATION PROGRAM COMMAND} \\
+\end{LongTable}
+
+\pnum
 If a \grammarterm{universal-character-name} outside
 the \grammarterm{c-char-sequence}, \grammarterm{s-char-sequence}, or
 \grammarterm{r-char-sequence} of
@@ -1330,7 +1472,7 @@ that cannot be represented by any of the allowed types.
 
 \begin{bnf}
 \nontermdef{conditional-escape-sequence-char}\br
-    \textnormal{any member of the basic character set that is not an} octal-digit\textnormal{, a} simple-escape-sequence-char\textnormal{, or the characters \terminal{u}, \terminal{U}, or \terminal{x}}
+    \textnormal{any member of the basic character set that is not an} octal-digit\textnormal{, a} simple-escape-sequence-char\textnormal{, or the characters \terminal{N}, \terminal{u}, \terminal{U}, or \terminal{x}}
 \end{bnf}
 
 \pnum

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1784,6 +1784,7 @@ an \impldef{text of \mname{TIME} when time of translation is not available} vali
 \defnxname{cpp_lambdas}                           & \tcode{200907L} \\ \rowsep
 \defnxname{cpp_modules}                           & \tcode{201907L} \\ \rowsep
 \defnxname{cpp_multidimensional_subscript}        & \tcode{202110L} \\ \rowsep
+\defnxname{cpp_named_character_escapes}           & \tcode{202207L} \\ \rowsep
 \defnxname{cpp_namespace_attributes}              & \tcode{201411L} \\ \rowsep
 \defnxname{cpp_noexcept_function_type}            & \tcode{201510L} \\ \rowsep
 \defnxname{cpp_nontype_template_args}             & \tcode{201911L} \\ \rowsep


### PR DESCRIPTION
The wording as approved by CWG for P2071, including the control code alias table which would be tedious to reproduce. Uses a new code font macro for uname to clarify there is no internal invisible whitespace. 

Fixes cplusplus/papers#798