### PR TITLE
[range.join.with.sentinel] Fix template format

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -6656,7 +6656,7 @@ namespace std::ranges {
     constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> s)
       requires Const && @\libconcept{convertible_to}@<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
 
-    template <bool OtherConst>
+    template<bool OtherConst>
       requires @\libconcept{sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>
     friend constexpr bool operator==(const @\exposid{iterator}@<OtherConst>& x, const @\exposid{sentinel}@& y);
   };
@@ -6685,7 +6685,7 @@ Initializes \exposid{end_} with \tcode{std::move(s.\exposid{end_})}.
 \end{itemdescr}
 
 \begin{itemdecl}
-template <bool OtherConst>
+template<bool OtherConst>
   requires @\libconcept{sentinel_for}@<sentinel_t<@\exposid{Base}@>, iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>
 friend constexpr bool operator==(const @\exposid{iterator}@<OtherConst>& x, const @\exposid{sentinel}@& y);
 \end{itemdecl}


### PR DESCRIPTION
This seems to be the only place in `<ranges>` and other libraries where there is a space between `template` and `<`.