### PR TITLE
[expected.object.eq] Fix typo

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -8581,7 +8581,7 @@ template<class T2> friend constexpr bool operator==(const expected& x, const T2&
 The expression \tcode{*x == v} is well-formed and
 its result is convertible to \tcode{bool}.
 \begin{note}
-\tcode{T1} need not be \oldconcept{EqualityComparable}.
+\tcode{T} need not be \oldconcept{EqualityComparable}.
 \end{note}
 
 \pnum


### PR DESCRIPTION
There's no `T1` in sight; the relevant template parameter of `expected` is `T`.