### PR TITLE
[expected] Use `unex` as exposition-only name for all unexpected values

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6564,7 +6564,7 @@ namespace std {
     friend constexpr void swap(unexpected& x, unexpected& y) noexcept(noexcept(x.swap(y)));
 
   private:
-    E @\exposid{val}@;               // \expos
+    E @\exposid{unex}@;              // \expos
   };
 
   template<class E> unexpected(E) -> unexpected<E>;
@@ -6601,11 +6601,11 @@ template<class Err = E>
 
 \pnum
 \effects
-Direct-non-list-initializes \exposid{val} with \tcode{std::forward<Err>(e)}.
+Direct-non-list-initializes \exposid{unex} with \tcode{std::forward<Err>(e)}.
 
 \pnum
 \throws
-Any exception thrown by the initialization of \exposid{val}.
+Any exception thrown by the initialization of \exposid{unex}.
 \end{itemdescr}
 
 \indexlibraryctor{unexpected}%
@@ -6622,11 +6622,11 @@ template<class... Args>
 \pnum
 \effects
 Direct-non-list-initializes
-\exposid{val} with \tcode{std::forward<Args>(args)...}.
+\exposid{unex} with \tcode{std::forward<Args>(args)...}.
 
 \pnum
 \throws
-Any exception thrown by the initialization of \exposid{val}.
+Any exception thrown by the initialization of \exposid{unex}.
 \end{itemdescr}
 
 \indexlibraryctor{unexpected}%
@@ -6643,11 +6643,11 @@ template<class U, class... Args>
 \pnum
 \effects
 Direct-non-list-initializes
-\exposid{val} with \tcode{il, std::forward<Args>(args)...}.
+\exposid{unex} with \tcode{il, std::forward<Args>(args)...}.
 
 \pnum
 \throws
-Any exception thrown by the initialization of \exposid{val}.
+Any exception thrown by the initialization of \exposid{unex}.
 \end{itemdescr}
 
 \rSec4[expected.un.obs]{Observers}
@@ -6661,7 +6661,7 @@ constexpr E& value() & noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\exposid{val}.
+\exposid{unex}.
 \end{itemdescr}
 
 \indexlibrarymember{value}{unexpected}%
@@ -6673,7 +6673,7 @@ constexpr const E&& value() const && noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{std::move(\exposid{val})}.
+\tcode{std::move(\exposid{unex})}.
 \end{itemdescr}
 
 \rSec4[expected.un.swap]{Swap}
@@ -6691,7 +6691,7 @@ constexpr void swap(unexpected& other) noexcept(is_nothrow_swappable_v<E>);
 \pnum
 \effects
 Equivalent to:
-\tcode{using std::swap; swap(\exposid{val}, other.\exposid{val});}
+\tcode{using std::swap; swap(\exposid{unex}, other.\exposid{unex});}
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -6742,7 +6742,7 @@ namespace std {
     E&& error() && noexcept;
     const E&& error() const && noexcept;
   private:
-    E @\exposid{val}@;              // \expos
+    E @\exposid{unex}@;             // \expos
   };
 }
 \end{codeblock}
@@ -6761,7 +6761,7 @@ explicit bad_expected_access(E e);
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \exposid{val} with \tcode{std::move(e)}.
+Initializes \exposid{unex} with \tcode{std::move(e)}.
 \end{itemdescr}
 
 \indexlibrarymember{error}{bad_expected_access}%
@@ -6773,7 +6773,7 @@ E& error() & noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\exposid{val}.
+\exposid{unex}.
 \end{itemdescr}
 
 \indexlibrarymember{error}{bad_expected_access}%
@@ -6785,7 +6785,7 @@ const E&& error() const && noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{std::move(\exposid{val})}.
+\tcode{std::move(\exposid{unex})}.
 \end{itemdescr}
 
 \indexlibrarymember{what}{bad_expected_access}%


### PR DESCRIPTION
Currently _`val`_ is used as the exposition-only name of the data member of `std::unexpected` and `std::bad_expected_access` while the member represents an unexpected value, which is inconsistent with `std::expected`.

Such inconsistency has been discussed in Mick235711/wg21-papers#1.