### PR TITLE
[expected.object.ctor] Use the injected class name to refer to the current instantiation

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7158,7 +7158,7 @@ template<class U = T>
 \item
 \tcode{is_same_v<remove_cvref_t<U>, in_place_t>} is \tcode{false}; and
 \item
-\tcode{is_same_v<expected<T, E>, remove_cvref_t<U>>} is \tcode{false}; and
+\tcode{is_same_v<expected, remove_cvref_t<U>>} is \tcode{false}; and
 \item
 \tcode{remove_cvref_t<U>} is not a specialization of \tcode{unexpected}; and
 \item


### PR DESCRIPTION
.... as is conventional in library wording.