### PR TITLE
[version.syn] bump value of __cpp_lib_allocate_at_least

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -553,7 +553,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_addressof_constexpr}@               201603L // also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_algorithm_iterator_requirements}@   202207L
   // also in \libheader{algorithm}, \libheader{numeric}, \libheader{memory}
-#define @\defnlibxname{cpp_lib_allocate_at_least}@                 202106L // also in \libheader{memory}
+#define @\defnlibxname{cpp_lib_allocate_at_least}@                 202302L // also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_allocator_traits_is_always_equal}@  201411L
   // also in \libheader{memory}, \libheader{scoped_allocator}, \libheader{string}, \libheader{deque}, \libheader{forward_list}, \libheader{list}, \libheader{vector},
   // \libheader{map}, \libheader{set}, \libheader{unordered_map}, \libheader{unordered_set}


### PR DESCRIPTION
This is requested for the Tentatively Ready LWG issue 3887.

Fixes #6202