### PR TITLE
[iterator.concept.winc] Improve implementation-defined text

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1390,7 +1390,7 @@ template<class I>
 
 \pnum
 A type \tcode{I} is an \defnadj{integer-class}{type}
-if it is in a set of \impldef{integer-class type} types
+if it is in a set of \impldef{set of types that are integer-class types} types
 that behave as integer types do, as defined below.
 \begin{note}
 An integer-class type is not necessarily a class type.

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1390,7 +1390,7 @@ template<class I>
 
 \pnum
 A type \tcode{I} is an \defnadj{integer-class}{type}
-if it is in a set of \impldef{set of types that are integer-class types} types
+if it is in a set of \impldef{set of integer-class types} types
 that behave as integer types do, as defined below.
 \begin{note}
 An integer-class type is not necessarily a class type.


### PR DESCRIPTION
It should be clear what an implentation-defined term defines when reading just the index of implementation defined behavior. The current impldef text of integer-class types is so short as to be cryptic.