### PR TITLE
[range.istream.iterator] basic_istream_view::iterator is not a class …

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -3286,7 +3286,7 @@ constexpr default_sentinel_t end() const noexcept;
 Equivalent to: \tcode{return default_sentinel;}
 \end{itemdescr}
 
-\rSec3[range.istream.iterator]{Class template \tcode{basic_istream_view::\exposid{iterator}}}
+\rSec3[range.istream.iterator]{Class \tcode{basic_istream_view::\exposid{iterator}}}
 
 \indexlibraryglobal{basic_istream_view::iterator}%
 \begin{codeblock}


### PR DESCRIPTION
…template

... it's a class nested within a class template. Correct the subclause title appropriately, with thanks to @JohelEGP for pointing this out.