### PR TITLE
[tuple.cnstr] Remove bad escaping in codeblock

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1689,7 +1689,7 @@ The expression inside \keyword{explicit} is equivalent to:
 \end{codeblock}
 This constructor is defined as deleted if
 \begin{codeblock}
-(reference_constructs_from_temporary_v<Types, UTypes\&\&> || ...)
+(reference_constructs_from_temporary_v<Types, UTypes&&> || ...)
 \end{codeblock}
 is \tcode{true}.
 \end{itemdescr}


### PR DESCRIPTION
See https://eel.is/c++draft/tuple#cnstr-15.sentence-2.