### PR TITLE
[container.alloc.reqmts] Better cross-references for allocator-aware …

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -888,8 +888,8 @@ Linear.
 \rSec3[container.alloc.reqmts]{Allocator-aware containers}
 
 \pnum
-All of the containers defined in \ref{containers} except \tcode{array},
-in \ref{stacktrace.basic}, in \ref{basic.string}, and in \ref{re.results}
+Except for \tcode{array}, all of the containers defined in \ref{containers},
+\ref{stacktrace.basic}, \ref{basic.string}, and \ref{re.results}
 meet the additional requirements of an \defnadj{allocator-aware}{container},
 as described below.
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -888,7 +888,8 @@ Linear.
 \rSec3[container.alloc.reqmts]{Allocator-aware containers}
 
 \pnum
-All of the containers defined in \ref{containers} and in~\ref{basic.string} except \tcode{array}
+All of the containers defined in \ref{containers} except \tcode{array},
+in \ref{stacktrace.basic}, in \ref{basic.string}, and in \ref{re.results}
 meet the additional requirements of an \defnadj{allocator-aware}{container},
 as described below.
 

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -2131,8 +2131,8 @@ by the member functions of class template \tcode{match_results}.
 \indextext{requirements!container}%
 \indextext{requirements!sequence}%
 The class template \tcode{match_results} meets the requirements of an
-allocator-aware container and of
-a sequence container\iref{container.alloc.reqmts,sequence.reqmts}
+allocator-aware container\iref{container.alloc.reqmts} and of
+a sequence container\iref{container.requirements.general,sequence.reqmts}
 except that only
 copy assignment,
 move assignment, and

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -2378,7 +2378,7 @@ the type \tcode{traits} shall meet
 the character traits requirements\iref{char.traits}.
 \begin{note}
 Every specialization \tcode{basic_string<charT, traits, Allocator>} is
-an allocator-aware container,
+an allocator-aware container\iref{container.alloc.reqmts},
 but does not use the allocator's \tcode{construct} and \tcode{destroy}
 member functions\iref{container.requirements.pre}.
 The program is ill-formed if


### PR DESCRIPTION
…containers

There are now more allocator-aware containers in the standard than when this subclause was first written, so ensure we have call outs to all relevent subclauses.

The current wording for 'basic_stacktrace' also shows how containers can properly call out the allocator-aware container requirements, now they have their own titled subclause.