### PR TITLE
[mdspan.layout.left.cons] Fix editorial issue in layout_left/right conversion constructors

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -19215,7 +19215,7 @@ template<class OtherExtents>
 If \tcode{extents_type::rank() > 0} is \tcode{true},
 then for all $r$ in the range $[0, \tcode{extents_type::rank()})$,
 \tcode{other.stride($r$)} equals
-\tcode{extents().\exposid{fwd-prod-of-extents}($r$)}, and
+\tcode{other.extents().\exposid{fwd-prod-of-extents}($r$)}, and
 \item
 \tcode{other.required_span_size()} is representable as
 a value of type \tcode{index_type}\iref{basic.fundamental}.
@@ -19467,7 +19467,7 @@ template<class OtherExtents>
 If \tcode{extents_type::rank() > 0} is \tcode{true},
 then for all $r$ in the range $[0, \tcode{extents_type::rank()})$,
 \tcode{other.stride($r$)} equals
-\tcode{extents().\exposid{rev-prod-of-extents}($r$)}.
+\tcode{other.extents().\exposid{rev-prod-of-extents}($r$)}.
 \item
 \tcode{other.required_span_size()} is representable as
 a value of type \tcode{index_type}\iref{basic.fundamental}.


### PR DESCRIPTION
The precondition was erroneously referring to the not yet constructed extents instead of other.extents().
Note that the extents of the to be constructed layout will be initialized with other.extents - i.e. after construction they will return the same value for the fwd-prod-of-extents etc.

### Before:
```c++
template<class OtherExtents>
  constexpr explicit(extents_type::rank() > 0)
    mapping(const layout_stride::mapping<OtherExtents>& other);
```

- *Constraints:* `is_­constructible_­v<extents_­type, OtherExtents> is true`.
- *Preconditions:*
    - If `extents_­type​::​rank() > 0` is `true`, then for all r in the range [0, `extents_­type​::​rank()`), `other.stride(r)` equals `extents().fwd-prod-of-extents(r)`, and


### After:

```c++
template<class OtherExtents>
  constexpr explicit(extents_type::rank() > 0)
    mapping(const layout_stride::mapping<OtherExtents>& other);
```

- *Constraints:* `is_­constructible_­v<extents_­type, OtherExtents> is true`.
- *Preconditions:*
    - If `extents_­type​::​rank() > 0` is `true`, then for all r in the range [0, `extents_­type​::​rank()`), `other.stride(r)` equals `other.extents().fwd-prod-of-extents(r)`, and