### PR TITLE
[flat.set] [flat.multiset] Use value_type, not key_type

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -16402,23 +16402,23 @@ namespace std {
     template<class InputIterator, class Allocator>
       flat_set(sorted_unique_t, InputIterator first, InputIterator last, const Allocator& a);
 
-    flat_set(initializer_list<key_type> il, const key_compare& comp = key_compare())
+    flat_set(initializer_list<value_type> il, const key_compare& comp = key_compare())
         : flat_set(il.begin(), il.end(), comp) { }
     template<class Allocator>
-      flat_set(initializer_list<key_type> il, const key_compare& comp, const Allocator& a);
+      flat_set(initializer_list<value_type> il, const key_compare& comp, const Allocator& a);
     template<class Allocator>
-      flat_set(initializer_list<key_type> il, const Allocator& a);
+      flat_set(initializer_list<value_type> il, const Allocator& a);
 
-    flat_set(sorted_unique_t s, initializer_list<key_type> il,
+    flat_set(sorted_unique_t s, initializer_list<value_type> il,
              const key_compare& comp = key_compare())
         : flat_set(s, il.begin(), il.end(), comp) { }
     template<class Allocator>
-      flat_set(sorted_unique_t, initializer_list<key_type> il,
+      flat_set(sorted_unique_t, initializer_list<value_type> il,
                const key_compare& comp, const Allocator& a);
     template<class Allocator>
-      flat_set(sorted_unique_t, initializer_list<key_type> il, const Allocator& a);
+      flat_set(sorted_unique_t, initializer_list<value_type> il, const Allocator& a);
 
-    flat_set& operator=(initializer_list<key_type>);
+    flat_set& operator=(initializer_list<value_type>);
 
     // iterators
     iterator               begin() noexcept;
@@ -16464,9 +16464,9 @@ namespace std {
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       void insert_range(R&& rg);
 
-    void insert(initializer_list<key_type> il)
+    void insert(initializer_list<value_type> il)
       { insert(il.begin(), il.end()); }
-    void insert(sorted_unique_t s, initializer_list<key_type> il)
+    void insert(sorted_unique_t s, initializer_list<value_type> il)
       { insert(s, il.begin(), il.end()); }
 
     container_type extract() &&;
@@ -16643,14 +16643,14 @@ template<class InputIterator, class Allocator>
 template<class InputIterator, class Allocator>
   flat_set(sorted_unique_t, InputIterator first, InputIterator last, const Allocator& a);
 template<class Allocator>
-  flat_set(initializer_list<key_type> il, const key_compare& comp, const Allocator& a);
+  flat_set(initializer_list<value_type> il, const key_compare& comp, const Allocator& a);
 template<class Allocator>
-  flat_set(initializer_list<key_type> il, const Allocator& a);
+  flat_set(initializer_list<value_type> il, const Allocator& a);
 template<class Allocator>
-  flat_set(sorted_unique_t, initializer_list<key_type> il,
+  flat_set(sorted_unique_t, initializer_list<value_type> il,
            const key_compare& comp, const Allocator& a);
 template<class Allocator>
-  flat_set(sorted_unique_t, initializer_list<key_type> il, const Allocator& a);
+  flat_set(sorted_unique_t, initializer_list<value_type> il, const Allocator& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -17004,23 +17004,24 @@ namespace std {
       flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
                     const Allocator& a);
 
-    flat_multiset(initializer_list<key_type> il, const key_compare& comp = key_compare())
+    flat_multiset(initializer_list<value_type> il, const key_compare& comp = key_compare())
       : flat_multiset(il.begin(), il.end(), comp) { }
     template<class Allocator>
-      flat_multiset(initializer_list<key_type> il, const key_compare& comp, const Allocator& a);
+      flat_multiset(initializer_list<value_type> il, const key_compare& comp,
+                    const Allocator& a);
     template<class Allocator>
-      flat_multiset(initializer_list<key_type> il, const Allocator& a);
+      flat_multiset(initializer_list<value_type> il, const Allocator& a);
 
-    flat_multiset(sorted_equivalent_t s, initializer_list<key_type> il,
+    flat_multiset(sorted_equivalent_t s, initializer_list<value_type> il,
                   const key_compare& comp = key_compare())
         : flat_multiset(s, il.begin(), il.end(), comp) { }
     template<class Allocator>
-      flat_multiset(sorted_equivalent_t, initializer_list<key_type> il,
+      flat_multiset(sorted_equivalent_t, initializer_list<value_type> il,
                     const key_compare& comp, const Allocator& a);
     template<class Allocator>
-      flat_multiset(sorted_equivalent_t, initializer_list<key_type> il, const Allocator& a);
+      flat_multiset(sorted_equivalent_t, initializer_list<value_type> il, const Allocator& a);
 
-    flat_multiset& operator=(initializer_list<key_type>);
+    flat_multiset& operator=(initializer_list<value_type>);
 
     // iterators
     iterator               begin() noexcept;
@@ -17064,9 +17065,9 @@ namespace std {
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       void insert_range(R&& rg);
 
-    void insert(initializer_list<key_type> il)
+    void insert(initializer_list<value_type> il)
       { insert(il.begin(), il.end()); }
-    void insert(sorted_equivalent_t s, initializer_list<key_type> il)
+    void insert(sorted_equivalent_t s, initializer_list<value_type> il)
       { insert(s, il.begin(), il.end()); }
 
     container_type extract() &&;
@@ -17243,14 +17244,14 @@ template<class InputIterator, class Allocator>
 template<class InputIterator, class Allocator>
   flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last, const Allocator& a);
 template<class Allocator>
-  flat_multiset(initializer_list<key_type> il, const key_compare& comp, const Allocator& a);
+  flat_multiset(initializer_list<value_type> il, const key_compare& comp, const Allocator& a);
 template<class Allocator>
-  flat_multiset(initializer_list<key_type> il, const Allocator& a);
+  flat_multiset(initializer_list<value_type> il, const Allocator& a);
 template<class Allocator>
-  flat_multiset(sorted_equivalent_t, initializer_list<key_type> il,
+  flat_multiset(sorted_equivalent_t, initializer_list<value_type> il,
                 const key_compare& comp, const Allocator& a);
 template<class Allocator>
-  flat_multiset(sorted_equivalent_t, initializer_list<key_type> il, const Allocator& a);
+  flat_multiset(sorted_equivalent_t, initializer_list<value_type> il, const Allocator& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -17275,11 +17276,11 @@ template<class... Args> iterator emplace(Args&&... args);
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{is_constructible_v<key_type, Args...>} is \tcode{true}.
+\tcode{is_constructible_v<value_type, Args...>} is \tcode{true}.
 
 \pnum
 \effects
-First, initializes an object \tcode{t} of type \tcode{key_type}
+First, initializes an object \tcode{t} of type \tcode{value_type}
 with \tcode{std::forward<Args>(args)...},
 then inserts \tcode{t} as if by:
 \begin{codeblock}


### PR DESCRIPTION
For consistency with the other `set`, `unordered_set` containers. `key_type` is a synonym for `value_type`, and there's no reason the flat containers need to depart from existing practice here.