### PR TITLE
[time.zone.zonedtime.overview] Rename parameters to match [time.zone.zonedtime.ctor]

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -9622,7 +9622,7 @@ namespace std::chrono {
     explicit zoned_time(string_view name);
 
     template<class Duration2>
-      zoned_time(const zoned_time<Duration2, TimeZonePtr>& zt);
+      zoned_time(const zoned_time<Duration2, TimeZonePtr>& y);
 
     zoned_time(TimeZonePtr z,    const sys_time<Duration>& st);
     zoned_time(string_view name, const sys_time<Duration>& st);
@@ -9633,17 +9633,17 @@ namespace std::chrono {
     zoned_time(string_view name, const local_time<Duration>& tp, choose c);
 
     template<class Duration2, class TimeZonePtr2>
-      zoned_time(TimeZonePtr z, const zoned_time<Duration2, TimeZonePtr2>& zt);
+      zoned_time(TimeZonePtr z, const zoned_time<Duration2, TimeZonePtr2>& y);
     template<class Duration2, class TimeZonePtr2>
-      zoned_time(TimeZonePtr z, const zoned_time<Duration2, TimeZonePtr2>& zt, choose);
+      zoned_time(TimeZonePtr z, const zoned_time<Duration2, TimeZonePtr2>& y, choose);
 
     template<class Duration2, class TimeZonePtr2>
-      zoned_time(string_view name, const zoned_time<Duration2, TimeZonePtr2>& zt);
+      zoned_time(string_view name, const zoned_time<Duration2, TimeZonePtr2>& y);
     template<class Duration2, class TimeZonePtr2>
-      zoned_time(string_view name, const zoned_time<Duration2, TimeZonePtr2>& zt, choose);
+      zoned_time(string_view name, const zoned_time<Duration2, TimeZonePtr2>& y, choose c);
 
     zoned_time& operator=(const sys_time<Duration>& st);
-    zoned_time& operator=(const local_time<Duration>& ut);
+    zoned_time& operator=(const local_time<Duration>& lt);
 
     operator sys_time<duration>() const;
     explicit operator local_time<duration>() const;


### PR DESCRIPTION
This makes the parameters in the synopsis match the detailed descriptions.