### PR TITLE
[Motions 2023 02 lwg 13] P2679R2 Fixing std::start_lifetime_as and std::start_lifetime_as_array

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -881,7 +881,8 @@ template<class T>
 \begin{itemdescr}
 \pnum
 \mandates
-\tcode{T} is an implicit-lifetime type\iref{basic.types.general}.
+\tcode{T} is an implicit-lifetime type\iref{basic.types.general}
+and not an incomplete type\iref{term.incomplete.type}.
 
 \pnum
 \expects
@@ -931,14 +932,33 @@ template<class T>
 
 \begin{itemdescr}
 \pnum
+\mandates
+\tcode{T} is a complete type.
+
+\pnum
 \expects
-\tcode{n > 0} is \tcode{true}.
+\tcode{p} is suitably aligned for an array of \tcode{T} or is null.
+\tcode{n <= size_t(-1) / sizeof(T)} is \tcode{true}.
+If \tcode{n > 0} is \tcode{true},
+\range{(char*)p}{(char*)p + (n * sizeof(T))} denotes
+a region of allocated storage that is
+a subset of the region of storage
+reachable through\iref{basic.compound} \tcode{p}.
 
 \pnum
 \effects
-Equivalent to:
-\tcode{return *start_lifetime_as<U>(p);}
+If \tcode{n > 0} is \tcode{true},
+equivalent to
+\tcode{start_lifetime_as<U>(p)}
 where \tcode{U} is the type ``array of \tcode{n} \tcode{T}''.
+Otherwise, there are no effects.
+
+\pnum
+\returns
+A pointer to the first element of the created array,
+if any;
+otherwise,
+a pointer that compares equal to \tcode{p}\iref{expr.eq}.
 \end{itemdescr}
 
 \rSec2[allocator.tag]{Allocator argument tag}


### PR DESCRIPTION
Fixes #6103.
Fixes cplusplus/nbballot#459.
Fixes cplusplus/nbballot#508.
Fixes cplusplus/papers#1345.