### PR TITLE
P2165R4 Compatibility between tuple and tuple-like objects

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9308,14 +9308,14 @@ template<class InputIterator>
     typename iterator_traits<InputIterator>::value_type;                // \expos
 template<class InputIterator>
   using @\placeholder{iter-key-type}@ = remove_const_t<
-    typename iterator_traits<InputIterator>::value_type::first_type>;   // \expos
+    tuple_element_t<0, @\exposid{iter-value-type}@<InputIterator>>>;                // \expos
 template<class InputIterator>
   using @\placeholder{iter-mapped-type}@ =
-    typename iterator_traits<InputIterator>::value_type::second_type;   // \expos
+    tuple_element_t<1, @\exposid{iter-value-type}@<InputIterator>>;                 // \expos
 template<class InputIterator>
   using @\placeholder{iter-to-alloc-type}@ = pair<
-    add_const_t<typename iterator_traits<InputIterator>::value_type::first_type>,
-    typename iterator_traits<InputIterator>::value_type::second_type>;  // \expos
+    add_const_t<tuple_element_t<0, @\exposid{iter-value-type}@<InputIterator>>>,
+    tuple_element_t<1, @\exposid{iter-value-type}@<InputIterator>>>;                // \expos
 template<ranges::@\libconcept{input_range}@ Range>
   using @\exposid{range-key-type}@ =
     remove_const_t<typename ranges::range_value_t<Range>::first_type>;  // \expos

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1677,20 +1677,9 @@ namespace std::ranges {
       @\libconcept{convertible_to}@<From, To> &&
       !@\exposconcept{uses-nonqualification-pointer-conversion}@<decay_t<From>, decay_t<To>>;
 
-  template<class T>
-    concept @\defexposconceptnc{pair-like}@ =                                     // \expos
-      !is_reference_v<T> && requires(T t) {
-        typename tuple_size<T>::type;                       // ensures \tcode{tuple_size<T>} is complete
-        requires @\libconcept{derived_from}@<tuple_size<T>, integral_constant<size_t, 2>>;
-        typename tuple_element_t<0, remove_const_t<T>>;
-        typename tuple_element_t<1, remove_const_t<T>>;
-        { std::get<0>(t) } -> @\libconcept{convertible_to}@<const tuple_element_t<0, T>&>;
-        { std::get<1>(t) } -> @\libconcept{convertible_to}@<const tuple_element_t<1, T>&>;
-      };
-
   template<class T, class U, class V>
     concept @\defexposconceptnc{pair-like-convertible-from}@ =                    // \expos
-      !@\libconcept{range}@<T> && @\exposconcept{pair-like}@<T> &&
+      !@\libconcept{range}@<T> && !is_reference_v<T> && @\exposconcept{pair-like}@<T> &&
       @\libconcept{constructible_from}@<T, U, V> &&
       @\exposconcept{convertible-to-non-slicing}@<U, tuple_element_t<0, T>> &&
       @\libconcept{convertible_to}@<V, tuple_element_t<1, T>>;
@@ -7959,12 +7948,7 @@ cout << ranges::count_if(historical_figures | views::values, is_even);  // print
 namespace std::ranges {
   template<class T, size_t N>
   concept @\defexposconcept{has-tuple-element}@ =                   // \expos
-    requires(T t) {
-      typename tuple_size<T>::type;
-      requires N < tuple_size_v<T>;
-      typename tuple_element_t<N, T>;
-      { std::get<N>(t) } -> @\libconcept{convertible_to}@<const tuple_element_t<N, T>&>;
-    };
+    @\exposconcept{tuple-like}@<T> && N < tuple_size_v<T>;
 
   template<class T, size_t N>
   concept @\defexposconcept{returnable-element}@ =                  // \expos
@@ -8594,13 +8578,10 @@ namespace std::ranges {
     (!(@\libconcept{bidirectional_range}@<Rs> && ...) && (@\libconcept{common_range}@<Rs> && ...)) ||
     ((@\libconcept{random_access_range}@<Rs> && ...) && (@\libconcept{sized_range}@<Rs> && ...));
 
-  template<class... Ts>
-    using @\exposid{tuple-or-pair}@ = @\seebelow@;                 // \expos
-
   template<class F, class Tuple>
   constexpr auto @\exposid{tuple-transform}@(F&& f, Tuple&& tuple) { // \expos
     return apply([&]<class... Ts>(Ts&&... elements) {
-      return @\exposid{tuple-or-pair}@<invoke_result_t<F&, Ts>...>(
+      return tuple<invoke_result_t<F&, Ts>...>(
         invoke(f, std::forward<Ts>(elements))...
       );
     }, std::forward<Tuple>(tuple));
@@ -8665,17 +8646,6 @@ namespace std::ranges {
 \end{codeblock}
 
 \pnum
-Given some pack of types \tcode{Ts},
-the alias template \exposid{tuple-or-pair} is defined as follows:
-\begin{itemize}
-\item
-If \tcode{sizeof...(Ts)} is 2,
-\tcode{\exposid{tuple-or-pair}<Ts...>} denotes \tcode{pair<Ts...>}.
-\item
-Otherwise, \tcode{\exposid{tuple-or-pair}<Ts...>} denotes \tcode{tuple<Ts...>}.
-\end{itemize}
-
-\pnum
 Two \tcode{zip_view} objects have the same underlying sequence if and only if
 the corresponding elements of \exposid{views_} are equal\iref{concepts.equality}
 and have the same underlying sequence.
@@ -8731,13 +8701,13 @@ namespace std::ranges {
     requires (@\libconcept{view}@<Views> && ...) && (sizeof...(Views) > 0)
   template<bool Const>
   class zip_view<Views...>::@\exposid{iterator}@ {
-    @\exposid{tuple-or-pair}@<iterator_t<@\exposidnc{maybe-const}@<Const, Views>>...> @\exposid{current_}@;@\itcorr[-1]@       // \expos
-    constexpr explicit @\exposidnc{iterator}@(@\exposid{tuple-or-pair}@<iterator_t<@\exposidnc{maybe-const}@<Const, Views>>...>);
+    tuple<iterator_t<@\exposidnc{maybe-const}@<Const, Views>>...> @\exposid{current_}@;@\itcorr[-1]@       // \expos
+    constexpr explicit @\exposidnc{iterator}@(tuple<iterator_t<@\exposidnc{maybe-const}@<Const, Views>>...>);
                                                                             // \expos
   public:
     using iterator_category = input_iterator_tag;                           // not always present
     using iterator_concept  = @\seebelow@;
-    using value_type = @\exposid{tuple-or-pair}@<range_value_t<@\exposid{maybe-const}@<Const, Views>>...>;
+    using value_type = tuple<range_value_t<@\exposid{maybe-const}@<Const, Views>>...>;
     using difference_type = common_type_t<range_difference_t<@\exposid{maybe-const}@<Const, Views>>...>;
 
     @\exposid{iterator}@() = default;
@@ -8813,7 +8783,7 @@ exits via an exception,
 the iterator acquires a singular value.
 
 \begin{itemdecl}
-constexpr explicit @\exposid{iterator}@(@\exposid{tuple-or-pair}@<iterator_t<@\exposid{maybe-const}@<Const, Views>>...> current);
+constexpr explicit @\exposid{iterator}@(tuple<iterator_t<@\exposid{maybe-const}@<Const, Views>>...> current);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9104,8 +9074,8 @@ namespace std::ranges {
     requires (@\libconcept{view}@<Views> && ...) && (sizeof...(Views) > 0)
   template<bool Const>
   class zip_view<Views...>::@\exposid{sentinel}@ {
-    @\exposid{tuple-or-pair}@<sentinel_t<@\exposidnc{maybe-const}@<Const, Views>>...> @\exposid{end_}@;@\itcorr[-1]@               // \expos
-    constexpr explicit @\exposidnc{sentinel}@(@\exposid{tuple-or-pair}@<sentinel_t<@\exposidnc{maybe-const}@<Const, Views>>...> end);
+    tuple<sentinel_t<@\exposidnc{maybe-const}@<Const, Views>>...> @\exposid{end_}@;@\itcorr[-1]@               // \expos
+    constexpr explicit @\exposidnc{sentinel}@(tuple<sentinel_t<@\exposidnc{maybe-const}@<Const, Views>>...> end);
                                                                                 // \expos
   public:
     @\exposid{sentinel}@() = default;
@@ -9134,7 +9104,7 @@ namespace std::ranges {
 \end{codeblock}
 
 \begin{itemdecl}
-constexpr explicit @\exposid{sentinel}@(@\exposid{tuple-or-pair}@<sentinel_t<@\exposid{maybe-const}@<Const, Views>>...> end);
+constexpr explicit @\exposid{sentinel}@(tuple<sentinel_t<@\exposid{maybe-const}@<Const, Views>>...> end);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9879,7 +9849,7 @@ namespace std::ranges {
   public:
     using iterator_category = input_iterator_tag;
     using iterator_concept  = @\seebelow@;
-    using value_type = @\exposid{tuple-or-pair}@<@\exposid{REPEAT}@(range_value_t<@\exposid{Base}@>, N)...>;
+    using value_type = tuple<@\exposid{REPEAT}@(range_value_t<@\exposid{Base}@>, N)...>;
     using difference_type = range_difference_t<@\exposid{Base}@>;
 
     @\exposid{iterator}@() = default;

--- a/source/support.tex
+++ b/source/support.tex
@@ -718,6 +718,8 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_to_underlying}@                     202102L // also in \libheader{utility}
 #define @\defnlibxname{cpp_lib_transformation_trait_aliases}@      201304L // also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_transparent_operators}@             201510L // also in \libheader{memory}, \libheader{functional}
+#define @\defnlibxname{cpp_lib_tuple_like}@                        202207L
+  // also in \libheader{utility}, \libheader{tuple}, \libheader{map}, \libheader{unordered_map}
 #define @\defnlibxname{cpp_lib_tuple_element_t}@                   201402L // also in \libheader{tuple}
 #define @\defnlibxname{cpp_lib_tuples_by_type}@                    201304L // also in \libheader{utility}, \libheader{tuple}
 #define @\defnlibxname{cpp_lib_type_identity}@                     201806L // also in \libheader{type_traits}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -684,6 +684,8 @@ namespace std {
       constexpr explicit(@\seebelow@) pair(pair<U1, U2>&& p);
     template<class U1, class U2>
       constexpr explicit(@\seebelow@) pair(const pair<U1, U2>&& p);
+    template<@\exposconcept{pair-like}@ P>
+      constexpr explicit(@\seebelow@) pair(P&& p);
     template<class... Args1, class... Args2>
       constexpr pair(piecewise_construct_t,
                      tuple<Args1...> first_args, tuple<Args2...> second_args);
@@ -700,6 +702,10 @@ namespace std {
       constexpr pair& operator=(pair<U1, U2>&& p);
     template<class U1, class U2>
       constexpr const pair& operator=(pair<U1, U2>&& p) const;
+    template<@\exposconcept{pair-like}@ P>
+      constexpr pair& operator=(P&& p);
+    template<@\exposconcept{pair-like}@ P>
+      constexpr const pair& operator=(P&& p) const;
 
     constexpr void swap(pair& p) noexcept(@\seebelow@);
     constexpr void swap(const pair& p) const noexcept(@\seebelow@);
@@ -825,6 +831,7 @@ template<class U1, class U2> constexpr explicit(@\seebelow@) pair(pair<U1, U2>& 
 template<class U1, class U2> constexpr explicit(@\seebelow@) pair(const pair<U1, U2>& p);
 template<class U1, class U2> constexpr explicit(@\seebelow@) pair(pair<U1, U2>&& p);
 template<class U1, class U2> constexpr explicit(@\seebelow@) pair(const pair<U1, U2>&& p);
+template<@\exposconcept{pair-like}@ P> constexpr explicit(@\seebelow@) pair(P&& p);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1057,6 +1064,70 @@ template<class U1, class U2> constexpr pair& operator=(pair<U1, U2>&& p);
 \effects
 Assigns to \tcode{first} with \tcode{std::forward<U1>(p.first)}
 and to \tcode{second} with\\ \tcode{std::forward<U2>(p.second)}.
+
+\pnum
+\returns
+\tcode{*this}.
+\end{itemdescr}
+
+\indexlibrarymember{operator=}{pair}%
+\begin{itemdecl}
+template<@\exposconcept{pair-like}@ P> constexpr pair& operator=(P&& p);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\begin{itemize}
+\item
+\tcode{\exposconcept{different-from}<P, pair>}\iref{range.utility.helpers}
+is \tcode{true},
+\item
+\tcode{remove_cvref_t<P>} is not a specialization of \tcode{ranges::subrange},
+\item
+\tcode{is_assignable_v<T1\&, decltype(get<0>(std::forward<P>(p)))>}
+is \tcode{true}, and
+\item
+\tcode{is_assignable_v<T2\&, decltype(get<1>(std::forward<P>(p)))>}
+is \tcode{true}.
+\end{itemize}
+
+\pnum
+\effects
+Assigns \tcode{get<0>(std::forward<P>(p))} to \tcode{first} and
+\tcode{get<1>(std::forward<P>(p))} to \tcode{sec\-ond}.
+
+\pnum
+\returns
+\tcode{*this}.
+\end{itemdescr}
+
+\indexlibrarymember{operator=}{pair}%
+\begin{itemdecl}
+template<@\exposconcept{pair-like}@ P> constexpr const pair& operator=(P&& p) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\begin{itemize}
+\item
+\tcode{\exposconcept{different-from}<P, pair>}\iref{range.utility.helpers}
+is \tcode{true},
+\item
+\tcode{remove_cvref_t<P>} is not a specialization of \tcode{ranges::subrange},
+\item
+\tcode{is_assignable_v<const T1\&, decltype(get<0>(std::forward<P>(p)))>}
+is \tcode{true}, and
+\item
+\tcode{is_assignable_v<const T2\&, decltype(get<1>(std::forward<P>(p)))>}
+is \tcode{true}.
+\end{itemize}
+
+\pnum
+\effects
+Assigns \tcode{get<0>(std::forward<P>(p))} to \tcode{first} and
+\tcode{get<1>(std::forward<P>(p))} to \tcode{sec\-ond}.
 
 \pnum
 \returns
@@ -1359,18 +1430,19 @@ namespace std {
   template<class... Types>
     class tuple;
 
-  template<class... TTypes, class... UTypes, template<class> class TQual,
-           template<class> class UQual>
-    requires requires { typename tuple<common_reference_t<TQual<TTypes>, UQual<UTypes>>...>; }
-  struct basic_common_reference<tuple<TTypes...>, tuple<UTypes...>, TQual, UQual> {
-    using type = tuple<common_reference_t<TQual<TTypes>, UQual<UTypes>>...>;
-  };
+  // \ref{tuple.like}, concept \exposconcept{tuple-like}
+  template <typename T>
+    concept @\exposconcept{tuple-like}@ = @\seebelownc@;         // \expos
+  template <typename T>
+    concept @\defexposconcept{pair-like}@ =                     // \expos
+      @\exposconcept{tuple-like}@<T> && tuple_size_v<remove_cvref_t<T>> == 2;
 
-  template<class... TTypes, class... UTypes>
-    requires requires { typename tuple<common_type_t<TTypes, UTypes>...>; }
-  struct common_type<tuple<TTypes...>, tuple<UTypes...>> {
-    using type = tuple<common_type_t<TTypes, UTypes>...>;
-  };
+  // \ref{tuple.common.ref}, \tcode{common_reference} related specializations
+  template<@\exposconceptnc{tuple-like}@ TTuple, @\exposconceptnc{tuple-like}@ UTuple,
+           template<class> class TQual, template<class> class UQual>
+    struct basic_common_reference<TTuple, UTuple, TQual, UQual>;
+  template<@\exposconceptnc{tuple-like}@ TTuple, @\exposconceptnc{tuple-like}@ UTuple>
+    struct common_type<TTuple, UTuple>;
 
   // \ref{tuple.creation}, tuple creation functions
   inline constexpr @\unspec@ ignore;
@@ -1384,14 +1456,14 @@ namespace std {
   template<class... TTypes>
     constexpr tuple<TTypes&...> tie(TTypes&...) noexcept;
 
-  template<class... Tuples>
+  template<@\exposconceptnc{tuple-like}@... Tuples>
     constexpr tuple<CTypes...> tuple_cat(Tuples&&...);
 
   // \ref{tuple.apply}, calling a function with a tuple of arguments
-  template<class F, class Tuple>
+  template<class F, @\exposconceptnc{tuple-like}@ Tuple>
     constexpr decltype(auto) apply(F&& f, Tuple&& t);
 
-  template<class T, class Tuple>
+  template<class T, @\exposconceptnc{tuple-like}@ Tuple>
     constexpr T make_from_tuple(Tuple&& t);
 
   // \ref{tuple.helper}, tuple helper classes
@@ -1430,9 +1502,13 @@ namespace std {
   // \ref{tuple.rel}, relational operators
   template<class... TTypes, class... UTypes>
     constexpr bool operator==(const tuple<TTypes...>&, const tuple<UTypes...>&);
+  template<class... TTypes, @\exposconceptnc{tuple-like}@ UTuple>
+    constexpr bool operator==(const tuple<TTypes...>&, const UTuple&);
   template<class... TTypes, class... UTypes>
-    constexpr common_comparison_category_t<@\placeholder{synth-three-way-result}@<TTypes, UTypes>...>
+    constexpr common_comparison_category_t<@\placeholdernc{synth-three-way-result}@<TTypes, UTypes>...>
       operator<=>(const tuple<TTypes...>&, const tuple<UTypes...>&);
+  template<class... TTypes, @\exposconceptnc{tuple-like}@ UTuple>
+    constexpr @\seebelownc@ operator<=>(const tuple<TTypes...>&, const UTuple&);
 
   // \ref{tuple.traits}, allocator-related traits
   template<class... Types, class Alloc>
@@ -1449,6 +1525,21 @@ namespace std {
     inline constexpr size_t @\libglobal{tuple_size_v}@ = tuple_size<T>::value;
 }
 \end{codeblock}
+
+\rSec2[tuple.like]{Concept \ecname{tuple-like}}
+
+\begin{itemdecl}
+template <typename T>
+  concept @\defexposconcept{tuple-like}@ = @\seebelownc@;           // \expos
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+A type \tcode{T} models and satisfies
+the exposition-only concept \exposconcept{tuple-like}
+if \tcode{std::remove_cvref_t<T>} is a specialization of
+\tcode{array}, \tcode{pair}, \tcode{tuple}, or \tcode{ranges::subrange}.
+\end{itemdescr}
 
 \rSec2[tuple.tuple]{Class template \tcode{tuple}}
 \indexlibraryglobal{tuple}%
@@ -1484,6 +1575,9 @@ namespace std {
       constexpr explicit(@\seebelow@) tuple(pair<U1, U2>&&);        // only if \tcode{sizeof...(Types) == 2}
     template<class U1, class U2>
       constexpr explicit(@\seebelow@) tuple(const pair<U1, U2>&&);  // only if \tcode{sizeof...(Types) == 2}
+
+    template<@\exposconcept{tuple-like}@ UTuple>
+      constexpr explicit(@\seebelow@) tuple(UTuple&&);
 
     // allocator-extended constructors
     template<class Alloc>
@@ -1524,6 +1618,9 @@ namespace std {
       constexpr explicit(@\seebelow@)
         tuple(allocator_arg_t, const Alloc& a, const pair<U1, U2>&&);
 
+    template<class Alloc, @\exposconceptnc{tuple-like}@ UTuple>
+      constexpr explicit(@\seebelow@) tuple(allocator_arg_t, const Alloc& a, UTuple&&);
+
     // \ref{tuple.assign}, \tcode{tuple} assignment
     constexpr tuple& operator=(const tuple&);
     constexpr const tuple& operator=(const tuple&) const;
@@ -1548,6 +1645,11 @@ namespace std {
       constexpr tuple& operator=(pair<U1, U2>&&);               // only if \tcode{sizeof...(Types) == 2}
     template<class U1, class U2>
       constexpr const tuple& operator=(pair<U1, U2>&&) const;   // only if \tcode{sizeof...(Types) == 2}
+
+    template<@\exposconceptnc{tuple-like}@ UTuple>
+      constexpr tuple& operator=(UTuple&&);
+    template<@\exposconceptnc{tuple-like}@ UTuple>
+      constexpr const tuple& operator=(UTuple&&) const;
 
     // \ref{tuple.swap}, \tcode{tuple} swap
     constexpr void swap(tuple&) noexcept(@\seebelow@);
@@ -1821,6 +1923,56 @@ is \tcode{true}.
 
 \indexlibraryctor{tuple}%
 \begin{itemdecl}
+template<@\exposconcept{tuple-like}@ UTuple>
+  constexpr explicit(@\seebelow@) tuple(UTuple&& u);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{I} be the pack \tcode{0, 1, \ldots, (sizeof...(Types) - 1)}.
+
+\pnum
+\constraints
+\begin{itemize}
+\item
+\tcode{\exposconcept{different-from}<UTuple, tuple>}\iref{range.utility.helpers}
+is \tcode{true},
+
+\item
+\tcode{remove_cvref_t<UTuple>}
+is not a specialization of \tcode{ranges::subrange},
+
+\item
+\tcode{sizeof...(Types)}
+equals \tcode{tuple_size_v<remove_cvref_t<UTuple>>},
+
+\item
+\tcode{(is_constructible_v<Types, decltype(get<I>(std::forward<UTuple>(u)))> \&\& ...)}
+is\linebreak{} % Overfull
+\tcode{true}, and
+
+\item
+either \tcode{sizeof...(Types)} is not \tcode{1}, or
+(when \tcode{Types...} expands to \tcode{T})
+\tcode{is_convertible_v<UTuple, T>} and
+\tcode{is_constructible_v<T, UTuple>} are both \tcode{false}.
+\end{itemize}
+
+\pnum
+\effects
+For all $i$, initializes the $i^\text{th}$ element of \tcode{*this} with
+\tcode{get<$i$>(std::forward<UTuple>(u))}.
+
+\pnum
+\remarks
+The expression inside \tcode{explicit} is equivalent to:
+\begin{codeblock}
+!(is_convertible_v<decltype(get<I>(std::forward<UTuple>(u))), Types> && ...)
+\end{codeblock}
+\end{itemdescr}
+
+\indexlibraryctor{tuple}%
+\begin{itemdecl}
 template<class Alloc>
   constexpr explicit(@\seebelow@)
     tuple(allocator_arg_t, const Alloc& a);
@@ -1858,6 +2010,9 @@ template<class Alloc, class U1, class U2>
 template<class Alloc, class U1, class U2>
   constexpr explicit(@\seebelow@)
     tuple(allocator_arg_t, const Alloc& a, const pair<U1, U2>&&);
+template<class Alloc, @\exposconcept{tuple-like}@ UTuple>
+  constexpr explicit(@\seebelow@)
+    tuple(allocator_arg_t, const Alloc& a, UTuple&&);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2172,6 +2327,80 @@ Assigns \tcode{std::forward<U1>(u.first)} to the first element and\\
 \tcode{*this}.
 \end{itemdescr}
 
+\indexlibrarymember{operator=}{tuple}%
+\begin{itemdecl}
+template<@\exposconcept{tuple-like}@ UTuple>
+  constexpr tuple& operator=(UTuple&& u);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\begin{itemize}
+\item
+\tcode{\exposconcept{different-from}<UTuple, tuple>}\iref{range.utility.helpers}
+is \tcode{true},
+
+\item
+\tcode{remove_cvref_t<UTuple>}
+is not a specialization of \tcode{ranges::subrange},
+
+\item
+\tcode{sizeof...(Types)}
+equals \tcode{tuple_size_v<remove_cvref_t<UTuple>>}, and,
+
+\item
+\tcode{is_assignable_v<$\tcode{T}_i$\&, decltype(get<$i$>(std::forward<UTuple>(u)))>}
+is \tcode{true} for all $i$.
+\end{itemize}
+
+\pnum
+\effects
+For all $i$, assigns \tcode{get<$i$>(std::forward<UTuple>(u))}
+to \tcode{get<$i$>(*this)}.
+
+\pnum
+\returns
+\tcode{*this}.
+\end{itemdescr}
+
+\indexlibrarymember{operator=}{tuple}%
+\begin{itemdecl}
+template<@\exposconcept{tuple-like}@ UTuple>
+  constexpr const tuple& operator=(UTuple&& u) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\begin{itemize}
+\item
+\tcode{\exposconcept{different-from}<UTuple, tuple>}\iref{range.utility.helpers}
+is \tcode{true},
+
+\item
+\tcode{remove_cvref_t<UTuple>}
+is not a specialization of \tcode{ranges::subrange},
+
+\item
+\tcode{sizeof...(Types)}
+equals \tcode{tuple_size_v<remove_cvref_t<UTuple>>}, and,
+
+\item
+\tcode{is_assignable_v<const $\tcode{T}_i$\&, decltype(get<$i$>(std::forward<UTuple>(u)))>}
+is \tcode{true} for all $i$.
+\end{itemize}
+
+\pnum
+\effects
+For all $i$, assigns
+\tcode{get<$i$>(std::forward<UTuple>(u))} to \tcode{get<$i$>(*this)}.
+
+\pnum
+\returns
+\tcode{*this}.
+\end{itemdescr}
+
 \rSec3[tuple.swap]{\tcode{swap}}
 
 \indexlibrarymember{swap}{tuple}%
@@ -2292,62 +2521,54 @@ tie(i, ignore, s) = make_tuple(42, 3.14, "C++");
 
 \indexlibraryglobal{tuple_cat}
 \begin{itemdecl}
-template<class... Tuples>
+template<@\exposconcept{tuple-like}@... Tuples>
   constexpr tuple<CTypes...> tuple_cat(Tuples&&... tpls);
 \end{itemdecl}
 
-\begin{itemdescr}  % NOCHECK: order
+\begin{itemdescr}
 \pnum
-In the following paragraphs, let $\tcode{T}_i$ be the $i^\text{th}$ type in \tcode{Tuples},
-$\tcode{U}_i$ be \tcode{remove_reference_t<T$_i$>}, and $\tcode{tp}_i$ be the $i^\text{th}$
-parameter in the function parameter pack \tcode{tpls}, where all indexing is
-zero-based.
-
-\pnum
-\expects
-For all $i$, $\tcode{U}_i$ is the type
-$\cv_i$ \tcode{tuple<$\tcode{Args}_i$...>}, where $\cv_i$ is the (possibly empty) $i^\text{th}$
-\grammarterm{cv-qualifier-seq} and $\tcode{Args}_i$ is the template parameter pack representing the element
-types in $\tcode{U}_i$. Let $\tcode{A}_{ik}$ be the ${k}^\text{th}$ type in $\tcode{Args}_i$. For all
-$\tcode{A}_{ik}$ the following requirements are met:
+Let $n$ be \tcode{sizeof...(Tuples)}.
+For every integer $0 \leq i < n$:
 \begin{itemize}
-\item If $\tcode{T}_i$ is deduced as an lvalue reference type, then
-      \tcode{is_constructible_v<$\tcode{A}_{ik}$, $\cv{}_i\;\tcode{A}_{ik}$\&> == true}, otherwise
-\item \tcode{is_constructible_v<$\tcode{A}_{ik}$, $\cv{}_i\;\tcode{A}_{ik}$\&\&> == true}.
+\item
+Let $\tcode{T}_i$ be the $i^\text{th}$ type in \tcode{Tuples}.
+\item
+Let $\tcode{U}_i$ be \tcode{remove_cvref_t<$\tcode{T}_i$>}.
+\item
+Let $\tcode{tp}_i$ be the $i^\text{th}$ element
+in the function parameter pack \tcode{tpls}.
+\item
+Let $S_i$ be \tcode{tuple_size_v<$\tcode{U}_i$>}.
+\item
+Let $E_i^k$ be \tcode{tuple_element_t<$k$, $\tcode{U}_i$>}.
+\item
+Let $e_i^k$ be \tcode{get<$k$>(std::forward<$\tcode{T}_i$>($\tcode{tp}_i$))}.
+\item
+Let $Elems_i$ be a pack of the types $E_i^0, \dotsc, E_i^{S_{i-1}}$.
+\item
+Let $elems_i$ be a pack of the expressions $e_i^0, \dotsc, e_i^{S_{i-1}}$.
 \end{itemize}
+The types in \tcode{CTypes} are equal to the ordered sequence of
+the expanded packs of types
+\tcode{$Elems_0$...}, \tcode{$Elems_1$...}, \ldots, \tcode{$Elems_{n-1}$...}.
+Let \tcode{celems} be the ordered sequence of
+the expanded packs of expressions
+\tcode{$elems_0$...}, \ldots, \tcode{$elems_{n-1}$...}.
 
 \pnum
-\remarks
-The types in \tcode{CTypes} are equal to the ordered
-sequence of the extended types
-\tcode{$\tcode{Args}_0$..., $\tcode{Args}_1$..., $\dotsc$, $\tcode{Args}_{n-1}$...},
-where $n$ is
-equal to \tcode{sizeof...(Tuples)}. Let \tcode{$\tcode{e}_i$...} be the $i^\text{th}$
-ordered sequence of tuple elements of the resulting \tcode{tuple} object
-corresponding to the type sequence $\tcode{Args}_i$.
+\mandates
+\tcode{(is_constructible_v<CTypes, decltype(celems)> \&\& ...)} is \tcode{true}.
 
 \pnum
 \returns
-A \tcode{tuple} object constructed by initializing the ${k_i}^\text{th}$
-type element $\tcode{e}_{ik}$ in \tcode{$\tcode{e}_i$...} with
-\begin{codeblock}
-get<@$k_i$@>(std::forward<@$\tcode{T}_i$@>(@$\tcode{tp}_i$@))
-\end{codeblock}
-for each valid $k_i$ and each group $\tcode{e}_i$ in order.
-
-\pnum
-\begin{note}
-An implementation can support additional types in the template parameter
-pack \tcode{Tuples} that support the \tcode{tuple}-like protocol, such as
-\tcode{pair} and \tcode{array}.
-\end{note}
+\tcode{tuple<CTypes...>(celems...)}.
 \end{itemdescr}
 
 \rSec2[tuple.apply]{Calling a function with a \tcode{tuple} of arguments}
 
 \indexlibraryglobal{apply}%
 \begin{itemdecl}
-template<class F, class Tuple>
+template<class F, @\exposconcept{tuple-like}@ Tuple>
   constexpr decltype(auto) apply(F&& f, Tuple&& t);
 \end{itemdecl}
 
@@ -2357,7 +2578,7 @@ template<class F, class Tuple>
 Given the exposition-only function:
 \begin{codeblock}
 namespace std {
-  template<class F, class Tuple, size_t... I>
+  template<class F, @\exposconcept{tuple-like}@ Tuple, size_t... I>
   constexpr decltype(auto) @\placeholdernc{apply-impl}@(F&& f, Tuple&& t, index_sequence<I...>) {
                                                                         // \expos
     return @\placeholdernc{INVOKE}@(std::forward<F>(f), get<I>(std::forward<Tuple>(t))...);     // see \ref{func.require}
@@ -2373,7 +2594,7 @@ return @\placeholdernc{apply-impl}@(std::forward<F>(f), std::forward<Tuple>(t),
 
 \indexlibraryglobal{make_from_tuple}%
 \begin{itemdecl}
-template<class T, class Tuple>
+template<class T, @\exposconcept{tuple-like}@ Tuple>
   constexpr T make_from_tuple(Tuple&& t);
 \end{itemdecl}
 
@@ -2390,7 +2611,7 @@ is \tcode{false}.
 Given the exposition-only function:
 \begin{codeblock}
 namespace std {
-  template<class T, class Tuple, size_t... I>
+  template<class T, @\exposconcept{tuple-like}@ Tuple, size_t... I>
     requires is_constructible_v<T, decltype(get<I>(declval<Tuple>()))...>
   constexpr T @\placeholdernc{make-from-tuple-impl}@(Tuple&& t, index_sequence<I...>) {   // \expos
     return T(get<I>(std::forward<Tuple>(t))...);
@@ -2608,9 +2829,14 @@ the \keyword{template} keyword.
 \begin{itemdecl}
 template<class... TTypes, class... UTypes>
   constexpr bool operator==(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
+template<class... TTypes, @\exposconcept{tuple-like}@ UTuple>
+  constexpr bool operator==(const tuple<TTypes...>& t, const UTuple& u);
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+For the first overload let \tcode{UTuple} be \tcode{tuple<UTypes...>}.
+
 \pnum
 \mandates
 For all \tcode{i},
@@ -2618,20 +2844,27 @@ where $0 \leq \tcode{i} < \tcode{sizeof...(TTypes)}$,
 \tcode{get<i>(t) == get<i>(u)} is a valid expression
 returning a type that is convertible to \tcode{bool}.
 \tcode{sizeof...(TTypes)} equals
-\tcode{sizeof...(UTypes)}.
+\tcode{tuple_size_v<UTuple>}.
 
 \pnum
 \returns
 \tcode{true} if \tcode{get<i>(t) == get<i>(u)} for all
 \tcode{i}, otherwise \tcode{false}.
-For any two zero-length tuples \tcode{e} and \tcode{f}, \tcode{e == f} returns \tcode{true}.
+\begin{note}
+If \tcode{sizeof...(TTypes)} equals zero, returns \tcode{true}.
+\end{note}
 
 \pnum
 \remarks
+\begin{itemize}
+\item
 The elementary comparisons are performed in order from the
 zeroth index upwards.  No comparisons or element accesses are
 performed after the first equality comparison that evaluates to
 \tcode{false}.
+\item
+The second overload is to be found via argument-dependent lookup\iref{basic.lookup.argdep} only.
+\end{itemize}
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{tuple}%
@@ -2639,21 +2872,34 @@ performed after the first equality comparison that evaluates to
 template<class... TTypes, class... UTypes>
   constexpr common_comparison_category_t<@\placeholder{synth-three-way-result}@<TTypes, UTypes>...>
     operator<=>(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
+template<class... TTypes, @\exposconcept{tuple-like}@ UTuple>
+  constexpr common_comparison_category_t<@\placeholder{synth-three-way-result}@<TTypes, Elems>...>
+    operator<=>(const tuple<TTypes...>& t, const UTuple& u);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
+For the second overload, \tcode{Elems} denotes the pack of types
+\tcode{tuple_element_t<0, UTuple>},
+\tcode{tuple_element_t<1, UTuple>}, \ldots,
+\tcode{tuple_element_t<tuple_size_v<UTuple> - 1, UTuple>}.
+
+\pnum
 \effects
 Performs a lexicographical comparison between \tcode{t} and \tcode{u}.
-For any two zero-length tuples \tcode{t} and \tcode{u},
-\tcode{t <=> u} returns \tcode{strong_ordering::equal}.
+If \tcode{sizeof...(TTypes)} equals zero,
+returns \tcode{strong_ordering::equal}.
 Otherwise, equivalent to:
 \begin{codeblock}
 if (auto c = @\placeholder{synth-three-way}@(get<0>(t), get<0>(u)); c != 0) return c;
 return @$\tcode{t}_\mathrm{tail}$@ <=> @$\tcode{u}_\mathrm{tail}$@;
 \end{codeblock}
-where $\tcode{r}_\mathrm{tail}$ for some tuple \tcode{r}
+where $\tcode{r}_\mathrm{tail}$ for some \tcode{r}
 is a tuple containing all but the first element of \tcode{r}.
+
+\pnum
+\remarks
+The second overload is to be found via argument-dependent lookup\iref{basic.lookup.argdep} only.
 \end{itemdescr}
 
 \pnum
@@ -2665,6 +2911,80 @@ constructible. Also, all comparison operator functions are short circuited;
 they do not perform element accesses beyond what is required to determine the
 result of the comparison.
 \end{note}
+
+\rSec2[tuple.common.ref]{\tcode{common_reference} related specializations}
+
+\pnum
+In the descriptions that follow:
+\begin{itemize}
+\item
+Let \tcode{TTypes} be a pack formed by
+the sequence of \tcode{tuple_element_t<$i$, TTuple>}
+for every integer $0 \leq i < \tcode{tuple_size_v<TTuple>}$.
+
+\item
+Let \tcode{UTypes} be a pack formed by
+the sequence of \tcode{tuple_element_t<$i$, UTuple>}
+for every integer $0 \leq i < \tcode{tuple_size_v<UTuple>}$.
+\end{itemize}
+
+\indexlibrarymember{basic_common_reference}{tuple}%
+\begin{itemdecl}
+template<@\exposconcept{tuple-like}@ TTuple, @\exposconcept{tuple-like}@ UTuple,
+         template<class> class TQual, template<class> class UQual>
+struct basic_common_reference<TTuple, UTuple, TQual, UQual> {
+  using type = @\seebelow@;
+};
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\begin{itemize}
+\item
+\tcode{TTuple} is a specialization of \tcode{tuple} or
+\tcode{UTuple} is a specialization of \tcode{tuple}.
+\item
+\tcode{is_same_v<TTuple, decay_t<TTuple>>} is \tcode{true}.
+\item
+\tcode{is_same_v<UTuple, decay_t<UTuple>>} is \tcode{true}.
+\item
+\tcode{tuple_size_v<TTuple>} equals \tcode{tuple_size_v<UTuple>}.
+\item
+\tcode{tuple<common_reference_t<TQual<TTypes>, UQual<UTypes>>...>}
+denotes a type.
+\end{itemize}
+The member \grammarterm{typedef-name} \tcode{type} denotes the type
+\tcode{tuple<common_reference_t<TQual<TTypes>, \linebreak{}UQual<UTypes>>...>}.
+\end{itemdescr}
+
+\indexlibrarymember{common_type}{tuple}%
+\begin{itemdecl}
+template<@\exposconcept{tuple-like}@ TTuple, @\exposconcept{tuple-like}@ UTuple>
+struct common_type<TTuple, UTuple> {
+  using type = @\seebelow@;
+};
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\begin{itemize}
+\item
+\tcode{TTuple} is a specialization of \tcode{tuple} or
+\tcode{UTuple} is a specialization of \tcode{tuple}.
+\item
+\tcode{is_same_v<TTuple, decay_t<TTuple>>} is \tcode{true}.
+\item
+\tcode{is_same_v<UTuple, decay_t<UTuple>>} is \tcode{true}.
+\item
+\tcode{tuple_size_v<TTuple>} equals \tcode{tuple_size_v<UTuple>}.
+\item
+\tcode{tuple<common_type_t<TTypes, UTypes>...>} denotes a type.
+\end{itemize}
+The member \grammarterm{typedef-name} \tcode{type} denotes the type
+\tcode{tuple<common_type_t<TTypes, UTypes>...>}.
+\end{itemdescr}
 
 \rSec2[tuple.traits]{Tuple traits}
 


### PR DESCRIPTION
Fixes #5599

The 2nd part of this (replacing all usages of tuple-or-pair by tuple in the range clause) should be applied after P2374R4 #5605 as per the Editor's note at end of P2165R4.