### PR TITLE
[unord.general, container.adaptors.general] Complete the alias template that appears in the reduction guides

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -11105,10 +11105,10 @@ The header \libheader{unordered_map} defines the class templates
 
 \pnum
 The exposition-only alias templates
-\exposid{iter\--value\--type}, \exposid{iter\--key\--type},
-\exposid{iter\--mapped\--type}, \exposid{iter\--to\--alloc\--type},
-\exposid{range\--key\--type}, \exposid{iter\--mapped\--type},
-and \exposid{range\--to\--alloc\--type}
+\exposid{iter-value-type}, \exposid{iter-key-type},
+\exposid{iter-mapped-type}, \exposid{iter-to-alloc-type},
+\exposid{range-key-type}, \exposid{range-mapped-type},
+and \exposid{range-to-alloc-type}
 defined in \ref{associative.general} may appear in deduction guides for unordered containers.
 
 \rSec2[unord.map.syn]{Header \tcode{<unordered_map>} synopsis}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -11106,7 +11106,9 @@ The header \libheader{unordered_map} defines the class templates
 \pnum
 The exposition-only alias templates
 \exposid{iter\--value\--type}, \exposid{iter\--key\--type},
-\exposid{iter\--mapped\--type}, and \exposid{iter\--to\--alloc\--type}
+\exposid{iter\--mapped\--type}, \exposid{iter\--to\--alloc\--type},
+\exposid{range\--key\--type}, \exposid{iter\--mapped\--type},
+and \exposid{range\--to\--alloc\--type}
 defined in \ref{associative.general} may appear in deduction guides for unordered containers.
 
 \rSec2[unord.map.syn]{Header \tcode{<unordered_map>} synopsis}
@@ -13141,7 +13143,8 @@ A deduction guide for a container adaptor shall not participate in overload reso
 \pnum
 The exposition-only alias template \exposid{iter-value-type}
 defined in \ref{sequences.general} and
-the exposition-only alias templates \exposid{iter-key-type} and \exposid{iter-mapped-type}
+the exposition-only alias templates \exposid{iter-key-type}, \exposid{iter-mapped-type},
+\exposid{range-key-type} and \exposid{range-mapped-type}
 defined in \ref{associative.general}
 may appear in deduction guides for container adaptors.
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -11106,7 +11106,7 @@ The header \libheader{unordered_map} defines the class templates
 \pnum
 The exposition-only alias templates
 \exposid{iter-value-type}, \exposid{iter-key-type},
-\exposid{iter-mapped-type}, \exposid{iter-to-alloc-type},
+\exposid{iter-mapped-type}, \exposid{iter-to\--alloc-type},
 \exposid{range-key-type}, \exposid{range-mapped-type},
 and \exposid{range-to-alloc-type}
 defined in \ref{associative.general} may appear in deduction guides for unordered containers.

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -13144,7 +13144,7 @@ A deduction guide for a container adaptor shall not participate in overload reso
 The exposition-only alias template \exposid{iter-value-type}
 defined in \ref{sequences.general} and
 the exposition-only alias templates \exposid{iter-key-type}, \exposid{iter-mapped-type},
-\exposid{range-key-type} and \exposid{range-mapped-type}
+\exposid{range-key-type}, and \exposid{range-mapped-type}
 defined in \ref{associative.general}
 may appear in deduction guides for container adaptors.
 


### PR DESCRIPTION
This looks like neglect of the [P1206](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1206r7.pdf).  Is this an editorial?