### PR TITLE
[expr.call] Clarify the value of this

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3197,10 +3197,12 @@ template<typename ...T> int f(int n = 0, T ...t);
 int x = f<int>();               // error: no argument for second function parameter
 \end{codeblock}
 \end{example}
-If the function is an implicit object member
-function, the \keyword{this} parameter of the function\iref{expr.prim.this}
-is initialized with a pointer to the object of the call, converted
-as if by an explicit type conversion\iref{expr.cast}.
+If the function is an implicit object member function,
+the object for which it is invoked\iref{expr.prim.this}
+is the object which would be pointed to by the result
+of an explicit type conversion\iref{expr.cast}
+on a pointer pointing to the result of the \termref{object expression}
+to the type of \keyword{this} in the body of the function.
 \begin{note}
 There is no access or ambiguity checking on this conversion; the access
 checking and disambiguation are done as part of the (possibly implicit)


### PR DESCRIPTION
There is no such thing as «`this` parameter of the function», after all