### PR TITLE
[utilities] Consistently index all member typedefs in the utilites he…

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -123,14 +123,14 @@ namespace std {
     requires requires { typename pair<common_reference_t<TQual<T1>, UQual<U1>>,
                                       common_reference_t<TQual<T2>, UQual<U2>>>; }
   struct basic_common_reference<pair<T1, T2>, pair<U1, U2>, TQual, UQual> {
-    using type = pair<common_reference_t<TQual<T1>, UQual<U1>>,
+    using @\libmember{type}{basic_common_reference}@ = pair<common_reference_t<TQual<T1>, UQual<U1>>,
                       common_reference_t<TQual<T2>, UQual<U2>>>;
   };
 
   template<class T1, class T2, class U1, class U2>
     requires requires { typename pair<common_type_t<T1, U1>, common_type_t<T2, U2>>; }
   struct common_type<pair<T1, T2>, pair<U1, U2>> {
-    using type = pair<common_type_t<T1, U1>, common_type_t<T2, U2>>;
+    using @\libmember{type}{common_type}@ = pair<common_type_t<T1, U1>, common_type_t<T2, U2>>;
   };
 
   // \ref{pairs.spec}, pair specialized algorithms
@@ -752,8 +752,8 @@ and~\ref{tuple.elem}).%
 namespace std {
   template<class T1, class T2>
   struct pair {
-    using first_type  = T1;
-    using second_type = T2;
+    using @\libmember{first_type}{pair}@  = T1;
+    using @\libmember{second_type}{pair}@ = T2;
 
     T1 first;
     T2 second;
@@ -1399,7 +1399,7 @@ template<class T1, class T2>
 \begin{itemdecl}
 template<size_t I, class T1, class T2>
   struct tuple_element<I, pair<T1, T2>> {
-    using type = @\seebelow@ ;
+    using @\libmember{type}{tuple_element}@ = @\seebelow@ ;
   };
 \end{itemdecl}
 \begin{itemdescr}
@@ -2785,7 +2785,7 @@ template<class... Types>
 \begin{itemdecl}
 template<size_t I, class... Types>
   struct tuple_element<I, tuple<Types...>> {
-    using type = TI;
+    using @\libmember{type}{tuple_element}@ = TI;
   };
 \end{itemdecl}
 
@@ -3062,7 +3062,7 @@ for every integer $0 \leq i < \tcode{tuple_size_v<UTuple>}$.
 template<@\exposconcept{tuple-like}@ TTuple, @\exposconcept{tuple-like}@ UTuple,
          template<class> class TQual, template<class> class UQual>
 struct basic_common_reference<TTuple, UTuple, TQual, UQual> {
-  using type = @\seebelow@;
+  using @\libmember{type}{basic_common_reference}@ = @\seebelow@;
 };
 \end{itemdecl}
 
@@ -3091,7 +3091,7 @@ The member \grammarterm{typedef-name} \tcode{type} denotes the type
 \begin{itemdecl}
 template<@\exposconcept{tuple-like}@ TTuple, @\exposconcept{tuple-like}@ UTuple>
 struct common_type<TTuple, UTuple> {
-  using type = @\seebelow@;
+  using @\libmember{type}{common_type}@ = @\seebelow@;
 };
 \end{itemdecl}
 
@@ -3283,9 +3283,9 @@ namespace std {
   template<class T>
   class optional {
   public:
-    using value_type     = T;
-    using iterator       = @\impdefnc@;              // see~\ref{optional.iterators}
-    using const_iterator = @\impdefnc@;              // see~\ref{optional.iterators}
+    using @\libmember{value_type}{optional}@     = T;
+    using @\libmember{iterator}{optional}@       = @\impdefnc@;              // see~\ref{optional.iterators}
+    using @\libmember{const_iterator}{optional}@ = @\impdefnc@;              // see~\ref{optional.iterators}
 
     // \ref{optional.ctor}, constructors
     constexpr optional() noexcept;
@@ -4050,8 +4050,8 @@ the state of \tcode{*val} and \tcode{*rhs.val} is determined by the exception sa
 \indexlibrarymember{iterator}{optional}%
 \indexlibrarymember{const_iterator}{optional}%
 \begin{itemdecl}
-using iterator       = @\impdef@;
-using const_iterator = @\impdef@;
+using @\libmember{iterator}{optional}@       = @\impdef@;
+using @\libmember{const_iterator}{optional}@ = @\impdef@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11107,7 +11107,7 @@ namespace std {
   template<class T> class reference_wrapper {
   public:
     // types
-    using type = T;
+    using @\libmember{type}{reference_wrapper}@ = T;
 
     // \ref{refwrap.const}, constructors
     template<class U>
@@ -11427,14 +11427,14 @@ namespace std {
     requires (@\exposconcept{ref-wrap-common-reference-exists-with}@<R, T, RQual<R>, TQual<T>> &&
               !@\exposconcept{ref-wrap-common-reference-exists-with}@<T, R, TQual<T>, RQual<R>>)
   struct basic_common_reference<R, T, RQual, TQual> {
-    using type = common_reference_t<typename R::type&, TQual<T>>;
+    using @\libmember{type}{basic_common_reference}@ = common_reference_t<typename R::type&, TQual<T>>;
   };
 
   template<class T, class R, template<class> class TQual, template<class> class RQual>
     requires (@\exposconcept{ref-wrap-common-reference-exists-with}@<R, T, RQual<R>, TQual<T>> &&
               !@\exposconcept{ref-wrap-common-reference-exists-with}@<T, R, TQual<T>, RQual<R>>)
   struct basic_common_reference<T, R, TQual, RQual> {
-    using type = common_reference_t<typename R::type&, TQual<T>>;
+    using @\libmember{type}{basic_common_reference}@ = common_reference_t<typename R::type&, TQual<T>>;
   };
 }
 \end{codeblock}
@@ -11473,7 +11473,7 @@ template<> struct plus<void> {
   template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) + std::forward<U>(u));
 
-  using is_transparent = @\unspec@;
+  using @\libmember{is_transparent}{plus<>}@ = @\unspec@;
 };
 \end{itemdecl}
 
@@ -11515,7 +11515,7 @@ template<> struct minus<void> {
   template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) - std::forward<U>(u));
 
-  using is_transparent = @\unspec@;
+  using @\libmember{is_transparent}{minus<>}@ = @\unspec@;
 };
 \end{itemdecl}
 
@@ -11557,7 +11557,7 @@ template<> struct multiplies<void> {
   template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) * std::forward<U>(u));
 
-  using is_transparent = @\unspec@;
+  using @\libmember{is_transparent}{multiplies<>}@ = @\unspec@;
 };
 \end{itemdecl}
 
@@ -11599,7 +11599,7 @@ template<> struct divides<void> {
   template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) / std::forward<U>(u));
 
-  using is_transparent = @\unspec@;
+  using @\libmember{is_transparent}{divides<>}@ = @\unspec@;
 };
 \end{itemdecl}
 
@@ -11641,7 +11641,7 @@ template<> struct modulus<void> {
   template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) % std::forward<U>(u));
 
-  using is_transparent = @\unspec@;
+  using @\libmember{is_transparent}{modulus<>}@ = @\unspec@;
 };
 \end{itemdecl}
 
@@ -11683,7 +11683,7 @@ template<> struct negate<void> {
   template<class T> constexpr auto operator()(T&& t) const
     -> decltype(-std::forward<T>(t));
 
-  using is_transparent = @\unspec@;
+  using @\libmember{is_transparent}{negate<>}@ = @\unspec@;
 };
 \end{itemdecl}
 
@@ -11751,7 +11751,7 @@ template<> struct equal_to<void> {
   template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) == std::forward<U>(u));
 
-  using is_transparent = @\unspec@;
+  using @\libmember{is_transparent}{equal_to<>}@ = @\unspec@;
 };
 \end{itemdecl}
 
@@ -11793,7 +11793,7 @@ template<> struct not_equal_to<void> {
   template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) != std::forward<U>(u));
 
-  using is_transparent = @\unspec@;
+  using @\libmember{is_transparent}{not_equal_to<>}@ = @\unspec@;
 };
 \end{itemdecl}
 
@@ -11835,7 +11835,7 @@ template<> struct greater<void> {
   template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) > std::forward<U>(u));
 
-  using is_transparent = @\unspec@;
+  using @\libmember{is_transparent}{greater<>}@ = @\unspec@;
 };
 \end{itemdecl}
 
@@ -11877,7 +11877,7 @@ template<> struct less<void> {
   template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) < std::forward<U>(u));
 
-  using is_transparent = @\unspec@;
+  using @\libmember{is_transparent}{less<>}@ = @\unspec@;
 };
 \end{itemdecl}
 
@@ -11919,7 +11919,7 @@ template<> struct greater_equal<void> {
   template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) >= std::forward<U>(u));
 
-  using is_transparent = @\unspec@;
+  using @\libmember{is_transparent}{greater_equal<>}@ = @\unspec@;
 };
 \end{itemdecl}
 
@@ -11961,7 +11961,7 @@ template<> struct less_equal<void> {
   template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) <= std::forward<U>(u));
 
-  using is_transparent = @\unspec@;
+  using @\libmember{is_transparent}{less_equal<>}@ = @\unspec@;
 };
 \end{itemdecl}
 
@@ -11986,7 +11986,7 @@ namespace std {
     template<class T, class U>
       constexpr auto operator()(T&& t, U&& u) const;
 
-    using is_transparent = @\unspec@;
+    using @\libmember{is_transparent}{compare_three_way}@ = @\unspec@;
   };
 }
 \end{codeblock}
@@ -12035,7 +12035,7 @@ struct ranges::equal_to {
   template<class T, class U>
     constexpr bool operator()(T&& t, U&& u) const;
 
-  using is_transparent = @\unspecnc@;
+  using @\libmember{is_transparent}{equal_to}@ = @\unspecnc@;
 };
 \end{codeblock}
 
@@ -12079,7 +12079,7 @@ struct ranges::not_equal_to {
   template<class T, class U>
     constexpr bool operator()(T&& t, U&& u) const;
 
-  using is_transparent = @\unspecnc@;
+  using @\libmember{is_transparent}{not_equal_to}@ = @\unspecnc@;
 };
 \end{codeblock}
 
@@ -12107,7 +12107,7 @@ struct ranges::greater {
   template<class T, class U>
   constexpr bool operator()(T&& t, U&& u) const;
 
-  using is_transparent = @\unspecnc@;
+  using @\libmember{is_transparent}{greater}@ = @\unspecnc@;
 };
 \end{codeblock}
 
@@ -12135,7 +12135,7 @@ struct ranges::less {
   template<class T, class U>
     constexpr bool operator()(T&& t, U&& u) const;
 
-  using is_transparent = @\unspecnc@;
+  using @\libmember{is_transparent}{less}@ = @\unspecnc@;
 };
 \end{codeblock}
 
@@ -12186,7 +12186,7 @@ struct ranges::greater_equal {
   template<class T, class U>
     constexpr bool operator()(T&& t, U&& u) const;
 
-  using is_transparent = @\unspecnc@;
+  using @\libmember{is_transparent}{greater_equal}@ = @\unspecnc@;
 };
 \end{codeblock}
 
@@ -12214,7 +12214,7 @@ struct ranges::less_equal {
   template<class T, class U>
     constexpr bool operator()(T&& t, U&& u) const;
 
-  using is_transparent = @\unspecnc@;
+  using @\libmember{is_transparent}{less_equal}@ = @\unspecnc@;
 };
 \end{itemdecl}
 
@@ -12270,7 +12270,7 @@ template<> struct logical_and<void> {
   template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) && std::forward<U>(u));
 
-  using is_transparent = @\unspec@;
+  using @\libmember{is_transparent}{logical_and<>}@ = @\unspec@;
 };
 \end{itemdecl}
 
@@ -12312,7 +12312,7 @@ template<> struct logical_or<void> {
   template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) || std::forward<U>(u));
 
-  using is_transparent = @\unspec@;
+  using @\libmember{is_transparent}{logical_or<>}@ = @\unspec@;
 };
 \end{itemdecl}
 
@@ -12354,7 +12354,7 @@ template<> struct logical_not<void> {
   template<class T> constexpr auto operator()(T&& t) const
     -> decltype(!std::forward<T>(t));
 
-  using is_transparent = @\unspec@;
+  using @\libmember{is_transparent}{logical_not<>}@ = @\unspec@;
 };
 \end{itemdecl}
 
@@ -12405,7 +12405,7 @@ template<> struct bit_and<void> {
   template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) & std::forward<U>(u));
 
-  using is_transparent = @\unspec@;
+  using @\libmember{is_transparent}{bit_and<>}@ = @\unspec@;
 };
 \end{itemdecl}
 
@@ -12447,7 +12447,7 @@ template<> struct bit_or<void> {
   template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) | std::forward<U>(u));
 
-  using is_transparent = @\unspec@;
+  using @\libmember{is_transparent}{bit_or<>}@ = @\unspec@;
 };
 \end{itemdecl}
 
@@ -12489,7 +12489,7 @@ template<> struct bit_xor<void> {
   template<class T, class U> constexpr auto operator()(T&& t, U&& u) const
     -> decltype(std::forward<T>(t) ^ std::forward<U>(u));
 
-  using is_transparent = @\unspec@;
+  using @\libmember{is_transparent}{bit_xor<>}@ = @\unspec@;
 };
 \end{itemdecl}
 
@@ -12530,7 +12530,7 @@ template<> struct bit_not<void> {
   template<class T> constexpr auto operator()(T&& t) const
     -> decltype(~std::forward<T>(t));
 
-  using is_transparent = @\unspec@;
+  using @\libmember{is_transparent}{bit_not<>}@ = @\unspec@;
 };
 \end{itemdecl}
 
@@ -12555,7 +12555,7 @@ struct identity {
   template<class T>
     constexpr T&& operator()(T&& t) const noexcept;
 
-  using is_transparent = @\unspec@;
+  using @\libmember{is_transparent}{identity}@ = @\unspec@;
 };
 
 template<class T>
@@ -13107,7 +13107,7 @@ namespace std {
   template<class R, class... ArgTypes>
   class function<R(ArgTypes...)> {
   public:
-    using result_type = R;
+    using @\libmember{result_type}{function}@ = R;
 
     // \ref{func.wrap.func.con}, construct/copy/destroy
     function() noexcept;
@@ -13565,7 +13565,7 @@ namespace std {
   template<class R, class... ArgTypes>
   class move_only_function<R(ArgTypes...) @\cv{}@ @\placeholder{ref}@ noexcept(@\placeholder{noex}@)> {
   public:
-    using result_type = R;
+    using @\libmember{result_type}{move_only_function}@ = R;
 
     // \ref{func.wrap.move.ctor}, constructors, assignment, and destructor
     move_only_function() noexcept;
@@ -13958,7 +13958,7 @@ namespace std {
   template<class R, class... ArgTypes>
   class copyable_function<R(ArgTypes...) @\cv{}@ @\placeholder{ref}@ noexcept(@\placeholder{noex}@)> {
   public:
-    using result_type = R;
+    using @\libmember{result_type}{copyable_function}@ = R;
 
     // \ref{func.wrap.copy.ctor}, constructors, assignments, and destructors
     copyable_function() noexcept;


### PR DESCRIPTION
…ader

Audited the file `utilities.tex` for indexing of member typedefs.  Several idioms were in use, and not all typedef-names were indexed.  Adopted what seemed to be the preferred approach of using the `@\libmember{}@` style of definition within the class definition itself, so that omissions become obvious if more typedef-names are added in the future.

Please provide feedback on whether indexing the explicit template specialization for <void> types is the correct approach.  It pulls out the name that is not present for the primary template, and then the ranges library adds some non-template classes with the same name.

Noted that `char_type` for `basic_format_arg` is a private member marked as exposition only, so should really be `char-type` with the expos-id font.  After checking with the original paper, will supply a separate follow-up ticket for that --- this comment is only to confirm that the omission from the index in this patch is intentional.