### PR TITLE
[flat.set.syn] `<flat_set>` should include `<compare>` LWG3774

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -13284,6 +13284,7 @@ namespace std {
 \indexheader{flat_set}%
 
 \begin{codeblock}
+#include <compare>              // see \ref{compare.syn}
 #include <initializer_list>     // see \ref{initializer.list.syn}
 
 namespace std {


### PR DESCRIPTION
`std::flat_set` and `std::flat_multiset` have their `operator<=>`'s, so `<compare>` should be included in the corresponding header.

I'm not sure whether this can be treated as editorial, as the inclusion of `<compare>` is missing in [P1222R4](https://wg21.link/p1222r4).