### PR TITLE
[utility.arg.requirements] turn list of identifiers into a bullet list

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1590,16 +1590,25 @@ allocators.
 The template definitions in the \Cpp{} standard library
 refer to various named requirements whose details are set out in
 Tables~\ref{tab:cpp17.equalitycomparable}--\ref{tab:cpp17.destructible}.
-In these tables, \tcode{T} is an object or reference type to be
-supplied by a \Cpp{} program instantiating a template;
+In these tables,
+\begin{itemize}
+\item
+\tcode{T} denotes an object or reference type to be
+supplied by a \Cpp{} program instantiating a template,
+\item
 \tcode{a},
 \tcode{b}, and
-\tcode{c} are values of type (possibly \keyword{const}) \tcode{T};
-\tcode{s} and \tcode{t} are modifiable lvalues of type \tcode{T};
-\tcode{u} denotes an identifier;
-\tcode{rv} is an rvalue of type \tcode{T};
-and \tcode{v} is an lvalue of type (possibly \keyword{const}) \tcode{T} or an rvalue of
-type \tcode{const T}.
+\tcode{c} denote values of type (possibly \keyword{const}) \tcode{T},
+\item
+\tcode{s} and \tcode{t} denote modifiable lvalues of type \tcode{T},
+\item
+\tcode{u} denotes an identifier,
+\item
+\tcode{rv} denotes an rvalue of type \tcode{T}, and
+\item
+\tcode{v} denotes an lvalue of type (possibly \keyword{const}) \tcode{T} or an
+rvalue of type \tcode{const T}.
+\end{itemize}
 
 \pnum
 In general, a default constructor is not required. Certain container class


### PR DESCRIPTION
Lists providing the key for names used throughout a subclause are difficult to follow when buried as a single sentence in a paragraph.  This PR updates the key to tables 29-36 in [utility.arg.requirements] to a bullet list following the examples set elsewhere.

Each key is now consistently introduced with the word "denotes", following the precedent set by similar bullet lists.

It is not at all coincidental that this also resolves pagination issues at the end of the page, so that the floating tables to not float into the middle of a sentance in the following section.