### PR TITLE
[ranges] Add subrange_kind to the library index

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -131,7 +131,7 @@ namespace std::ranges {
   class view_interface;                                                             // freestanding
 
   // \ref{range.subrange}, sub-ranges
-  enum class subrange_kind : bool { unsized, sized };                               // freestanding
+  enum class @\libglobal{subrange_kind}@ : bool { @\libmember{unsized}{subrange_kind}@, @\libmember{sized}{subrange_kind}@ };                               // freestanding
 
   template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S = I, subrange_kind K = @\seebelow@>
     requires (K == subrange_kind::sized || !@\libconcept{sized_sentinel_for}@<S, I>)


### PR DESCRIPTION
Add `subrange_kind` and its enumerators `unsized` and `sized` to the library index.