### PR TITLE
[alg.min.max] Consistently specify `ranges::minmax_element` with `ranges::minmax_element_result`

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -8643,11 +8643,11 @@ template<class ExecutionPolicy, class ForwardIterator, class Compare>
 
 template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
          @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
-  constexpr ranges::minmax_result<I>
+  constexpr ranges::minmax_element_result<I>
     ranges::minmax_element(I first, S last, Comp comp = {}, Proj proj = {});
 template<@\libconcept{forward_range}@ R, class Proj = identity,
          @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
-  constexpr ranges::minmax_result<borrowed_iterator_t<R>>
+  constexpr ranges::minmax_element_result<borrowed_iterator_t<R>>
     ranges::minmax_element(R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 


### PR DESCRIPTION
Fixes #5375