### PR TITLE
2022-11 CWG Motion 8

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -7367,7 +7367,18 @@ an implicit or explicit class member access expression\iref{expr.ref};
 a control flow that passes through
 a declaration of a variable with
 static\iref{basic.stc.static} or
-thread\iref{basic.stc.thread} storage duration;
+thread\iref{basic.stc.thread} storage duration,
+unless that variable is usable in constant expressions;
+\begin{example}
+\begin{codeblock}
+constexpr char test() {
+  static const int x = 5;
+  static constexpr char c[] = "Hello World";
+  return *(c + x);
+}
+static_assert(' ' == test());
+\end{codeblock}
+\end{example}
 
 \item
 an invocation of a non-constexpr function;

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1801,7 +1801,7 @@ an \impldef{text of \mname{TIME} when time of translation is not available} vali
 \defnxname{cpp_char8_t}                           & \tcode{202207L} \\ \rowsep
 \defnxname{cpp_concepts}                          & \tcode{202002L} \\ \rowsep
 \defnxname{cpp_conditional_explicit}              & \tcode{201806L} \\ \rowsep
-\defnxname{cpp_constexpr}                         & \tcode{202207L} \\ \rowsep
+\defnxname{cpp_constexpr}                         & \tcode{202211L} \\ \rowsep
 \defnxname{cpp_constexpr_dynamic_alloc}           & \tcode{201907L} \\ \rowsep
 \defnxname{cpp_constexpr_in_decltype}             & \tcode{201711L} \\ \rowsep
 \defnxname{cpp_consteval}                         & \tcode{201811L} \\ \rowsep


### PR DESCRIPTION
P2647R1 Permitting static constexpr variables in constexpr functions

Fixes #5963.
Fixes cplusplus/nbballot#443
Fixes cplusplus/papers#1318