### PR TITLE
Post-LWG3713, use "sorted with respect to `comp`" consistently

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2851,7 +2851,7 @@ uses \tcode{c} as a comparison object.
 \pnum
 \complexity
 $N \log N$ in general, where $N$ has the value \tcode{distance(i, j)};
-linear if \range{i}{j} is sorted with \tcode{value_comp()}.
+linear if \range{i}{j} is sorted with respect to \tcode{value_comp()}.
 \end{itemdescr}
 
 \indexlibraryctor{set}%
@@ -2878,7 +2878,7 @@ uses \tcode{Compare()} as a comparison object.
 \pnum
 \complexity
 $N \log N$ in general, where $N$ has the value \tcode{distance(i, j)};
-linear if \range{i}{j} is sorted with \tcode{value_comp()}.
+linear if \range{i}{j} is sorted with respect to \tcode{value_comp()}.
 \end{itemdescr}
 
 \indexlibraryctor{set}%
@@ -2905,7 +2905,7 @@ Uses \tcode{c} as the comparison object.
 \pnum
 \complexity
 $N \log N$ in general, where $N$ has the value \tcode{ranges::distance(rg)};
-linear if \tcode{rg} is sorted with \tcode{value_comp()}.
+linear if \tcode{rg} is sorted with respect to \tcode{value_comp()}.
 \end{itemdescr}
 
 \indexlibraryctor{set}%
@@ -2984,7 +2984,7 @@ All existing elements of \tcode{a} are either assigned to or destroyed.
 \pnum
 \complexity
 $N \log N$ in general, where $N$ has the value \tcode{il.size() + a.size()};
-linear if \range{il.begin()}{il.end()} is sorted with \tcode{value_comp()}.
+linear if \range{il.begin()}{il.end()} is sorted with respect to \tcode{value_comp()}.
 \end{itemdescr}
 
 \indexordmem{key_comp}%
@@ -9741,7 +9741,7 @@ and inserts elements from the range
 \complexity
 Linear in $N$ if the range
 \range{first}{last}
-is already sorted using \tcode{comp}
+is already sorted with respect to \tcode{comp}
 and otherwise $N \log N$, where $N$
 is \tcode{last - first}.
 \end{itemdescr}
@@ -9761,7 +9761,7 @@ and inserts elements from the range \tcode{rg}.
 
 \pnum
 \complexity
-Linear in $N$ if \tcode{rg} is already sorted using \tcode{comp} and
+Linear in $N$ if \tcode{rg} is already sorted with respect to \tcode{comp} and
 otherwise $N \log N$, where $N$ is \tcode{ranges::distance(rg)}.
 \end{itemdescr}
 
@@ -10303,7 +10303,7 @@ and inserts elements from the range
 \complexity
 Linear in $N$ if the range
 \range{first}{last}
-is already sorted using \tcode{comp}
+is already sorted with respect to \tcode{comp}
 and otherwise $N \log N$,
 where $N$ is
 \tcode{last - first}.
@@ -10324,7 +10324,7 @@ inserts elements from the range \tcode{rg}.
 
 \pnum
 \complexity
-Linear in $N$ if \tcode{rg} is already sorted using \tcode{comp} and
+Linear in $N$ if \tcode{rg} is already sorted with respect to \tcode{comp} and
 otherwise $N \log N$, where $N$ is \tcode{ranges::distance(rg)}.
 \end{itemdescr}
 
@@ -10637,7 +10637,7 @@ and inserts elements from the range
 \complexity
 Linear in $N$ if the range
 \range{first}{last}
-is already sorted using \tcode{comp}
+is already sorted with respect to \tcode{comp}
 and otherwise $N \log N$,
 where $N$ is
 \tcode{last - first}.
@@ -10657,7 +10657,7 @@ and inserts elements from the range \tcode{rg}.
 
 \pnum
 \complexity
-Linear in $N$ if \tcode{rg} is already sorted using \tcode{comp} and
+Linear in $N$ if \tcode{rg} is already sorted with respect to \tcode{comp} and
 otherwise $N \log N$, where $N$ is \tcode{ranges::distance(rg)}.
 \end{itemdescr}
 
@@ -10950,7 +10950,7 @@ and inserts elements from the range
 Linear in $N$
 if the range
 \range{first}{last}
-is already sorted using \tcode{comp} and otherwise $N \log N$,
+is already sorted with respect to \tcode{comp} and otherwise $N \log N$,
 where $N$ is
 \tcode{last - first}.
 \end{itemdescr}
@@ -10970,7 +10970,7 @@ inserts elements from the range \tcode{rg}.
 
 \pnum
 \complexity
-Linear in $N$ if \tcode{rg} is already sorted using \tcode{comp} and
+Linear in $N$ if \tcode{rg} is already sorted with respect to \tcode{comp} and
 otherwise $N \log N$, where $N$ is \tcode{ranges::distance(rg)}.
 \end{itemdescr}
 


### PR DESCRIPTION
[LWG3713](https://cplusplus.github.io/LWG/issue3713) points out that we temporarily lost the term of art "sorted with respect to `comp`," and brings back a definition for it. However, several places in the existing draft never actually used that term of art in the first place. Fix them up so that they do. (hat tip @CaseyCarter)