### PR TITLE
[expr.shift] more precise wording for arithmetic shift rounding CWG2724

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6302,7 +6302,7 @@ vacated bits are zero-filled.
 \end{note}
 
 \pnum
-The value of \tcode{E1 >> E2} is $\tcode{E1} / 2^\tcode{E2}$, rounded down.
+The value of \tcode{E1 >> E2} is $\tcode{E1} / 2^\tcode{E2}$, rounded towards negative infinity.
 \begin{note}
 \tcode{E1} is right-shifted \tcode{E2} bit positions.
 Right-shift on signed integral types is an arithmetic right shift,


### PR DESCRIPTION
## Problems with the present wording

> rounded down

is sometimes used to describe rounding towards zero, and sometimes to describe rounding towards negative infinity. For example, Java uses [java.math.RoundingMode.DOWN](https://docs.oracle.com/javase/7/docs/api/java/math/RoundingMode.html#DOWN) to describe rounding towards zero.

It is intuitively clear to the committee and to implementers that this should mirror the semantics of the "arithmetic right shift" instruction (which rounds towards negative infinity), but the wording is not so clear.

## Improvements made by the suggested wording

> rounded towards negative infinity

is unambiguous.
The wording is also quite popular, e.g. [the Wikipedia article on rounding](https://en.wikipedia.org/wiki/Rounding) uses it.