### PR TITLE
[check] Flag any space between 'template' and '<'

### DIFF
--- a/tools/check-source.sh
+++ b/tools/check-source.sh
@@ -108,9 +108,9 @@ grep -Hne '^\\\(change\|rationale\|effect\|difficulty\|howwide\)\s.\+$' compatib
     fail "change marker in [diff] followed by stuff" || failed=1
 # Fixup: sed 's/^\\\(change\|rationale\|effect\|difficulty\|howwide\)\s\(.\)/\\\1\n\2/'q
 
-# "template <class" (with space) in library clause.
-grep -ne 'template\s<class' $texlib |
-    fail 'space between "template" and "<class"' || failed=1
+# "template <" (with space) in library clause.
+grep -ne 'template\s\+<' $texlib |
+    fail 'space between "template" and "<"' || failed=1
 
 # "Class" heading without namespace
 for f in $texlib; do


### PR DESCRIPTION
Previously, the pattern required 'class' after '<' to fire.

This prevents the need for future piecemeal fixes such as 356fb7ff88b63d956b1109c72c5e3bf424f6ba29 or eca39f43798d7a58fdd482232c60b6db428b656f.

Tested with the state before 356fb7ff88b63d956b1109c72c5e3bf424f6ba29, which was successfully flagged.