### PR TITLE
[support, etc.] New subclause "Arithmetic types".

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1441,7 +1441,7 @@ include at least the headers shown in \tref{headers.cpp.fs}.
 \ref{support.types}      & Types                     & \tcode{<cstddef>}          \\ \rowsep
 \ref{support.limits}     & Implementation properties &
   \tcode{<cfloat>}, \tcode{<climits>}, \tcode{<limits>}, \tcode{<version>} \\ \rowsep
-\ref{cstdint}            & Integer types             & \tcode{<cstdint>}          \\ \rowsep
+\ref{cstdint.syn}        & Integer types             & \tcode{<cstdint>}   \\ \rowsep
 \ref{support.start.term} & Start and termination     & \tcode{<cstdlib>}          \\ \rowsep
 \ref{support.dynamic}    & Dynamic memory management & \tcode{<new>}              \\ \rowsep
 \ref{support.rtti}       & Type identification       & \tcode{<typeinfo>}         \\ \rowsep

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -474,7 +474,7 @@ using arithmetic that has at least the ranges specified
 in~\ref{support.limits}. For the purposes of this token conversion and evaluation
 all signed and unsigned integer types
 act as if they have the same representation as, respectively,
-\tcode{intmax_t} or \tcode{uintmax_t}\iref{cstdint}.
+\tcode{intmax_t} or \tcode{uintmax_t}\iref{cstdint.syn}.
 \begin{note}
 Thus on an
 implementation where \tcode{std::numeric_limits<int>::max()} is \tcode{0x7FFF}

--- a/source/support.tex
+++ b/source/support.tex
@@ -1997,7 +1997,8 @@ respectively.
 
 \pnum
 The header \libheader{stdfloat} defines type aliases for
-the optional extended floating-point types\iref{basic.extended.fp}.
+the optional extended floating-point types that are specified in
+\ref{basic.extended.fp}.
 
 \indexheader{stdfloat}%
 \begin{codeblock}

--- a/source/support.tex
+++ b/source/support.tex
@@ -26,8 +26,7 @@ as summarized in \tref{support.summary}.
   \tcode{<cstddef>}, \tcode{<cstdlib>}   \\ \rowsep
 \ref{support.limits}      & Implementation properties &
   \tcode{<cfloat>}, \tcode{<climits>}, \tcode{<limits>}, \tcode{<version>}    \\ \rowsep
-\ref{cstdint}             & Integer types             &   \tcode{<cstdint>}   \\ \rowsep
-\ref{stdfloat.syn}        & Header \libheader{stdfloat} synopsis & \tcode{<stdfloat>} \\ \rowsep
+\ref{support.arith.types} & Arithmetic types          &   \tcode{<cstdint>}, \tcode{<stdfloat>}  \\ \rowsep
 \ref{support.start.term}  & Start and termination     &   \tcode{<cstdlib>}   \\ \rowsep
 \ref{support.dynamic}     & Dynamic memory management &   \tcode{<new>}       \\ \rowsep
 \ref{support.rtti}        & Type identification       &   \tcode{<typeinfo>}  \\ \rowsep
@@ -1844,17 +1843,14 @@ the C standard library header \libheader{float.h}.
 
 \xrefc{5.2.4.2.2}
 
-\rSec1[cstdint]{Integer types}
-
-\rSec2[cstdint.general]{General}
-
-\pnum
-The header
-\libheaderref{cstdint}
-supplies integer types having specified widths, and
-macros that specify limits of integer types.
+\rSec1[support.arith.types]{Arithmetic types}
 
 \rSec2[cstdint.syn]{Header \tcode{<cstdint>} synopsis}
+
+\pnum
+The header \libheader{cstdint}
+supplies integer types having specified widths, and
+macros that specify limits of integer types.
 
 \indexheader{cstdint}%
 \indexlibraryglobal{int8_t}%
@@ -1997,7 +1993,11 @@ correspond to the \grammarterm{typedef-name}s
 respectively.
 \end{note}
 
-\rSec1[stdfloat.syn]{Header \tcode{<stdfloat>} synopsis}
+\rSec2[stdfloat.syn]{Header \tcode{<stdfloat>} synopsis}
+
+\pnum
+The header \libheader{stdfloat} defines type aliases for
+the optional extended floating-point types\iref{basic.extended.fp}.
 
 \indexheader{stdfloat}%
 \begin{codeblock}

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -100,6 +100,8 @@
 
 % P1467R9 Extended floating-point types and standard names
 \movedxref{complex.special}{complex.members}
+\movedxref{cstdint}{support.arith.types}
+\removedxref{cstdint.general}
 
 % LWG3659 Consider ATOMIC_FLAG_INIT undeprecation
 \removedxref{depr.atomics.flag}


### PR DESCRIPTION
The new subclause contains both "integer types" (<cstdint>) and "extended floating-point types" (<stdfloat>).

Previously, the newly added <stdfloat> synopsis was somewhat disconnected and out of context.

Fixes #5714.