### PR TITLE
[range.cartesian.view] Fix definition of cartesian-product-is-common

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -14288,7 +14288,8 @@ namespace std::ranges {
 
   template<class First, class... Vs>
   concept @\defexposconcept{cartesian-product-is-common}@ =                 // \expos
-    @\exposconcept{cartesian-product-common-arg}@<Const, First>>;
+    (@\exposconcept{cartesian-product-common-arg}@<First> && ... &&
+     @\exposconcept{cartesian-product-common-arg}@<Vs>);
 
   template<class... Vs>
   concept @\defexposconcept{cartesian-product-is-sized}@ =                  // \expos


### PR DESCRIPTION
The original wording seems to have been a copy-paste error.

Fixes #5735.