### PR TITLE
[range.istream] Start `CharT` and `Traits` with lowercase

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -219,7 +219,7 @@ namespace std::ranges {
   namespace views { inline constexpr @\unspecnc@ repeat = @\unspecnc@; }            // freestanding
 
   // \ref{range.istream}, istream view
-  template<@\libconcept{movable}@ Val, class CharT, class Traits = char_traits<CharT>>
+  template<@\libconcept{movable}@ Val, class charT, class traits = char_traits<charT>>
     requires @\seebelow@
   class basic_istream_view;
   template<class Val>
@@ -3816,18 +3816,18 @@ ranges::copy(views::istream<int>(ints), ostream_iterator<int>{cout, "-"});
 \indexlibraryglobal{basic_istream_view}%
 \begin{codeblock}
 namespace std::ranges {
-  template<class Val, class CharT, class Traits>
+  template<class Val, class charT, class traits>
     concept @\defexposconceptnc{stream-extractable}@ =                // \expos
-      requires(basic_istream<CharT, Traits>& is, Val& t) {
+      requires(basic_istream<charT, traits>& is, Val& t) {
          is >> t;
       };
 
-  template<@\libconcept{movable}@ Val, class CharT, class Traits = char_traits<CharT>>
+  template<@\libconcept{movable}@ Val, class charT, class traits = char_traits<charT>>
     requires @\libconcept{default_initializable}@<Val> &&
-             @\exposconcept{stream-extractable}@<Val, CharT, Traits>
-  class basic_istream_view : public view_interface<basic_istream_view<Val, CharT, Traits>> {
+             @\exposconcept{stream-extractable}@<Val, charT, traits>
+  class basic_istream_view : public view_interface<basic_istream_view<Val, charT, traits>> {
   public:
-    constexpr explicit basic_istream_view(basic_istream<CharT, Traits>& stream);
+    constexpr explicit basic_istream_view(basic_istream<charT, traits>& stream);
 
     constexpr auto begin() {
       *@\exposid{stream_}@ >> @\exposid{value_}@;
@@ -3839,7 +3839,7 @@ namespace std::ranges {
   private:
     // \ref{range.istream.iterator}, class \tcode{basic_istream_view::\exposid{iterator}}
     struct @\exposidnc{iterator}@;                            // \expos
-    basic_istream<CharT, Traits>* @\exposid{stream_}@;      // \expos
+    basic_istream<charT, traits>* @\exposid{stream_}@;      // \expos
     Val @\exposid{value_}@ = Val();                         // \expos
   };
 }
@@ -3847,7 +3847,7 @@ namespace std::ranges {
 
 \indexlibraryctor{basic_istream_view}%
 \begin{itemdecl}
-constexpr explicit basic_istream_view(basic_istream<CharT, Traits>& stream);
+constexpr explicit basic_istream_view(basic_istream<charT, traits>& stream);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3871,10 +3871,10 @@ Equivalent to: \tcode{return default_sentinel;}
 
 \begin{codeblock}
 namespace std::ranges {
-  template<@\libconcept{movable}@ Val, class CharT, class Traits>
+  template<@\libconcept{movable}@ Val, class charT, class traits>
     requires @\libconcept{default_initializable}@<Val> &&
-             @\exposconcept{stream-extractable}@<Val, CharT, Traits>
-  class basic_istream_view<Val, CharT, Traits>::@\exposid{iterator}@ {
+             @\exposconcept{stream-extractable}@<Val, charT, traits>
+  class basic_istream_view<Val, charT, traits>::@\exposid{iterator}@ {
   public:
     using iterator_concept = input_iterator_tag;
     using difference_type = ptrdiff_t;


### PR DESCRIPTION
I noticed that whether it is 
- `basic_istream`/`basic_ostream` in `<iosfwd>`, 
- or `istream_iterator`/`ostream_iterator` in `<iterator>`, 
- or `string`/`string_view` in `<string>`, 
- or `formatter` in `<format>`, 

their template parameters `charT`/`traits` all start with lowercase.

We should make `istream_view` consistent with such a style.