### PR TITLE
[intro.object] Clarify [intro.object]/3.1

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3150,7 +3150,7 @@ that array \defn{provides storage}
 for the created object if:
 \begin{itemize}
 \item
-the lifetime of \placeholder{e} has begun and not ended, and
+the lifetime of \placeholder{e} has begun and not ended immediately before creating the new object, and
 \item
 the storage for the new object fits entirely within \placeholder{e}, and
 \item


### PR DESCRIPTION
Some reading may consider that "the lifetime of _e_ has begun and not ended" can be interferred by the creation of the new object. It seems better to clarify that the condition only applies to the state immediately before the creation, and there should be no logical circular dependency on [basic.life]/1.5.

(Not sure whether the bullet should be applied to simultaneous implicit object creations.)

Fixes cplusplus/CWG#247 (perhaps).