### PR TITLE
[memory.syn] Add missing "// freestanding" comment to "destroy"

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -363,7 +363,8 @@ namespace std {
   template<class T>
     constexpr void destroy_at(T* location);                                         // freestanding
   template<class NoThrowForwardIterator>
-    constexpr void destroy(NoThrowForwardIterator first, NoThrowForwardIterator last);
+    constexpr void destroy(NoThrowForwardIterator first,                            // freestanding
+                           NoThrowForwardIterator last);
   template<class ExecutionPolicy, class NoThrowForwardIterator>
     void destroy(ExecutionPolicy&& exec,                                            // see \ref{algorithms.parallel.overloads}
                  NoThrowForwardIterator first, NoThrowForwardIterator last);


### PR DESCRIPTION
The comment was supposed to be added by P1642R11, but was accidentally
omitted.

Fixes #5731.