### PR TITLE
[over.literal] Cross-reference deprecated grammar

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3954,7 +3954,7 @@ implicit terminating \tcode{'\textbackslash 0'}.
 The \grammarterm{ud-suffix} of the \grammarterm{user-defined-string-literal} or
 the \grammarterm{identifier} in a \grammarterm{literal-operator-id} is called a
 \defnx{literal suffix identifier}{literal!suffix identifier}.
-The first form of \grammarterm{literal-operator-id} is deprecated.
+The first form of \grammarterm{literal-operator-id} is deprecated\iref{depr.lit}.
 Some literal suffix identifiers are reserved for future standardization;
 see~\ref{usrlit.suffix}.  A declaration whose \grammarterm{literal-operator-id} uses
 such a literal suffix identifier is ill-formed, no diagnostic required.


### PR DESCRIPTION
The core conention is to retain deprecated wording in the core clauses, but always make a forward link to Annex D where a feature, or parts of a feature, are deprecated.