### PR TITLE
[basic.life]/8.3 don't put const in the middle of "complete object" words of power

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3515,7 +3515,7 @@ the storage that $o_1$ occupied, and
 \item $o_1$ and $o_2$ are of the same type
 (ignoring the top-level cv-qualifiers), and
 
-\item $o_1$ is not a complete const object, and
+\item $o_1$ is not a const complete object, and
 
 \item neither $o_1$ nor $o_2$
 is a potentially-overlapping subobject\iref{intro.object}, and

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3515,7 +3515,7 @@ the storage that $o_1$ occupied, and
 \item $o_1$ and $o_2$ are of the same type
 (ignoring the top-level cv-qualifiers), and
 
-\item $o_1$ is not a const complete object, and
+\item $o_1$ is not a const, complete object, and
 
 \item neither $o_1$ nor $o_2$
 is a potentially-overlapping subobject\iref{intro.object}, and
@@ -3586,7 +3586,7 @@ void h() {
 \end{example}
 
 \pnum
-Creating a new object within the storage that a const complete
+Creating a new object within the storage that a const, complete
 object with static, thread, or automatic storage duration occupies,
 or within the storage that such a const object used to occupy before
 its lifetime ended, results in undefined behavior.


### PR DESCRIPTION
"Complete object" is a defined term (https://eel.is/c++draft/basic#def:complete_object). Putting const in the middle of that makes it unclear if we are referring to a const-qualified "complete object" or a complete const object with some other meaning of "complete" such as "with a complete type". Using the order "const complete object" avoids that ambiguity. It also matches the word order used in https://eel.is/c++draft/basic.life#10 to make it UB to create a new object on top of a "const complete object", unless it has dynamic storage duration.