### PR TITLE
[expected.object.general, expected.void.general] copy and move constr…

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6843,8 +6843,8 @@ namespace std {
 
     // \ref{expected.object.ctor}, constructors
     constexpr expected();
-    constexpr explicit(@\seebelow@) expected(const expected&);
-    constexpr explicit(@\seebelow@) expected(expected&&) noexcept(@\seebelow@);
+    constexpr expected(const expected&);
+    constexpr expected(expected&&) noexcept(@\seebelow@);
     template<class U, class G>
       constexpr explicit(@\seebelow@) expected(const expected<U, G>&);
     template<class U, class G>
@@ -7917,8 +7917,8 @@ public:
 
   // \ref{expected.void.ctor}, constructors
   constexpr expected() noexcept;
-  constexpr explicit(@\seebelow@) expected(const expected&);
-  constexpr explicit(@\seebelow@) expected(expected&&) noexcept(@\seebelow@);
+  constexpr expected(const expected&);
+  constexpr expected(expected&&) noexcept(@\seebelow@);
   template<class U, class G>
     constexpr explicit(@\seebelow@) expected(const expected<U, G>&);
   template<class U, class G>


### PR DESCRIPTION
…uctors of expected are never explicit

These `explicit(see below)`s in the class synopses are not present in the detailed specifications of the constructors.