### PR TITLE
[headers] Order `<type_traits>` before `<typeindex>` in the header table

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1138,9 +1138,9 @@ shown in \tref{headers.cpp}.
 \tcode{<system_error>} \\
 \tcode{<thread>} \\
 \tcode{<tuple>} \\
+\tcode{<type_traits>} \\
 \tcode{<typeindex>} \\
 \tcode{<typeinfo>} \\
-\tcode{<type_traits>} \\
 \tcode{<unordered_map>} \\
 \tcode{<unordered_set>} \\
 \tcode{<utility>} \\


### PR DESCRIPTION
Fixes #5853.