### PR TITLE
[conv.lval] Fix cross-reference for 'invalid pointer value'

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -666,7 +666,7 @@ type, the conversion copy-initializes the result object from
 the glvalue.
 
 \item Otherwise, if the object to which the glvalue refers contains an invalid
-pointer value\iref{basic.stc.dynamic.deallocation}, the behavior is
+pointer value\iref{basic.compound}, the behavior is
 \impldef{lvalue-to-rvalue conversion of an invalid pointer value}.
 
 \item Otherwise, the object indicated by the glvalue is read\iref{defns.access},

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -850,7 +850,7 @@ template<class T>
 
 \pnum
 \expects
-\range{p}{(char*)p + sizeof(T)} denotes a region of allocated storage
+\range{p}{static_cast<char*>(p) + sizeof(T)} denotes a region of allocated storage
 that is
 a subset of the region of storage
 reachable through\iref{basic.compound} \tcode{p} and


### PR DESCRIPTION
The definition of 'invalid pointer value' is in [basic.compound] rather than [basic.stc.dynamic.deallocation].