### PR TITLE
[depr.atomics.volatile] Use tcode to call out template name

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -2697,7 +2697,7 @@ namespace std {
 \rSec2[depr.atomics.volatile]{Volatile access}
 
 \pnum
-If an atomic specialization has one of the following overloads,
+If an \tcode{atomic}\iref{atomics.types.generic} specialization has one of the following overloads,
 then that overload participates in overload resolution
 even if \tcode{atomic<T>::is_always_lock_free} is \tcode{false}:
 \begin{codeblock}


### PR DESCRIPTION
There is no such thing as an "atomic specialization", so the only valid reading of this text is that "atomic" refers to the class template `atomic`.

This PR makes the intent clear with code font and a cross reference, and I believe is editorial.  However, the LWG chair might want to confirm whether the change of font counts as a normative change that deserves LWG review.