### PR TITLE
Replace "possibly \tcode{const}" with "possibly const"

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -158,7 +158,7 @@ the type \tcode{decltype(pred(*first))} shall model
 \exposconcept{boolean-testable}\iref{concept.booleantestable}.
 The function object \tcode{pred} shall not apply any non-constant function
 through its argument.
-Given a glvalue \tcode{u} of type (possibly \keyword{const}) \tcode{T}
+Given a glvalue \tcode{u} of type (possibly const) \tcode{T}
 that designates the same object as \tcode{*first},
 \tcode{pred(u)} shall be a valid expression
 that is equal to \tcode{pred(*first)}.
@@ -185,9 +185,9 @@ the type \tcode{decltype(binary_pred(*first1, value))} shall model
 \exposconcept{boolean-testable}.
 \tcode{binary_pred} shall not apply any non-constant function
 through any of its arguments.
-Given a glvalue \tcode{u} of type (possibly \keyword{const}) \tcode{T1}
+Given a glvalue \tcode{u} of type (possibly const) \tcode{T1}
 that designates the same object as \tcode{*first1}, and
-a glvalue \tcode{v} of type (possibly \keyword{const}) \tcode{T2}
+a glvalue \tcode{v} of type (possibly const) \tcode{T2}
 that designates the same object as \tcode{*first2},
 \tcode{binary_pred(u, *first2)},
 \tcode{binary_pred(*first1, v)}, and

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -13667,7 +13667,7 @@ either
 \tcode{basic_string} or \tcode{basic_string_view}, or
 \item
 the \grammarterm{qualified-id} \tcode{iterator_traits<decay_t<Source>>::value_type} is valid and
-denotes a possibly \keyword{const} encoded character type\iref{temp.deduct}.
+denotes a possibly const encoded character type\iref{temp.deduct}.
 \end{itemize}
 
 \pnum

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1599,7 +1599,7 @@ supplied by a \Cpp{} program instantiating a template,
 \item
 \tcode{a},
 \tcode{b}, and
-\tcode{c} denote values of type (possibly \keyword{const}) \tcode{T},
+\tcode{c} denote values of type (possibly const) \tcode{T},
 \item
 \tcode{s} and \tcode{t} denote modifiable lvalues of type \tcode{T},
 \item
@@ -1607,7 +1607,7 @@ supplied by a \Cpp{} program instantiating a template,
 \item
 \tcode{rv} denotes an rvalue of type \tcode{T}, and
 \item
-\tcode{v} denotes an lvalue of type (possibly \keyword{const}) \tcode{T} or an
+\tcode{v} denotes an lvalue of type (possibly const) \tcode{T} or an
 rvalue of type \tcode{const T}.
 \end{itemize}
 
@@ -1861,8 +1861,8 @@ via an exception.
 \pnum
 In \tref{cpp17.nullablepointer}, \tcode{u} denotes an identifier, \tcode{t}
 denotes a non-\keyword{const} lvalue of type \tcode{P}, \tcode{a} and \tcode{b}
-denote values of type (possibly \keyword{const}) \tcode{P}, and \tcode{np} denotes
-a value of type (possibly \keyword{const}) \tcode{std::nullptr_t}.
+denote values of type (possibly const) \tcode{P}, and \tcode{np} denotes
+a value of type (possibly const) \tcode{std::nullptr_t}.
 
 \begin{oldconcepttable}{NullablePointer}{}{cpp17.nullablepointer}
 {lx{2in}l}
@@ -1915,9 +1915,9 @@ are valid and have the indicated semantics.
 
 \pnum
 Given \tcode{Key} is an argument type for function objects of type \tcode{H}, in
-\tref{cpp17.hash} \tcode{h} is a value of type (possibly \keyword{const}) \tcode{H},
+\tref{cpp17.hash} \tcode{h} is a value of type (possibly const) \tcode{H},
 \tcode{u} is an lvalue of type \tcode{Key}, and \tcode{k} is a value of a type convertible to
-(possibly \keyword{const}) \tcode{Key}.
+(possibly const) \tcode{Key}.
 
 \begin{oldconcepttable}{Hash}{}{cpp17.hash}
 {llp{.55\hsize}}
@@ -1998,7 +1998,7 @@ obtained by conversion from a value \tcode{q} or a value \tcode{w},
 \item
 \tcode{y} denotes a value of type \tcode{XX::const_void_pointer}
 obtained by conversion from a result value of \tcode{YY::allocate}, or else
-a value of type (possibly \tcode{const}) \tcode{std::nullptr_t},
+a value of type (possibly const) \tcode{std::nullptr_t},
 \item
 \tcode{n} denotes a value of type \tcode{XX::size_type},
 \item
@@ -2658,7 +2658,7 @@ Identical to or derived from \tcode{true_type} or \tcode{false_type}.
 \pnum
 \returns
 \tcode{true_type} only if the expression \tcode{a1 == a2} is guaranteed
-to be \tcode{true} for any two (possibly \tcode{const}) values
+to be \tcode{true} for any two (possibly const) values
 \tcode{a1}, \tcode{a2} of type \tcode{X}.
 
 \pnum

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -1789,7 +1789,7 @@ In that Table and throughout this subclause:
   \item
     \tcode{e} is a value of \tcode{E},
     \tcode{v} is an lvalue of \tcode{E},
-    \tcode{x} and \tcode{y} are (possibly \keyword{const}) values of \tcode{E};
+    \tcode{x} and \tcode{y} are (possibly const) values of \tcode{E};
   \item
     \tcode{s} is a value of \tcode{T};
   \item
@@ -2172,7 +2172,7 @@ In that Table and throughout this subclause,
     \tcode{d} is a
     value of \tcode{D},
     and
-    \tcode{x} and \tcode{y} are (possibly \keyword{const}) values of \tcode{D};
+    \tcode{x} and \tcode{y} are (possibly const) values of \tcode{D};
   \item
     \tcode{glb} and \tcode{lub}
     are values of \tcode{T}
@@ -2181,7 +2181,7 @@ In that Table and throughout this subclause,
     on the values potentially returned by \tcode{d}'s \tcode{operator()},
     as determined by the current values of \tcode{d}'s parameters;
   \item
-    \tcode{p} is a (possibly \keyword{const}) value of \tcode{P};
+    \tcode{p} is a (possibly const) value of \tcode{P};
   \item
     \tcode{g}, \tcode{g1}, and \tcode{g2} are lvalues of a type
     meeting the requirements

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15656,7 +15656,7 @@ Given character type \tcode{charT}, output iterator type
 \tcode{Out}, and formatting argument type \tcode{T},
 in \tref{formatter.basic} and \tref{formatter}:
 \begin{itemize}
-\item \tcode{f} is a value of type (possibly \tcode{const}) \tcode{F},
+\item \tcode{f} is a value of type (possibly const) \tcode{F},
 \item \tcode{g} is an lvalue of type \tcode{F},
 \item \tcode{u} is an lvalue of type \tcode{T},
 \item \tcode{t} is a value of a type convertible to (possibly const) \tcode{T},


### PR DESCRIPTION
The "const" here is not syntax, but just normal text. This is similar to "inline" and "public", which have previously been cleaned up similarly.

Fixes #117.