### PR TITLE
[CWG 4] P2796R0 CWG2521 User-defined literals and reserved identifiers

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -188,6 +188,15 @@ a user-declared destructor.
 It is possible that future versions of \Cpp{} will specify
 that these implicit definitions are deleted\iref{dcl.fct.def.delete}.
 
+\rSec1[depr.lit]{Literal operator function declarations using an identifier}
+
+\pnum
+A \grammarterm{literal-operator-id}\iref{over.literal} of the form
+\begin{codeblock}
+operator @\grammarterm{string-literal}@ @\grammarterm{identifier}@
+\end{codeblock}
+is deprecated.
+
 \rSec1[depr.template.template]{\tcode{template} keyword before qualified names}
 
 \pnum

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -968,7 +968,9 @@ token as a regular \grammarterm{identifier}.
 \indextext{\idxcode{_}|see{character, underscore}}%
 \indextext{character!underscore!in identifier}%
 \indextext{reserved identifier}%
-In addition, some identifiers are reserved for use by \Cpp{}
+In addition, some identifiers
+appearing as a \grammarterm{token} or \grammarterm{preprocessing-token}
+are reserved for use by \Cpp{}
 implementations and shall
 not be used otherwise; no diagnostic is required.
 \begin{itemize}
@@ -2257,19 +2259,19 @@ without its \grammarterm{ud-suffix}. If \placeholder{S} contains a literal opera
 parameter type \tcode{unsigned long long}, the literal \placeholder{L} is treated as a call of
 the form
 \begin{codeblock}
-operator "" @\placeholder{X}@(@\placeholder{n}@ULL)
+operator ""@\placeholder{X}@(@\placeholder{n}@ULL)
 \end{codeblock}
 Otherwise, \placeholder{S} shall contain a raw literal operator
 or a numeric literal operator template\iref{over.literal} but not both.
 If \placeholder{S} contains a raw literal operator,
 the literal \placeholder{L} is treated as a call of the form
 \begin{codeblock}
-operator "" @\placeholder{X}@("@\placeholder{n}@")
+operator ""@\placeholder{X}@("@\placeholder{n}@")
 \end{codeblock}
 Otherwise (\placeholder{S} contains a numeric literal operator template),
 \placeholder{L} is treated as a call of the form
 \begin{codeblock}
-operator "" @\placeholder{X}@<'@$c_1$@', '@$c_2$@', ... '@$c_k$@'>()
+operator ""@\placeholder{X}@<'@$c_1$@', '@$c_2$@', ... '@$c_k$@'>()
 \end{codeblock}
 where \placeholder{n} is the source character sequence $c_1c_2...c_k$.
 \begin{note}
@@ -2283,19 +2285,19 @@ literal without its \grammarterm{ud-suffix}. If \placeholder{S} contains a liter
 with parameter type \tcode{long double}, the literal \placeholder{L} is treated as a call of
 the form
 \begin{codeblock}
-operator "" @\placeholder{X}@(@\placeholder{f}@L)
+operator ""@\placeholder{X}@(@\placeholder{f}@L)
 \end{codeblock}
 Otherwise, \placeholder{S} shall contain a raw literal operator
 or a numeric literal operator template\iref{over.literal} but not both.
 If \placeholder{S} contains a raw literal operator,
 the \grammarterm{literal} \placeholder{L} is treated as a call of the form
 \begin{codeblock}
-operator "" @\placeholder{X}@("@\placeholder{f}@")
+operator ""@\placeholder{X}@("@\placeholder{f}@")
 \end{codeblock}
 Otherwise (\placeholder{S} contains a numeric literal operator template),
 \placeholder{L} is treated as a call of the form
 \begin{codeblock}
-operator "" @\placeholder{X}@<'@$c_1$@', '@$c_2$@', ... '@$c_k$@'>()
+operator ""@\placeholder{X}@<'@$c_1$@', '@$c_2$@', ... '@$c_k$@'>()
 \end{codeblock}
 where \placeholder{f} is the source character sequence $c_1c_2...c_k$.
 \begin{note}
@@ -2313,11 +2315,11 @@ a non-type template parameter for which \placeholder{str} is
 a well-formed \grammarterm{template-argument},
 the literal \placeholder{L} is treated as a call of the form
 \begin{codeblock}
-operator "" @\placeholder{X}@<@\placeholder{str}{}@>()
+operator ""@\placeholder{X}@<@\placeholder{str}{}@>()
 \end{codeblock}
 Otherwise, the literal \placeholder{L} is treated as a call of the form
 \begin{codeblock}
-operator "" @\placeholder{X}@(@\placeholder{str}{}@, @\placeholder{len}{}@)
+operator ""@\placeholder{X}@(@\placeholder{str}{}@, @\placeholder{len}{}@)
 \end{codeblock}
 
 \pnum
@@ -2328,19 +2330,19 @@ the type of \placeholder{ch} and the
 literal \placeholder{L} is treated as a call
 of the form
 \begin{codeblock}
-operator "" @\placeholder{X}@(@\placeholder{ch}{}@)
+operator ""@\placeholder{X}@(@\placeholder{ch}{}@)
 \end{codeblock}
 
 \pnum
 \begin{example}
 \begin{codeblock}
-long double operator "" _w(long double);
-std::string operator "" _w(const char16_t*, std::size_t);
-unsigned operator "" _w(const char*);
+long double operator ""_w(long double);
+std::string operator ""_w(const char16_t*, std::size_t);
+unsigned operator ""_w(const char*);
 int main() {
-  1.2_w;            // calls \tcode{operator "" _w(1.2L)}
-  u"one"_w;         // calls \tcode{operator "" _w(u"one", 3)}
-  12_w;             // calls \tcode{operator "" _w("12")}
+  1.2_w;            // calls \tcode{operator ""_w(1.2L)}
+  u"one"_w;         // calls \tcode{operator ""_w(u"one", 3)}
+  12_w;             // calls \tcode{operator ""_w("12")}
   "two"_w;          // error: no applicable literal operator
 }
 \end{codeblock}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -3154,6 +3154,10 @@ shall be identical to
 
 \pnum
 Literal suffix identifiers\iref{over.literal} that do not start with an underscore are reserved for future standardization.
+Literal suffix identifiers that contain a double underscore
+\tcode{\unun}
+\indextext{character!underscore}%
+are reserved for use by \Cpp{} implementations.
 
 \rSec3[alt.headers]{Headers}
 

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3934,6 +3934,7 @@ implicit terminating \tcode{'\textbackslash 0'}.
 The \grammarterm{ud-suffix} of the \grammarterm{user-defined-string-literal} or
 the \grammarterm{identifier} in a \grammarterm{literal-operator-id} is called a
 \defnx{literal suffix identifier}{literal!suffix identifier}.
+The first form of \grammarterm{literal-operator-id} is deprecated.
 Some literal suffix identifiers are reserved for future standardization;
 see~\ref{usrlit.suffix}.  A declaration whose \grammarterm{literal-operator-id} uses
 such a literal suffix identifier is ill-formed, no diagnostic required.
@@ -4008,19 +4009,19 @@ taken, etc.
 \pnum
 \begin{example}
 \begin{codeblock}
-void operator "" _km(long double);                  // OK
-string operator "" _i18n(const char*, std::size_t); // OK
-template <char...> double operator "" _\u03C0();    // OK, UCN for lowercase pi
+void operator ""_km(long double);                   // OK
+string operator "" _i18n(const char*, std::size_t); // OK, deprecated
+template <char...> double operator ""_\u03C0();     // OK, UCN for lowercase pi
 float operator ""_e(const char*);                   // OK
 float operator ""E(const char*);                    // ill-formed, no diagnostic required:
                                                     // reserved literal suffix\iref{usrlit.suffix,lex.ext}
 double operator""_Bq(long double);                  // OK, does not use the reserved \grammarterm{identifier} \tcode{_Bq}\iref{lex.name}
 double operator"" _Bq(long double);                 // ill-formed, no diagnostic required:
                                                     // uses the reserved \grammarterm{identifier} \tcode{_Bq}\iref{lex.name}
-float operator " " B(const char*);                  // error: non-empty \grammarterm{string-literal}
-string operator "" 5X(const char*, std::size_t);    // error: invalid literal suffix identifier
-double operator "" _miles(double);                  // error: invalid \grammarterm{parameter-declaration-clause}
-template <char...> int operator "" _j(const char*); // error: invalid \grammarterm{parameter-declaration-clause}
-extern "C" void operator "" _m(long double);        // error: C language linkage
+float operator " "B(const char*);                   // error: non-empty \grammarterm{string-literal}
+string operator ""5X(const char*, std::size_t);     // error: invalid literal suffix identifier
+double operator ""_miles(double);                   // error: invalid \grammarterm{parameter-declaration-clause}
+template <char...> int operator ""_j(const char*);  // error: invalid \grammarterm{parameter-declaration-clause}
+extern "C" void operator ""_m(long double);         // error: C language linkage
 \end{codeblock}
 \end{example}


### PR DESCRIPTION
[lex.name] Attempt to fix wording; identifiers (plural) can't appear as a single token, and there's no "pp-token"

Fixes #6086.
Fixes cplusplus/papers#1367