### PR TITLE
2022-11 LWG Motion 11

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -6883,6 +6883,8 @@ if \tcode{out} contains invalid code units,
 \indextext{undefined}%
 the behavior is undefined and
 implementations are encouraged to diagnose it.
+If the native Unicode API is used,
+the function flushes \tcode{os} before writing \tcode{out}.
 Otherwise (if \tcode{os} is not such a stream or
 the function is \tcode{vprint_nonunicode}),
 inserts the character sequence
@@ -7809,6 +7811,8 @@ if \tcode{out} contains invalid code units,
 the behavior is undefined and
 implementations are encouraged to diagnose it.
 Otherwise writes \tcode{out} to \tcode{stream} unchanged.
+If the native Unicode API is used,
+the function flushes \tcode{stream} before writing \tcode{out}.
 \begin{note}
 On POSIX and Windows, \tcode{stream} referring to a terminal means that,
 respectively,


### PR DESCRIPTION
P2539R4 Should the output of std::print to a terminal be synchronized with the underlying stream?

Fixes #5972.
Fixes https://github.com/cplusplus/papers/issues/1219.
Fixes https://github.com/cplusplus/nbballot/issues/537.
Fixes https://github.com/cplusplus/nbballot/issues/536.
Fixes https://github.com/cplusplus/nbballot/issues/535.