### PR TITLE
[diff] Uniform style for examples

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -34,11 +34,10 @@ Removal of unimplemented conditionally-supported feature.
 Concatenation of \grammarterm{string-literal}s
 with different \grammarterm{encoding-prefix}es
 is now ill-formed.
-\begin{example}
+For example:
 \begin{codeblock}
 auto c = L"a" U"b";             // was conditionally-supported; now ill-formed
 \end{codeblock}
-\end{example}
 
 \rSec2[diff.cpp20.dcl]{\ref{dcl.dcl}: declarations}
 
@@ -53,8 +52,7 @@ Arrays of \keyword{char} or \tcode{\keyword{unsigned} \keyword{char}}
 may now be initialized with a UTF-8 string literal.
 This can affect initialization that includes arrays
 that are directly initialized within class types, typically aggregates.
-
-Example:
+For example:
 \begin{codeblock}
 struct A {
   char8_t s[10];
@@ -80,7 +78,8 @@ Change move-eligible \grammarterm{id-expression}s from lvalues to xvalues.
 Simplify the rules for implicit move.
 \effect
 Valid \CppXX{} code that relies on a returned \grammarterm{id-expression}'s
-being an lvalue may change behavior or fail to compile. For example:
+being an lvalue may change behavior or fail to compile.
+For example:
 \begin{codeblock}
 decltype(auto) f(int&& x) { return (x); }       // returns \tcode{int\&\&}; previously returned \tcode{int\&}
 int& g(int&& x) { return x; }                   // ill-formed; previously well-formed
@@ -93,7 +92,8 @@ Change the meaning of comma in subscript expressions.
 Enable repurposing a deprecated syntax to support multidimensional indexing.
 \effect
 Valid \CppXX{} code that uses a comma expression within a
-subscript expression may fail to compile. For example:
+subscript expression may fail to compile.
+For example:
 \begin{codeblock}
 arr[1, 2]               // was equivalent to \tcode{arr[(1, 2)]},
                         // now equivalent to \tcode{arr.operator[](1, 2)} or ill-formed
@@ -108,6 +108,7 @@ Deducing template arguments from exception specifications.
 Facilitate generic handling of throwing and non-throwing functions.
 \effect
 Valid ISO \CppXX{} code may be ill-formed in this revision of \Cpp{}.
+For example:
 \begin{codeblock}
 template<bool> struct A { };
 template<bool B> void f(void (*)(A<B>) noexcept(B));
@@ -145,7 +146,8 @@ Allow uncopyable, but movable, types to model these concepts.
 \effect
 Valid \CppXX{} code relying on subsumption
 with \tcode{common_reference_with}
-may fail to compile in this revision of \Cpp{}. For example:
+may fail to compile in this revision of \Cpp{}.
+For example:
 \begin{codeblock}
 template<class T, class U>
   requires @\libconcept{equality_comparable_with}@<T, U>
@@ -191,7 +193,8 @@ that do not support iteration when const-qualified and
 that are not copyable.
 \effect
 Valid \CppXX{} code that passes bit fields to formatting functions
-may become ill-formed. For example:
+may become ill-formed.
+For example:
 \begin{codeblock}
 struct tiny {
   int bit: 1;
@@ -215,6 +218,7 @@ by calling \tcode{substr} (or the corresponding constructor)
 on an xvalue expression with type \tcode{S}
 that is a specialization of \tcode{basic_string}
 may change meaning in this revision of \Cpp{}.
+For example:
 \begin{codeblock}
 std::string s1 = "some long string that forces allocation", s2 = s1;
 std::move(s1).substr(10, 5);
@@ -268,7 +272,7 @@ Logical lines beginning with
 \tcode{module} or \tcode{import} may
 be interpreted differently
 in this revision of \Cpp{}.
-\begin{example}
+For example:
 \begin{codeblock}
 class module {};
 module m1;          // was variable declaration; now \grammarterm{module-declaration}
@@ -278,7 +282,6 @@ class import {};
 import j1;          // was variable declaration; now \grammarterm{module-import-declaration}
 ::import j2;        // variable declaration
 \end{codeblock}
-\end{example}
 
 \diffref{lex.header}
 \change
@@ -289,13 +292,12 @@ Required for new features.
 When the identifier \tcode{import}
 is followed by a \tcode{<} character,
 a \grammarterm{header-name} token may be formed.
-\begin{example}
+For example:
 \begin{codeblock}
 template<typename> class import {};
 import<int> f();                // ill-formed; previously well-formed
 ::import<int> g();              // OK
 \end{codeblock}
-\end{example}
 
 \diffref{lex.key}
 \change
@@ -342,7 +344,8 @@ Necessary for new functionality.
 \effect
 Valid \CppXVII{} code that contains a \tcode{<=} token
 immediately followed by a \tcode{>} token
-may be ill-formed or have different semantics in this revision of \Cpp{}:
+may be ill-formed or have different semantics in this revision of \Cpp{}.
+For example:
 \begin{codeblock}
 namespace N {
   struct X {};
@@ -365,6 +368,7 @@ Valid \CppXVII{} code that depends on
 UTF-8 string literals having type ``array of \tcode{const char}'' and
 UTF-8 character literals having type ``\tcode{char}''
 is not valid in this revision of \Cpp{}.
+For example:
 \begin{codeblock}
 const auto *u8s = u8"text";     // \tcode{u8s} previously deduced as \tcode{const char*}; now deduced as \tcode{const char8_t*}
 const char *ps = u8s;           // ill-formed; previously well-formed
@@ -395,7 +399,7 @@ Increase consistency of the language model.
 \effect
 Valid ISO \CppXVII{} code may be ill-formed or
 have undefined behavior in this revision of \Cpp{}.
-\begin{example}
+For example:
 \begin{codeblock}
 int f() {
   int a = 123;
@@ -404,7 +408,6 @@ int f() {
   return a;         // undefined behavior; previously returned 123
 }
 \end{codeblock}
-\end{example}
 
 \diffref{intro.races}
 \change
@@ -443,6 +446,7 @@ can contain only C-compatible constructs.
 Necessary for implementability.
 \effect
 Valid \CppXVII{} code may be ill-formed in this revision of \Cpp{}.
+For example:
 \begin{codeblock}
 typedef struct {
   void f() {}           // ill-formed; previously well-formed
@@ -458,6 +462,7 @@ Required for modules support.
 \effect
 Valid \CppXVII{} code may be ill-formed in this revision of \Cpp{},
 with no diagnostic required.
+For example:
 \begin{codeblock}
 // Translation unit 1
 int f(int a = 42);
@@ -480,6 +485,7 @@ Valid \CppXVII{} code that aggregate-initializes
 a type with a user-declared constructor
 may be ill-formed or have different semantics
 in this revision of \Cpp{}.
+For example:
 \begin{codeblock}
 struct A {              // not an aggregate; previously an aggregate
   A() = delete;
@@ -521,7 +527,8 @@ is now a narrowing conversion.
 Catches bugs.
 \effect
 Valid \CppXVII{} code may fail to compile
-in this revision of \Cpp{}. For example:
+in this revision of \Cpp{}.
+For example:
 \begin{codeblock}
 bool y[] = { "bc" };    // ill-formed; previously well-formed
 \end{codeblock}
@@ -540,7 +547,8 @@ in a conversion function declaration.
 Necessary for new functionality.
 \effect
 Valid \CppXVII{} code may fail to compile
-in this revision of \Cpp{}. For example:
+in this revision of \Cpp{}.
+For example:
 \begin{codeblock}
 struct S {
   explicit (S)(const S&);       // ill-formed; previously well-formed
@@ -557,7 +565,8 @@ is no longer valid as the \grammarterm{declarator-id} of a constructor or destru
 Remove potentially error-prone option for redundancy.
 \effect
 Valid \CppXVII{} code may fail to compile
-in this revision of \Cpp{}. For example:
+in this revision of \Cpp{}.
+For example:
 \begin{codeblock}
 template<class T>
 struct A {
@@ -627,6 +636,7 @@ where one is convertible to the other,
 could invoke a different operator.
 Equality and inequality expressions between two objects of the same type
 could become ambiguous.
+For example:
 \begin{codeblock}
 struct A {
   operator int() const;
@@ -663,6 +673,7 @@ visible via normal lookup.
 Previously valid code that uses a function name
 as the left operand of a \tcode{<} operator
 would become ill-formed.
+For example:
 \begin{codeblock}
 struct A {};
 bool operator<(void (*fp)(), A);
@@ -801,7 +812,8 @@ Character array extraction only takes array types.
 \rationale
 Increase safety via preventing buffer overflow at compile time.
 \effect
-Valid \CppXVII{} code may fail to compile in this revision of \Cpp{}:
+Valid \CppXVII{} code may fail to compile in this revision of \Cpp{}.
+For example:
 \begin{codeblock}
 auto p = new char[100];
 char q[100];
@@ -819,6 +831,7 @@ Required for new features.
 Valid \CppXVII{} code that passes UTF-8 literals to
 \tcode{basic_ostream<char, ...>::operator<<} or
 \tcode{basic_ostream<wchar_t, ...>::operator<<} is now ill-formed.
+For example:
 \begin{codeblock}
 std::cout << u8"text";          // previously called \tcode{operator<<(const char*)} and printed a string;
                                 // now ill-formed
@@ -838,6 +851,7 @@ Valid \CppXVII{} code that passes
 to \tcode{basic_ostream<char, ...>::operator<<} or
 that passes \keyword{char16_t} or \keyword{char32_t} characters or strings
 to \tcode{basic_ostream<wchar_t, ...>::operator<<} is now ill-formed.
+For example:
 \begin{codeblock}
 std::cout << u"text";           // previously formatted the string as a pointer value;
                                 // now ill-formed
@@ -854,6 +868,7 @@ Required for new features.
 Valid \CppXVII{} code that depends on the \tcode{u8string()} and
 \tcode{generic_u8string()} member functions of \tcode{std::filesystem::path}
 returning \tcode{std::string} is not valid in this revision of \Cpp{}.
+For example:
 \begin{codeblock}
 std::filesystem::path p;
 std::string s1 = p.u8string();          // ill-formed; previously well-formed
@@ -1042,7 +1057,8 @@ The specifier can simply be removed to retain the original meaning.
 More intuitive deduction behavior.
 \effect
 Valid \CppXIV{} code may fail to compile or may change meaning
-in this revision of \Cpp{}. For example:
+in this revision of \Cpp{}.
+For example:
 \begin{codeblock}
 auto x1{1};         // was \tcode{std::initializer_list<int>}, now \tcode{int}
 auto x2{1, 2};      // was \tcode{std::initializer_list<int>}, now ill-formed
@@ -1102,6 +1118,7 @@ or may have different semantics. A \grammarterm{using-declaration}
 that names a constructor now makes the corresponding base class constructors
 visible to initializations of the derived class
 rather than declaring additional derived class constructors.
+For example:
 \begin{codeblock}
 struct A {
   template<typename T> A(T, typename T::type = 0);
@@ -1240,7 +1257,7 @@ for \tcode{char*} and \tcode{const char*} arguments
 will execute differently
 when called with a non-const string's \tcode{.data()} member
 in this revision of \Cpp{}.
-
+For example:
 \begin{codeblock}
 int f(char *) = delete;
 int f(const char *);
@@ -1258,7 +1275,8 @@ Increase portability, clarification of associative container requirements.
 \effect
 Valid \CppXIV{} code that attempts to use associative containers
 having a comparison object with non-const function call operator
-may fail to compile in this revision of \Cpp{}:
+may fail to compile in this revision of \Cpp{}.
+For example:
 \begin{codeblock}
 #include <set>
 
@@ -1332,8 +1350,8 @@ Valid \CppXI{} code may fail to compile or may change meaning in this
 revision of \Cpp{}. For example, the following code is valid both in \CppXI{} and in
 this revision of \Cpp{}, but the macro invocation produces different outcomes
 because the single quotes delimit a \grammarterm{character-literal} in \CppXI{}, whereas they are digit
-separators in this revision of \Cpp{}:
-
+separators in this revision of \Cpp{}.
+For example:
 \begin{codeblock}
 #define M(x, ...) __VA_ARGS__
 int x[2] = { M(1'2,3'4, 5) };
@@ -1355,7 +1373,6 @@ deallocation function as follows:
 void* operator new(std::size_t, std::size_t);
 void operator delete(void*, std::size_t) noexcept;
 \end{codeblock}
-
 In this revision of \Cpp{}, however, the declaration of \tcode{operator delete}
 might match a predefined usual (non-placement)
 \tcode{operator delete}\iref{basic.stc.dynamic}. If so, the
@@ -1375,8 +1392,8 @@ standard conversions), especially the creation of the temporary due to
 lvalue-to-rvalue conversion, were considered gratuitous and surprising.
 \effect
 Valid \CppXI{} code that relies on the conversions may behave differently
-in this revision of \Cpp{}:
-
+in this revision of \Cpp{}.
+For example:
 \begin{codeblock}
 struct S {
   int x = 1;
@@ -1388,14 +1405,11 @@ int f(bool cond) {
   return s.x;
 }
 \end{codeblock}
-
 In \CppXI{}, \tcode{f(true)} returns \tcode{1}. In this revision of \Cpp{},
 it returns \tcode{2}.
-
 \begin{codeblock}
 sizeof(true ? "" : throw 0)
 \end{codeblock}
-
 In \CppXI{}, the expression yields \tcode{sizeof(const char*)}. In this
 revision of \Cpp{}, it yields \tcode{sizeof(const char[1])}.
 
@@ -1410,15 +1424,16 @@ Necessary to allow \keyword{constexpr} member functions to mutate
 the object.
 \effect
 Valid \CppXI{} code may fail to compile in this revision of \Cpp{}.
-For example, the following code is valid in \CppXI{}
-but invalid in this revision of \Cpp{} because it declares the same member
-function twice with different return types:
+For example:
 \begin{codeblock}
 struct S {
   constexpr const int &f();
   int &f();
 };
 \end{codeblock}
+This code is valid in \CppXI{}
+but invalid in this revision of \Cpp{} because it declares the same member
+function twice with different return types.
 
 \diffref{dcl.init.aggr}
 \change
@@ -1488,7 +1503,8 @@ Valid \CppIII{} code may fail to compile or produce different results in
 this revision of \Cpp{}. Specifically, macros named \tcode{R}, \tcode{u8},
 \tcode{u8R}, \tcode{u}, \tcode{uR}, \tcode{U}, \tcode{UR}, or \tcode{LR} will
 not be expanded when adjacent to a \grammarterm{string-literal} but will be interpreted as
-part of the \grammarterm{string-literal}. For example:
+part of the \grammarterm{string-literal}.
+For example:
 \begin{codeblock}
 #define u8 "abc"
 const char* s = u8"def";        // Previously \tcode{"abcdef"}, now \tcode{"def"}
@@ -1607,13 +1623,15 @@ Narrowing restrictions in aggregate initializers.
 \rationale
 Catches bugs.
 \effect
-Valid \CppIII{} code may fail to compile in this revision of \Cpp{}. For
-example, the following code is valid in \CppIII{} but invalid in this
-revision of \Cpp{} because \tcode{double} to \tcode{int} is a narrowing
-conversion:
+Valid \CppIII{} code may fail to compile in this revision of \Cpp{}.
+For
+example:
 \begin{codeblock}
 int x[] = { 2.0 };
 \end{codeblock}
+This code is valid in \CppIII{} but invalid in this
+revision of \Cpp{} because \tcode{double} to \tcode{int} is a narrowing
+conversion.
 
 \rSec2[diff.cpp03.class]{\ref{class}: classes}
 
@@ -1661,15 +1679,15 @@ representing non-class types would exacerbate whitespace issues.
 Change to semantics of well-defined expression. A valid \CppIII{} expression
 containing a right angle bracket (``\tcode{>}'') followed immediately by
 another right angle bracket may now be treated as closing two templates.
-For example, the following code is valid in \CppIII{} because ``\tcode{>>}''
-is a right-shift operator, but invalid in this revision of \Cpp{} because
-``\tcode{>>}'' closes two templates.
-
+For example:
 \begin{codeblock}
 template <class T> struct X { };
 template <int N> struct Y { };
 X< Y< 1 >> 2 > > x;
 \end{codeblock}
+This code is valid in \CppIII{} because ``\tcode{>>}''
+is a right-shift operator, but invalid in this revision of \Cpp{} because
+``\tcode{>>}'' closes two templates.
 
 \diffref{temp.dep.candidate}
 \change
@@ -1996,7 +2014,8 @@ Required for new features.
 \effect
 Valid \CppIII{} code that relies on \tcode{std::ios_base} flag types being
 represented as \tcode{std::bitset} or as an integer type may fail to compile
-with this revision of \Cpp{}. For example:
+with this revision of \Cpp{}.
+For example:
 \begin{codeblock}
 #include <iostream>
 
@@ -2043,26 +2062,21 @@ Common.
 Type of \grammarterm{character-literal} is changed from \tcode{int} to \tcode{char}.
 \rationale
 This is needed for improved overloaded function argument type
-matching.
-For example:
-
+matching. For example:
 \begin{codeblock}
 int function( int i );
 int function( char c );
 
 function( 'x' );
 \end{codeblock}
-
 It is preferable that this call match the second version of
 function rather than the first.
 \effect
 Change to semantics of well-defined feature.
 ISO C programs which depend on
-
 \begin{codeblock}
 sizeof('x') == sizeof(int)
 \end{codeblock}
-
 will not work the same as \Cpp{} programs.
 \difficulty
 Simple.
@@ -2112,7 +2126,6 @@ which might expect to be able to modify its argument.
 Change to semantics of well-defined feature.
 \difficulty
 Syntactic transformation. The fix is to add a cast:
-
 \begin{codeblock}
 char* p = "abc";                // valid in C, invalid in \Cpp{}
 void f(char*) {
@@ -2121,7 +2134,6 @@ void f(char*) {
   f((char*)"def");              // OK, cast added
 }
 \end{codeblock}
-
 \howwide
 Programs that have a legitimate reason to treat string literal objects
 as potentially modifiable memory are probably rare.
@@ -2148,7 +2160,6 @@ static struct X a;
 static struct X b = { 0, &a };
 static struct X a = { 1, &b };
 \end{codeblock}
-
 \rationale
 This avoids having different initialization rules for
 fundamental types and user-defined types.
@@ -2243,7 +2254,6 @@ Common.
 \diffref{conv.ptr}
 \change
 Converting \tcode{\keyword{void}*} to a pointer-to-object type requires casting.
-
 \begin{codeblock}
 char a[10];
 void* b=a;
@@ -2318,13 +2328,12 @@ yield lvalues.
 \effect
 Change to semantics of well-defined feature.  Some C
 expressions that implicitly rely on lvalue-to-rvalue
-conversions will yield different results.  For example,
-
+conversions will yield different results.
+For example,
 \begin{codeblock}
 char arr[100];
 sizeof(0, arr)
 \end{codeblock}
-
 yields
 \tcode{100}
 in \Cpp{} and
@@ -2474,6 +2483,7 @@ Seldom.
 \change
 The keyword \keyword{auto} cannot be used as a storage class specifier.
 
+Example:
 \begin{codeblock}
 void f() {
   auto int x;       // valid C, invalid \Cpp{}
@@ -2497,7 +2507,6 @@ In \Cpp{}, a function declared with an empty parameter list takes no arguments.
 In C, an empty parameter list means that the number and type of the function arguments are unknown.
 
 Example:
-
 \begin{codeblock}
 int f();            // means   \tcode{int f(void)} in \Cpp{}
                     // \tcode{int f(} unknown \tcode{)} in C
@@ -2525,7 +2534,6 @@ In \Cpp{}, types may not be defined in return or parameter types.
 In C, these type definitions are allowed.
 
 Example:
-
 \begin{codeblock}
 void f( struct S { int a; } arg ) {}    // valid C, invalid \Cpp{}
 enum E { A, B, C } f() {}               // valid C, invalid \Cpp{}

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1624,8 +1624,7 @@ Narrowing restrictions in aggregate initializers.
 Catches bugs.
 \effect
 Valid \CppIII{} code may fail to compile in this revision of \Cpp{}.
-For
-example:
+For example:
 \begin{codeblock}
 int x[] = { 2.0 };
 \end{codeblock}


### PR DESCRIPTION
For C++ differences, examples are always preceded by the phrase "For
example:", do not use the usual [Example n: ... -- end example] style,
and always appear in the "Effects on original feature" paragraph.

For differences with C, a different set of styles is used (examples
being part of paragraphs such as "Change" and "Rationale"), and that
subclause remains unchanged by this commit.

Suggested by CD review.

I will update the wiki accordingly.