### PR TITLE
[flat.set] [flat.multiset] [flat.map] [flat.multimap] Editorial part of LWG3802

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -14724,71 +14724,75 @@ namespace std {
       mapped_container_type values;
     };
 
-    // \ref{flat.map.cons}, construct/copy/destroy
+    // \ref{flat.map.cons}, constructors
     flat_map() : flat_map(key_compare()) { }
-
-    flat_map(key_container_type key_cont, mapped_container_type mapped_cont);
-    template<class Allocator>
-      flat_map(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
-               const Allocator& a);
-
-    flat_map(sorted_unique_t, key_container_type key_cont, mapped_container_type mapped_cont);
-    template<class Allocator>
-      flat_map(sorted_unique_t, const key_container_type& key_cont,
-               const mapped_container_type& mapped_cont, const Allocator& a);
 
     explicit flat_map(const key_compare& comp)
       : c(), compare(comp) { }
-    template<class Allocator>
-      flat_map(const key_compare& comp, const Allocator& a);
-    template<class Allocator>
-      explicit flat_map(const Allocator& a);
+
+    flat_map(key_container_type key_cont, mapped_container_type mapped_cont);
+    flat_map(sorted_unique_t, key_container_type key_cont, mapped_container_type mapped_cont);
 
     template<class InputIterator>
       flat_map(InputIterator first, InputIterator last, const key_compare& comp = key_compare())
         : c(), compare(comp) { insert(first, last); }
-    template<class InputIterator, class Allocator>
-      flat_map(InputIterator first, InputIterator last,
-               const key_compare& comp, const Allocator& a);
-    template<class InputIterator, class Allocator>
-      flat_map(InputIterator first, InputIterator last, const Allocator& a);
 
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       flat_map(from_range_t fr, R&& rg)
         : flat_map(fr, std::forward<R>(rg), key_compare()) { }
-    template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-      flat_map(from_range_t, R&& rg, const Allocator& a);
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       flat_map(from_range_t, R&& rg, const key_compare& comp)
         : flat_map(comp) { insert_range(std::forward<R>(rg)); }
-    template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-      flat_map(from_range_t, R&& rg, const key_compare& comp, const Allocator& a);
-
     template<class InputIterator>
       flat_map(sorted_unique_t s, InputIterator first, InputIterator last,
                const key_compare& comp = key_compare())
         : c(), compare(comp) { insert(s, first, last); }
-    template<class InputIterator, class Allocator>
-      flat_map(sorted_unique_t, InputIterator first, InputIterator last,
-               const key_compare& comp, const Allocator& a);
-    template<class InputIterator, class Allocator>
-      flat_map(sorted_unique_t, InputIterator first, InputIterator last, const Allocator& a);
 
     flat_map(initializer_list<value_type> il, const key_compare& comp = key_compare())
         : flat_map(il.begin(), il.end(), comp) { }
-    template<class Allocator>
-      flat_map(initializer_list<value_type> il, const key_compare& comp, const Allocator& a);
-    template<class Allocator>
-      flat_map(initializer_list<value_type> il, const Allocator& a);
-
     flat_map(sorted_unique_t s, initializer_list<value_type> il,
              const key_compare& comp = key_compare())
         : flat_map(s, il.begin(), il.end(), comp) { }
-    template<class Allocator>
+
+    // \ref{flat.map.cons.alloc}, constructors with allocators
+    template<class Alloc>
+      explicit flat_map(const Alloc& a);
+
+    template<class Alloc>
+      flat_map(const key_compare& comp, const Alloc& a);
+
+    template<class Alloc>
+      flat_map(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
+               const Alloc& a);
+    template<class Alloc>
+      flat_map(sorted_unique_t, const key_container_type& key_cont,
+               const mapped_container_type& mapped_cont, const Alloc& a);
+
+    template<class InputIterator, class Alloc>
+      flat_map(InputIterator first, InputIterator last, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_map(InputIterator first, InputIterator last,
+               const key_compare& comp, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_map(sorted_unique_t, InputIterator first, InputIterator last, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_map(sorted_unique_t, InputIterator first, InputIterator last,
+               const key_compare& comp, const Alloc& a);
+
+    template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+      flat_map(from_range_t, R&& rg, const Alloc& a);
+    template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+      flat_map(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
+
+    template<class Alloc>
+      flat_map(initializer_list<value_type> il, const Alloc& a);
+    template<class Alloc>
+      flat_map(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
+    template<class Alloc>
+      flat_map(sorted_unique_t, initializer_list<value_type> il, const Alloc& a);
+    template<class Alloc>
       flat_map(sorted_unique_t, initializer_list<value_type> il,
-               const key_compare& comp, const Allocator& a);
-    template<class Allocator>
-      flat_map(sorted_unique_t, initializer_list<value_type> il, const Allocator& a);
+               const key_compare& comp, const Alloc& a);
 
     flat_map& operator=(initializer_list<value_type> il);
 
@@ -15033,30 +15037,6 @@ where $N$ is the value of \tcode{key_cont.size()} before this call.
 
 \indexlibraryctor{flat_map}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_map(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
-           const Allocator& a);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\constraints
-\tcode{uses_allocator_v<key_container_type, Allocator>} is \tcode{true} and
-\tcode{uses_allocator_v<mapped_container_type, Allocator>} is \tcode{true}.
-
-\pnum
-\effects
-Equivalent to \tcode{flat_map(key_cont, mapped_cont)},
-except that \tcode{c.keys} and \tcode{c.values} are constructed with
-uses-allocator construction\iref{allocator.uses.construction}.
-
-\pnum
-\complexity
-Same as \tcode{flat_map(key_cont, mapped_cont)}.
-\end{itemdescr}
-
-\indexlibraryctor{flat_map}%
-\begin{itemdecl}
 flat_map(sorted_unique_t, key_container_type key_cont, mapped_container_type mapped_cont);
 \end{itemdecl}
 
@@ -15072,19 +15052,40 @@ value-initializes \tcode{compare}.
 Constant.
 \end{itemdescr}
 
+\rSec3[flat.map.cons.alloc]{Constructors with allocators}
+
+\pnum
+If \tcode{uses_allocator_v<key_container_type, Alloc>} is \tcode{false}
+or \tcode{uses_allocator_v<mapped_container_type, Alloc>} is \tcode{false}
+the constructors in this subclause shall not participate in overload resolution.
+
 \indexlibraryctor{flat_map}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_map(sorted_unique_t s, const key_container_type& key_cont,
-           const mapped_container_type& mapped_cont, const Allocator& a);
+template<class Alloc>
+  flat_map(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
+           const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\constraints
-\tcode{uses_allocator_v<key_container_type, Allocator>} is \tcode{true} and
-\tcode{uses_allocator_v<mapped_container_type, Allocator>} is \tcode{true}.
+\effects
+Equivalent to \tcode{flat_map(key_cont, mapped_cont)},
+except that \tcode{c.keys} and \tcode{c.values} are constructed with
+uses-allocator construction\iref{allocator.uses.construction}.
 
+\pnum
+\complexity
+Same as \tcode{flat_map(key_cont, mapped_cont)}.
+\end{itemdescr}
+
+\indexlibraryctor{flat_map}%
+\begin{itemdecl}
+template<class Alloc>
+  flat_map(sorted_unique_t s, const key_container_type& key_cont,
+           const mapped_container_type& mapped_cont, const Alloc& a);
+\end{itemdecl}
+
+\begin{itemdescr}
 \pnum
 \effects
 Equivalent to \tcode{flat_map(s, key_cont, mapped_cont)},
@@ -15098,40 +15099,35 @@ Linear.
 
 \indexlibraryctor{flat_map}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_map(const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  explicit flat_map(const Allocator& a);
-template<class InputIterator, class Allocator>
-  flat_map(InputIterator first, InputIterator last, const key_compare& comp, const Allocator& a);
-template<class InputIterator, class Allocator>
-  flat_map(InputIterator first, InputIterator last, const Allocator& a);
-template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-  flat_map(from_range_t, R&& rg, const Allocator& a);
-template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-  flat_map(from_range_t, R&& rg, const key_compare& comp, const Allocator& a);
-template<class InputIterator, class Allocator>
+template<class Alloc>
+  explicit flat_map(const Alloc& a);
+template<class Alloc>
+  flat_map(const key_compare& comp, const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_map(InputIterator first, InputIterator last, const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_map(InputIterator first, InputIterator last, const key_compare& comp, const Alloc& a);
+template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+  flat_map(from_range_t, R&& rg, const Alloc& a);
+template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+  flat_map(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_map(sorted_unique_t, InputIterator first, InputIterator last, const Alloc& a);
+template<class InputIterator, class Alloc>
   flat_map(sorted_unique_t, InputIterator first, InputIterator last,
-           const key_compare& comp, const Allocator& a);
-template<class InputIterator, class Allocator>
-  flat_map(sorted_unique_t, InputIterator first, InputIterator last, const Allocator& a);
-template<class Allocator>
-  flat_map(initializer_list<value_type> il, const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  flat_map(initializer_list<value_type> il, const Allocator& a);
-template<class Allocator>
+           const key_compare& comp, const Alloc& a);
+template<class Alloc>
+  flat_map(initializer_list<value_type> il, const Alloc& a);
+template<class Alloc>
+  flat_map(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
+template<class Alloc>
+  flat_map(sorted_unique_t, initializer_list<value_type> il, const Alloc& a);
+template<class Alloc>
   flat_map(sorted_unique_t, initializer_list<value_type> il,
-           const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  flat_map(sorted_unique_t, initializer_list<value_type> il, const Allocator& a);
+           const key_compare& comp, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\constraints
-\tcode{uses_allocator_v<key_container_type, Allocator} is \tcode{true} and
-\tcode{uses_allocator_v<mapped_container_type, Allocator>} is \tcode{true}.
-
 \pnum
 \effects
 Equivalent to the corresponding non-allocator constructors
@@ -15867,76 +15863,80 @@ namespace std {
       mapped_container_type values;
     };
 
-    // \ref{flat.multimap.cons}, construct/copy/destroy
+    // \ref{flat.multimap.cons}, constructors
     flat_multimap() : flat_multimap(key_compare()) { }
-
-    flat_multimap(key_container_type key_cont, mapped_container_type mapped_cont);
-    template<class Allocator>
-      flat_multimap(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
-                    const Allocator& a);
-
-    flat_multimap(sorted_equivalent_t,
-                  key_container_type key_cont, mapped_container_type mapped_cont);
-    template<class Allocator>
-      flat_multimap(sorted_equivalent_t, const key_container_type& key_cont,
-                    const mapped_container_type& mapped_cont, const Allocator& a);
 
     explicit flat_multimap(const key_compare& comp)
       : c(), compare(comp) { }
-    template<class Allocator>
-      flat_multimap(const key_compare& comp, const Allocator& a);
-    template<class Allocator>
-      explicit flat_multimap(const Allocator& a);
+
+    flat_multimap(key_container_type key_cont, mapped_container_type mapped_cont);
+    flat_multimap(sorted_equivalent_t,
+                  key_container_type key_cont, mapped_container_type mapped_cont);
 
     template<class InputIterator>
       flat_multimap(InputIterator first, InputIterator last,
                     const key_compare& comp = key_compare())
         : c(), compare(comp)
         { insert(first, last); }
-    template<class InputIterator, class Allocator>
-      flat_multimap(InputIterator first, InputIterator last,
-                    const key_compare& comp, const Allocator& a);
-    template<class InputIterator, class Allocator>
-      flat_multimap(InputIterator first, InputIterator last, const Allocator& a);
-
-    template<@\exposconcept{container-compatible-range}@<value_type> R>
-      flat_multimap(from_range_t fr, R&& rg)
-        : flat_multimap(fr, std::forward<R>(rg), key_compare()) { }
-    template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-      flat_multimap(from_range_t, R&& rg, const Allocator& a);
-    template<@\exposconcept{container-compatible-range}@<value_type> R>
-      flat_multimap(from_range_t, R&& rg, const key_compare& comp)
-        : flat_multimap(comp) { insert_range(std::forward<R>(rg)); }
-    template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-      flat_multimap(from_range_t, R&& rg, const key_compare& comp, const Allocator& a);
-
     template<class InputIterator>
       flat_multimap(sorted_equivalent_t s, InputIterator first, InputIterator last,
                     const key_compare& comp = key_compare())
         : c(), compare(comp) { insert(s, first, last); }
-    template<class InputIterator, class Allocator>
-      flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
-                    const key_compare& comp, const Allocator& a);
-    template<class InputIterator, class Allocator>
-      flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
-                    const Allocator& a);
+
+    template<@\exposconcept{container-compatible-range}@<value_type> R>
+      flat_multimap(from_range_t fr, R&& rg)
+        : flat_multimap(fr, std::forward<R>(rg), key_compare()) { }
+    template<@\exposconcept{container-compatible-range}@<value_type> R>
+      flat_multimap(from_range_t, R&& rg, const key_compare& comp)
+        : flat_multimap(comp) { insert_range(std::forward<R>(rg)); }
 
     flat_multimap(initializer_list<value_type> il, const key_compare& comp = key_compare())
         : flat_multimap(il.begin(), il.end(), comp) { }
-    template<class Allocator>
-      flat_multimap(initializer_list<value_type> il, const key_compare& comp,
-                    const Allocator& a);
-    template<class Allocator>
-      flat_multimap(initializer_list<value_type> il, const Allocator& a);
-
     flat_multimap(sorted_equivalent_t s, initializer_list<value_type> il,
                   const key_compare& comp = key_compare())
         : flat_multimap(s, il.begin(), il.end(), comp) { }
-    template<class Allocator>
+
+    // \ref{flat.multimap.cons.alloc}, constructors with allocators
+    template<class Alloc>
+      explicit flat_multimap(const Alloc& a);
+
+    template<class Alloc>
+      flat_multimap(const key_compare& comp, const Alloc& a);
+
+    template<class Alloc>
+      flat_multimap(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
+                    const Alloc& a);
+    template<class Alloc>
+      flat_multimap(sorted_equivalent_t, const key_container_type& key_cont,
+                    const mapped_container_type& mapped_cont, const Alloc& a);
+
+    template<class InputIterator, class Alloc>
+      flat_multimap(InputIterator first, InputIterator last, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_multimap(InputIterator first, InputIterator last,
+                    const key_compare& comp, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
+                    const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
+                    const key_compare& comp, const Alloc& a);
+
+    template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+      flat_multimap(from_range_t, R&& rg, const Alloc& a);
+    template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+      flat_multimap(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
+
+    template<class Alloc>
+      flat_multimap(initializer_list<value_type> il, const Alloc& a);
+    template<class Alloc>
+      flat_multimap(initializer_list<value_type> il, const key_compare& comp,
+                    const Alloc& a);
+    template<class Alloc>
+      flat_multimap(sorted_equivalent_t, initializer_list<value_type> il, const Alloc& a);
+    template<class Alloc>
       flat_multimap(sorted_equivalent_t, initializer_list<value_type> il,
-                    const key_compare& comp, const Allocator& a);
-    template<class Allocator>
-      flat_multimap(sorted_equivalent_t, initializer_list<value_type> il, const Allocator& a);
+                    const key_compare& comp, const Alloc& a);
 
     flat_multimap& operator=(initializer_list<value_type> il);
 
@@ -16134,30 +16134,6 @@ where $N$ is the value of \tcode{key_cont.size()} before this call.
 
 \indexlibraryctor{flat_multimap}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_multimap(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
-                const Allocator& a);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\constraints
-\tcode{uses_allocator_v<key_container_type, Allocator>} is \tcode{true} and
-\tcode{uses_allocator_v<mapped_container_type, Allocator>} is \tcode{true}.
-
-\pnum
-\effects
-Equivalent to \tcode{flat_multimap(key_cont, mapped_cont)},
-except that \tcode{c.keys} and \tcode{c.values} are constructed
-with uses-allocator construction\iref{allocator.uses.construction}.
-
-\pnum
-\complexity
-Same as \tcode{flat_multimap(key_cont, mapped_cont)}.
-\end{itemdescr}
-
-\indexlibraryctor{flat_multimap}%
-\begin{itemdecl}
 flat_multimap(sorted_equivalent_t, key_container_type key_cont, mapped_container_type mapped_cont);
 \end{itemdecl}
 
@@ -16173,19 +16149,40 @@ value-initializes \tcode{compare}.
 Constant.
 \end{itemdescr}
 
+\rSec3[flat.multimap.cons.alloc]{Constructors with allocators}
+
+\pnum
+If \tcode{uses_allocator_v<key_container_type, Alloc>} is \tcode{false}
+or \tcode{uses_allocator_v<mapped_container_type, Alloc>} is \tcode{false}
+the constructors in this subclause shall not participate in overload resolution.
+
 \indexlibraryctor{flat_multimap}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_multimap(sorted_equivalent_t s, const key_container_type& key_cont,
-                const mapped_container_type& mapped_cont, const Allocator& a);
+template<class Alloc>
+  flat_multimap(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
+                const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\constraints
-\tcode{uses_allocator_v<key_container_type, Allocator>} is \tcode{true} and
-\tcode{uses_allocator_v<mapped_container_type, Allocator>} is \tcode{true}.
+\effects
+Equivalent to \tcode{flat_multimap(key_cont, mapped_cont)},
+except that \tcode{c.keys} and \tcode{c.values} are constructed
+with uses-allocator construction\iref{allocator.uses.construction}.
 
+\pnum
+\complexity
+Same as \tcode{flat_multimap(key_cont, mapped_cont)}.
+\end{itemdescr}
+
+\indexlibraryctor{flat_multimap}%
+\begin{itemdecl}
+template<class Allocator>
+  flat_multimap(sorted_equivalent_t s, const key_container_type& key_cont,
+                const mapped_container_type& mapped_cont, const Alloc& a);
+\end{itemdecl}
+
+\begin{itemdescr}
 \pnum
 \effects
 Equivalent to \tcode{flat_multimap(s, key_cont, mapped_cont)},
@@ -16199,42 +16196,37 @@ Linear.
 
 \indexlibraryctor{flat_multimap}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_multimap(const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  explicit flat_multimap(const Allocator& a);
-template<class InputIterator, class Allocator>
+template<class Alloc>
+  explicit flat_multimap(const Alloc& a);
+template<class Alloc>
+  flat_multimap(const key_compare& comp, const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_multimap(InputIterator first, InputIterator last, const Alloc& a);
+template<class InputIterator, class Alloc>
   flat_multimap(InputIterator first, InputIterator last, const key_compare& comp,
-                const Allocator& a);
-template<class InputIterator, class Allocator>
-  flat_multimap(InputIterator first, InputIterator last, const Allocator& a);
-template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-  flat_multimap(from_range_t, R&& rg, const Allocator& a);
-template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-  flat_multimap(from_range_t, R&& rg, const key_compare& comp, const Allocator& a);
-template<class InputIterator, class Allocator>
+                const Alloc& a);
+template<class InputIterator, class Alloc>
   flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
-                const key_compare& comp, const Allocator& a);
-template<class InputIterator, class Allocator>
+                const Alloc& a);
+template<class InputIterator, class Alloc>
   flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
-                const Allocator& a);
-template<class Allocator>
-  flat_multimap(initializer_list<value_type> il, const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  flat_multimap(initializer_list<value_type> il, const Allocator& a);
-template<class Allocator>
+                const key_compare& comp, const Alloc& a);
+template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+  flat_multimap(from_range_t, R&& rg, const Alloc& a);
+template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+  flat_multimap(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
+template<class Alloc>
+  flat_multimap(initializer_list<value_type> il, const Alloc& a);
+template<class Alloc>
+  flat_multimap(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
+template<class Alloc>
+  flat_multimap(sorted_equivalent_t, initializer_list<value_type> il, const Alloc& a);
+template<class Alloc>
   flat_multimap(sorted_equivalent_t, initializer_list<value_type> il,
-                const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  flat_multimap(sorted_equivalent_t, initializer_list<value_type> il, const Allocator& a);
+                const key_compare& comp, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\constraints
-\tcode{uses_allocator_v<key_container_type, Allocator>} is \tcode{true} and
-\tcode{uses_allocator_v<mapped_container_type, Allocator>} is \tcode{true}.
-
 \pnum
 \effects
 Equivalent to the corresponding non-allocator constructors
@@ -16390,69 +16382,73 @@ namespace std {
     // \ref{flat.set.cons}, constructors
     flat_set() : flat_set(key_compare()) { }
 
-    explicit flat_set(container_type cont);
-    template<class Allocator>
-      flat_set(const container_type& cont, const Allocator& a);
-
-    flat_set(sorted_unique_t, container_type cont)
-      : @\exposid{c}@(std::move(cont)), @\exposid{compare}@(key_compare()) { }
-    template<class Allocator>
-      flat_set(sorted_unique_t, const container_type& cont, const Allocator& a);
-
     explicit flat_set(const key_compare& comp)
       : @\exposid{c}@(), @\exposid{compare}@(comp) { }
-    template<class Allocator>
-      flat_set(const key_compare& comp, const Allocator& a);
-    template<class Allocator>
-      explicit flat_set(const Allocator& a);
+
+    explicit flat_set(container_type cont);
+    flat_set(sorted_unique_t, container_type cont)
+      : @\exposid{c}@(std::move(cont)), @\exposid{compare}@(key_compare()) { }
 
     template<class InputIterator>
       flat_set(InputIterator first, InputIterator last, const key_compare& comp = key_compare())
         : @\exposid{c}@(), @\exposid{compare}@(comp)
         { insert(first, last); }
-    template<class InputIterator, class Allocator>
-      flat_set(InputIterator first, InputIterator last,
-               const key_compare& comp, const Allocator& a);
-    template<class InputIterator, class Allocator>
-      flat_set(InputIterator first, InputIterator last, const Allocator& a);
-
-    template<@\exposconcept{container-compatible-range}@<value_type> R>
-      flat_set(from_range_t fr, R&& rg)
-        : flat_set(fr, std::forward<R>(rg), key_compare()) { }
-    template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-      flat_set(from_range_t, R&& rg, const Allocator& a);
-    template<@\exposconcept{container-compatible-range}@<value_type> R>
-      flat_set(from_range_t, R&& rg, const key_compare& comp)
-        : flat_set(comp)
-        { insert_range(std::forward<R>(rg)); }
-    template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-       flat_set(from_range_t, R&& rg, const key_compare& comp, const Allocator& a);
-
     template<class InputIterator>
       flat_set(sorted_unique_t, InputIterator first, InputIterator last,
                const key_compare& comp = key_compare())
         : @\exposid{c}@(first, last), @\exposid{compare}@(comp) { }
-    template<class InputIterator, class Allocator>
-      flat_set(sorted_unique_t, InputIterator first, InputIterator last,
-               const key_compare& comp, const Allocator& a);
-    template<class InputIterator, class Allocator>
-      flat_set(sorted_unique_t, InputIterator first, InputIterator last, const Allocator& a);
+
+    template<@\exposconcept{container-compatible-range}@<value_type> R>
+      flat_set(from_range_t fr, R&& rg)
+        : flat_set(fr, std::forward<R>(rg), key_compare()) { }
+    template<@\exposconcept{container-compatible-range}@<value_type> R>
+      flat_set(from_range_t, R&& rg, const key_compare& comp)
+        : flat_set(comp)
+        { insert_range(std::forward<R>(rg)); }
 
     flat_set(initializer_list<value_type> il, const key_compare& comp = key_compare())
         : flat_set(il.begin(), il.end(), comp) { }
-    template<class Allocator>
-      flat_set(initializer_list<value_type> il, const key_compare& comp, const Allocator& a);
-    template<class Allocator>
-      flat_set(initializer_list<value_type> il, const Allocator& a);
-
     flat_set(sorted_unique_t s, initializer_list<value_type> il,
              const key_compare& comp = key_compare())
         : flat_set(s, il.begin(), il.end(), comp) { }
-    template<class Allocator>
+
+    // \ref{flat.set.cons.alloc}, constructors with allocators
+    template<class Alloc>
+      explicit flat_set(const Alloc& a);
+
+    template<class Alloc>
+      flat_set(const key_compare& comp, const Alloc& a);
+
+    template<class Alloc>
+      flat_set(const container_type& cont, const Alloc& a);
+    template<class Alloc>
+      flat_set(sorted_unique_t, const container_type& cont, const Alloc& a);
+
+    template<class InputIterator, class Alloc>
+      flat_set(InputIterator first, InputIterator last, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_set(InputIterator first, InputIterator last,
+               const key_compare& comp, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_set(sorted_unique_t, InputIterator first, InputIterator last, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_set(sorted_unique_t, InputIterator first, InputIterator last,
+               const key_compare& comp, const Alloc& a);
+
+    template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+      flat_set(from_range_t, R&& rg, const Alloc& a);
+    template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+       flat_set(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
+
+    template<class Alloc>
+      flat_set(initializer_list<value_type> il, const Alloc& a);
+    template<class Alloc>
+      flat_set(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
+    template<class Alloc>
       flat_set(sorted_unique_t, initializer_list<value_type> il,
-               const key_compare& comp, const Allocator& a);
-    template<class Allocator>
-      flat_set(sorted_unique_t, initializer_list<value_type> il, const Allocator& a);
+               const key_compare& comp, const Alloc& a);
+    template<class Alloc>
+      flat_set(sorted_unique_t, initializer_list<value_type> il, const Alloc& a);
 
     flat_set& operator=(initializer_list<value_type>);
 
@@ -16615,17 +16611,19 @@ Linear in $N$ if \tcode{cont} is sorted with respect to \exposid{compare} and
 otherwise $N \log N$, where $N$ is the value of \tcode{cont.size()} before this call.
 \end{itemdescr}
 
+\rSec3[flat.set.cons.alloc]{Constructors with allocators}
+
+\pnum
+If \tcode{uses_allocator_v<container_type, Alloc>} is \tcode{false}
+the constructors in this subclause shall not participate in overload resolution.
+
 \indexlibraryctor{flat_set}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_set(const container_type& cont, const Allocator& a);
+template<class Alloc>
+  flat_set(const container_type& cont, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\constraints
-\tcode{uses_allocator_v<container_type, Allocator>} is \tcode{true}.
-
 \pnum
 \effects
 Equivalent to \tcode{flat_set(cont)},
@@ -16639,15 +16637,11 @@ Same as \tcode{flat_set(cont)}.
 
 \indexlibraryctor{flat_set}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_set(sorted_unique_t s, const container_type& cont, const Allocator& a);
+template<class Alloc>
+  flat_set(sorted_unique_t s, const container_type& cont, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\constraints
-\tcode{uses_allocator_v<container_type, Allocator>} is \tcode{true}.
-
 \pnum
 \effects
 Equivalent to \tcode{flat_set(s, cont)},
@@ -16661,39 +16655,35 @@ Linear.
 
 \indexlibraryctor{flat_set}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_set(const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  explicit flat_set(const Allocator& a);
-template<class InputIterator, class Allocator>
-  flat_set(InputIterator first, InputIterator last, const key_compare& comp, const Allocator& a);
-template<class InputIterator, class Allocator>
-  flat_set(InputIterator first, InputIterator last, const Allocator& a);
-template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-  flat_set(from_range_t, R&& rg, const Allocator& a);
-template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-  flat_set(from_range_t, R&& rg, const key_compare& comp, const Allocator& a);
-template<class InputIterator, class Allocator>
+template<class Alloc>
+  explicit flat_set(const Alloc& a);
+template<class Alloc>
+  flat_set(const key_compare& comp, const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_set(InputIterator first, InputIterator last, const key_compare& comp, const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_set(InputIterator first, InputIterator last, const Alloc& a);
+template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+  flat_set(from_range_t, R&& rg, const Alloc& a);
+template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+  flat_set(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_set(sorted_unique_t, InputIterator first, InputIterator last, const Alloc& a);
+template<class InputIterator, class Alloc>
   flat_set(sorted_unique_t, InputIterator first, InputIterator last,
-           const key_compare& comp, const Allocator& a);
-template<class InputIterator, class Allocator>
-  flat_set(sorted_unique_t, InputIterator first, InputIterator last, const Allocator& a);
-template<class Allocator>
-  flat_set(initializer_list<value_type> il, const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  flat_set(initializer_list<value_type> il, const Allocator& a);
-template<class Allocator>
+           const key_compare& comp, const Alloc& a);
+template<class Alloc>
+  flat_set(initializer_list<value_type> il, const Alloc& a);
+template<class Alloc>
+  flat_set(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
+template<class Alloc>
   flat_set(sorted_unique_t, initializer_list<value_type> il,
-           const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  flat_set(sorted_unique_t, initializer_list<value_type> il, const Allocator& a);
+           const key_compare& comp, const Alloc& a);
+template<class Alloc>
+  flat_set(sorted_unique_t, initializer_list<value_type> il, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\constraints
-\tcode{uses_allocator_v<container_type, Allocator>} is \tcode{true}.
-
 \pnum
 \effects
 Equivalent to the corresponding non-allocator constructors
@@ -16990,72 +16980,75 @@ namespace std {
     // \ref{flat.multiset.cons}, constructors
     flat_multiset() : flat_multiset(key_compare()) { }
 
-    explicit flat_multiset(container_type cont);
-    template<class Allocator>
-      flat_multiset(const container_type& cont, const Allocator& a);
-
-    flat_multiset(sorted_equivalent_t, container_type cont)
-      : @\exposid{c}@(std::move(cont)), @\exposid{compare}@(key_compare()) { }
-    template<class Allocator>
-      flat_multiset(sorted_equivalent_t, const container_type&, const Allocator& a);
-
     explicit flat_multiset(const key_compare& comp)
       : @\exposid{c}@(), @\exposid{compare}@(comp) { }
-    template<class Allocator>
-      flat_multiset(const key_compare& comp, const Allocator& a);
-    template<class Allocator>
-      explicit flat_multiset(const Allocator& a);
+
+    explicit flat_multiset(container_type cont);
+    flat_multiset(sorted_equivalent_t, container_type cont)
+      : @\exposid{c}@(std::move(cont)), @\exposid{compare}@(key_compare()) { }
 
     template<class InputIterator>
       flat_multiset(InputIterator first, InputIterator last,
                     const key_compare& comp = key_compare())
         : @\exposid{c}@(), @\exposid{compare}@(comp)
         { insert(first, last); }
-    template<class InputIterator, class Allocator>
-      flat_multiset(InputIterator first, InputIterator last,
-                    const key_compare& comp, const Allocator& a);
-    template<class InputIterator, class Allocator>
-      flat_multiset(InputIterator first, InputIterator last, const Allocator& a);
-
-    template<@\exposconcept{container-compatible-range}@<value_type> R>
-      flat_multiset(from_range_t fr, R&& rg)
-        : flat_multiset(fr, std::forward<R>(rg), key_compare()) { }
-    template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-      flat_multiset(from_range_t, R&& rg, const Allocator& a);
-    template<@\exposconcept{container-compatible-range}@<value_type> R>
-      flat_multiset(from_range_t, R&& rg, const key_compare& comp)
-        : flat_multiset(comp)
-        { insert_range(std::forward<R>(rg)); }
-    template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-      flat_multiset(from_range_t, R&& rg, const key_compare& comp, const Allocator& a);
-
     template<class InputIterator>
       flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
                     const key_compare& comp = key_compare())
         : @\exposid{c}@(first, last), @\exposid{compare}@(comp) { }
-    template<class InputIterator, class Allocator>
-      flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
-                    const key_compare& comp, const Allocator& a);
-    template<class InputIterator, class Allocator>
-      flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
-                    const Allocator& a);
+
+    template<@\exposconcept{container-compatible-range}@<value_type> R>
+      flat_multiset(from_range_t fr, R&& rg)
+        : flat_multiset(fr, std::forward<R>(rg), key_compare()) { }
+    template<@\exposconcept{container-compatible-range}@<value_type> R>
+      flat_multiset(from_range_t, R&& rg, const key_compare& comp)
+        : flat_multiset(comp)
+        { insert_range(std::forward<R>(rg)); }
 
     flat_multiset(initializer_list<value_type> il, const key_compare& comp = key_compare())
       : flat_multiset(il.begin(), il.end(), comp) { }
-    template<class Allocator>
-      flat_multiset(initializer_list<value_type> il, const key_compare& comp,
-                    const Allocator& a);
-    template<class Allocator>
-      flat_multiset(initializer_list<value_type> il, const Allocator& a);
-
     flat_multiset(sorted_equivalent_t s, initializer_list<value_type> il,
                   const key_compare& comp = key_compare())
         : flat_multiset(s, il.begin(), il.end(), comp) { }
-    template<class Allocator>
+
+    // \ref{flat.multiset.cons.alloc}, constructors with allocators
+    template<class Alloc>
+      explicit flat_multiset(const Alloc& a);
+
+    template<class Alloc>
+      flat_multiset(const key_compare& comp, const Alloc& a);
+
+    template<class Alloc>
+      flat_multiset(const container_type& cont, const Alloc& a);
+    template<class Alloc>
+      flat_multiset(sorted_equivalent_t, const container_type&, const Alloc& a);
+
+    template<class InputIterator, class Alloc>
+      flat_multiset(InputIterator first, InputIterator last, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_multiset(InputIterator first, InputIterator last,
+                    const key_compare& comp, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
+                    const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
+                    const key_compare& comp, const Alloc& a);
+
+    template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+      flat_multiset(from_range_t, R&& rg, const Alloc& a);
+    template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+      flat_multiset(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
+
+    template<class Alloc>
+      flat_multiset(initializer_list<value_type> il, const Alloc& a);
+    template<class Alloc>
+      flat_multiset(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
+    template<class Alloc>
       flat_multiset(sorted_equivalent_t, initializer_list<value_type> il,
-                    const key_compare& comp, const Allocator& a);
-    template<class Allocator>
-      flat_multiset(sorted_equivalent_t, initializer_list<value_type> il, const Allocator& a);
+                    const key_compare& comp, const Alloc& a);
+    template<class Alloc>
+      flat_multiset(sorted_equivalent_t, initializer_list<value_type> il, const Alloc& a);
 
     flat_multiset& operator=(initializer_list<value_type>);
 
@@ -17215,17 +17208,19 @@ Linear in $N$ if \tcode{cont} is sorted with respect to \exposid{compare} and
 otherwise $N \log N$, where $N$ is the value of \tcode{cont.size()} before this call.
 \end{itemdescr}
 
+\rSec3[flat.multiset.cons.alloc]{Constructors with allocators}
+
+\pnum
+If \tcode{uses_allocator_v<container_type, Alloc>} is \tcode{false}
+the constructors in this subclause shall not participate in overload resolution.
+
 \indexlibraryctor{flat_multiset}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_multiset(const container_type& cont, const Allocator& a);
+template<class Alloc>
+  flat_multiset(const container_type& cont, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\constraints
-\tcode{uses_allocator_v<container_type, Allocator>} is \tcode{true}.
-
 \pnum
 \effects
 Equivalent to \tcode{flat_multiset(cont)},
@@ -17239,15 +17234,11 @@ Same as \tcode{flat_multiset(cont)}.
 
 \indexlibraryctor{flat_multiset}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_multiset(sorted_equivalent_t s, const container_type& cont, const Allocator& a);
+template<class Alloc>
+  flat_multiset(sorted_equivalent_t s, const container_type& cont, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\constraints
-\tcode{uses_allocator_v<container_type, Allocator>} is \tcode{true}.
-
 \pnum
 \effects
 Equivalent to \tcode{flat_multiset(s, cont)},
@@ -17261,40 +17252,36 @@ Linear.
 
 \indexlibraryctor{flat_multiset}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_multiset(const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  explicit flat_multiset(const Allocator& a);
-template<class InputIterator, class Allocator>
+template<class Alloc>
+  explicit flat_multiset(const Alloc& a);
+template<class Alloc>
+  flat_multiset(const key_compare& comp, const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_multiset(InputIterator first, InputIterator last, const Alloc& a);
+template<class InputIterator, class Alloc>
   flat_multiset(InputIterator first, InputIterator last,
-                const key_compare& comp, const Allocator& a);
-template<class InputIterator, class Allocator>
-  flat_multiset(InputIterator first, InputIterator last, const Allocator& a);
-template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-  flat_multiset(from_range_t, R&& rg, const Allocator& a);
-template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-  flat_multiset(from_range_t, R&& rg, const key_compare& comp, const Allocator& a);
-template<class InputIterator, class Allocator>
+                const key_compare& comp, const Alloc& a);
+template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+  flat_multiset(from_range_t, R&& rg, const Alloc& a);
+template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+  flat_multiset(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
+template<class InputIterator, class Alloc>
   flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
-                const key_compare& comp, const Allocator& a);
-template<class InputIterator, class Allocator>
-  flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last, const Allocator& a);
-template<class Allocator>
-  flat_multiset(initializer_list<value_type> il, const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  flat_multiset(initializer_list<value_type> il, const Allocator& a);
-template<class Allocator>
+                const key_compare& comp, const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last, const Alloc& a);
+template<class Alloc>
+  flat_multiset(initializer_list<value_type> il, const Alloc& a);
+template<class Alloc>
+  flat_multiset(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
+template<class Alloc>
+  flat_multiset(sorted_equivalent_t, initializer_list<value_type> il, const Alloc& a);
+template<class Alloc>
   flat_multiset(sorted_equivalent_t, initializer_list<value_type> il,
-                const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  flat_multiset(sorted_equivalent_t, initializer_list<value_type> il, const Allocator& a);
+                const key_compare& comp, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\constraints
-\tcode{uses_allocator_v<container_type, Allocator>} is \tcode{true}.
-
 \pnum
 \effects
 Equivalent to the corresponding non-allocator constructors


### PR DESCRIPTION
In LWG3802 I wrote:

> (B) Almost certainly the Allocator parameter should be named Alloc instead,
> and there should be a separate "Constructors with allocators" section with
> wording similar to 24.6.7.3 [priqueue.cons.alloc] explaining that these
> ctors don't participate in overload resolution unless
> `uses_allocator_v<KeyContainer, Alloc> && uses_allocator_v<MappedContainer, Alloc>`.

This is that change. It is intended to be purely editorial (although possibly major/controversial). Specifically this commit is *not* intended to change any signatures, add or remove any signatures, nor trigger/untrigger any blanket wording based on the name of the `Allocator`/`Alloc` parameter.  If you see anything non-editorial, please call it out, as it's probably a typo on my part.

This harmonizes the flat container adaptors' organization with `{stack,queue,priqueue}.cons.alloc`.
If adopted, I expect this will also make the resolutions for [LWG 3802](https://wg21.link/lwg3802), [LWG 3803](https://wg21.link/lwg3803), and [LWG 3804](https://wg21.link/lwg3804) easier to understand and apply.

I've got proposed wording for the functional part of LWG3802, based on top of this patch; see that (non-editorial) wording here: https://github.com/Quuxplusone/draft/commit/f43c4c3002f26c5baee16c3c456a013bd01227dc