### PR TITLE
[basic.life] Move definition of "before" and "after" from last paragraph

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3347,6 +3347,15 @@ Some functions in the \Cpp{} standard library implicitly create objects%
 \rSec2[basic.life]{Lifetime}
 
 \pnum
+In this subclause, ``before'' and ``after'' refer to the ``happens before''
+relation\iref{intro.multithread}.
+\begin{note}
+Therefore, undefined behavior results if an object that is being constructed in
+one thread is referenced from another thread without adequate synchronization.
+\end{note}
+\indextext{object lifetime|)}
+
+\pnum
 \indextext{object lifetime|(}%
 The \defn{lifetime} of an object or reference is a runtime property of the
 object or reference.
@@ -3611,16 +3620,6 @@ void h() {
 }
 \end{codeblock}
 \end{example}
-
-\pnum
-In this subclause, ``before'' and ``after'' refer to the ``happens before''
-relation\iref{intro.multithread}.
-\begin{note}
-Therefore, undefined behavior results
-if an object that is being constructed in one thread is referenced from another
-thread without adequate synchronization.
-\end{note}
-\indextext{object lifetime|)}
 
 \rSec2[basic.indet]{Indeterminate values}
 


### PR DESCRIPTION
The last paragraph of this subclause changes the definition of English words used throughout the preceding paragraphs.  While it might be preferable to replace all such usage with the new definitions, that would be a Core issue, see paragraph 6 for an example of awkward usage.  Hence, we move the redefinition to the start of the subclause so we know how to read this text from the start.