### PR TITLE
[range.adaptors] Make the prints message format consistent

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2472,7 +2472,7 @@ are expression-equivalent to
 \begin{example}
 \begin{codeblock}
 for (int i : views::iota(1, 10))
-  cout << i << ' '; // prints: 1 2 3 4 5 6 7 8 9
+  cout << i << ' '; // prints \tcode{1 2 3 4 5 6 7 8 9}
 \end{codeblock}
 \end{example}
 
@@ -3405,7 +3405,7 @@ vector<int> ints{0,1,2,3,4,5};
 auto even = [](int i) { return 0 == i % 2; };
 auto square = [](int i) { return i * i; };
 for (int i : ints | views::filter(even) | views::transform(square)) {
-  cout << i << ' '; // prints: 0 4 16
+  cout << i << ' '; // prints \tcode{0 4 16}
 }
 assert(ranges::equal(ints | views::filter(even), views::filter(ints, even)));
 \end{codeblock}
@@ -3823,7 +3823,7 @@ the expression \tcode{views::filter(E, P)} is expression-equivalent to
 vector<int> is{ 0, 1, 2, 3, 4, 5, 6 };
 auto evens = views::filter(is, [](int i) { return 0 == i % 2; });
 for (int i : evens)
-  cout << i << ' '; // prints: 0 2 4 6
+  cout << i << ' '; // prints \tcode{0 2 4 6}
 \end{codeblock}
 \end{example}
 
@@ -4248,7 +4248,7 @@ Given subexpressions \tcode{E} and \tcode{F}, the expression
 vector<int> is{ 0, 1, 2, 3, 4 };
 auto squares = views::transform(is, [](int i) { return i * i; });
 for (int i : squares)
-  cout << i << ' '; // prints: 0 1 4 9 16
+  cout << i << ' '; // prints \tcode{0 1 4 9 16}
 \end{codeblock}
 \end{example}
 
@@ -4976,7 +4976,7 @@ Otherwise, \tcode{ranges::take_view(E, F)}.
 \begin{codeblock}
 vector<int> is{0,1,2,3,4,5,6,7,8,9};
 for (int i : is | views::take(5))
-  cout << i << ' '; // prints: 0 1 2 3 4
+  cout << i << ' '; // prints \tcode{0 1 2 3 4}
 \end{codeblock}
 \end{example}
 
@@ -5642,7 +5642,7 @@ Given a subexpression \tcode{E}, the expression
 \begin{codeblock}
 vector<string> ss{"hello", " ", "world", "!"};
 for (char ch : ss | views::join)
-  cout << ch;                                   // prints: \tcode{hello world!}
+  cout << ch;                                   // prints \tcode{hello world!}
 \end{codeblock}
 \end{example}
 
@@ -6137,8 +6137,8 @@ vector<string> vs = {"the", "quick", "brown", "fox"};
 for (char c : vs | join_with('-')) {
   cout << c;
 }
+// The above prints \tcode{the-quick-brown-fox}
 \end{codeblock}
-The above prints: \tcode{the-quick-brown-fox}
 \end{example}
 
 \rSec3[range.join.with.view]{Class template \tcode{join_with_view}}
@@ -6719,7 +6719,7 @@ for (auto word : str | views::lazy_split(' ')) {
     cout << ch;
   cout << '*';
 }
-// The above prints: the*quick*brown*fox*
+// The above prints \tcode{the*quick*brown*fox*}
 \end{codeblock}
 \end{example}
 
@@ -7278,7 +7278,7 @@ string str{"the quick brown fox"};
 for (string_view word : split(str, ' ')) {
   cout << word << '*';
 }
-// The above prints: the*quick*brown*fox*
+// The above prints \tcode{the*quick*brown*fox*}
 \end{codeblock}
 \end{example}
 
@@ -7760,7 +7760,7 @@ subrange<I, I, K>(E.end().base(), E.begin().base())
 \begin{codeblock}
 vector<int> is {0,1,2,3,4};
 for (int i : is | views::reverse)
-  cout << i << ' '; // prints: 4 3 2 1 0
+  cout << i << ' '; // prints \tcode{4 3 2 1 0}
 \end{codeblock}
 \end{example}
 
@@ -8550,7 +8550,7 @@ range_reference_t<decltype(z)> f = z.front();   // \tcode{f} is a \tcode{pair<in
                                                 // that refers to the first element of \tcode{v} and \tcode{l}
 
 for (auto&& [x, y] : z) {
-  cout << '(' << x << ", " << y << ") ";        // prints: (1, a) (2, b)
+  cout << '(' << x << ", " << y << ") ";        // prints \tcode{(1, a) (2, b)}
 }
 \end{codeblock}
 \end{example}
@@ -9281,7 +9281,7 @@ vector v1 = {1, 2};
 vector v2 = {4, 5, 6};
 
 for (auto i : views::zip_transform(plus(), v1, v2)) {
-  cout << i << ' ';     // prints: 5 7
+  cout << i << ' ';     // prints \tcode{5 7}
 }
 \end{codeblock}
 \end{example}
@@ -9815,7 +9815,7 @@ otherwise, \tcode{adjacent_view<views::all_t<decltype((E))>, N>(E)}.
 vector v = {1, 2, 3, 4};
 
 for (auto i : v | views::adjacent<2>) {
-  cout << "(" << i.first << ", " << i.second << ") ";   // prints: (1, 2) (2, 3) (3, 4)
+  cout << "(" << i.first << ", " << i.second << ") ";   // prints \tcode{(1, 2) (2, 3) (3, 4)}
 }
 \end{codeblock}
 \end{example}
@@ -10455,7 +10455,7 @@ expression-equivalent to
 vector v = {1, 2, 3, 4};
 
 for (auto i : v | views::adjacent_transform<2>(std::multiplies())) {
-  cout << i << ' ';     // prints: 2 6 12
+  cout << i << ' ';     // prints \tcode{2 6 12}
 }
 \end{codeblock}
 \end{example}
@@ -10963,8 +10963,8 @@ for (auto r : v | views::chunk(2)) {
   }
   cout << "] ";
 }
+// The above prints \tcode{[1, 2] [3, 4] [5]}
 \end{codeblock}
-The above prints: \tcode{[1, 2] [3, 4] [5]}
 \end{example}
 
 \rSec3[range.chunk.view.input]{\tcode{chunk_view} for input ranges}
@@ -11923,7 +11923,7 @@ the expression \tcode{views::slide(E, N)} is expression-equivalent to
 vector v = {1, 2, 3, 4};
 
 for (auto i : v | views::slide(2)) {
-  cout << '[' << i[0] << ", " << i[1] << "] ";          // prints: [1, 2] [2, 3] [3, 4]
+  cout << '[' << i[0] << ", " << i[1] << "] ";          // prints \tcode{[1, 2] [2, 3] [3, 4]}
 }
 \end{codeblock}
 \end{example}
@@ -12581,8 +12581,8 @@ for (auto r : v | views::chunk_by(ranges::less_equal{})) {
   }
   cout << "] ";
 }
+// The above prints \tcode{[1, 2, 2, 3] [0, 4, 5] [2]}
 \end{codeblock}
-The above prints: \tcode{[1, 2, 2, 3] [0, 4, 5] [2]}
 \end{example}
 
 \rSec3[range.chunk.by.view]{Class template \tcode{chunk_by_view}}


### PR DESCRIPTION
Currently `<ranges>` has two formats for the description of print messages, one is

`// prints: 1 2 3 4 5 6 7 8 9`

The other is

`// prints \tcode{1 2 3 4 5 6 7 8 9}
`

This pull request converts all the first form to the second form, that is, omits the colon after `prints`, and then outputs the message in code format.
It also fixes incorrect formatting of `The above prints:` in [[range.join.with.overview]](https://timsong-cpp.github.io/cppwp/range.join.with.overview)[[range.chunk.overview]](https://timsong-cpp.github.io/cppwp/range.chunk.overview), [[range.chunk.by.overview]](https://timsong-cpp.github.io/cppwp/range.chunk.by.overview).