### PR TITLE
[format.range.fmtmap] Fix undefined type name

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16736,7 +16736,7 @@ Either:
 \exposid{element-type} is a specialization of \tcode{pair}, or
 \item
 \exposid{element-type} is a specialization of \tcode{tuple} and
-\tcode{tuple_size_v<T> == 2}.
+\tcode{tuple_size_v<\exposid{element-type}> == 2}.
 \end{itemize}
 
 \pnum


### PR DESCRIPTION
I don't see where this `T` is defined, so let me assume this might be a typo (or I'm dazzled).