### PR TITLE
[intro.object] References are not potentially-overlapping subobjects

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3267,7 +3267,7 @@ an object of a most derived class type or of a non-class type is called a
 A \defn{potentially-overlapping subobject} is either:
 \begin{itemize}
 \item a base class subobject, or
-\item a non-static data member
+\item a non-static data member that is of an object type and
 declared with the \tcode{no_unique_address} attribute\iref{dcl.attr.nouniqueaddr}.
 \end{itemize}
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -9311,11 +9311,15 @@ should be \tcode{0} unless the implementation can issue such warnings.
 
 \pnum
 The \grammarterm{attribute-token} \tcode{no_unique_address}
-specifies that a non-static data member
+specifies that a non-static data member of an object type
 is a potentially-overlapping subobject\iref{intro.object}.
 No \grammarterm{attribute-argument-clause} shall be present.
 The attribute may appertain to a non-static data member
 other than a bit-field.
+\begin{note}
+The \tcode{no_unique_address} attribute has no effect on a
+non-static data member of a reference type.
+\end{note}
 
 \pnum
 \begin{note}


### PR DESCRIPTION
Fixes #6158.