### PR TITLE
[range.zip.overview] Use tuple in example, not pair

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -9379,7 +9379,7 @@ vector v = {1, 2};
 list l = {'a', 'b', 'c'};
 
 auto z = views::zip(v, l);
-range_reference_t<decltype(z)> f = z.front();   // \tcode{f} is a \tcode{pair<int\&, char\&>}
+range_reference_t<decltype(z)> f = z.front();   // \tcode{f} is a \tcode{tuple<int\&, char\&>}
                                                 // that refers to the first element of \tcode{v} and \tcode{l}
 
 for (auto&& [x, y] : z) {


### PR DESCRIPTION
This is #5779's cousin.