### PR TITLE
[stmt.return], [stmt.return.coroutine] update notes re implicit move

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -900,10 +900,10 @@ A constructor or destructor does not have a return type.
 \end{note}
 \begin{note}
 A \tcode{return} statement can involve
-an invocation of a constructor to perform a copy or move of the operand
+a copy or move of the operand
 if it is not a prvalue or if its type differs from the return type of the function.
-A copy operation associated with a \tcode{return} statement can be elided or
-converted to a move operation if an automatic storage duration variable is returned\iref{class.copy.elision}.
+A copy operation associated with a \tcode{return} statement can be elided\iref{class.copy.elision}
+or converted to a move operation if an implicitly movable entity\iref{expr.prim.id.unqual} is returned.
 \end{note}
 
 \pnum
@@ -993,6 +993,10 @@ and \placeholder{S} is defined as follows:
 \item
 If the operand is a \grammarterm{braced-init-list} or an expression of non-\keyword{void} type,
 \placeholder{S} is \placeholder{p}\tcode{.return_value(}\grammarterm{expr-or-braced-init-list}{}\tcode{)}.
+\begin{note}
+The overload resolution of \placeholder{S} is affected
+by whether the operand is an implicitly movable entity\iref{expr.prim.id.unqual}.
+\end{note}
 The expression \placeholder{S} shall be a prvalue of type \keyword{void}.
 
 \item


### PR DESCRIPTION
These notes probably should have been changed when P1825 was adopted.