### PR TITLE
Qualify all calls to std::get

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -4910,7 +4910,7 @@ template<class I2, class S2>
 \pnum
 \effects
 Initializes \tcode{v_} as if by
-\tcode{v_\{in_place_index<$i$>, get<$i$>(x.v_)\}},
+\tcode{v_\{in_place_index<$i$>, std::get<$i$>(x.v_)\}},
 where $i$ is \tcode{x.v_.index()}.
 \end{itemdescr}
 
@@ -4932,9 +4932,9 @@ template<class I2, class S2>
 Equivalent to:
 \begin{itemize}
 \item If \tcode{v_.index() == x.v_.index()}, then
-\tcode{get<$i$>(v_) = get<$i$>(x.v_)}.
+\tcode{std::get<$i$>(v_) = std::get<$i$>(x.v_)}.
 
-\item Otherwise, \tcode{v_.emplace<$i$>(get<$i$>(x.v_))}.
+\item Otherwise, \tcode{v_.emplace<$i$>(std::get<$i$>(x.v_))}.
 \end{itemize}
 where $i$ is \tcode{x.v_.index()}.
 
@@ -4959,7 +4959,7 @@ constexpr decltype(auto) operator*() const
 
 \pnum
 \effects
-Equivalent to: \tcode{return *get<I>(v_);}
+Equivalent to: \tcode{return *std::get<I>(v_);}
 \end{itemdescr}
 
 \indexlibrarymember{operator->}{common_iterator}%
@@ -4987,19 +4987,19 @@ The expression in the \grammarterm{requires-clause} is equivalent to:
 \begin{itemize}
 \item
 If \tcode{I} is a pointer type or if the expression
-\tcode{get<I>(v_).operator->()} is
-well-formed, equivalent to: \tcode{return get<I>(v_);}
+\tcode{std::get<I>(v_).operator->()} is
+well-formed, equivalent to: \tcode{return std::get<I>(v_);}
 
 \item
 Otherwise, if \tcode{iter_reference_t<I>} is a reference type, equivalent to:
 \begin{codeblock}
-auto&& tmp = *get<I>(v_);
+auto&& tmp = *std::get<I>(v_);
 return addressof(tmp);
 \end{codeblock}
 
 \item
 Otherwise, equivalent to:
-\tcode{return \exposid{proxy}(*get<I>(v_));} where
+\tcode{return \exposid{proxy}(*std::get<I>(v_));} where
 \exposid{proxy} is the exposition-only class:
 \begin{codeblock}
 class @\exposid{proxy}@ {
@@ -5029,7 +5029,7 @@ constexpr common_iterator& operator++();
 
 \pnum
 \effects
-Equivalent to \tcode{++get<I>(v_)}.
+Equivalent to \tcode{++std::get<I>(v_)}.
 
 \pnum
 \returns
@@ -5064,7 +5064,7 @@ is \tcode{true} or
 is \tcode{false},
 equivalent to:
 \begin{codeblock}
-return get<I>(v_)++;
+return std::get<I>(v_)++;
 \end{codeblock}
 Otherwise, equivalent to:
 \begin{codeblock}
@@ -5105,7 +5105,7 @@ are each \tcode{false}.
 \pnum
 \returns
 \tcode{true} if \tcode{$i$ == $j$},
-and otherwise \tcode{get<$i$>(x.v_) == get<$j$>(y.v_)},
+and otherwise \tcode{std::get<$i$>(x.v_) == std::get<$j$>(y.v_)},
 where $i$ is \tcode{x.v_.index()} and $j$ is \tcode{y.v_.index()}.
 \end{itemdescr}
 
@@ -5126,7 +5126,7 @@ are each \tcode{false}.
 \pnum
 \returns
 \tcode{true} if $i$ and $j$ are each \tcode{1}, and otherwise
-\tcode{get<$i$>(x.v_) == get<$j$>(y.v_)}, where
+\tcode{std::get<$i$>(x.v_) == std::get<$j$>(y.v_)}, where
 $i$ is \tcode{x.v_.index()} and $j$ is \tcode{y.v_.index()}.
 \end{itemdescr}
 
@@ -5147,7 +5147,7 @@ are each \tcode{false}.
 \pnum
 \returns
 \tcode{0} if $i$ and $j$ are each \tcode{1}, and otherwise
-\tcode{get<$i$>(x.v_) - get<$j$>(y.v_)}, where
+\tcode{std::get<$i$>(x.v_) - std::get<$j$>(y.v_)}, where
 $i$ is \tcode{x.v_.index()} and $j$ is \tcode{y.v_.index()}.
 \end{itemdescr}
 
@@ -5167,7 +5167,7 @@ friend constexpr iter_rvalue_reference_t<I> iter_move(const common_iterator& i)
 
 \pnum
 \effects
-Equivalent to: \tcode{return ranges::iter_move(get<I>(i.v_));}
+Equivalent to: \tcode{return ranges::iter_move(std::get<I>(i.v_));}
 \end{itemdescr}
 
 \indexlibrarymember{iter_swap}{common_iterator}%
@@ -5185,7 +5185,7 @@ are each \tcode{true}.
 
 \pnum
 \effects
-Equivalent to \tcode{ranges::iter_swap(get<I>(x.v_), get<I2>(y.v_))}.
+Equivalent to \tcode{ranges::iter_swap(std::get<I>(x.v_), std::get<I2>(y.v_))}.
 \end{itemdescr}
 
 \rSec2[default.sentinel]{Default sentinel}

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -1054,8 +1054,8 @@ template<class T, class Alloc, class U, class V>
 Equivalent to:
 \begin{codeblock}
 return uses_allocator_construction_args<T>(alloc, piecewise_construct,
-                                           forward_as_tuple(get<0>(std::move(pr))),
-                                           forward_as_tuple(get<1>(std::move(pr))));
+                                           forward_as_tuple(std::get<0>(std::move(pr))),
+                                           forward_as_tuple(std::get<1>(std::move(pr))));
 \end{codeblock}
 \end{itemdescr}
 

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -8961,7 +8961,7 @@ if \tcode{\exposconcept{all-bidirectional}<Const, Views...>} is \tcode{true}.
 \item
 Otherwise, \tcode{true}
 if there exists an integer $0 \leq i < \tcode{sizeof...(Views)}$
-such that \tcode{bool(std::\brk{}get<$i$>(x.\exposid{current_}) ==
+such that \tcode{bool(std::\brk{}std::get<$i$>(x.\exposid{current_}) ==
 std::get<$i$>(y.\exposid{current_}))} is \tcode{true}.
 \begin{note}
 This allows \tcode{zip_view} to model \libconcept{common_range}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -8961,7 +8961,7 @@ if \tcode{\exposconcept{all-bidirectional}<Const, Views...>} is \tcode{true}.
 \item
 Otherwise, \tcode{true}
 if there exists an integer $0 \leq i < \tcode{sizeof...(Views)}$
-such that \tcode{bool(std::\brk{}std::get<$i$>(x.\exposid{current_}) ==
+such that \tcode{bool(std::\brk{}get<$i$>(x.\exposid{current_}) ==
 std::get<$i$>(y.\exposid{current_}))} is \tcode{true}.
 \begin{note}
 This allows \tcode{zip_view} to model \libconcept{common_range}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -6970,7 +6970,7 @@ Nothing.
 \pnum
 \effects
 For all \tcode{i} in \range{0}{sizeof...(MutexTypes)},
-\tcode{get<i>(pm).unlock()}.
+\tcode{std::get<i>(pm).unlock()}.
 \end{itemdescr}
 
 \rSec3[thread.lock.unique]{Class template \tcode{unique_lock}}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1799,8 +1799,8 @@ Let \tcode{\exposid{FWD}(u)} be \tcode{static_cast<decltype(u)>(u)}.
 
 \pnum
 \effects
-Initializes the first element with \tcode{std::get<0>(\exposid{FWD}(u))} and
-the second element with \tcode{std::get<1>(\exposid{FWD}(\brk{}u))}.
+Initializes the first element with \tcode{std::get<0>(\exposid{FWD}(u))}\\
+and the second element with \tcode{std::get<1>(\exposid{FWD}(\brk{}u))}.
 
 \pnum
 \remarks
@@ -2358,7 +2358,8 @@ namespace std {
   template<class F, class Tuple, size_t... I>
   constexpr decltype(auto) @\placeholdernc{apply-impl}@(F&& f, Tuple&& t, index_sequence<I...>) {
                                                                         // \expos
-    return @\placeholdernc{INVOKE}@(std::forward<F>(f), std::get<I>(std::forward<Tuple>(t))...);     // see \ref{func.require}
+    return @\placeholdernc{INVOKE}@(std::forward<F>(f), std::get<I>(std::forward<Tuple>(t))...);
+                                                                        // see \ref{func.require}
   }
 }
 \end{codeblock}
@@ -5324,7 +5325,8 @@ Lvalues of type $\tcode{T}_i$ are swappable\iref{swappable.requirements}.
 \item
 If \tcode{valueless_by_exception() \&\& rhs.valueless_by_exception()} no effect.
 \item
-Otherwise, if \tcode{index() == rhs.index()}, calls \tcode{swap(std::get<$i$>(*this), std::get<$i$>(rhs))} where $i$ is \tcode{index()}.
+Otherwise, if \tcode{index() == rhs.index()},\\
+calls \tcode{swap(std::get<$i$>(*this), std::get<$i$>(rhs))} where $i$ is \tcode{index()}.
 \item
 Otherwise, exchanges values of \tcode{rhs} and \tcode{*this}.
 \end{itemize}
@@ -5332,7 +5334,8 @@ Otherwise, exchanges values of \tcode{rhs} and \tcode{*this}.
 \pnum
 \throws
 If \tcode{index() == rhs.index()},
-any exception thrown by \tcode{swap(std::get<$i$>(*this), std::get<$i$>(rhs))}
+any exception thrown by\\
+\tcode{swap(std::get<$i$>(*this), std::get<$i$>(rhs))}
 with $i$ being \tcode{index()}.
 Otherwise, any exception thrown by the move constructor
 of $\tcode{T}_i$ or $\tcode{T}_j$
@@ -5340,7 +5343,8 @@ with $i$ being \tcode{index()} and $j$ being \tcode{rhs.index()}.
 
 \pnum
 \remarks
-If an exception is thrown during the call to function \tcode{swap(std::get<$i$>(*this), std::get<$i$>(rhs))},
+If an exception is thrown during the call to function\\
+tcode{swap(std::get<$i$>(*this), std::get<$i$>(rhs))},
 the states of the contained values of \tcode{*this} and of \tcode{rhs} are
 determined by the exception safety guarantee of \tcode{swap} for lvalues of
 $\tcode{T}_i$ with $i$ being \tcode{index()}.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -834,29 +834,29 @@ Let \tcode{\exposid{FWD}(u)} be \tcode{static_cast<decltype(u)>(u)}.
 \constraints
 \begin{itemize}
 \item
-\tcode{is_constructible_v<T1, decltype(get<0>(\exposid{FWD}(p)))>}
+\tcode{is_constructible_v<T1, decltype(std::get<0>(\exposid{FWD}(p)))>}
 is \tcode{true} and
 \item
-\tcode{is_constructible_v<T2, decltype(get<1>(\exposid{FWD}(p)))>}
+\tcode{is_constructible_v<T2, decltype(std::get<1>(\exposid{FWD}(p)))>}
 is \tcode{true}.
 \end{itemize}
 
 \pnum
 \effects
-Initializes \tcode{first} with \tcode{get<0>(\exposid{FWD}(p))} and
-\tcode{second} with \tcode{get<1>(\exposid{FWD}(p))}.
+Initializes \tcode{first} with \tcode{std::get<0>(\exposid{FWD}(p))} and
+\tcode{second} with \tcode{std::get<1>(\exposid{FWD}(p))}.
 
 \pnum
 \remarks
 The expression inside \keyword{explicit} is equivalent to:
 \begin{codeblock}
-!is_convertible_v<decltype(get<0>(@\exposid{FWD}@(p))), T1> ||
-!is_convertible_v<decltype(get<1>(@\exposid{FWD}@(p))), T2>
+!is_convertible_v<decltype(std::get<0>(@\exposid{FWD}@(p))), T1> ||
+!is_convertible_v<decltype(std::get<1>(@\exposid{FWD}@(p))), T2>
 \end{codeblock}
 The constructor is defined as deleted if
 \begin{codeblock}
-reference_constructs_from_temporary_v<first_type, decltype(get<0>(@\exposid{FWD}@(p)))> ||
-reference_constructs_from_temporary_v<second_type, decltype(get<1>(@\exposid{FWD}@(p)))>
+reference_constructs_from_temporary_v<first_type, decltype(std::get<0>(@\exposid{FWD}@(p)))> ||
+reference_constructs_from_temporary_v<second_type, decltype(std::get<1>(@\exposid{FWD}@(p)))>
 \end{codeblock}
 is \tcode{true}.
 \end{itemdescr}
@@ -1723,7 +1723,7 @@ tuple(tuple&& u) = default;
 \pnum
 \effects
 For all $i$, initializes the $i^\text{th}$ element of \tcode{*this} with
-\tcode{std::forward<$\tcode{T}_i$>(get<$i$>(u))}.
+\tcode{std::forward<$\tcode{T}_i$>(std::get<$i$>(u))}.
 \end{itemdescr}
 
 \indexlibraryctor{tuple}%
@@ -1745,7 +1745,7 @@ Let \tcode{\exposid{FWD}(u)} be \tcode{static_cast<decltype(u)>(u)}.
 \item
 \tcode{sizeof...(Types)} equals \tcode{sizeof...(UTypes)}, and
 \item
-\tcode{(is_constructible_v<Types, decltype(get<I>(\exposid{FWD}(u)))> \&\& ...)}
+\tcode{(is_constructible_v<Types, decltype(std::get<I>(\exposid{FWD}(u)))> \&\& ...)}
 is \tcode{true}, and
 \item
 either \tcode{sizeof...(Types)} is not 1, or
@@ -1759,17 +1759,17 @@ either \tcode{sizeof...(Types)} is not 1, or
 \pnum
 \effects
 For all $i$, initializes the $i^\textrm{th}$ element of \tcode{*this}
-with \tcode{get<$i$>(\exposid{FWD}(u))}.
+with \tcode{std::get<$i$>(\exposid{FWD}(u))}.
 
 \pnum
 \remarks
 The expression inside \keyword{explicit} is equivalent to:
 \begin{codeblock}
-!(is_convertible_v<decltype(get<I>(@\exposid{FWD}@(u))), Types> && ...)
+!(is_convertible_v<decltype(std::get<I>(@\exposid{FWD}@(u))), Types> && ...)
 \end{codeblock}
 The constructor is defined as deleted if
 \begin{codeblock}
-(reference_constructs_from_temporary_v<Types, decltype(get<I>(@\exposid{FWD}@(u)))> || ...)
+(reference_constructs_from_temporary_v<Types, decltype(std::get<I>(@\exposid{FWD}@(u)))> || ...)
 \end{codeblock}
 is \tcode{true}.
 \end{itemdescr}
@@ -1792,27 +1792,27 @@ Let \tcode{\exposid{FWD}(u)} be \tcode{static_cast<decltype(u)>(u)}.
 \item
 \tcode{sizeof...(Types)} is 2,
 \item
-\tcode{is_constructible_v<$\tcode{T}_0$, decltype(get<0>(\exposid{FWD}(u)))>} is \tcode{true}, and
+\tcode{is_constructible_v<$\tcode{T}_0$, decltype(std::get<0>(\exposid{FWD}(u)))>} is \tcode{true}, and
 \item
-\tcode{is_constructible_v<$\tcode{T}_1$, decltype(get<1>(\exposid{FWD}(u)))>} is \tcode{true}.
+\tcode{is_constructible_v<$\tcode{T}_1$, decltype(std::get<1>(\exposid{FWD}(u)))>} is \tcode{true}.
 \end{itemize}
 
 \pnum
 \effects
-Initializes the first element with \tcode{get<0>(\exposid{FWD}(u))} and
-the second element with \tcode{get<1>(\exposid{FWD}(\brk{}u))}.
+Initializes the first element with \tcode{std::get<0>(\exposid{FWD}(u))} and
+the second element with \tcode{std::get<1>(\exposid{FWD}(\brk{}u))}.
 
 \pnum
 \remarks
 The expression inside \tcode{explicit} is equivalent to:
 \begin{codeblock}
-!is_convertible_v<decltype(get<0>(@\exposid{FWD}@(u))), @$\tcode{T}_0$@> ||
-!is_convertible_v<decltype(get<1>(@\exposid{FWD}@(u))), @$\tcode{T}_1$@>
+!is_convertible_v<decltype(std::get<0>(@\exposid{FWD}@(u))), @$\tcode{T}_0$@> ||
+!is_convertible_v<decltype(std::get<1>(@\exposid{FWD}@(u))), @$\tcode{T}_1$@>
 \end{codeblock}
 The constructor is defined as deleted if
 \begin{codeblock}
-reference_constructs_from_temporary_v<@$\tcode{T}_0$@, decltype(get<0>(@\exposid{FWD}@(u)))> ||
-reference_constructs_from_temporary_v<@$\tcode{T}_1$@, decltype(get<1>(@\exposid{FWD}@(u)))>
+reference_constructs_from_temporary_v<@$\tcode{T}_0$@, decltype(std::get<0>(@\exposid{FWD}@(u)))> ||
+reference_constructs_from_temporary_v<@$\tcode{T}_1$@, decltype(std::get<1>(@\exposid{FWD}@(u)))>
 \end{codeblock}
 is \tcode{true}.
 \end{itemdescr}
@@ -1932,8 +1932,8 @@ constexpr tuple& operator=(tuple&& u) noexcept(@\seebelow@);
 
 \pnum
 \effects
-For all $i$, assigns \tcode{std::forward<$\tcode{T}_i$>(get<$i$>(u))} to
-\tcode{get<$i$>(*this)}.
+For all $i$, assigns \tcode{std::forward<$\tcode{T}_i$>(std::get<$i$>(u))} to
+\tcode{std::get<$i$>(*this)}.
 
 \pnum
 \returns
@@ -1963,7 +1963,7 @@ constexpr const tuple& operator=(tuple&& u) const;
 \pnum
 \effects
 For all $i$,
-assigns \tcode{std::forward<T$_i$>(get<$i$>(u))} to \tcode{get<$i$>(*this)}.
+assigns \tcode{std::forward<T$_i$>(std::get<$i$>(u))} to \tcode{std::get<$i$>(*this)}.
 
 \pnum
 \returns
@@ -2032,8 +2032,8 @@ template<class... UTypes> constexpr tuple& operator=(tuple<UTypes...>&& u);
 
 \pnum
 \effects
-For all $i$, assigns \tcode{std::forward<$\tcode{U}_i$>(get<$i$>(u))} to
-\tcode{get<$i$>(*this)}.
+For all $i$, assigns \tcode{std::forward<$\tcode{U}_i$>(std::get<$i$>(u))} to
+\tcode{std::get<$i$>(*this)}.
 
 \pnum
 \returns
@@ -2058,7 +2058,7 @@ template<class... UTypes> constexpr const tuple& operator=(tuple<UTypes...>&& u)
 \pnum
 \effects
 For all $i$,
-assigns \tcode{std::forward<U$_i$>(get<$i$>(u))} to \tcode{get<$i$>(*this)}.
+assigns \tcode{std::forward<U$_i$>(std::get<$i$>(u))} to \tcode{std::get<$i$>(*this)}.
 
 \pnum
 \returns
@@ -2358,7 +2358,7 @@ namespace std {
   template<class F, class Tuple, size_t... I>
   constexpr decltype(auto) @\placeholdernc{apply-impl}@(F&& f, Tuple&& t, index_sequence<I...>) {
                                                                         // \expos
-    return @\placeholdernc{INVOKE}@(std::forward<F>(f), get<I>(std::forward<Tuple>(t))...);     // see \ref{func.require}
+    return @\placeholdernc{INVOKE}@(std::forward<F>(f), std::get<I>(std::forward<Tuple>(t))...);     // see \ref{func.require}
   }
 }
 \end{codeblock}
@@ -2380,7 +2380,7 @@ template<class T, class Tuple>
 \mandates
 If \tcode{tuple_size_v<remove_reference_t<Tuple>>} is 1,
 then
-\tcode{reference_constructs_from_temporary_v<T, decltype(get<0>(declval<Tuple>()))>}
+\tcode{reference_constructs_from_temporary_v<T, decltype(std::get<0>(declval<Tuple>()))>}
 is \tcode{false}.
 
 \pnum
@@ -2389,9 +2389,9 @@ Given the exposition-only function:
 \begin{codeblock}
 namespace std {
   template<class T, class Tuple, size_t... I>
-    requires is_constructible_v<T, decltype(get<I>(declval<Tuple>()))...>
+    requires is_constructible_v<T, decltype(std::get<I>(declval<Tuple>()))...>
   constexpr T @\placeholdernc{make-from-tuple-impl}@(Tuple&& t, index_sequence<I...>) {   // \expos
-    return T(get<I>(std::forward<Tuple>(t))...);
+    return T(std::get<I>(std::forward<Tuple>(t))...);
   }
 }
 \end{codeblock}
@@ -2584,9 +2584,9 @@ A reference to the element of \tcode{t} corresponding to the type
 \begin{example}
 \begin{codeblock}
 const tuple<int, const int, double, double> t(1, 2, 3.4, 5.6);
-const int& i1 = get<int>(t);                    // OK, \tcode{i1} has value \tcode{1}
-const int& i2 = get<const int>(t);              // OK, \tcode{i2} has value \tcode{2}
-const double& d = get<double>(t);               // error: type \tcode{double} is not unique within \tcode{t}
+const int& i1 = std::get<int>(t);               // OK, \tcode{i1} has value \tcode{1}
+const int& i2 = std::get<const int>(t);         // OK, \tcode{i2} has value \tcode{2}
+const double& d = std::get<double>(t);          // error: type \tcode{double} is not unique within \tcode{t}
 \end{codeblock}
 \end{example}
 \end{itemdescr}
@@ -2613,14 +2613,14 @@ template<class... TTypes, class... UTypes>
 \mandates
 For all \tcode{i},
 where $0 \leq \tcode{i} < \tcode{sizeof...(TTypes)}$,
-\tcode{get<i>(t) == get<i>(u)} is a valid expression
+\tcode{std::get<i>(t) == std::get<i>(u)} is a valid expression
 returning a type that is convertible to \tcode{bool}.
 \tcode{sizeof...(TTypes)} equals
 \tcode{sizeof...(UTypes)}.
 
 \pnum
 \returns
-\tcode{true} if \tcode{get<i>(t) == get<i>(u)} for all
+\tcode{true} if \tcode{std::get<i>(t) == std::get<i>(u)} for all
 \tcode{i}, otherwise \tcode{false}.
 For any two zero-length tuples \tcode{e} and \tcode{f}, \tcode{e == f} returns \tcode{true}.
 
@@ -2647,7 +2647,7 @@ For any two zero-length tuples \tcode{t} and \tcode{u},
 \tcode{t <=> u} returns \tcode{strong_ordering::equal}.
 Otherwise, equivalent to:
 \begin{codeblock}
-if (auto c = @\placeholder{synth-three-way}@(get<0>(t), get<0>(u)); c != 0) return c;
+if (auto c = @\placeholder{synth-three-way}@(std::get<0>(t), std::get<0>(u)); c != 0) return c;
 return @$\tcode{t}_\mathrm{tail}$@ <=> @$\tcode{u}_\mathrm{tail}$@;
 \end{codeblock}
 where $\tcode{r}_\mathrm{tail}$ for some tuple \tcode{r}
@@ -4696,7 +4696,7 @@ constexpr variant(const variant& w);
 \effects
 If \tcode{w} holds a value, initializes the \tcode{variant} to hold the same
 alternative as \tcode{w} and direct-initializes the contained value
-with \tcode{get<j>(w)}, where \tcode{j} is \tcode{w.index()}.
+with \tcode{std::get<j>(w)}, where \tcode{j} is \tcode{w.index()}.
 Otherwise, initializes the \tcode{variant} to not hold a value.
 
 \pnum
@@ -4725,7 +4725,7 @@ constexpr variant(variant&& w) noexcept(@\seebelow@);
 \effects
 If \tcode{w} holds a value, initializes the \tcode{variant} to hold the same
 alternative as \tcode{w} and direct-initializes the contained value with
-\tcode{get<j>(std::move(w))}, where \tcode{j} is \tcode{w.index()}.
+\tcode{std::get<j>(std::move(w))}, where \tcode{j} is \tcode{w.index()}.
 Otherwise, initializes the \tcode{variant} to not hold a value.
 
 \pnum
@@ -4983,7 +4983,7 @@ to the value contained in \tcode{*this}.
 Otherwise, if either \tcode{is_nothrow_copy_constructible_v<$\tcode{T}_j$>}
 is \tcode{true} or
 \tcode{is_nothrow_move_con\-structible_v<$\tcode{T}_j$>} is \tcode{false},
-equivalent to \tcode{emplace<$j$>(get<$j$>(rhs))}.
+equivalent to \tcode{emplace<$j$>(std::get<$j$>(rhs))}.
 \item
 Otherwise, equivalent to \tcode{operator=(variant(rhs))}.
 \end{itemize}
@@ -5032,10 +5032,10 @@ If neither \tcode{*this} nor \tcode{rhs} holds a value, there is no effect.
 Otherwise, if \tcode{*this} holds a value but \tcode{rhs} does not, destroys the value
 contained in \tcode{*this} and sets \tcode{*this} to not hold a value.
 \item
-Otherwise, if \tcode{index() == $j$}, assigns \tcode{get<$j$>(std::move(rhs))} to
+Otherwise, if \tcode{index() == $j$}, assigns \tcode{std::get<$j$>(std::move(rhs))} to
 the value contained in \tcode{*this}.
 \item
-Otherwise, equivalent to \tcode{emplace<$j$>(get<$j$>(std::move(rhs)))}.
+Otherwise, equivalent to \tcode{emplace<$j$>(std::get<$j$>(std::move(rhs)))}.
 \end{itemize}
 
 \pnum
@@ -5324,7 +5324,7 @@ Lvalues of type $\tcode{T}_i$ are swappable\iref{swappable.requirements}.
 \item
 If \tcode{valueless_by_exception() \&\& rhs.valueless_by_exception()} no effect.
 \item
-Otherwise, if \tcode{index() == rhs.index()}, calls \tcode{swap(get<$i$>(*this), get<$i$>(rhs))} where $i$ is \tcode{index()}.
+Otherwise, if \tcode{index() == rhs.index()}, calls \tcode{swap(std::get<$i$>(*this), std::get<$i$>(rhs))} where $i$ is \tcode{index()}.
 \item
 Otherwise, exchanges values of \tcode{rhs} and \tcode{*this}.
 \end{itemize}
@@ -5332,7 +5332,7 @@ Otherwise, exchanges values of \tcode{rhs} and \tcode{*this}.
 \pnum
 \throws
 If \tcode{index() == rhs.index()},
-any exception thrown by \tcode{swap(get<$i$>(*this), get<$i$>(rhs))}
+any exception thrown by \tcode{swap(std::get<$i$>(*this), std::get<$i$>(rhs))}
 with $i$ being \tcode{index()}.
 Otherwise, any exception thrown by the move constructor
 of $\tcode{T}_i$ or $\tcode{T}_j$
@@ -5340,7 +5340,7 @@ with $i$ being \tcode{index()} and $j$ being \tcode{rhs.index()}.
 
 \pnum
 \remarks
-If an exception is thrown during the call to function \tcode{swap(get<$i$>(*this), get<$i$>(rhs))},
+If an exception is thrown during the call to function \tcode{swap(std::get<$i$>(*this), std::get<$i$>(rhs))},
 the states of the contained values of \tcode{*this} and of \tcode{rhs} are
 determined by the exception safety guarantee of \tcode{swap} for lvalues of
 $\tcode{T}_i$ with $i$ being \tcode{index()}.
@@ -5529,14 +5529,14 @@ template<class... Types>
 \begin{itemdescr}
 \pnum
 \mandates
-\tcode{get<$i$>(v) == get<$i$>(w)} is a valid expression that is
+\tcode{std::get<$i$>(v) == std::get<$i$>(w)} is a valid expression that is
 convertible to \tcode{bool}, for all $i$.
 
 \pnum
 \returns
 If \tcode{v.index() != w.index()}, \tcode{false};
 otherwise if \tcode{v.valueless_by_exception()}, \tcode{true};
-otherwise \tcode{get<$i$>(v) == get<$i$>(w)} with $i$ being \tcode{v.index()}.
+otherwise \tcode{std::get<$i$>(v) == std::get<$i$>(w)} with $i$ being \tcode{v.index()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator"!=}{variant}%
@@ -5548,14 +5548,14 @@ template<class... Types>
 \begin{itemdescr}
 \pnum
 \mandates
-\tcode{get<$i$>(v) != get<$i$>(w)} is a valid expression that is
+\tcode{std::get<$i$>(v) != std::get<$i$>(w)} is a valid expression that is
 convertible to \tcode{bool}, for all $i$.
 
 \pnum
 \returns
 If \tcode{v.index() != w.index()}, \tcode{true};
 otherwise if \tcode{v.valueless_by_exception()}, \tcode{false};
-otherwise \tcode{get<$i$>(v) != get<$i$>(w)} with $i$ being \tcode{v.index()}.
+otherwise \tcode{std::get<$i$>(v) != std::get<$i$>(w)} with $i$ being \tcode{v.index()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<}{variant}%
@@ -5567,7 +5567,7 @@ template<class... Types>
 \begin{itemdescr}
 \pnum
 \mandates
-\tcode{get<$i$>(v) < get<$i$>(w)} is a valid expression that is
+\tcode{std::get<$i$>(v) < std::get<$i$>(w)} is a valid expression that is
 convertible to \tcode{bool}, for all $i$.
 
 \pnum
@@ -5576,7 +5576,7 @@ If \tcode{w.valueless_by_exception()}, \tcode{false};
 otherwise if \tcode{v.valueless_by_exception()}, \tcode{true};
 otherwise, if \tcode{v.index() < w.index()}, \tcode{true};
 otherwise if \tcode{v.index() > w.index()}, \tcode{false};
-otherwise \tcode{get<$i$>(v) < get<$i$>(w)} with $i$ being \tcode{v.index()}.
+otherwise \tcode{std::get<$i$>(v) < std::get<$i$>(w)} with $i$ being \tcode{v.index()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>}{variant}%
@@ -5588,7 +5588,7 @@ template<class... Types>
 \begin{itemdescr}
 \pnum
 \mandates
-\tcode{get<$i$>(v) > get<$i$>(w)} is a valid expression that is
+\tcode{std::get<$i$>(v) > std::get<$i$>(w)} is a valid expression that is
 convertible to \tcode{bool}, for all $i$.
 
 \pnum
@@ -5597,7 +5597,7 @@ If \tcode{v.valueless_by_exception()}, \tcode{false};
 otherwise if \tcode{w.valueless_by_exception()}, \tcode{true};
 otherwise, if \tcode{v.index() > w.index()}, \tcode{true};
 otherwise if \tcode{v.index() < w.index()}, \tcode{false};
-otherwise \tcode{get<$i$>(v) > get<$i$>(w)} with $i$ being \tcode{v.index()}.
+otherwise \tcode{std::get<$i$>(v) > std::get<$i$>(w)} with $i$ being \tcode{v.index()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=}{variant}%
@@ -5609,7 +5609,7 @@ template<class... Types>
 \begin{itemdescr}
 \pnum
 \mandates
-\tcode{get<$i$>(v) <= get<$i$>(w)} is a valid expression that is
+\tcode{std::get<$i$>(v) <= std::get<$i$>(w)} is a valid expression that is
 convertible to \tcode{bool}, for all $i$.
 
 \pnum
@@ -5618,7 +5618,7 @@ If \tcode{v.valueless_by_exception()}, \tcode{true};
 otherwise if \tcode{w.valueless_by_exception()}, \tcode{false};
 otherwise, if \tcode{v.index() < w.index()}, \tcode{true};
 otherwise if \tcode{v.index() > w.index()}, \tcode{false};
-otherwise \tcode{get<$i$>(v) <= get<$i$>(w)} with $i$ being \tcode{v.index()}.
+otherwise \tcode{std::get<$i$>(v) <= std::get<$i$>(w)} with $i$ being \tcode{v.index()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>=}{variant}%
@@ -5630,7 +5630,7 @@ template<class... Types>
 \begin{itemdescr}
 \pnum
 \mandates
-\tcode{get<$i$>(v) >= get<$i$>(w)} is a valid expression that is
+\tcode{std::get<$i$>(v) >= std::get<$i$>(w)} is a valid expression that is
 convertible to \tcode{bool}, for all $i$.
 
 \pnum
@@ -5639,7 +5639,7 @@ If \tcode{w.valueless_by_exception()}, \tcode{true};
 otherwise if \tcode{v.valueless_by_exception()}, \tcode{false};
 otherwise, if \tcode{v.index() > w.index()}, \tcode{true};
 otherwise if \tcode{v.index() < w.index()}, \tcode{false};
-otherwise \tcode{get<$i$>(v) >= get<$i$>(w)} with $i$ being \tcode{v.index()}.
+otherwise \tcode{std::get<$i$>(v) >= std::get<$i$>(w)} with $i$ being \tcode{v.index()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{variant}%
@@ -5659,7 +5659,7 @@ if (v.valueless_by_exception() && w.valueless_by_exception())
 if (v.valueless_by_exception()) return strong_ordering::less;
 if (w.valueless_by_exception()) return strong_ordering::greater;
 if (auto c = v.index() <=> w.index(); c != 0) return c;
-return get<@$i$@>(v) <=> get<@$i$@>(w);
+return std::get<@$i$@>(v) <=> std::get<@$i$@>(w);
 \end{codeblock}
 with $i$ being \tcode{v.index()}.
 \end{itemdescr}
@@ -5707,11 +5707,11 @@ $0 \leq m_i < \tcode{variant_size_v<remove_reference_t<V}_i\tcode{>>}$
 for all $0 \leq i < n$.
 For each valid pack $m$, let $e(m)$ denote the expression:
 \begin{codeblock}
-@\placeholder{INVOKE}@(std::forward<Visitor>(vis), get<@$m$@>(std::forward<V>(vars))...)  // see \ref{func.require}
+@\placeholder{INVOKE}@(std::forward<Visitor>(vis), std::get<@$m$@>(std::forward<V>(vars))...)  // see \ref{func.require}
 \end{codeblock}
 for the first form and
 \begin{codeblock}
-@\placeholder{INVOKE}@<R>(std::forward<Visitor>(vis), get<@$m$@>(std::forward<V>(vars))...)  // see \ref{func.require}
+@\placeholder{INVOKE}@<R>(std::forward<Visitor>(vis), std::get<@$m$@>(std::forward<V>(vars))...)  // see \ref{func.require}
 \end{codeblock}
 for the second form.
 


### PR DESCRIPTION
There have been some discussions and confusion about whether `std::get`
can be specialized for user types.
It can't, it's not a customization point and the standard always
calls it qualified. As the issue has come around a few times,
the standard should make it clear that this calls is always
qualified, like it does for std::move and std::forward.