### PR TITLE
[tuple.syn, tuple.like] Standardized template format

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1484,9 +1484,9 @@ namespace std {
     class tuple;
 
   // \ref{tuple.like}, concept \exposconcept{tuple-like}
-  template <typename T>
+  template<class T>
     concept @\exposconcept{tuple-like}@ = @\seebelownc@;         // \expos
-  template <typename T>
+  template<class T>
     concept @\defexposconcept{pair-like}@ =                     // \expos
       @\exposconcept{tuple-like}@<T> && tuple_size_v<remove_cvref_t<T>> == 2;
 
@@ -1582,7 +1582,7 @@ namespace std {
 \rSec2[tuple.like]{Concept \ecname{tuple-like}}
 
 \begin{itemdecl}
-template <typename T>
+template<class T>
   concept @\defexposconcept{tuple-like}@ = @\seebelownc@;           // \expos
 \end{itemdecl}
 


### PR DESCRIPTION
1. Change `typename` to `class` to be consistent with the standard library.
2. Remove the space between `template` and `<`.