### PR TITLE
[depr.meta.types] Remove is_literal_type index entry

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -1364,7 +1364,6 @@ As if by \tcode{p->\~T()}.
 The header \libheaderrefx{type_traits}{meta.type.synop}
 has the following addition:
 
-\indexlibraryglobal{is_literal_type}%
 \begin{codeblock}
 namespace std {
   template<class T> struct is_pod;


### PR DESCRIPTION
This subclause doesn't mention `is_literal_type`. I believe the index entry is a historical artifact from when the trait was deprecated; it should have been removed when the trait was removed.