### PR TITLE
[expected.expected] Missing explicit specification for unexpected-converting constructor LWG3754

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7237,9 +7237,9 @@ namespace std {
       constexpr explicit(@\seebelow@) expected(U&& v);
 
     template<class G>
-      constexpr expected(const unexpected<G>&);
+      constexpr explicit(@\seebelow@) expected(const unexpected<G>&);
     template<class G>
-      constexpr expected(unexpected<G>&&);
+      constexpr explicit(@\seebelow@) expected(unexpected<G>&&);
 
     template<class... Args>
       constexpr explicit expected(in_place_t, Args&&...);


### PR DESCRIPTION
Fixes  #5864