### PR TITLE
[format.string.escaped] Fix invalid examples

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15367,15 +15367,15 @@ then \placeholder{C} is appended unchanged.
 %% FIXME: their Unicode characters are not available in our font (Latin Modern).
 \begin{example}
 \begin{codeblock}
-string s0 = format("[{}]", "h\tllo");                   // \tcode{s0} has value: \tcode{[h    llo]}
-string s1 = format("[{:?}]", "h\tllo");                 // \tcode{s1} has value: \tcode{["h\textbackslash tllo"]}
-string s3 = format("[{:?}] [{:?}]", '\'', '"');         // \tcode{s3} has value: \tcode{['\textbackslash '', '"']}
+string s0 = format("[{}]", "h\tllo");               // \tcode{s0} has value: \tcode{[h    llo]}
+string s1 = format("[{:?}]", "h\tllo");             // \tcode{s1} has value: \tcode{["h\textbackslash tllo"]}
+string s3 = format("[{:?}, {:?}]", '\'', '"');      // \tcode{s3} has value: \tcode{['\textbackslash '', '"']}
 
 // The following examples assume use of the UTF-8 encoding
 string s4 = format("[{:?}]", string("\0 \n \t \x02 \x1b", 9));
-                                                        // \tcode{s4} has value: \tcode{[\textbackslash u\{0\} \textbackslash n \textbackslash t \textbackslash u\{2\} \textbackslash u\{1b\}]}
-string s5 = format("[{:?}]", "\xc3\x28");               // invalid UTF-8
-                                                        // \tcode{s5} has value: \tcode{["\textbackslash x\{c3\}\textbackslash x\{28\}"]}
+                                                    // \tcode{s4} has value: \tcode{["\textbackslash u\{0\} \textbackslash n \textbackslash t \textbackslash u\{2\} \textbackslash u\{1b\}"]}
+string s5 = format("[{:?}]", "\xc3\x28");           // invalid UTF-8
+                                                    // \tcode{s5} has value: \tcode{["\textbackslash x\{c3\}\textbackslash x\{28\}"]}
 \end{codeblock}
 \end{example}
 


### PR DESCRIPTION
While implementing new features introduced by P2286R8 Formatting Ranges
I noticed some issues in the examples. These issues are in the paper
too.

For s3 the alternative would be to adjust the output instead of the
input.