### PR TITLE
[check] Add check for "explicit constexpr" in the library

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9238,7 +9238,7 @@ namespace std {
     constexpr iterator erase(const_iterator position);
     constexpr iterator erase(const_iterator first, const_iterator last);
     constexpr void swap(vector&);
-    constexpr static void swap(reference x, reference y) noexcept;
+    static constexpr void swap(reference x, reference y) noexcept;
     constexpr void flip() noexcept;     // flips all bits
     constexpr void clear() noexcept;
   };
@@ -9279,7 +9279,7 @@ Replaces each element in the container with its complement.
 
 \indexlibrarymember{swap}{vector<bool>}%
 \begin{itemdecl}
-constexpr static void swap(reference x, reference y) noexcept;
+static constexpr void swap(reference x, reference y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/tools/check-source.sh
+++ b/tools/check-source.sh
@@ -116,6 +116,14 @@ grep -Hne '^\\\(change\|rationale\|effect\|difficulty\|howwide\)\s.\+$' compatib
 grep -ne 'template\s\+<' $texlib |
     fail 'space between "template" and "<"' || failed=1
 
+# In library declarations, constexpr should not follow explicit
+grep -ne '\bexplicit\b.*\bconstexpr\b' $texlib |
+    fail 'explicit constexpr' || failed=1
+
+# In library declarations, static should not follow constexpr
+grep -ne '\bconstexpr\b.*\bstatic\b' $texlib | grep -ve '\bconstexpr\b.*\bnon-static\b' |
+    fail 'constexpr static' || failed=1
+
 # "Class" heading without namespace
 for f in $texlib; do
     sed -n '/rSec[0-9].*{Class/,/\\end{codeblock}/{/\\begin{example}/,/\\end{example}/b;/\\begin{codeblock}/,/\(^namespace\)\|\(\\end{codeblock}\)/{s/template<[^>]*>//;/\(class\|struct\)[A-Za-z0-9_: ]*{/{=;p;};};}' $f |


### PR DESCRIPTION
Per our style guide, `constexpr` should precede `explicit` in declarations. Nevertheless, the persnickety `explicit constexpr` seems to frequently sneak into the library wording.