### PR TITLE
[time.zone.leap.members] update note about leap seconds

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -10194,7 +10194,7 @@ constexpr seconds value() const noexcept;
 \tcode{+1s} to indicate a positive leap second or
 \tcode{-1s} to indicate a negative leap second.
 \begin{note}
-All leap seconds inserted up through 2019 were positive leap seconds.
+All leap seconds inserted up through 2022 were positive leap seconds.
 \end{note}
 \end{itemdescr}
 


### PR DESCRIPTION
This note about leap seconds is still true, but should be updated to be more precise. Saying something about 2019 in C++23 seems odd, and will lead readers to wonder if a negative leap seconds was inserted in 2020.

There has been no leap second inserted since 2016, and none will be inserted before 2023-06-28 at the earliest.

https://en.wikipedia.org/wiki/Leap_second

