### PR TITLE
[ios.overview] Remove unconventional empty line

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -1846,7 +1846,6 @@ namespace std {
     void move(basic_ios&& rhs);
     void swap(basic_ios& rhs) noexcept;
     void set_rdbuf(basic_streambuf<charT, traits>* sb);
-
   };
 }
 \end{codeblock}


### PR DESCRIPTION
We don't typically put empty lines before closing braces.