### PR TITLE
[CWG 5] P2796R0 CWG2678 std::source_location::current is unimplementable

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -680,6 +680,11 @@ const objects with static or thread storage duration
 shall be constant-initialized if
 the object is constant-initialized in any such definition.
 
+\item In each such definition,
+corresponding manifestly constant-evaluated expressions
+that are not value-dependent
+shall have the same value\iref{expr.const,temp.dep.constexpr}.
+
 \item In each such definition, the overloaded operators referred
 to, the implicit calls to conversion functions, constructors, operator
 new functions and operator delete functions, shall refer to the same


### PR DESCRIPTION
Fixes #6087.
Fixes cplusplus/papers#1416 