### PR TITLE
[obj.lifetime] Fix preconditions for `start_lifetime_as_array`

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -895,7 +895,7 @@ template<class T>
 
 \begin{itemdescr}
 \pnum
-\mandates
+\expects
 \tcode{n > 0} is \tcode{true}.
 
 \pnum


### PR DESCRIPTION
"_Mandates_:" is misused, as "`n > 0` is `true`" can't be checked at compilation-time. And the condition is in "_Preconditions_:" according to [P2590R2](https://wg21.link/p2590r2).