### PR TITLE
[class.abstract] Missing change of note for inherited member functions in P1787R6

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -4096,7 +4096,7 @@ a \defnx{pure virtual function}{function!virtual!pure} by using a
 \grammarterm{pure-specifier}\iref{class.mem} in the function declaration
 in the class definition.
 \begin{note}
-Such a function might be inherited: see below.
+Such a function might be declared in a base class.
 \end{note}
 A class is an \defnadj{abstract}{class}
 if it has at least one pure virtual function.


### PR DESCRIPTION
Before [P1787R6](https://wg21.link/p1787r6), we said members other than constructors could be inherited from a base class. With the changed in [#[class.derived]](https://wg21.link/p1787r6#class.derived) of P1787R6, inherited members are restricted to constructors. As a result, Note 2 in [class.abstract] is incorrect now.

I think we can just say a pure virtual function is declared in a base class. The "see below" part doesn't seem helpful, and I guess it should be removed. Another choice might be removing the whole note since it seems slightly redundant.

Related to cplusplus/CWG#267, but I don't see the need of a core issue.