### PR TITLE
[ranges] Improve examples

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -15010,7 +15010,7 @@ generator<int> ints(int start = 0) {
 
 void f() {
   for (auto i : ints() | views::take(3))
-    cout << i << ' ';      // prints \tcode{0 1 2}
+    cout << i << ' ';       // prints \tcode{0 1 2}
 }
 \end{codeblock}
 \end{example}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2201,11 +2201,11 @@ rather than a single value.
 \begin{example}
 \begin{codeblock}
 template<bool YieldElements>
-std::generator<any> f(std::ranges::@\libconcept{input_range}@ auto&& r) {
+generator<any> f(ranges::@\libconcept{input_range}@ auto&& r) {
   if constexpr (YieldElements)
-    co_yield std::ranges::elements_of(r);       // yield each element of \tcode{r}
+    co_yield ranges::elements_of(r);       // yield each element of \tcode{r}
   else
-    co_yield r;                                 // yield \tcode{r} as a single value
+    co_yield r;                            // yield \tcode{r} as a single value
 }
 \end{codeblock}
 \end{example}
@@ -3825,7 +3825,7 @@ otherwise, \tcode{views::istream<T>(E)} is ill-formed.
 \begin{example}
 \begin{codeblock}
 auto ints = istringstream{"0 1  2   3     4"};
-ranges::copy(ranges::istream_view<int>(ints), ostream_iterator<int>{cout, "-"});
+ranges::copy(views::istream<int>(ints), ostream_iterator<int>{cout, "-"});
 // prints \tcode{0-1-2-3-4-}
 \end{codeblock}
 \end{example}
@@ -5919,7 +5919,7 @@ is expression-equivalent to \tcode{take_while_view(E, F)}.
 \begin{codeblock}
 auto input = istringstream{"0 1 2 3 4 5 6 7 8 9"};
 auto small = [](const auto x) noexcept { return x < 5; };
-auto small_ints = istream_view<int>(input) | views::take_while(small);
+auto small_ints = views::istream<int>(input) | views::take_while(small);
 for (const auto i : small_ints) {
   cout << i << ' ';                             // prints \tcode{0 1 2 3 4}
 }
@@ -14251,9 +14251,9 @@ otherwise,
 \pnum
 \begin{example}
 \begin{codeblock}
-std::vector<int> v { 0, 1, 2 };
+vector<int> v { 0, 1, 2 };
 for (auto&& [a, b, c] : views::cartesian_product(v, v, v)) {
-  std::cout << a << ' ' << b << ' ' << c << '\n';
+  cout << a << ' ' << b << ' ' << c << '\n';
 }
 // The above prints
 // \tcode{0 0 0}
@@ -15003,14 +15003,14 @@ each element of the range \tcode{r}
 is successively produced as an element of the sequence.
 \begin{example}
 \begin{codeblock}
-std::generator<int> ints(int start = 0) {
+generator<int> ints(int start = 0) {
   while (true)
     co_yield start++;
 }
 
 void f() {
-  for (auto i : ints() | std::views::take(3))
-    std::cout << i << ' ';      // prints \tcode{0 1 2}
+  for (auto i : ints() | views::take(3))
+    cout << i << ' ';      // prints \tcode{0 1 2}
 }
 \end{codeblock}
 \end{example}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2205,7 +2205,7 @@ generator<any> f(ranges::@\libconcept{input_range}@ auto&& r) {
   if constexpr (YieldElements)
     co_yield ranges::elements_of(r);        // yield each element of \tcode{r}
   else
-    co_yield r;                            // yield \tcode{r} as a single value
+    co_yield r;                             // yield \tcode{r} as a single value
 }
 \end{codeblock}
 \end{example}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2203,7 +2203,7 @@ rather than a single value.
 template<bool YieldElements>
 generator<any> f(ranges::@\libconcept{input_range}@ auto&& r) {
   if constexpr (YieldElements)
-    co_yield ranges::elements_of(r);       // yield each element of \tcode{r}
+    co_yield ranges::elements_of(r);        // yield each element of \tcode{r}
   else
     co_yield r;                            // yield \tcode{r} as a single value
 }


### PR DESCRIPTION
1. Use `views::istream` instead of `ranges::istream_view` (consistent with #4659).
2. Remove unnecessary `std::` qualification.