### PR TITLE
[expr.prim.id.unqual] Fix parameter name in example ("y", not "z")

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1513,6 +1513,7 @@ it is a bit-field if the identifier designates a bit-field.
 \begin{codeblock}
 void f() {
   float x, &r = x;
+
   [=]() -> decltype((x)) {      // lambda returns \tcode{float const\&} because this lambda is not \tcode{mutable} and
                                 // \tcode{x} is an lvalue
     decltype(x) y1;             // \tcode{y1} has type \tcode{float}
@@ -1522,14 +1523,16 @@ void f() {
     return y2;
   };
 
-  [=](decltype((x)) y){
+  [=](decltype((x)) y) {
     decltype((x)) z = x;        // OK, \tcode{y} has type \tcode{float\&}, \tcode{z} has type \tcode{float const\&}
   };
-  [=]{
-      [](decltype((x)) y){};    // OK, lambda takes a parameter of type \tcode{float const\&}
-      [x=1](decltype((x)) z){
-        decltype((x)) z = x;    // OK, \tcode{y} has type \tcode{int\&}, \tcode{z} has type \tcode{int const\&}
-      };
+
+  [=] {
+    [](decltype((x)) y) {};     // OK, lambda takes a parameter of type \tcode{float const\&}
+
+    [x=1](decltype((x)) y) {
+      decltype((x)) z = x;      // OK, \tcode{y} has type \tcode{int\&}, \tcode{z} has type \tcode{int const\&}
+    };
   };
 }
 \end{codeblock}


### PR DESCRIPTION
The misspelling was a misapplication of the motion paper P2579R0.

Also harmonize the local use of whitespace.