### PR TITLE
[flat.map.defn] [flat.multimap.defn] Exposition-only markup for "c" and "compare"

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -14702,7 +14702,7 @@ namespace std {
                const mapped_container_type& mapped_cont, const Allocator& a);
 
     explicit flat_map(const key_compare& comp)
-      : c(), compare(comp) { }
+      : \exposid{c}(), \exposid{compare}(comp) { }
     template<class Allocator>
       flat_map(const key_compare& comp, const Allocator& a);
     template<class Allocator>
@@ -14710,7 +14710,7 @@ namespace std {
 
     template<class InputIterator>
       flat_map(InputIterator first, InputIterator last, const key_compare& comp = key_compare())
-        : c(), compare(comp) { insert(first, last); }
+        : \exposid{c}(), \exposid{compare}(comp) { insert(first, last); }
     template<class InputIterator, class Allocator>
       flat_map(InputIterator first, InputIterator last,
                const key_compare& comp, const Allocator& a);
@@ -14731,7 +14731,7 @@ namespace std {
     template<class InputIterator>
       flat_map(sorted_unique_t s, InputIterator first, InputIterator last,
                const key_compare& comp = key_compare())
-        : c(), compare(comp) { insert(s, first, last); }
+        : \exposid{c}(), \exposid{compare}(comp) { insert(s, first, last); }
     template<class InputIterator, class Allocator>
       flat_map(sorted_unique_t, InputIterator first, InputIterator last,
                const key_compare& comp, const Allocator& a);
@@ -14895,8 +14895,8 @@ namespace std {
       { x.swap(y); }
 
   private:
-    containers c;               // \expos
-    key_compare compare;        // \expos
+    containers \exposid{c};               // \expos
+    key_compare \exposid{compare};        // \expos
 
     struct key_equiv {  // \expos
       key_equiv(key_compare c) : comp(c) { }
@@ -15843,7 +15843,7 @@ namespace std {
                     const mapped_container_type& mapped_cont, const Allocator& a);
 
     explicit flat_multimap(const key_compare& comp)
-      : c(), compare(comp) { }
+      : \exposid{c}(), \exposid{compare}(comp) { }
     template<class Allocator>
       flat_multimap(const key_compare& comp, const Allocator& a);
     template<class Allocator>
@@ -15852,7 +15852,7 @@ namespace std {
     template<class InputIterator>
       flat_multimap(InputIterator first, InputIterator last,
                     const key_compare& comp = key_compare())
-        : c(), compare(comp)
+        : \exposid{c}(), \exposid{compare}(comp)
         { insert(first, last); }
     template<class InputIterator, class Allocator>
       flat_multimap(InputIterator first, InputIterator last,
@@ -15874,7 +15874,7 @@ namespace std {
     template<class InputIterator>
       flat_multimap(sorted_equivalent_t s, InputIterator first, InputIterator last,
                     const key_compare& comp = key_compare())
-        : c(), compare(comp) { insert(s, first, last); }
+        : \exposid{c}(), \exposid{compare}(comp) { insert(s, first, last); }
     template<class InputIterator, class Allocator>
       flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
                     const key_compare& comp, const Allocator& a);
@@ -16008,8 +16008,8 @@ namespace std {
       { x.swap(y); }
 
   private:
-    containers c;               // \expos
-    key_compare compare;        // \expos
+    containers \exposid{c};               // \expos
+    key_compare \exposid{compare};        // \expos
   };
 
   template<class KeyContainer, class MappedContainer>


### PR DESCRIPTION
`flat_set` already has the correct `\exposid` markup.

Fixes #5812.