### PR TITLE
[LWG 14] P2674R1 A trait for implicit lifetime types

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -245,6 +245,8 @@ namespace std {
 
   template<class T> struct is_nothrow_destructible;
 
+  template<class T> struct is_implicit_lifetime;
+
   template<class T> struct has_virtual_destructor;
 
   template<class T> struct has_unique_object_representations;
@@ -519,6 +521,8 @@ namespace std {
     constexpr bool @\libglobal{is_nothrow_swappable_v}@ = is_nothrow_swappable<T>::value;
   template<class T>
     constexpr bool @\libglobal{is_nothrow_destructible_v}@ = is_nothrow_destructible<T>::value;
+  template<class T>
+    constexpr bool @\libglobal{is_implicit_lifetime_v}@ = is_implicit_lifetime<T>::value;
   template<class T>
     constexpr bool @\libglobal{has_virtual_destructor_v}@ = has_virtual_destructor<T>::value;
   template<class T>
@@ -1198,6 +1202,13 @@ The compilation of the
   \tcode{T} shall be a complete type,
   \cv{}~\keyword{void}, or an array of unknown
   bound.                \\ \rowsep
+
+\indexlibraryglobal{is_implicit_lifetime}%
+\tcode{template<class T>}\br
+  \tcode{struct is_implicit_lifetime;} &
+  \tcode{T} is an implicit-lifetime type\iref{basic.types.general}. &
+  \tcode{T} shall be an array type,
+  a complete type, or \cv{}~\keyword{void}.  \\ \rowsep
 
 \indexlibraryglobal{has_virtual_destructor}%
 \tcode{template<class T>}\br

--- a/source/support.tex
+++ b/source/support.tex
@@ -647,6 +647,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_is_aggregate}@                      201703L // also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_is_constant_evaluated}@             201811L // also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_is_final}@                          201402L // also in \libheader{type_traits}
+#define @\defnlibxname{cpp_lib_is_implicit_lifetime}@              202302L // also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_is_invocable}@                      201703L // also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_is_layout_compatible}@              201907L // also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_is_nothrow_convertible}@            201806L // also in \libheader{type_traits}


### PR DESCRIPTION
Fixes NB GB 089 (C++23 CD).

Fixes #6104.
Fixes cplusplus/papers#1340
Fixes cplusplus/nbballot#457 