### PR TITLE
[time.syn] Fixes ymwd abbreviation consistency.

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -597,7 +597,7 @@ namespace std::chrono {
 
   template<class charT, class traits>
     basic_ostream<charT, traits>&
-      operator<<(basic_ostream<charT, traits>& os, const year_month_weekday& ymwdi);
+      operator<<(basic_ostream<charT, traits>& os, const year_month_weekday& ymwd);
 
   // \ref{time.cal.ymwdlast}, class \tcode{year_month_weekday_last}
   class year_month_weekday_last;


### PR DESCRIPTION
Only `operator<<` uses `ymwdi` instead of `ymwd` in the synopsis. [time.cal.ymwd.nonmembers]/11 also uses `ymwd` for `operator<<`.