### PR TITLE
[dcl.init.general] Fix the informative description in 16.6.1 Example 2 CWG2612

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4619,7 +4619,7 @@ and the cv-unqualified version of the source type
 is the same class as the class of the destination,
 the initializer expression is used to initialize the destination object.
 \begin{example}
-\tcode{T x = T(T(T()));} calls the \tcode{T} default constructor to initialize \tcode{x}.
+\tcode{T x = T(T(T()));} value-initializes \tcode{x}.
 \end{example}
 \item
 Otherwise, if the initialization is direct-initialization,


### PR DESCRIPTION
`T x = T(T(T()));` value-initializes `x`, and according to [[dcl.init.general]/(9.1.2)](https://eel.is/c++draft/dcl.init.general#9.1.2), the initialization (when well-formed) skips the constructor call if the default constructor is trivial.

Fixes #5488.