### PR TITLE
Three editorial fixes re "X means that Y"

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -883,7 +883,7 @@ and user specializations of \tcode{allocator<T>} are not instantiated:
 \item
 \tcode{T} is \defnx{\oldconcept{DefaultInsertable} into \tcode{X}}
 {\oldconceptname{DefaultInsertable} into X@\oldconcept{DefaultInsertable} into \tcode{X}}
-means that the following expression is well-formed:
+if the following expression is well-formed:
 \begin{codeblock}
 allocator_traits<A>::construct(m, p)
 \end{codeblock}
@@ -900,7 +900,7 @@ allocated within \tcode{X}.
 \item
 \tcode{T} is \defnx{\oldconcept{MoveInsertable} into \tcode{X}}
 {\oldconceptname{MoveInsertable} into X@\oldconcept{MoveInsertable} into \tcode{X}}
-means that the following expression
+if the following expression
 is well-formed:
 \begin{codeblock}
 allocator_traits<A>::construct(m, p, rv)
@@ -914,7 +914,7 @@ of \tcode{*p} is equivalent to the value of \tcode{rv} before the evaluation.
 \item
 \tcode{T} is \defnx{\oldconcept{CopyInsertable} into \tcode{X}}
 {\oldconceptname{CopyInsertable} into X@\oldconcept{CopyInsertable} into \tcode{X}}
-means that, in addition to \tcode{T} being \oldconcept{MoveInsertable} into
+if, in addition to \tcode{T} being \oldconcept{MoveInsertable} into
 \tcode{X}, the following expression is well-formed:
 \begin{codeblock}
 allocator_traits<A>::construct(m, p, v)
@@ -927,7 +927,7 @@ The value of \tcode{v} is unchanged and is equivalent to \tcode{*p}.
 \defnx{\oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}}
 {\oldconceptname{EmplaceConstructible} into X from args@\oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{args}},
 for zero
-or more arguments \tcode{args}, means that the following expression is well-formed:
+or more arguments \tcode{args}, if the following expression is well-formed:
 \begin{codeblock}
 allocator_traits<A>::construct(m, p, args)
 \end{codeblock}
@@ -936,7 +936,7 @@ allocator_traits<A>::construct(m, p, args)
 \tcode{T} is
 \defnx{\oldconcept{Erasable} from \tcode{X}}
 {\oldconceptname{Erasable} from X@\oldconcept{Erasable} from \tcode{X}}
-means that the following expression is well-formed:
+if the following expression is well-formed:
 \begin{codeblock}
 allocator_traits<A>::destroy(m, p)
 \end{codeblock}

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -3225,7 +3225,7 @@ a pointer type \tcode{T*} when either
 
 \pnum
 In the constructor definitions below,
-enables \tcode{shared_from_this} with \tcode{p},
+\defnx{enables \tcode{shared_from_this} with \tcode{p}}{enables \tcode{shared_from_this}},
 for a pointer \tcode{p} of type \tcode{Y*},
 means that if \tcode{Y} has an unambiguous and accessible base class
 that is a specialization of \tcode{enable_shared_from_this}\iref{util.smartptr.enab},

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -3300,7 +3300,7 @@ namespace std {
 
 \pnum
 Any instance of \tcode{optional<T>} at any given time either contains a value or does not contain a value.
-When an instance of \tcode{optional<T>} \defnx{contains a value}{contains a value!\idxcode{optional}},
+When an instance of \tcode{optional<T>} contains a value,
 it means that an object of type \tcode{T}, referred to as the optional object's \defnx{contained value}{contained value!\idxcode{optional}},
 is allocated within the storage of the optional object.
 Implementations are not permitted to use additional storage, such as dynamic memory, to allocate its contained value.


### PR DESCRIPTION
[util.smartptr.shared.const] defines the phrase "enables `shared_from_this`" without a \defnx entry.

[optional.general] used \defnx when defining the phrase "contains a value", but [variant.general] does not \defnx the phrase "holds a value"; let's be consistent, and I think this is the right direction in which to be consistent.

[container.alloc.reqmts] has many instances of "T is _foo_ means that...", which should be either "T is _foo_ if..." or else "[The phrase] _T is foo_ means that...". The proposed resolution of [LWG 2158](https://cplusplus.github.io/LWG/issue2158) is related, in that it currently says "Syntactic requirements of T is _foo_" when what it means is "Syntactic requirements of _T is foo_" (use-mention distinction).

Happy to split this into separate PRs, but I figure the same grammar-lawyers will be interested in all three.