### PR TITLE
[coro.generator] Editorial fixes

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -15835,11 +15835,11 @@ generator(generator&& other) noexcept;
 Initializes \exposid{coroutine_} with
 \tcode{exchange(other.\exposid{coroutine_}, \{\})} and
 \exposid{active_} with
-\tcode{exchange(\brk{}other.active_, nullptr)}.
+\tcode{std::move(\brk{}other.active_)}.
 
 \pnum
 \begin{note}
-Iterators previously obtained from \tcode{other} are not invalidated;
+Iterators previously into \tcode{other} are not invalidated;
 they become iterators into \tcode{*this}.
 \end{note}
 \end{itemdescr}
@@ -15889,7 +15889,7 @@ swap(@\exposid{active_}@, other.@\exposid{active_}@);
 
 \pnum
 \begin{note}
-Iterators previously obtained from \tcode{other} are not invalidated;
+Iterators previously into \tcode{other} are not invalidated;
 they become iterators into \tcode{*this}.
 \end{note}
 \end{itemdescr}


### PR DESCRIPTION
Iterators can't have been "previously obtained from" a by-value parameter; they must have been obtained elsewhere (e.g. from `x` and then `other` was move-constructed from `x`, so now we have iterators into `x`).

`std::exchange(x, nullptr)` for `unique_ptr x` is equivalent to `std::move(x)`.