### PR TITLE
[mdspan.{overview,extents.ctor}] Increase reuse of definitions

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -15083,6 +15083,10 @@ the product of $U_i - L_i$ for each dimension $i$
 if its rank is greater than 0, and 1 otherwise.
 
 \pnum
+An integer $r$ is a \defn{rank index} of an index space $S$
+if $r$ is in the range $[0, \text{rank of $S$})$.
+
+\pnum
 A pack of integers \tcode{idx} is
 a \defnadj{multidimensional}{index} in a multidimensional index space $S$
 (or representation thereof) if both of the following are true:
@@ -15090,14 +15094,10 @@ a \defnadj{multidimensional}{index} in a multidimensional index space $S$
 \item
 \tcode{sizeof...(idx)} is equal to the rank of $S$, and
 \item
-for all $i$ in the range $[0, \text{rank of $S$})$,
+for every rank index $i$ of $S$,
 the $i^\text{th}$ value of \tcode{idx} is an integer
 in the interval $[L_i, U_i)$ of $S$.
 \end{itemize}
-
-\pnum
-An integer $r$ is a \defn{rank index} of an index space $S$
-if $r$ is in the range $[0, \text{rank of $S$})$.
 
 \rSec2[mdspan.extents]{Class template \tcode{extents}}
 
@@ -15332,8 +15332,12 @@ template<class... OtherIndexTypes>
 
 \begin{itemdescr}
 \pnum
+Let \tcode{N} be \tcode{sizeof...(OtherIndexTypes)},
+and let \tcode{exts_arr} be
+\tcode{array<index_type, N>\{static_cast<\\index_type>(std::move(exts))...\}}.
+
+\pnum
 \constraints
-Let \tcode{N} be \tcode{sizeof...(OtherIndexTypes)}.
 \begin{itemize}
 \item
 \tcode{(is_convertible_v<OtherIndexTypes, index_type> \&\& ...)} is \tcode{true},
@@ -15349,16 +15353,10 @@ from all the extents with a precondition.
 \end{itemize}
 
 \pnum
-Let \tcode{exts_arr} be
-\begin{codeblock}
-array<index_type, sizeof...(OtherIndexTypes)>{static_cast<index_type>(std::move(exts))...}
-\end{codeblock}
-
-\pnum
 \expects
 \begin{itemize}
 \item
-If \tcode{sizeof...(OtherIndexTypes) != rank_dynamic()} is \tcode{true},
+If \tcode{N != rank_dynamic()} is \tcode{true},
 \tcode{exts_arr[$r$]} equals $E_r$
 for each $r$ for which $E_r$ is a static extent, and
 \item


### PR DESCRIPTION
The definition of "rank index" can be used at least once more. We might even be able to use it if we can say that `extents_type` is an index space.