### PR TITLE
[range.zip, ranges.cartesian.iterator] Simplify `maybe-const<Const, Views>` into `const Views`

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -9600,8 +9600,7 @@ Initializes \exposid{current_} with \tcode{std::move(current)}.
 
 \begin{itemdecl}
 constexpr @\exposid{iterator}@(@\exposid{iterator}@<!Const> i)
-  requires Const &&
-           (@\libconcept{convertible_to}@<iterator_t<Views>, iterator_t<const Views>> && ...);
+  requires Const && (@\libconcept{convertible_to}@<iterator_t<Views>, iterator_t<const Views>> && ...);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9886,8 +9885,7 @@ namespace std::ranges {
   public:
     @\exposid{sentinel}@() = default;
     constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> i)
-      requires Const &&
-               (@\libconcept{convertible_to}@<sentinel_t<Views>, sentinel_t<const Views>> && ...);
+      requires Const && (@\libconcept{convertible_to}@<sentinel_t<Views>, sentinel_t<const Views>> && ...);
 
     template<bool OtherConst>
       requires (@\libconcept{sentinel_for}@<sentinel_t<@\exposid{maybe-const}@<Const, Views>>,
@@ -9921,8 +9919,7 @@ Initializes \exposid{end_} with \tcode{end}.
 
 \begin{itemdecl}
 constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> i)
-  requires Const &&
-           (@\libconcept{convertible_to}@<sentinel_t<Views>, sentinel_t<const Views>> && ...);
+  requires Const && (@\libconcept{convertible_to}@<sentinel_t<Views>, sentinel_t<const Views>> && ...);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -9519,8 +9519,7 @@ namespace std::ranges {
 
     @\exposid{iterator}@() = default;
     constexpr @\exposid{iterator}@(@\exposid{iterator}@<!Const> i)
-      requires Const && (@\libconcept{convertible_to}@<iterator_t<Views>,
-                                        iterator_t<const Views>> && ...);
+      requires Const && (@\libconcept{convertible_to}@<iterator_t<Views>, iterator_t<const Views>> && ...);
 
     constexpr auto operator*() const;
     constexpr @\exposid{iterator}@& operator++();

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -9520,7 +9520,7 @@ namespace std::ranges {
     @\exposid{iterator}@() = default;
     constexpr @\exposid{iterator}@(@\exposid{iterator}@<!Const> i)
       requires Const && (@\libconcept{convertible_to}@<iterator_t<Views>,
-                                        iterator_t<@\exposid{maybe-const}@<Const, Views>>> && ...);
+                                        iterator_t<const Views>> && ...);
 
     constexpr auto operator*() const;
     constexpr @\exposid{iterator}@& operator++();
@@ -9602,7 +9602,7 @@ Initializes \exposid{current_} with \tcode{std::move(current)}.
 \begin{itemdecl}
 constexpr @\exposid{iterator}@(@\exposid{iterator}@<!Const> i)
   requires Const &&
-           (@\libconcept{convertible_to}@<iterator_t<Views>, iterator_t<@\exposid{maybe-const}@<Const, Views>>> && ...);
+           (@\libconcept{convertible_to}@<iterator_t<Views>, iterator_t<const Views>> && ...);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9888,7 +9888,7 @@ namespace std::ranges {
     @\exposid{sentinel}@() = default;
     constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> i)
       requires Const &&
-               (@\libconcept{convertible_to}@<sentinel_t<Views>, sentinel_t<@\exposid{maybe-const}@<Const, Views>>> && ...);
+               (@\libconcept{convertible_to}@<sentinel_t<Views>, sentinel_t<const Views>> && ...);
 
     template<bool OtherConst>
       requires (@\libconcept{sentinel_for}@<sentinel_t<@\exposid{maybe-const}@<Const, Views>>,
@@ -9923,7 +9923,7 @@ Initializes \exposid{end_} with \tcode{end}.
 \begin{itemdecl}
 constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> i)
   requires Const &&
-           (@\libconcept{convertible_to}@<sentinel_t<Views>, sentinel_t<@\exposid{maybe-const}@<Const, Views>>> && ...);
+           (@\libconcept{convertible_to}@<sentinel_t<Views>, sentinel_t<const Views>> && ...);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -14479,8 +14479,8 @@ namespace std::ranges {
     @\exposid{iterator}@() requires @\libconcept{forward_range}@<@\exposid{maybe-const}@<Const, First>> = default;
 
     constexpr @\exposid{iterator}@(@\exposid{iterator}@<!Const> i) requires Const &&
-      (@\libconcept{convertible_to}@<iterator_t<First>, iterator_t<@\exposid{maybe-const}@<Const, First>>> &&
-        ... && @\libconcept{convertible_to}@<iterator_t<Vs>, iterator_t<@\exposid{maybe-const}@<Const, Vs>>>);
+      (@\libconcept{convertible_to}@<iterator_t<First>, iterator_t<const First>> &&
+        ... && @\libconcept{convertible_to}@<iterator_t<Vs>, iterator_t<const Vs>>);
 
     constexpr auto operator*() const;
     constexpr @\exposid{iterator}@& operator++();
@@ -14668,8 +14668,8 @@ Initializes \exposid{current_} with \tcode{std::move(current)}.
 
 \begin{itemdecl}
 constexpr @\exposid{iterator}@(@\exposid{iterator}@<!Const> i) requires Const &&
-  (@\libconcept{convertible_to}@<iterator_t<First>, iterator_t<@\exposid{maybe-const}@<Const, First>>> &&
-    ... && @\libconcept{convertible_to}@<iterator_t<Vs>, iterator_t<@\exposid{maybe-const}@<Const, Vs>>>);
+  (@\libconcept{convertible_to}@<iterator_t<First>, iterator_t<const First>> &&
+    ... && @\libconcept{convertible_to}@<iterator_t<Vs>, iterator_t<const Vs>>);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Elsewhere it is simple enough since there is no fold expression and `Base` is defined, and I think this improves readability.