### PR TITLE
[intro, front] Special page header before Clause 1

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -1,6 +1,17 @@
 %!TEX root = std.tex
 
+\clearpage
+\bigskip\noindent\textlarger{\textbf{Programming languages --- \Cpp{}}}
+\bigskip\bigskip
+
+\begingroup
+\let\clearpage\relax
 \rSec0[intro.scope]{Scope}
+\endgroup
+\copypagestyle{cpppageone}{cpppage}
+\makeoddhead{cpppageone}{\textbf{WORKING DRAFT}}{}{\leaders\hrule height 2pt\hfill\kern0pt\\\textbf{\docno}}
+\makeheadrule{cpppageone}{\textwidth}{2pt}
+\thispagestyle{cpppageone}
 
 \pnum
 \indextext{scope|(}%

--- a/source/layout.tex
+++ b/source/layout.tex
@@ -10,7 +10,7 @@
 %%--------------------------------------------------
 %%  set header and footer positions and sizes
 
-\setheadfoot{\onelineskip}{4\onelineskip}
+\setheadfoot{3\onelineskip}{4\onelineskip}
 \setheaderspaces{*}{2\onelineskip}{*}
 
 %%--------------------------------------------------


### PR DESCRIPTION
ISO House Style requires a special header on page 1; the two-ruled format follows the rice model (and is what I'm doing for the LFTS).

![image](https://user-images.githubusercontent.com/6378233/216329057-0e0e84c7-7a51-4a24-a0a1-632f2d15e4b6.png)

The published wording will say "INTERNATIONAL STANDARD" etc.