### PR TITLE
[conv.lval] Fix cross-reference for 'invalid pointer value'

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5240,7 +5240,7 @@ a \defn{pointer past the end of} an object\iref{expr.add}, or
 the \defnx{null pointer value}{value!null pointer} for that type, or
 \item
 \indextext{invalid pointer value|see{value, invalid pointer}}
-an \defnx{invalid pointer value}{value!invalid pointer}.
+an \defnx{invalid pointer value}{value!invalid pointer}\iref{basic.stc.general}.
 \end{itemize}
 A value of a
 pointer type

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -666,7 +666,7 @@ type, the conversion copy-initializes the result object from
 the glvalue.
 
 \item Otherwise, if the object to which the glvalue refers contains an invalid
-pointer value\iref{basic.stc.dynamic.deallocation}, the behavior is
+pointer value\iref{basic.compound}, the behavior is
 \impldef{lvalue-to-rvalue conversion of an invalid pointer value}.
 
 \item Otherwise, the object indicated by the glvalue is read\iref{defns.access},


### PR DESCRIPTION
The definition of 'invalid pointer value' is in [basic.compound] rather than [basic.stc.dynamic.deallocation].