### PR TITLE
[iterator.concept.readable] remove obsolete Note

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1248,10 +1248,6 @@ template<class In>
 \pnum
 Given a value \tcode{i} of type \tcode{I}, \tcode{I} models \libconcept{indirectly_readable}
 only if the expression \tcode{*i} is equality-preserving.
-\begin{note}
-The expression \tcode{*i} is indirectly required to be valid via the
-exposition-only \exposconcept{dereferenceable} concept\iref{iterator.synopsis}.
-\end{note}
 
 \rSec3[iterator.concept.writable]{Concept \cname{indirectly_writable}}
 


### PR DESCRIPTION
There is a note in this section
> The expression *i is indirectly required to be valid via the exposition-only dereferenceable concept

This makes sense before P1878R1. But after P1878R1, the expression `*i`
is "directly" required in the requires clause. So this note is no longer
valid.

The change that adds `*i` in the require clause is here
https://github.com/cplusplus/draft/commit/333b6eb8c147fce1a9ddcd905ee3bb1a09b91e30#diff-0043c904d3e034a77b44feeddf18719e63e646d55db1c564f2a5defe7330c9eaR1213