### PR TITLE
Substatements of if consteval

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -46,7 +46,7 @@ A \defn{substatement} of a \grammarterm{statement} is one of the following:
 \item
   for a \grammarterm{compound-statement}, any \grammarterm{statement} of its \grammarterm{statement-seq},
 \item
-  for a \grammarterm{selection-statement}, any of its \grammarterm{statement}{s} (but not its \grammarterm{init-statement}), or
+  for a \grammarterm{selection-statement}, any of its \grammarterm{statement}{s} or \grammarterm{compound-statement}{s} (but not its \grammarterm{init-statement}), or
 \item
   for an \grammarterm{iteration-statement}, its \grammarterm{statement} (but not an \grammarterm{init-statement}).
 \end{itemize}


### PR DESCRIPTION
As noted [here](https://lists.isocpp.org/std-discussion/2022/07/1737.php), we talk about the substatements of `if consteval`, but those are currently defined just in terms of _statement_ whereas `if consteval` has a _compound-statement_.