### PR TITLE
[cons.slice] Add copy constructor for 'slice' to synopsis

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -7979,6 +7979,7 @@ namespace std {
   public:
     slice();
     slice(size_t, size_t, size_t);
+    slice(const slice&);
 
     size_t start() const;
     size_t size() const;


### PR DESCRIPTION
Fixes  #5429