### PR TITLE
[expr.prim.req.general] Correct the IFNDR example

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2863,7 +2863,7 @@ no diagnostic required.
 \begin{codeblock}
 template<typename T> concept C =
 requires {
-  new int[-(int)sizeof(T)];     // ill-formed, no diagnostic required
+  new decltype((void)T{});      // ill-formed, no diagnostic required
 };
 \end{codeblock}
 \end{example}


### PR DESCRIPTION
Fixes #6055.

The old example is made well-formed by CWG2392. And it's doubtful whether it was definitely correct before CWG2392, as an implementation may allow a large object type `T` such that `(int)sizeof(T)` is equal to `0`.

The expression `new decltype((void)T{})` used by this PR is guaranteed to be ill-formed and thus makes the program IFNDR - either `T{}` is ill-formed, or the expression is equivalent to `new void` which is ill-formed.