### PR TITLE
[dcl.fct.def.default] Elaborate on the difference of two declarations

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6168,7 +6168,9 @@ that would have been implicitly declared, as follows:
   if $\tcode{F}_2$ has an implicit object parameter of
   type ``reference to \tcode{C}'',
   $\tcode{F}_1$ may be an explicit object member function whose
-  explicit object parameter is of type ``reference to \tcode{C}'';
+  explicit object parameter is of type ``reference to \tcode{C}'',
+  in which case $\tcode{T}_1$ would differ from $\tcode{T}_2$
+  in that $\tcode{T}_1$ has an additional parameter;
 \item
   $\tcode{T}_1$ and $\tcode{T}_2$ may have differing exception specifications; and
 \item


### PR DESCRIPTION
This makes it clear that T_1 and T_2 may differ because of the present
rule for the purposes of the blanket statement "other than as allowed
by the preceding rules" futher below.