### PR TITLE
[ranges.syn] Add missing "freestanding" comment for as_rvalue.

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -249,7 +249,8 @@ namespace std::ranges {
   class as_rvalue_view;                                                             // freestanding
 
   template<class T>
-    inline constexpr bool enable_borrowed_range<as_rvalue_view<T>> = enable_borrowed_range<T>;
+    inline constexpr bool enable_borrowed_range<as_rvalue_view<T>> =                // freestanding
+      enable_borrowed_range<T>;
 
   namespace views { inline constexpr @\unspecnc@ as_rvalue = @\unspecnc@; }         // freestanding
 


### PR DESCRIPTION
Fixes #5738.