### PR TITLE
[expr.unary.op] Cleanup of {ones',two's} complement, and of "operator"

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4664,7 +4664,7 @@ The type of the result is \keyword{bool}.
 
 \pnum
 \indextext{operator!ones' complement}%
-The operand of \tcode{\~{}} shall have integral or unscoped enumeration type.
+The operand of the \tcode{\~{}} operator shall have integral or unscoped enumeration type.
 Integral promotions are performed.
 The type of the result is the type of the promoted operand.
 % FIXME: [basic.fundamental]/p5 uses $x_i$; [expr] uses $\tcode{x}_i$.
@@ -4677,7 +4677,7 @@ is 1 if $\tcode{x}_i$ is 0, and 0 otherwise.
 There is an ambiguity
 in the grammar when \tcode{\~{}} is followed by
 a \grammarterm{type-name} or \grammarterm{decltype-specifier}.
-The ambiguity is resolved by treating \tcode{\~{}} as the unary complement
+The ambiguity is resolved by treating \tcode{\~{}} as the
 operator rather than as the start of an \grammarterm{unqualified-id}
 naming a destructor.
 \begin{note}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4653,6 +4653,10 @@ promotion is performed on integral or enumeration operands. The negative
 of an unsigned quantity is computed by subtracting its value from $2^n$,
 where $n$ is the number of bits in the promoted operand. The type of the
 result is the type of the promoted operand.
+\begin{note}
+The result is the two's complement of the operand
+(where operand and result are considered as unsigned).
+\end{note}
 
 \pnum
 \indextext{operator!logical negation}%
@@ -4674,6 +4678,10 @@ of the promoted operand \tcode{x},
 the coefficient $\tcode{r}_i$
 of the base-2 representation of the result \tcode{r}
 is 1 if $\tcode{x}_i$ is 0, and 0 otherwise.
+\begin{note}
+The result is the ones' complement of the operand
+(where operand and result are considered as unsigned).
+\end{note}
 There is an ambiguity
 in the grammar when \tcode{\~{}} is followed by
 a \grammarterm{type-name} or \grammarterm{decltype-specifier}.


### PR DESCRIPTION
We are currently using the term "unary complement" to refer to the "~" operator without ever giving it that name.

This change removes unnecessary uses of the terms "unary" and "complement", but adds notes that make referenes to "ones'/two's complement".