### PR TITLE
[meta, thread] Add/amend references to func.require, func.invoke

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -1480,7 +1480,7 @@ Base classes that are private, protected, or ambiguous
 \indexlibraryglobal{is_invocable_r}%
 \tcode{template<class R, class Fn, class... ArgTypes>}\br
  \tcode{struct is_invocable_r;}                      &
- The expression \tcode{\placeholdernc{INVOKE}<R>(declval<Fn>(), declval<ArgTypes>()...)}\iref{func.require}
+ The expression \tcode{\placeholdernc{INVOKE}<R>(declval<Fn>(), declval<ArgTypes>()...)}
  is well-formed when treated as an unevaluated operand                &
  \tcode{Fn}, \tcode{R}, and all types in the template parameter pack \tcode{ArgTypes}
  shall be complete types, \cv{}~\keyword{void}, or
@@ -1490,7 +1490,7 @@ Base classes that are private, protected, or ambiguous
 \tcode{template<class Fn, class... ArgTypes>}\br
  \tcode{struct is_nothrow_invocable;}              &
  \tcode{is_invocable_v<}\br\tcode{Fn, ArgTypes...>} is \tcode{true} and
- the expression \tcode{\placeholdernc{INVOKE}(declval<Fn>(), declval<ArgTypes>()...)}\iref{func.require}
+ the expression \tcode{\placeholdernc{INVOKE}(declval<Fn>(), declval<ArgTypes>()...)}
  is known not to throw any exceptions\iref{expr.unary.noexcept}       &
  \tcode{Fn} and all types in the template parameter pack \tcode{ArgTypes}
  shall be complete types, \cv{}~\keyword{void}, or
@@ -1500,7 +1500,7 @@ Base classes that are private, protected, or ambiguous
 \tcode{template<class R, class Fn, class... ArgTypes>}\br
  \tcode{struct is_nothrow_invocable_r;}              &
  \tcode{is_invocable_r_v<}\br\tcode{R, Fn, ArgTypes...>} is \tcode{true} and
- the expression \tcode{\placeholdernc{INVOKE}<R>(declval<Fn>(), declval<ArgTypes>()...)}\iref{func.require}
+ the expression \tcode{\placeholdernc{INVOKE}<R>(declval<Fn>(), declval<ArgTypes>()...)}
  is known not to throw any exceptions\iref{expr.unary.noexcept}       &
  \tcode{Fn}, \tcode{R}, and all types in the template parameter pack \tcode{ArgTypes}
  shall be complete types, \cv{}~\keyword{void}, or

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -1471,7 +1471,7 @@ Base classes that are private, protected, or ambiguous
 \indexlibraryglobal{is_invocable}%
 \tcode{template<class Fn, class... ArgTypes>}\br
  \tcode{struct is_invocable;}                      &
- The expression \tcode{\placeholdernc{INVOKE}(declval<Fn>(), declval<ArgTypes>()...)}
+ The expression \tcode{\placeholdernc{INVOKE}(declval<Fn>(), declval<ArgTypes>()...)}\iref{func.require}
  is well-formed when treated as an unevaluated operand\iref{term.unevaluated.operand} &
  \tcode{Fn} and all types in the template parameter pack \tcode{ArgTypes}
  shall be complete types, \cv{}~\keyword{void}, or
@@ -1480,7 +1480,7 @@ Base classes that are private, protected, or ambiguous
 \indexlibraryglobal{is_invocable_r}%
 \tcode{template<class R, class Fn, class... ArgTypes>}\br
  \tcode{struct is_invocable_r;}                      &
- The expression \tcode{\placeholdernc{INVOKE}<R>(declval<Fn>(), declval<ArgTypes>()...)}
+ The expression \tcode{\placeholdernc{INVOKE}<R>(declval<Fn>(), declval<ArgTypes>()...)}\iref{func.require}
  is well-formed when treated as an unevaluated operand                &
  \tcode{Fn}, \tcode{R}, and all types in the template parameter pack \tcode{ArgTypes}
  shall be complete types, \cv{}~\keyword{void}, or
@@ -1490,7 +1490,7 @@ Base classes that are private, protected, or ambiguous
 \tcode{template<class Fn, class... ArgTypes>}\br
  \tcode{struct is_nothrow_invocable;}              &
  \tcode{is_invocable_v<}\br\tcode{Fn, ArgTypes...>} is \tcode{true} and
- the expression \tcode{\placeholdernc{INVOKE}(declval<Fn>(), declval<ArgTypes>()...)}
+ the expression \tcode{\placeholdernc{INVOKE}(declval<Fn>(), declval<ArgTypes>()...)}\iref{func.require}
  is known not to throw any exceptions\iref{expr.unary.noexcept}       &
  \tcode{Fn} and all types in the template parameter pack \tcode{ArgTypes}
  shall be complete types, \cv{}~\keyword{void}, or
@@ -1500,7 +1500,7 @@ Base classes that are private, protected, or ambiguous
 \tcode{template<class R, class Fn, class... ArgTypes>}\br
  \tcode{struct is_nothrow_invocable_r;}              &
  \tcode{is_invocable_r_v<}\br\tcode{R, Fn, ArgTypes...>} is \tcode{true} and
- the expression \tcode{\placeholdernc{INVOKE}<R>(declval<Fn>(), declval<ArgTypes>()...)}
+ the expression \tcode{\placeholdernc{INVOKE}<R>(declval<Fn>(), declval<ArgTypes>()...)}\iref{func.require}
  is known not to throw any exceptions\iref{expr.unary.noexcept}       &
  \tcode{Fn}, \tcode{R}, and all types in the template parameter pack \tcode{ArgTypes}
  shall be complete types, \cv{}~\keyword{void}, or
@@ -1900,7 +1900,7 @@ argument passing.
  \tcode{class... ArgTypes>}\br
  \tcode{struct invoke_result;}
  &
- If the expression \tcode{\placeholdernc{INVOKE}(declval<Fn>(), declval<ArgTypes>()...)}
+ If the expression \tcode{\placeholdernc{INVOKE}(declval<Fn>(), declval<ArgTypes>()...)}\iref{func.require}
  is well-formed when treated as an unevaluated operand\iref{term.unevaluated.operand},
  the member typedef \tcode{type} denotes the type
  \tcode{decltype(\placeholdernc{INVOKE}(declval<Fn>(), declval<ArgTypes>()...))};

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -1669,7 +1669,7 @@ The following are all \tcode{true}:
 Initializes \tcode{ssource}.
 The new thread of execution executes
 \begin{codeblock}
-invoke(auto(std::forward<F>(f)), get_stop_token(),  // for invoke, see \ref{func.invoke}
+invoke(auto(std::forward<F>(f)), get_stop_token(),  // for \tcode{invoke}, see \ref{func.invoke}
        auto(std::forward<Args>(args))...)
 \end{codeblock}
 if that expression is well-formed,

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -1669,7 +1669,7 @@ The following are all \tcode{true}:
 Initializes \tcode{ssource}.
 The new thread of execution executes
 \begin{codeblock}
-invoke(auto(std::forward<F>(f)), get_stop_token(),  // see \ref{func.invoke}, \ref{thread.jthread.stop}
+invoke(auto(std::forward<F>(f)), get_stop_token(),  // for invoke, see \ref{func.invoke}
        auto(std::forward<Args>(args))...)
 \end{codeblock}
 if that expression is well-formed,

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -1338,7 +1338,7 @@ The following are all \tcode{true}:
 \effects
 The new thread of execution executes
 \begin{codeblock}
-invoke(auto(std::forward<F>(f)), auto(std::forward<Args>(args))...)  // see \ref{func.invoke}
+invoke(auto(std::forward<F>(f)), auto(std::forward<Args>(args))...) // see \ref{func.invoke}
 \end{codeblock}
 with the values produced by \tcode{auto}
 being materialized\iref{conv.rval} in the constructing thread.

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -1338,7 +1338,7 @@ The following are all \tcode{true}:
 \effects
 The new thread of execution executes
 \begin{codeblock}
-invoke(auto(std::forward<F>(f)), auto(std::forward<Args>(args))...)     // see \ref{func.invoke}
+invoke(auto(std::forward<F>(f)), auto(std::forward<Args>(args))...)     // for \tcode{invoke}, see \ref{func.invoke}
 \end{codeblock}
 with the values produced by \tcode{auto}
 being materialized\iref{conv.rval} in the constructing thread.

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -1338,7 +1338,8 @@ The following are all \tcode{true}:
 \effects
 The new thread of execution executes
 \begin{codeblock}
-invoke(auto(std::forward<F>(f)), auto(std::forward<Args>(args))...)     // for \tcode{invoke}, see \ref{func.invoke}
+invoke(auto(std::forward<F>(f)),                // for \tcode{invoke}, see \ref{func.invoke}
+       auto(std::forward<Args>(args))...)
 \end{codeblock}
 with the values produced by \tcode{auto}
 being materialized\iref{conv.rval} in the constructing thread.

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -1338,7 +1338,7 @@ The following are all \tcode{true}:
 \effects
 The new thread of execution executes
 \begin{codeblock}
-invoke(auto(std::forward<F>(f)), auto(std::forward<Args>(args))...) // see \ref{func.invoke}
+invoke(auto(std::forward<F>(f)), auto(std::forward<Args>(args))...)     // see \ref{func.invoke}
 \end{codeblock}
 with the values produced by \tcode{auto}
 being materialized\iref{conv.rval} in the constructing thread.

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -1669,7 +1669,7 @@ The following are all \tcode{true}:
 Initializes \tcode{ssource}.
 The new thread of execution executes
 \begin{codeblock}
-    invoke(auto(std::forward<F>(f)), get_stop_token(), // \ref{func.invoke}, \ref{thread.jthread.stop}
+invoke(auto(std::forward<F>(f)), get_stop_token(),  // see \ref{func.invoke}, \ref{thread.jthread.stop}
        auto(std::forward<Args>(args))...)
 \end{codeblock}
 if that expression is well-formed,

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -1338,7 +1338,7 @@ The following are all \tcode{true}:
 \effects
 The new thread of execution executes
 \begin{codeblock}
-invoke(auto(std::forward<F>(f)), auto(std::forward<Args>(args))...)
+invoke(auto(std::forward<F>(f)), auto(std::forward<Args>(args))...) // \ref{func.invoke}
 \end{codeblock}
 with the values produced by \tcode{auto}
 being materialized\iref{conv.rval} in the constructing thread.
@@ -1669,7 +1669,7 @@ The following are all \tcode{true}:
 Initializes \tcode{ssource}.
 The new thread of execution executes
 \begin{codeblock}
-invoke(auto(std::forward<F>(f)), get_stop_token(),
+    invoke(auto(std::forward<F>(f)), get_stop_token(), // \ref{func.invoke}, \ref{thread.jthread.stop}
        auto(std::forward<Args>(args))...)
 \end{codeblock}
 if that expression is well-formed,
@@ -8096,7 +8096,7 @@ An execution of \tcode{call_once} that does not call its \tcode{func} is a
 is an \term{active} execution. An active execution calls
 \tcode{\placeholdernc{INVOKE}(\brk{}%
 std::forward<Callable>(func),
-std::forward<Args>(args)...)}. If such a call to \tcode{func}
+std::forward<Args>(args)...)}\iref{func.require}. If such a call to \tcode{func}
 throws an exception the execution is \term{exceptional}, otherwise it is \term{returning}.
 An exceptional execution propagates the exception to the caller of
 \tcode{call_once}. Among all executions of \tcode{call_once} for any given
@@ -11115,7 +11115,7 @@ the corresponding policies):
 \begin{itemize}
 \item
 If \tcode{launch::async} is set in \tcode{policy}, calls
-\tcode{invoke(auto(std::forward<F>(f)), auto(std::for\-ward<Args>(args))...)}\iref{func.require,thread.thread.constr}
+\tcode{invoke(auto(std::forward<F>(f)), auto(std::for\-ward<Args>(args))...)}\iref{func.invoke,thread.thread.constr}
 as if in a new thread of execution represented by a \tcode{thread} object
 with the values produced by \tcode{auto}
 being materialized\iref{conv.rval} in the thread that called \tcode{async}.

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -1338,7 +1338,7 @@ The following are all \tcode{true}:
 \effects
 The new thread of execution executes
 \begin{codeblock}
-invoke(auto(std::forward<F>(f)), auto(std::forward<Args>(args))...) // \ref{func.invoke}
+invoke(auto(std::forward<F>(f)), auto(std::forward<Args>(args))...)  // see \ref{func.invoke}
 \end{codeblock}
 with the values produced by \tcode{auto}
 being materialized\iref{conv.rval} in the constructing thread.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -10009,6 +10009,7 @@ collectively referred to as \defnx{state entities}{state entity}.
 \rSec2[func.require]{Requirements}
 
 \pnum
+\indextext{invoke@\tcode{\placeholder{INVOKE}}}%
 \indexlibrary{invoke@\tcode{\placeholder{INVOKE}}}%
 Define \tcode{\placeholdernc{INVOKE}(f, t$_1$, t$_2$, $\dotsc$, t$_N$)} as follows:
 \begin{itemize}


### PR DESCRIPTION
In particular, not knowing where to find the definition of *INVOKE* (it's in the library index, but not the main index) is highly frustrating when reading is_invocable et al.

Corrected references in [thread] and added some more for completeness.

There's a bunch of uses of 'invoke' in [algorithm] and [ranges] that could also have references added, but that feels less necessary.