### PR TITLE
2022-11 LWG Motion 14

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -612,13 +612,13 @@ The expression \tcode{a.swap(b)}, for containers \tcode{a} and \tcode{b} of a st
 container type other than \tcode{array}, shall exchange the values of \tcode{a} and
 \tcode{b} without invoking any move, copy, or swap operations on the individual
 container elements.
-Lvalues of any \tcode{Compare}, \tcode{Pred}, or \tcode{Hash} types
-belonging to \tcode{a} and \tcode{b} shall be swappable
+Any \tcode{Compare}, \tcode{Pred}, or \tcode{Hash} types
+belonging to \tcode{a} and \tcode{b} shall meet the \oldconcept{Swappable} requirements
 and shall be exchanged by calling \tcode{swap}
 as described in~\ref{swappable.requirements}. If
 \tcode{allocator_traits<allocator_type>::propagate_on_container_swap::value} is
 \tcode{true}, then
-lvalues of type \tcode{allocator_type} shall be swappable and
+\tcode{allocator_type} shall meet the \oldconcept{Swap\-pable} requirements and
 the allocators of \tcode{a} and \tcode{b} shall also be exchanged
 by calling \tcode{swap} as described in~\ref{swappable.requirements}.
 Otherwise, the allocators shall not be swapped, and the behavior is
@@ -1550,9 +1550,10 @@ a.insert(p, i, j)
 For \tcode{vector} and \tcode{deque},
 \tcode{T} is also
 \oldconcept{MoveInsertable} into \tcode{X},
+and \tcode{T} meets the
 \oldconcept{MoveConstructible},
 \oldconcept{MoveAssignable}, and
-lvalues of type \tcode{T} are swappable\iref{swappable.requirements}.
+\oldconcept{Swappable}\iref{swappable.requirements} requirements.
 Neither \tcode{i} nor \tcode{j} are iterators into \tcode{a}.
 
 \pnum
@@ -1584,9 +1585,10 @@ from \tcode{*ranges::begin(rg)}.
 For \tcode{vector} and \tcode{deque},
 \tcode{T} is also
 \oldconcept{MoveInsertable} into \tcode{X},
+and \tcode{T} meets the
 \oldconcept{MoveConstructible},
-\oldconcept{MoveAssignable}, and
-lvalues of type \tcode{T} are swappable\iref{swappable.requirements}.
+\oldconcept{Move\-Assignable}, and
+\oldconcept{Swappable}\iref{swappable.requirements} requirements.
 \tcode{rg} and \tcode{a} do not overlap.
 
 \pnum

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2011,9 +2011,8 @@ bidirectional.iterators,random.access.iterators}.
 \pnum
 A type \tcode{X} meets the \defnoldconcept{Iterator} requirements if:
 \begin{itemize}
-\item \tcode{X} meets the \oldconcept{CopyConstructible}, \oldconcept{CopyAssignable}, and
-\oldconcept{Destructible} requirements\iref{utility.arg.requirements} and lvalues
-of type \tcode{X} are swappable\iref{swappable.requirements}, and
+\item \tcode{X} meets the \oldconcept{CopyConstructible}, \oldconcept{CopyAssignable}, \oldconcept{Swappable}, and
+\oldconcept{Destructible} requirements\iref{utility.arg.requirements,swappable.requirements}, and
 
 \item \tcode{iterator_traits<X>::difference_type} is a signed integer type or \keyword{void}, and
 

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1767,6 +1767,10 @@ An rvalue or lvalue \tcode{t} is \defn{swappable} if and only if \tcode{t} is
 swappable with any rvalue or lvalue, respectively, of type \tcode{T}.
 
 \pnum
+A type \tcode{X} meets the \oldconcept{Swappable} requirements
+if lvalues of type \tcode{X} are swappable.
+
+\pnum
 A type \tcode{X} meeting any of the iterator requirements\iref{iterator.requirements}
 meets the \oldconcept{ValueSwappable} requirements if,
 for any dereferenceable object
@@ -1789,7 +1793,7 @@ void value_swap(T&& t, U&& u) {
                                                 // for rvalues and lvalues
 }
 
-// Preconditions: lvalues of \tcode{T} are swappable.
+// Preconditions: \tcode{T} meets the \oldconcept{Swappable} requirements.
 template<class T>
 void lv_swap(T& t1, T& t2) {
   using std::swap;
@@ -1828,9 +1832,7 @@ A type \tcode{P} meets the \oldconcept{\-Nullable\-Pointer} requirements if:
 \begin{itemize}
 \item \tcode{P} meets the \oldconcept{EqualityComparable},
 \oldconcept{DefaultConstructible}, \oldconcept{CopyConstructible}, \oldconcept{\-Copy\-Assign\-able},
-and \oldconcept{Destructible} requirements,
-
-\item lvalues of type \tcode{P} are swappable\iref{swappable.requirements},
+\oldconcept{Swappable}, and \oldconcept{Destructible} requirements,
 
 \item the expressions shown in \tref{cpp17.nullablepointer} are
 valid and have the indicated semantics, and
@@ -2636,7 +2638,7 @@ Identical to or derived from \tcode{true_type} or \tcode{false_type}.
 \tcode{true_type} only if an allocator of type \tcode{X} should be swapped
 when the client container is swapped;
 if so,
-lvalues of type \tcode{X} shall be swappable\iref{swappable.requirements} and
+\tcode{X} shall meet the \oldconcept{Swappable} requirements\iref{swappable.requirements} and
 the \tcode{swap} operation shall not throw exceptions.
 
 \pnum

--- a/source/support.tex
+++ b/source/support.tex
@@ -3397,11 +3397,10 @@ namespace std {
 The type \tcode{source_location} meets the
 \oldconcept{DefaultConstructible},
 \oldconcept{CopyConstructible},
-\oldconcept{Copy\-Assignable}, and
+\oldconcept{Copy\-Assignable},
+\oldconcept{Swappable}, and
 \oldconcept{Destructible}
-requirements\iref{utility.arg.requirements}.
-Lvalues of type \tcode{source_location}
-are swappable\iref{swappable.requirements}.
+requirements\iref{utility.arg.requirements,swappable.requirements}.
 All of the following conditions are \tcode{true}:
 \begin{itemize}
 \item \tcode{is_nothrow_move_constructible_v<source_location>}

--- a/source/time.tex
+++ b/source/time.tex
@@ -1017,15 +1017,13 @@ A type \tcode{TC} meets the \oldconcept{TrivialClock} requirements if:
 \item the types \tcode{TC::rep}, \tcode{TC::duration}, and \tcode{TC::time_point}
 meet the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable}) and
 \oldconcept{LessThanComparable} (\tref{cpp17.lessthancomparable})
+and \oldconcept{Swappable}\iref{swappable.requirements}
 requirements and the requirements of
 numeric types\iref{numeric.requirements}.
 \begin{note}
 This means, in particular,
 that operations on these types will not throw exceptions.
 \end{note}
-
-\item lvalues of the types \tcode{TC::rep}, \tcode{TC::duration}, and
-\tcode{TC::time_point} are swappable\iref{swappable.requirements},
 
 \item the function \tcode{TC::now()} does not throw exceptions, and
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2473,6 +2473,9 @@ constexpr void swap(const tuple& rhs) const noexcept(@\seebelow@);
 
 \begin{itemdescr}
 \pnum
+Let $i$ be in the range \range{0}{sizeof...(Types)} in order.
+
+\pnum
 \mandates
 \begin{itemize}
 \item
@@ -2485,13 +2488,11 @@ For the second overload,
 
 \pnum
 \expects
-Each element in \tcode{*this} is swappable with\iref{swappable.requirements}
-the corresponding element in \tcode{rhs}.
+For all $i$, \tcode{get<$i$>(*this)} is swappable with\iref{swappable.requirements} \tcode{get<$i$>(rhs)}.
 
 \pnum
 \effects
-Calls \tcode{swap} for each element in \tcode{*this} and its
-corresponding element in \tcode{rhs}.
+For each $i$, calls \tcode{swap} for \tcode{get<$i$>(*this)} with \tcode{get<$i$>(rhs)}.
 
 \pnum
 \throws
@@ -3942,7 +3943,7 @@ constexpr void swap(optional& rhs) noexcept(@\seebelow@);
 
 \pnum
 \expects
-Lvalues of type \tcode{T} are swappable.
+\tcode{T} meets the \oldconcept{Swappable} requirements\iref{swappable.requirements}.
 
 \pnum
 \effects
@@ -5713,7 +5714,7 @@ constexpr void swap(variant& rhs) noexcept(@\seebelow@);
 
 \pnum
 \expects
-Lvalues of type $\tcode{T}_i$ are swappable\iref{swappable.requirements}.
+Each $\tcode{T}_i$ meets the \oldconcept{Swappable} requirements\iref{swappable.requirements}.
 
 \pnum
 \effects
@@ -13732,7 +13733,7 @@ An enabled specialization \tcode{hash<Key>} will:
 with \tcode{Key} as the function
 call argument type, the \oldconcept{Default\-Constructible} requirements (\tref{cpp17.defaultconstructible}),
 the \oldconcept{CopyAssignable} requirements (\tref{cpp17.copyassignable}),
-\item be swappable\iref{swappable.requirements} for lvalues,
+the \oldconcept{Swappable} requirements\iref{swappable.requirements},
 \item meet the requirement that if \tcode{k1 == k2} is \tcode{true}, \tcode{h(k1) == h(k2)} is
 also \tcode{true}, where \tcode{h} is an object of type \tcode{hash<Key>} and \tcode{k1} and \tcode{k2}
 are objects of type \tcode{Key};
@@ -15661,13 +15662,11 @@ it meets the
 \begin{itemize}
 \item \oldconcept{DefaultConstructible} (\tref{cpp17.defaultconstructible}),
 \item \oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible}),
-\item \oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}), and
+\item \oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}),
+\item \oldconcept{Swappable}\iref{swappable.requirements}, and
 \item \oldconcept{Destructible} (\tref{cpp17.destructible})
 \end{itemize}
-requirements,
-
-\item
-it is swappable\iref{swappable.requirements} for lvalues, and
+requirements, and
 
 \item
 the expressions shown in \tref{formatter.basic} are valid and


### PR DESCRIPTION
P2696R0 Introduce Cpp17Swappable as additional convenience requirements

Fixes #5975.
Also fixes #5627.
Also fixes https://github.com/cplusplus/draft/issues/5628.