### PR TITLE
[container.adaptors] uses_allocator specializations consistently use "Alloc"

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -13285,9 +13285,8 @@ namespace std {
   inline constexpr sorted_unique_t sorted_unique{};
 
   template<class Key, class T, class Compare, class KeyContainer, class MappedContainer,
-           class Allocator>
-    struct uses_allocator<flat_map<Key, T, Compare, KeyContainer, MappedContainer>,
-                          Allocator>;
+           class Alloc>
+    struct uses_allocator<flat_map<Key, T, Compare, KeyContainer, MappedContainer>, Alloc>;
 
   // \ref{flat.map.erasure}, erasure for \tcode{flat_map}
   template<class Key, class T, class Compare, class KeyContainer, class MappedContainer,
@@ -13304,9 +13303,8 @@ namespace std {
   inline constexpr sorted_equivalent_t sorted_equivalent{};
 
   template<class Key, class T, class Compare, class KeyContainer, class MappedContainer,
-           class Allocator>
-    struct uses_allocator<flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>,
-                          Allocator>;
+           class Alloc>
+    struct uses_allocator<flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>, Alloc>;
 
   // \ref{flat.multimap.erasure}, erasure for \tcode{flat_multimap}
   template<class Key, class T, class Compare, class KeyContainer, class MappedContainer,
@@ -13331,8 +13329,8 @@ namespace std {
   struct sorted_unique_t { explicit sorted_unique_t() = default; };
   inline constexpr sorted_unique_t sorted_unique{};
 
-  template<class Key, class Compare, class KeyContainer, class Allocator>
-    struct uses_allocator<flat_set<Key, Compare, KeyContainer>, Allocator>;
+  template<class Key, class Compare, class KeyContainer, class Alloc>
+    struct uses_allocator<flat_set<Key, Compare, KeyContainer>, Alloc>;
 
   // \ref{flat.set.erasure}, erasure for \tcode{flat_set}
   template<class Key, class Compare, class KeyContainer, class Predicate>
@@ -13346,8 +13344,8 @@ namespace std {
   struct sorted_equivalent_t { explicit sorted_equivalent_t() = default; };
   inline constexpr sorted_equivalent_t sorted_equivalent{};
 
-  template<class Key, class Compare, class KeyContainer, class Allocator>
-    struct uses_allocator<flat_multiset<Key, Compare, KeyContainer>, Allocator>;
+  template<class Key, class Compare, class KeyContainer, class Alloc>
+    struct uses_allocator<flat_multiset<Key, Compare, KeyContainer>, Alloc>;
 
   // \ref{flat.multiset.erasure}, erasure for \tcode{flat_multiset}
   template<class Key, class Compare, class KeyContainer, class Predicate>
@@ -14989,10 +14987,10 @@ namespace std {
         -> flat_map<Key, T, Compare>;
 
   template<class Key, class T, class Compare, class KeyContainer, class MappedContainer,
-            class Allocator>
-    struct uses_allocator<flat_map<Key, T, Compare, KeyContainer, MappedContainer>, Allocator>
-      : bool_constant<uses_allocator_v<KeyContainer, Allocator> &&
-                      uses_allocator_v<MappedContainer, Allocator>> { };
+           class Alloc>
+    struct uses_allocator<flat_map<Key, T, Compare, KeyContainer, MappedContainer>, Alloc>
+      : bool_constant<uses_allocator_v<KeyContainer, Alloc> &&
+                      uses_allocator_v<MappedContainer, Alloc>> { };
 }
 \end{codeblock}
 
@@ -16097,11 +16095,10 @@ namespace std {
         -> flat_multimap<Key, T, Compare>;
 
   template<class Key, class T, class Compare, class KeyContainer, class MappedContainer,
-            class Allocator>
-    struct uses_allocator<flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>,
-                          Allocator>
-      : bool_constant<uses_allocator_v<KeyContainer, Allocator> &&
-                      uses_allocator_v<MappedContainer, Allocator>> { };
+           class Alloc>
+    struct uses_allocator<flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>, Alloc>
+      : bool_constant<uses_allocator_v<KeyContainer, Alloc> &&
+                      uses_allocator_v<MappedContainer, Alloc>> { };
 }
 \end{codeblock}
 
@@ -16587,9 +16584,9 @@ namespace std {
     flat_set(sorted_unique_t, initializer_list<Key>, Compare = Compare())
       -> flat_set<Key, Compare>;
 
-  template<class Key, class Compare, class KeyContainer, class Allocator>
-    struct uses_allocator<flat_set<Key, Compare, KeyContainer>, Allocator>
-      : bool_constant<uses_allocator_v<KeyContainer, Allocator>> { };
+  template<class Key, class Compare, class KeyContainer, class Alloc>
+    struct uses_allocator<flat_set<Key, Compare, KeyContainer>, Alloc>
+      : bool_constant<uses_allocator_v<KeyContainer, Alloc>> { };
 }
 \end{codeblock}
 
@@ -17189,9 +17186,9 @@ namespace std {
   flat_multiset(sorted_equivalent_t, initializer_list<Key>, Compare = Compare())
       -> flat_multiset<Key, Compare>;
 
-  template<class Key, class Compare, class KeyContainer, class Allocator>
-    struct uses_allocator<flat_multiset<Key, Compare, KeyContainer>, Allocator>
-      : bool_constant<uses_allocator_v<KeyContainer, Allocator>> { };
+  template<class Key, class Compare, class KeyContainer, class Alloc>
+    struct uses_allocator<flat_multiset<Key, Compare, KeyContainer>, Alloc>
+      : bool_constant<uses_allocator_v<KeyContainer, Alloc>> { };
 }
 \end{codeblock}
 


### PR DESCRIPTION
This is not intended to trigger (nor un-trigger) any blanket wording; it's purely cosmetic, aligning the parameter names for the flat_foo containers' `uses_allocator` specializations, with the parameter names for stack/queue/priority_queue.

Intuitively, `Alloc` is the more appropriate name because this type is not necessarily something that qualifies as an Allocator; it is the same kind of type as the `Alloc` constructor parameters in [queue.defn] for example.

My understanding is that the old wording's choice to use `Alloc` in one specialization and `Allocator` in another is _not_ motivated by any intentional difference in semantics between the two specializations; it's just a bit of inconsistency that we can patch up editorially.