### PR TITLE
[coro.generator.promise] Fix tparams for generator::promise_type::yield_value

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -15210,8 +15210,8 @@ namespace std {
         @\libconcept{constructible_from}@<remove_cvref_t<yielded>, const remove_reference_t<yielded>&>;
 
     template<class R2, class V2, class Alloc2, class Unused>
-      requires @\libconcept{same_as}@<typename generator<T2, V2, Alloc2>::yielded, yielded>
-        auto yield_value(ranges::elements_of<generator<T2, V2, Alloc2>&&, Unused> g) noexcept;
+      requires @\libconcept{same_as}@<typename generator<R2, V2, Alloc2>::yielded, yielded>
+        auto yield_value(ranges::elements_of<generator<R2, V2, Alloc2>&&, Unused> g) noexcept;
 
     template<ranges::@\libconcept{input_range}@ R, class Alloc>
       requires @\libconcept{convertible_to}@<ranges::range_reference_t<R>, yielded>
@@ -15336,9 +15336,9 @@ has type \tcode{void}\iref{expr.yield}.
 
 \indexlibrarymember{yield_value}{generator::promise_type}%
 \begin{itemdecl}
-template<class T2, class V2, class Alloc2, class Unused>
-  requires @\libconcept{same_as}@<typename generator<T2, V2, Alloc2>::yielded, yielded>
-  auto yield_value(ranges::elements_of<generator<T2, V2, Alloc2>&&, Unused> g) noexcept;
+template<class R2, class V2, class Alloc2, class Unused>
+  requires @\libconcept{same_as}@<typename generator<R2, V2, Alloc2>::yielded, yielded>
+  auto yield_value(ranges::elements_of<generator<R2, V2, Alloc2>&&, Unused> g) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
The synopsis and definition of the respective `yield_value` overload are inconsistent. Given that the first tparam of generator is `Ref` it makes sense to switch from `T2` to `R2` consistently whilst fixing the issue,