### PR TITLE
[meta.const.eval] Add is_constant_evaluated() to index of library names

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -2359,6 +2359,8 @@ static_assert( is_corresponding_member<C, C>( &C::a, &C::b ) );
 \end{note}
 
 \rSec2[meta.const.eval]{Constant evaluation context}
+
+\indexlibraryglobal{is_constant_evaluated}%
 \begin{itemdecl}
 constexpr bool is_constant_evaluated() noexcept;
 \end{itemdecl}


### PR DESCRIPTION
Previously, only its feature-test macro was listed there.