### PR TITLE
P2404R3 Move-only types for equality_comparable_with, totally_ordered_with, and three_way_comparable_with

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -133,6 +133,33 @@ The following \Cpp{} headers are new:
 Valid \CppXX{} code that \tcode{\#include}{s} headers with these names may be
 invalid in this revision of \Cpp{}.
 
+\rSec2[diff.cpp20.concepts]{\ref{concepts}: concepts library}
+
+\diffref{cmp.concept,concept.equalitycomparable,concept.totallyordered}
+\change
+Replace \tcode{common_reference_with} in \tcode{three_way_comparable_with},
+\tcode{equality_comparable_with}, and \tcode{totally_ordered_with}
+with an exposition-only concept.
+\rationale
+Allow uncopyable, but movable, types to model these concepts.
+\effect
+Valid \CppXX{} code relying on subsumption
+with \tcode{common_reference_with}
+may fail to compile in this revision of \Cpp{}. For example:
+\begin{codeblock}
+template<class T, class U>
+  requires @\libconcept{equality_comparable_with}@<T, U>
+bool attempted_equals(const T&, const U& u);    // previously selected overload
+
+template<class T, class U>
+  requires @\libconcept{common_reference_with}@<const remove_reference_t<T>&, const remove_reference_t<U>&>
+bool attempted_equals(const T& t, const U& u);  // ambiguous overload; previously
+                                                // rejected by partial ordering
+bool test(shared_ptr<int> p) {
+  return attempted_equals(p, nullptr);          // ill-formed; previously well-formed
+}
+\end{codeblock}
+
 \rSec2[diff.cpp20.utilities]{\ref{utilities}: general utilities library}
 
 \diffref{format}

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -849,6 +849,16 @@ If \tcode{T} is an object type, then let \tcode{v} be an lvalue of type
 Subclause \ref{concepts.compare} describes concepts that establish relationships and orderings
 on values of possibly differing object types.
 
+\pnum
+Given an expression \tcode{E} and a type \tcode{C},
+let \tcode{\exposid{CONVERT_TO_LVALUE}<C>(E)} be:
+\begin{itemize}
+\item
+\tcode{static_cast<const C\&>(as_const(E))} if that is a valid expression, and
+\item
+\tcode{static_cast<const C\&>(std::move(E))} otherwise.
+\end{itemize}
+
 \rSec2[concept.booleantestable]{Boolean testability}
 
 \pnum
@@ -985,6 +995,42 @@ The types
 model \exposconcept{boolean-testable}.
 \end{example}
 
+\rSec2[concept.comparisoncommontype]{Comparison common types}
+
+\begin{itemdecl}
+template<class T, class U, class C = common_reference_t<const T&, const U&>>
+  concept @\defexposconcept{comparison-common-type-with-impl}@ =   // \expos
+    @\libconcept{same_as}@<common_reference_t<const T&, const U&>,
+            common_reference_t<const U&, const T&>> &&
+    requires {
+      requires @\libconcept{convertible_to}@<const T&, const C&> || @\libconcept{convertible_to}@<T, const C&>;
+      requires @\libconcept{convertible_to}@<const U&, const C&> || @\libconcept{convertible_to}@<U, const C&>;
+    };
+
+template<class T, class U>
+  concept @\defexposconcept{comparison-common-type-with}@ =   // \expos
+    @\exposconcept{comparison-common-type-with-impl}@<remove_cvref_t<T>, remove_cvref_t<U>>;
+\end{itemdecl}
+
+\pnum
+Let \tcode{C} be \tcode{common_reference_t<const T\&, const U\&>}.
+Let \tcode{t1} and \tcode{t2} be equality-preserving expressions
+that are lvalues of type \tcode{remove_cvref_t<T>}, and
+let \tcode{u1} and \tcode{u2} be equality-preserving expressions
+that are lvalues of type \tcode{remove_cvref_t<U>}.
+\tcode{T} and \tcode{U} model
+\tcode{\exposconcept{comparison-common-type-with}<T, U>} only if:
+\begin{itemize}
+\item
+\tcode{\exposid{CONVERT_TO_LVALUE}<C>(t1)} equals
+\tcode{\exposid{CONVERT_TO_LVALUE}<C>(t2)}
+if and only if \tcode{t1} equals \tcode{t2}, and
+\item
+\tcode{\exposid{CONVERT_TO_LVALUE}<C>(u1)} equals
+\tcode{\exposid{CONVERT_TO_LVALUE}<C>(u2)}
+if and only if \tcode{u1} equals \tcode{u2}
+\end{itemize}
+
 \rSec2[concept.equalitycomparable]{Concept \cname{equality_comparable}}
 
 \begin{itemdecl}
@@ -1039,7 +1085,7 @@ implies that \tcode{==} is transitive and symmetric.
 template<class T, class U>
   concept @\deflibconcept{equality_comparable_with}@ =
     @\libconcept{equality_comparable}@<T> && @\libconcept{equality_comparable}@<U> &&
-    @\libconcept{common_reference_with}@<const remove_reference_t<T>&, const remove_reference_t<U>&> &&
+    @\exposconcept{comparison-common-type-with}@<T, U> &&
     @\libconcept{equality_comparable}@<
       common_reference_t<
         const remove_reference_t<T>&,
@@ -1050,15 +1096,21 @@ template<class T, class U>
 \begin{itemdescr}
 \pnum
 Given types \tcode{T} and \tcode{U},
-let \tcode{t} be an lvalue of type \tcode{const remove_reference_t<T>},
-\tcode{u} be an lvalue of type \tcode{const remove_reference_t<U>},
-and \tcode{C} be:
+let \tcode{t} and \tcode{t2} be lvalues
+denoting distinct equal objects of types \tcode{const remove_reference_t<T>} and
+\tcode{remove_cvref_t<T>}, respectively,
+let \tcode{u} and \tcode{u2} be lvalues
+denoting distinct equal objects of types \tcode{const remove_reference_t<U>} and
+\tcode{remove_cvref_t<U>}, respectively, and
+let \tcode{C} be:
 \begin{codeblock}
 common_reference_t<const remove_reference_t<T>&, const remove_reference_t<U>&>
 \end{codeblock}
 \tcode{T} and \tcode{U} model
 \tcode{\libconcept{equality_comparable_with}<T, U>} only if
-\tcode{bool(t == u) == bool(C(t) == C(u))}.
+\begin{codeblock}
+bool(t == u) == bool(@\exposid{CONVERT_TO_LVALUE}@<C>(t2) == @\exposid{CONVERT_TO_LVALUE}@<C>(u2))
+\end{codeblock}
 \end{itemdescr}
 
 \rSec2[concept.totallyordered]{Concept \cname{totally_ordered}}
@@ -1101,24 +1153,27 @@ template<class T, class U>
 \begin{itemdescr}
 \pnum
 Given types \tcode{T} and \tcode{U},
-let \tcode{t} be an lvalue of type \tcode{const remove_reference_t<T>},
-\tcode{u} be an lvalue of type \tcode{const remove_reference_t<U>},
-and \tcode{C} be:
+let \tcode{t} and \tcode{t2} be lvalues
+denoting distinct equal objects of types \tcode{const remove_reference_t<T>} and
+\tcode{remove_cvref_t<T>}, respectively,
+let \tcode{u} and \tcode{u2} be lvalues
+denoting distinct equal objects of types \tcode{const remove_reference_t<U>} and
+\tcode{remove_cvref_t<U>}, respectively, and
+let \tcode{C} be:
 \begin{codeblock}
 common_reference_t<const remove_reference_t<T>&, const remove_reference_t<U>&>
 \end{codeblock}
 \tcode{T} and \tcode{U} model
 \tcode{\libconcept{totally_ordered_with}<T, U>} only if
-
 \begin{itemize}
-\item \tcode{bool(t <  u) == bool(C(t) <  C(u)).}
-\item \tcode{bool(t >  u) == bool(C(t) >  C(u)).}
-\item \tcode{bool(t <= u) == bool(C(t) <= C(u)).}
-\item \tcode{bool(t >= u) == bool(C(t) >= C(u)).}
-\item \tcode{bool(u <  t) == bool(C(u) <  C(t)).}
-\item \tcode{bool(u >  t) == bool(C(u) >  C(t)).}
-\item \tcode{bool(u <= t) == bool(C(u) <= C(t)).}
-\item \tcode{bool(u >= t) == bool(C(u) >= C(t)).}
+\item \tcode{bool(t <  u) == bool(\exposid{CONVERT_TO_LVALUE}<C>(t2) <  \exposid{CONVERT_TO_LVALUE}<C>(u2))}.
+\item \tcode{bool(t >  u) == bool(\exposid{CONVERT_TO_LVALUE}<C>(t2) >  \exposid{CONVERT_TO_LVALUE}<C>(u2))}.
+\item \tcode{bool(t <= u) == bool(\exposid{CONVERT_TO_LVALUE}<C>(t2) <= \exposid{CONVERT_TO_LVALUE}<C>(u2))}.
+\item \tcode{bool(t >= u) == bool(\exposid{CONVERT_TO_LVALUE}<C>(t2) >= \exposid{CONVERT_TO_LVALUE}<C>(u2))}.
+\item \tcode{bool(u <  t) == bool(\exposid{CONVERT_TO_LVALUE}<C>(u2) <  \exposid{CONVERT_TO_LVALUE}<C>(t2))}.
+\item \tcode{bool(u >  t) == bool(\exposid{CONVERT_TO_LVALUE}<C>(u2) >  \exposid{CONVERT_TO_LVALUE}<C>(t2))}.
+\item \tcode{bool(u <= t) == bool(\exposid{CONVERT_TO_LVALUE}<C>(u2) <= \exposid{CONVERT_TO_LVALUE}<C>(t2))}.
+\item \tcode{bool(u >= t) == bool(\exposid{CONVERT_TO_LVALUE}<C>(u2) >= \exposid{CONVERT_TO_LVALUE}<C>(t2))}.
 \end{itemize}
 \end{itemdescr}
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -589,7 +589,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_chrono_udls}@                       201304L // also in \libheader{chrono}
 #define @\defnlibxname{cpp_lib_clamp}@                             201603L // also in \libheader{algorithm}
 #define @\defnlibxname{cpp_lib_complex_udls}@                      201309L // also in \libheader{complex}
-#define @\defnlibxname{cpp_lib_concepts}@                          202002L // also in \libheader{concepts}
+#define @\defnlibxname{cpp_lib_concepts}@                          202207L // also in \libheader{concepts}, \libheader{compare}
 #define @\defnlibxname{cpp_lib_constexpr_algorithms}@              201806L // also in \libheader{algorithm}
 #define @\defnlibxname{cpp_lib_constexpr_charconv}@                202207L // also in \libheader{charconv}
 #define @\defnlibxname{cpp_lib_constexpr_cmath}@                   202202L // also in \libheader{cmath}, \libheader{cstdlib}
@@ -4830,7 +4830,7 @@ template<class T, class U, class Cat = partial_ordering>
   concept @\deflibconcept{three_way_comparable_with}@ =
     @\libconcept{three_way_comparable}@<T, Cat> &&
     @\libconcept{three_way_comparable}@<U, Cat> &&
-    @\libconcept{common_reference_with}@<const remove_reference_t<T>&, const remove_reference_t<U>&> &&
+    @\exposconcept{comparison-common-type-with}@<T, U> &&
     @\libconcept{three_way_comparable}@<
       common_reference_t<const remove_reference_t<T>&, const remove_reference_t<U>&>, Cat> &&
     @\exposconcept{weakly-equality-comparable-with}@<T, U> &&
@@ -4842,11 +4842,17 @@ template<class T, class U, class Cat = partial_ordering>
 \end{codeblock}
 
 \pnum
-Let \tcode{t} and \tcode{u} be lvalues
+Let \tcode{t} and \tcode{t2} be lvalues
+denoting distinct equal objects
 of types \tcode{const remove_reference_t<T>} and
-\tcode{const remove_reference_t<U>}, respectively.
+\tcode{remove_cvref_t<T>}, respectively, and
+let \tcode{u} and \tcode{u2} be lvalues denoting distinct equal objects
+of types \tcode{const remove_reference_t<U>} and
+\tcode{remove_cvref_t<U>}, respectively.
 Let \tcode{C} be
 \tcode{common_reference_t<const remove_reference_t<T>\&, const remove_reference_t<U>\&>}.
+Let \tcode{\exposid{CONVERT_TO_LVALUE}<C>(E)} be defined
+as in \ref{concepts.compare.general}.
 \tcode{T}, \tcode{U}, and \tcode{Cat}
 model \tcode{\libconcept{three_way_comparable_with}<T, U, Cat>} only if:
 \begin{itemize}
@@ -4859,7 +4865,8 @@ model \tcode{\libconcept{three_way_comparable_with}<T, U, Cat>} only if:
 \item
   \tcode{(t <=> u != 0) == bool(t != u)} is \tcode{true},
 \item
-  \tcode{Cat(t <=> u) == Cat(C(t) <=> C(u))} is \tcode{true},
+  \tcode{Cat(t <=> u) == Cat(\exposid{CONVERT_TO_LVALUE}<C>(t2) <=>
+\exposid{CONVERT_TO_LVALUE}<C>(u2))} is \tcode{true},
 \item
   \tcode{(t <=> u < 0) == bool(t < u)} is \tcode{true},
 \item


### PR DESCRIPTION
Fixes #5607
Fixes cplusplus/papers#1074