### PR TITLE
Fix the typo for "apostrohpe"

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1511,7 +1511,7 @@ is supported for compatibility with ISO \CppXIV{} and ISO C.
 \ucode{0007} & \uname{alert}                & \tcode{\textbackslash a} \\
 \ucode{005c} & \uname{reverse solidus}      & \tcode{\textbackslash\textbackslash} \\
 \ucode{003f} & \uname{question mark}        & \tcode{\textbackslash ?} \\
-\ucode{0027} & \uname{apostrohpe}           & \tcode{\textbackslash '} \\
+\ucode{0027} & \uname{apostrophe}           & \tcode{\textbackslash '} \\
 \ucode{0022} & \uname{quotation mark}       & \tcode{\textbackslash "} \\
 \end{floattable}
 


### PR DESCRIPTION
Correct "apostrohpe" to "apostrophe".

Fixes #5410