### PR TITLE
One \grammarterm{x}, two \grammarterm{x}{s} (and likewise)

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -7884,9 +7884,9 @@ return ranges::inplace_merge(ranges::begin(r), middle, ranges::end(r), comp, pro
 
 \pnum
 Subclause \ref{alg.set.operations} defines all the basic set operations on sorted structures.
-They also work with \tcode{multiset}s\iref{multiset}
+They also work with \tcode{multiset}{s}\iref{multiset}
 containing multiple copies of equivalent elements.
-The semantics of the set operations are generalized to \tcode{multiset}s
+The semantics of the set operations are generalized to \tcode{multiset}{s}
 in a standard way by defining \tcode{set_union}
 to contain the maximum number of occurrences of every element,
 \tcode{set_intersection} to contain the minimum, and so on.

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -863,7 +863,7 @@ declarations of qualified names and
 template specializations do not bind names\iref{dcl.meaning};
 those with qualified names target a specified scope, and
 other friend declarations and
-certain \grammarterm{elaborated-type-specifier}s\iref{dcl.type.elab}
+certain \grammarterm{elaborated-type-specifier}{s}\iref{dcl.type.elab}
 target a larger enclosing scope.
 \item
 Block-scope extern declarations target a larger enclosing scope
@@ -939,14 +939,14 @@ both declare functions with the same non-object-parameter-type-list,
 An implicit object parameter\iref{over.match.funcs}
 is not part of the parameter-type-list.
 \end{footnote}
-equivalent\iref{temp.over.link} trailing \grammarterm{requires-clause}s
+equivalent\iref{temp.over.link} trailing \grammarterm{requires-clause}{s}
 (if any, except as specified in \ref{temp.friend}), and,
 if both are non-static members,
 they have corresponding object parameters, or
 \item
 both declare function templates with corresponding signatures and equivalent
-\grammarterm{template-head}s and
-trailing \grammarterm{requires-clause}s (if any).
+\grammarterm{template-head}{s} and
+trailing \grammarterm{requires-clause}{s} (if any).
 \end{itemize}
 \end{itemize}
 \begin{note}
@@ -998,7 +998,7 @@ that potentially conflict and one precedes the other\iref{basic.lookup}.
 \begin{note}
 Overload resolution can consider potentially conflicting declarations
 found in multiple scopes
-(e.g., via \grammarterm{using-directive}s or for operator functions),
+(e.g., via \grammarterm{using-directive}{s} or for operator functions),
 in which case it is often ambiguous.
 \end{note}
 \begin{example}
@@ -1967,7 +1967,7 @@ to be considered.
 The set of entities is determined entirely by
 the types of the function arguments
 (and any template template arguments).
-Any \grammarterm{typedef-name}s and \grammarterm{using-declaration}{s}
+Any \grammarterm{typedef-name}{s} and \grammarterm{using-declaration}{s}
 used to specify the types
 do not contribute to this set.
 The set of entities
@@ -2022,7 +2022,7 @@ parameter types and return type.
 Additionally, if the aforementioned overload set is named with
 a \grammarterm{template-id}, its associated entities also include
 its template \grammarterm{template-argument}{s} and
-those associated with its type \grammarterm{template-argument}s.
+those associated with its type \grammarterm{template-argument}{s}.
 
 \pnum
 The \term{associated namespaces} for a call are
@@ -4831,7 +4831,7 @@ $-2^{N-1}$ to $2^{N-1}-1$ (inclusive),
 where \placeholder{N} is called the \defn{width} of the type.
 \indextext{integral type!implementation-defined \tcode{sizeof}}%
 \begin{note}
-Plain \tcode{int}s are intended to have
+Plain \tcode{int}{s} are intended to have
 the natural width suggested by the architecture of the execution environment;
 the other signed integer types are provided to meet special needs.
 \end{note}
@@ -5404,7 +5404,7 @@ A function or reference type is always cv-unqualified.
 \end{itemize}
 \begin{note}
 The type of an object\iref{intro.object} includes
-the \grammarterm{cv-qualifier}s specified in the
+the \grammarterm{cv-qualifier}{s} specified in the
 \grammarterm{decl-specifier-seq}\iref{dcl.spec},
 \grammarterm{declarator}\iref{dcl.decl},
 \grammarterm{type-id}\iref{dcl.name}, or
@@ -6574,7 +6574,7 @@ arguments passed to the program from the environment in which the
 program is run. If
 \tcode{argc} is nonzero these arguments shall be supplied in
 \tcode{argv[0]} through \tcode{argv[argc-1]} as pointers to the initial
-characters of null-terminated multibyte strings (\ntmbs{}s)\iref{multibyte.strings}
+characters of null-terminated multibyte strings (\ntmbs{}{s})\iref{multibyte.strings}
 and \tcode{argv[0]} shall be the pointer to
 the initial character of a \ntmbs{} that represents the name used to
 invoke the program or \tcode{""}. The value of \tcode{argc} shall be

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1088,7 +1088,7 @@ Two special member functions are of the same kind if:
 with the same first parameter type, or
 \item they are both copy or move assignment operators
 with the same first parameter type
-and the same \grammarterm{cv-qualifier}s and \grammarterm{ref-qualifier}, if any.
+and the same \grammarterm{cv-qualifier}{s} and \grammarterm{ref-qualifier}, if any.
 \end{itemize}
 
 \pnum
@@ -3740,7 +3740,7 @@ If a virtual member function $F$ is declared in a class $B$, and,
 in a class $D$ derived (directly or indirectly) from $B$,
 a declaration of a member function $G$
 corresponds\iref{basic.scope.scope} to a declaration of $F$,
-ignoring trailing \grammarterm{requires-clause}s,
+ignoring trailing \grammarterm{requires-clause}{s},
 \indextext{override|see{function, virtual, override}}%
 then $G$ \defnx{overrides}{function!virtual!override}
 \begin{footnote}
@@ -5807,7 +5807,7 @@ public:
 \ref{class.cdtor} describes the results of virtual function calls,
 \tcode{typeid}
 and
-\keyword{dynamic_cast}s
+\keyword{dynamic_cast}{s}
 during construction for the well-defined cases;
 that is, describes the polymorphic behavior
 of an object under construction.
@@ -6144,7 +6144,7 @@ bases, the behavior is undefined.
 \indextext{destruction!dynamic cast and}%
 \indextext{cast!dynamic!construction and}%
 \indextext{cast!dynamic!destruction and}%
-\keyword{dynamic_cast}s\iref{expr.dynamic.cast} can be used during construction
+\keyword{dynamic_cast}{s}\iref{expr.dynamic.cast} can be used during construction
 or destruction\iref{class.base.init}. When a
 \keyword{dynamic_cast}
 is used in a constructor (including the

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -26,13 +26,13 @@ Some identifiers are no longer well-formed.
 
 \diffref{lex.string}
 \change
-Concatenated \grammarterm{string-literal}s can no longer have
-conflicting \grammarterm{encoding-prefix}es.
+Concatenated \grammarterm{string-literal}{s} can no longer have
+conflicting \grammarterm{encoding-prefix}{es}.
 \rationale
 Removal of unimplemented conditionally-supported feature.
 \effect
-Concatenation of \grammarterm{string-literal}s
-with different \grammarterm{encoding-prefix}es
+Concatenation of \grammarterm{string-literal}{s}
+with different \grammarterm{encoding-prefix}{es}
 is now ill-formed.
 For example:
 \begin{codeblock}
@@ -43,7 +43,7 @@ auto c = L"a" U"b";             // was conditionally-supported; now ill-formed
 
 \diffref{expr.prim.id.unqual}
 \change
-Change move-eligible \grammarterm{id-expression}s from lvalues to xvalues.
+Change move-eligible \grammarterm{id-expression}{s} from lvalues to xvalues.
 \rationale
 Simplify the rules for implicit move.
 \effect
@@ -1128,7 +1128,7 @@ the translation character set.
 \grammarterm{pp-number} can contain \tcode{p} \grammarterm{sign} and
 \tcode{P} \grammarterm{sign}.
 \rationale
-Necessary to enable \grammarterm{hexadecimal-floating-point-literal}s.
+Necessary to enable \grammarterm{hexadecimal-floating-point-literal}{s}.
 \effect
 Valid \CppXIV{} code may fail to compile or produce different results in
 this revision of \Cpp{}. Specifically, character sequences like \tcode{0p+0}
@@ -1624,7 +1624,7 @@ by the chapters of this document.
 
 \diffref{lex.pptoken}
 \change
-New kinds of \grammarterm{string-literal}s.
+New kinds of \grammarterm{string-literal}{s}.
 \rationale
 Required for new features.
 \effect
@@ -2213,13 +2213,13 @@ Programs which depend upon \tcode{sizeof('x')} are probably rare.
 
 \diffref{lex.string}
 \change
-Concatenated \grammarterm{string-literal}s can no longer have
-conflicting \grammarterm{encoding-prefix}es.
+Concatenated \grammarterm{string-literal}{s} can no longer have
+conflicting \grammarterm{encoding-prefix}{es}.
 \rationale
 Removal of non-portable feature.
 \effect
-Concatenation of \grammarterm{string-literal}s
-with different \grammarterm{encoding-prefix}es
+Concatenation of \grammarterm{string-literal}{s}
+with different \grammarterm{encoding-prefix}{es}
 is now ill-formed.
 \difficulty
 Syntactic transformation.

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1245,12 +1245,12 @@ linear arrangement. The library provides four basic kinds of sequence containers
 \tcode{array} is provided as a sequence container which provides limited sequence operations
 because it has a fixed number of elements. The library also provides container adaptors that
 make it easy to construct abstract data types,
-such as \tcode{stack}s,
-\tcode{queue}s,
-\tcode{flat_map}s,
-\tcode{flat_multimap}s,
-\tcode{flat_set}s, or
-\tcode{flat_multiset}s, out of
+such as \tcode{stack}{s},
+\tcode{queue}{s},
+\tcode{flat_map}{s},
+\tcode{flat_multimap}{s},
+\tcode{flat_set}{s}, or
+\tcode{flat_multiset}{s}, out of
 the basic sequence container kinds (or out of other program-defined sequence containers).
 
 \pnum
@@ -2542,8 +2542,8 @@ and
 \tcode{multimap}.
 The library also provides container adaptors
 that make it easy to construct abstract data types,
-such as \tcode{flat_map}s, \tcode{flat_multimap}s,
-\tcode{flat_set}s, or \tcode{flat_multiset}s,
+such as \tcode{flat_map}{s}, \tcode{flat_multimap}{s},
+\tcode{flat_set}{s}, or \tcode{flat_multiset}{s},
 out of the basic sequence container kinds
 (or out of other program-defined sequence containers).
 
@@ -4139,7 +4139,7 @@ In this subclause,
   when \tcode{X} supports equivalent keys,
 \item
 \tcode{a_tran} denotes a value of type \tcode{X} or \tcode{const X}
-  when the \grammarterm{qualified-id}s
+  when the \grammarterm{qualified-id}{s}
   \tcode{X::key_equal::is_transparent} and
   \tcode{X::hasher::is_transparent}
   are both valid and denote types\iref{temp.deduct},
@@ -5861,7 +5861,7 @@ The member function templates
 \tcode{find}, \tcode{count}, \tcode{equal_range}, \tcode{contains},
 \tcode{extract}, and \tcode{erase}
 shall not participate in overload resolution unless
-the \grammarterm{qualified-id}s
+the \grammarterm{qualified-id}{s}
 \tcode{Pred::is_transparent} and
 \tcode{Hash::is_transparent}
 are both valid and denote types\iref{temp.deduct}.

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5226,7 +5226,7 @@ Likewise the next two lines initialize
 and
 \tcode{y[2]}.
 The initializer ends early and therefore
-\tcode{y[3]}s
+\tcode{y[3]}{'s}
 elements are initialized as if explicitly initialized with an
 expression of the form
 \tcode{float()},

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1784,7 +1784,7 @@ program being ill-formed\iref{temp.deduct}.
 template <class T> auto f(T t) { return t; }    // return type deduced at instantiation time
 typedef decltype(f(1)) fint_t;                  // instantiates \tcode{f<int>} to deduce return type
 template<class T> auto f(T* t) { return *t; }
-void g() { int (*p)(int*) = &f; }               // instantiates both \tcode{f}s to determine return types,
+void g() { int (*p)(int*) = &f; }               // instantiates both \tcode{f}{s} to determine return types,
                                                 // chooses second
 \end{codeblock}
 \end{example}
@@ -6382,7 +6382,7 @@ constitute a reference.
 \pnum
 \begin{example}
 One can prevent default initialization and
-initialization by non-\tcode{double}s with
+initialization by non-\tcode{double}{s} with
 \begin{codeblock}
 struct onlydouble {
   onlydouble() = delete;                // OK, but redundant
@@ -7250,7 +7250,7 @@ void f() {
 
 \pnum
 \begin{note}
-Two \grammarterm{using-enum-declaration}s
+Two \grammarterm{using-enum-declaration}{s}
 that introduce two enumerators of the same name conflict.
 \begin{example}
 \begin{codeblock}
@@ -7899,7 +7899,7 @@ void f() {
 \end{example}
 
 \pnum
-If a declaration is named by two \grammarterm{using-declarator}s
+If a declaration is named by two \grammarterm{using-declarator}{s}
 that inhabit the same class scope, the program is ill-formed.
 
 \pnum
@@ -7939,7 +7939,7 @@ If a declaration named by a \grammarterm{using-declaration}
 that inhabits the target scope of another declaration
 potentially conflicts with it\iref{basic.scope.scope}, and
 either is reachable from the other, the program is ill-formed.
-If two declarations named by \grammarterm{using-declaration}s
+If two declarations named by \grammarterm{using-declaration}{s}
 that inhabit the same scope potentially conflict,
 either is reachable from the other, and
 they do not both declare functions or function templates,
@@ -8222,7 +8222,7 @@ extern "C" {
 A \grammarterm{module-import-declaration} appearing in
 a linkage specification with other than \Cpp{} language linkage
 is conditionally-supported with
-\impldef{support for \grammarterm{module-import-declaration}s
+\impldef{support for \grammarterm{module-import-declaration}{s}
 with non-\Cpp{} language linkage} semantics.
 
 \pnum
@@ -8909,7 +8909,7 @@ void f(int n) {
 \indextext{attribute!unlikely}
 
 \pnum
-The \grammarterm{attribute-token}s
+The \grammarterm{attribute-token}{s}
 \tcode{likely} and \tcode{unlikely}
 may be applied to labels or statements.
 No \grammarterm{attribute-argument-clause} shall be present.
@@ -9034,7 +9034,7 @@ from the entity.
 \end{note}
 Redeclarations using different forms of the attribute
 (with or without the \grammarterm{attribute-argument-clause}
-or with different \grammarterm{attribute-argument-clause}s)
+or with different \grammarterm{attribute-argument-clause}{s})
 are allowed.
 
 \pnum

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -1727,7 +1727,7 @@ namespace std {
   template<class Allocator>
     class basic_stacktrace;
 
-  // \tcode{basic_stacktrace} \grammarterm{typedef-name}s
+  // \tcode{basic_stacktrace} \grammarterm{typedef-name}{s}
   using stacktrace = basic_stacktrace<allocator<stacktrace_entry>>;
 
   // \ref{stacktrace.basic.nonmem}, non-member functions

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2617,7 +2617,7 @@ if \tcode{m1} is not \keyword{mutable}, the non-static data member is considered
 entity captured by \tcode{m1}.
 \end{itemize}
 \begin{example}
-The nested \grammarterm{lambda-expression}s and invocations below will output
+The nested \grammarterm{lambda-expression}{s} and invocations below will output
 \tcode{123234}.
 \begin{codeblock}
 int a = 1, b = 1, c = 1;
@@ -2795,7 +2795,7 @@ are unevaluated operands\iref{term.unevaluated.operand}.
 
 \pnum
 \begin{example}
-A common use of \grammarterm{requires-expression}s is to define
+A common use of \grammarterm{requires-expression}{s} is to define
 requirements in concepts such as the one below:
 \begin{codeblock}
 template<typename T>
@@ -2823,7 +2823,7 @@ A \grammarterm{requires-expression} may introduce local parameters using a
 A local parameter of a \grammarterm{requires-expression} shall not have a
 default argument.
 These parameters have no linkage, storage, or lifetime; they are only used
-as notation for the purpose of defining \grammarterm{requirement}s.
+as notation for the purpose of defining \grammarterm{requirement}{s}.
 The \grammarterm{parameter-declaration-clause} of a
 \grammarterm{requirement-parameter-list}
 shall not terminate with an ellipsis.
@@ -2839,7 +2839,7 @@ concept C = requires(T t, ...) {    // error: terminates with an ellipsis
 \pnum
 The substitution of template arguments into a \grammarterm{requires-expression}
 may result in the formation of invalid types or expressions in its
-\grammarterm{requirement}s or the violation of the semantic constraints of those \grammarterm{requirement}s.
+\grammarterm{requirement}{s} or the violation of the semantic constraints of those \grammarterm{requirement}{s}.
 In such cases, the \grammarterm{requires-expression} evaluates to \keyword{false};
 it does not cause the program to be ill-formed.
 The substitution and semantic constraint checking
@@ -2849,7 +2849,7 @@ If substitution (if any) and semantic constraint checking succeed,
 the \grammarterm{requires-expression} evaluates to \keyword{true}.
 \begin{note}
 If a \grammarterm{requires-expression} contains invalid types or expressions in
-its \grammarterm{requirement}s, and it does not appear within the declaration of a templated
+its \grammarterm{requirement}{s}, and it does not appear within the declaration of a templated
 entity, then the program is ill-formed.
 \end{note}
 If the substitution of template arguments into a \grammarterm{requirement}
@@ -3106,7 +3106,7 @@ tokens\iref{temp.names}.
 \indextext{\idxcode{[]}|see{operator, subscripting}}%
 A \defnadj{subscript}{expression} is a postfix expression
 followed by square brackets containing
-a possibly empty, comma-separated list of \grammarterm{initializer-clause}s
+a possibly empty, comma-separated list of \grammarterm{initializer-clause}{s}
 that constitute the arguments to the subscript operator.
 The \grammarterm{postfix-expression} and
 the initialization of the object parameter of
@@ -7611,7 +7611,7 @@ The copy/move of the active member is trivial.
 
 \pnum
 During the evaluation of an expression $E$ as a core constant expression,
-all \grammarterm{id-expression}s and uses of \tcode{*\keyword{this}}
+all \grammarterm{id-expression}{s} and uses of \tcode{*\keyword{this}}
 that refer to an object or reference
 whose lifetime did not begin with the evaluation of $E$
 are treated as referring to a specific instance of that object or reference

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -521,7 +521,7 @@ does not reference any of the standard iostream objects.
 \pnum
 Mixing operations on corresponding wide- and narrow-character streams
 follows the same semantics as mixing such operations on
-\tcode{FILE}s,
+\tcode{FILE}{s},
 as specified in the C standard library.
 
 \pnum
@@ -6471,9 +6471,9 @@ The first argument provides an object of the
 \tcode{ostreambuf_iterator<>}
 class which is an iterator for class \tcode{basic_ostream<>}.
 It bypasses
-\tcode{ostream}s
+\tcode{ostream}{s}
 and uses
-\tcode{streambuf}s
+\tcode{streambuf}{s}
 directly.
 Class
 \tcode{locale}
@@ -10684,7 +10684,7 @@ The restrictions on reading and writing a sequence controlled by an
 object of class
 \tcode{basic_filebuf<charT, traits>}
 are the same as for reading and writing with the C standard library
-\tcode{FILE}s.
+\tcode{FILE}{s}.
 
 \pnum
 In particular:

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1729,7 +1729,7 @@ the library that satisfy but do not in fact model \libconcept{sized_sentinel_for
 \pnum
 \begin{example}
 The \libconcept{sized_sentinel_for} concept is modeled by pairs of
-\libconcept{random_access_iterator}s\iref{iterator.concept.random.access} and by
+\libconcept{random_access_iterator}{s}\iref{iterator.concept.random.access} and by
 counted iterators and their sentinels\iref{counted.iterator}.
 \end{example}
 \end{itemdescr}
@@ -5485,7 +5485,7 @@ namespace std {
 \rSec3[common.iter.types]{Associated types}
 
 \pnum
-The nested \grammarterm{typedef-name}s of the specialization of
+The nested \grammarterm{typedef-name}{s} of the specialization of
 \tcode{iterator_traits} for \tcode{common_iterator<I, S>} are defined as follows.
 \begin{itemize}
 \item

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -143,7 +143,7 @@ except when matching a
 \grammarterm{r-char-sequence},
 \grammarterm{h-char-sequence}, or
 \grammarterm{q-char-sequence},
-\grammarterm{universal-character-name}s are recognized and
+\grammarterm{universal-character-name}{s} are recognized and
 replaced by the designated element of the translation character set.
 The process of dividing a source file's
 characters into preprocessing tokens is context-dependent.
@@ -357,7 +357,7 @@ of the form \tcode{\textbackslash u} \grammarterm{hex-quad},
 \tcode{\textbackslash u\{\grammarterm{simple-hexadecimal-digit-sequence}\}}
 designates the character in the translation character set
 whose Unicode scalar value is the hexadecimal number represented by
-the sequence of \grammarterm{hexadecimal-digit}s
+the sequence of \grammarterm{hexadecimal-digit}{s}
 in the \grammarterm{universal-character-name}.
 The program is ill-formed if that number is not a Unicode scalar value.
 
@@ -597,7 +597,7 @@ punctuators.
 \indextext{digraph}%
 These include ``digraphs'' and additional reserved words. The term
 ``digraph'' (token consisting of two characters) is not perfectly
-descriptive, since one of the alternative \grammarterm{preprocessing-token}s is
+descriptive, since one of the alternative \grammarterm{preprocessing-token}{s} is
 \tcode{\%:\%:} and of course several primary tokens contain two
 characters. Nonetheless, those alternative tokens that aren't lexical
 keywords are colloquially known as ``digraphs''.
@@ -837,7 +837,7 @@ Identifiers are case-sensitive.
 \begin{note}
 In translation phase 4,
 \grammarterm{identifier} also includes
-those \grammarterm{preprocessing-token}s\iref{lex.pptoken}
+those \grammarterm{preprocessing-token}{s}\iref{lex.pptoken}
 differentiated as keywords\iref{lex.key}
 in the later translation phase 7\iref{lex.token}.
 \end{note}
@@ -1190,10 +1190,10 @@ a literal has a type and a value category\iref{expr.prim.literal}.
 \indextext{literal!base of integer}%
 In an \grammarterm{integer-literal},
 the sequence of
-\grammarterm{binary-digit}s,
-\grammarterm{octal-digit}s,
-\grammarterm{digit}s, or
-\grammarterm{hexadecimal-digit}s
+\grammarterm{binary-digit}{s},
+\grammarterm{octal-digit}{s},
+\grammarterm{digit}{s}, or
+\grammarterm{hexadecimal-digit}{s}
 is interpreted as a base $N$ integer as shown in table \tref{lex.icon.base};
 the lexically first digit of the sequence of digits is the most significant.
 \begin{note}
@@ -1214,12 +1214,12 @@ when determining the value.
 \end{simpletypetable}
 
 \pnum
-The \grammarterm{hexadecimal-digit}s
+The \grammarterm{hexadecimal-digit}{s}
 \tcode{a} through \tcode{f} and \tcode{A} through \tcode{F}
 have decimal values ten through fifteen.
 \begin{example}
 The number twelve can be written \tcode{12}, \tcode{014},
-\tcode{0XC}, or \tcode{0b1100}. The \grammarterm{integer-literal}s \tcode{1048576},
+\tcode{0XC}, or \tcode{0b1100}. The \grammarterm{integer-literal}{s} \tcode{1048576},
 \tcode{1'048'576}, \tcode{0X100000}, \tcode{0x10'0000}, and
 \tcode{0'004'000'000} all have the same value.
 \end{example}
@@ -1238,7 +1238,7 @@ the first type in the list in \tref{lex.icon.type}
 corresponding to its optional \grammarterm{integer-suffix}
 in which its value can be represented.
 
-\begin{floattable}{Types of \grammarterm{integer-literal}s}{lex.icon.type}{l|l|l}
+\begin{floattable}{Types of \grammarterm{integer-literal}{s}}{lex.icon.type}{l|l|l}
 \topline
 \lhdr{\grammarterm{integer-suffix}} & \chdr{\grammarterm{decimal-literal}}  & \rhdr{\grammarterm{integer-literal} other than \grammarterm{decimal-literal}}   \\  \capsep
 none    &
@@ -1441,7 +1441,7 @@ more than one \grammarterm{c-char}.
 The \grammarterm{encoding-prefix} of
 a non-encodable character literal or a multicharacter literal
 shall be absent.
-Such \grammarterm{character-literal}s are conditionally-supported.
+Such \grammarterm{character-literal}{s} are conditionally-supported.
 
 \pnum
 The kind of a \grammarterm{character-literal},
@@ -1702,7 +1702,7 @@ or the \grammarterm{hexadecimal-fractional-constant}
 or \grammarterm{hexadecimal-digit-sequence}
 of a \grammarterm{hexadecimal-floating-point-literal}.
 In the significand,
-the sequence of \grammarterm{digit}s or \grammarterm{hexadecimal-digit}s
+the sequence of \grammarterm{digit}{s} or \grammarterm{hexadecimal-digit}{s}
 and optional period are interpreted as a base $N$ real number $s$,
 where $N$ is 10 for a \grammarterm{decimal-floating-point-literal} and
 16 for a \grammarterm{hexadecimal-floating-point-literal}.
@@ -1713,7 +1713,7 @@ If an \grammarterm{exponent-part} or \grammarterm{binary-exponent-part}
 is present,
 the exponent $e$ of the \grammarterm{floating-point-literal}
 is the result of interpreting
-the sequence of an optional \grammarterm{sign} and the \grammarterm{digit}s
+the sequence of an optional \grammarterm{sign} and the \grammarterm{digit}{s}
 as a base 10 integer.
 Otherwise, the exponent $e$ is 0.
 The scaled value of the literal is
@@ -1808,7 +1808,7 @@ The kind of a \grammarterm{string-literal},
 its type, and
 its associated character encoding\iref{lex.charset}
 are determined by its encoding prefix and sequence of
-\grammarterm{s-char}s or \grammarterm{r-char}s
+\grammarterm{s-char}{s} or \grammarterm{r-char}{s}
 as defined by \tref{lex.string.literal}
 where $n$ is the number of encoded code units as described below.
 
@@ -1906,7 +1906,7 @@ also referred to as narrow string literals.
 \pnum
 \indextext{concatenation!string}%
 The common \grammarterm{encoding-prefix}
-for a sequence of adjacent \grammarterm{string-literal}s
+for a sequence of adjacent \grammarterm{string-literal}{s}
 is determined pairwise as follows:
 If two \grammarterm{string-literal}{s} have
 the same \grammarterm{encoding-prefix},
@@ -1922,9 +1922,9 @@ no effect on the determination of the common \grammarterm{encoding-prefix}.
 
 \pnum
 In translation phase 6\iref{lex.phases},
-adjacent \grammarterm{string-literal}s are concatenated.
+adjacent \grammarterm{string-literal}{s} are concatenated.
 The lexical structure and grouping of
-the contents of the individual \grammarterm{string-literal}s is retained.
+the contents of the individual \grammarterm{string-literal}{s} is retained.
 \begin{example}
 \begin{codeblock}
 "\xA" "B"
@@ -1969,7 +1969,7 @@ Means \\
 Evaluating a \grammarterm{string-literal} results in a string literal object
 with static storage duration\iref{basic.stc}.
 \indextext{string!distinct}%
-Whether all \grammarterm{string-literal}s are distinct (that is, are stored in
+Whether all \grammarterm{string-literal}{s} are distinct (that is, are stored in
 nonoverlapping objects) and whether successive evaluations of a
 \grammarterm{string-literal} yield the same or a different object is
 unspecified.
@@ -1984,17 +1984,17 @@ The effect of attempting to modify a string literal object is undefined.
 String literal objects are initialized with
 the sequence of code unit values
 corresponding to the \grammarterm{string-literal}'s sequence of
-\grammarterm{s-char}s (originally from non-raw string literals) and
-\grammarterm{r-char}s (originally from raw string literals),
+\grammarterm{s-char}{s} (originally from non-raw string literals) and
+\grammarterm{r-char}{s} (originally from raw string literals),
 plus a terminating \unicode{0000}{null} character,
 in order as follows:
 \begin{itemize}
 \item
 The sequence of characters denoted by each contiguous sequence of
-\grammarterm{basic-s-char}s,
-\grammarterm{r-char}s,
-\grammarterm{simple-escape-sequence}s\iref{lex.ccon}, and
-\grammarterm{universal-character-name}s\iref{lex.charset}
+\grammarterm{basic-s-char}{s},
+\grammarterm{r-char}{s},
+\grammarterm{simple-escape-sequence}{s}\iref{lex.ccon}, and
+\grammarterm{universal-character-name}{s}\iref{lex.charset}
 is encoded to a code unit sequence
 using the \grammarterm{string-literal}'s associated character encoding.
 If a character lacks representation in the associated character encoding,
@@ -2250,8 +2250,8 @@ int main() {
 \end{example}
 
 \pnum
-In translation phase 6\iref{lex.phases}, adjacent \grammarterm{string-literal}s are concatenated and
-\grammarterm{user-defined-string-literal}{s} are considered \grammarterm{string-literal}s for that
+In translation phase 6\iref{lex.phases}, adjacent \grammarterm{string-literal}{s} are concatenated and
+\grammarterm{user-defined-string-literal}{s} are considered \grammarterm{string-literal}{s} for that
 purpose. During concatenation, \grammarterm{ud-suffix}{es} are removed and ignored and
 the concatenation process occurs as described in~\ref{lex.string}. At the end of phase
 6, if a \grammarterm{string-literal} is the result of a concatenation involving at least one

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -746,7 +746,7 @@ no other element in the sequence has the value zero.
 \begin{footnote}
 Many of the objects manipulated by
 function signatures declared in
-\libheaderref{cstring} are character sequences or \ntbs{}s.
+\libheaderref{cstring} are character sequences or \ntbs{}{s}.
 The size of some of these character sequences is limited by
 a length value, maintained separately from the character sequence.
 \end{footnote}
@@ -819,7 +819,7 @@ are equivalent.
 
 \pnum
 The type \tcode{T} of a customization point object,
-ignoring \grammarterm{cv-qualifier}s, shall model
+ignoring \grammarterm{cv-qualifier}{s}, shall model
 \tcode{\libconcept{invocable}<T\&, Args...>},
 \tcode{\libconcept{invocable}<const T\&, Args...>},
 \tcode{\libconcept{invocable}<T, Args...>}, and
@@ -2679,7 +2679,7 @@ Let \tcode{x1} and \tcode{x2} denote objects of (possibly different) types
 or \tcode{XX::const_pointer}. Then, \tcode{x1} and \tcode{x2} are
 \defn{equivalently-valued} pointer values, if and only if both \tcode{x1} and \tcode{x2}
 can be explicitly converted to the two corresponding objects \tcode{px1} and \tcode{px2}
-of type \tcode{XX::const_pointer}, using a sequence of \keyword{static_cast}s
+of type \tcode{XX::const_pointer}, using a sequence of \keyword{static_cast}{s}
 using only these four types, and the expression \tcode{px1 == px2}
 evaluates to \tcode{true}.
 

--- a/source/limits.tex
+++ b/source/limits.tex
@@ -118,7 +118,7 @@ Member initializers in a constructor definition\iref{class.base.init} [6\,144].
 \item%
 Scope qualifications of one identifier\iref{expr.prim.id.qual} [256].
 \item%
-Nested \grammarterm{linkage-specification}s\iref{dcl.link} [1\,024].
+Nested \grammarterm{linkage-specification}{s}\iref{dcl.link} [1\,024].
 \item%
 Recursive constexpr function invocations\iref{dcl.constexpr} [512].
 \item%

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -1240,7 +1240,7 @@ from a \tcode{char} value or sequence of \tcode{char} values
 to the corresponding \tcode{charT} value or values.
 \begin{footnote}
 The parameter \tcode{c} of \tcode{do_widen} is intended to
-accept values derived from \grammarterm{character-literal}s
+accept values derived from \grammarterm{character-literal}{s}
 for conversion to the locale's encoding.
 \end{footnote}
 The only characters for which unique transformations are required

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -2372,7 +2372,7 @@ is declared as a (nested) \keyword{class}
 or via a \keyword{typedef}.
 In this subclause \ref{rand},
 declarations of \tcode{D::param_type}
-are in the form of \keyword{typedef}s
+are in the form of \keyword{typedef}{s}
 for convenience of exposition only.
 
 \pnum
@@ -7121,7 +7121,7 @@ of inlining, constant propagation, loop fusion,
 tracking of pointers obtained from
 \tcode{operator new},
 and other techniques to generate efficient
-\tcode{valarray}s.
+\tcode{valarray}{s}.
 \end{note}
 
 \pnum

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3671,7 +3671,7 @@ there exist candidate operator functions of the form
 \pnum
 For every (possibly cv-qualified) object type \tcode{\placeholder{T}} and
 for every function type \tcode{\placeholder{T}}
-that has neither \grammarterm{cv-qualifier}s nor a \grammarterm{ref-qualifier},
+that has neither \grammarterm{cv-qualifier}{s} nor a \grammarterm{ref-qualifier},
 there exist candidate operator functions of the form
 \begin{codeblock}
 @\placeholder{T}@&    operator*(@\placeholder{T}@*);

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -449,9 +449,9 @@ the behavior is undefined.
 \pnum
 After all replacements due to macro expansion and
 evaluations of
-\grammarterm{defined-macro-expression}s,
-\grammarterm{has-include-expression}s, and
-\grammarterm{has-attribute-expression}s
+\grammarterm{defined-macro-expression}{s},
+\grammarterm{has-include-expression}{s}, and
+\grammarterm{has-attribute-expression}{s}
 have been performed,
 all remaining identifiers and keywords,
 except for
@@ -484,7 +484,7 @@ the integer literal \tcode{0x8000} is signed and positive within a \tcode{\#if}
 expression even though it is unsigned in translation phase
 7\iref{lex.phases}.
 \end{note}
-This includes interpreting \grammarterm{character-literal}s
+This includes interpreting \grammarterm{character-literal}{s}
 according to the rules in \ref{lex.ccon}.
 \begin{note}
 The associated character encodings of literals are the same
@@ -660,10 +660,10 @@ If the directive resulting after all replacements does not match
 one of the two previous forms, the behavior is
 undefined.
 \begin{footnote}
-Note that adjacent \grammarterm{string-literal}s are not concatenated into
+Note that adjacent \grammarterm{string-literal}{s} are not concatenated into
 a single \grammarterm{string-literal}
 (see the translation phases in~\ref{lex.phases});
-thus, an expansion that results in two \grammarterm{string-literal}s is an
+thus, an expansion that results in two \grammarterm{string-literal}{s} is an
 invalid directive.
 \end{footnote}
 The method by which a sequence of preprocessing tokens between a
@@ -1056,7 +1056,7 @@ defines an
 causes each subsequent instance of the macro name
 \begin{footnote}
 Since, by macro-replacement time,
-all \grammarterm{character-literal}s and \grammarterm{string-literal}s are preprocessing tokens,
+all \grammarterm{character-literal}{s} and \grammarterm{string-literal}{s} are preprocessing tokens,
 not sequences possibly containing identifier-like subsequences
 (see \ref{lex.phases}, translation phases),
 they are never scanned for macro names or parameters.
@@ -1318,7 +1318,7 @@ preprocessing token comprising the stringizing argument is deleted.
 Otherwise, the original spelling of each preprocessing token in the
 stringizing argument is retained in the character string literal,
 except for special handling for producing the spelling of
-\grammarterm{string-literal}s and \grammarterm{character-literal}s:
+\grammarterm{string-literal}{s} and \grammarterm{character-literal}{s}:
 a
 \tcode{\textbackslash}
 character is inserted before each
@@ -1378,7 +1378,7 @@ If the result begins with a sequence matching the syntax of \grammarterm{univers
 the behavior is undefined.
 \begin{note}
 This determination does not consider the replacement of
-\grammarterm{universal-character-name}s in translation phase 3\iref{lex.phases}.
+\grammarterm{universal-character-name}{s} in translation phase 3\iref{lex.phases}.
 \end{note}
 If the result is not a valid preprocessing token,
 the behavior is undefined.

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -8132,7 +8132,7 @@ Equivalent to
 
 \pnum
 \tcode{split_view} takes a view and a delimiter, and
-splits the view into \tcode{subrange}s on the delimiter.
+splits the view into \tcode{subrange}{s} on the delimiter.
 The delimiter can be a single element or a view of elements.
 
 \pnum
@@ -13991,7 +13991,7 @@ friend constexpr range_difference_t<V>
 
 \pnum
 \tcode{chunk_by_view} takes a view and a predicate, and
-splits the view into \tcode{subrange}s
+splits the view into \tcode{subrange}{s}
 between each pair of adjacent elements
 for which the predicate returns \tcode{false}.
 

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -3249,7 +3249,7 @@ defined. For any other iterator value a const
 \tcode{match_results<BidirectionalIterator>\&} is returned. The result of
 \tcode{operator->} on an end-of-sequence iterator is not defined. For any other
 iterator value a \tcode{const match_results<BidirectionalIterator>*} is
-returned. It is impossible to store things into \tcode{regex_iterator}s. Two
+returned. It is impossible to store things into \tcode{regex_iterator}{s}. Two
 end-of-sequence iterators are always equal. An end-of-sequence
 iterator is not equal to a non-end-of-sequence iterator. Two
 non-end-of-sequence iterators are equal when they are constructed from
@@ -3521,7 +3521,7 @@ sub_match<BidirectionalIterator>*} is returned.
 \pnum
 \indexlibrarymember{regex_token_iterator}{operator==}%
 It is impossible to store things
-into \tcode{regex_token_iterator}s. Two end-of-sequence iterators are always
+into \tcode{regex_token_iterator}{s}. Two end-of-sequence iterators are always
 equal. An end-of-sequence iterator is not equal to a
 non-end-of-sequence iterator. Two non-end-of-sequence iterators are
 equal when they are constructed from the same arguments.
@@ -3867,7 +3867,7 @@ according to the rules in \tref{re.synopt}.
 \pnum
 A \regrammarterm{ClassName} production, when used in \regrammarterm{ClassAtomExClass},
 is not valid if \tcode{traits_inst.lookup_classname} returns zero for
-that name.  The names recognized as valid \regrammarterm{ClassName}s are
+that name.  The names recognized as valid \regrammarterm{ClassName}{s} are
 determined by the type of the traits class, but at least the following
 names shall be recognized:
 \tcode{alnum}, \tcode{alpha}, \tcode{blank}, \tcode{cntrl}, \tcode{digit},

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -561,7 +561,7 @@ namespace std {
       operator<<(basic_ostream<charT, traits>& os,
                  basic_string_view<charT, traits> str);
 
-  // \tcode{basic_string_view} \grammarterm{typedef-name}s
+  // \tcode{basic_string_view} \grammarterm{typedef-name}{s}
   using string_view    = basic_string_view<char>;
   using u8string_view  = basic_string_view<char8_t>;
   using u16string_view = basic_string_view<char16_t>;
@@ -1117,7 +1117,7 @@ constexpr const_pointer data() const noexcept;
 
 \pnum
 \begin{note}
-Unlike \tcode{basic_string::data()} and \grammarterm{string-literal}s,
+Unlike \tcode{basic_string::data()} and \grammarterm{string-literal}{s},
 \tcode{data()} can return a pointer to a buffer that is not null-terminated.
 Therefore it is typically a mistake to pass \tcode{data()} to a function that takes just a \tcode{const charT*} and expects a null-terminated string.
 \end{note}
@@ -1911,7 +1911,7 @@ namespace std {
     constexpr typename basic_string<charT, traits, Allocator>::size_type
       erase_if(basic_string<charT, traits, Allocator>& c, Predicate pred);
 
-  // \tcode{basic_string} \grammarterm{typedef-name}s
+  // \tcode{basic_string} \grammarterm{typedef-name}{s}
   using @\libglobal{string}@    = basic_string<char>;
   using @\libglobal{u8string}@  = basic_string<char8_t>;
   using @\libglobal{u16string}@ = basic_string<char16_t>;

--- a/source/support.tex
+++ b/source/support.tex
@@ -1899,13 +1899,13 @@ for \placeholder{N} = \tcode{8}, \tcode{16}, \tcode{32}, and \tcode{64}
 are also optional;
 however, if an implementation defines integer types
 with the corresponding width and no padding bits,
-it defines the corresponding \grammarterm{typedef-name}s.
+it defines the corresponding \grammarterm{typedef-name}{s}.
 Each of the macros listed in this subclause
 is defined if and only if
 the implementation defines the corresponding \grammarterm{typedef-name}.
 \begin{note}
 The macros \tcode{INT\placeholdernc{N}_C} and \tcode{UINT\placeholdernc{N}_C}
-correspond to the \grammarterm{typedef-name}s
+correspond to the \grammarterm{typedef-name}{s}
 \tcode{int_least\placeholdernc{N}_t} and \tcode{uint_least\placeholdernc{N}_t},
 respectively.
 \end{note}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1608,14 +1608,14 @@ if they are formed from the same appearance of the same
 \grammarterm{expression}
 and if, given a hypothetical template $A$
 whose \grammarterm{template-parameter-list} consists of
-\grammarterm{template-parameter}s corresponding and equivalent\iref{temp.over.link} to
+\grammarterm{template-parameter}{s} corresponding and equivalent\iref{temp.over.link} to
 those mapped by the parameter mappings of the expression,
 a \grammarterm{template-id} naming $A$
-whose \grammarterm{template-argument}s are
+whose \grammarterm{template-argument}{s} are
 the targets of the parameter mapping of $e_1$
 is the same\iref{temp.type} as
 a \grammarterm{template-id} naming $A$
-whose \grammarterm{template-argument}s are
+whose \grammarterm{template-argument}{s} are
 the targets of the parameter mapping of $e_2$.
 \begin{note}
 The comparison of parameter mappings of atomic constraints
@@ -1632,7 +1632,7 @@ template <unsigned M> void f()
 template <unsigned M> int f()
   requires AddOne<2 * M> && true;
 
-int x = f<0>();     // OK, the atomic constraints from concept \tcode{C} in both \tcode{f}s are \tcode{Atomic<N>}
+int x = f<0>();     // OK, the atomic constraints from concept \tcode{C} in both \tcode{f}{s} are \tcode{Atomic<N>}
                     // with mapping similar to $\tcode{N} \mapsto \tcode{2 * M + 1}$
 
 template <unsigned N> struct WrapN;
@@ -1804,7 +1804,7 @@ is equivalent\iref{temp.over.link} to the corresponding
 outside the class body,
 $C_1$ is instantiated.
 If the instantiation results in an invalid expression,
-the \grammarterm{constraint-expression}s are not equivalent.
+the \grammarterm{constraint-expression}{s} are not equivalent.
 \begin{note}
 This can happen when determining which member template is specialized
 by an explicit specialization declaration.
@@ -2671,7 +2671,7 @@ void foo(Args... args) {
     };
 }
 
-foo();                          // \tcode{xs} contains zero \grammarterm{init-capture}s
+foo();                          // \tcode{xs} contains zero \grammarterm{init-capture}{s}
 foo(1);                         // \tcode{xs} contains one \grammarterm{init-capture}
 \end{codeblock}
 \end{example}
@@ -3154,7 +3154,7 @@ an implicit or explicit instantiation; no diagnostic is required.
 \pnum
 Two partial specialization declarations declare the same entity
 if they are partial specializations of the same template and have equivalent
-\grammarterm{template-head}s and template argument lists\iref{temp.over.link}.
+\grammarterm{template-head}{s} and template argument lists\iref{temp.over.link}.
 Each partial specialization is a distinct template.
 
 \pnum
@@ -3728,7 +3728,7 @@ Two \grammarterm{template-head}{s} are
 \defnx{equivalent}{equivalent!\idxgram{template-head}{s}} if
 their \grammarterm{template-parameter-list}{s} have the same length,
 corresponding \grammarterm{template-parameter}{s} are equivalent
-and are both declared with \grammarterm{type-constraint}s that are equivalent
+and are both declared with \grammarterm{type-constraint}{s} that are equivalent
 if either \grammarterm{template-parameter}
 is declared with a \grammarterm{type-constraint},
 and if either \grammarterm{template-head} has a \grammarterm{requires-clause},
@@ -6374,7 +6374,7 @@ template<> void sort<char*>(Array<char*>&);
 Given these declarations,
 \tcode{stream<char>}
 will be used as the definition of streams of
-\tcode{char}s;
+\tcode{char}{s};
 other streams will be handled by class template specializations instantiated
 from the class template.
 Similarly,
@@ -8325,7 +8325,7 @@ satisfies the rules for an \tcode{\opt{i}} above.
 
 \begin{note}
 If a type matches such a form but contains no
-\tcode{T}s, \tcode{i}s, or \tcode{TT}s, deduction is not possible.
+\tcode{T}{s}, \tcode{i}{s}, or \tcode{TT}{s}, deduction is not possible.
 \end{note}
 
 Similarly,

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -2842,7 +2842,7 @@ The program is ill-formed if \tcode{is_trivially_copyable_v<T>} is \tcode{false}
 
 \pnum
 The lifetime\iref{basic.life} of an object referenced by \tcode{*ptr}
-shall exceed the lifetime of all \tcode{atomic_ref}s that reference the object.
+shall exceed the lifetime of all \tcode{atomic_ref}{s} that reference the object.
 While any \tcode{atomic_ref} instances exist
 that reference the \tcode{*ptr} object,
 all accesses to that object shall exclusively occur
@@ -5945,7 +5945,7 @@ It is unspecified whether \libheader{stdatomic.h} makes available
 any declarations in namespace \tcode{std}.
 
 \pnum
-Each of the \grammarterm{using-declaration}s for
+Each of the \grammarterm{using-declaration}{s} for
 \tcode{int$N$_t}, \tcode{uint$N$_t}, \tcode{intptr_t}, and \tcode{uintptr_t}
 listed above is defined if and only if the implementation defines
 the corresponding \grammarterm{typedef-name} in \ref{atomics.syn}.

--- a/source/time.tex
+++ b/source/time.tex
@@ -1047,8 +1047,8 @@ The \tcode{duration} template uses the \tcode{treat_as_floating_point} trait to
 help determine if a \tcode{duration} object can be converted to another
 \tcode{duration} with a different tick \tcode{period}. If
 \tcode{treat_as_floating_point_v<Rep>} is \tcode{true}, then implicit conversions
-are allowed among \tcode{duration}s. Otherwise, the implicit convertibility
-depends on the tick \tcode{period}s of the \tcode{duration}s.
+are allowed among \tcode{duration}{s}. Otherwise, the implicit convertibility
+depends on the tick \tcode{period}{s} of the \tcode{duration}{s}.
 \begin{note}
 The intention of this trait is to indicate whether a given class behaves like a floating-point
 type, and thus allows division of one value by another with acceptable loss of precision. If
@@ -1167,7 +1167,7 @@ template<class Clock, class Duration1, class Duration2>
 
 \pnum
 The common type of two \tcode{time_point} types is a \tcode{time_point} with the same
-clock as the two types and the common type of their two \tcode{duration}s.
+clock as the two types and the common type of their two \tcode{duration}{s}.
 
 \rSec2[time.traits.is.clock]{Class template \tcode{is_clock}}
 
@@ -1188,7 +1188,7 @@ except that as a minimum
 a type \tcode{T} shall not qualify as a \oldconcept{Clock}
 unless it meets all of the following conditions:
 \begin{itemize}
-\item the \grammarterm{qualified-id}s
+\item the \grammarterm{qualified-id}{s}
 \tcode{T::rep},
 \tcode{T::period},
 \tcode{T::duration}, and
@@ -1210,7 +1210,7 @@ The behavior of a program that adds specializations for \tcode{is_clock} is unde
 \rSec2[time.duration.general]{General}
 
 \pnum
-A \tcode{duration} type measures time between two points in time (\tcode{time_point}s).
+A \tcode{duration} type measures time between two points in time (\tcode{time_point}{s}).
 A \tcode{duration} has a representation which holds a count of ticks and a tick period.
 The tick period is the amount of time which occurs from one tick to the next, in units
 of seconds. It is expressed as a rational constant using the template \tcode{ratio}.
@@ -2071,7 +2071,7 @@ Otherwise, if \tcode{Period::type} is \tcode{micro},
 it is
 \impldef{unit suffix when \tcode{Period::type} is \tcode{micro}}
 whether \tcode{\placeholder{units-suffix}} is
-\tcode{"\textmu{}s"} (\tcode{"\textbackslash{}u00b5\textbackslash{}u0073"}) or
+\tcode{"\textmu{}{s}"} (\tcode{"\textbackslash{}u00b5\textbackslash{}u0073"}) or
 \tcode{"us"}.
 
 \item
@@ -8956,7 +8956,7 @@ A reference to the database.
 \throws
 \tcode{runtime_error} if for any reason
 a reference cannot be returned to a valid \tcode{tzdb_list}
-containing one or more valid \tcode{tzdb}s.
+containing one or more valid \tcode{tzdb}{s}.
 \end{itemdescr}
 
 \indexlibraryglobal{get_tzdb}%
@@ -10375,7 +10375,7 @@ namespace std::chrono {
 
 \pnum
 A \tcode{time_zone_link} specifies an alternative name for a \tcode{time_zone}.
-\tcode{time_zone_link}s are constructed when the time zone database is initialized.
+\tcode{time_zone_link}{s} are constructed when the time zone database is initialized.
 
 \rSec3[time.zone.link.members]{Member functions}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -14749,11 +14749,11 @@ string s = format("{0}-{{", 8);         // value of \tcode{s} is \tcode{"8-\{"}
 \end{example}
 
 \pnum
-If all \fmtgrammarterm{arg-id}s in a format string are omitted
+If all \fmtgrammarterm{arg-id}{s} in a format string are omitted
 (including those in the \fmtgrammarterm{format-spec},
 as interpreted by the corresponding \tcode{formatter} specialization),
 argument indices 0, 1, 2, \ldots{} will automatically be used in that order.
-If some \fmtgrammarterm{arg-id}s are omitted and some are present,
+If some \fmtgrammarterm{arg-id}{s} are omitted and some are present,
 the string is not a format string.
 \begin{note}
 A format string cannot contain a


### PR DESCRIPTION
There was inconsistent use of grouping after `\grammarterm`, `\tcode`, `\keyword`, etc.

Update plurals to consistently use `{s}`/`{es}` after these.

Also fix a missing apostrophe in [dcl.init.aggr]/16, example 11.