### PR TITLE
[index] Remove undefined term

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -66,7 +66,6 @@ occur, although in practice different phases can be folded together.
 \begin{enumerate}
 \item
 \indextext{character!source file}%
-\indextext{character set!basic source}%
 An implementation shall support input files
 that are a sequence of UTF-8 code units (UTF-8 files).
 It may also support


### PR DESCRIPTION
The notion of a basic _source_ character set has been eliminated by the work on a better specification for translating source. Remove the last definition to it in the index, that points to a definition that no longer exists.