### PR TITLE
[LWG 9] P2713R1 Escaping improvements in std::format

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15963,11 +15963,19 @@ Otherwise, if \placeholder{C} is not \unicode{0020}{space} and
 \begin{itemize}
 \item
 \placeholder{CE} is UTF-8, UTF-16, or UTF-32 and
-\placeholder{C} corresponds to either
-a Unicode scalar value whose Unicode property \tcode{General_Category}
-has a value in the groups \tcode{Separator} (\tcode{Z}) or \tcode{Other} (\tcode{C}) or to
-a Unicode scalar value with the Unicode property \tcode{Grapheme_Extend=Yes},
+\placeholder{C} corresponds to a Unicode scalar value
+whose Unicode property \tcode{General_Category} has a value in the groups
+\tcode{Separator} (\tcode{Z}) or \tcode{Other} (\tcode{C}),
 as described by \UAX{44} of the Unicode Standard, or
+
+\item
+\placeholder{CE} is UTF-8, UTF-16, or UTF-32 and
+\placeholder{C} corresponds to a Unicode scalar value
+with the Unicode property \tcode{Grapheme_Extend=Yes}
+as described by \UAX{44} of the Unicode Standard and
+\placeholder{C} is not immediately preceded in \placeholder{S} by
+a character \placeholder{P} appended to \placeholder{E}
+without translation to an escape sequence, or
 
 \item
 \placeholder{CE} is neither UTF-8, UTF-16, nor UTF-32 and
@@ -16050,7 +16058,8 @@ if \placeholder{C} is \unicode{0022}{quotation mark},
 then \placeholder{C} is appended unchanged.
 \end{itemize}
 
-%% FIXME: Example is incomplete; s2 and s6 are missing below;
+%% FIXME: Example is incomplete; s2 and s6 from P2286R8
+%%        and s8 (which should be s9) from P2713R1 are missing below;
 %% FIXME: their Unicode characters are not available in our font (Latin Modern).
 \begin{example}
 \begin{codeblock}
@@ -16062,6 +16071,8 @@ string s3 = format("[{:?}, {:?}]", '\'', '"');      // \tcode{s3} has value: \tc
 string s4 = format("[{:?}]", string("\0 \n \t \x02 \x1b", 9));
                                                     // \tcode{s4} has value: \tcode{["\textbackslash u\{0\} \textbackslash n \textbackslash t \textbackslash u\{2\} \textbackslash u\{1b\}"]}
 string s5 = format("[{:?}]", "\xc3\x28");           // invalid UTF-8, \tcode{s5} has value: \tcode{["\textbackslash x\{c3\}("]}
+string s7 = format("[{:?}]", "\u0301");             // \tcode{s7} has value: \tcode{["\u{301}"]}
+string s8 = format("[{:?}]", "\\\u0301");           // \tcode{s8} has value: \tcode{["\\\u{301}"]}
 \end{codeblock}
 \end{example}
 


### PR DESCRIPTION
Fixes NB US 38-098, FR 5-134 (C++23 CD).

Fixes #6099.
Fixes cplusplus/papers#1418
Fixes cplusplus/nbballot#515
Fixes cplusplus/nbballot#408

So I couldn't get the s8 example to build - maybe I don't have the right setup? Can someone else take this and see if they can get the s8 example to build for them?