### PR TITLE
[concept.copyconstructible] Avoid "possibly \tcode{const}"

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -833,7 +833,7 @@ template<class T>
 \begin{itemdescr}
 \pnum
 If \tcode{T} is an object type, then let \tcode{v} be an lvalue of type
-(possibly \keyword{const}) \tcode{T} or an rvalue of type \tcode{const T}.
+\tcode{T} or \tcode{\keyword{const} T} or an rvalue of type \tcode{const T}.
 \tcode{T} models \libconcept{copy_constructible} only if
 
 \begin{itemize}

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -833,7 +833,7 @@ template<class T>
 \begin{itemdescr}
 \pnum
 If \tcode{T} is an object type, then let \tcode{v} be an lvalue of type
-\tcode{T} or \tcode{\keyword{const} T} or an rvalue of type \tcode{const T}.
+\tcode{T} or \tcode{\keyword{const} T} or an rvalue of type \tcode{\keyword{const} T}.
 \tcode{T} models \libconcept{copy_constructible} only if
 
 \begin{itemize}


### PR DESCRIPTION
A small rewrite avoids the phrase "possibly \tcode{const}", which we would like to remove entirely in favour of just "possibly const".

Partially addresses #117.