### PR TITLE
[template.bitset] reorder synopsis and member descriptions

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -8994,6 +8994,8 @@ namespace std {
     constexpr bitset& operator^=(const bitset& rhs) noexcept;
     constexpr bitset& operator<<=(size_t pos) noexcept;
     constexpr bitset& operator>>=(size_t pos) noexcept;
+    constexpr bitset  operator<<(size_t pos) const noexcept;
+    constexpr bitset  operator>>(size_t pos) const noexcept;
     constexpr bitset& set() noexcept;
     constexpr bitset& set(size_t pos, bool val = true);
     constexpr bitset& reset() noexcept;
@@ -9003,8 +9005,8 @@ namespace std {
     constexpr bitset& flip(size_t pos);
 
     // element access
-    constexpr bool operator[](size_t pos) const;        // for \tcode{b[i];}
-    constexpr reference operator[](size_t pos);         // for \tcode{b[i];}
+    constexpr bool operator[](size_t pos) const;
+    constexpr reference operator[](size_t pos);
 
     constexpr unsigned long to_ulong() const;
     constexpr unsigned long long to_ullong() const;
@@ -9014,6 +9016,7 @@ namespace std {
       constexpr basic_string<charT, traits, Allocator>
         to_string(charT zero = charT('0'), charT one = charT('1')) const;
 
+    // observers
     constexpr size_t count() const noexcept;
     constexpr size_t size() const noexcept;
     constexpr bool operator==(const bitset& rhs) const noexcept;
@@ -9021,8 +9024,6 @@ namespace std {
     constexpr bool all() const noexcept;
     constexpr bool any() const noexcept;
     constexpr bool none() const noexcept;
-    constexpr bitset operator<<(size_t pos) const noexcept;
-    constexpr bitset operator>>(size_t pos) const noexcept;
   };
 
   // \ref{bitset.hash}, hash support
@@ -9282,6 +9283,28 @@ If \tcode{pos < N - I}, the new value is the previous value of the bit at positi
 \tcode{*this}.
 \end{itemdescr}
 
+\indexlibrarymember{operator<<}{bitset}%
+\begin{itemdecl}
+constexpr bitset operator<<(size_t pos) const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{bitset(*this) <<= pos}.
+\end{itemdescr}
+
+\indexlibrarymember{operator>>}{bitset}%
+\begin{itemdecl}
+constexpr bitset operator>>(size_t pos) const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{bitset(*this) >>= pos}.
+\end{itemdescr}
+
 % Do not use \indexlibrarymember.
 \indexlibrary{\idxcode{set} (member)!\idxcode{bitset}}%
 \indexlibrary{\idxcode{bitset}!\idxcode{set}}%
@@ -9414,6 +9437,59 @@ Toggles the bit at position \tcode{pos} in
 \throws
 \indexlibraryglobal{out_of_range}%
 \tcode{out_of_range} if \tcode{pos} does not correspond to a valid bit position.
+\end{itemdescr}
+
+\indexlibrarymember{operator[]}{bitset}%
+\begin{itemdecl}
+constexpr bool operator[](size_t pos) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{pos} is valid.
+
+\pnum
+\returns
+\tcode{true} if the bit at position \tcode{pos} in \tcode{*this} has the value
+one, otherwise \tcode{false}.
+
+\pnum
+\throws
+Nothing.
+\end{itemdescr}
+
+\indexlibrarymember{operator[]}{bitset}%
+\begin{itemdecl}
+constexpr bitset::reference operator[](size_t pos);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{pos} is valid.
+
+\pnum
+\returns
+An object of type
+\tcode{bitset::reference}
+such that
+\tcode{(*this)[pos] == this->test(pos)},
+and such that
+\tcode{(*this)[pos] = val}
+is equivalent to
+\tcode{this->set(pos, val)}.
+
+\pnum
+\throws
+Nothing.
+
+\pnum
+\remarks
+For the purpose of determining the presence of a data
+race\iref{intro.multithread}, any access or update through the resulting
+reference potentially accesses or modifies, respectively, the entire
+underlying bitset.
 \end{itemdescr}
 
 \indexlibrarymember{to_ulong}{bitset}%
@@ -9569,81 +9645,6 @@ constexpr bool none() const noexcept;
 \pnum
 \returns
 \tcode{count() == 0}.
-\end{itemdescr}
-
-\indexlibrarymember{operator<<}{bitset}%
-\begin{itemdecl}
-constexpr bitset operator<<(size_t pos) const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\tcode{bitset(*this) <<= pos}.
-\end{itemdescr}
-
-\indexlibrarymember{operator>>}{bitset}%
-\begin{itemdecl}
-constexpr bitset operator>>(size_t pos) const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-\tcode{bitset(*this) >>= pos}.
-\end{itemdescr}
-
-\indexlibrarymember{operator[]}{bitset}%
-\begin{itemdecl}
-constexpr bool operator[](size_t pos) const;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\expects
-\tcode{pos} is valid.
-
-\pnum
-\returns
-\tcode{true} if the bit at position \tcode{pos} in \tcode{*this} has the value
-one, otherwise \tcode{false}.
-
-\pnum
-\throws
-Nothing.
-\end{itemdescr}
-
-\indexlibrarymember{operator[]}{bitset}%
-\begin{itemdecl}
-constexpr bitset::reference operator[](size_t pos);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\expects
-\tcode{pos} is valid.
-
-\pnum
-\returns
-An object of type
-\tcode{bitset::reference}
-such that
-\tcode{(*this)[pos] == this->test(pos)},
-and such that
-\tcode{(*this)[pos] = val}
-is equivalent to
-\tcode{this->set(pos, val)}.
-
-\pnum
-\throws
-Nothing.
-
-\pnum
-\remarks
-For the purpose of determining the presence of a data
-race\iref{intro.multithread}, any access or update through the resulting
-reference potentially accesses or modifies, respectively, the entire
-underlying bitset.
 \end{itemdescr}
 
 \rSec2[bitset.hash]{\tcode{bitset} hash support}


### PR DESCRIPTION
Group shifts together and use same order for synopsis and detailed descriptions.

Also remove the unnecessary "for b[i];" comments explaining what operator[] does, and add a comment introducing the group containing count(), size() etc.