### PR TITLE
[cmp.alg] Add missing formatting for `F`

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -4949,7 +4949,7 @@ of a template instantiation.
 \pnum
 The name \tcode{compare_strong_order_fallback}
 denotes a customization point object\iref{customization.point.object}.
-Given subexpressions \tcode{E} and {F},
+Given subexpressions \tcode{E} and \tcode{F},
 the expression \tcode{compare_strong_order_fallback(E, F)}
 is expression-equivalent\iref{defns.expression.equivalent} to:
 \begin{itemize}


### PR DESCRIPTION
In [N4944](https://wg21.link/n4944), there's one occurence of `F` in [cmp.alg]/4 that is not properly formatted.

![cmp-alg-bad-format](https://user-images.githubusercontent.com/23228989/236119229-bd2a92f1-801e-4ad8-8da4-5b4fb20d959c.png)

Also reflected in https://eel.is/c++draft/cmp.alg#4.