### PR TITLE
[format.string.std] Fixing grammar error (#5912)

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -14739,7 +14739,7 @@ is interpreted.
 \rSec3[format.string.std]{Standard format specifiers}
 
 \pnum
-Each \tcode{formatter} specializations
+Each \tcode{formatter} specialization
 described in \ref{format.formatter.spec}
 for fundamental and string types
 interprets \fmtgrammarterm{format-spec} as a


### PR DESCRIPTION
Fixes #5912.