### PR TITLE
[CWG 6] P2796R0 CWG2659 Missing feature-test macro for lifetime extension in range-fo…

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1836,7 +1836,7 @@ an \impldef{text of \mname{TIME} when time of translation is not available} vali
 \defnxname{cpp_nontype_template_args}             & \tcode{201911L} \\ \rowsep
 \defnxname{cpp_nontype_template_parameter_auto}   & \tcode{201606L} \\ \rowsep
 \defnxname{cpp_nsdmi}                             & \tcode{200809L} \\ \rowsep
-\defnxname{cpp_range_based_for}                   & \tcode{201603L} \\ \rowsep
+\defnxname{cpp_range_based_for}                   & \tcode{202211L} \\ \rowsep
 \defnxname{cpp_raw_strings}                       & \tcode{200710L} \\ \rowsep
 \defnxname{cpp_ref_qualifiers}                    & \tcode{200710L} \\ \rowsep
 \defnxname{cpp_return_type_deduction}             & \tcode{201304L} \\ \rowsep


### PR DESCRIPTION
…r loop

Also fixes NB DE 038 (C++23 CD).

Fixes #6088.