### PR TITLE
[format.arg] Apply `\exposid` consistently

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16512,7 +16512,7 @@ namespace std {
   template<class Context>
   class basic_format_arg<Context>::handle {
     const void* @\exposid{ptr_}@;                                           // \expos
-    void (*@\exposid{format_}@)(basic_format_parse_context<char_type>&,
+    void (*@\exposid{format_}@)(basic_format_parse_context<\exposid{char-type}>&,
                     Context&, const void*);                     // \expos
 
     template<class T> explicit handle(T&& val) noexcept;        // \expos

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16304,7 +16304,7 @@ namespace std {
             int, unsigned int, long long int, unsigned long long int,
             float, double, long double,
             const @\exposid{char-type}@*, basic_string_view<@\exposid{char-type}@>,
-            const void*, handle> @\exposid{value_}@;                                         // \expos
+            const void*, handle> @\exposid{value_}@;                                        // \expos
 
     template<class T> explicit basic_format_arg(T&& v) noexcept;                // \expos
     explicit basic_format_arg(float n) noexcept;                                // \expos

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16688,8 +16688,8 @@ template<class... Args>
 \pnum
 \effects
 Initializes
-\tcode{\exposid{size_}} with \tcode{sizeof...(Args)} and
-\tcode{\exposid{data_}} with \tcode{store.args.data()}.
+\exposid{size_} with \tcode{sizeof...(Args)} and
+\exposid{data_} with \tcode{store.args.data()}.
 \end{itemdescr}
 
 \indexlibrarymember{get}{basic_format_args}%

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16304,7 +16304,7 @@ namespace std {
             int, unsigned int, long long int, unsigned long long int,
             float, double, long double,
             const @\exposid{char-type}@*, basic_string_view<@\exposid{char-type}@>,
-            const void*, handle> value;                                         // \expos
+            const void*, handle> @\exposid{value_}@;                                         // \expos
 
     template<class T> explicit basic_format_arg(T&& v) noexcept;                // \expos
     explicit basic_format_arg(float n) noexcept;                                // \expos
@@ -16379,30 +16379,30 @@ shall be well-formed when treated as an unevaluated operand\iref{term.unevaluate
 \begin{itemize}
 \item
 if \tcode{T} is \tcode{bool} or \tcode{\exposid{char-type}},
-initializes \tcode{value} with \tcode{v};
+initializes \exposid{value_} with \tcode{v};
 \item
 otherwise, if \tcode{T} is \tcode{char} and \tcode{\exposid{char-type}} is
-\keyword{wchar_t}, initializes \tcode{value} with
+\keyword{wchar_t}, initializes \exposid{value_} with
 \tcode{static_cast<wchar_t>(v)};
 \item
 otherwise, if \tcode{T} is a signed integer type\iref{basic.fundamental}
 and \tcode{sizeof(T) <= sizeof(int)},
-initializes \tcode{value} with \tcode{static_cast<int>(v)};
+initializes \exposid{value_} with \tcode{static_cast<int>(v)};
 \item
 otherwise, if \tcode{T} is an unsigned integer type and
 \tcode{sizeof(T) <= sizeof(unsigned int)}, initializes
-\tcode{value} with \tcode{static_cast<unsigned int>(v)};
+\exposid{value_} with \tcode{static_cast<unsigned int>(v)};
 \item
 otherwise, if \tcode{T} is a signed integer type and
 \tcode{sizeof(T) <= sizeof(long long int)}, initializes
-\tcode{value} with \tcode{static_cast<long long int>(v)};
+\exposid{value_} with \tcode{static_cast<long long int>(v)};
 \item
 otherwise, if \tcode{T} is an unsigned integer type and
 \tcode{sizeof(T) <= sizeof(unsigned long long int)}, initializes
-\tcode{value} with
+\exposid{value_} with
 \tcode{static_cast<unsigned long long int>(v)};
 \item
-otherwise, initializes \tcode{value} with \tcode{handle(v)}.
+otherwise, initializes \exposid{value_} with \tcode{handle(v)}.
 \end{itemize}
 \end{itemdescr}
 
@@ -16415,7 +16415,7 @@ explicit basic_format_arg(long double n) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{value} with \tcode{n}.
+Initializes \exposid{value_} with \tcode{n}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -16429,7 +16429,7 @@ explicit basic_format_arg(const @\exposid{char-type}@* s);
 
 \pnum
 \effects
-Initializes \tcode{value} with \tcode{s}.
+Initializes \exposid{value_} with \tcode{s}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -16440,7 +16440,7 @@ template<class traits>
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{value} with
+Initializes \exposid{value_} with
 \tcode{basic_string_view<\exposid{char-type}>(s.data(), s.size())}.
 \end{itemdescr}
 
@@ -16453,7 +16453,7 @@ template<class traits, class Allocator>
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{value} with
+Initializes \exposid{value_} with
 \tcode{basic_string_view<\exposid{char-type}>(s.data(), s.size())}.
 \end{itemdescr}
 
@@ -16464,7 +16464,7 @@ explicit basic_format_arg(nullptr_t) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{value} with
+Initializes \exposid{value_} with
   \tcode{static_cast<const void*>(nullptr)}.
 \end{itemdescr}
 
@@ -16479,7 +16479,7 @@ template<class T> explicit basic_format_arg(T* p) noexcept;
 
 \pnum
 \effects
-Initializes \tcode{value} with \tcode{p}.
+Initializes \exposid{value_} with \tcode{p}.
 
 \pnum
 \begin{note}
@@ -16499,7 +16499,7 @@ explicit operator bool() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{!holds_alternative<monostate>(value)}.
+\tcode{!holds_alternative<monostate>(\exposid{value_})}.
 \end{itemdescr}
 
 \pnum
@@ -16520,7 +16520,7 @@ namespace std {
     friend class basic_format_arg<Context>;                     // \expos
 
   public:
-    void format(basic_format_parse_context<char_type>&, Context& ctx) const;
+    void format(basic_format_parse_context<@\exposid{char-type}@>&, Context& ctx) const;
   };
 }
 \end{codeblock}
@@ -16555,7 +16555,7 @@ Initializes
 \tcode{\exposid{ptr_}} with \tcode{addressof(val)} and
 \tcode{\exposid{format_}} with
 \begin{codeblock}
-[](basic_format_parse_context<char_type>& parse_ctx,
+[](basic_format_parse_context<@\exposid{char-type}@>& parse_ctx,
    Context& format_ctx, const void* ptr) {
   typename Context::template formatter_type<TD> f;
   parse_ctx.advance_to(f.parse(parse_ctx));
@@ -16567,7 +16567,7 @@ Initializes
 
 \indexlibrarymember{format}{basic_format_arg::handle}%
 \begin{itemdecl}
-void format(basic_format_parse_context<char_type>& parse_ctx, Context& format_ctx) const;
+void format(basic_format_parse_context<@\exposid{char-type}@>& parse_ctx, Context& format_ctx) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -16585,7 +16585,7 @@ template<class Visitor, class Context>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return visit(forward<Visitor>(vis), arg.value);}
+Equivalent to: \tcode{return visit(forward<Visitor>(vis), arg.\exposid{value_});}
 \end{itemdescr}
 
 \rSec3[format.arg.store]{Class template \exposid{format-arg-store}}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16298,27 +16298,27 @@ namespace std {
     class handle;
 
   private:
-    using char_type = typename Context::char_type;                              // \expos
+    using @\exposid{char-type}@ = typename Context::char_type;                              // \expos
 
-    variant<monostate, bool, char_type,
+    variant<monostate, bool, @\exposid{char-type}@,
             int, unsigned int, long long int, unsigned long long int,
             float, double, long double,
-            const char_type*, basic_string_view<char_type>,
+            const @\exposid{char-type}@*, basic_string_view<@\exposid{char-type}@>,
             const void*, handle> value;                                         // \expos
 
     template<class T> explicit basic_format_arg(T&& v) noexcept;                // \expos
     explicit basic_format_arg(float n) noexcept;                                // \expos
     explicit basic_format_arg(double n) noexcept;                               // \expos
     explicit basic_format_arg(long double n) noexcept;                          // \expos
-    explicit basic_format_arg(const char_type* s);                              // \expos
+    explicit basic_format_arg(const @\exposid{char-type}@* s);                              // \expos
 
     template<class traits>
       explicit basic_format_arg(
-        basic_string_view<char_type, traits> s) noexcept;                       // \expos
+        basic_string_view<@\exposid{char-type}@, traits> s) noexcept;                       // \expos
 
     template<class traits, class Allocator>
       explicit basic_format_arg(
-        const basic_string<char_type, traits, Allocator>& s) noexcept;          // \expos
+        const basic_string<@\exposid{char-type}@, traits, Allocator>& s) noexcept;          // \expos
 
     explicit basic_format_arg(nullptr_t) noexcept;                              // \expos
 
@@ -16378,10 +16378,10 @@ shall be well-formed when treated as an unevaluated operand\iref{term.unevaluate
 \effects
 \begin{itemize}
 \item
-if \tcode{T} is \tcode{bool} or \tcode{char_type},
+if \tcode{T} is \tcode{bool} or \tcode{\exposid{char-type}},
 initializes \tcode{value} with \tcode{v};
 \item
-otherwise, if \tcode{T} is \tcode{char} and \tcode{char_type} is
+otherwise, if \tcode{T} is \tcode{char} and \tcode{\exposid{char-type}} is
 \keyword{wchar_t}, initializes \tcode{value} with
 \tcode{static_cast<wchar_t>(v)};
 \item
@@ -16419,7 +16419,7 @@ Initializes \tcode{value} with \tcode{n}.
 \end{itemdescr}
 
 \begin{itemdecl}
-explicit basic_format_arg(const char_type* s);
+explicit basic_format_arg(const @\exposid{char-type}@* s);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -16434,27 +16434,27 @@ Initializes \tcode{value} with \tcode{s}.
 
 \begin{itemdecl}
 template<class traits>
-  explicit basic_format_arg(basic_string_view<char_type, traits> s) noexcept;
+  explicit basic_format_arg(basic_string_view<@\exposid{char-type}@, traits> s) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects
 Initializes \tcode{value} with
-\tcode{basic_string_view<char_type>(s.data(), s.size())}.
+\tcode{basic_string_view<\exposid{char-type}>(s.data(), s.size())}.
 \end{itemdescr}
 
 \begin{itemdecl}
 template<class traits, class Allocator>
   explicit basic_format_arg(
-    const basic_string<char_type, traits, Allocator>& s) noexcept;
+    const basic_string<@\exposid{char-type}@, traits, Allocator>& s) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects
 Initializes \tcode{value} with
-\tcode{basic_string_view<char_type>(s.data(), s.size())}.
+\tcode{basic_string_view<\exposid{char-type}>(s.data(), s.size())}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -16511,8 +16511,8 @@ The class \tcode{handle} allows formatting an object of a user-defined type.
 namespace std {
   template<class Context>
   class basic_format_arg<Context>::handle {
-    const void* ptr_;                                           // \expos
-    void (*format_)(basic_format_parse_context<char_type>&,
+    const void* @\exposid{ptr_}@;                                           // \expos
+    void (*@\exposid{format_}@)(basic_format_parse_context<char_type>&,
                     Context&, const void*);                     // \expos
 
     template<class T> explicit handle(T&& val) noexcept;        // \expos
@@ -16552,8 +16552,8 @@ and \tcode{TD} otherwise.
 \pnum
 \effects
 Initializes
-\tcode{ptr_} with \tcode{addressof(val)} and
-\tcode{format_} with
+\tcode{\exposid{ptr_}} with \tcode{addressof(val)} and
+\tcode{\exposid{format_}} with
 \begin{codeblock}
 [](basic_format_parse_context<char_type>& parse_ctx,
    Context& format_ctx, const void* ptr) {
@@ -16573,7 +16573,7 @@ void format(basic_format_parse_context<char_type>& parse_ctx, Context& format_ct
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{format_(parse_ctx, format_ctx, ptr_);}
+Equivalent to: \tcode{\exposid{format_}(parse_ctx, format_ctx, \exposid{ptr_});}
 \end{itemdescr}
 
 \indexlibraryglobal{visit_format_arg}%
@@ -16642,8 +16642,8 @@ Equivalent to:
 namespace std {
   template<class Context>
   class basic_format_args {
-    size_t size_;                               // \expos
-    const basic_format_arg<Context>* data_;     // \expos
+    size_t using @\exposid{size_}@;                               // \expos
+    const basic_format_arg<Context>* using @\exposid{data_}@;     // \expos
 
   public:
     basic_format_args() noexcept;
@@ -16675,7 +16675,7 @@ basic_format_args() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{size_} with \tcode{0}.
+Initializes \tcode{\exposid{size_}} with \tcode{0}.
 \end{itemdescr}
 
 \indexlibraryctor{basic_format_args}%
@@ -16688,8 +16688,8 @@ template<class... Args>
 \pnum
 \effects
 Initializes
-\tcode{size_} with \tcode{sizeof...(Args)} and
-\tcode{data_} with \tcode{store.args.data()}.
+\tcode{\exposid{size_}} with \tcode{sizeof...(Args)} and
+\tcode{\exposid{data_}} with \tcode{store.args.data()}.
 \end{itemdescr}
 
 \indexlibrarymember{get}{basic_format_args}%
@@ -16700,7 +16700,7 @@ basic_format_arg<Context> get(size_t i) const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{i < size_ ?\ data_[i] :\ basic_format_arg<Context>()}.
+\tcode{i < \exposid{size_} ?\ \exposid{data_}[i] :\ basic_format_arg<Context>()}.
 \end{itemdescr}
 
 \rSec2[format.tuple]{Tuple formatter}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16675,7 +16675,7 @@ basic_format_args() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{\exposid{size_}} with \tcode{0}.
+Initializes \exposid{size_} with \tcode{0}.
 \end{itemdescr}
 
 \indexlibraryctor{basic_format_args}%


### PR DESCRIPTION
Consistently apply the `\exposid` macro when typesetting exposition-only private data members and typedef-name members in `basic_format_arg` and related parts.

Note that I confirmed the exposition-only intent against P0645R10 to ensure that the use of code font was a genuine misapplication of the original paper.