### PR TITLE
[temp.expl.spec] Use normal spacing after "etc." within a sentence

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -993,7 +993,7 @@ that potentially conflict and one precedes the other\iref{basic.lookup}.
 \begin{note}
 Overload resolution can consider potentially conflicting declarations
 found in multiple scopes
-(e.g. via \grammarterm{using-directive}s or for operator functions),
+(e.g., via \grammarterm{using-directive}s or for operator functions),
 in which case it is often ambiguous.
 \end{note}
 \begin{example}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -497,7 +497,7 @@ c.size()
 \pnum
 \returns
 \tcode{distance(c.begin(), c.end())},
-i.e. the number of elements in the container.
+i.e., the number of elements in the container.
 
 \pnum
 \complexity

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6300,7 +6300,7 @@ defaulted or deleted on its first declaration. A user-provided explicitly-defaul
 is implicitly defined at the point where it is explicitly defaulted; if such a function is implicitly
 defined as deleted, the program is ill-formed.
 A non-user-provided defaulted function
-(i.e. implicitly declared or explicitly defaulted in the class)
+(i.e., implicitly declared or explicitly defaulted in the class)
 that is not defined as deleted is implicitly defined when it is odr-used\iref{basic.def.odr}
 or needed for constant evaluation\iref{expr.const}.
 \begin{note}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -321,7 +321,7 @@ for a union of type \tcode{U} with a glvalue argument
 that does not denote an object of type \cv{}~\keyword{U} within its lifetime,
 the behavior is undefined.
 \begin{note}
-In C, an entire object of structure type can be accessed, e.g. using assignment.
+In C, an entire object of structure type can be accessed, e.g., using assignment.
 By contrast, \Cpp{} has no notion of accessing an object of class type
 through an lvalue of class type.
 \end{note}
@@ -7262,7 +7262,7 @@ right operand is a bit-field.
 \pnum
 \begin{note}
 In contexts where the comma token is given special meaning
-(e.g. function calls\iref{expr.call},
+(e.g., function calls\iref{expr.call},
 subscript expressions\iref{expr.sub},
 lists of initializers\iref{dcl.init},
 or \grammarterm{template-argument-list}{s}\iref{temp.names}),

--- a/source/styles.tex
+++ b/source/styles.tex
@@ -262,7 +262,7 @@
   \ifvmode\else\par\fi\lst@emptylinepenalty
   \vskip\parskip
   \vskip\baselineskip
-  % \lsthk@EveryLine has \lst@parshape, i.e. \parshape, which causes an \hbox
+  % \lsthk@EveryLine has \lst@parshape, i.e., \parshape, which causes an \hbox
   % \lsthk@EveryPar increments line counters; \refstepcounter balloons the PDF
   \global\advance\lst@newlines\m@ne
   \lst@newlinetrue}

--- a/source/support.tex
+++ b/source/support.tex
@@ -1155,8 +1155,7 @@ Equivalent to \tcode{FLT_RADIX}.
 For integer types, specifies the base of the
 representation.
 \begin{footnote}
-Distinguishes types with bases other than 2 (e.g.
-BCD).
+Distinguishes types with bases other than 2 (e.g., BCD).
 \end{footnote}
 
 \pnum

--- a/source/tables.tex
+++ b/source/tables.tex
@@ -63,7 +63,7 @@
 
 % General Usage: TITLE is the title of the table, XREF is the
 % cross-reference for the table. LAYOUT is a sequence of column
-% type specifiers (e.g. cp{1.0}c), without '|' for the left edge
+% type specifiers (e.g., cp{1.0}c), without '|' for the left edge
 % or right edge.
 
 % usage: \begin{floattablebase}{TITLE}{XREF}{LAYOUT}{PLACEMENT}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6436,7 +6436,7 @@ shall be reachable from the definition of any member of it.
 The definition of an explicitly specialized class is unrelated to the
 definition of a generated specialization.
 That is, its members need
-not have the same names, types, etc. as the members of a generated
+not have the same names, types, etc.\ as the members of a generated
 specialization.
 Members of an explicitly specialized
 class template are defined in the same manner as members of normal classes, and

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -2840,7 +2840,7 @@ The instantiation of a \grammarterm{fold-expression}\iref{expr.prim.fold} produc
 \begin{itemize}
 \item
 % Note: "\space" used below because " " inside tcode adds too much whitespace;
-% one could optionally use mathfont inside tcode, e.g. "\tcode{($ $}".
+% one could optionally use mathfont inside tcode, e.g., "\tcode{($ $}".
 \tcode{(}\space
 \tcode{((}$\mathtt{E}_1$
            \placeholder{op} $\mathtt{E}_2$\tcode{)}

--- a/source/time.tex
+++ b/source/time.tex
@@ -10560,7 +10560,7 @@ A \tcode{duration} does not contain enough information
 to format as a \tcode{weekday}.
 \end{example}
 However, if a flag refers to a ``time of day''
-(e.g. \tcode{\%H}, \tcode{\%I}, \tcode{\%p}, etc.),
+(e.g., \tcode{\%H}, \tcode{\%I}, \tcode{\%p}, etc.),
 then a specialization of \tcode{duration} is interpreted as
 the time of day elapsed since midnight.
 
@@ -11174,7 +11174,7 @@ the information that the format flag refers to,
 A \tcode{duration} cannot represent a \tcode{weekday}.
 \end{example}
 However, if a flag refers to a ``time of day''
-(e.g. \tcode{\%H}, \tcode{\%I}, \tcode{\%p}, etc.),
+(e.g., \tcode{\%H}, \tcode{\%I}, \tcode{\%p}, etc.),
 then a specialization of \tcode{duration} is parsed as
 the time of day elapsed since midnight.
 
@@ -11401,7 +11401,7 @@ The modified command \tcode{\%EX} interprets the locale's alternate time represe
 \tcode{\%y} &
 The last two decimal digits of the year.
 If the century is not otherwise specified
-(e.g.  with \tcode{\%C}),
+(e.g.,  with \tcode{\%C}),
 values in the range \crange{69}{99}
 are presumed to refer to the years 1969 to 1999,
 and values in the range \crange{00}{68}


### PR DESCRIPTION
I believe LaTeX assumes that a full stop after a lower case letter ends a sentence, so it inserts slightly more space than between other words. I think this is the only occurrence of "etc." that does not end a sentence.

Before:
![image](https://user-images.githubusercontent.com/1254480/222428854-55d6ca87-8e6a-45c5-8d8b-bf6c5df9aff2.png)
After:
![image](https://user-images.githubusercontent.com/1254480/222428999-c7d79bae-404f-4208-82ee-a0c83416576c.png)

