### PR TITLE
[over.match.best.general] Fix typo in example

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1809,7 +1809,7 @@ void f() {
                     // and \tcode{1L} $\to$ \tcode{short} and \tcode{1L} $\to$ \tcode{int} are indistinguishable
 
   Fcn(&i, 'c');     // calls \tcode{Fcn(int*, int)}, because \tcode{\&i} $\to$ \tcode{int*} is better than \tcode{\&i} $\to$ \tcode{const int*}
-                    // and \tcode{c} $\to$ \tcode{int} is better than \tcode{c} $\to$ \tcode{short}
+                    // and \tcode{'c'} $\to$ \tcode{int} is better than \tcode{'c'} $\to$ \tcode{short}
 }
 \end{codeblock}
 \end{example}


### PR DESCRIPTION
Fixes  #5433