### PR TITLE
[module.private.frag] Remove misleading example and broaden note

### DIFF
--- a/source/modules.tex
+++ b/source/modules.tex
@@ -797,7 +797,7 @@ The presence of a \grammarterm{private-module-fragment} affects:
 \begin{itemize}
 \item
 the point by which the definition of
-an exported inline function
+an inline function or variable
 is required\iref{dcl.inline},
 
 \item
@@ -827,12 +827,11 @@ the reachability of declarations within it\iref{module.reach}.
 export module A;
 export inline void fn_e();      // error: exported inline function \tcode{fn_e} not defined
                                 // before private module fragment
-inline void fn_m();             // OK, module-linkage inline function
+inline void fn_m();             // error: non-exported inline function \tcode{fn_m} not defined
 static void fn_s();
 export struct X;
 export void g(X *x) {
   fn_s();                       // OK, call to static function in same translation unit
-  fn_m();                       // OK, call to module-linkage inline function
 }
 export X *factory();            // OK
 


### PR DESCRIPTION
@zygoloid, this addresses http://lists.isocpp.org/ext/2022/06/19564.php

Note that the example believes that fn_m (module linkage) is ok, but [dcl.inline] p7 makes no distinction between external and module linkage (both fn_e and fn_m are attached to the named module "A", I believe):

> If an inline function or variable that is attached to a named module is declared in a definition domain, it shall be defined in that domain.