### PR TITLE
[iterators] Add missing definitions from the iterators library to the library index

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -59,7 +59,7 @@ namespace std {
   template<class T> requires is_object_v<T> struct iterator_traits<T*>;             // freestanding
 
   template<@\exposconcept{dereferenceable}@ T>
-    using iter_reference_t = decltype(*declval<T&>());                              // freestanding
+    using @\libglobal{iter_reference_t}@ = decltype(*declval<T&>());                              // freestanding
 
   namespace ranges {
     // \ref{iterator.cust}, customization point objects
@@ -76,7 +76,7 @@ namespace std {
     requires requires(T& t) {
       { ranges::iter_move(t) } -> @\exposconcept{can-reference}@;
     }
-  using iter_rvalue_reference_t                                                     // freestanding
+  using @\libglobal{iter_rvalue_reference_t}@                                                     // freestanding
     = decltype(ranges::iter_move(declval<T&>()));
 
   // \ref{iterator.concepts}, iterator concepts
@@ -85,7 +85,7 @@ namespace std {
     concept indirectly_readable = @\seebelow@;                                        // freestanding
 
   template<@\libconcept{indirectly_readable}@ T>
-    using iter_common_reference_t =                                                 // freestanding
+    using @\libglobal{iter_common_reference_t}@ =                                                 // freestanding
       common_reference_t<iter_reference_t<T>, iter_value_t<T>&>;
 
   // \ref{iterator.concept.writable}, concept \libconcept{indirectly_writable}
@@ -161,7 +161,7 @@ namespace std {
 
   template<class F, class... Is>
     requires (@\libconcept{indirectly_readable}@<Is> && ...) && @\libconcept{invocable}@<F, iter_reference_t<Is>...>
-      using indirect_result_t = invoke_result_t<F, iter_reference_t<Is>...>;        // freestanding
+      using @\libglobal{indirect_result_t}@ = invoke_result_t<F, iter_reference_t<Is>...>;        // freestanding
 
   // \ref{projected}, projected
   template<@\libconcept{indirectly_readable}@ I, @\libconcept{indirectly_regular_unary_invocable}@<I> Proj>
@@ -363,10 +363,10 @@ namespace std {
   };
 
   template<@\libconcept{input_iterator}@ I>
-    constexpr const_iterator<I> make_const_iterator(I it) { return it; }            // freestanding
+    constexpr const_iterator<I> @\libglobal{make_const_iterator}@(I it) { return it; }            // freestanding
 
   template<@\libconcept{semiregular}@ S>
-    constexpr const_sentinel<S> make_const_sentinel(S s) { return s; }              // freestanding
+    constexpr const_sentinel<S> @\libglobal{make_const_sentinel}@(S s) { return s; }              // freestanding
 
   // \ref{move.iterators}, move iterators and sentinels
   template<class Iterator> class move_iterator;                                     // freestanding
@@ -4176,7 +4176,7 @@ Specializations of \tcode{basic_const_iterator} are constant iterators.
 
 \begin{itemdecl}
 template<@\libconcept{indirectly_readable}@ It>
-  using iter_const_reference_t =
+  using @\libglobal{iter_const_reference_t}@ =
     common_reference_t<const iter_value_t<It>&&, iter_reference_t<It>>;
 
 template<class It>


### PR DESCRIPTION
Add following definitions from the iterators library to the library index:

- indirect_result_t
- iter_common_reference_t
- iter_const_reference_t 
- iter_reference_t
- iter_rvalue_reference_t
- make_const_iterator
- make_const_sentinel