### PR TITLE
[range.chunk] Add the class template description for `chunk_view`

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -10968,7 +10968,7 @@ for (auto r : v | views::chunk(2)) {
 \end{codeblock}
 \end{example}
 
-\rSec3[range.chunk.view.input]{\tcode{chunk_view} for input ranges}
+\rSec3[range.chunk.view.input]{Class template \tcode{chunk_view} for input ranges}
 
 \indexlibrarymember{begin}{chunk_view}%
 \indexlibrarymember{end}{chunk_view}%
@@ -11407,7 +11407,7 @@ friend constexpr difference_type operator-(const @\exposid{inner-iterator}@& x, 
 Equivalent to: \tcode{return -(y - x);}
 \end{itemdescr}
 
-\rSec3[range.chunk.view.fwd]{\tcode{chunk_view} for forward ranges}
+\rSec3[range.chunk.view.fwd]{Class template \tcode{chunk_view} for forward ranges}
 
 \indexlibrarymember{begin}{chunk_view}%
 \indexlibrarymember{end}{chunk_view}%
@@ -11495,7 +11495,7 @@ return @\exposid{to-unsigned-like}@(@\exposid{div-ceil}@(ranges::distance(@\expo
 \end{codeblock}
 \end{itemdescr}
 
-\rSec3[range.chunk.fwd.iter]{Class template \tcode{chunk_view<V>::\exposid{iterator}} for forward ranges}
+\rSec3[range.chunk.fwd.iter]{Class template \tcode{chunk_view::\exposid{iterator}} for forward ranges}
 
 \indexlibraryglobal{chunk_view::iterator}%
 \begin{codeblock}


### PR DESCRIPTION
Note that I also removed the "`<V>`" part in "Class template `chunk_view<V>​::​iterator` for forward ranges" to be consistent with other sections.