### PR TITLE
[range.cartesian.view] Further fixing of cartesian-product-is-common

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -14288,8 +14288,7 @@ namespace std::ranges {
 
   template<class First, class... Vs>
   concept @\defexposconcept{cartesian-product-is-common}@ =                 // \expos
-    (@\exposconcept{cartesian-product-common-arg}@<First> && ... &&
-     @\exposconcept{cartesian-product-common-arg}@<Vs>);
+    @\exposconcept{cartesian-product-common-arg}@<First>;
 
   template<class... Vs>
   concept @\defexposconcept{cartesian-product-is-sized}@ =                  // \expos


### PR DESCRIPTION
The first fix in 8275c19b3fa9e7cb09f84049ebd6207aceb7ca80 was incorrect. Only Const and the extraneous angle bracket needed to be dropped (which was an errorin the paper), but ignoring Vs... is intentional.

Fixes #5768.