### PR TITLE
[container.reqmts] Fix cross-references to contiguous container

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -628,6 +628,14 @@ element in the other container after the swap. It is unspecified whether an iter
 with value \tcode{a.end()} before the swap will have value \tcode{b.end()} after the
 swap.
 
+\pnum
+A \defnadj{contiguous}{container}
+is a container
+whose member types \tcode{iterator} and \tcode{const_iterator}
+meet the
+\oldconcept{RandomAccessIterator} requirements\iref{random.access.iterators} and
+model \libconcept{contiguous_iterator}\iref{iterator.concept.contiguous}.
+
 \rSec3[container.rev.reqmts]{Reversible container requirements}
 
 % Local command to index names as members of all containers.
@@ -808,14 +816,6 @@ function in terms of other functions), invoking a container member
 function or passing a container as an argument to a library function
 shall not invalidate iterators to, or change the values of, objects
 within that container.
-
-\pnum
-A \defnadj{contiguous}{container}
-is a container
-whose member types \tcode{iterator} and \tcode{const_iterator}
-meet the
-\oldconcept{RandomAccessIterator} requirements\iref{random.access.iterators} and
-model \libconcept{contiguous_iterator}\iref{iterator.concept.contiguous}.
 
 \rSec3[container.opt.reqmts]{Optional container requirements}
 
@@ -6149,7 +6149,7 @@ namespace std {
 \indextext{\idxcode{array}!contiguous storage}%
 The header \libheader{array} defines a class template for storing fixed-size
 sequences of objects.
-An \tcode{array} is a contiguous container\iref{container.requirements.general}.
+An \tcode{array} is a contiguous container\iref{container.reqmts}.
 An instance of \tcode{array<T, N>} stores \tcode{N} elements of type \tcode{T},
 so that \tcode{size() == N} is an invariant.
 
@@ -8590,7 +8590,7 @@ of an allocator-aware container\iref{container.alloc.reqmts},
 of a sequence container, including most of the optional sequence container
 requirements\iref{sequence.reqmts},
 and, for an element type other than \tcode{bool},
-of a contiguous container\iref{container.requirements.general}.
+of a contiguous container\iref{container.reqmts}.
 The exceptions are the
 \tcode{push_front}, \tcode{prepend_range}, \tcode{pop_front}, and \tcode{emplace_front} member functions, which are not
 provided. Descriptions are provided here only for operations on \tcode{vector}

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -2006,7 +2006,7 @@ the type of the char-like objects held in a \tcode{basic_string} object
 is designated by \tcode{charT}.
 
 \pnum
-A specialization of \tcode{basic_string} is a contiguous container\iref{container.requirements.general}.
+A specialization of \tcode{basic_string} is a contiguous container\iref{container.reqmts}.
 
 \pnum
 In all cases,


### PR DESCRIPTION
This edit deserves describing in detail, to establish that it is purely editorial.

As part of the mission to clean up tables in the standard, the general container requirements were split into 5 more focused leaf nodes.  Due to its location in the original text, the definition for a contiguous container fell into the subclause for reversible containers, to which it is entirely unrelated.  There is no requirement that a contiguous container be reversible, only that it has the correct category for its iterators.

Meanwhile, all 3 of the existing cross-references point to the wrong leaf node, that simply provides a key to the identifiers used throughout the specification of this clause.

The fix has two parts.  First move the definition of contiguous container, and a container with special iterators, into the [container.reqmts] clause where it best belongs.  This move is appended to the end so that there can be no ambiguity that any existing text could be confused with requirements only on contiguous
containers after the edit.  The other part is to fix up the three cross-references to point to [container.reqmts] rather than its sibling that has no information on contiguous containers.

A grep of the .tex source files confirms that these three references (array,basic_string, and vector) are the only current uses of contiguous container, even though basic_stacktrace would also meet the requirements.