### PR TITLE
[except.pre] Reword "shall not be used to" avoiding question of actual "use"

### DIFF
--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -72,8 +72,8 @@ Within this Clause
 \indextext{\idxcode{switch}!and try block}%
 \indextext{\idxcode{goto}!and handler}%
 \indextext{\idxcode{switch}!and handler}%
-A \tcode{goto} or \keyword{switch} statement shall not be used to transfer control
-into a try block or into a handler.
+The \grammarterm{compound-statement} of a try block or of a handler is a
+control-flow-limited statement\iref{stmt.label}.
 \begin{example}
 \begin{codeblock}
 void f() {

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -146,6 +146,18 @@ before its introduction by a \grammarterm{labeled-statement}.
 \indextext{label!\idxcode{default}}%
 Case labels and default labels shall occur only in \keyword{switch} statements.
 
+\pnum
+A \defnadj{control-flow-limited}{statement} is a statement \tcode{S} for which:
+\begin{itemize}
+\item
+  a \keyword{case} or \keyword{default} label appearing within \tcode{S} shall
+  be associated with a \keyword{switch} statement\iref{stmt.switch} within
+  \tcode{S}, and
+\item
+  a label declared in \tcode{S} shall only be referred to by a
+  statement\iref{stmt.goto} in \tcode{S}.
+\end{itemize}
+
 
 \rSec1[stmt.expr]{Expression statement}%
 \indextext{statement!expression}
@@ -262,6 +274,8 @@ present, is a discarded statement. During the instantiation of an
 enclosing templated entity\iref{temp.pre}, if the condition is
 not value-dependent after its instantiation, the discarded substatement
 (if any) is not instantiated.
+Each substatement of a constexpr if statement is a control-flow-limited
+statement\iref{stmt.label}.
 \begin{example}
 \begin{codeblock}
 if constexpr (sizeof(int[2])) {}        // OK, narrowing allowed
@@ -271,12 +285,6 @@ if constexpr (sizeof(int[2])) {}        // OK, narrowing allowed
 Odr-uses\iref{term.odr.use} in a discarded statement do not require
 an entity to be defined.
 \end{note}
-A \keyword{case} or \keyword{default} label appearing within such an
-\keyword{if} statement shall be associated with a \keyword{switch}
-statement\iref{stmt.switch} within the same \keyword{if} statement.
-A label\iref{stmt.label} declared in a substatement of a constexpr if
-statement shall only be referred to by a statement\iref{stmt.goto} in
-the same substatement.
 \begin{example}
 \begin{codeblock}
 template<typename T, typename ... Rest> void g(T&& p, Rest&& ...rs) {
@@ -349,12 +357,8 @@ The first substatement is an immediate function context.
 \end{note}
 Otherwise, if the \keyword{else} part of the selection statement is present,
 then the second substatement is executed.
-A \keyword{case} or \keyword{default} label
-appearing within such an \keyword{if} statement
-shall be associated with a \keyword{switch} statement
-within the same \keyword{if} statement.
-A label declared in a substatement of a consteval if statement
-shall only be referred to by a statement in the same substatement.
+Each substatement of a consteval if statement is a control-flow-limited
+statement\iref{stmt.label}.
 
 \pnum
 An \keyword{if} statement of the form


### PR DESCRIPTION

The "shall not be used to" phrasing may be taken to refer only in cases
where the actual use occurs or is the primary intent. Instead, the
intended restriction can be written in terms of static properties of the
constructs so restricted in the style of [stmt.if].

A new term of art (control-flow-limited statement) is introduced in
[stmt.label] to express the restrictions. Both [stmt.if] and
[except.pre] are updated to use the new term.

Co-authored-by: Johel Ernesto Guerrero Peña <johelegp@gmail.com>