### PR TITLE
Update references to Unicode Standard & Annexes.

### DIFF
--- a/source/back.tex
+++ b/source/back.tex
@@ -30,7 +30,7 @@
   The Unicode Consortium. Unicode Standard Annex, UAX \#31,
   \doccite{Unicode Identifier and Pattern Syntax} [online].
   Edited by Mark Davis and Robin Leroy. Revision 37; issued for Unicode 15.0.0.
-  2022-08-31 [viewed 	2022-09-14].
+  2022-08-31 [viewed 2022-09-14].
   Available from: \url{https://www.unicode.org/reports/tr31/tr31-37.html}
 \item
   The Unicode Standard Version 15.0,

--- a/source/back.tex
+++ b/source/back.tex
@@ -23,19 +23,20 @@
   %%% http://www.iec.ch/standardsdev/resources/draftingpublications/directives/principles/referencing.htm
   The Unicode Consortium. Unicode Standard Annex, UAX \#29,
   \doccite{Unicode Text Segmentation} [online].
-  Edited by Mark Davis. Revision 35; issued for Unicode 12.0.0. 2019-02-15 [viewed 2020-02-23].
-  Available from: \url{http://www.unicode.org/reports/tr29/tr29-35.html}
+  Edited by Christopher Chapman. Revision 41; issued for Unicode 15.0.0.
+  2022-08-26 [viewed 2022-09-14].
+  Available from: \url{https://www.unicode.org/reports/tr29/tr29-41.html}
 \item
   The Unicode Consortium. Unicode Standard Annex, UAX \#31,
   \doccite{Unicode Identifier and Pattern Syntax} [online].
-  Edited by Mark Davis. Revision 33; issued for Unicode 13.0.0.
-  2020-02-13 [viewed 2021-06-08].
-  Available from: \url{https://www.unicode.org/reports/tr31/tr31-33.html}
+  Edited by Mark Davis and Robin Leroy. Revision 37; issued for Unicode 15.0.0.
+  2022-08-31 [viewed 	2022-09-14].
+  Available from: \url{https://www.unicode.org/reports/tr31/tr31-37.html}
 \item
-  The Unicode Standard Version 14.0,
+  The Unicode Standard Version 15.0,
   \doccite{Core Specification}.
-  Unicode Consortium, ISBN 978-1-936213-29-0, copyright \copyright 2021 Unicode, Inc.
-  Available from: \url{https://www.unicode.org/versions/Unicode14.0.0/UnicodeStandard-14.0.pdf}
+  Unicode Consortium, ISBN 978-1-936213-32-0, copyright \copyright 2022 Unicode, Inc.
+  Available from: \url{https://www.unicode.org/versions/Unicode15.0.0/UnicodeStandard-15.0.pdf}
 \item
   IANA Time Zone Database.
   Available from: \url{https://www.iana.org/time-zones}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -6886,7 +6886,7 @@ For \tcode{vprint_unicode},
 if invoking the native Unicode API requires transcoding,
 implementations should substitute invalid code units
 with \unicode{fffd}{replacement character} per
-The Unicode Standard Version 14.0 - Core Specification, Chapter 3.9.
+The Unicode Standard Version 15.0 - Core Specification, Chapter 3.9.
 \end{itemdescr}
 
 \rSec3[ostream.unformatted]{Unformatted output functions}
@@ -7820,7 +7820,7 @@ May throw \tcode{bad_alloc}.
 If invoking the native Unicode API requires transcoding,
 implementations should substitute invalid code units
 with \unicode{fffd}{replacement character} per
-The Unicode Standard Version 14.0 - Core Specification, Chapter 3.9.
+The Unicode Standard Version 15.0 - Core Specification, Chapter 3.9.
 \end{itemdescr}
 
 \indexlibraryglobal{vprint_nonunicode}%


### PR DESCRIPTION
Currently we have a normative reference to ISO 10646 (Unicode 13.0), a floating normative reference to UAX44 (= Unicode 15.0), bibligraphy items for Unicode (14.0),
text segmentation UAX (12.0), and identifier syntax (13.0).

This align the bibligraphy items and mentions of Unicode to refer to 15.0.

Mention of Unicode 14 in the specification of print are also updated to refer to Unicode 15.

No further changes are necessary to comply to the updated standard and annexes.