### PR TITLE
[dcl.init.general] Clarify initialization of arrays

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4488,7 +4488,7 @@ In some cases, additional initialization is done later.
 If no initializer is specified for an object, the object is default-initialized.
 
 \pnum
-If the entity being initialized does not have class type, the
+If the entity being initialized does not have class or array type, the
 \grammarterm{expression-list} in a
 parenthesized initializer shall be a single expression.
 
@@ -4569,7 +4569,8 @@ expr.type.conv,class.base.init}.
 
 \item
 Otherwise, if the destination type is an array,
-the object is initialized as follows.
+the initialization shall be direct-initialization,
+and proceeds as follows.
 Let $x_1$, $\dotsc$, $x_k$ be
 the elements of the \grammarterm{expression-list}.
 If the destination type is an array of unknown bound,


### PR DESCRIPTION
[[dcl.init.general]/13](https://wg21.link/dcl.init.general#13) interferes with parenthesized initialization of arrays, and [[dcl.init.general]/16](https://wg21.link/dcl.init.general#16) does not specify the behavior of copy-initialization for array types.