### PR TITLE
[expr.rel] Clarify confusing wording CWG2749

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6489,7 +6489,7 @@ them to their composite pointer type\iref{expr.type}.
 After conversions, the operands shall have the same type.
 
 \pnum
-The result of comparing unequal pointers to objects
+The result of comparing unequal values of pointer-to-object type
 \begin{footnote}
 As specified in \ref{basic.compound},
 an object that is not an array element


### PR DESCRIPTION
'[Pointer to an object](https://wg21.link/basic.compound#def:pointer_to)' is one of the pointer value categories defined in [basic.compound], but according to [CWG2526](https://cplusplus.github.io/CWG/issues/2526.html) the intended reading here is that `void*` values are excluded from the ordering.