### PR TITLE
[container.opt.reqmts] Index 3-way compare for containers

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -868,10 +868,6 @@ are implemented by constexpr functions.
 \indexlibrarymemberx{set}{#1}%
 \indexlibrarymemberx{multiset}{#1}%
 \indexlibrarymemberx{multimap}{#1}%
-\indexlibrarymemberx{unordered_map}{#1}%
-\indexlibrarymemberx{unordered_set}{#1}%
-\indexlibrarymemberx{unordered_multiset}{#1}%
-\indexlibrarymemberx{unordered_multimap}{#1}%
 \indexlibrarymemberx{flat_map}{#1}%
 \indexlibrarymemberx{flat_set}{#1}%
 \indexlibrarymemberx{flat_multiset}{#1}%

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -856,19 +856,8 @@ meet the constexpr iterator requirements\iref{iterator.requirements.general}
 then the operations described below
 are implemented by constexpr functions.
 
-\indexlibrarymember{array}{operator<=>}%
-\indexlibrarymember{deque}{operator<=>}%
 \indexlibrarymember{forward_list}{operator<=>}%
-\indexlibrarymember{list}{operator<=>}%
-\indexlibrarymember{vector}{operator<=>}%
-\indexlibrarymember{map}{operator<=>}%
-\indexlibrarymember{set}{operator<=>}%
-\indexlibrarymember{multiset}{operator<=>}%
-\indexlibrarymember{multimap}{operator<=>}%
-\indexlibrarymember{unordered_map}{operator<=>}%
-\indexlibrarymember{unordered_set}{operator<=>}%
-\indexlibrarymember{unordered_multiset}{operator<=>}%
-\indexlibrarymember{unordered_multimap}{operator<=>}%
+\indexcont{operator<=>}%
 \indexlibrarymember{flat_map}{operator<=>}%
 \indexlibrarymember{flat_set}{operator<=>}%
 \indexlibrarymember{flat_multiset}{operator<=>}%

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -856,13 +856,30 @@ meet the constexpr iterator requirements\iref{iterator.requirements.general}
 then the operations described below
 are implemented by constexpr functions.
 
-\indexlibrarymember{forward_list}{operator<=>}%
+% Local command to index names as members of all containers.
+\renewcommand{\indexcont}[1]{%
+\indexlibrarymisc{\idxcode{#1}}{optional container requirements}%
+\indexlibrarymemberx{array}{#1}%
+\indexlibrarymemberx{deque}{#1}%
+\indexlibrarymemberx{forward_list}{#1}%
+\indexlibrarymemberx{list}{#1}%
+\indexlibrarymemberx{vector}{#1}%
+\indexlibrarymemberx{map}{#1}%
+\indexlibrarymemberx{set}{#1}%
+\indexlibrarymemberx{multiset}{#1}%
+\indexlibrarymemberx{multimap}{#1}%
+\indexlibrarymemberx{unordered_map}{#1}%
+\indexlibrarymemberx{unordered_set}{#1}%
+\indexlibrarymemberx{unordered_multiset}{#1}%
+\indexlibrarymemberx{unordered_multimap}{#1}%
+\indexlibrarymemberx{flat_map}{#1}%
+\indexlibrarymemberx{flat_set}{#1}%
+\indexlibrarymemberx{flat_multiset}{#1}%
+\indexlibrarymemberx{flat_multimap}{#1}%
+\indexlibrarymemberx{basic_string}{#1}%
+}
+
 \indexcont{operator<=>}%
-\indexlibrarymember{flat_map}{operator<=>}%
-\indexlibrarymember{flat_set}{operator<=>}%
-\indexlibrarymember{flat_multiset}{operator<=>}%
-\indexlibrarymember{flat_multimap}{operator<=>}%
-\indexlibrarymember{basic_string}{operator<=>}%
 \begin{itemdecl}
 a <=> b
 \end{itemdecl}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -856,6 +856,24 @@ meet the constexpr iterator requirements\iref{iterator.requirements.general}
 then the operations described below
 are implemented by constexpr functions.
 
+\indexlibrarymember{array}{operator<=>}%
+\indexlibrarymember{deque}{operator<=>}%
+\indexlibrarymember{forward_list}{operator<=>}%
+\indexlibrarymember{list}{operator<=>}%
+\indexlibrarymember{vector}{operator<=>}%
+\indexlibrarymember{map}{operator<=>}%
+\indexlibrarymember{set}{operator<=>}%
+\indexlibrarymember{multiset}{operator<=>}%
+\indexlibrarymember{multimap}{operator<=>}%
+\indexlibrarymember{unordered_map}{operator<=>}%
+\indexlibrarymember{unordered_set}{operator<=>}%
+\indexlibrarymember{unordered_multiset}{operator<=>}%
+\indexlibrarymember{unordered_multimap}{operator<=>}%
+\indexlibrarymember{flat_map}{operator<=>}%
+\indexlibrarymember{flat_set}{operator<=>}%
+\indexlibrarymember{flat_multiset}{operator<=>}%
+\indexlibrarymember{flat_multimap}{operator<=>}%
+\indexlibrarymember{basic_string}{operator<=>}%
 \begin{itemdecl}
 a <=> b
 \end{itemdecl}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -856,7 +856,7 @@ meet the constexpr iterator requirements\iref{iterator.requirements.general}
 then the operations described below
 are implemented by constexpr functions.
 
-% Local command to index names as members of all containers.
+% Local command to index a name as a member of all containers.
 \renewcommand{\indexcont}[1]{%
 \indexlibrarymisc{\idxcode{#1}}{optional container requirements}%
 \indexlibrarymemberx{array}{#1}%


### PR DESCRIPTION
All of the standard containers are 3-way comparable, but the specification is provided under optional container requirements so does not show up in the index.

Adding these links shows just how poorly indexed the members of the 'flat_*' container adapters are, but that is properly the business on a separate PR.