### PR TITLE
Ill-formed example in [range.drop.while.overview]

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -6270,7 +6270,7 @@ is expression-equivalent to \tcode{drop_while_view(E, F)}.
 \pnum
 \begin{example}
 \begin{codeblock}
-constexpr auto source = "  \t   \t   \t   hello there";
+constexpr decltype(auto) source = "  \t   \t   \t   hello there";
 auto is_invisible = [](const auto x) { return x == ' ' || x == '\t'; };
 auto skip_ws = views::drop_while(source, is_invisible);
 for (auto c : skip_ws) {

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -6270,7 +6270,7 @@ is expression-equivalent to \tcode{drop_while_view(E, F)}.
 \pnum
 \begin{example}
 \begin{codeblock}
-constexpr decltype(auto) source = "  \t   \t   \t   hello there";
+constexpr auto source = "  \t   \t   \t   hello there"sv;
 auto is_invisible = [](const auto x) { return x == ' ' || x == '\t'; };
 auto skip_ws = views::drop_while(source, is_invisible);
 for (auto c : skip_ws) {


### PR DESCRIPTION
The example in [range.drop.while.overview] is ill-formed. It attempts to use a `const char*` as a `range`, which isn't. The fix simply makes it a `const char (&)[N]`, which is a `range`