### PR TITLE
[format.range.fmtstr] Add ranges namespace qualifier for range concepts

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16244,7 +16244,7 @@ template<class FormatContext>
 \begin{itemdescr}
 \pnum
 The type of \tcode{r} is \tcode{const R\&}
-if \tcode{\libconcept{input_range}<const R>} is \tcode{true} and
+if \tcode{ranges::\libconcept{input_range}<const R>} is \tcode{true} and
 \tcode{R\&} otherwise.
 
 \pnum


### PR DESCRIPTION
since we are not under the `ranges `namespace.