### PR TITLE
Prevent double spacing in tcode

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -175,7 +175,7 @@
 % This command uses the "cooked" \indeximpldef command to emit index
 % entries; thus they only work for simple index entries that do not contain
 % special indexing instructions.
-\newcommand{\impldef}[1]{\indeximpldef{#1}implementation-defined}
+\newcommand{\impldef}[1]{\indeximpldef{#1}imple\-men\-ta\-tion-defined}
 % \impldefplain passes the argument directly to the index, allowing you to
 % use special indexing instructions (!, @, |).
 \newcommand{\impldefplain}[1]{\index[impldefindex]{#1}implementation-defined}

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -219,7 +219,7 @@
 % General code style
 %%--------------------------------------------------
 \newcommand{\CodeStyle}{\ttfamily}
-\newcommand{\CodeStylex}[1]{\texttt{#1}}
+\newcommand{\CodeStylex}[1]{\texttt{\protect\frenchspacing #1}}
 
 \definecolor{grammar-gray}{gray}{0.2}
 

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -10873,7 +10873,7 @@ is \tcode{true},
 Otherwise,
 if \tcode{(\libconcept{derived_from}<Cs, bidirectional_iterator_tag> \&\& ...)}
 is \tcode{true},
-\tcode{itera\-tor_category} denotes \tcode{bidirectional_iterator_tag}.
+\tcode{iterator\-_category} denotes \tcode{bidirectional_iterator_tag}.
 \item
 Otherwise,
 if \tcode{(\libconcept{derived_from}<Cs, forward_iterator_tag> \&\& ...)}
@@ -15110,7 +15110,7 @@ for any \tcode{rng} among the underlying ranges except the first one and
 \tcode{false} otherwise; and
 \item
 \tcode{\exposid{begin-or-first-end}(rng)} be expression-equivalent to
-\tcode{\exposid{is-empty} ? ranges::begin(rng) : \exposid{cartesian-common-arg-end}(rng)}
+\tcode{\exposid{is-empty} ? ranges::begin(rng) : \brk{}\exposid{cartesian-common-arg-end}(rng)}
 if \tcode{rng} is the first underlying range and
 \tcode{ranges::begin(rng)} otherwise.
 \end{itemize}

--- a/source/std.tex
+++ b/source/std.tex
@@ -74,6 +74,7 @@
 \pdfstringdefDisableCommands{\def\textbf#1{#1}}
 \pdfstringdefDisableCommands{\def\raisebox#1{}}
 \pdfstringdefDisableCommands{\def\hspace#1{}}
+\pdfstringdefDisableCommands{\def\frenchspacing{}}
 
 %%--------------------------------------------------
 %% add special hyphenation rules


### PR DESCRIPTION
Due to `nofrenchspacing`, a space after `.`, `:`, `?` are rendered as two spaces in monospaced fonts if these punctuations are preceded by non-capital characters. For example, `\tcode{a ? b : c}` is rendered as `a ?  b :  c`, and
```
\tcode{template <class... A> void f(A...) noexcept}
```
is rendered as
```
template <class...  A> void f(A...)  noexcept;
```

Currently, there are tens of these double spacings in the Standard.
This PR prevents them by adding `\frenchspacing` to `CodeStylex`.