### PR TITLE
[expr.prim.lambda.capture] Cross-reference [basic.def.odr] for 'odr-usable'

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2391,7 +2391,7 @@ the local entities named by its \grammarterm{simple-capture}{s}.
 \end{itemize}
 
 If an expression potentially references a local entity
-within a scope in which it is odr-usable,
+within a scope in which it is odr-usable\iref{basic.def.odr},
 and the expression would be potentially evaluated
 if the effect of any enclosing \keyword{typeid} expressions\iref{expr.typeid} were ignored,
 the entity is said to be \defnx{implicitly captured}{capture!implicit}


### PR DESCRIPTION
Fixes #5824