### PR TITLE
[re.results.general] Add type of `match_results::const_iterator` to index of imp def behaviour

### DIFF
--- a/source/regex.tex
+++ b/source/regex.tex
@@ -2176,7 +2176,7 @@ namespace std {
       using value_type      = sub_match<BidirectionalIterator>;
       using const_reference = const value_type&;
       using reference       = value_type&;
-      using const_iterator  = @{\impdef}@;
+      using const_iterator  = @\impdefx{type of \tcode{match_results::const_iterator}}@;
       using iterator        = const_iterator;
       using difference_type =
               typename iterator_traits<BidirectionalIterator>::difference_type;


### PR DESCRIPTION
The type of most container iterators is records in the index of implementation defined types, but somehow the `match_results` iterator in the <regex> clause was missed.

After applying this patch, I grepped for any other occurrences of "\\impdef}" and the only remaining (and intentional) match is the definition of this macro in macros.tex, so there should be no more latent cases to find.