### PR TITLE
[class.compare] Don't introduce `V` for the return value

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6517,8 +6517,8 @@ in the expanded lists of subobjects for \tcode{x} and \tcode{y}
 until the first index $i$
 where $\tcode{x}_i\tcode{ == }\tcode{y}_i$ yields a result value which,
 when contextually converted to \tcode{bool}, yields \tcode{false}.
-If no such index exists, the return value is \tcode{true}.
-Otherwise, the return value is \tcode{false}.
+The return value is \tcode{true} if such an index exists
+and \tcode{false} otherwise.
 
 \pnum
 \begin{example}
@@ -6627,10 +6627,10 @@ until the first index $i$ where
 the synthesized three-way comparison of type \tcode{R}
 between $\tcode{x}_i$ and $\tcode{y}_i$
 yields a result value $\tcode{v}_i$ where $\tcode{v}_i \mathrel{\tcode{!=}} 0$,
-contextually converted to \tcode{bool}, yields \tcode{true};
-the return value is a copy of $\tcode{v}_i$.
-If no such index exists, the return value is
-\tcode{static_cast<R>(std::strong_ordering::equal)}.
+contextually converted to \tcode{bool}, yields \tcode{true}.
+The return value is a copy of $\tcode{v}_i$
+if such an index exists and
+\tcode{static_cast<R>(std::strong_ordering::equal)} otherwise.
 
 \pnum
 The \defn{common comparison type} \tcode{U}

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6509,7 +6509,7 @@ $\tcode{x}_i\tcode{ == }\tcode{x}_i$
 is usable\iref{class.compare.default}.
 
 \pnum
-The return value \tcode{V} of a defaulted \tcode{==} operator function
+The return value of a defaulted \tcode{==} operator function
 with parameters \tcode{x} and \tcode{y} is determined
 by comparing corresponding elements $\tcode{x}_i$ and $\tcode{y}_i$
 in the expanded lists of subobjects for \tcode{x} and \tcode{y}
@@ -6517,8 +6517,8 @@ in the expanded lists of subobjects for \tcode{x} and \tcode{y}
 until the first index $i$
 where $\tcode{x}_i\tcode{ == }\tcode{y}_i$ yields a result value which,
 when contextually converted to \tcode{bool}, yields \tcode{false}.
-If no such index exists, \tcode{V} is \tcode{true}.
-Otherwise, \tcode{V} is \tcode{false}.
+If no such index exists, the return value is \tcode{true}.
+Otherwise, the return value is \tcode{false}.
 
 \pnum
 \begin{example}
@@ -6616,7 +6616,7 @@ the operator function is defined as deleted.
 \end{itemize}
 
 \pnum
-The return value \tcode{V} of type \tcode{R}
+The return value of type \tcode{R}
 of the defaulted three-way comparison operator function
 with parameters \tcode{x} and \tcode{y} of the same type
 is determined by comparing corresponding elements
@@ -6628,8 +6628,8 @@ the synthesized three-way comparison of type \tcode{R}
 between $\tcode{x}_i$ and $\tcode{y}_i$
 yields a result value $\tcode{v}_i$ where $\tcode{v}_i \mathrel{\tcode{!=}} 0$,
 contextually converted to \tcode{bool}, yields \tcode{true};
-\tcode{V} is a copy of $\tcode{v}_i$.
-If no such index exists, \tcode{V} is
+the return value is a copy of $\tcode{v}_i$.
+If no such index exists, the return value is
 \tcode{static_cast<R>(std::strong_ordering::equal)}.
 
 \pnum


### PR DESCRIPTION
In both cases, I'm not sure introducing `V` helps much - just requires name lookup for `V`. If we just say "the return value" in every case, I think that's clearer.