### PR TITLE
[climits.syn] Correct note about types of macros

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -1744,8 +1744,10 @@ namespace std {
 The header \libheader{climits} defines all macros the same as
 the C standard library header \libheader{limits.h}.
 \begin{note}
-The types of the constants defined by macros in \libheader{climits} are not
-required to match the types to which the macros refer.
+Except for \tcode{CHAR_BIT}, the types of the constants defined by macros in
+\libheader{climits} that refer to types of integer conversion rank less than
+that of \tcode{int} are the types obtained by the integral
+promotions\iref{conv.prom}.
 \end{note}
 
 \xrefc{5.2.4.2.1}


### PR DESCRIPTION
This note was added apparently as a response to LWG 416 (https://cplusplus.github.io/LWG/issue416). However, the submitter of that issue misunderstood the C standard. The required types are not the types that would be produced by an unadorned integer literal, but rather those produced by the integer promotions. Thus, only the macros for (signed|unsigned)? char and (unsigned)? will have a different type. And this is what actual implementations do: https://godbolt.org/z/5E1MojhGh.

Accordingly, the note, as currently written, is at best misleading, because it implies that all the macros may have types that don't match.