### PR TITLE
[strings.general,thread.general] Remove nonexistent header and fix some style error

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -20,7 +20,7 @@ as summarized in \tref{strings.summary}.
 \begin{libsumtab}[x{2.1in}]{Strings library summary}{strings.summary}
 \ref{char.traits}     & Character traits                    & \tcode{<string>}  \\
 \ref{string.view}     & String view classes                 & \tcode{<string_view>} \\ \rowsep
-\ref{string.classes}  & String classes                      &   \\ \rowsep
+\ref{string.classes}  & String classes                      & \tcode{<string>}  \\ \rowsep
 \ref{c.strings}       & Null-terminated sequence utilities  &
   \tcode{<cctype>}, \tcode{<cstdlib>}, \tcode{<cstring>},
   \tcode{<cuchar>}, \tcode{<cwchar>}, \tcode{<cwctype>}  \\

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -14,7 +14,7 @@ between threads, as summarized in \tref{thread.summary}.
 \ref{thread.stoptoken}& Stop tokens           & \tcode{<stop_token>}          \\ \rowsep
 \ref{thread.threads}  & Threads               & \tcode{<thread>}              \\ \rowsep
 \ref{atomics}         & Atomic operations     &
- \tcode{<atomic>} \tcode{<atomic_ref>} \tcode{<stdatomic.h>} \\ \rowsep
+  \tcode{<atomic>}, \tcode{<stdatomic.h>} \\ \rowsep
 \ref{thread.mutex}    & Mutual exclusion      &
   \tcode{<mutex>}, \tcode{<shared_mutex>} \\ \rowsep
 \ref{thread.condition}& Condition variables   & \tcode{<condition_variable>}  \\ \rowsep


### PR DESCRIPTION
[strings.general]: Add `<string>` to the String classes subclause
[thread.general]: Remove nonexistent header `<atomic_ref>` and add a comma.