### PR TITLE
[stacktrace.syn] Add '#include <compare>'

### DIFF
--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -1707,6 +1707,8 @@ A \defn{stacktrace entry} represents an evaluation in a stacktrace.
 
 \indexheader{stacktrace}%
 \begin{codeblock}
+#include <compare>              // see \ref{compare.syn}
+
 namespace std {
   // \ref{stacktrace.entry}, class \tcode{stacktrace_entry}
   class stacktrace_entry;


### PR DESCRIPTION
LWG3330 added #include <compare> to all header files
where a three-way comparison operator was declared,
but missed this one.

Fixes #5373