### PR TITLE
[expr.prim.req.compound] Move compound requirement example from inner to outer bullet

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2973,6 +2973,8 @@ into the \grammarterm{return-type-requirement} is performed.
 The immediately-declared constraint\iref{temp.param}
 of the \grammarterm{type-constraint} for \tcode{\keyword{decltype}((E))}
 shall be satisfied.
+\end{itemize}
+\end{itemize}
 \begin{example}
 Given concepts \tcode{C} and \tcode{D},
 \begin{codeblock}
@@ -2990,8 +2992,6 @@ requires {
 \end{codeblock}
 (including in the case where $n$ is zero).
 \end{example}
-\end{itemize}
-\end{itemize}
 
 \pnum
 \begin{example}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2974,7 +2974,6 @@ The immediately-declared constraint\iref{temp.param}
 of the \grammarterm{type-constraint} for \tcode{\keyword{decltype}((E))}
 shall be satisfied.
 \end{itemize}
-\end{itemize}
 \begin{example}
 Given concepts \tcode{C} and \tcode{D},
 \begin{codeblock}
@@ -2992,7 +2991,7 @@ requires {
 \end{codeblock}
 (including in the case where $n$ is zero).
 \end{example}
-
+\end{itemize}
 \pnum
 \begin{example}
 \begin{codeblock}


### PR DESCRIPTION
[The example for compound requirement](http://eel.is/c++draft/expr.prim#req.compound-example-1) is currently attached to the inner bullet point, but should be attached to the outer one.