### PR TITLE
[range.utility.conv.to] Use model instead of satisfy for range concept

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2297,7 +2297,7 @@ An object of type \tcode{C}
 constructed from the elements of \tcode{r} in the following manner:
 \begin{itemize}
 \item
-If \tcode{C} does not satisfy \libconcept{input_range} or
+If \tcode{C} does not model \libconcept{input_range} or
 \tcode{\libconcept{convertible_to}<range_reference_t<R>, range_value_t<C>>}
 is \tcode{true}:
 \begin{itemize}


### PR DESCRIPTION
Is this editorial? If not, is this change worthwhile?