### PR TITLE
[cpp.pre] Fix grammar for #elifdef

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -82,8 +82,8 @@
 \begin{bnf}\obeyspaces
 \nontermdef{elif-group}\br
     \terminal{\# elif    } constant-expression new-line \opt{group}\br
-    \terminal{\# elifdef } constant-expression new-line \opt{group}\br
-    \terminal{\# elifndef} constant-expression new-line \opt{group}
+    \terminal{\# elifdef } identifier new-line \opt{group}\br
+    \terminal{\# elifndef} identifier new-line \opt{group}
 \end{bnf}
 
 \begin{bnf}\obeyspaces


### PR DESCRIPTION
This fix is editorial as it corrects a mis-application of the original paper, https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2334r1.pdf.

Note that the corresponding use of this grammar in [cpp.cond]p13 assumes the correct grammar, making the intent equally clear.