### PR TITLE
[flat.*.{syn,erasure}] Change return type of erase_if to member size_type

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -13244,7 +13244,8 @@ namespace std {
   // \ref{flat.map.erasure}, erasure for \tcode{flat_map}
   template<class Key, class T, class Compare, class KeyContainer, class MappedContainer,
            class Predicate>
-    size_t erase_if(flat_map<Key, T, Compare, KeyContainer, MappedContainer>& c, Predicate pred);
+    typename flat_map<Key, T, Compare, KeyContainer, MappedContainer>::size_type
+      erase_if(flat_map<Key, T, Compare, KeyContainer, MappedContainer>& c, Predicate pred);
 
   // \ref{flat.multimap}, class template \tcode{flat_multimap}
   template<class Key, class T, class Compare = less<Key>,
@@ -13262,8 +13263,8 @@ namespace std {
   // \ref{flat.multimap.erasure}, erasure for \tcode{flat_multimap}
   template<class Key, class T, class Compare, class KeyContainer, class MappedContainer,
            class Predicate>
-    size_t erase_if(flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>& c,
-                    Predicate pred);
+    typename flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>::size_type
+      erase_if(flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>& c, Predicate pred);
 }
 \end{codeblock}
 
@@ -13286,7 +13287,8 @@ namespace std {
 
   // \ref{flat.set.erasure}, erasure for \tcode{flat_set}
   template<class Key, class Compare, class KeyContainer, class Predicate>
-    size_t erase_if(flat_set<Key, Compare, KeyContainer>& c, Predicate pred);
+    typename flat_set<Key, Compare, KeyContainer>::size_type
+      erase_if(flat_set<Key, Compare, KeyContainer>& c, Predicate pred);
 
   // \ref{flat.multiset}, class template \tcode{flat_multiset}
   template<class Key, class Compare = less<Key>, class KeyContainer = vector<Key>>
@@ -13298,9 +13300,10 @@ namespace std {
   template<class Key, class Compare, class KeyContainer, class Allocator>
     struct uses_allocator<flat_multiset<Key, Compare, KeyContainer>, Allocator>;
 
-  // \ref{flat.set.erasure}, erasure for \tcode{flat_multiset}
+  // \ref{flat.multiset.erasure}, erasure for \tcode{flat_multiset}
   template<class Key, class Compare, class KeyContainer, class Predicate>
-    size_t erase_if(flat_multiset<Key, Compare, KeyContainer>& c, Predicate pred);
+    typename flat_multiset<Key, Compare, KeyContainer>::size_type
+      erase_if(flat_multiset<Key, Compare, KeyContainer>& c, Predicate pred);
 }
 \end{codeblock}
 
@@ -16816,7 +16819,8 @@ Equivalent to: \tcode{c = std::move(cont);}
 \indexlibrarymember{erase_if}{flat_set}%
 \begin{itemdecl}
 template<class Key, class Compare, class KeyContainer, class Predicate>
-  size_t erase_if(flat_set<Key, Compare, KeyContainer>& c, Predicate pred);
+  typename flat_set<Key, Compare, KeyContainer>::size_type
+    erase_if(flat_set<Key, Compare, KeyContainer>& c, Predicate pred);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -17380,7 +17384,8 @@ Equivalent to: \tcode{c = std::move(cont);}
 \indexlibrarymember{erase_if}{flat_multiset}%
 \begin{itemdecl}
 template<class Key, class Compare, class KeyContainer, class Predicate>
-  size_t erase_if(flat_multiset<Key, Compare, KeyContainer>& c, Predicate pred);
+  typename flat_multiset<Key, Compare, KeyContainer>::size_type
+    erase_if(flat_multiset<Key, Compare, KeyContainer>& c, Predicate pred);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
All other containers and container adapters use the member size_type,
and the flat maps already did so in the item specification, but not in
the synopsis.

The current wording follows the approved proposals, but this change
seems like an improvement.

Suggested by CD review.