### PR TITLE
[mdspan.extents.cons] "constexpr" should precede "explicit"

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -18497,7 +18497,7 @@ The expression inside \tcode{explicit} is equivalent to:
 \indexlibraryctor{extents}%
 \begin{itemdecl}
 template<class... OtherIndexTypes>
-  explicit constexpr extents(OtherIndexTypes... exts) noexcept;
+  constexpr explicit extents(OtherIndexTypes... exts) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
In library function declarations, the `constexpr` specifier always precedes the `explicit` specifier per our standing style guide.