### PR TITLE
[ranges.syn] Make get overloads freestanding

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -140,15 +140,15 @@ namespace std::ranges {
 
   template<size_t N, class I, class S, subrange_kind K>
     requires ((N == 0 && @\libconcept{copyable}@<I>) || N == 1)
-    constexpr auto get(const subrange<I, S, K>& r);
+    constexpr auto get(const subrange<I, S, K>& r);                                 // freestanding
 
   template<size_t N, class I, class S, subrange_kind K>
     requires (N < 2)
-    constexpr auto get(subrange<I, S, K>&& r);
+    constexpr auto get(subrange<I, S, K>&& r);                                      // freestanding
 }
 
 namespace std {
-  using ranges::get;
+  using ranges::get;                                                                // freestanding
 }
 
 namespace std::ranges {


### PR DESCRIPTION
These were moved to the synopsis after the P1642 changes to mark nearly everything in the synopsis freestanding, so they were not marked.

Fixes #5837 