### PR TITLE
[views.span] Add \exposid for `span`'s `data_` and `size_`

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -17586,8 +17586,8 @@ namespace std {
     constexpr const_reverse_iterator crend() const noexcept { return rend(); }
 
   private:
-    pointer data_;              // \expos
-    size_type size_;            // \expos
+    pointer @\exposid{data_}@;              // \expos
+    size_type @\exposid{size_}@;            // \expos
   };
 
   template<class It, class EndOrSize>
@@ -17660,8 +17660,8 @@ then \tcode{count} is equal to \tcode{extent}.
 
 \pnum
 \effects
-Initializes \tcode{data_} with \tcode{to_address(first)} and
-\tcode{size_} with \tcode{count}.
+Initializes \tcode{\exposid{data_}} with \tcode{to_address(first)} and
+\tcode{\exposid{size_}} with \tcode{count}.
 
 \pnum
 \throws
@@ -17703,8 +17703,8 @@ then \tcode{last - first} is equal to \tcode{extent}.
 
 \pnum
 \effects
-Initializes \tcode{data_} with \tcode{to_address(first)} and
-\tcode{size_} with \tcode{last - first}.
+Initializes \tcode{\exposid{data_}} with \tcode{to_address(first)} and
+\tcode{\exposid{size_}} with \tcode{last - first}.
 
 \pnum
 \throws
@@ -17781,8 +17781,8 @@ then \tcode{ranges::size(r)} is equal to \tcode{extent}.
 
 \pnum
 \effects
-Initializes \tcode{data_} with \tcode{ranges::data(r)} and
-\tcode{size_} with \tcode{ranges::size(r)}.
+Initializes \tcode{\exposid{data_}} with \tcode{ranges::data(r)} and
+\tcode{\exposid{size_}} with \tcode{ranges::size(r)}.
 
 \pnum
 \throws
@@ -18020,7 +18020,7 @@ constexpr size_type size() const noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return size_;}
+Equivalent to: \tcode{return \exposid{size_};}
 \end{itemdescr}
 
 \indexlibrarymember{span}{size_bytes}%
@@ -18100,7 +18100,7 @@ constexpr pointer data() const noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return data_;}
+Equivalent to: \tcode{return \exposid{data_};}
 \end{itemdescr}
 
 \rSec3[span.iterators]{Iterator support}


### PR DESCRIPTION
Currently most of exposition-only names in [containers] are formatted with \exposid, and its absence is already addressed by several PRs. I think `span`'s _`data_`_ and _`size_`_ should also be so formatted for consistency.