### PR TITLE
[LWG 15] P2655R3 common_reference_t of reference_wrapper Should Be a Reference…

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -2121,9 +2121,11 @@ present as follows:
 \item Otherwise, if \tcode{sizeof...(T)} is two, let \tcode{T1} and \tcode{T2}
   denote the two types in the pack \tcode{T}. Then
   \begin{itemize}
-  \item If \tcode{T1} and \tcode{T2} are reference types and
-    \tcode{\placeholdernc{COMMON-REF}(T1, T2)} is well-formed, then the member
-    typedef \tcode{type} denotes that type.
+  \item Let \tcode{R} be \tcode{\placeholdernc{COMMON-REF}(T1, T2)}.
+    If \tcode{T1} and \tcode{T2} are reference types,
+    \tcode{R} is well-formed, and
+    \tcode{is_convertible_v<add_pointer_t<T1>, add_pointer_t<R>> \&\& is_convertible_v<add_poin\linebreak{}ter_t<T2>, add_pointer_t<R>>} is \tcode{true},
+    then the member typedef \tcode{type} denotes \tcode{R}.
 
   \item Otherwise, if
     \tcode{basic_common_reference<remove_cvref_t<T1>, remove_cvref_t<T2>,

--- a/source/support.tex
+++ b/source/support.tex
@@ -588,6 +588,8 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_chrono}@                            201907L // also in \libheader{chrono}
 #define @\defnlibxname{cpp_lib_chrono_udls}@                       201304L // also in \libheader{chrono}
 #define @\defnlibxname{cpp_lib_clamp}@                             201603L // also in \libheader{algorithm}
+#define @\defnlibxname{cpp_lib_common_reference}@                  202302L // also in \libheader{type_traits}
+#define @\defnlibxname{cpp_lib_common_reference_wrapper}@          202302L // also in \libheader{functional}
 #define @\defnlibxname{cpp_lib_complex_udls}@                      201309L // also in \libheader{complex}
 #define @\defnlibxname{cpp_lib_concepts}@                          202207L // also in \libheader{concepts}, \libheader{compare}
 #define @\defnlibxname{cpp_lib_constexpr_algorithms}@              201806L // also in \libheader{algorithm}, \libheader{utility}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -10453,6 +10453,15 @@ namespace std {
   template<class T>
     constexpr reference_wrapper<const T> cref(reference_wrapper<T>) noexcept;       // freestanding
 
+  // \ref{refwrap.common.ref}, \tcode{common_reference} related specializations
+  template<class R, class T, template<class> class RQual, template<class> class TQual>
+    requires @\seebelow@
+  struct basic_common_reference<R, T, RQual, TQual>;
+
+  template<class T, class R, template<class> class TQual, template<class> class RQual>
+    requires @\seebelow@
+  struct basic_common_reference<T, R, TQual, RQual>;
+
   // \ref{arithmetic.operations}, arithmetic operations
   template<class T = void> struct plus;                                             // freestanding
   template<class T = void> struct minus;                                            // freestanding
@@ -11003,6 +11012,39 @@ template<class T> constexpr reference_wrapper<const T> cref(reference_wrapper<T>
 \returns
 \tcode{t}.
 \end{itemdescr}
+
+\rSec3[refwrap.common.ref]{\tcode{common_reference} related specializations}
+
+\indexlibraryglobal{basic_common_reference}%
+\begin{codeblock}
+namespace std {
+  template<class T>
+    constexpr bool @\exposid{is-ref-wrapper}@ = false;                              // \expos
+
+  template<class T>
+    constexpr bool @\exposid{is-ref-wrapper}@<reference_wrapper<T>> = true;
+
+  template<class R, class T, class RQ, class TQ>
+    concept @\defexposconcept{ref-wrap-common-reference-exists-with}@ =                     // \expos
+      @\exposid{is-ref-wrapper}@<R> &&
+      requires { typename common_reference_t<typename R::type&, TQ>; } &&
+      @\libconcept{convertible_to}@<RQ, common_reference_t<typename R::type&, TQ>>;
+
+  template<class R, class T, template<class> class RQual, template<class> class TQual>
+    requires (@\exposconcept{ref-wrap-common-reference-exists-with}@<R, T, RQual<R>, TQual<T>> &&
+              !@\exposconcept{ref-wrap-common-reference-exists-with}@<T, R, TQual<T>, RQual<R>>)
+  struct basic_common_reference<R, T, RQual, TQual> {
+    using type = common_reference_t<typename R::type&, TQual<T>>;
+  };
+
+  template<class T, class R, template<class> class TQual, template<class> class RQual>
+    requires (@\exposconcept{ref-wrap-common-reference-exists-with}@<R, T, RQual<R>, TQual<T>> &&
+              !@\exposconcept{ref-wrap-common-reference-exists-with}@<T, R, TQual<T>, RQual<R>>)
+  struct basic_common_reference<T, R, TQual, RQual> {
+    using type = common_reference_t<typename R::type&, TQual<T>>;
+  };
+}
+\end{codeblock}
 
 \rSec2[arithmetic.operations]{Arithmetic operations}
 


### PR DESCRIPTION
[refwrap.common.ref] Enclose code in namespace std for consistency.

Fixes #6105.
Fixes cplusplus/papers#1322