### PR TITLE
Fixed wording regarding omitting the template argument list <> CWG2608

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6826,7 +6826,7 @@ may be omitted from the list of explicit \grammarterm{template-argument}{s}.
 A trailing template parameter pack\iref{temp.variadic} not otherwise deduced will be
 deduced as an empty sequence of template arguments.
 \end{note}
-If all of the template arguments can be deduced, they may all be omitted;
+If all of the template arguments can be deduced or obtained from default template arguments, they may all be omitted;
 in this case, the empty template argument list \tcode{<>}
 itself may also be omitted.
 \begin{example}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6850,9 +6850,9 @@ void h() {
 template <typename T = int> void func(T) { }
 int main()
 {
-    func();                     //calls specialization func<int>
-    auto a = func<>;            //\tcode{a} has type void (*)(int)
-    auto b = func;              //OK: \tcode{b} has type void (*)(int)
+    func();                     // calls the specialization \tcode{func<int>}
+    auto a = func<>;            // \tcode{a} has type \tcode{void (*)(int)}
+    auto b = func;              // OK: \tcode{b} has type \tcode{void (*)(int)}
 }
 \end{codeblock}
 \end{example}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6845,6 +6845,18 @@ void h() {
 \end{codeblock}
 \end{example}
 
+\begin{example}
+\begin{codeblock}
+template <typename T = int> void f(T) { }
+int main()
+{
+    func();                     //calls specialization func<int>
+    auto a = func<>;            //\tcode{a} has type void (*)(int)
+    auto b = func;              //OK: \tcode{b} has type void (*)(int)
+}
+\end{codeblock}
+\end{example}
+
 \pnum
 \begin{note}
 An empty template argument list can be used to indicate that a given

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6847,7 +6847,7 @@ void h() {
 
 \begin{example}
 \begin{codeblock}
-template <typename T = int> void f(T) { }
+template <typename T = int> void func(T) { }
 int main()
 {
     func();                     //calls specialization func<int>

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6847,7 +6847,7 @@ void h() {
 
 \begin{example}
 \begin{codeblock}
-template <typename T = int> void func(T) { }
+template <typename T = int> void func(T = T{}) { }
 int main()
 {
     func();                     // calls the specialization \tcode{func<int>}


### PR DESCRIPTION
I was reading [temp.arg.explicit] and noticed that there may be some defect in the wording there. In particular, it currently says:

> Trailing template arguments that can be deduced or obtained from default template-arguments may be omitted from the list of explicit template-arguments.
>
>A trailing template parameter pack ([temp.variadic]) not otherwise deduced will be deduced as an empty sequence of template arguments.
>
> **If all of the template arguments can be deduced, they may all be omitted; in this case, the empty template argument list <> itself may also be omitted.**

(emphasis mine)

Note carefully, in the last statement it says that when all of the template arguments can be deduced then they may all be omitted and in this case the empty <> itself may also be omitted. This is an issue because it does not mention that we can also omit the empty <> when all of the template arguments can be obtained from the default template arguments.  Since deducing arguments and using default values are two different things, there should be a separate mention of the latter.

Only in the first sentence(quoted above) there is a mention of default template arguments but that is only in the context of the list of explicit template arguments.

This also means that according to the current wording(sentence 3 quoted above) the following should be invalid:

```
template<typename T = int>
void func()
{

}
int main()
{
    func(); //this should be invalid according to the current wording
}
```

But we know that the above is not invalid and so there should be changes made to the sentence 3 quoted above to include the case of default template arguments.