### PR TITLE
[uaxid, macros, etc.] Smaller capital-style glyphs

### DIFF
--- a/source/back.tex
+++ b/source/back.tex
@@ -21,12 +21,12 @@
 \item
   %%% Format for the following entry is based on that specified at
   %%% http://www.iec.ch/standardsdev/resources/draftingpublications/directives/principles/referencing.htm
-  The Unicode Consortium. Unicode Standard Annex, UAX \#29,
+  The Unicode Consortium. Unicode Standard Annex, \UAX{29},
   \doccite{Unicode Text Segmentation} [online].
   Edited by Mark Davis. Revision 35; issued for Unicode 12.0.0. 2019-02-15 [viewed 2020-02-23].
   Available from: \url{http://www.unicode.org/reports/tr29/tr29-35.html}
 \item
-  The Unicode Consortium. Unicode Standard Annex, UAX \#31,
+  The Unicode Consortium. Unicode Standard Annex, \UAX{31},
   \doccite{Unicode Identifier and Pattern Syntax} [online].
   Edited by Mark Davis. Revision 33; issued for Unicode 13.0.0.
   2020-02-13 [viewed 2021-06-08].

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -16,7 +16,7 @@ by the chapters of this document.
 \diffref{lex.name}
 \change
 Previously valid identifiers containing characters
-not present in UAX \#44 properties XID_Start or XID_Continue, or
+not present in \UAX{44} properties XID_Start or XID_Continue, or
 not in Normalization Form C, are now rejected.
 \rationale
 Prevent confusing characters in identifiers.

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -76,7 +76,7 @@ Language Specification},
 Standard Ecma-262, third edition, 1999.
 \item
 The Unicode Consortium.
-Unicode Standard Annex, UAX \#44, \doccite{Unicode Character Database}.
+Unicode Standard Annex, \UAX{44}, \doccite{Unicode Character Database}.
 Edited by Ken Whistler and Lauren\c{t}iu Iancu.
 Available from: \url{http://www.unicode.org/reports/tr44/}
 \item

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -914,7 +914,7 @@ a \grammarterm{floating-point-literal} token.%
 \indextext{name!length of}%
 \indextext{name}%
 The character classes XID_Start and XID_Continue
-are Derived Core Properties as described by UAX \#44.
+are Derived Core Properties as described by \UAX{44}.
 \begin{footnote}
 On systems in which linkers cannot accept extended
 characters, an encoding of the \grammarterm{universal-character-name} can be used in

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -406,6 +406,7 @@
 }
 \newcommand{\uname}[1]{\textsc{#1}}
 \newcommand{\unicode}[2]{\ucode{#1} \uname{#2}}
+\newcommand{\UAX}[1]{\texorpdfstring{UAX~\textsmaller[1]{\raisebox{0.35ex}{\#}}#1}{UAX \##1}}
 \newcommand{\NTS}[1]{\textsc{#1}}
 \newcommand{\ntbs}{\NTS{ntbs}}
 \newcommand{\ntmbs}{\NTS{ntmbs}}

--- a/source/uax31.tex
+++ b/source/uax31.tex
@@ -1,14 +1,14 @@
 %!TEX root = std.tex
-\infannex{uaxid}{Conformance with UAX \#31}
+\infannex{uaxid}{Conformance with \UAX{31}}
 
 \rSec1[uaxid.general]{General}
 
 \pnum
 This Annex describes the choices made in application of
-UAX \#31 (``Unicode Identifier and Pattern Syntax'')
-to \Cpp{} in terms of the requirements from UAX \#31 and
+\UAX{31} (``Unicode Identifier and Pattern Syntax'')
+to \Cpp{} in terms of the requirements from \UAX{31} and
 how they do or do not apply to \Cpp{}.
-In terms of UAX \#31,
+In terms of \UAX{31},
 \Cpp{} conforms by meeting the requirements
 R1 ``Default Identifiers'' and
 R4 ``Equivalent Normalized Identifiers''.
@@ -20,8 +20,8 @@ are either alternatives not taken or do not apply to \Cpp{}.
 \rSec2[uaxid.def.general]{General}
 
 \pnum
-UAX \#31 specifies a default syntax for identifiers
-based on properties from the Unicode Character Database, UAX \#44.
+\UAX{31} specifies a default syntax for identifiers
+based on properties from the Unicode Character Database, \UAX{44}.
 The general syntax is
 \begin{codeblock}
 <Identifier> := <Start> <Continue>* (<Medial> <Continue>+)*
@@ -33,7 +33,7 @@ For \Cpp{} we add the character \unicode{005f}{low line}, or \tcode{_},
 to the set of permitted \tcode{<Start>} characters,
 the \tcode{<Medial>} set is empty, and
 the \tcode{<Continue>} characters are unmodified.
-In the grammar used in UAX \#31, this is
+In the grammar used in \UAX{31}, this is
 \begin{codeblock}
 <Identifier> := <Start> <Continue>*
 <Start> := XID_Start + @\textrm{\ucode{005f}}@
@@ -49,8 +49,8 @@ where \grammarterm{identifier} is formed from
 \rSec2[uaxid.def.rfmt]{R1a Restricted format characters}
 
 \pnum
-If an implementation of UAX \#31 wishes to allow format characters
-such as ZERO WIDTH JOINER or ZERO WIDTH NON-JOINER
+If an implementation of \UAX{31} wishes to allow format characters
+such as \unicode{200d}{zero width joiner} or \unicode{200c}{zero width non-joiner}
 it must define a profile allowing them, or
 describe precisely which combinations are permitted.
 
@@ -60,13 +60,13 @@ describe precisely which combinations are permitted.
 \rSec2[uaxid.def.stable]{R1b Stable identifiers}
 
 \pnum
-An implementation of UAX \#31 may choose to guarantee
+An implementation of \UAX{31} may choose to guarantee
 that identifiers are stable across versions of the Unicode Standard.
 Once a string qualifies as an identifier it does so in all future versions.
 
 \pnum
 \Cpp{} does not make this guarantee,
-except to the extent that UAX \#31 guarantees
+except to the extent that \UAX{31} guarantees
 the stability of the XID_Start and XID_Continue properties.
 
 \rSec1[uaxid.immutable]{R2 Immutable identifiers}
@@ -85,7 +85,7 @@ for use in identifiers.
 \rSec1[uaxid.pattern]{R3 Pattern_White_Space and Pattern_Syntax characters}
 
 \pnum
-UAX \#31 describes how formal languages
+\UAX{31} describes how formal languages
 such as computer languages should describe and implement
 their use of whitespace and syntactically significant characters
 during the processes of lexing and parsing.
@@ -96,7 +96,7 @@ during the processes of lexing and parsing.
 \rSec1[uaxid.eqn]{R4 Equivalent normalized identifiers}
 
 \pnum
-UAX \#31 requires that implementations describe
+\UAX{31} requires that implementations describe
 how identifiers are compared and considered equivalent.
 
 \pnum
@@ -115,7 +115,7 @@ This requirement does not apply to \Cpp{}.
 
 \pnum
 If any characters are excluded from normalization,
-UAX \#31 requires a precise specification of those exclusions.
+\UAX{31} requires a precise specification of those exclusions.
 
 \pnum
 \Cpp{} does not make any such exclusions.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -14365,7 +14365,7 @@ For a string in a Unicode encoding,
 implementations should estimate the width of a string
 as the sum of estimated widths of
 the first code points in its extended grapheme clusters.
-The extended grapheme clusters of a string are defined by UAX \#29.
+The extended grapheme clusters of a string are defined by \UAX{29}.
 The estimated width of the following code points is 2:
 \begin{itemize}
 \item \ucode{1100} -- \ucode{115f}
@@ -15312,7 +15312,7 @@ Otherwise, if \placeholder{C} is not \unicode{0020}{space} and
 a UCS scalar value whose Unicode property \tcode{General_Category}
 has a value in the groups \tcode{Separator} (\tcode{Z}) or \tcode{Other} (\tcode{C}) or to
 a UCS scalar value which has the Unicode property \tcode{Grapheme_Extend=Yes},
-as described by table 12 of UAX \#44, or
+as described by table 12 of \UAX{44}, or
 
 \item
 \placeholder{CE} is not a Unicode encoding and


### PR DESCRIPTION
The "hash"/"number" sign is reduced in size and placed on the baseline. This seems to look less distracting and disruptive.

We also use the usual small-caps presentation for universal character names.