### PR TITLE
[meta.type.synop] Make template parameter names start with capital

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -352,10 +352,10 @@ namespace std {
     using @\libglobal{remove_cvref_t}@     = typename remove_cvref<T>::type;
   template<class T>
     using @\libglobal{decay_t}@            = typename decay<T>::type;
-  template<bool b, class T = void>
-    using @\libglobal{enable_if_t}@        = typename enable_if<b, T>::type;
-  template<bool b, class T, class F>
-    using @\libglobal{conditional_t}@      = typename conditional<b, T, F>::type;
+  template<bool B, class T = void>
+    using @\libglobal{enable_if_t}@        = typename enable_if<B, T>::type;
+  template<bool B, class T, class F>
+    using @\libglobal{conditional_t}@      = typename conditional<B, T, F>::type;
   template<class... T>
     using @\libglobal{common_type_t}@      = typename common_type<T...>::type;
   template<class... T>


### PR DESCRIPTION
Changing the name of the bool parameter of enable_if_t and conditional_t from b to B. This increases the consistency of presentation and agrees with the names used in the specification of enable_if and conditional ([meta.trans.other]), as well as the definition of bool_constant.