### PR TITLE
[ranges] Remove redundant `// exposition only` comments in itemdecl section

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -5857,7 +5857,7 @@ common_type_t<
 empty inner ranges.
 
 \begin{itemdecl}
-constexpr void @\exposid{satisfy}@();       // \expos
+constexpr void @\exposid{satisfy}@();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7379,7 +7379,7 @@ for use on subsequent calls.
 \end{itemdescr}
 
 \begin{itemdecl}
-constexpr subrange<iterator_t<V>> @\exposid{find-next}@(iterator_t<V> it); // \expos
+constexpr subrange<iterator_t<V>> @\exposid{find-next}@(iterator_t<V> it);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8115,7 +8115,7 @@ Otherwise, \tcode{iterator_category} denotes \tcode{C}.
 
 \indexlibrarymember{\exposid{get-element}}{elements_view::iterator}%
 \begin{itemdecl}
-static constexpr decltype(auto) @\exposid{get-element}@(const iterator_t<@\exposid{Base}@>& i);     // \expos
+static constexpr decltype(auto) @\exposid{get-element}@(const iterator_t<@\exposid{Base}@>& i);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
This is a follow-up of #5498, which removes redundant `// exposition only` comment in the `{itemdecl}` section of `join_view​::​iterator::satisfy`, `split_view::find-next`, and `elements_view​::​iterator::get-element`.