### PR TITLE
[defns.dynamic.type] Say "most derived object" in the example

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -279,7 +279,7 @@ glvalue refers
 
 \begin{example}
 If a pointer\iref{dcl.ptr} \tcode{p} whose type is ``pointer to
-class \tcode{B}'' is pointing to a base class subobject class object
+class \tcode{B}'' is pointing to a base class subobject
 of class \tcode{B}, whose most derived object is of class \tcode{D}, derived
 from \tcode{B}\iref{class.derived}, the dynamic type of the
 expression \tcode{*p} is ``\tcode{D}''. References\iref{dcl.ref} are

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -278,8 +278,9 @@ that is not list-initialization
 glvalue refers
 
 \begin{example}
-If a pointer\iref{dcl.ptr} \tcode{p} whose static type is ``pointer to
-class \tcode{B}'' is pointing to an object of class \tcode{D}, derived
+If a pointer\iref{dcl.ptr} \tcode{p} whose type is ``pointer to
+class \tcode{B}'' is pointing to a base class subobject class object
+of class \tcode{B}, whose most derived object is of class \tcode{D}, derived
 from \tcode{B}\iref{class.derived}, the dynamic type of the
 expression \tcode{*p} is ``\tcode{D}''. References\iref{dcl.ref} are
 treated similarly.


### PR DESCRIPTION
and
- don't say the static type of a pointer, because the difference between static and dynamic types is only present for glvalues of class types;
- say that the `B*` pointer is pointing to a `B` base class subobject, which avoids involving problematic cases of `reinterpret_cast` or `static_cast` from _cv_ `void*` (see [[expr.static.cast]/14](https://eel.is/c++draft/expr.static.cast#14)).

Fixes #5762.
Fixes cplusplus/CWG#257.