### PR TITLE
[ranges.cartesian.iterator] Fix format of `decltype(current_)`

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -14652,8 +14652,8 @@ for every integer $0 \le N \le \tcode{sizeof...(Vs)}$.
 \end{itemdescr}
 
 \begin{itemdecl}
-constexpr explicit @\exposid{iterator}@(tuple<iterator_t<maybe-const<Const, First>>,
-  iterator_t<maybe-const<Const, Vs>>...> current);
+constexpr explicit @\exposid{iterator}@(tuple<iterator_t<@\exposid{maybe-const}@<Const, First>>,
+  iterator_t<@\exposid{maybe-const}@<Const, Vs>>...> current);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Unfortunately, this got lost in https://github.com/cplusplus/draft/pull/5647#discussion_r929145700 because I suggested to simplify it as `decltype(current_) along with the class synopsis at https://github.com/cplusplus/draft/pull/5647#discussion_r929132253.