### PR TITLE
Improve automatic LaTeX checking of concept names

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -19633,9 +19633,9 @@ defined as follows:
 template<class M>
 concept @\defexposconcept{layout-mapping-alike}@ = requires {                         // \expos
   requires @\exposid{is-extents}@<typename M::extents_type>;
-  { M::is_always_strided() } -> same_as<bool>;
-  { M::is_always_exhaustive() } -> same_as<bool>;
-  { M::is_always_unique() } -> same_as<bool>;
+  { M::is_always_strided() } -> @\libconcept{same_as}@<bool>;
+  { M::is_always_exhaustive() } -> @\libconcept{same_as}@<bool>;
+  { M::is_always_unique() } -> @\libconcept{same_as}@<bool>;
   bool_constant<M::is_always_strided()>::value;
   bool_constant<M::is_always_exhaustive()>::value;
   bool_constant<M::is_always_unique()>::value;

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -4477,7 +4477,7 @@ namespace std::ranges {
     as_rvalue_view() requires @\libconcept{default_initializable}@<V> = default;
     constexpr explicit as_rvalue_view(V base);
 
-    constexpr V base() const & requires copy_constructible<V> { return @\exposid{base_}@; }
+    constexpr V base() const & requires @\libconcept{copy_constructible}@<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
     constexpr auto begin() requires (!@\exposconcept{simple-view}@<V>)

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2097,7 +2097,7 @@ constexpr subrange& advance(iter_difference_t<I> n);
 \effects
 Equivalent to:
 \begin{codeblock}
-if constexpr (bidirectional_iterator<I>) {
+if constexpr (@\libconcept{bidirectional_iterator}@<I>) {
   if (n < 0) {
     ranges::advance(@\exposid{begin_}@, n);
     if constexpr (@\exposid{StoreSize}@)

--- a/tools/check-output.sh
+++ b/tools/check-output.sh
@@ -50,10 +50,27 @@ cat std-grammarindex.ind |
 
 # Find concept index entries missing a definition
 cat std-conceptindex.ind |
-    sed 's/.hyperindexformat/\nhyperindexformat/' |
+    sed 's/.hyperindexformat/\nhyperindexformat/;s/.hyperpage/hyperpage/' |
     awk 'BEGIN { def=1 } /^  .item/ { if (def==0) { gsub("[{},]", "", item); print item } item=$NF; def=0; next } /hyperindexformat/ { def=1 }' |
     sed 's/^\(.*\)$/concept \1 has no definition/' |
     fail || failed=1
+
+# Find undecorated concept names in code blocks
+patt="`cat std-conceptindex.ind |
+       sed 's/.hyperindexformat/\nhyperindexformat/;s/.hyperpage/\nhyperpage/' |
+       sed -n 's/^  .item.*{\([-a-z_]*\)}.*$/\1/p'`"
+
+patt="`echo $patt | sed 's/ /\\\\|/g'`"
+# $patt contains all concept names, separated by \| to use as a sed regex
+
+for f in *.tex; do
+    sed -n 's,//.*$,,;s/%.*$//;s/"[^"]*"/""/;/begin{codeblock\(tu\)\?}/,/end{codeblock\(tu\)\?}/{/[^-_{a-z\]\('"$patt"'\)[^-_}a-z();]/{=;p;};}' $f |
+	# prefix output with filename and line
+	sed '/^[0-9]\+$/{N;s/\n/:/;}' | sed "s/.*/$f:&/" |
+	grep -v "@.seebelow" |
+	sed "s/\$/ -- concept name without markup/" |
+	    fail || failed=1
+done
 
 # Cross references since the previous standard.
 function indexentries() { sed 's,\\glossaryentry{\(.*\)@.*,\1,' "$1" | LANG=C sort; }

--- a/tools/check-output.sh
+++ b/tools/check-output.sh
@@ -48,6 +48,13 @@ cat std-grammarindex.ind |
     sed 's/^\(.*\)$/grammar non-terminal \1 has no definition/' |
     fail || failed=1
 
+# Find concept index entries missing a definition
+cat std-conceptindex.ind |
+    sed 's/.hyperindexformat/\nhyperindexformat/' |
+    awk 'BEGIN { def=1 } /^  .item/ { if (def==0) { gsub("[{},]", "", item); print item } item=$NF; def=0; next } /hyperindexformat/ { def=1 }' |
+    sed 's/^\(.*\)$/concept \1 has no definition/' |
+    fail || failed=1
+
 # Cross references since the previous standard.
 function indexentries() { sed 's,\\glossaryentry{\(.*\)@.*,\1,' "$1" | LANG=C sort; }
 function removals() { diff -u "$1" "$2" | grep '^-' | grep -v '^---' | sed 's/^-//'; }


### PR DESCRIPTION
complain about undefined concepts
and about concepts in codeblocks not decorated with \libconcept
(we had quite a few late-ish fixes for the latter in the CD cycle)