### PR TITLE
[flat.map] s/compare/key_comp()/

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -14985,7 +14985,7 @@ sorts the range \range{begin()}{end()} with respect to \tcode{value_comp()}; and
 finally erases the duplicate elements as if by:
 \begin{codeblock}
 auto zv = ranges::zip_view(c.keys, c.values);
-auto it = ranges::unique(zv, key_equiv(compare)).begin();
+auto it = ranges::unique(zv, key_equiv(key_comp())).begin();
 auto dist = distance(zv.begin(), it);
 c.keys.erase(c.keys.begin() + dist, c.keys.end());
 c.values.erase(c.values.begin() + dist, c.values.end());
@@ -15300,7 +15300,7 @@ the sorted range of pre-existing elements into a single sorted range; and
 finally erases the duplicate elements as if by:
 \begin{codeblock}
 auto zv = ranges::zip_view(c.keys, c.values);
-auto it = ranges::unique(zv, key_equiv(compare)).begin();
+auto it = ranges::unique(zv, key_equiv(key_comp())).begin();
 auto dist = distance(zv.begin(), it);
 c.keys.erase(c.keys.begin() + dist, c.keys.end());
 c.values.erase(c.values.begin() + dist, c.values.end());
@@ -15339,7 +15339,7 @@ the sorted range of pre-existing elements into a single sorted range; and
 finally erases the duplicate elements as if by:
 \begin{codeblock}
 auto zv = ranges::zip_view(c.keys, c.values);
-auto it = ranges::unique(zv, key_equiv(compare)).begin();
+auto it = ranges::unique(zv, key_equiv(key_comp())).begin();
 auto dist = distance(zv.begin(), it);
 c.keys.erase(c.keys.begin() + dist, c.keys.end());
 c.values.erase(c.values.begin() + dist, c.values.end());
@@ -15377,7 +15377,7 @@ the sorted range of pre-existing elements into a single sorted range; and
 finally erases the duplicate elements as if by:
 \begin{codeblock}
 auto zv = ranges::zip_view(c.keys, c.values);
-auto it = ranges::unique(zv, key_equiv(compare)).begin();
+auto it = ranges::unique(zv, key_equiv(key_comp())).begin();
 auto dist = distance(zv.begin(), it);
 c.keys.erase(c.keys.begin() + dist, c.keys.end());
 c.values.erase(c.values.begin() + dist, c.values.end());


### PR DESCRIPTION
It looks to me as if the identifier `compare` is not defined in these scopes.

(I also think `key_equiv` should be replaced throughout with `@\exposid{key-equiv}@`, but exposid markup is an orthogonal issue with discussion in #5812. I _also_ think the `key_equiv(key_compare)` ctor should be `explicit`, but that's purely stylistic AFAICT.)