### PR TITLE
Bring pointer terminology up to date

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2040,9 +2040,9 @@ if the function call operator
 has a non-throwing exception specification.
 If the function call operator is a static member function,
 then the value returned by this conversion function is
-the address of the function call operator.
+a pointer to the function call operator.
 Otherwise, the value returned by this conversion function
-is the address of a function \tcode{F} that, when invoked,
+is a pointer to a function \tcode{F} that, when invoked,
 has the same effect as invoking the closure type's function call operator
 on a default-constructed instance of the closure type.
 \tcode{F} is a constexpr function
@@ -2115,10 +2115,10 @@ int& (*fpi)(int*) = [](auto* a) -> auto& { return *a; };        // OK
 If the function call operator template is a static member function template,
 then the value returned by
 any given specialization of this conversion function template is
-the address of the corresponding function call operator template specialization.
+a pointer to the corresponding function call operator template specialization.
 Otherwise,
 the value returned by any given specialization of this conversion function
-template is the address of a function \tcode{F} that, when invoked, has the same
+template is a pointer to a function \tcode{F} that, when invoked, has the same
 effect as invoking the generic lambda's corresponding function call operator
 template specialization on a default-constructed instance of the closure type.
 \tcode{F} is a constexpr function
@@ -7777,10 +7777,10 @@ satisfies the following constraints:
   it does not have an indeterminate value\iref{basic.indet},
 
   \item
-  if the value is of pointer type, it contains
-  the address of an object with static storage duration,
-  the address past the end of such an object\iref{expr.add},
-  the address of a non-immediate function,
+  if the value is of pointer type, it is
+  a pointer to an object with static storage duration,
+  a pointer past the end of such an object\iref{expr.add},
+  a pointer to a non-immediate function,
   or a null pointer value,
 
   \item

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1198,8 +1198,8 @@ the matching function is selected from the set\iref{over.over}.
 For a non-type \grammarterm{template-parameter} of reference or pointer type,
 or for each non-static data member of reference or pointer type
 in a non-type \grammarterm{template-parameter} of class type or subobject thereof,
-the reference or pointer value shall not refer to
-or be the address of (respectively):
+the reference or pointer value shall not refer
+or point to (respectively):
 \begin{itemize}
 \item a temporary object\iref{class.temporary},
 \item a string literal object\iref{lex.string},


### PR DESCRIPTION
Pointer values are not addresses ([[basic.compound]/3](https://wg21.link/basic.compound#3.sentence-8)), this updates some of the old text to use proper terminology. The intent of the wording is clear, and this PR does not change its normative meaning.

I'm not sure if changing 'address of' to 'pointer representing the address of' is an improvement, so the following are left untouched:
* [[basic.stc.dynamic.allocation]/2](https://wg21.link/basic.stc.dynamic.allocation#2.sentence-2)
* [[expr.delete]/11](https://wg21.link/expr.delete#11.sentence-4)
* [[dcl.fct.def.coroutine]/12](https://wg21.link/dcl.fct.def.coroutine#12.sentence-6)

Also, in [[temp.arg.nontype]/3](https://wg21.link/temp.arg.nontype#3), the text should probably also include past-the-end pointers, but that's not editorial.