### PR TITLE
[allocator.requirements.general] Specify all member types with `typename`

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2464,7 +2464,7 @@ Default: \tcode{return a;}
 \end{itemdescr}
 
 \begin{itemdecl}
-X::propagate_on_container_copy_assignment
+typename X::propagate_on_container_copy_assignment
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2486,7 +2486,7 @@ Default: \tcode{false_type}
 \end{itemdescr}
 
 \begin{itemdecl}
-X::propagate_on_container_move_assignment
+typename X::propagate_on_container_move_assignment
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2508,7 +2508,7 @@ Default: \tcode{false_type}
 \end{itemdescr}
 
 \begin{itemdecl}
-X::propagate_on_container_swap
+typename X::propagate_on_container_swap
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2530,7 +2530,7 @@ Default: \tcode{false_type}
 \end{itemdescr}
 
 \begin{itemdecl}
-X::is_always_equal
+typename X::is_always_equal
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Requirements for some member types in [allocator.requirements.general] are specified with `typename`, but the following are currently not:
- `X::propagate_on_container_copy_assignment`
- `X::propagate_on_container_move_assignment`
- `X::propagate_on_container_swap`
- `X::is_always_equal`