### PR TITLE
[expr.sizeof] Clarify padding in class types CWG2609

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4838,6 +4838,7 @@ of the referenced type.
 When applied to a class, the result is the number of bytes in an object
 of that class including any padding required for placing objects of that
 type in an array.
+The amount and placement of padding in a class type is unspecified.
 The result of applying \keyword{sizeof} to a
 potentially-overlapping subobject is
 the size of the type, not the size of the subobject.


### PR DESCRIPTION
Fixes cplusplus/CWG#89