### PR TITLE
[temp.over.link] Reword to clarify that declarations correspond

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3916,9 +3916,7 @@ declare the same name,
 have corresponding signatures\iref{basic.scope.scope},
 \item
 would declare the same entity,
-where in the determination in \ref{basic.link}
-of whether two declarations do declare the same entity,
-$A$ and $B$ are assumed to correspond, and
+when considering $A$ and $B$ to correspond in the determination per \ref{basic.link}, and
 \item
 accept and are satisfied by the same set of template argument lists,
 \end{itemize}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3911,12 +3911,12 @@ no diagnostic required.
 Furthermore, if two declarations $A$ and $B$ of function templates
 \begin{itemize}
 \item
-declare the same name,
+introduce the same name,
 \item
 have corresponding signatures\iref{basic.scope.scope},
 \item
 would declare the same entity,
-when considering $A$ and $B$ to correspond in the determination per \ref{basic.link}, and
+when considering $A$ and $B$ to correspond in that determination\iref{basic.link}, and
 \item
 accept and are satisfied by the same set of template argument lists,
 \end{itemize}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3908,10 +3908,21 @@ If the validity or meaning of the program depends on
 whether two constructs are equivalent, and they are
 functionally equivalent but not equivalent, the program is ill-formed,
 no diagnostic required.
-Furthermore, if two declarations of function templates with the same name
-and corresponding signatures\iref{basic.scope.scope} do not correspond
-but would declare the same entity\iref{basic.link} considering them to do so, and
+Furthermore, if two declarations $A$ and $B$ of function templates
+\begin{itemize}
+\item
+declare the same name,
+\item
+have corresponding signatures\iref{basic.scope.scope},
+\item
+would declare the same entity,
+where in the determination in \ref{basic.link}
+of whether two declarations do declare the same entity,
+$A$ and $B$ are assumed to correspond, and
+\item
 accept and are satisfied by the same set of template argument lists,
+\end{itemize}
+but do not correspond,
 the program is ill-formed, no diagnostic required.
 
 \pnum

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3908,15 +3908,10 @@ If the validity or meaning of the program depends on
 whether two constructs are equivalent, and they are
 functionally equivalent but not equivalent, the program is ill-formed,
 no diagnostic required.
-% FIXME: What does it mean for two function templates to correspond?
-Furthermore, if two function templates that do not correspond
-\begin{itemize}
-\item have the same name,
-\item have corresponding signatures\iref{basic.scope.scope},
-\item would declare the same entity\iref{basic.link} considering them to correspond, and
-% FIXME: What does it mean for a set of template argument lists to satisfy a function template?
-\item accept and are satisfied by the same set of template argument lists,
-\end{itemize}
+Furthermore, if two declarations of function templates with the same name
+and corresponding signatures\iref{basic.scope.scope} do not correspond
+but would declare the same entity\iref{basic.link} considering them to do so, and
+accept and are satisfied by the same set of template argument lists,
 the program is ill-formed, no diagnostic required.
 
 \pnum


### PR DESCRIPTION
Fixes #https://github.com/cplusplus/draft/issues/5997.