### PR TITLE
[depr.conversions.string] remove redundent respecification

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -2133,6 +2133,10 @@ std::cout << mbstring;
 \end{example}
 
 \indexlibraryglobal{wstring_convert}%
+\indexlibrarymember{byte_string}{wstring_convert}%
+\indexlibrarymember{int_type}{wstring_convert}%
+\indexlibrarymember{state_type}{wstring_convert}%
+\indexlibrarymember{wide_string}{wstring_convert}%
 \begin{codeblock}
 namespace std {
   template<class Codecvt, class Elem = wchar_t,
@@ -2203,16 +2207,6 @@ An object of this class template stores:
 \item \tcode{cvtcount} --- a conversion count
 \end{itemize}
 
-\indexlibrarymember{byte_string}{wstring_convert}%
-\begin{itemdecl}
-using byte_string = basic_string<char, char_traits<char>, ByteAlloc>;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-The type shall be a synonym for \tcode{basic_string<char, char_traits<char>, ByteAlloc>}.
-\end{itemdescr}
-
 \indexlibrarymember{converted}{wstring_convert}%
 \begin{itemdecl}
 size_t converted() const noexcept;
@@ -2261,16 +2255,6 @@ member function shall return the wide-error string.
 Otherwise, the member function throws an object of class \tcode{range_error}.
 \end{itemdescr}
 
-\indexlibrarymember{int_type}{wstring_convert}%
-\begin{itemdecl}
-using int_type = typename wide_string::traits_type::int_type;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-The type shall be a synonym for \tcode{wide_string::traits_type::int_type}.
-\end{itemdescr}
-
 \indexlibrarymember{state}{wstring_convert}%
 \begin{itemdecl}
 state_type state() const;
@@ -2280,16 +2264,6 @@ state_type state() const;
 \pnum
 \returns
 \tcode{cvtstate}.
-\end{itemdescr}
-
-\indexlibrarymember{state_type}{wstring_convert}%
-\begin{itemdecl}
-using state_type = typename Codecvt::state_type;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-The type shall be a synonym for \tcode{Codecvt::state_type}.
 \end{itemdescr}
 
 \indexlibrarymember{to_bytes}{wstring_convert}%
@@ -2327,17 +2301,6 @@ If no conversion error occurs, the member function shall return the converted by
 Otherwise, if the object was constructed with a byte-error string, the
 member function shall return the byte-error string.
 Otherwise, the member function shall throw an object of class \tcode{range_error}.
-\end{itemdescr}
-
-\indexlibrarymember{wide_string}{wstring_convert}%
-\begin{itemdecl}
-using wide_string = basic_string<Elem, char_traits<Elem>, WideAlloc>;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-The type shall be a synonym for \tcode{basic_string<Elem,
-char_traits<Elem>, WideAlloc>}.
 \end{itemdescr}
 
 \indexlibraryctor{wstring_convert}%
@@ -2390,6 +2353,7 @@ lets you specify a code conversion facet to perform the conversions,
 without affecting any streams or locales.
 
 \indexlibraryglobal{wbuffer_convert}%
+\indexlibrarymember{state_type}{wbuffer_convert}%
 \begin{codeblock}
 namespace std {
   template<class Codecvt, class Elem = wchar_t, class Tr = char_traits<Elem>>
@@ -2474,16 +2438,6 @@ Stores \tcode{bytebuf} in \tcode{bufptr}.
 \pnum
 \returns
 The previous value of \tcode{bufptr}.
-\end{itemdescr}
-
-\indexlibrarymember{state_type}{wbuffer_convert}%
-\begin{itemdecl}
-using state_type = typename Codecvt::state_type;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-The type shall be a synonym for \tcode{Codecvt::state_type}.
 \end{itemdescr}
 
 \indexlibraryctor{wbuffer_convert}%


### PR DESCRIPTION
There are several typedef names defined precisely in the deprecated convenience conversion interface classes that are redundantly respecified in text.  Nowhere else in the library does this; any specified typedef names are _see below_ definitions, not repeats of the class definition.  Needless redundancy is always a risk of divergance, however small, so remove the respecification in text form.