### PR TITLE
[mdspan.extents.cons] Correct spelling of "dynamic-extents"

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -18583,11 +18583,11 @@ is representable as a value of type \tcode{index_type} for every rank index $r$.
 \item
 If \tcode{N} equals \tcode{dynamic_rank()},
 for all $d$ in the range $[0, \tcode{rank_dynamic()})$,
-direct-non-list-initializes \tcode{\exposidnc{dynamic-extent}[$d$]}
+direct-non-list-initializes \tcode{\exposidnc{dynamic-extents}[$d$]}
 with \tcode{as_const(exts[$d$])}.
 \item
 Otherwise, for all $d$ in the range $[0, \tcode{rank_dynamic()})$,
-direct-non-list-initializes \exposidnc{dynamic-ex\-tent}\tcode{[$d$]}
+direct-non-list-initializes \exposidnc{dynamic-ex\-tents}\tcode{[$d$]}
 with \tcode{as_const(exts[\exposidnc{dynamic-index-inv}($d$)])}.
 \end{itemize}
 \end{itemdescr}


### PR DESCRIPTION
There is a namespace-scope variable `dynamic_extent` defined in `<span>`, but this wording is clearly referring to the non-static data member _`dynamic-extents`_.