### PR TITLE
[c.math.hypot3] Fix the mis-specified `double` parameter of 3-argument `hypot`

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -9401,7 +9401,7 @@ The absolute value of \tcode{x}.
 
 \indexlibrary{\idxcode{hypot}!3-argument form}%
 \begin{itemdecl}
-@\placeholder{floating-point-type}@ hypot(@\placeholder{floating-point-type}@ x, @\placeholder{floating-point-type}@ y, double z);
+@\placeholder{floating-point-type}@ hypot(@\placeholder{floating-point-type}@ x, @\placeholder{floating-point-type}@ y, @\placeholder{floating-point-type}@ z);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
In [P1467R9](https://wg21.link/p1467r9) and the current synopsis of `<cmath>` ([cmath.syn]), the last parameter of 3-argument overloads of `std::hypot` is specified with _`floating-point-type`_, but it is specified with `double` in [c.math.hypot3].

This looks like an editorial mistake, and thus I think we should consistently use _`floating-point-type`_.