### PR TITLE
[dcl.link] Fix the wording of the application of the specified language linkage

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -8124,7 +8124,7 @@ A \grammarterm{linkage-specification} shall inhabit a namespace scope.
 In a \grammarterm{linkage-specification},
 the specified language linkage applies
 to the function types of all function declarators and
-to all functions and variables.
+to all functions and variables whose names have external linkage.
 \begin{example}
 \begin{codeblock}
 extern "C"                      // \tcode{f1} and its function type have C language linkage;


### PR DESCRIPTION
[dcl.link]/1:

> All functions and variables **whose names have external linkage** and all function types have a language linkage.