### PR TITLE
[ratio.ratio] Use defined function for sign

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -2498,7 +2498,7 @@ where \tcode{gcd} represents the greatest common divisor of the absolute values 
 \tcode{N} and \tcode{D}:
 
 \begin{itemize}
-\item \tcode{num} shall have the value \tcode{sign(N) * sign(D) * abs(N) / gcd}.
+\item \tcode{num} shall have the value \tcode{$\operatorname{sgn}(\tcode{N})$ * $\operatorname{sgn}(\tcode{D})$ * abs(N) / gcd}.
 \item \tcode{den} shall have the value \tcode{abs(D) / gcd}.
 \end{itemize}
 


### PR DESCRIPTION
Resolves #5879.
Before and after:
![1667143015](https://user-images.githubusercontent.com/21071787/198886486-84d3bd80-67fa-4ecb-b693-17b0073be32e.png)
![1667143022](https://user-images.githubusercontent.com/21071787/198886488-de4eeb6e-fe58-4b8e-a751-3206b0cc543f.png)

Is it OK to only use math font on the relevant subexpressions?