### PR TITLE
[func.require] Use math font for non-code conditions

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -10644,15 +10644,15 @@ and \tcode{remove_cvref_t<decltype(t$_1$)>} is a specialization of \tcode{refere
 member function of a class \tcode{T}
 and \tcode{t$_1$} does not satisfy the previous two items;
 
-\item \tcode{t$_1$.*f} when \tcode{N == 1} and \tcode{f} is a pointer to
+\item \tcode{t$_1$.*f} when $N = 1$ and \tcode{f} is a pointer to
 data member of a class \tcode{T}
 and \tcode{is_base_of_v<T, remove_reference_t<decltype(t$_1$)>>} is \tcode{true};
 
-\item \tcode{t$_1$.get().*f} when \tcode{N == 1} and \tcode{f} is a pointer to
+\item \tcode{t$_1$.get().*f} when $N = 1$ and \tcode{f} is a pointer to
 data member of a class \tcode{T}
 and \tcode{remove_cvref_t<decltype(t$_1$)>} is a specialization of \tcode{reference_wrapper};
 
-\item \tcode{(*t$_1$).*f} when \tcode{N == 1} and \tcode{f} is a pointer to
+\item \tcode{(*t$_1$).*f} when $N = 1$ and \tcode{f} is a pointer to
 data member of a class \tcode{T}
 and \tcode{t$_1$} does not satisfy the previous two items;
 


### PR DESCRIPTION
N is not a C++ entity, it refers to the N suffix of tN, and the equality is mathematical not a C++ operator.

If this was an actual C++ expression using a variable `N` we would need to say "`N == 1` is `true`" and that would be much worse :sweat_smile: 
