### PR TITLE
[lex.ccon] Add xref to lex.charset, where encodings are defined

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1541,7 +1541,7 @@ Such \grammarterm{character-literal}s are conditionally-supported.
 
 \pnum
 The kind of a \grammarterm{character-literal},
-its type, and its associated character encoding
+its type, and its associated character encoding\iref{lex.charset}
 are determined by
 its \grammarterm{encoding-prefix} and its \grammarterm{c-char-sequence}
 as defined by \tref{lex.ccon.literal}.


### PR DESCRIPTION
Partially addresses #4394.