### PR TITLE
Add cross-references between [basic.life],

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3451,6 +3451,9 @@ program has undefined behavior if:
   the pointer is used as the operand of a
   \keyword{dynamic_cast}\iref{expr.dynamic.cast}.
 \end{itemize}
+\begin{note}
+For an object with a non-trivial constructor or destructor, see also~\ref{class.cdtor}.
+\end{note}
 \begin{example}
 \begin{codeblock}
 #include <cstdlib>
@@ -3501,6 +3504,9 @@ well-defined. The program has undefined behavior if:
 \keyword{dynamic_cast}\iref{expr.dynamic.cast} or as the operand of
 \keyword{typeid}.
 \end{itemize}
+\begin{note}
+For an object with a non-trivial constructor or destructor, see also~\ref{class.cdtor}.
+\end{note}
 
 \pnum
 If, after the lifetime of an object has ended and before the storage

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -5931,6 +5931,9 @@ or base class of the object before the constructor begins execution results in
 undefined behavior. For an object with a non-trivial destructor, referring to
 any non-static member or base class of the object after the destructor finishes
 execution results in undefined behavior.
+\begin{note}
+See also~\ref{basic.life}.
+\end{note}
 \begin{example}
 \begin{codeblock}
 struct X { int i; };

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6023,6 +6023,9 @@ the construction of
 shall have started and its destruction shall not have completed,
 otherwise the computation of the pointer value (or accessing the member
 value) results in undefined behavior.
+\begin{note}
+See also~\ref{except.handle}.
+\end{note}
 \begin{example}
 \begin{codeblock}
 struct A { };


### PR DESCRIPTION
[class.cdtor] and [except.handle].

To resolve confusion noted in
https://github.com/cplusplus/CWG/issues/204