### PR TITLE
[format.string.std] Replace "Derived Extracted Property" with simply "property"

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -874,8 +874,7 @@ literals, and alternative tokens containing alphabetic characters.
 \indextext{name!length of}%
 \indextext{name}%
 \begin{note}
-The character properties XID_Start and XID_Continue are Derived Core Properties
-as described by \UAX{44} of the Unicode Standard.
+The character properties XID_Start and XID_Continue are described by \UAX{44} of the Unicode Standard.
 \begin{footnote}
 On systems in which linkers cannot accept extended
 characters, an encoding of the \grammarterm{universal-character-name} can be used in

--- a/source/text.tex
+++ b/source/text.tex
@@ -6352,7 +6352,7 @@ The following code points have a field width of 2:
 \begin{itemize}
 \item
 any code point with the \tcode{East_Asian_Width="W"} or
-\tcode{East_Asian_Width="F"} Derived Extracted Property as described by
+\tcode{East_Asian_Width="F"} property as described by
 \UAX{44} of the Unicode Standard
 \item
 \ucode{4dc0} -- \ucode{4dff} (Yijing Hexagram Symbols)


### PR DESCRIPTION
"Derived Extracted Property" refers to the fact that the data for the `East_Asian_Width` property are extracted into the file [`DerivedEastAsianWidth.txt`]. It is not really a terminology.

[`DerivedEastAsianWidth.txt`]: https://www.unicode.org/Public/UCD/latest/ucd/extracted/DerivedEastAsianWidth.txt
[`EastAsianWidth.txt`]: https://www.unicode.org/Public/UCD/latest/ucd/EastAsianWidth.txt