### PR TITLE
[range.take.overview, range.drop.overview] Remove redundant ranges:: qualifier

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -5630,7 +5630,7 @@ is expression-equivalent to:
 \begin{itemize}
 \item
 If \tcode{T} is a specialization
-of \tcode{ranges::empty_view}\iref{range.empty.view},
+of \tcode{empty_view}\iref{range.empty.view},
 then \tcode{((void)F, \placeholdernc{decay-copy}(E))},
 except that the evaluations of \tcode{E} and \tcode{F}
 are indeterminately sequenced.
@@ -5641,7 +5641,7 @@ Otherwise, if \tcode{T} models
 and is a specialization of
 \tcode{span}\iref{views.span},
 \tcode{basic_string_view}\iref{string.view}, or
-\tcode{ranges::subrange}\iref{range.subrange},
+\tcode{subrange}\iref{range.subrange},
 then
 \tcode{U(ranges::begin(E),
 ranges::be\-gin(E) + std::min<D>(ranges::distance(E), F))},
@@ -5653,22 +5653,22 @@ where \tcode{U} is a type determined as follows:
 then \tcode{U} is \tcode{span<typename T::element_type>};
 \item otherwise, if \tcode{T} is a specialization of \tcode{basic_string_view},
 then \tcode{U} is \tcode{T};
-\item otherwise, \tcode{T} is a specialization of \tcode{ranges::subrange}, and
-\tcode{U} is \tcode{ranges::subrange<iterator_t<T>>};
+\item otherwise, \tcode{T} is a specialization of \tcode{subrange}, and
+\tcode{U} is \tcode{subrange<iterator_t<T>>};
 \end{itemize}
 
 \item
 otherwise, if \tcode{T} is
-a specialization of \tcode{ranges::iota_view}\iref{range.iota.view}
+a specialization of \tcode{iota_view}\iref{range.iota.view}
 that models \libconcept{random_access_range} and \libconcept{sized_range},
 then
-\tcode{ranges::iota_view(*ranges::begin(E),
+\tcode{iota_view(*ranges::begin(E),
 *(ranges::begin(E) + std::\linebreak{}min<D>(ranges::distance(E), F)))},
 except that \tcode{E} is evaluated only once.
 
 \item
 Otherwise, if \tcode{T} is
-a specialization of \tcode{ranges::repeat_view}\iref{range.repeat.view}:
+a specialization of \tcode{repeat_view}\iref{range.repeat.view}:
 \begin{itemize}
 \item
 if \tcode{T} models \libconcept{sized_range},
@@ -5682,7 +5682,7 @@ otherwise, \tcode{views::repeat(*E.\exposid{value_}, static_cast<D>(F))}.
 \end{itemize}
 
 \item
-Otherwise, \tcode{ranges::take_view(E, F)}.
+Otherwise, \tcode{take_view(E, F)}.
 \end{itemize}
 
 \pnum
@@ -6095,7 +6095,7 @@ is expression-equivalent to:
 \begin{itemize}
 \item
 If \tcode{T} is a specialization of
-\tcode{ranges::empty_view}\iref{range.empty.view},
+\tcode{empty_view}\iref{range.empty.view},
 then \tcode{((void)F, \placeholdernc{decay-copy}(E))},
 except that the evaluations of \tcode{E} and \tcode{F}
 are indeterminately sequenced.
@@ -6107,8 +6107,8 @@ and is
 \begin{itemize}
 \item a specialization of \tcode{span}\iref{views.span},
 \item a specialization of \tcode{basic_string_view}\iref{string.view},
-\item a specialization of \tcode{ranges::iota_view}\iref{range.iota.view}, or
-\item a specialization of \tcode{ranges::subrange}\iref{range.subrange}
+\item a specialization of \tcode{iota_view}\iref{range.iota.view}, or
+\item a specialization of \tcode{subrange}\iref{range.subrange}
 where \tcode{T::\exposid{StoreSize}} is \tcode{false},
 \end{itemize}
 then \tcode{U(ranges::begin(E) + std::min<D>(ranges::distance(E), F), ranges::end(E))},
@@ -6119,7 +6119,7 @@ if \tcode{T} is a specialization of \tcode{span} and \tcode{T} otherwise.
 \item
 Otherwise,
 if \tcode{T} is
-a specialization of \tcode{ranges::subrange}\iref{range.subrange}
+a specialization of \tcode{subrange}\iref{range.subrange}
 that models \libconcept{random_access_range} and \libconcept{sized_range},
 then
 \tcode{T(ranges::begin(E) + std::min<D>(ranges::distance(E), F), ranges::\linebreak{}end(E),
@@ -6129,7 +6129,7 @@ except that \tcode{E} and \tcode{F} are each evaluated only once.
 
 \item
 Otherwise, if \tcode{T} is
-a specialization of \tcode{ranges::repeat_view}\iref{range.repeat.view}:
+a specialization of \tcode{repeat_view}\iref{range.repeat.view}:
 \begin{itemize}
 \item
 if \tcode{T} models \libconcept{sized_range},
@@ -6144,7 +6144,7 @@ except that the evaluations of \tcode{E} and \tcode{F} are indeterminately seque
 \end{itemize}
 
 \item
-Otherwise, \tcode{ranges::drop_view(E, F)}.
+Otherwise, \tcode{drop_view(E, F)}.
 \end{itemize}
 
 \pnum


### PR DESCRIPTION
This makes it consistent with other [range.xxx.overview].