### PR TITLE
[dcl.decl.general] Fix cross-references

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2165,10 +2165,10 @@ auto j = 2.0;           // OK, \tcode{j} deduced to have type \tcode{double}
 \end{note}
 
 \pnum
-The optional \grammarterm{requires-clause}\iref{temp.pre} in an
+The optional \grammarterm{requires-clause} in an
 \grammarterm{init-declarator} or \grammarterm{member-declarator}
 shall be present only if the declarator declares a
-templated function\iref{dcl.fct}.
+templated function\iref{temp.pre}.
 %
 \indextext{trailing requires-clause@trailing \gterm{requires-clause}|see{\gterm{requires-clause}, trailing}}%
 When present after a declarator, the \grammarterm{requires-clause}


### PR DESCRIPTION
"templated function" is defined in [temp.pre], but avoid having two cross-references to the same place in the same paragraph by dropping the cross-reference for the definition of the grammar non-terminal "requires-clause".

Partially addresses llvm/llvm-project#61748