### PR TITLE
[range.utility.conv.general] Add missing constexpr for container-inserter

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2102,7 +2102,7 @@ constexpr bool @\exposid{container-insertable}@ =          // \expos
 Let \exposid{container-inserter} be defined as follows:
 \begin{codeblock}
 template<class Ref, class Container>
-auto @\exposid{container-inserter}@(Container& c) {                // \expos
+constexpr auto @\exposid{container-inserter}@(Container& c) {                // \expos
   if constexpr (requires { c.push_back(declval<Ref>()); })
     return back_inserter(c);
   else


### PR DESCRIPTION
This is the follow up of [pull/5333](https://github.com/cplusplus/draft/pull/5333), and I think the authors agree that the missing `constexpr` is not intended, it's more like a bug in the paper.