### PR TITLE
[version.syn] Fix value of __cpp_lib_constexpr_bitset

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -592,7 +592,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_complex_udls}@                      201309L // also in \libheader{complex}
 #define @\defnlibxname{cpp_lib_concepts}@                          202207L // also in \libheader{concepts}, \libheader{compare}
 #define @\defnlibxname{cpp_lib_constexpr_algorithms}@              201806L // also in \libheader{algorithm}, \libheader{utility}
-#define @\defnlibxname{cpp_lib_constexpr_bitset}@                  202202L // also in \libheader{bitset}
+#define @\defnlibxname{cpp_lib_constexpr_bitset}@                  202207L // also in \libheader{bitset}
 #define @\defnlibxname{cpp_lib_constexpr_charconv}@                202207L // also in \libheader{charconv}
 #define @\defnlibxname{cpp_lib_constexpr_cmath}@                   202202L // also in \libheader{cmath}, \libheader{cstdlib}
 #define @\defnlibxname{cpp_lib_constexpr_complex}@                 201711L // also in \libheader{complex}


### PR DESCRIPTION
Paper P2417R2 was approved in July 2022, but commit 75518ffdc476cbc239918466588d963fc97a8013 did not set the feature-test to the approriate value.

Fixes #6065