### PR TITLE
[string.capacity] Use \tcode+\placeholder for placeholder

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -2948,32 +2948,32 @@ The values in the range \crange{p + k}{p + n} may be indeterminate\iref{basic.in
 \tcode{m} be a value of type \tcode{size_type} or \tcode{const size_type}
 equal to \tcode{n}.
 \item
-$OP$ be the expression \tcode{std::move(op)(p, m)}.
+\tcode{\placeholder{OP}} be the expression \tcode{std::move(op)(p, m)}.
 \item
-\tcode{r} = $OP$.
+\tcode{r} = \tcode{\placeholder{OP}}.
 \end{itemize}
 
 \pnum
 \mandates
-$OP$ has an integer-like type\iref{iterator.concept.winc}.
+\tcode{\placeholder{OP}} has an integer-like type\iref{iterator.concept.winc}.
 
 \pnum
 \expects
 \begin{itemize}
 \item
-$OP$ does not throw an exception or modify \tcode{p} or \tcode{m}.
+\tcode{\placeholder{OP}} does not throw an exception or modify \tcode{p} or \tcode{m}.
 \item
 $\tcode{r} \geq 0$.
 \item
 $\tcode{r} \leq \tcode{m}$.
 \item
-After evaluating $OP$
+After evaluating \tcode{\placeholder{OP}}
 there are no indeterminate values in the range \range{p}{p + r}.
 \end{itemize}
 
 \pnum
 \effects
-Evaluates $OP$,
+Evaluates \tcode{\placeholder{OP}},
 replaces the contents of \tcode{*this} with \range{p}{p + r}, and
 invalidates all pointers and references to the range \crange{p}{p + n}.
 
@@ -2981,7 +2981,7 @@ invalidates all pointers and references to the range \crange{p}{p + n}.
 \recommended
 Implementations should avoid unnecessary copies and allocations
 by, for example, making \tcode{p} a pointer into internal storage and
-by restoring \tcode{*(p + r)} to \tcode{charT()} after evaluating $OP$.
+by restoring \tcode{*(p + r)} to \tcode{charT()} after evaluating \tcode{\placeholder{OP}}.
 \end{itemdescr}
 
 \indexlibrarymember{capacity}{basic_string}%


### PR DESCRIPTION
While we aren't entirely clear when to use maths variables and when to use code placeholders, in the present case math mode is not good for multi-character symbols (since $ab$ really means $a$ times $b$ etc.), and we have precendent for using placeholder-code for "expression aliases".