### PR TITLE
[stringbuf.virtuals] Add missing 'override' for setbuf

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -8320,7 +8320,7 @@ to indicate failure.
 
 \indexlibrarymember{setbuf}{basic_streambuf}%
 \begin{itemdecl}
-basic_streambuf<charT, traits>* setbuf(charT* s, streamsize n);
+basic_streambuf<charT, traits>* setbuf(charT* s, streamsize n) override;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
for consistency with the class synopsis.

Fixes #5437