### PR TITLE
[range.adaptor.helpers] make as-lvalue noexcept

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -4302,7 +4302,7 @@ namespace std::ranges {
   }
 
   template<class T>
-  constexpr T& @\exposid{as-lvalue}@(T&& t) {                   // \expos
+  constexpr T& @\exposid{as-lvalue}@(T&& t) noexcept {          // \expos
     return static_cast<T&>(t);
   }
 }


### PR DESCRIPTION
Given that it's a sibling of `std::as_const`, would adding `noexcept` here conform to a more standard style even though it's exposition only?