### PR TITLE
[over.over] Missed edit for P0847R7

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3004,7 +3004,7 @@ static member functions, and
 explicit object member functions
 match targets of function pointer type or
 reference to function type.
-Non-static member functions match targets of
+Implicit object member functions match targets of
 pointer-to-member-function type.
 \begin{note}
 %% FIXME: Should this only apply after the eliminations in the next paragraph?


### PR DESCRIPTION
P0847R7 (Deducing this) was approved at the October, 2021 meeting and applied with commit ee5117e100bbe9b7adb3510b2d7bb6d4d150f810, missing this change.