### PR TITLE
[expected.object.general] Add missing noexcept for expected::error()

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6905,10 +6905,10 @@ namespace std {
     constexpr T& value() &;
     constexpr const T&& value() const &&;
     constexpr T&& value() &&;
-    constexpr const E& error() const &;
-    constexpr E& error() &;
-    constexpr const E&& error() const &&;
-    constexpr E&& error() &&;
+    constexpr const E& error() const & noexcept;
+    constexpr E& error() & noexcept;
+    constexpr const E&& error() const && noexcept;
+    constexpr E&& error() && noexcept;
     template<class U> constexpr T value_or(U&&) const &;
     template<class U> constexpr T value_or(U&&) &&;
 
@@ -7962,10 +7962,10 @@ public:
   constexpr void operator*() const noexcept;
   constexpr void value() const &;
   constexpr void value() &&;
-  constexpr const E& error() const &;
-  constexpr E& error() &;
-  constexpr const E&& error() const &&;
-  constexpr E&& error() &&;
+  constexpr const E& error() const & noexcept;
+  constexpr E& error() & noexcept;
+  constexpr const E&& error() const && noexcept;
+  constexpr E&& error() && noexcept;
 
   // \ref{expected.void.eq}, equality operators
   template<class T2, class E2> requires is_void_v<T2>

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -8449,8 +8449,8 @@ if \tcode{has_value()} is \tcode{false}.
 
 \indexlibrarymember{error}{expected<void>}%
 \begin{itemdecl}
-constexpr const E& error() const &;
-constexpr E& error() &;
+constexpr const E& error() const & noexcept;
+constexpr E& error() & noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8465,8 +8465,8 @@ constexpr E& error() &;
 
 \indexlibrarymember{error}{expected<void>}%
 \begin{itemdecl}
-constexpr E&& error() &&;
-constexpr const E&& error() const &&;
+constexpr E&& error() && noexcept;
+constexpr const E&& error() const && noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
In [[expected.object.general]](https://timsong-cpp.github.io/cppwp/expected.object.general), the function is defined as

`constexpr const E& error() const &;`

However in [[expected.object.obs]](https://timsong-cpp.github.io/cppwp/expected.object.obs), it is defined as

`constexpr const E& error() const & noexcept;`

So let me assume it's just that the author of the paper forgot to add `noexcept`.