### PR TITLE
[diff.cpp03.containers] Add overdue compatibility note on allocators

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1881,6 +1881,19 @@ Clarification of container requirements.
 Valid \CppIII{} code that attempts to explicitly instantiate a container using
 a user-defined type with no default constructor may fail to compile.
 
+\diffref{container.requirements.general}
+\change
+Containers now access their allocators through the \tcode{allocator_traits}
+template.
+\rationale
+Simplifies writing new allocators.
+\effect
+\tcode{allocator_traits} supplies default definitions for many allocator type
+names and operations. Valid \CppIII{} code that follows the original
+allocator-aware container requirements may not support allocators written to
+the simpler set of requirements in this standard, and may propagate allocators
+incorrectly.
+
 \diffref{sequence.reqmts,associative.reqmts}
 \change
 Signature changes: from \keyword{void} return types.


### PR DESCRIPTION
Revisiting my abandoned paper P0177, there was approval to add this historical compatibility with C++03 text back in 2016, but I never turned it into an editorial request after abandoning the paper.