### PR TITLE
[specialized.algorithms] remove voidify completely

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -10775,16 +10775,6 @@ the algorithms specified in \ref{specialized.algorithms}
 result in undefined behavior.
 \end{note}
 
-\pnum
-Some algorithms specified in \ref{specialized.algorithms} make use of the exposition-only function
-\tcode{\placeholdernc{voidify}}:
-\begin{codeblock}
-template<class T>
-  constexpr void* @\placeholdernc{voidify}@(T& obj) noexcept {
-    return addressof(obj);
-  }
-\end{codeblock}
-
 \rSec2[special.mem.concepts]{Special memory concepts}
 
 \pnum
@@ -10885,7 +10875,7 @@ template<class NoThrowForwardIterator>
 Equivalent to:
 \begin{codeblock}
 for (; first != last; ++first)
-  ::new (@\placeholdernc{voidify}@(*first))
+  ::new (addressof(*first))
     typename iterator_traits<NoThrowForwardIterator>::value_type;
 \end{codeblock}
 \end{itemdescr}
@@ -10908,7 +10898,7 @@ namespace ranges {
 Equivalent to:
 \begin{codeblock}
 for (; first != last; ++first)
-  ::new (@\placeholdernc{voidify}@(*first)) remove_reference_t<iter_reference_t<I>>;
+  ::new (addressof(*first)) remove_reference_t<iter_reference_t<I>>;
 return first;
 \end{codeblock}
 \end{itemdescr}
@@ -10925,7 +10915,7 @@ template<class NoThrowForwardIterator, class Size>
 Equivalent to:
 \begin{codeblock}
 for (; n > 0; (void)++first, --n)
-  ::new (@\placeholdernc{voidify}@(*first))
+  ::new (addressof(*first))
     typename iterator_traits<NoThrowForwardIterator>::value_type;
 return first;
 \end{codeblock}
@@ -10964,7 +10954,7 @@ template<class NoThrowForwardIterator>
 Equivalent to:
 \begin{codeblock}
 for (; first != last; ++first)
-  ::new (@\placeholdernc{voidify}@(*first))
+  ::new (addressof(*first))
     typename iterator_traits<NoThrowForwardIterator>::value_type();
 \end{codeblock}
 \end{itemdescr}
@@ -10987,7 +10977,7 @@ namespace ranges {
 Equivalent to:
 \begin{codeblock}
 for (; first != last; ++first)
-  ::new (@\placeholdernc{voidify}@(*first)) remove_reference_t<iter_reference_t<I>>();
+  ::new (addressof(*first)) remove_reference_t<iter_reference_t<I>>();
 return first;
 \end{codeblock}
 \end{itemdescr}
@@ -11004,7 +10994,7 @@ template<class NoThrowForwardIterator, class Size>
 Equivalent to:
 \begin{codeblock}
 for (; n > 0; (void)++first, --n)
-  ::new (@\placeholdernc{voidify}@(*first))
+  ::new (addressof(*first))
     typename iterator_traits<NoThrowForwardIterator>::value_type();
 return first;
 \end{codeblock}
@@ -11048,7 +11038,7 @@ template<class InputIterator, class NoThrowForwardIterator>
 Equivalent to:
 \begin{codeblock}
 for (; first != last; ++result, (void) ++first)
-  ::new (@\placeholdernc{voidify}@(*result))
+  ::new (addressof(*result))
     typename iterator_traits<NoThrowForwardIterator>::value_type(*first);
 \end{codeblock}
 
@@ -11082,7 +11072,7 @@ namespace ranges {
 Equivalent to:
 \begin{codeblock}
 for (; ifirst != ilast && ofirst != olast; ++ofirst, (void)++ifirst)
-  ::new (@\placeholdernc{voidify}@(*ofirst)) remove_reference_t<iter_reference_t<O>>(*ifirst);
+  ::new (addressof(*ofirst)) remove_reference_t<iter_reference_t<O>>(*ifirst);
 return {std::move(ifirst), ofirst};
 \end{codeblock}
 \end{itemdescr}
@@ -11104,7 +11094,7 @@ template<class InputIterator, class Size, class NoThrowForwardIterator>
 Equivalent to:
 \begin{codeblock}
 for ( ; n > 0; ++result, (void) ++first, --n)
-  ::new (@\placeholdernc{voidify}@(*result))
+  ::new (addressof(*result))
     typename iterator_traits<NoThrowForwardIterator>::value_type(*first);
 \end{codeblock}
 
@@ -11158,7 +11148,7 @@ template<class InputIterator, class NoThrowForwardIterator>
 Equivalent to:
 \begin{codeblock}
 for (; first != last; (void)++result, ++first)
-  ::new (@\placeholdernc{voidify}@(*result))
+  ::new (addressof(*result))
     typename iterator_traits<NoThrowForwardIterator>::value_type(std::move(*first));
 return result;
 \end{codeblock}
@@ -11189,7 +11179,7 @@ namespace ranges {
 Equivalent to:
 \begin{codeblock}
 for (; ifirst != ilast && ofirst != olast; ++ofirst, (void)++ifirst)
-  ::new (@\placeholder{voidify}@(*ofirst))
+  ::new (addressof(*ofirst))
     remove_reference_t<iter_reference_t<O>>(ranges::iter_move(ifirst));
 return {std::move(ifirst), ofirst};
 \end{codeblock}
@@ -11218,7 +11208,7 @@ template<class InputIterator, class Size, class NoThrowForwardIterator>
 Equivalent to:
 \begin{codeblock}
 for (; n > 0; ++result, (void) ++first, --n)
-  ::new (@\placeholdernc{voidify}@(*result))
+  ::new (addressof(*result))
     typename iterator_traits<NoThrowForwardIterator>::value_type(std::move(*first));
 return {first, result};
 \end{codeblock}
@@ -11270,7 +11260,7 @@ template<class NoThrowForwardIterator, class T>
 Equivalent to:
 \begin{codeblock}
 for (; first != last; ++first)
-  ::new (@\placeholdernc{voidify}@(*first))
+  ::new (addressof(*first))
     typename iterator_traits<NoThrowForwardIterator>::value_type(x);
 \end{codeblock}
 \end{itemdescr}
@@ -11293,7 +11283,7 @@ namespace ranges {
 Equivalent to:
 \begin{codeblock}
 for (; first != last; ++first)
-  ::new (@\placeholdernc{voidify}@(*first)) remove_reference_t<iter_reference_t<I>>(x);
+  ::new (addressof(*first)) remove_reference_t<iter_reference_t<I>>(x);
 return first;
 \end{codeblock}
 \end{itemdescr}
@@ -11310,7 +11300,7 @@ template<class NoThrowForwardIterator, class Size, class T>
 Equivalent to:
 \begin{codeblock}
 for (; n--; ++first)
-  ::new (@\placeholdernc{voidify}@(*first))
+  ::new (addressof(*first))
     typename iterator_traits<NoThrowForwardIterator>::value_type(x);
 return first;
 \end{codeblock}
@@ -11357,7 +11347,7 @@ is well-formed when treated as an unevaluated operand\iref{term.unevaluated.oper
 \effects
 Equivalent to:
 \begin{codeblock}
-return ::new (@\placeholdernc{voidify}@(*location)) T(std::forward<Args>(args)...);
+return ::new (location) T(std::forward<Args>(args)...);
 \end{codeblock}
 \end{itemdescr}
 


### PR DESCRIPTION
After [LWG3870](https://wg21.link/lwg3870), `voidify` can now simply be replaced by `addressof`.