### PR TITLE
[range.join.iterator, range.join.with.iterator] Add `InnerBase` and replace more `OuterIter/InnerIter`

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -5741,7 +5741,7 @@ namespace std::ranges {
   private:
     using @\exposidnc{Parent}@    = @\exposidnc{maybe-const}@<Const, join_view>;            // \expos
     using @\exposidnc{Base}@      = @\exposidnc{maybe-const}@<Const, V>;                    // \expos
-    using @\exposidnc{InnerBase}@ = range_reference_t<@\exposid{Base}@>;                  // \expos
+    using @\exposidnc{InnerBase}@ = range_reference_t<@\exposidnc{Base}@>;                  // \expos
     using @\exposidnc{OuterIter}@ = iterator_t<@\exposidnc{Base}@>;                         // \expos
     using @\exposidnc{InnerIter}@ = iterator_t<@\exposidnc{InnerBase}@>;                    // \expos
 
@@ -5810,11 +5810,11 @@ namespace std::ranges {
 \begin{itemize}
 \item If \exposid{ref-is-glvalue} is \tcode{true},
   \exposid{Base} models \libconcept{bidirectional_range}, and
-  \tcode{\exposid{InnerBase}} models
-  both \libconcept{bidire\-ctional_range} and \libconcept{common_range},
+  \exposid{InnerBase} models
+  both \libconcept{bidirec\-tional_range} and \libconcept{common_range},
   then \tcode{iterator_concept} denotes \tcode{bidirectio\-nal_iterator_tag}.
 \item Otherwise, if \exposid{ref-is-glvalue} is \tcode{true} and
-  \exposid{Base} and \tcode{\exposid{InnerBase}}
+  \exposid{Base} and \exposid{InnerBase}
   each model \libconceptx{for\-ward_range}{forward_range}, then \tcode{iterator_concept} denotes
   \tcode{forward_iterator_tag}.
 \item Otherwise, \tcode{iterator_concept} denotes \tcode{input_iterator_tag}.
@@ -5824,7 +5824,7 @@ namespace std::ranges {
 The member \grammarterm{typedef-name} \tcode{iterator_category} is defined
 if and only if \exposid{ref-is-glvalue} is \tcode{true},
 \exposid{Base} models \libconcept{forward_range}, and
-\tcode{\exposid{InnerBase}} models \libconcept{forward_range}.
+\exposid{InnerBase} models \libconcept{forward_range}.
 In that case,
 \tcode{iterator::iter\-ator_category} is defined as follows:
 \begin{itemize}
@@ -5835,7 +5835,7 @@ In that case,
 \item If
   \placeholder{OUTERC} and \placeholder{INNERC} each model
   \tcode{\libconcept{derived_from}<bidirectional_iterator_tag>} and
-  \tcode{\exposid{InnerBase}} models \libconcept{common_range},
+  \exposid{InnerBase} models \libconcept{common_range},
   \tcode{iterator_category} denotes \tcode{bidirectional_iterator_tag}.
 \item Otherwise, if
   \placeholder{OUTERC} and \placeholder{INNERC} each model

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -5811,7 +5811,7 @@ namespace std::ranges {
 \item If \exposid{ref-is-glvalue} is \tcode{true},
   \exposid{Base} models \libconcept{bidirectional_range}, and
   \tcode{\exposid{InnerBase}} models
-  both \libconcept{bidirectional_range} and \libconcept{common_range},
+  both \libconcept{bidire\-ctional_range} and \libconcept{common_range},
   then \tcode{iterator_concept} denotes \tcode{bidirectio\-nal_iterator_tag}.
 \item Otherwise, if \exposid{ref-is-glvalue} is \tcode{true} and
   \exposid{Base} and \tcode{\exposid{InnerBase}}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -5741,11 +5741,12 @@ namespace std::ranges {
   private:
     using @\exposidnc{Parent}@    = @\exposidnc{maybe-const}@<Const, join_view>;            // \expos
     using @\exposidnc{Base}@      = @\exposidnc{maybe-const}@<Const, V>;                    // \expos
+    using @\exposidnc{InnerBase}@ = range_reference_t<@\exposid{Base}@>;                  // \expos
     using @\exposidnc{OuterIter}@ = iterator_t<@\exposidnc{Base}@>;                         // \expos
-    using @\exposidnc{InnerIter}@ = iterator_t<range_reference_t<@\exposidnc{Base}@>>;      // \expos
+    using @\exposidnc{InnerIter}@ = iterator_t<@\exposidnc{InnerBase}@>;                    // \expos
 
     static constexpr bool @\exposidnc{ref-is-glvalue}@ =                      // \expos
-      is_reference_v<range_reference_t<@\exposidnc{Base}@>>;
+      is_reference_v<@\exposid{InnerBase}@>;
 
     @\exposidnc{OuterIter}@ @\exposid{outer_}@ = @\exposidnc{OuterIter}@();                             // \expos
     @\exposidnc{InnerIter}@ @\exposid{inner_}@ = @\exposidnc{InnerIter}@();                             // \expos
@@ -5756,7 +5757,7 @@ namespace std::ranges {
   public:
     using iterator_concept  = @\seebelow@;
     using iterator_category = @\seebelow@;                        // not always present
-    using value_type        = range_value_t<range_reference_t<@\exposid{Base}@>>;
+    using value_type        = range_value_t<@\exposid{InnerBase}@>;
     using difference_type   = @\seebelow@;
 
     @\exposid{iterator}@() requires @\libconcept{default_initializable}@<@\exposid{OuterIter}@> &&
@@ -5776,21 +5777,21 @@ namespace std::ranges {
     constexpr void operator++(int);
     constexpr @\exposid{iterator}@ operator++(int)
       requires @\exposid{ref-is-glvalue}@ && @\libconcept{forward_range}@<@\exposid{Base}@> &&
-               @\libconcept{forward_range}@<range_reference_t<@\exposid{Base}@>>;
+               @\libconcept{forward_range}@<@\exposid{InnerBase}@>;
 
     constexpr @\exposid{iterator}@& operator--()
       requires @\exposid{ref-is-glvalue}@ && @\libconcept{bidirectional_range}@<@\exposid{Base}@> &&
-               @\libconcept{bidirectional_range}@<range_reference_t<@\exposid{Base}@>> &&
-               @\libconcept{common_range}@<range_reference_t<@\exposid{Base}@>>;
+               @\libconcept{bidirectional_range}@<@\exposid{InnerBase}@> &&
+               @\libconcept{common_range}@<@\exposid{InnerBase}@>;
 
     constexpr @\exposid{iterator}@ operator--(int)
       requires @\exposid{ref-is-glvalue}@ && @\libconcept{bidirectional_range}@<@\exposid{Base}@> &&
-               @\libconcept{bidirectional_range}@<range_reference_t<@\exposid{Base}@>> &&
-               @\libconcept{common_range}@<range_reference_t<@\exposid{Base}@>>;
+               @\libconcept{bidirectional_range}@<@\exposid{InnerBase}@> &&
+               @\libconcept{common_range}@<@\exposid{InnerBase}@>;
 
     friend constexpr bool operator==(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-      requires @\exposid{ref-is-glvalue}@ && @\libconcept{equality_comparable}@<iterator_t<@\exposid{Base}@>> &&
-               @\libconcept{equality_comparable}@<iterator_t<range_reference_t<@\exposid{Base}@>>>;
+      requires @\exposid{ref-is-glvalue}@ && @\libconcept{equality_comparable}@<@\exposid{OuterIter}@> &&
+               @\libconcept{equality_comparable}@<@\exposid{InnerIter}@>;
 
     friend constexpr decltype(auto) iter_move(const @\exposid{iterator}@& i)
     noexcept(noexcept(ranges::iter_move(i.@\exposid{inner_}@))) {
@@ -5809,11 +5810,11 @@ namespace std::ranges {
 \begin{itemize}
 \item If \exposid{ref-is-glvalue} is \tcode{true},
   \exposid{Base} models \libconcept{bidirectional_range}, and
-  \tcode{range_reference_t<\exposid{Base}>} models
+  \tcode{\exposid{InnerBase}} models
   both \libconcept{bidirectional_range} and \libconcept{common_range},
   then \tcode{iterator_concept} denotes \tcode{bidirectio\-nal_iterator_tag}.
 \item Otherwise, if \exposid{ref-is-glvalue} is \tcode{true} and
-  \exposid{Base} and \tcode{range_reference_t<\exposid{Base}>}
+  \exposid{Base} and \tcode{\exposid{InnerBase}}
   each model \libconceptx{for\-ward_range}{forward_range}, then \tcode{iterator_concept} denotes
   \tcode{forward_iterator_tag}.
 \item Otherwise, \tcode{iterator_concept} denotes \tcode{input_iterator_tag}.
@@ -5823,18 +5824,18 @@ namespace std::ranges {
 The member \grammarterm{typedef-name} \tcode{iterator_category} is defined
 if and only if \exposid{ref-is-glvalue} is \tcode{true},
 \exposid{Base} models \libconcept{forward_range}, and
-\tcode{range_reference_t<\exposid{Base}>} models \libconcept{forward_range}.
+\tcode{\exposid{InnerBase}} models \libconcept{forward_range}.
 In that case,
 \tcode{iterator::iter\-ator_category} is defined as follows:
 \begin{itemize}
 \item Let \placeholder{OUTERC} denote
-  \tcode{iterator_traits<iterator_t<\exposid{Base}>>::iterator_category}, and
+  \tcode{iterator_traits<\exposid{OuterIter}>::iterator_category}, and
   let \placeholder{INNERC} denote
-  \tcode{iterator_traits<iterator_t<range_reference_t<\exposid{Base}>>>::iterator_category}.
+  \tcode{iterator_traits<\exposid{InnerIter}>::iterator_category}.
 \item If
   \placeholder{OUTERC} and \placeholder{INNERC} each model
   \tcode{\libconcept{derived_from}<bidirectional_iterator_tag>} and
-  \tcode{range_reference_t<\exposid{Base}>} models \libconcept{common_range},
+  \tcode{\exposid{InnerBase}} models \libconcept{common_range},
   \tcode{iterator_category} denotes \tcode{bidirectional_iterator_tag}.
 \item Otherwise, if
   \placeholder{OUTERC} and \placeholder{INNERC} each model
@@ -5849,7 +5850,7 @@ In that case,
 \begin{codeblock}
 common_type_t<
   range_difference_t<@\exposid{Base}@>,
-  range_difference_t<range_reference_t<@\exposid{Base}@>>>
+  range_difference_t<@\exposid{InnerBase}@>>
 \end{codeblock}
 
 \pnum
@@ -5865,7 +5866,7 @@ constexpr void @\exposid{satisfy}@();       // \expos
 \effects
 Equivalent to:
 \begin{codeblock}
-auto update_inner = [this](const iterator_t<@\exposid{Base}@>& x) -> auto&& {
+auto update_inner = [this](const @\exposid{OuterIter}@& x) -> auto&& {
   if constexpr (@\exposid{ref-is-glvalue}@)     // \tcode{*x} is a reference
     return *x;
   else
@@ -5964,7 +5965,7 @@ Equivalent to: \tcode{++*this}.
 \begin{itemdecl}
 constexpr @\exposid{iterator}@ operator++(int)
   requires @\exposid{ref-is-glvalue}@ && @\libconcept{forward_range}@<@\exposid{Base}@> &&
-           @\libconcept{forward_range}@<range_reference_t<@\exposid{Base}@>>;
+           @\libconcept{forward_range}@<@\exposid{InnerBase}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5982,8 +5983,8 @@ return tmp;
 \begin{itemdecl}
 constexpr @\exposid{iterator}@& operator--()
   requires @\exposid{ref-is-glvalue}@ && @\libconcept{bidirectional_range}@<@\exposid{Base}@> &&
-           @\libconcept{bidirectional_range}@<range_reference_t<@\exposid{Base}@>> &&
-           @\libconcept{common_range}@<range_reference_t<@\exposid{Base}@>>;
+           @\libconcept{bidirectional_range}@<@\exposid{InnerBase}@> &&
+           @\libconcept{common_range}@<@\exposid{InnerBase}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6004,8 +6005,8 @@ return *this;
 \begin{itemdecl}
 constexpr @\exposid{iterator}@ operator--(int)
   requires @\exposid{ref-is-glvalue}@ && @\libconcept{bidirectional_range}@<@\exposid{Base}@> &&
-           @\libconcept{bidirectional_range}@<range_reference_t<@\exposid{Base}@>> &&
-           @\libconcept{common_range}@<range_reference_t<@\exposid{Base}@>>;
+           @\libconcept{bidirectional_range}@<@\exposid{InnerBase}@> &&
+           @\libconcept{common_range}@<@\exposid{InnerBase}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6022,8 +6023,8 @@ return tmp;
 \indexlibrarymember{operator==}{join_view::iterator}%
 \begin{itemdecl}
 friend constexpr bool operator==(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
-  requires @\exposid{ref-is-glvalue}@ && @\libconcept{equality_comparable}@<iterator_t<@\exposid{Base}@>> &&
-           @\libconcept{equality_comparable}@<iterator_t<range_reference_t<@\exposid{Base}@>>>;
+  requires @\exposid{ref-is-glvalue}@ && @\libconcept{equality_comparable}@<@\exposid{OuterIter}@> &&
+           @\libconcept{equality_comparable}@<@\exposid{InnerIter}@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6263,7 +6264,7 @@ namespace std::ranges {
   class join_with_view<V, Pattern>::@\exposid{iterator}@ {
     using @\exposid{Parent}@ = @\exposid{maybe-const}@<Const, join_with_view>;                  // \expos
     using @\exposid{Base}@ = @\exposid{maybe-const}@<Const, V>;                                 // \expos
-    using @\exposid{InnerBase}@ = range_reference_t<Base>;                          // \expos
+    using @\exposid{InnerBase}@ = range_reference_t<@\exposid{Base}@>;                          // \expos
     using @\exposid{PatternBase}@ = @\exposid{maybe-const}@<Const, Pattern>;                    // \expos
 
     using @\exposid{OuterIter}@ = iterator_t<@\exposid{Base}@>;                                 // \expos
@@ -6276,7 +6277,7 @@ namespace std::ranges {
     @\exposid{OuterIter}@ @\exposid{outer_it_}@ = @\exposid{OuterIter}@();                                  // \expos
     variant<@\exposid{PatternIter}@, @\exposid{InnerIter}@> @\exposid{inner_it_}@;                          // \expos
 
-    constexpr @\exposid{iterator}@(@\exposid{Parent}@& parent, iterator_t<@\exposid{Base}@> outer);         // \expos
+    constexpr @\exposid{iterator}@(@\exposid{Parent}@& parent, @\exposid{OuterIter}@ outer);                // \expos
     constexpr auto&& @\exposid{update-inner}@(const @\exposid{OuterIter}@&);                    // \expos
     constexpr auto&& @\exposid{get-inner}@(const @\exposid{OuterIter}@&);                       // \expos
     constexpr void @\exposid{satisfy}@();                                           // \expos
@@ -6466,7 +6467,7 @@ to skip over empty inner ranges.
 \end{itemdescr}
 
 \begin{itemdecl}
-constexpr iterator(@\exposid{Parent}@& parent, iterator_t<@\exposid{Base}@> outer);
+constexpr iterator(@\exposid{Parent}@& parent, @\exposid{OuterIter}@ outer);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -5742,6 +5742,7 @@ namespace std::ranges {
     using @\exposidnc{Parent}@    = @\exposidnc{maybe-const}@<Const, join_view>;            // \expos
     using @\exposidnc{Base}@      = @\exposidnc{maybe-const}@<Const, V>;                    // \expos
     using @\exposidnc{InnerBase}@ = range_reference_t<@\exposidnc{Base}@>;                  // \expos
+
     using @\exposidnc{OuterIter}@ = iterator_t<@\exposidnc{Base}@>;                         // \expos
     using @\exposidnc{InnerIter}@ = iterator_t<@\exposidnc{InnerBase}@>;                    // \expos
 
@@ -5811,7 +5812,7 @@ namespace std::ranges {
 \item If \exposid{ref-is-glvalue} is \tcode{true},
   \exposid{Base} models \libconcept{bidirectional_range}, and
   \exposid{InnerBase} models
-  both \libconcept{bidire\-ctional_range} and \libconcept{common_range},
+  both \libconcept{bi\-directional_range} and \libconcept{common_range},
   then \tcode{iterator_concept} denotes \tcode{bidirectio\-nal_iterator_tag}.
 \item Otherwise, if \exposid{ref-is-glvalue} is \tcode{true} and
   \exposid{Base} and \exposid{InnerBase}
@@ -6192,6 +6193,7 @@ namespace std::ranges {
         @\exposconcept{simple-view}@<V> && is_reference_v<@\exposid{InnerRng}@> && @\exposconcept{simple-view}@<Pattern>;
       return @\exposid{iterator}@<use_const>{*this, ranges::begin(@\exposid{base_}@)};
     }
+
     constexpr auto begin() const
       requires @\libconcept{input_range}@<const V> &&
                @\libconcept{forward_range}@<const Pattern> &&
@@ -6207,6 +6209,7 @@ namespace std::ranges {
       else
         return @\exposid{sentinel}@<@\exposconcept{simple-view}@<V> && @\exposconcept{simple-view}@<Pattern>>{*this};
     }
+
     constexpr auto end() const
       requires @\libconcept{input_range}@<const V> && @\libconcept{forward_range}@<const Pattern> &&
                is_reference_v<range_reference_t<const V>> {

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -5811,7 +5811,7 @@ namespace std::ranges {
 \item If \exposid{ref-is-glvalue} is \tcode{true},
   \exposid{Base} models \libconcept{bidirectional_range}, and
   \exposid{InnerBase} models
-  both \libconcept{bidirec\-tional_range} and \libconcept{common_range},
+  both \libconcept{bidire\-ctional_range} and \libconcept{common_range},
   then \tcode{iterator_concept} denotes \tcode{bidirectio\-nal_iterator_tag}.
 \item Otherwise, if \exposid{ref-is-glvalue} is \tcode{true} and
   \exposid{Base} and \exposid{InnerBase}


### PR DESCRIPTION
This is basically a follow-up to #5474, which mainly does three things

1. Added type alias `InnerBase` for `join_view::iterator` to be consistent with `join_with_view::iterator`.
2. Replaced more `InnerIter`/`OuterIter` for `join_view::iterator`.
3. Replaced one missing `OuterIter` for `join_with_view::iterator` and corrected the italics for `Base` in `using InnerBase = range_reference_t<Base>;`.

Hope there are no errors.