### PR TITLE
[reverse.iter.conv] Remove unclear explicit comments

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -3358,7 +3358,7 @@ Assigns \tcode{u.current} to \tcode{current}.
 
 \indexlibrarymember{base}{reverse_iterator}%
 \begin{itemdecl}
-constexpr Iterator base() const;          // explicit
+constexpr Iterator base() const;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
I don't know what explicit refers to here, it seems to be more appropriate to remove. People who disagree with me are also welcome.