### PR TITLE
[mem.poly.allocator.class.general] Clarify `polymorphic_allocator<void>` etc.

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -5402,8 +5402,9 @@ to behave as if they used different allocator types at run time
 even though they use the same static allocator type.
 
 \pnum
-All specializations of class template \tcode{pmr::polymorphic_allocator}
-meet the allocator completeness requirements\iref{allocator.requirements.completeness}.
+Every specialization of class template \tcode{pmr::polymorphic_allocator}
+meets the allocator completeness requirements\iref{allocator.requirements.completeness}
+if its template argument is a \cv-unqualified object type.
 
 \indexlibraryglobal{polymorphic_allocator}%
 \indexlibrarymember{value_type}{polymorphic_allocator}%

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -5402,7 +5402,7 @@ to behave as if they used different allocator types at run time
 even though they use the same static allocator type.
 
 \pnum
-Every specialization of class template \tcode{pmr::polymorphic_allocator}
+A specialization of class template \tcode{pmr::polymorphic_allocator}
 meets the allocator completeness requirements\iref{allocator.requirements.completeness}
 if its template argument is a \cv-unqualified object type.
 

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -5392,7 +5392,8 @@ bool operator==(const memory_resource& a, const memory_resource& b) noexcept;
 
 \pnum
 A specialization of class template \tcode{pmr::polymorphic_allocator} meets
-the \oldconcept{Allocator} requirements\iref{allocator.requirements.general}.
+the \oldconcept{Allocator} requirements\iref{allocator.requirements.general}
+if its template argument is a \cv-unqualified object type.
 Constructed with different memory resources,
 different instances of the same specialization of \tcode{pmr::polymorphic_allocator}
 can exhibit entirely different allocation behavior.


### PR DESCRIPTION
`std::pmr::polymorphic_allocator<T>` meets the _Cpp17Allocator_ requirements only if `T` is a cv-unqualified object type.

Fixes #5468.