### PR TITLE
[range.take.overview]  Correct punctuation for `take_view` overview

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -238,7 +238,7 @@ namespace std::ranges {
   namespace views { inline constexpr @\unspec@ transform = @\unspec@; }
 
   // \ref{range.take}, take view
-  template<@\libconcept{view}@ V> class take_view;
+  template<@\libconcept{view}@> class take_view;
 
   template<class T>
     inline constexpr bool enable_borrowed_range<take_view<T>> = enable_borrowed_range<T>;

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -238,7 +238,7 @@ namespace std::ranges {
   namespace views { inline constexpr @\unspec@ transform = @\unspec@; }
 
   // \ref{range.take}, take view
-  template<@\libconcept{view}@> class take_view;
+  template<@\libconcept{view}@ V> class take_view;
 
   template<class T>
     inline constexpr bool enable_borrowed_range<take_view<T>> = enable_borrowed_range<T>;
@@ -4966,7 +4966,7 @@ that models \libconcept{random_access_range} and \libconcept{sized_range},
 then
 \tcode{ranges::iota_view(*ranges::begin(E),
 *(ranges::begin(E) + std::\linebreak{}min<D>(ranges::distance(E), F)))},
-except that \tcode{E} is evaluated only once;
+except that \tcode{E} is evaluated only once.
 
 \item
 Otherwise, \tcode{ranges::take_view(E, F)}.


### PR DESCRIPTION
In [[ranges.syn]](https://eel.is/c++draft/ranges.syn), only the template list of `take_view` has no name, so I added it for consistency.