### PR TITLE
[container.alloc.reqmts] Fix incorrect change of \mandates to \expects

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1031,7 +1031,7 @@ typename X::allocator_type
 \tcode{A}
 
 \pnum
-\expects
+\mandates
 \tcode{allocator_type::value_type} is the same as \tcode{X::value_type}.
 \end{itemdescr}
 


### PR DESCRIPTION
This was incorrectly changed from a \mandates to an \expects when 93ff092d1cd2b335f372b9546365b3d495caf2d8 replaced the requirements tables.

https://github.com/cplusplus/draft/commit/93ff092d1cd2b335f372b9546365b3d495caf2d8#diff-3b5851f7056b7c68cb3ba2ab51cf0b75a780c6a11e5e181770067700454ace7bL734 (click on "Load diff") shows the previous state, with `\mandates`, and https://github.com/cplusplus/draft/commit/93ff092d1cd2b335f372b9546365b3d495caf2d8#diff-3b5851f7056b7c68cb3ba2ab51cf0b75a780c6a11e5e181770067700454ace7bR1005 shows the new state, with `\expects`. That change was supposed to be editorial, but this is a normative change.
