### PR TITLE
Add extra notes to `ranges::c*` to mirror `ranges::*`

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -753,6 +753,13 @@ let \tcode{U} be \tcode{ranges::begin(\exposid{possibly-const-range}(t))}.
 
 \pnum
 \begin{note}
+Diagnosable ill-formed cases above
+result in substitution failure when \tcode{ranges::cbegin(E)}
+appears in the immediate context of a template instantiation.
+\end{note}
+
+\pnum
+\begin{note}
 Whenever \tcode{ranges::cbegin(E)} is a valid expression, its type models
 \libconcept{input_or_output_iterator} and \exposconcept{constant-iterator}.
 \end{note}
@@ -777,6 +784,13 @@ let \tcode{U} be \tcode{ranges::end(\exposid{possibly-const-range}(t))}.
 \tcode{ranges::cend(E)} is expression-equivalent to
 \tcode{const_sentinel<decltype(U)>(U)}.
 \end{itemize}
+
+\pnum
+\begin{note}
+Diagnosable ill-formed cases above
+result in substitution failure when \tcode{ranges::cend(E)}
+appears in the immediate context of a template instantiation.
+\end{note}
 
 \pnum
 \begin{note}
@@ -941,6 +955,13 @@ let \tcode{U} be \tcode{ranges::rbegin(\exposid{possibly-const-range}(t))}.
 
 \pnum
 \begin{note}
+Diagnosable ill-formed cases above
+result in substitution failure when \tcode{ranges::crbegin(E)}
+appears in the immediate context of a template instantiation.
+\end{note}
+
+\pnum
+\begin{note}
 Whenever \tcode{ranges::crbegin(E)} is a valid expression, its
 type models \libconcept{input_or_output_iterator} and
 \exposconcept{constant-iterator}.
@@ -966,6 +987,13 @@ let \tcode{U} be \tcode{ranges::rend(\exposid{possibly-const-range}(t))}.
 \tcode{ranges::crend(E)} is expression-equivalent to
 \tcode{const_sentinel<decltype(U)>(U)}.
 \end{itemize}
+
+\pnum
+\begin{note}
+Diagnosable ill-formed cases above
+result in substitution failure when \tcode{ranges::crend(E)}
+appears in the immediate context of a template instantiation.
+\end{note}
 
 \pnum
 \begin{note}
@@ -1191,6 +1219,13 @@ Otherwise,
 \tcode{ranges::cdata(E)} is expression-equivalent to
 \tcode{\exposid{as-const-pointer}(ranges::data(\exposid{possi\-bly-const-range}(t)))}.
 \end{itemize}
+
+\pnum
+\begin{note}
+Diagnosable ill-formed cases above
+result in substitution failure when \tcode{ranges::cdata(E)}
+appears in the immediate context of a template instantiation.
+\end{note}
 
 \pnum
 \begin{note}


### PR DESCRIPTION
Given the new changes to `cbegin` and friends from [P2278R4][], where they are no longer simple wrappers around `begin` and friends, it is (in my opinion) confusing that they lack a similar note about how "ill-formed means substitution failure".

[P2278R4]: https://wg21.link/p2278r4