### PR TITLE
[execpol.unseq] Fix inconsistent indent

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -13417,6 +13417,7 @@ if the invocation of an element access function exits via an exception,
 class execution::unsequenced_policy { @\unspec@ };
 \end{itemdecl}
 
+\begin{itemdescr}
 \pnum
 The class \tcode{unsequenced_policy} is an execution policy type
 used as a unique type to disambiguate parallel algorithm overloading and
@@ -13429,6 +13430,7 @@ During the execution of a parallel algorithm with
 the \tcode{execution::unsequenced_policy} policy,
 if the invocation of an element access function exits via an exception,
 \tcode{terminate} is invoked\iref{except.terminate}.
+\end{itemdescr}
 
 \rSec2[execpol.objects]{Execution policy objects}
 


### PR DESCRIPTION
I have visually checked with [eel](http://eel.is/c++draft/execpol#unseq) and fixed the inconsistencies in the code, but have not built and checked.