### PR TITLE
[expr] Replace `\^` with `\caret`

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6720,7 +6720,7 @@ The result is the bitwise \logop{and} function of the operands.
 \end{bnf}
 
 \pnum
-The \tcode{\^} operator groups left-to-right.
+The \tcode{\caret} operator groups left-to-right.
 The operands shall be of integral or unscoped enumeration type.
 The usual arithmetic conversions\iref{expr.arith.conv} are performed.
 Given the coefficients $\tcode{x}_i$ and $\tcode{y}_i$
@@ -7168,7 +7168,7 @@ that \tcode{E1} is evaluated only once.
 Such expressions are deprecated
 if \tcode{E1} has volatile-qualified type
 and \placeholder{op} is not one of the bitwise operators
-\tcode{|}, \tcode{\&}, \tcode{\^}; see~\ref{depr.volatile.type}.
+\tcode{|}, \tcode{\&}, \tcode{\caret}; see~\ref{depr.volatile.type}.
 For \tcode{+=} and \tcode{-=},
 \tcode{E1} shall either have arithmetic type or be a pointer to a
 possibly cv-qualified completely-defined object type. In all other


### PR DESCRIPTION
`\^` produces the circumflex accent `ˆ` instead of the ASCII character `^`.

The `\caret` command was added after #205 points out that `\^` produces a bad caret. PR #1902 fixed two uses of `\^` that were added after #205 got fixed. But another two uses of `\^` snuck in after that.

Given that `\^` keeps reoccuring, there's currently no use of the diacritic `ˆ` in this document, and there's precedent of redefining `\~` to mean something other than the diacritic, would it make sense to redefine `\^` to mean the ASCII letter, or else add a check to prohibit `\^`?