### PR TITLE
[dcl.attr.grammar] Add note about the semantic ignorability of standard attributes CWG2695

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -8505,6 +8505,9 @@ specified in \ref{dcl.attr} that violates
 the rules specifying to which entity or statement the attribute can apply or
 the syntax rules for the attribute's \grammarterm{attribute-argument-clause}, if any.
 \end{note}
+\begin{note}
+The \grammarterm{attribute}s specified in \ref{dcl.attr} have optional semantics: given a well-formed program, removing all instances of a particular such \grammarterm{attribute} results in a program whose observable behavior is a conforming realization of the original program.
+\end{note}
 An \grammarterm{attribute-token} is reserved for future standardization if
 \begin{itemize}
 \item it is not an \grammarterm{attribute-scoped-token} and


### PR DESCRIPTION
On 2023-02-06 in Issaquah, EWG had consensus on the following poll:

The semantic ignorability of standard attributes in general should be explicitly stated in the C++26 standard (Question 2 in paper P2552R1, Option 2a).
SF/F/N/A/SA 8/18/1/2/0 Consensus

EWG directed me to draft wording, which I presented to EWG on 2023-06-08.

Following that, EWG directed me to create a PR against the C++ draft, containing this draft wording, since this is a clarifying note with no normative changes and can be handled editorially.