### PR TITLE
[futures.errors] Add `\tcode` for `equivalent`

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -9917,7 +9917,7 @@ const error_category& future_category() noexcept;
 A reference to an object of a type derived from class \tcode{error_category}.
 
 \pnum
-The object's \tcode{default_error_condition} and equivalent virtual functions shall
+The object's \tcode{default_error_condition} and \tcode{equivalent} virtual functions shall
 behave as specified for the class \tcode{error_category}. The object's \tcode{name}
 virtual function returns a pointer to the string \tcode{"future"}.
 \end{itemdescr}


### PR DESCRIPTION
It refers to the member function that overrides `error_category::equivalent`.