### PR TITLE
[dcl.enum] Enumerators don't have "initializers"

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6972,12 +6972,11 @@ constants, and can appear wherever constants are required.
 An \grammarterm{enumerator-definition} with \tcode{=} gives the associated
 \grammarterm{enumerator} the value indicated by the
 \grammarterm{constant-expression}.
-If the first \grammarterm{enumerator}
-has no \grammarterm{initializer}, the value of the corresponding constant
-is zero. An \grammarterm{enumerator-definition} without an
-\grammarterm{initializer} gives the \grammarterm{enumerator} the value
-obtained by increasing the value of the previous \grammarterm{enumerator}
-by one.
+An \grammarterm{enumerator-definition} without \tcode{=} gives the associated
+\grammarterm{enumerator} the value zero
+if it is the first \grammarterm{enumerator-definition},
+and the value of the previous \grammarterm{enumerator}
+increased by one otherwise.
 \begin{example}
 \begin{codeblock}
 enum { a, b, c=0 };


### PR DESCRIPTION
I might just be missing something obvious here, but the current wording of [dcl.enum/2](https://eel.is/c++draft/enum#dcl.enum-2.sentence-8) seems to use the grammar production _initializer_ when it means _constant-expression_. The grammar production [_initializer_](https://eel.is/c++draft/dcl.init.general#nt:initializer) is defined as

    initializer:
        brace-or-equal-initializer
        '(' expression-list ')'

I could have just replaced "an _initializer_" with "a _constant-expression_". But, looking at the preceding sentence, I think "with `=`" and "without `=`" are the perfect way to describe what we're talking about here. So this change is bigger (but still, IMHO, editorial).