### PR TITLE
[format.string.std] Clarify location of 0x prefix for pointers

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -14640,7 +14640,7 @@ If \tcode{uintptr_t} is defined,
 \begin{codeblock}
 to_chars(first, last, reinterpret_cast<uintptr_t>(value), 16)
 \end{codeblock}
-with the prefix \tcode{0x} added to the output;
+with the prefix \tcode{0x} inserted immediately before the output of \tcode{to_chars};
 otherwise, implementation-defined.
 \\
 \end{floattable}


### PR DESCRIPTION
Fixes #5817