### PR TITLE
[class.mem.general] Clarify ambiguous 'and'

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -605,11 +605,10 @@ the \grammarterm{member-specification} of the enclosing class.
 \end{note}
 
 \pnum
-A class is regarded as complete
-where its definition is reachable and
-within its complete-class contexts;
-otherwise it is regarded as incomplete within its own class
-\grammarterm{member-specification}.
+A class \tcode{C} is complete at a program point $P$
+if the definition of \tcode{C} is reachable from $P$\iref{module.reach}
+or if $P$ is in a complete-class context of \tcode{C}.
+Otherwise, \tcode{C} is incomplete at $P$.
 
 \pnum
 In a \grammarterm{member-declarator},


### PR DESCRIPTION
Fixes cplusplus/CWG#229