### PR TITLE
Use new term "constexpr-suitable"

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1313,8 +1313,8 @@ constructor for that class with no
 \grammarterm{compound-statement}.
 If that user-written default constructor would be ill-formed,
 the program is ill-formed.
-If that user-written default constructor would satisfy the requirements
-of a constexpr function\iref{dcl.constexpr}, the implicitly-defined
+If that user-written default constructor would be constexpr-suitable\iref{dcl.constexpr},
+the implicitly-defined
 default constructor is \keyword{constexpr}.
 Before the defaulted default constructor for a class is
 implicitly defined,
@@ -1601,8 +1601,8 @@ otherwise the copy/move constructor is
 The copy/move constructor is implicitly defined even if the implementation elided
 its odr-use\iref{term.odr.use,class.temporary}.
 \end{note}
-If an implicitly-defined\iref{dcl.fct.def.default} constructor would satisfy the requirements of a
-constexpr function\iref{dcl.constexpr}, the implicitly-defined
+If an implicitly-defined\iref{dcl.fct.def.default} constructor would be constexpr-suitable\iref{dcl.constexpr},
+the implicitly-defined
 constructor is \keyword{constexpr}.
 
 \pnum

--- a/source/time.tex
+++ b/source/time.tex
@@ -1282,7 +1282,7 @@ those thrown by the indicated operations on their representations.
 The defaulted copy constructor of duration shall be a
 constexpr function if and only if the required initialization
 of the member \tcode{rep_} for copy and move, respectively, would
-satisfy the requirements for a constexpr function.
+be constexpr-suitable\iref{dcl.constexpr}.
 
 \pnum
 \begin{example}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -779,8 +779,8 @@ throws an exception.
 \pnum
 The defaulted move and copy constructor, respectively, of \tcode{pair}
 is a constexpr function if and only if all required element-wise
-initializations for move and copy, respectively, would satisfy the
-requirements for a constexpr function.
+initializations for move and copy, respectively,
+would be constexpr-suitable\iref{dcl.constexpr}.
 
 \pnum
 If \tcode{(is_trivially_destructible_v<T1> \&\& is_trivially_destructible_v<T2>)}
@@ -1749,8 +1749,8 @@ one of the types in \tcode{Types} throws an exception.
 The defaulted move and copy constructor, respectively, of
 \tcode{tuple} is a constexpr function if and only if all
 required element-wise initializations for move and copy, respectively,
-would satisfy the requirements for a constexpr function. The
-defaulted move and copy constructor of \tcode{tuple<>} are
+would be constexpr-suitable\iref{dcl.constexpr}.
+The defaulted move and copy constructor of \tcode{tuple<>} are
 constexpr functions.
 
 \pnum
@@ -5066,8 +5066,8 @@ Any exception thrown by the value-initialization of $\tcode{T}_0$.
 \pnum
 \remarks
 This function is \keyword{constexpr} if and only if the
-value-initialization of the alternative type $\tcode{T}_0$ would satisfy the
-requirements for a constexpr function.
+value-initialization of the alternative type $\tcode{T}_0$
+would be constexpr-suitable\iref{dcl.constexpr}.
 The exception specification is equivalent to
 \tcode{is_nothrow_default_constructible_v<$\tcode{T}_0$>}.
 \begin{note}


### PR DESCRIPTION
As of CWG2602 (https://github.com/tkoeppe/draft/commit/ce7d8b0360e1509de6f7fd073d0a091238b1326f), the term "constexpr-suitable" replaces the previous phrase "satisfy the requirements for a constexpr function".