### PR TITLE
[range.repeat] Change template parameter name `W` to `T`

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -211,8 +211,8 @@ namespace std::ranges {
   namespace views { inline constexpr @\unspecnc@ iota = @\unspecnc@; }              // freestanding
 
   // \ref{range.repeat}, repeat view
-  template<@\libconcept{move_constructible}@ W, @\libconcept{semiregular}@ Bound = unreachable_sentinel_t>
-    requires (is_object_v<W> && @\libconcept{same_as}@<W, remove_cv_t<W>>
+  template<@\libconcept{move_constructible}@ T, @\libconcept{semiregular}@ Bound = unreachable_sentinel_t>
+    requires (is_object_v<T> && @\libconcept{same_as}@<T, remove_cv_t<T>>
       && (@\exposid{is-integer-like}@<Bound> || @\libconcept{same_as}@<Bound, unreachable_sentinel_t>))
   class repeat_view;                                                                // freestanding
 
@@ -3386,28 +3386,28 @@ for (int i : views::repeat(17, 4))
 
 \begin{codeblock}
 namespace std::ranges {
-  template<@\libconcept{move_constructible}@ W, @\libconcept{semiregular}@ Bound = unreachable_sentinel_t>
-    requires (is_object_v<W> && @\libconcept{same_as}@<W, remove_cv_t<W>> &&
+  template<@\libconcept{move_constructible}@ T, @\libconcept{semiregular}@ Bound = unreachable_sentinel_t>
+    requires (is_object_v<T> && @\libconcept{same_as}@<T, remove_cv_t<T>> &&
               (@\exposid{is-integer-like}@<Bound> || @\libconcept{same_as}@<Bound, unreachable_sentinel_t>))
-  class @\libglobal{repeat_view}@ : public view_interface<repeat_view<W, Bound>> {
+  class @\libglobal{repeat_view}@ : public view_interface<repeat_view<T, Bound>> {
   private:
     // \ref{range.repeat.iterator}, class \tcode{repeat_view::\exposid{iterator}}
     struct @\exposidnc{iterator}@;                            // \expos
 
-    @\exposidnc{movable-box}@<W> @\exposid{value_}@;                      // \expos, see \ref{range.move.wrap}
+    @\exposidnc{movable-box}@<T> @\exposid{value_}@;                      // \expos, see \ref{range.move.wrap}
     Bound @\exposid{bound_}@ = Bound();                     // \expos
 
   public:
-    repeat_view() requires @\libconcept{default_initializable}@<W> = default;
+    repeat_view() requires @\libconcept{default_initializable}@<T> = default;
 
-    constexpr explicit repeat_view(const W& value, Bound bound = Bound())
-      requires @\libconcept{copy_constructible}@<W>;
-    constexpr explicit repeat_view(W&& value, Bound bound = Bound());
-    template<class... WArgs, class... BoundArgs>
-      requires @\libconcept{constructible_from}@<W, WArgs...> &&
+    constexpr explicit repeat_view(const T& value, Bound bound = Bound())
+      requires @\libconcept{copy_constructible}@<T>;
+    constexpr explicit repeat_view(T&& value, Bound bound = Bound());
+    template<class... TArgs, class... BoundArgs>
+      requires @\libconcept{constructible_from}@<T, TArgs...> &&
                @\libconcept{constructible_from}@<Bound, BoundArgs...>
     constexpr explicit repeat_view(piecewise_construct_t,
-      tuple<WArgs...> value_args, tuple<BoundArgs...> bound_args = tuple<>{});
+      tuple<TArgs...> value_args, tuple<BoundArgs...> bound_args = tuple<>{});
 
     constexpr @\exposid{iterator}@ begin() const;
     constexpr @\exposid{iterator}@ end() const requires (!@\libconcept{same_as}@<Bound, unreachable_sentinel_t>);
@@ -3416,15 +3416,15 @@ namespace std::ranges {
     constexpr auto size() const requires (!@\libconcept{same_as}@<Bound, unreachable_sentinel_t>);
   };
 
-  template<class W, class Bound>
-    repeat_view(W, Bound) -> repeat_view<W, Bound>;
+  template<class T, class Bound>
+    repeat_view(T, Bound) -> repeat_view<T, Bound>;
 }
 \end{codeblock}
 
 \indexlibraryctor{repeat_view}%
 \begin{itemdecl}
-constexpr explicit repeat_view(const W& value, Bound bound = Bound())
-  requires @\libconcept{copy_constructible}@<W>;
+constexpr explicit repeat_view(const T& value, Bound bound = Bound())
+  requires @\libconcept{copy_constructible}@<T>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3441,7 +3441,7 @@ Initializes \exposid{value_} with \tcode{value} and
 
 \indexlibraryctor{repeat_view}%
 \begin{itemdecl}
-constexpr explicit repeat_view(W&& value, Bound bound = Bound());
+constexpr explicit repeat_view(T&& value, Bound bound = Bound());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3457,17 +3457,17 @@ Initializes \exposid{value_} with \tcode{std::move(value)} and
 
 \indexlibraryctor{repeat_view}%
 \begin{itemdecl}
-template<class... WArgs, class... BoundArgs>
-  requires @\libconcept{constructible_from}@<W, WArgs...> &&
+template<class... TArgs, class... BoundArgs>
+  requires @\libconcept{constructible_from}@<T, TArgs...> &&
            @\libconcept{constructible_from}@<Bound, BoundArgs...>
 constexpr explicit repeat_view(piecewise_construct_t,
-  tuple<Wargs...> value_args, tuple<BoundArgs...> bound_args = tuple<>{});
+  tuple<TArgs...> value_args, tuple<BoundArgs...> bound_args = tuple<>{});
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \exposid{value_} with arguments of types \tcode{WArgs...}
+Initializes \exposid{value_} with arguments of types \tcode{TArgs...}
 obtained by forwarding the elements of \tcode{value_args} and
 initializes \exposid{bound_} with arguments of types \tcode{BoundArgs...}
 obtained by forwarding the elements of \tcode{bound_args}.
@@ -3523,29 +3523,29 @@ Equivalent to: \tcode{return \exposid{to-unsigned-like}(\exposid{bound_});}
 
 \begin{codeblock}
 namespace std::ranges {
-  template<@\libconcept{move_constructible}@ W, @\libconcept{semiregular}@ Bound = unreachable_sentinel_t>
-    requires (is_object_v<W> && @\libconcept{same_as}@<W, remove_cv_t<W>> &&
+  template<@\libconcept{move_constructible}@ T, @\libconcept{semiregular}@ Bound = unreachable_sentinel_t>
+    requires (is_object_v<T> && @\libconcept{same_as}@<T, remove_cv_t<T>> &&
               (@\exposid{is-integer-like}@<Bound> || @\libconcept{same_as}@<Bound, unreachable_sentinel_t>))
-  class repeat_view<W, Bound>::@\exposid{iterator}@ {
+  class repeat_view<T, Bound>::@\exposid{iterator}@ {
   private:
     using @\exposidnc{index-type}@ =                          // \expos
       conditional_t<@\libconcept{same_as}@<Bound, unreachable_sentinel_t>, ptrdiff_t, Bound>;
-    const W* @\exposidnc{value_}@ = nullptr;                  // \expos
+    const T* @\exposidnc{value_}@ = nullptr;                  // \expos
     @\exposidnc{index-type}@ @\exposidnc{current_}@ = @\exposidnc{index-type}@();         // \expos
 
-    constexpr explicit @\exposid{iterator}@(const W* value, @\exposid{index-type}@ b = @\exposidnc{index-type}@());   // \expos
+    constexpr explicit @\exposid{iterator}@(const T* value, @\exposid{index-type}@ b = @\exposidnc{index-type}@());   // \expos
 
   public:
     using iterator_concept = random_access_iterator_tag;
     using iterator_category = random_access_iterator_tag;
-    using value_type = W;
+    using value_type = T;
     using difference_type = conditional_t<@\exposid{is-signed-integer-like}@<@\exposid{index-type}@>,
         @\exposid{index-type}@,
         @\placeholdernc{IOTA-DIFF-T}@(@\exposid{index-type}@)>;
 
     @\exposid{iterator}@() = default;
 
-    constexpr const W& operator*() const noexcept;
+    constexpr const T& operator*() const noexcept;
 
     constexpr @\exposid{iterator}@& operator++();
     constexpr @\exposid{iterator}@ operator++(int);
@@ -3555,7 +3555,7 @@ namespace std::ranges {
 
     constexpr @\exposid{iterator}@& operator+=(difference_type n);
     constexpr @\exposid{iterator}@& operator-=(difference_type n);
-    constexpr const W& operator[](difference_type n) const noexcept;
+    constexpr const T& operator[](difference_type n) const noexcept;
 
     friend constexpr bool operator==(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y);
     friend constexpr auto operator<=>(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y);
@@ -3571,7 +3571,7 @@ namespace std::ranges {
 
 \indexlibraryctor{repeat_view::\exposid{iterator}}%
 \begin{itemdecl}
-constexpr explicit @\exposid{iterator}@(const W* value, @\exposid{index-type}@ b = @\exposid{index-type}@());
+constexpr explicit @\exposid{iterator}@(const T* value, @\exposid{index-type}@ b = @\exposid{index-type}@());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3587,7 +3587,7 @@ Initializes \exposid{value_} with \tcode{value} and
 
 \indexlibrarymember{operator*}{repeat_view::\exposid{iterator}}%
 \begin{itemdecl}
-constexpr const W& operator*() const noexcept;
+constexpr const T& operator*() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3705,7 +3705,7 @@ return *this;
 
 \indexlibrarymember{operator[]}{repeat_view::\exposid{iterator}}%
 \begin{itemdecl}
-constexpr const W& operator[](difference_type n) const noexcept;
+constexpr const T& operator[](difference_type n) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Currently, the first template parameter of `repeat_view` is called `W`, which is consistent with `iota_view`.

However, such consistency makes wrong suggestions, because two `W`'s have totally different constraints. Presumably `W` comes from `weakly_incrementable`, which is not related to the first template parameter of `repeat_view`.

This PR changes `W` to `T`, because `T` is a general name for type template parameters, and the constraints of `move_constructible` are relatively loose. And it also changes `WArgs` to `TArgs` for mirroring `BoundArgs`. I'm not sure whether the plain `Args` would be better.

Fixes #5902.