### PR TITLE
[basic.align] Fix cross-reference to meanwhile deprecated aligned_storage

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4156,8 +4156,9 @@ Comparing alignments is meaningful and provides the obvious results:
 \pnum
 \begin{note}
 The runtime pointer alignment function\iref{ptr.align}
-can be used to obtain an aligned pointer within a buffer; the aligned-storage templates
-in the library\iref{meta.trans.other} can be used to obtain aligned storage.
+can be used to obtain an aligned pointer within a buffer;
+an \grammarterm{alignment-specifier}\iref{dcl.align}
+can be used to align storage explicitly.
 \end{note}
 
 \pnum


### PR DESCRIPTION
Fixes #5521 