### PR TITLE
[container.reqmts] Relocate more container requirements

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -629,12 +629,81 @@ with value \tcode{a.end()} before the swap will have value \tcode{b.end()} after
 swap.
 
 \pnum
+Unless otherwise specified (see~\ref{associative.reqmts.except}, \ref{unord.req.except}, \ref{deque.modifiers}, and
+\ref{vector.modifiers})
+all container types defined in this Clause meet
+the following additional requirements:
+
+\begin{itemize}
+\item
+If an exception is thrown by an
+\tcode{insert()} or \tcode{emplace()}
+function while inserting a single element, that
+function has no effects.
+\item
+If an exception is thrown by a
+\tcode{push_back()},
+\tcode{push_front()},
+\tcode{emplace_back()}, or \tcode{emplace_front()}
+function, that function has no effects.
+\item
+No
+\tcode{erase()},
+\tcode{clear()},
+\tcode{pop_back()}
+or
+\tcode{pop_front()}
+function throws an exception.
+\item
+No copy constructor or assignment operator of a returned iterator
+throws an exception.
+\item
+No
+\tcode{swap()}
+function throws an exception.
+\item
+No
+\tcode{swap()}
+function invalidates any references,
+pointers, or iterators referring to the elements
+of the containers being swapped.
+\begin{note}
+The \tcode{end()} iterator does not refer to any element, so it can be invalidated.
+\end{note}
+\end{itemize}
+
+\pnum
+Unless otherwise specified (either explicitly or by defining a
+function in terms of other functions), invoking a container member
+function or passing a container as an argument to a library function
+shall not invalidate iterators to, or change the values of, objects
+within that container.
+
+\pnum
 A \defnadj{contiguous}{container}
 is a container
 whose member types \tcode{iterator} and \tcode{const_iterator}
 meet the
 \oldconcept{RandomAccessIterator} requirements\iref{random.access.iterators} and
 model \libconcept{contiguous_iterator}\iref{iterator.concept.contiguous}.
+
+\pnum
+The behavior of certain container member functions and deduction guides
+depends on whether types qualify as input iterators or allocators.
+The extent to which an implementation determines that a type cannot be an input
+iterator is unspecified, except that as a minimum integral types shall not qualify
+as input iterators.
+Likewise, the extent to which an implementation determines that a type cannot be
+an allocator is unspecified, except that as a minimum a type \tcode{A} shall not qualify
+as an allocator unless it meets both of the following conditions:
+
+\begin{itemize}
+\item The \grammarterm{qualified-id} \tcode{A::value_type}
+is valid and denotes a type\iref{temp.deduct}.
+
+\item The expression \tcode{declval<A\&>().allocate(size_t\{\})}
+is well-formed when treated as an unevaluated operand.
+\end{itemize}
 
 \rSec3[container.rev.reqmts]{Reversible container requirements}
 
@@ -766,56 +835,6 @@ a.crend()
 Constant.
 \end{itemdescr}
 
-\pnum
-Unless otherwise specified (see~\ref{associative.reqmts.except}, \ref{unord.req.except}, \ref{deque.modifiers}, and
-\ref{vector.modifiers})
-all container types defined in this Clause meet
-the following additional requirements:
-
-\begin{itemize}
-\item
-If an exception is thrown by an
-\tcode{insert()} or \tcode{emplace()}
-function while inserting a single element, that
-function has no effects.
-\item
-If an exception is thrown by a
-\tcode{push_back()},
-\tcode{push_front()},
-\tcode{emplace_back()}, or \tcode{emplace_front()}
-function, that function has no effects.
-\item
-No
-\tcode{erase()},
-\tcode{clear()},
-\tcode{pop_back()}
-or
-\tcode{pop_front()}
-function throws an exception.
-\item
-No copy constructor or assignment operator of a returned iterator
-throws an exception.
-\item
-No
-\tcode{swap()}
-function throws an exception.
-\item
-No
-\tcode{swap()}
-function invalidates any references,
-pointers, or iterators referring to the elements
-of the containers being swapped.
-\begin{note}
-The \tcode{end()} iterator does not refer to any element, so it can be invalidated.
-\end{note}
-\end{itemize}
-
-\pnum
-Unless otherwise specified (either explicitly or by defining a
-function in terms of other functions), invoking a container member
-function or passing a container as an argument to a library function
-shall not invalidate iterators to, or change the values of, objects
-within that container.
 
 \rSec3[container.opt.reqmts]{Optional container requirements}
 
@@ -1192,23 +1211,6 @@ Exchanges the contents of \tcode{a} and \tcode{b}.
 Constant.
 \end{itemdescr}
 
-\pnum
-The behavior of certain container member functions and deduction guides
-depends on whether types qualify as input iterators or allocators.
-The extent to which an implementation determines that a type cannot be an input
-iterator is unspecified, except that as a minimum integral types shall not qualify
-as input iterators.
-Likewise, the extent to which an implementation determines that a type cannot be
-an allocator is unspecified, except that as a minimum a type \tcode{A} shall not qualify
-as an allocator unless it meets both of the following conditions:
-
-\begin{itemize}
-\item The \grammarterm{qualified-id} \tcode{A::value_type}
-is valid and denotes a type\iref{temp.deduct}.
-
-\item The expression \tcode{declval<A\&>().allocate(size_t\{\})}
-is well-formed when treated as an unevaluated operand.
-\end{itemize}
 
 \rSec2[container.requirements.dataraces]{Container data races}
 


### PR DESCRIPTION
As part of rewriting the container requirements tables as text, several paragraphs of general container requirements were buried in the new subsection for more specific requirements such as reversible containers or allocator-aware containers.  This seems to have happened when general container requirements followed one of the container requirements tables that are noe expressed as text.

This PR carefully restores text to the general container requirements clause, in the original order they appeared in C++20, and audits that there are no further paragraphs to move that do not have outstanding pull requests.