### PR TITLE
Fix inconsistencies with hyphens

### DIFF
--- a/source/back.tex
+++ b/source/back.tex
@@ -45,7 +45,7 @@ called \defn{LIA-1} in this document.
 \renewcommand{\glossitem}[4]{\hangpara{4em}{1}\realglossitem{#1}{#2}{#3}{#4}}
 
 \clearpage
-\renewcommand{\glossaryname}{Cross references}
+\renewcommand{\glossaryname}{Cross-references}
 \renewcommand{\preglossaryhook}{Each clause and subclause label is listed below along with the
 corresponding clause or subclause number and page number, in alphabetical order by label.\\}
 \twocolglossary
@@ -57,7 +57,7 @@ corresponding clause or subclause number and page number, in alphabetical order 
 
 \clearpage
 \input{xrefdelta}
-\renewcommand{\glossaryname}{Cross references from ISO \CppXX{}}
+\renewcommand{\glossaryname}{Cross-references from ISO \CppXX{}}
 \renewcommand{\preglossaryhook}{All clause and subclause labels from
 ISO \CppXX{} (ISO/IEC 14882:2020, \doccite{Programming Languages --- \Cpp{}})
 are present in this document, with the exceptions described below.\\}

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -320,7 +320,7 @@ In the definition of an object,
 the type of that object shall not be
 an incomplete type\iref{term.incomplete.type},
 an abstract class type\iref{class.abstract}, or
-a (possibly multi-dimensional) array thereof.
+a (possibly multidimensional) array thereof.
 
 \rSec1[basic.def.odr]{One-definition rule}%
 \indextext{object!definition}%
@@ -3362,7 +3362,7 @@ The \defn{lifetime} of an object or reference is a runtime property of the
 object or reference.
 A variable is said to have \defnadj{vacuous}{initialization}
 if it is default-initialized and,
-if it is of class type or a (possibly multi-dimensional) array thereof,
+if it is of class type or a (possibly multidimensional) array thereof,
 that class type has a trivial default constructor.
 The lifetime of an object of type \tcode{T} begins when:
 \begin{itemize}

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -699,7 +699,7 @@ function\iref{class.virtual}.
 The type of a non-static data member shall not be an
 incomplete type\iref{term.incomplete.type},
 an abstract class type\iref{class.abstract},
-or a (possibly multi-dimensional) array thereof.
+or a (possibly multidimensional) array thereof.
 \begin{note}
 In particular, a class \tcode{C} cannot contain
 a non-static member of class \tcode{C},

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1077,7 +1077,7 @@ Remove \tcode{shared_ptr::unique}.
 The result of a call to this member function is not reliable in the presence of
 multiple threads and weak pointers. The member function \tcode{use_count} is
 similarly unreliable, but has a clearer contract in such cases, and remains
-available for well defined use in single-threaded cases.
+available for well-defined use in single-threaded cases.
 \effect
 A valid \CppXVII{} program that calls \tcode{unique} on a \tcode{shared_ptr}
 object may fail to compile.

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -812,7 +812,7 @@ void f() {}
 int main() {
   A a;
   f < a;    // ill-formed; previously well-formed
-  (f) < a;  // still well formed
+  (f) < a;  // still well-formed
 }
 \end{codeblock}
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5147,7 +5147,7 @@ struct A {
 \end{example}
 
 \pnum
-When initializing a multi-dimensional array,
+When initializing a multidimensional array,
 the
 \grammarterm{initializer-clause}{s}
 initialize the elements with the last (rightmost) index of the array

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -279,7 +279,7 @@ and rvalues in other significant contexts.
 \pnum
 Unless otherwise indicated\iref{dcl.type.decltype},
 a prvalue shall always have complete type or the \keyword{void} type;
-if it has a class type or (possibly multi-dimensional) array of class type,
+if it has a class type or (possibly multidimensional) array of class type,
 that class shall not be an abstract class\iref{class.abstract}.
 A glvalue shall not have type \cv{}~\keyword{void}.
 \begin{note}
@@ -5834,7 +5834,7 @@ the one without a parameter of type \tcode{std::size_t} is selected.
 If the type is complete
 and if, for an array delete expression only,
 the operand is a pointer to a class type with a
-non-trivial destructor or a (possibly multi-dimensional) array thereof,
+non-trivial destructor or a (possibly multidimensional) array thereof,
 the function with a parameter of type \tcode{std::size_t} is selected.
 \item
 Otherwise, it is unspecified
@@ -7678,9 +7678,9 @@ constexpr auto& gallagher = typeid(trident);    // error: constexpr-unknown dyna
 An object \tcode{a} is said to have \defnadj{constant}{destruction} if:
 \begin{itemize}
 \item
-  it is not of class type nor (possibly multi-dimensional) array thereof, or
+  it is not of class type nor (possibly multidimensional) array thereof, or
 \item
-  it is of class type or (possibly multi-dimensional) array thereof,
+  it is of class type or (possibly multidimensional) array thereof,
   that class type has a constexpr destructor, and
   for a hypothetical expression $E$
   whose only effect is to destroy \tcode{a},

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -13610,8 +13610,8 @@ native ordinary encoding is determined by calling a Windows API function.
 \begin{note}
 This results in behavior identical to other C and \Cpp{}
 standard library functions that perform file operations using ordinary character
-strings to identify paths. Changing this behavior would be surprising and error
-prone.
+strings to identify paths. Changing this behavior would be surprising and
+error-prone.
 \end{note}
 \item \keyword{wchar_t}: The encoding is the native wide encoding.
 The method of conversion is unspecified.

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -15237,12 +15237,12 @@ Every other constant in the table represents a distinct bitmask element.
 \tcode{update_existing} &
     Overwrite the existing file if it is older than the replacement file.  \\ \capsep
 
-\ohdrx{2}{Option group controlling \tcode{copy} function effects for sub-directories} \\ \rowsep
+\ohdrx{2}{Option group controlling \tcode{copy} function effects for subdirectories} \\ \rowsep
 \lhdr{Constant}	& \rhdr{Meaning}	\\ \capsep
 \tcode{none} &
-    (Default) Do not copy sub-directories.  \\ \rowsep
+    (Default) Do not copy subdirectories.  \\ \rowsep
 \tcode{recursive} &
-    Recursively copy sub-directories and their contents.  \\ \capsep
+    Recursively copy subdirectories and their contents.  \\ \capsep
 
 \ohdrx{2}{Option group controlling \tcode{copy} function effects for symbolic links} \\ \rowsep
 \lhdr{Constant}	& \rhdr{Meaning}	\\ \capsep
@@ -15998,7 +15998,7 @@ path and any cached attribute values\iref{fs.class.directory.entry}
 for each file in a directory
 or in an \impldef{type of a directory-like file} directory-like file type.
 \begin{note}
-For iteration into sub-directories, see class \tcode{recursive_directory_iterator}\iref{fs.class.rec.dir.itr}.
+For iteration into subdirectories, see class \tcode{recursive_directory_iterator}\iref{fs.class.rec.dir.itr}.
 \end{note}
 
 \begin{codeblock}
@@ -16236,7 +16236,7 @@ directory_iterator end(directory_iterator) noexcept;
 An object of type \tcode{recursive_directory_iterator} provides an iterator for
 a sequence of \tcode{directory_entry} elements representing the files in a
 directory or in an \impldef{type of a directory-like file} directory-like file
-type, and its sub-directories.
+type, and its subdirectories.
 
 \begin{codeblock}
 namespace std::filesystem {

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -61,7 +61,7 @@
 \def\stopindexescape#1\doneindexescape{}
 
 %%--------------------------------------------------
-%% Cross references.
+%% Cross-references.
 %%--------------------------------------------------
 \newcommand{\addxref}[1]{%
  \glossary[xrefindex]{\indexescape{#1}}{(\ref{\indexescape{#1}})}%
@@ -358,7 +358,7 @@
 \newcommand{\ctype}{\Fundesc{Type}}
 \newcommand{\templalias}{\Fundesc{Alias template}}
 
-%% Cross reference
+%% Cross-reference
 \newcommand{\xref}{\textsc{See also:}\space}
 \newcommand{\xrefc}[1]{\xref{} ISO C #1}
 

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -1792,7 +1792,7 @@ For multidimensional arrays, only the first array dimension is
 \indexlibraryglobal{remove_all_extents}%
 \tcode{template<class T>\br
  struct remove_all_extents;}                &
- If \tcode{T} is ``multi-dimensional array of \tcode{U}'', the resulting member
+ If \tcode{T} is ``multidimensional array of \tcode{U}'', the resulting member
  typedef \tcode{type} denotes \tcode{U}, otherwise \tcode{T}.                                       \\
 \end{libreqtab2a}
 

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -402,7 +402,7 @@ A \defnadj{structural}{type} is one of the following:
 all base classes and non-static data members are public and non-mutable and
 \item
 the types of all bases classes and non-static data members are
-structural types or (possibly multi-dimensional) array thereof.
+structural types or (possibly multidimensional) array thereof.
 \end{itemize}
 \end{itemize}
 


### PR DESCRIPTION
* "cross-reference": [dictionary](https://www.thefreedictionary.com/cross-reference), [repo](https://github.com/cplusplus/draft/search?l=TeX&q=%22cross+references%22), [ngrams](https://books.google.com/ngrams/graph?content=cross+reference%2C%5Bcross+-+reference%5D&year_start=1800&year_end=2019&corpus=en-2019&smoothing=3&case_insensitive=true)
* "multidimensional": [dictionary](https://www.thefreedictionary.com/multidimensional), [repo](https://github.com/cplusplus/draft/search?l=TeX&q=%22multidimensional%22%2C%22multi-dimensional%22), [ngrams](https://books.google.com/ngrams/graph?content=multidimensional%2C%5Bmulti+-+dimensional%5D&year_start=1800&year_end=2019&case_insensitive=on&corpus=en-2019&smoothing=3)
* "well-formed": [dictionary](https://www.thefreedictionary.com/well-formed), [repo](https://github.com/cplusplus/draft/search?q=%22well+formed%22), [ngrams](https://books.google.com/ngrams/graph?content=well+formed%2C%5Bwell+-+formed%5D&year_start=1800&year_end=2019&case_insensitive=on&corpus=en-2019&smoothing=3)
* "well-defined": [dictionary](https://www.thefreedictionary.com/well-defined), [repo](https://github.com/cplusplus/draft/search?l=TeX&q=%22well+defined%22), [ngrams](https://books.google.com/ngrams/graph?content=well+defined%2C%5Bwell+-+defined%5D&year_start=1800&year_end=2019&case_insensitive=on&corpus=en-2019&smoothing=3)
* "error-prone": [dictionary](https://www.thefreedictionary.com/error-prone), [repo](https://github.com/cplusplus/draft/search?l=TeX&q=%22error+prone%22), [ngrams](https://books.google.com/ngrams/graph?content=error+prone%2C%5Berror+-+prone%5D&year_start=1800&year_end=2019&case_insensitive=on&corpus=en-2019&smoothing=3)
* "subdirectory": [dictionary](https://www.thefreedictionary.com/subdirectory), [repo](https://github.com/cplusplus/draft/blob/842424bd228b79876437a1a9393f20f00033476a/source/iostreams.tex#L16485), [ngrams](https://books.google.com/ngrams/graph?content=subdirectory%2C%5Bsub+-+directory%5D&year_start=1800&year_end=2019&case_insensitive=on&corpus=en-2019&smoothing=3)
