### PR TITLE
[range.join.with.overview, range.split.overview] use fully-qualified name

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -6136,7 +6136,7 @@ the expression \tcode{views::join_with(E, F)} is expression-equivalent to
 \begin{example}
 \begin{codeblock}
 vector<string> vs = {"the", "quick", "brown", "fox"};
-for (char c : vs | join_with('-')) {
+for (char c : vs | views::join_with('-')) {
   cout << c;
 }
 // The above prints \tcode{the-quick-brown-fox}
@@ -7278,7 +7278,7 @@ the expression \tcode{views::split(E, F)} is expression-equivalent to
 \begin{example}
 \begin{codeblock}
 string str{"the quick brown fox"};
-for (string_view word : split(str, ' ')) {
+for (string_view word : views::split(str, ' ')) {
   cout << word << '*';
 }
 // The above prints \tcode{the*quick*brown*fox*}


### PR DESCRIPTION
which is consistent with other examples.