### PR TITLE
[lex, expr, dcl.dcl] Disable character protrusion from BNF lines.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2228,6 +2228,7 @@ Declarators have the syntax
 \end{bnf}
 
 \begin{bnf}
+\microtypesetup{protrusion=false}\obeyspaces
 \nontermdef{ptr-operator}\br
     \terminal{*} \opt{attribute-specifier-seq} \opt{cv-qualifier-seq}\br
     \terminal{\&} \opt{attribute-specifier-seq}\br
@@ -8446,6 +8447,7 @@ such as types, variables, names, blocks, or translation units.
 \end{bnf}
 
 \begin{bnf}
+\microtypesetup{protrusion=false}\obeyspaces
 \nontermdef{balanced-token}\br
     \terminal{(} \opt{balanced-token-seq} \terminal{)}\br
     \terminal{[} \opt{balanced-token-seq} \terminal{]}\br

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2769,6 +2769,7 @@ or by checking properties of types and expressions.
 \end{bnf}
 
 \begin{bnf}
+\microtypesetup{protrusion=false}\obeyspaces
 \nontermdef{requirement-body}\br
     \terminal{\{} requirement-seq \terminal{\}}
 \end{bnf}

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -692,6 +692,7 @@ characters \tcode{//} and \tcode{/*} have no special meaning within a
 
 \indextext{header!name|(}%
 \begin{bnf}
+\microtypesetup{protrusion=false}\obeyspaces
 \nontermdef{header-name}\br
     \terminal{<} h-char-sequence \terminal{>}\br
     \terminal{"} q-char-sequence \terminal{"}


### PR DESCRIPTION
Microtype's character protrusion is not desired in the presentation of certain grammar productions, and strict alignment is better.

Fixes #6239.