### PR TITLE
[range.dangling] The `tag` of a `struct` is not a C++ term

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2138,7 +2138,7 @@ else
 \rSec2[range.dangling]{Dangling iterator handling}
 
 \pnum
-The tag type \tcode{dangling} is used together with the template aliases
+The type \tcode{dangling} is used together with the template aliases
 \tcode{borrowed_iterator_t} and \tcode{borrowed_subrange_t}.
 When an algorithm
 that typically returns an iterator into, or a subrange of, a range argument
@@ -2146,7 +2146,7 @@ is called with an rvalue range argument
 that does not model \libconcept{borrowed_range}\iref{range.range},
 the return value possibly refers to a range whose lifetime has ended.
 In such cases,
-the tag type \tcode{dangling} is returned instead of an iterator or subrange.
+the type \tcode{dangling} is returned instead of an iterator or subrange.
 \indexlibraryglobal{dangling}%
 \begin{codeblock}
 namespace std::ranges {


### PR DESCRIPTION
Only in C is the term `tag` defined with respect to `struct`s. Replace the term "tag type" with simply "type" in [range.dangling].