### PR TITLE
[temp.deduct.conv] Remove misleading paragraph break

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -7750,8 +7750,6 @@ its \keyword{noexcept}.
 Any cv-qualifiers in \tcode{A}
 that can be restored by a qualification conversion.
 \end{itemize}
-
-\pnum
 These attributes are ignored only if type deduction would
 otherwise fail.
 If ignoring them allows more than one possible deduced


### PR DESCRIPTION
As directed by CWG 2022-11-09.