### PR TITLE
[format.string.escaped] Fix invalid example

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15406,7 +15406,7 @@ string s3 = format("[{:?}, {:?}]", '\'', '"');      // \tcode{s3} has value: \tc
 string s4 = format("[{:?}]", string("\0 \n \t \x02 \x1b", 9));
                                                     // \tcode{s4} has value: \tcode{["\textbackslash u\{0\} \textbackslash n \textbackslash t \textbackslash u\{2\} \textbackslash u\{1b\}"]}
 string s5 = format("[{:?}]", "\xc3\x28");           // invalid UTF-8
-                                                    // \tcode{s5} has value: \tcode{["\textbackslash x\{c3\}\textbackslash x\{28\}"]}
+                                                    // \tcode{s5} has value: \tcode{["\textbackslash x\{c3\}("]}
 \end{codeblock}
 \end{example}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15405,8 +15405,7 @@ string s3 = format("[{:?}, {:?}]", '\'', '"');      // \tcode{s3} has value: \tc
 // The following examples assume use of the UTF-8 encoding
 string s4 = format("[{:?}]", string("\0 \n \t \x02 \x1b", 9));
                                                     // \tcode{s4} has value: \tcode{["\textbackslash u\{0\} \textbackslash n \textbackslash t \textbackslash u\{2\} \textbackslash u\{1b\}"]}
-string s5 = format("[{:?}]", "\xc3\x28");           // invalid UTF-8
-                                                    // \tcode{s5} has value: \tcode{["\textbackslash x\{c3\}("]}
+string s5 = format("[{:?}]", "\xc3\x28");           // invalid UTF-8, \tcode{s5} has value: \tcode{["\textbackslash x\{c3\}("]}
 \end{codeblock}
 \end{example}
 


### PR DESCRIPTION
Example 5 should only have one invalid code unit. The second code unit is a valid code point. This issue was already in the paper
  P2286R8 Formatting Ranges