### PR TITLE
[container.requirements.general] Move exposition-only concept

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -95,6 +95,14 @@ an rvalue of type \tcode{const X},
 \tcode{rv} denotes a non-const rvalue of type \tcode{X}.
 \end{itemize}
 
+\pnum
+The following exposition-only concept is used in the definition of containers:
+\begin{codeblock}
+template<class R, class T>
+concept @\defexposconcept{container-compatible-range}@ =    // \expos
+  ranges::@\libconcept{input_range}@<R> && @\libconcept{convertible_to}@<ranges::range_reference_t<R>, T>;
+\end{codeblock}
+
 \rSec3[container.reqmts]{Containers}
 
 % Local command to index names as members of all containers.
@@ -950,14 +958,6 @@ The default \tcode{construct} in \tcode{allocator} will
 call \tcode{::new((void*)p) T(args)},
 but specialized allocators can choose a different definition.
 \end{note}
-
-\pnum
-The following exposition-only concept is used in the definition of containers:
-\begin{codeblock}
-template<class R, class T>
-concept @\defexposconcept{container-compatible-range}@ =    // \expos
-  ranges::@\libconcept{input_range}@<R> && @\libconcept{convertible_to}@<ranges::range_reference_t<R>, T>;
-\end{codeblock}
 
 \pnum
 In this subclause,


### PR DESCRIPTION
The exposition-only concept _container-compatible-range_ is defined in the subclause for allocator-aware containers, that does not actually use it.  This requirement is used throughout the subclause for a variety of containers, so relocate the definition into the leading subclause that provides a key to definitions used throughout the containers subclauses.