### PR TITLE
[dcl.pre] Add missing markup that makes "fails" a definition.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -251,7 +251,7 @@ can only be used in a \grammarterm{template-declaration}\iref{temp.pre},
 \end{note}
 
 \pnum
-\indextext{\idxgram{static_assert}}%
+\indextext{\idxcode{static_assert}}%
 In a \grammarterm{static_assert-declaration},
 the \grammarterm{constant-expression}
 is contextually converted to \keyword{bool} and
@@ -261,7 +261,7 @@ so converted is \tcode{true}
 or the expression is evaluated in the context of a template definition,
 the declaration has no
 effect. Otherwise,
-the \grammarterm{static_assert-declaration} fails,
+the \grammarterm{static_assert-declaration} \defnx{fails}{\idxcode{static_assert}!failed},
 the program is ill-formed, and the resulting
 diagnostic message\iref{intro.compliance} should include the text of
 the \grammarterm{string-literal}, if one is supplied.


### PR DESCRIPTION
This change was missed from the application of CWG2518.

Also fixes the indexing of "static_assert" (which is a keyword, not a grammar production).