### PR TITLE
Fix Subclause name for cstddef in headers.cpp.fs

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1439,7 +1439,7 @@ A freestanding implementation has an
 include at least the headers shown in \tref{headers.cpp.fs}.
 
 \begin{libsumtab}{\Cpp{} headers for freestanding implementations}{headers.cpp.fs}
-\ref{support.types}      & Types                     & \tcode{<cstddef>}          \\ \rowsep
+\ref{support.types}      & Common definitions        & \tcode{<cstddef>}          \\ \rowsep
 \ref{support.limits}     & Implementation properties &
   \tcode{<cfloat>}, \tcode{<climits>}, \tcode{<limits>}, \tcode{<version>} \\ \rowsep
 \ref{cstdint.syn}        & Integer types             & \tcode{<cstdint>}   \\ \rowsep


### PR DESCRIPTION
The new name "Common definitions" for the entry of section 17.2 in Table headers.cpp.fs
is already used as name for the entry of section 17.2 in Table support.summary
and is also used as the name in section 17.2 (support.types)

There is still a difference for cstdlib (17.2.2: cstdlib.syn):
Table "support.summary" lists cstdlib for entry 17.2 and entry 17.5, but 
Table "headers.cpp.fs" lists cstdlib only for entry 17.5.

According to the Text in 17.2.2, cstdlib has 2 freestanding entries related to section 17.2
and 5 freestanding entries related to section 17.5.

cstdlib has references to a lot more sections, which are not listed in Table "support.summary",
but adding every reference from cstdlib to Table "support.summary" makes the Table very ugly.

--
Regards ... Detlef Riekenberg