### PR TITLE
[intro.abstract] Index the you-know-what clause

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -943,6 +943,7 @@ produce the same observable behavior as one of the possible executions
 of the corresponding instance of the abstract machine with the
 same program and the same input.
 \indextext{behavior!undefined}%
+\indextext{time travel}%
 However, if any such execution contains an undefined operation, this document places no
 requirement on the implementation executing that program with that input
 (not even with regard to operations preceding the first undefined


### PR DESCRIPTION
Given we have been colloquially referring to this clause by name
for many years, it seems reasonable to add it to the index.                     

If I were aiming more at an Easter egg, I would have indexed as
"travel!time" but I don't think we do Easter eggs any more?

The index entry might be better served by adding a footnote that
"this freedom is often referred to as the time travel clause",
but I did not want to draw excessive attention for such a minor
edit (OK, leaving it half-way to an Easter Egg).