### PR TITLE
[range.subrange.general,range.adaptors] Use present only if condition is `true`

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1813,7 +1813,7 @@ namespace std::ranges {
     I @\exposid{begin_}@ = I();                                         // \expos
     S @\exposid{end_}@ = S();                                           // \expos
     @\exposidnc{make-unsigned-like-t}@<iter_difference_t<I>> @\exposid{size_}@ = 0;   // \expos; present only
-                                                            // when \exposid{StoreSize} is \tcode{true}
+                                                            // if \exposid{StoreSize} is \tcode{true}
   public:
     subrange() requires @\libconcept{default_initializable}@<I> = default;
 
@@ -6415,7 +6415,7 @@ namespace std::ranges {
     V @\exposid{base_}@ = V();                                          // \expos
 
     @\exposidnc{non-propagating-cache}@<remove_cv_t<@\exposidnc{InnerRng}@>> @\exposid{inner_}@;    // \expos, present only
-                                                            // when \tcode{!is_reference_v<\exposid{InnerRng}>}
+                                                            // if \tcode{is_reference_v<\exposid{InnerRng}>} is \tcode{false}
 
   public:
     join_view() requires @\libconcept{default_initializable}@<V> = default;
@@ -6904,7 +6904,7 @@ namespace std::ranges {
 
     V @\exposid{base_}@ = V();                                          // \expos
     @\exposid{non-propagating-cache}@<remove_cv_t<@\exposid{InnerRng}@>> @\exposid{inner_}@;   // \expos, present only
-                                                            // when \tcode{!is_reference_v<\exposid{InnerRng}>}
+                                                            // if \tcode{is_reference_v<\exposid{InnerRng}>} is \tcode{false}
     Pattern @\exposid{pattern_}@ = Pattern();                           // \expos
 
     // \ref{range.join.with.iterator}, class template \tcode{join_with_view::\exposid{iterator}}
@@ -7491,7 +7491,7 @@ namespace std::ranges {
     Pattern @\exposid{pattern_}@ = Pattern();                               // \expos
 
     @\exposidnc{non-propagating-cache}@<iterator_t<V>> @\exposid{current_}@;              // \expos, present only
-                                                                // if \tcode{!\libconcept{forward_range}<V>}
+                                                                // if \tcode{\libconcept{forward_range}<V>} is \tcode{false}
 
     // \ref{range.lazy.split.outer}, class template \tcode{lazy_split_view::\exposid{outer-iterator}}
     template<bool> struct @\exposidnc{outer-iterator}@;                       // \expos


### PR DESCRIPTION
Running `git grep -C 1 'present only' *` in `sources` shows:
```
declarations.tex-\grammarterm{init-declarator} or \grammarterm{member-declarator}
declarations.tex:shall be present only if the declarator declares a
declarations.tex-templated function\iref{dcl.fct}.
--
iterators.tex-    using iterator_type = I;
iterators.tex:    using value_type = iter_value_t<I>;                         // present only
iterators.tex-                        // if \tcode{I} models \libconcept{indirectly_readable}
iterators.tex-    using difference_type = iter_difference_t<I>;
iterators.tex:    using iterator_concept = typename I::iterator_concept;      // present only
iterators.tex-                        // if the \grammarterm{qualified-id} \tcode{I::iterator_concept} is valid and denotes a type
iterators.tex:    using iterator_category = typename I::iterator_category;    // present only
iterators.tex-                        // if the \grammarterm{qualified-id} \tcode{I::iterator_category} is valid and denotes a type
--
ranges.tex-    S @\exposid{end_}@ = S();                                           // \expos
ranges.tex:    @\exposidnc{make-unsigned-like-t}@<iter_difference_t<I>> @\exposid{size_}@ = 0;   // \expos; present only
ranges.tex-                                                            // when \exposid{StoreSize} is \tcode{true}
--
ranges.tex-    using iterator_concept = @\seebelow@;
ranges.tex:    using iterator_category = input_iterator_tag;       // present only if \tcode{W} models \libconcept{incrementable} and
ranges.tex-                                                        // \tcode{\placeholdernc{IOTA-DIFF-T}(W)} is an integral type
--
ranges.tex-
ranges.tex:    @\exposidnc{non-propagating-cache}@<remove_cv_t<@\exposidnc{InnerRng}@>> @\exposid{inner_}@;    // \expos, present only
ranges.tex-                                                            // when \tcode{!is_reference_v<\exposid{InnerRng}>}
--
ranges.tex-    V @\exposid{base_}@ = V();                                          // \expos
ranges.tex:    @\exposid{non-propagating-cache}@<remove_cv_t<@\exposid{InnerRng}@>> @\exposid{inner_}@;   // \expos, present only
ranges.tex-                                                            // when \tcode{!is_reference_v<\exposid{InnerRng}>}
--
ranges.tex-
ranges.tex:    @\exposidnc{non-propagating-cache}@<iterator_t<V>> @\exposid{current_}@;              // \expos, present only
ranges.tex-                                                                // if \tcode{!\libconcept{forward_range}<V>}
--
ranges.tex-
ranges.tex:    iterator_t<@\exposidnc{Base}@> @\exposid{current_}@ = iterator_t<@\exposidnc{Base}@>();         // \expos, present only
ranges.tex-                                                            // if \tcode{V} models \libconcept{forward_range}
--
ranges.tex-
ranges.tex:    using iterator_category = input_iterator_tag;           // present only if \exposid{Base}
ranges.tex-                                                            // models \libconcept{forward_range}
--
ranges.tex-
ranges.tex:    using iterator_category = @\seebelownc@;                    // present only if \exposid{Base}
ranges.tex-                                                            // models \libconcept{forward_range}
--
ranges.tex-    iterator_t<@\exposid{Base}@> @\exposid{last_ele_}@  = iterator_t<@\exposid{Base}@>();   // \expos,
ranges.tex:                                               // present only if \tcode{\exposid{Base}} models \tcode{\exposconcept{slide-caches-first}}
ranges.tex-    range_difference_t<@\exposid{Base}@> @\exposid{n_}@ = 0;                    // \expos
```
Ignoring the first result, we have:
- Present only if models-condition:
```
iterators.tex:    using value_type = iter_value_t<I>;                         // present only
iterators.tex-                        // if \tcode{I} models \libconcept{indirectly_readable}
ranges.tex:    iterator_t<@\exposidnc{Base}@> @\exposid{current_}@ = iterator_t<@\exposidnc{Base}@>();         // \expos, present only
ranges.tex-                                                            // if \tcode{V} models \libconcept{forward_range}
ranges.tex:    using iterator_category = input_iterator_tag;           // present only if \exposid{Base}
ranges.tex-                                                            // models \libconcept{forward_range}
ranges.tex:    using iterator_category = @\seebelownc@;                    // present only if \exposid{Base}
ranges.tex-                                                            // models \libconcept{forward_range}
ranges.tex:                                               // present only if \tcode{\exposid{Base}} models \tcode{\exposconcept{slide-caches-first}}
```
- Present only if English-condition:
```
iterators.tex:    using iterator_concept = typename I::iterator_concept;      // present only
iterators.tex-                        // if the \grammarterm{qualified-id} \tcode{I::iterator_concept} is valid and denotes a type
iterators.tex:    using iterator_category = typename I::iterator_category;    // present only
iterators.tex-                        // if the \grammarterm{qualified-id} \tcode{I::iterator_category} is valid and denotes a type
ranges.tex:    using iterator_category = input_iterator_tag;       // present only if \tcode{W} models \libconcept{incrementable} and
ranges.tex-                                                        // \tcode{\placeholdernc{IOTA-DIFF-T}(W)} is an integral type
```
- Present only 1 if, 3 when `bool`-condition:
```
ranges.tex:    @\exposidnc{make-unsigned-like-t}@<iter_difference_t<I>> @\exposid{size_}@ = 0;   // \expos; present only
ranges.tex-                                                            // when \exposid{StoreSize} is \tcode{true}
ranges.tex:    @\exposidnc{non-propagating-cache}@<remove_cv_t<@\exposidnc{InnerRng}@>> @\exposid{inner_}@;    // \expos, present only
ranges.tex-                                                            // when \tcode{!is_reference_v<\exposid{InnerRng}>}
ranges.tex:    @\exposid{non-propagating-cache}@<remove_cv_t<@\exposid{InnerRng}@>> @\exposid{inner_}@;   // \expos, present only
ranges.tex-                                                            // when \tcode{!is_reference_v<\exposid{InnerRng}>}
ranges.tex:    @\exposidnc{non-propagating-cache}@<iterator_t<V>> @\exposid{current_}@;              // \expos, present only
ranges.tex-                                                                // if \tcode{!\libconcept{forward_range}<V>}
```

#6128 adds 2 when `bool`-condition, 2 if models-condition:
```
    @\exposidnc{non-propagating-cache}@<iterator_t<V>> @\exposidnc{outer_}@;            // \expos, present only
                                                            // when \tcode{!\libconcept{forward_range}<V>}
    @\exposidnc{OuterIter}@ @\exposid{outer_}@ = @\exposidnc{OuterIter}@();                     // \expos, present only
                                                        // if \exposid{Base} models \libconcept{forward_range}
    @\exposid{non-propagating-cache}@<iterator_t<V>> @\exposid{outer_it_}@;         // \expos, present only
                                                            // when \tcode{!\libconcept{forward_range}<V>}
    @\exposid{OuterIter}@ @\exposid{outer_it_}@ = @\exposid{OuterIter}@();                          // \expos, present only
                                                                // if \exposid{Base} models \libconcept{forward_range}
```

This fixes the only "present only if `bool`-condition" to use "when".