### PR TITLE
[lex.charset] Add missing hyphens

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -447,9 +447,9 @@ have leading or trailing spaces.
 \unicode{008d}{reverse line feed} \\
 \unicode{008d}{reverse index} \\
 \unicode{008e}{single shift two} \\
-\unicode{008e}{single shift-2} \\
+\unicode{008e}{single-shift-2} \\
 \unicode{008f}{single shift three} \\
-\unicode{008f}{single shift-3} \\
+\unicode{008f}{single-shift-3} \\
 \unicode{0090}{device control string} \\
 \unicode{0091}{private use one} \\
 \unicode{0091}{private use-1} \\


### PR DESCRIPTION
In P2071R2 and NameAliases.txt, 0+008E is named SINGLE-SHIFT-2, but it went
into the draft as "single shift-2", losing the hyphen between the words.