### PR TITLE
[range.adaptor.tuple] Fix annoying tuple naming conflict

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -4266,17 +4266,17 @@ to temporarily cache values as it is iterated over.
 \begin{codeblock}
 namespace std::ranges {
   template<class F, class Tuple>
-  constexpr auto @\exposid{tuple-transform}@(F&& f, Tuple&& tuple) { // \expos
+  constexpr auto @\exposid{tuple-transform}@(F&& f, Tuple&& t) { // \expos
     return apply([&]<class... Ts>(Ts&&... elements) {
       return tuple<invoke_result_t<F&, Ts>...>(invoke(f, std::forward<Ts>(elements))...);
-    }, std::forward<Tuple>(tuple));
+    }, std::forward<Tuple>(t));
   }
 
   template<class F, class Tuple>
-  constexpr void @\exposid{tuple-for-each}@(F&& f, Tuple&& tuple) { // \expos
+  constexpr void @\exposid{tuple-for-each}@(F&& f, Tuple&& t) { // \expos
     apply([&]<class... Ts>(Ts&&... elements) {
       (invoke(f, std::forward<Ts>(elements)), ...);
-    }, std::forward<Tuple>(tuple));
+    }, std::forward<Tuple>(t));
   }
 \end{codeblock}
 


### PR DESCRIPTION
```cpp
namespace std::ranges {
  template<class F, class Tuple>
  constexpr auto tuple_transform(F&& f, Tuple&& tuple) { // \expos
    return apply([&]<class... Ts>(Ts&&... elements) {
      return tuple<invoke_result_t<F&, Ts>...>(invoke(f, std::forward<Ts>(elements))...);
    }, std::forward<Tuple>(tuple));
  }
}

```
`error: 'tuple' does not name a template but is followed by template arguments; did you mean '::std::tuple'?`