### PR TITLE
[const.iterators.alias] Rename template parameter `It` to `I`

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -363,7 +363,7 @@ namespace std {
   };
 
   template<@\libconcept{input_iterator}@ I>
-    constexpr const_iterator<I> make_const_iterator(I it) { return it; }            // freestanding
+    constexpr const_iterator<I> make_const_iterator(I i) { return i; }            // freestanding
 
   template<class S>
     constexpr const_sentinel<S> make_const_sentinel(S s) { return s; }              // freestanding

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -4174,13 +4174,13 @@ Specializations of \tcode{basic_const_iterator} are constant iterators.
 \rSec3[const.iterators.alias]{Alias templates}
 
 \begin{itemdecl}
-template<@\libconcept{indirectly_readable}@ It>
+template<@\libconcept{indirectly_readable}@ I>
   using iter_const_reference_t =
-    common_reference_t<const iter_value_t<It>&&, iter_reference_t<It>>;
+    common_reference_t<const iter_value_t<I>&&, iter_reference_t<I>>;
 
-template<class It>
+template<class I>
   concept @\defexposconcept{constant-iterator}@ =                                                   // \expos
-    @\libconcept{input_iterator}@<It> && @\libconcept{same_as}@<iter_const_reference_t<It>, iter_reference_t<It>>;
+    @\libconcept{input_iterator}@<I> && @\libconcept{same_as}@<iter_const_reference_t<I>, iter_reference_t<I>>;
 
 template<@\libconcept{input_iterator}@ I>
   using @\libglobal{const_iterator}@ = @\seebelow@;

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -363,7 +363,7 @@ namespace std {
   };
 
   template<@\libconcept{input_iterator}@ I>
-    constexpr const_iterator<I> make_const_iterator(I i) { return i; }            // freestanding
+    constexpr const_iterator<I> make_const_iterator(I i) { return i; }              // freestanding
 
   template<class S>
     constexpr const_sentinel<S> make_const_sentinel(S s) { return s; }              // freestanding


### PR DESCRIPTION
This makes them consistent with the template names in the [[iterator.synopsis]](https://eel.is/c++draft/iterator.synopsis) and consistent with the `<iterator>` naming style (which basically uses `Iterator` or `I` as the template name).