### PR TITLE
[range.join.view] Simplify `range_reference_t<V>` to `InnerRng`

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -5682,7 +5682,7 @@ namespace std::ranges {
 
     constexpr auto begin() {
       constexpr bool use_const = @\exposconcept{simple-view}@<V> &&
-                                 is_reference_v<range_reference_t<V>>;
+                                 is_reference_v<@\exposid{InnerRng}@>;
       return @\exposid{iterator}@<use_const>{*this, ranges::begin(@\exposid{base_}@)};
     }
 


### PR DESCRIPTION
I think this is a reasonable simplification and also makes it consistent with `end()`.