### PR TITLE
[ranges.syn] remove trailing `-> see below` return type from three `t…

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -143,11 +143,11 @@ namespace std::ranges {
   template<class C, @\libconcept{input_range}@ R, class... Args> requires (!@\libconcept{view}@<C>)
     constexpr C to(R&& r, Args&&... args);
   template<template<class...> class C, @\libconcept{input_range}@ R, class... Args>
-    constexpr auto to(R&& r, Args&&... args) -> @\seebelow@;
+    constexpr auto to(R&& r, Args&&... args);
   template<class C, class... Args> requires (!@\libconcept{view}@<C>)
-    constexpr auto to(Args&&... args) -> @\seebelow@;
+    constexpr auto to(Args&&... args);
   template<template<class...> class C, class... Args>
-    constexpr auto to(Args&&... args) -> @\seebelow@;
+    constexpr auto to(Args&&... args);
 
   // \ref{range.empty}, empty view
   template<class T>


### PR DESCRIPTION
…o` overloads

Since there is actually no return type specification to see below in [range.utility.conv].