### PR TITLE
[intro.defs] Move the definition of "multibyte character" to library

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -422,11 +422,6 @@ assignment of an rvalue of some object type to a modifiable lvalue of the same t
 \indexdefn{construction!move}%
 direct-initialization of an object of some type with an rvalue of the same type
 
-\indexdefn{character!multibyte}%
-\definition{multibyte character}{defns.multibyte}
-sequence of one or more bytes representing
-the code unit sequence for an encoded character of the execution character set
-
 \indexdefn{library call!non-constant}%
 \definition{non-constant library call}{defns.nonconst.libcall}
 invocation of a library function that,

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -790,6 +790,12 @@ is a static \ntbs{}.
 
 \rSec5[multibyte.strings]{Multibyte strings}
 
+\pnum
+A \defnx{multibyte character}{character!multibyte} is
+a sequence of one or more bytes representing the
+code unit sequence for an encoded character of the
+execution character set.
+
 \indextext{string!null-terminated multibyte|see{\ntmbs{}}}%
 \pnum
 A \defnx{null-terminated multibyte string}{NTMBS@\ntmbs{}},

--- a/source/xrefprev
+++ b/source/xrefprev
@@ -31,7 +31,6 @@
 \glossaryentry{defns.modifier@ {\memgloterm{defns.modifier}}{\memglodesc{(\ref  {defns.modifier})}} {\memgloref{}}|memjustarg}{5}
 \glossaryentry{defns.move.assign@ {\memgloterm{defns.move.assign}}{\memglodesc{(\ref  {defns.move.assign})}} {\memgloref{}}|memjustarg}{5}
 \glossaryentry{defns.move.constr@ {\memgloterm{defns.move.constr}}{\memglodesc{(\ref  {defns.move.constr})}} {\memgloref{}}|memjustarg}{5}
-\glossaryentry{defns.multibyte@ {\memgloterm{defns.multibyte}}{\memglodesc{(\ref  {defns.multibyte})}} {\memgloref{}}|memjustarg}{5}
 \glossaryentry{defns.ntcts@ {\memgloterm{defns.ntcts}}{\memglodesc{(\ref  {defns.ntcts})}} {\memgloref{}}|memjustarg}{5}
 \glossaryentry{defns.observer@ {\memgloterm{defns.observer}}{\memglodesc{(\ref  {defns.observer})}} {\memgloref{}}|memjustarg}{5}
 \glossaryentry{defns.parameter@ {\memgloterm{defns.parameter}}{\memglodesc{(\ref  {defns.parameter})}} {\memgloref{}}|memjustarg}{6}


### PR DESCRIPTION
This address the US-2 NB comment as per the direction voted on by SG-16.

No use of "multibyte character" remains before [multibyte.strings] (we still cross reference "multibyte string" in [basic.start.main] but it's pre-existing (and otherwise correct).

@steve-downey @jensmaurer @tahonermann 