### PR TITLE
[time.format] use basic_ostringstream<charT> instead of ostringstream

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -10787,7 +10787,7 @@ A \tcode{\%} character.
 \pnum
 If the \fmtgrammarterm{chrono-specs} is omitted,
 the chrono object is formatted
-as if by streaming it to \tcode{std::ostringstream os}
+as if by streaming it to \tcode{basic_ostring\-stream<charT> os}
 with the formatting locale imbued
 and copying \tcode{os.str()} through the output iterator of the context
 with additional padding and adjustments as specified by the format specifiers.


### PR DESCRIPTION
This seems editorial, because if `charT` is not `char` then `os_str()` cannot be written to the output without widening it, so the current spec isn't implementable. The intention is to use a stringstream to build up the result then write it out, but there's no reason to do that as a narrow string then widen it, so clearly it should be a stringstream of the correct character type. This was confirmed by @vitaut on the LWG reflector, and matches what all implementations do.

The hyphenation hint is needed to fix an overfull hbox.

