### PR TITLE
[expr.prim.lambda.capture] Improve wording on anonymous unions in lambda captures

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2535,7 +2535,7 @@ these members is unspecified. The type of such a data member is
 the referenced type if the entity is a reference to an object,
 an lvalue reference to the referenced function type if the entity is a reference to a function, or
 the type of the corresponding captured entity otherwise.
-A member of an anonymous union shall not be captured by copy.
+An anonymous union variable shall not be captured by copy.
 
 \pnum
 Every \grammarterm{id-expression} within the \grammarterm{compound-statement} of a
@@ -2577,7 +2577,7 @@ If declared, such non-static data members shall be of literal type.
 static_assert([](int n) { return [&n] { return ++n; }(); }(3) == 4);
 \end{codeblock}
 \end{example}
-A bit-field or a member of an anonymous union
+A bit-field or an anonymous union variable
 shall not be captured by reference.
 
 \pnum


### PR DESCRIPTION
The restrictions in [[expr.prim.lambda.capture]](https://wg21.link/expr.prim.lambda.capture) should refer to anonymous union variables instead of their members, as the latter aren't local entities and can't be captured anyway.