### PR TITLE
[allocator.requirements.general] Remove redundant template syntax

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2234,7 +2234,7 @@ Default:
 \end{itemdescr}
 
 \begin{itemdecl}
-typename X::template rebind<U>::other
+typename X::rebind<U>::other
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
In the Cpp17Allocator requirements, all identifiers name specific types, even if they are template instantiations.  Hence, all use of `typename`, `.template`, and `::template` is redundant.  Not in the sense of we are awaiting LWG to review P2150 for policy, but in the sense these have been redundant since C++11, and were outright ill-formed prior to that.

The majority of the wording throughout this subclause already (correctly) avoids use of these redundant keywords.  This PR brings the title rows into agreement with the body text, and fixes one outstanding redundant use of `::template`.