### PR TITLE
LWG3687. `expected<cv void, E>` move constructor should move

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -8272,7 +8272,7 @@ construct_at(addressof(@\exposid{unex}@), std::move(rhs.@\exposid{unex}@));
 Otherwise, if \tcode{rhs.has_value()} is \tcode{true},
 destroys \exposid{unex} and sets \exposid{has_val} to \tcode{true}.
 \item
-Otherwise, equivalent to \tcode{\exposid{unex} = rhs.error()}.
+Otherwise, equivalent to \tcode{\exposid{unex} = std::move(rhs.error())}.
 \end{itemize}
 
 \pnum


### PR DESCRIPTION
Which it's apparently a bug in the paper.