### PR TITLE
[span.iterators] Fix cross-reference to container iterators

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -18364,7 +18364,7 @@ Equivalent to: \tcode{return \exposid{data_};}
 
 \rSec4[span.iterators]{Iterator support}
 
-\indexlibrarymember{span}{iterator}%
+\indexlibrarymember{iterator}{span}%
 \begin{itemdecl}
 using iterator = @\impdefx{type of \tcode{span::iterator}}@;
 \end{itemdecl}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -18364,7 +18364,7 @@ Equivalent to: \tcode{return \exposid{data_};}
 
 \rSec4[span.iterators]{Iterator support}
 
-\indexlibrarymember{iterator}{span}%
+\indexlibrarymember{span}{iterator}%
 \begin{itemdecl}
 using iterator = @\impdefx{type of \tcode{span::iterator}}@;
 \end{itemdecl}
@@ -18382,7 +18382,7 @@ whose value type is \tcode{value_type} and
 whose reference type is \tcode{reference}.
 
 \pnum
-All requirements on container iterators\iref{container.requirements} apply to
+All requirements on container iterators\iref{container.reqmts} apply to
 \tcode{span::iterator} as well.
 \end{itemdescr}
 


### PR DESCRIPTION
The current cross-reference is to [containers.requirements], which is the whole containers requirements clause, including not just general containers, but also allocator-aware, reversible, sequence, associative, and unodered associative containers.  It seems very unlikely that the cross-reference expects to be the intersection of all of those.

Rather, the reference seems to intend just the [containers.reqmts] subclause, which adds just two useful constraints: random access iterators should support the 3-way comparison operator, and the interoperabiity of container iterators and const_iterators.

As a drive-by, fixed the \indexlibrarymember macro by ordering the type, span, before the member, iterator, as is the convention. This has no impact on the index, as entries in both directions are created.  However, it makes the wording of index macros across the clause consistent.