### PR TITLE
[module.reach] Remove redundant module implementation unit declaration

### DIFF
--- a/source/modules.tex
+++ b/source/modules.tex
@@ -1043,7 +1043,6 @@ export void f(B b = B());
 \end{codeblocktu}
 
 \begin{codeblocktu}{Translation unit \#5}
-module X;
 import M;
 B b3;                           // error: no reachable definition of \tcode{struct B}
 void g() { f(); }               // error: no reachable definition of \tcode{struct B}
@@ -1064,7 +1063,6 @@ export using Y = X;
 \end{codeblocktu}
 
 \begin{codeblocktu}{Translation unit \#2}
-module B;
 import A;
 Y y;                // OK, definition of \tcode{X} is reachable
 X x;                // error: \tcode{X} not visible to unqualified lookup


### PR DESCRIPTION
I found this one when trying to implement [module.reach]. The problem here is that when the compiler see the module implementation unit declaration, the compiler would try to find the primary module interface. However, the primary module interface doesn't exist in the example.

Even we don't care the implementation details, it looks problematic from the perspective of language. According to [module.unit]p2 (https://eel.is/c++draft/module.unit#2):
> A module interface unit is a module unit whose module-declaration starts with export-keyword; any other module unit is a module implementation unit. A named module shall contain exactly one module interface unit with no module-partition, known as the primary module interface unit of the module; no diagnostic is required.

But the example doesn't contain a primary module interface for module X and module B. So the example is problematic. Comparing to add the primary module interface, I think it is simpler to remove them simply.