### PR TITLE
[over.match.funcs.general]/9 fix the style of references

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -333,15 +333,15 @@ if the argument list has exactly one argument and
 \begin{codeblock}
 struct A {
   A();                                  // \#1
-  A(A &&);                              // \#2
-  template<typename T> A(T &&);         // \#3
+  A(A&&);                              // \#2
+  template<typename T> A(T&&);         // \#3
 };
 struct B : A {
   using A::A;
-  B(const B &);                         // \#4
-  B(B &&) = default;                    // \#5, implicitly deleted
+  B(const B&);                         // \#4
+  B(B&&) = default;                    // \#5, implicitly deleted
 
-  struct X { X(X &&) = delete; } x;
+  struct X { X(X&&) = delete; } x;
 };
 extern B b1;
 B b2 = static_cast<B&&>(b1);            // calls \#4: \#1 is not viable, \#2, \#3, and \#5 are not candidates

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -333,13 +333,13 @@ if the argument list has exactly one argument and
 \begin{codeblock}
 struct A {
   A();                                  // \#1
-  A(A&&);                              // \#2
-  template<typename T> A(T&&);         // \#3
+  A(A&&);                               // \#2
+  template<typename T> A(T&&);          // \#3
 };
 struct B : A {
   using A::A;
-  B(const B&);                         // \#4
-  B(B&&) = default;                    // \#5, implicitly deleted
+  B(const B&);                          // \#4
+  B(B&&) = default;                     // \#5, implicitly deleted
 
   struct X { X(X&&) = delete; } x;
 };


### PR DESCRIPTION
The style of references here (`T &&`) is different from that elsewhere (`T&&`).