### PR TITLE
Motions 2022 11 lwg 9

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -620,6 +620,11 @@ template<class T>
   exchange the values denoted by
   \tcode{E1} and \tcode{E2},
   the program is ill-formed, no diagnostic required.
+  \begin{note}
+  This precludes calling unconstrained program-defined overloads of
+  \tcode{swap}. When the deleted overload is viable, program-defined overloads
+  need to be more specialized\iref{temp.func.order} to be selected.
+  \end{note}
 
 \item
   Otherwise, if \tcode{E1} and \tcode{E2}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1133,12 +1133,8 @@ expression-equivalent to:
 \item \tcode{iter_move(E)}, if
 \tcode{E} has class or enumeration type and
 \tcode{iter_move(E)} is a well-formed expression when treated as an unevaluated operand,
-with overload resolution performed in a context
-that does not include a declaration of \tcode{ranges::iter_move}
-but does include the declaration
-\begin{codeblock}
-void iter_move();
-\end{codeblock}
+where the meaning of \tcode{iter_move} is established as-if by performing
+argument-dependent lookup only\iref{basic.lookup.argdep}.
 
 \item Otherwise, if the expression \tcode{*E} is well-formed:
 \begin{itemize}
@@ -1203,6 +1199,11 @@ and does not include a declaration of \tcode{ranges::iter_swap}.
 If the function selected by overload resolution does not exchange the values
 denoted by \tcode{E1} and \tcode{E2},
 the program is ill-formed, no diagnostic required.
+\begin{note}
+This precludes calling unconstrained \tcode{std::iter_swap}. When the deleted
+overload is viable, program-defined overloads need to be more
+specialized\iref{temp.func.order} to be selected.
+\end{note}
 
 \item Otherwise, if the types of \tcode{E1} and \tcode{E2} each model
 \libconcept{indirectly_readable}, and if the reference types of \tcode{E1} and \tcode{E2}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -845,21 +845,6 @@ the following expressions have effects equivalent to \tcode{o(args...)}:
 Each customization point object type constrains its return type to model a
 particular concept.
 
-\pnum
-\begin{note}
-Many of the customization point objects in the library evaluate function call
-expressions with an unqualified name which results in a call to a
-program-defined function found by argument dependent name
-lookup\iref{basic.lookup.argdep}. To preclude such an expression resulting in a
-call to unconstrained functions with the same name in namespace \tcode{std},
-customization point objects specify that lookup for these expressions is
-performed in a context that includes deleted overloads matching the signatures
-of overloads defined in namespace \tcode{std}. When the deleted overloads are
-viable, program-defined overloads need to be more specialized\iref{temp.func.order}
-or more constrained\iref{temp.constr.order} to be used by a customization point
-object.
-\end{note}
-
 \rSec3[functions.within.classes]{Functions within classes}
 
 \pnum

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -640,15 +640,10 @@ Then:
   \tcode{auto(begin(t))}
   is a valid expression whose type models
   \libconcept{input_or_output_iterator}
-  with overload resolution performed in a context in which
-  unqualified lookup for \tcode{begin} finds only the declarations
-\begin{codeblock}
-void begin(auto&) = delete;
-void begin(const auto&) = delete;
-\end{codeblock}
+  where the meaning of \tcode{begin} is established as-if by performing
+  argument-dependent lookup only\iref{basic.lookup.argdep},
   then \tcode{ranges::begin(E)} is expression-equivalent to
-  \tcode{auto(begin(t))}
-  with overload resolution performed in the above context.
+  that expression.
 
 \item
   Otherwise, \tcode{ranges::begin(E)} is ill-formed.
@@ -711,15 +706,10 @@ Then:
   \tcode{auto(end(t))}
   is a valid expression whose type models
   \tcode{\libconcept{sentinel_for}<iterator_t<T>>}
-  with overload resolution performed in a context in which
-  unqualified lookup for \tcode{end} finds only the declarations
-\begin{codeblock}
-void end(auto&) = delete;
-void end(const auto&) = delete;
-\end{codeblock}
+  where the meaning of \tcode{end} is established as-if by performing
+  argument-dependent lookup only\iref{basic.lookup.argdep},
   then \tcode{ranges::end(E)} is expression-equivalent to
-  \tcode{auto(end(t))}
-  with overload resolution performed in the above context.
+  that expression.
 
 \item
   Otherwise, \tcode{ranges::end(E)} is ill-formed.
@@ -833,15 +823,10 @@ Then:
   \tcode{auto(rbegin(t))}
   is a valid expression whose type models
   \libconcept{input_or_output_iterator}
-  with overload resolution performed in a context in which
-  unqualified lookup for \tcode{rbegin} finds only the declarations
-\begin{codeblock}
-void rbegin(auto&) = delete;
-void rbegin(const auto&) = delete;
-\end{codeblock}
+  where the meaning of \tcode{rbegin} is established as-if by performing
+  argument-dependent lookup only\iref{basic.lookup.argdep},
   then \tcode{ranges::rbegin(E)} is expression-equivalent to
-  \tcode{auto(rbegin(t))}
-  with overload resolution performed in the above context.
+  that expression.
 
 \item
   Otherwise, if both \tcode{ranges::begin(t)} and \tcode{ranges::end(t)}
@@ -902,15 +887,10 @@ Then:
   \tcode{auto(rend(t))}
   is a valid expression whose type models
   \tcode{\libconcept{sentinel_for}<decltype(ranges::rbegin(E))>}
-  with overload resolution performed in a context in which
-  unqualified lookup for \tcode{rend} finds only the declarations
-\begin{codeblock}
-void rend(auto&) = delete;
-void rend(const auto&) = delete;
-\end{codeblock}
+  where the meaning of \tcode{rend} is established as-if by performing
+  argument-dependent lookup only\iref{basic.lookup.argdep},
   then \tcode{ranges::rend(E)} is expression-equivalent to
-  \tcode{auto(rend(t))}
-  with overload resolution performed in the above context.
+  that expression.
 
 \item
   Otherwise, if both \tcode{ranges::begin(t)} and \tcode{ranges::end(t)}
@@ -1032,15 +1012,10 @@ Then:
   \tcode{disable_sized_range<remove_cv_t<T>>} is \tcode{false} and
   \tcode{auto(size(t))}
   is a valid expression of integer-like type
-  with overload resolution performed in a context in which
-  unqualified lookup for \tcode{size} finds only the declarations
-\begin{codeblock}
-void size(auto&) = delete;
-void size(const auto&) = delete;
-\end{codeblock}
+  where the meaning of \tcode{size} is established as-if by performing
+  argument-dependent lookup only\iref{basic.lookup.argdep},
   then \tcode{ranges::size(E)} is expression-equivalent to
-  \tcode{auto(size(t))}
-  with overload resolution performed in the above context.
+  that expression.
 
 \item
   Otherwise, if

--- a/source/support.tex
+++ b/source/support.tex
@@ -684,7 +684,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_polymorphic_allocator}@             201902L // also in \libheader{memory_resource}
 #define @\defnlibxname{cpp_lib_print}@                             202207L // also in \libheader{print}, \libheader{ostream}
 #define @\defnlibxname{cpp_lib_quoted_string_io}@                  201304L // also in \libheader{iomanip}
-#define @\defnlibxname{cpp_lib_ranges}@                            202207L
+#define @\defnlibxname{cpp_lib_ranges}@                            202211L
   // also in \libheader{algorithm}, \libheader{functional}, \libheader{iterator}, \libheader{memory}, \libheader{ranges}
 #define @\defnlibxname{cpp_lib_ranges_as_const}@                   202207L // also in \libheader{ranges}
 #define @\defnlibxname{cpp_lib_ranges_as_rvalue}@                  202207L // also in \libheader{ranges}
@@ -4924,8 +4924,8 @@ is expression-equivalent\iref{defns.expression.equivalent} to the following:
 \item
   Otherwise, \tcode{strong_ordering(strong_order(E, F))}
   if it is a well-formed expression
-  with overload resolution performed in a context
-  that does not include a declaration of \tcode{std::strong_order}.
+  where the meaning of \tcode{strong_order} is established as-if by performing
+  argument-dependent lookup only\iref{basic.lookup.argdep}.
 \item
   Otherwise, if the decayed type \tcode{T} of \tcode{E} is
   a floating-point type,
@@ -4962,8 +4962,8 @@ is expression-equivalent\iref{defns.expression.equivalent} to the following:
 \item
   Otherwise, \tcode{weak_ordering(weak_order(E, F))}
   if it is a well-formed expression
-  with overload resolution performed in a context
-  that does not include a declaration of \tcode{std::weak_order}.
+  where the meaning of \tcode{weak_order} is established as-if by performing
+  argument-dependent lookup only\iref{basic.lookup.argdep}.
 \item
   Otherwise, if the decayed type \tcode{T} of \tcode{E}
   is a floating-point type,
@@ -5014,8 +5014,8 @@ is expression-equivalent\iref{defns.expression.equivalent} to the following:
 \item
   Otherwise, \tcode{partial_ordering(partial_order(E, F))}
   if it is a well-formed expression
-  with overload resolution performed in a context
-  that does not include a declaration of \tcode{std::partial_order}.
+  where the meaning of \tcode{partial_order} is established as-if by performing
+  argument-dependent lookup only\iref{basic.lookup.argdep}.
 \item
   Otherwise, \tcode{partial_ordering(compare_three_way()(E, F))}
   if it is a well-formed expression.


### PR DESCRIPTION
P2602R2 Poison Pills are Too Toxic

Fixes #5970.
Also fixes https://github.com/cplusplus/papers/issues/1266.
Also fixes https://github.com/cplusplus/nbballot/issues/526.


Also: Following discussion with @brevzin and @tkoeppe, added an extra note explaining why `swap` poison pill is still needed.