### PR TITLE
[vector.syn, vector.bool] Add subclause structure.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -6095,23 +6095,26 @@ namespace std {
     constexpr typename vector<T, Allocator>::size_type
       erase_if(vector<T, Allocator>& c, Predicate pred);
 
-  // \ref{vector.bool}, class \tcode{vector<bool>}
-  template<class Allocator> class vector<bool, Allocator>;
+  namespace pmr {
+    template<class T>
+      using vector = std::vector<T, polymorphic_allocator<T>>;
+  }
+
+  // \ref{vector.bool}, specialization of \tcode{vector} for \tcode{bool}
+  // \ref{vector.bool.pspc}, partial class template specialization \tcode{vector<bool, Allocator>}
+  template<class Allocator>
+    class vector<bool, Allocator>;
 
   template<class T>
     constexpr bool @\exposid{is-vector-bool-reference}@ = @\seebelow@;          // \expos
-
-  template<class T, class charT> requires @\exposid{is-vector-bool-reference}@<T>
-    struct formatter<T, charT>;
 
   // hash support
   template<class T> struct hash;
   template<class Allocator> struct hash<vector<bool, Allocator>>;
 
-  namespace pmr {
-    template<class T>
-      using vector = std::vector<T, polymorphic_allocator<T>>;
-  }
+  // \ref{vector.bool.fmt}, formatter specialization for \tcode{vector<bool>}
+  template<class T, class charT> requires @\exposid{is-vector-bool-reference}@<T>
+    struct formatter<T, charT>;
 }
 \end{codeblock}
 
@@ -9112,14 +9115,14 @@ return r;
 \end{codeblock}
 \end{itemdescr}
 
-\rSec2[vector.bool]{Class \tcode{vector<bool>}}
+\rSec2[vector.bool]{Specialization of \tcode{vector} for \tcode{bool}}
+
+\rSec3[vector.bool.pspc]{Partial class template specialization \tcode{vector<bool, Allocator>}}
 
 \pnum
 \indexlibraryglobal{vector<bool>}%
-To optimize space allocation, a specialization of vector for
-\tcode{bool}
-elements is provided:
-
+To optimize space allocation, a partial specialization of \tcode{vector} for
+\tcode{bool} elements is provided:
 \begin{codeblock}
 namespace std {
   template<class Allocator>
@@ -9311,6 +9314,8 @@ if \tcode{T} denotes the type \tcode{vector<bool, Alloc>::\linebreak{}reference}
 for some type \tcode{Alloc} and
 \tcode{vector<bool, Alloc>} is not a program-defined specialization.
 \end{itemdescr}
+
+\rSec3[vector.bool.fmt]{Formatter specialization for \tcode{vector<bool>}}
 
 \indexlibraryglobal{formatter}%
 \begin{codeblock}


### PR DESCRIPTION
After the addition of the formatting-related specialization, the
original subclause contained several class template synopses without
any intervening separation. The header synopsis is rearranged to
follow the document order.

Fixes #5719.