### PR TITLE
Mac modernization: allow listings 1.9, and don't allow errors in a pipe

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,6 +33,11 @@ jobs:
       - name: check-source.sh
         run: ../tools/check-source.sh
 
+      - name: update brew
+        if: matrix.cfg.os == 'macos-12'
+        run: |
+          brew update
+
       - name: update-apt-cache
         if: matrix.cfg.os == 'ubuntu-22.04'
         run: sudo apt-get update
@@ -41,7 +46,7 @@ jobs:
         if: matrix.cfg.os == 'ubuntu-22.04'
         run: sudo apt-get install latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended lmodern
 
-      - name: install (MacOS, Part 1/2)
+      - name: install (MacOS)
         if: matrix.cfg.os == 'macos-12'
         run: |
           brew install basictex
@@ -50,8 +55,13 @@ jobs:
           sudo tlmgr update --self
           sudo tlmgr install latexmk isodate substr relsize ulem fixme rsfs extract layouts enumitem l3packages l3kernel imakeidx splitindex xstring
 
-      - name: make
+      - name: make (Linux)
+        if: matrix.cfg.os == 'ubuntu-22.04'
         run: make quiet
+
+      - name: make (MacOS)
+        if: matrix.cfg.os == 'macos-12'
+        run: make full
 
       - name: check-output.sh
         run: ../tools/check-output.sh

--- a/source/styles.tex
+++ b/source/styles.tex
@@ -142,14 +142,6 @@
 %% (copied verbatim from listings.sty version 1.6 except where commented)
 \makeatletter
 
-\lst@CheckVersion{1.8d}{\lst@CheckVersion{1.8c}{\lst@CheckVersion{1.8b}{\lst@CheckVersion{1.7}{\lst@CheckVersion{1.6}{\lst@CheckVersion{1.5b}{
- \typeout{^^J%
- ***^^J%
- *** This file requires listings.sty version 1.6.^^J%
- *** You have version \lst@version; exiting ...^^J%
- ***^^J}%
- \batchmode \@@end}}}}}}
-
 \def\lst@Init#1{%
     \begingroup
     \ifx\lst@float\relax\else


### PR DESCRIPTION
@jensmaurer We need to allow listings 1.9 for MacOS. Is there any point in having the version check at all?