### PR TITLE
[ranges] Remove unnecessary copy-list-initialization LWG3796

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -3411,7 +3411,7 @@ namespace std::ranges {
     // \ref{range.repeat.iterator}, class \tcode{repeat_view::\exposid{iterator}}
     struct @\exposidnc{iterator}@;                            // \expos
 
-    @\exposidnc{movable-box}@<W> @\exposid{value_}@ = W();                // \expos, see \ref{range.move.wrap}
+    @\exposidnc{movable-box}@<W> @\exposid{value_}@;                      // \expos, see \ref{range.move.wrap}
     Bound @\exposid{bound_}@ = Bound();                     // \expos
 
   public:
@@ -13301,7 +13301,7 @@ namespace std::ranges {
     requires @\libconcept{view}@<V> && is_object_v<Pred>
   class chunk_by_view : public view_interface<chunk_by_view<V, Pred>> {
     V @\exposid{base_}@ = V();                                          // \expos
-    @\exposidnc{movable-box}@<Pred> @\exposid{pred_}@ = Pred();                       // \expos
+    @\exposidnc{movable-box}@<Pred> @\exposid{pred_}@;                                // \expos
 
     // \ref{range.chunk.by.iter}, class \tcode{chunk_by_view::\exposid{iterator}}
     class @\exposidnc{iterator}@;                                         // \expos


### PR DESCRIPTION
The two should be equivalent. This is consistent with the rest of `<ranges>`.