### PR TITLE
[time.clock.system.nonmembers], [time.zone.zonedtime.nonmembers] add <charT>

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -2717,7 +2717,7 @@ template<class charT, class traits, class Duration>
 \effects
 Equivalent to:
 \begin{codeblock}
-return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@("{:L%F %T}"), tp);
+return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:L%F %T}"), tp);
 \end{codeblock}
 
 \pnum
@@ -10100,7 +10100,7 @@ template<class charT, class traits, class Duration, class TimeZonePtr>
 \effects
 Equivalent to:
 \begin{codeblock}
-return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@("{:L%F %T %Z}"), t);
+return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:L%F %T %Z}"), t);
 \end{codeblock}
 \end{itemdescr}
 


### PR DESCRIPTION
It doesn't mean anything to use `STATICALLY-WIDEN` withOUT a template argument list.