### PR TITLE
[flat.set.modifiers] `(first, last)` should be `rg`

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -16955,7 +16955,7 @@ from each group of consecutive equivalent elements.
 \pnum
 \complexity
 $N$ + $M \log M$, where $N$ is \tcode{size()} before the operation and $M$
-is \tcode{distance(first, last)}.
+is \tcode{ranges::distance(rg)}.
 
 \pnum
 \remarks


### PR DESCRIPTION
Restore consistency with [[flat.map.modifiers]/13](https://eel.is/c++draft/flat.map.modifiers#13), which already uses `ranges::distance(rg)`.

However, @jwakely can I also get some LWG guidance here?  Right now, there is no `insert_range` in [flat.multiset.modifiers](https://eel.is/c++draft/flat.multiset.modifiers), and there is no [flat.multimap.modifiers](https://eel.is/c++draft/flat.multimap.modifiers) at all. My intuition is that this `insert_range` wording should appear in both places.

I'm planning P2767R0 "flat_foo omnibus" for Varna. Should I submit a pull-request _before_ Varna to add a section named [flat.multimap.modifiers], with contents similar to [flat.map.modifiers]? Should I just make P2767 introduce all of [flat.multimap.modifiers]? Or does LWG think it's "obvious" what `flat_multimap::insert_range` should do, and therefore it shouldn't be documented explicitly? See the [index of library names](https://eel.is/c++draft/libraryindex#lib:insert_range) for the status quo.