### PR TITLE
[allocator.requirements.general]/98 make sure SimpleAllocator meets t…

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2748,10 +2748,10 @@ struct SimpleAllocator {
 
   template<class U> SimpleAllocator(const SimpleAllocator<U>& other);
 
-  [[nodiscard]] T* allocate(std::size_t n);
+  T* allocate(std::size_t n);
   void deallocate(T* p, std::size_t n);
 
-  bool operator==(const SimpleAllocator&) const;
+  template<class U> bool operator==(const SimpleAllocator<U>& rhs) const;
 };
 \end{codeblock}
 \end{example}


### PR DESCRIPTION
`[[nodiscard]]` is not required.

`operator==` needs to be a template, otherwise the original will be ambiguous with the rewritten candidate, for example:

    SimpleAllocator<int> a;
    SimpleAllocator<float> b;
    a == b;

There are two candidates:

    bool SimpleAllocator<int>::operator==(const SimpleAllocator<int>&) const;
    bool SimpleAllocator<float>::operator==(const SimpleAllocator<float>&) const; // rewritten candidate

Neither candidate is better than the other, hence ambiguous.