### PR TITLE
[module.interface] Fix outdated example

### DIFF
--- a/source/modules.tex
+++ b/source/modules.tex
@@ -382,9 +382,10 @@ are exported and subject to the rules of exported declarations.
 \begin{example}
 \begin{codeblock}
 export module M;
+int g;
 export namespace N {
   int x;                        // OK
-  static_assert(1 == 1);        // error: does not declare a name
+  using ::g;                    // error: \tcode{::g} has module linkage
 }
 \end{codeblock}
 \end{example}


### PR DESCRIPTION
The `static_assert` is no longer ill-formed as of [P2615](https://wg21.link/p2615).