### PR TITLE
[range.drop.overview, range.take.overview] Fixed unformatted `(void)F, decay-copy(E)`

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -5651,7 +5651,7 @@ is expression-equivalent to:
 \item
 If \tcode{T} is a specialization
 of \tcode{ranges::empty_view}\iref{range.empty.view},
-then \tcode{((void) F, \placeholdernc{decay-copy}(E))},
+then \tcode{((void)F, \placeholdernc{decay-copy}(E))},
 except that the evaluations of \tcode{E} and \tcode{F}
 are indeterminately sequenced.
 
@@ -6101,7 +6101,7 @@ is expression-equivalent to:
 \item
 If \tcode{T} is a specialization of
 \tcode{ranges::empty_view}\iref{range.empty.view},
-then \tcode{((void) F, \placeholdernc{decay-copy}(E))},
+then \tcode{((void)F, \placeholdernc{decay-copy}(E))},
 except that the evaluations of \tcode{E} and \tcode{F}
 are indeterminately sequenced.
 
@@ -6144,7 +6144,7 @@ views::repeat(*E.@\exposid{value_}@, ranges::distance(E) - std::min<D>(ranges::d
 \end{codeblock}
 except that \tcode{E} is evaluated only once;
 \item
-otherwise, ((void) F, \placeholdernc{decay-copy}(E)),
+otherwise, \tcode{((void)F, \placeholdernc{decay-copy}(E))},
 except that the evaluations of \tcode{E} and \tcode{F} are indeterminately sequenced.
 \end{itemize}
 


### PR DESCRIPTION
1. Remove the space between `(void)` and `F`, which is consistent with the zip family overview.
2. Formatted unformatted `((void)F, decay-copy(E))` in [[range.drop.overview-2.4.2]](https://eel.is/c++draft/ranges#range.drop.overview-2.4.2).
3. Extended question: Is it correct to use `auto(E)` in these contexts?