### PR TITLE
[depr.tuple],[depr.variant] Use struct class-key consistently

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -1488,17 +1488,17 @@ The header \libheaderref{tuple} has the following additions:
 
 \begin{codeblock}
 namespace std {
-  template<class T> class tuple_size<volatile T>;
-  template<class T> class tuple_size<const volatile T>;
+  template<class T> struct tuple_size<volatile T>;
+  template<class T> struct tuple_size<const volatile T>;
 
-  template<size_t I, class T> class tuple_element<I, volatile T>;
-  template<size_t I, class T> class tuple_element<I, const volatile T>;
+  template<size_t I, class T> struct tuple_element<I, volatile T>;
+  template<size_t I, class T> struct tuple_element<I, const volatile T>;
 }
 \end{codeblock}
 
 \begin{itemdecl}
-template<class T> class tuple_size<volatile T>;
-template<class T> class tuple_size<const volatile T>;
+template<class T> struct tuple_size<volatile T>;
+template<class T> struct tuple_size<const volatile T>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1526,8 +1526,8 @@ are included.
 \end{itemdescr}
 
 \begin{itemdecl}
-template<size_t I, class T> class tuple_element<I, volatile T>;
-template<size_t I, class T> class tuple_element<I, const volatile T>;
+template<size_t I, class T> struct tuple_element<I, volatile T>;
+template<size_t I, class T> struct tuple_element<I, const volatile T>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1567,8 +1567,8 @@ namespace std {
 \end{codeblock}
 
 \begin{itemdecl}
-template<class T> class variant_size<volatile T>;
-template<class T> class variant_size<const volatile T>;
+template<class T> struct variant_size<volatile T>;
+template<class T> struct variant_size<const volatile T>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1581,8 +1581,8 @@ with a base characteristic of \tcode{integral_constant<size_t, VS::value>}.
 \end{itemdescr}
 
 \begin{itemdecl}
-template<size_t I, class T> class variant_alternative<I, volatile T>;
-template<size_t I, class T> class variant_alternative<I, const volatile T>;
+template<size_t I, class T> struct variant_alternative<I, volatile T>;
+template<size_t I, class T> struct variant_alternative<I, const volatile T>;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Similar to #2570 and #2679