### PR TITLE
[temp.pre] [temp.decls.general] Templated function

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -155,7 +155,8 @@ so all specializations of a template belong to the same scope as it does.
 
 \pnum
 \indextext{entity!templated}%
-An entity is \defn{templated}
+\indextext{templated entity}%
+An entity is a \defn{templated entity}
 if it is
 \begin{itemize}
 \item a template,
@@ -171,6 +172,26 @@ if it is
 A local class, a local or block variable, or a friend function defined in a
 templated entity is a templated entity.
 \end{note}
+
+\pnum
+\indextext{function!templated}%
+\indextext{templated function}%
+An entity is a \defn{templated function}
+if it is
+\begin{itemize}
+\item a function template, or
+\item a templated entity which is a function.
+\end{itemize}
+
+\pnum
+\indextext{class!templated}%
+\indextext{templated class}%
+An entity is a \defn{templated class}
+if it is
+\begin{itemize}
+\item a class template, or
+\item a templated entity which is a class type.
+\end{itemize}
 
 \pnum
 A \grammarterm{template-declaration} is written
@@ -1698,7 +1719,7 @@ void g() {
 
 \pnum
 A template declaration\iref{temp.pre}
-or templated function declaration\iref{dcl.fct}
+or declaration of a templated function\iref{temp.pre}
 can be constrained by the use of a \grammarterm{requires-clause}.
 This allows the specification of constraints for that declaration as
 an expression:
@@ -2177,7 +2198,7 @@ or
 \grammarterm{noexcept-specifier}
 is a separate definition
 which is unrelated
-to the templated function definition or
+to the definition of the templated function or
 to any other
 default arguments,
 \grammarterm{type-constraint}{s},
@@ -6194,7 +6215,7 @@ function\iref{special}, the program is ill-formed.
 \pnum
 The \grammarterm{declaration} in an \grammarterm{explicit-instantiation} and
 the \grammarterm{declaration} produced by the corresponding substitution
-into the templated function, variable, or class
+into the templated entity
 are two declarations of the same entity.
 \begin{note}
 These declarations are required to have matching types as specified in~\ref{basic.link}, except as specified in~\ref{except.spec}.

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -2186,9 +2186,7 @@ default arguments,
 \grammarterm{requires-clause}{s}\iref{temp.pre},
 and
 \grammarterm{noexcept-specifier}{s}
-of function templates
-and
-of member functions of class templates
+of templated functions\iref{temp.pre}
 are considered definitions;
 each
 default argument,
@@ -4548,9 +4546,8 @@ template<class... T> struct A : T...,  T... { };    // error: duplicate base cla
 \pnum
 \begin{note}
 For purposes of name lookup, default arguments and
-\grammarterm{noexcept-specifier}{s} of function templates and default
-arguments and \grammarterm{noexcept-specifier}{s} of
-member functions of class templates are considered definitions\iref{temp.decls}.
+\grammarterm{noexcept-specifier}{s} of templated functions\iref{temp.pre}
+are considered definitions\iref{temp.decls}.
 \end{note}
 
 \rSec2[temp.local]{Locally declared names}


### PR DESCRIPTION
As proposed in reflector thread `[core] What is a "templated function"?`

The first commit here is intended to be editorial and to match the intent described by Jens and Mike.

The second commit, I claim, is _not_ editorial; either it should not be made (because something subtle that I hope someone will explain to me in a PR comment), or it changes the normative wording for the better. Specifically, it would make the affected wording apply to _all_ templated functions, rather than to only a subset of them. An example of an entity affected by the change would be a templated function that is a _member function of a member class of a class template._