### PR TITLE
[expr.prim.lambda.general] Clarify deduced lambda return type

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1757,9 +1757,11 @@ it is as if \tcode{()} were inserted
 at the start of the \grammarterm{lambda-declarator}.
 If the \grammarterm{lambda-declarator}
 does not include a \grammarterm{trailing-return-type},
-the lambda return type is \keyword{auto},
-which is deduced from \keyword{return} statements
+it is considered to be \tcode{-> \keyword{auto}}.
+\begin{note}
+In that case, the return type is deduced from \keyword{return} statements
 as described in \ref{dcl.spec.auto}.
+\end{note}
 \begin{example}
 \begin{codeblock}
 auto x1 = [](int i) { return i; };      // OK, return type is \tcode{int}


### PR DESCRIPTION
Fixes #5400