### PR TITLE
[alg.unique] namepace -> namespace

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -5934,7 +5934,7 @@ let $E$ be
 
 \pnum
 \expects
-For the overloads in namepace \tcode{std},
+For the overloads in namespace \tcode{std},
 \tcode{pred} is an equivalence relation and
 the type of \tcode{*first} meets
 the \oldconcept{MoveAssignable} requirements (\tref{cpp17.moveassignable}).


### PR DESCRIPTION
I could have sworn there was an aspell dictionary or something checked in that would prevent such misspellings; if such a dictionary exists, I guess "namepace" should be added to it. :)