### PR TITLE
[range.utility.conv.general] Strike extraneous semicolon

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2107,7 +2107,7 @@ auto @\exposid{container-inserter}@(Container& c) {                // \expos
     return back_inserter(c);
   else
     return inserter(c, c.end());
-};
+}
 \end{codeblock}
 
 \rSec3[range.utility.conv.to]{\tcode{ranges::to}}


### PR DESCRIPTION
Just an unnecessary semicolon after a function definition ostensibly at namespace scope.