### PR TITLE
[range.cartesian.view] Fix cartesian-product-is-common

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -14286,9 +14286,9 @@ namespace std::ranges {
       (@\libconcept{bidirectional_range}@<@\exposid{maybe-const}@<Const, Vs>>
         && @\exposconcept{cartesian-product-common-arg}@<@\exposid{maybe-const}@<Const, Vs>>));
 
-  template<class... Vs>
+  template<class First>
   concept @\defexposconcept{cartesian-product-is-common}@ =                 // \expos
-    (@\exposconcept{cartesian-product-common-arg}@<Vs> && ...);
+    @\exposconcept{cartesian-product-common-arg}@<First>;
 
   template<class... Vs>
   concept @\defexposconcept{cartesian-product-is-sized}@ =                  // \expos
@@ -14329,9 +14329,9 @@ namespace std::ranges {
 
     constexpr @\exposid{iterator}@<false> end()
       requires ((!@\exposconcept{simple-view}@<First> || ... || !@\exposconcept{simple-view}@<Vs>) &&
-        @\exposconcept{cartesian-product-is-common}@<First, Vs...>);
+        @\exposconcept{cartesian-product-is-common}@<First>);
     constexpr @\exposid{iterator}@<true> end() const
-      requires @\exposconcept{cartesian-product-is-common}@<const First, const Vs...>;
+      requires @\exposconcept{cartesian-product-is-common}@<const First>;
     constexpr default_sentinel_t end() const noexcept;
 
     constexpr @\seebelow@ size()
@@ -14383,9 +14383,9 @@ Equivalent to:
 \begin{itemdecl}
 constexpr @\exposid{iterator}@<false> end()
   requires ((!@\exposconcept{simple-view}@<First> || ... || !@\exposconcept{simple-view}@<Vs>)
-    && @\exposconcept{cartesian-product-is-common}@<First, Vs...>);
+    && @\exposconcept{cartesian-product-is-common}@<First>);
 constexpr @\exposid{iterator}@<true> end() const
-  requires @\exposconcept{cartesian-product-is-common}@<const First, const Vs...>;
+  requires @\exposconcept{cartesian-product-is-common}@<const First>;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -14286,10 +14286,9 @@ namespace std::ranges {
       (@\libconcept{bidirectional_range}@<@\exposid{maybe-const}@<Const, Vs>>
         && @\exposconcept{cartesian-product-common-arg}@<@\exposid{maybe-const}@<Const, Vs>>));
 
-  template<class First, class... Vs>
+  template<class... Vs>
   concept @\defexposconcept{cartesian-product-is-common}@ =                 // \expos
-    (@\exposconcept{cartesian-product-common-arg}@<First> && ... &&
-     @\exposconcept{cartesian-product-common-arg}@<Vs>);
+    (@\exposconcept{cartesian-product-common-arg}@<Vs> && ...);
 
   template<class... Vs>
   concept @\defexposconcept{cartesian-product-is-sized}@ =                  // \expos


### PR DESCRIPTION
I think this should be correct.
(In fact, I implemented `cartesian_product_view` after the pre-version p2374r3 was published. There are quite a lot of editorial mistakes in that paper. From my experience, the constraints here should only be aimed at `First`)