### PR TITLE
[pairs.pair] Consistent wording for assignment

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1064,8 +1064,8 @@ constexpr pair& operator=(pair&& p) noexcept(@\seebelow@);
 
 \pnum
 \effects
-Assigns to \tcode{first} with \tcode{std::forward<T1>(p.first)}
-and to \tcode{second} with \tcode{std::forward<T2>(\brk{}p.second)}.
+Assigns \tcode{std::forward<T1>(p.first)} to \tcode{first} and
+\tcode{std::forward<T2>(p.second)} to \tcode{second}.
 
 \pnum
 \returns


### PR DESCRIPTION
Apply a consistent pattern to how we specify assigning members in assignment operators.

It looks like we have old wording on one overload, that causes an unnecessary line-wrap, so propose this editorial cleanup, that happens to bring consistency to the phrasing of all of the overloads.