### PR TITLE
[concepts.object] Changed built-in types to fundamental types

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -1200,14 +1200,14 @@ template<class T>
 \pnum
 \begin{note}
 The \libconcept{semiregular} concept is modeled by types that behave similarly
-to built-in types like \tcode{int}, except that they need not
+to fundamental types like \tcode{int}, except that they need not
 be comparable with \tcode{==}.
 \end{note}
 
 \pnum
 \begin{note}
 The \libconcept{regular} concept is modeled by types that behave similarly to
-built-in types like \tcode{int} and that are comparable with
+fundamental types like \tcode{int} and that are comparable with
 \tcode{==}.
 \end{note}
 \end{itemdescr}


### PR DESCRIPTION
[concepts.object]Replacing the term "built-in type" with "fundamental type"

Fixes cplusplus/CWG#192