### PR TITLE
[flat.{map,multiset,set}.modifiers] Harmonize description of insert(s, first, last)

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -15427,32 +15427,11 @@ template<class InputIterator>
 \begin{itemdescr}
 \pnum
 \effects
-Adds elements to \tcode{c} as if by:
-\begin{codeblock}
-for (; first != last; ++first) {
-  value_type value = *first;
-  c.keys.insert(c.keys.end(), std::move(value.first));
-  c.values.insert(c.values.end(), std::move(value.second));
-}
-\end{codeblock}
-Then, merges the sorted range of newly added elements and
-the sorted range of pre-existing elements into a single sorted range; and
-finally erases the duplicate elements as if by:
-\begin{codeblock}
-auto zv = ranges::zip_view(c.keys, c.values);
-auto it = ranges::unique(zv, key_equiv(compare)).begin();
-auto dist = distance(zv.begin(), it);
-c.keys.erase(c.keys.begin() + dist, c.keys.end());
-c.values.erase(c.values.begin() + dist, c.values.end());
-\end{codeblock}
+Equivalent to \tcode{insert(first, last)}.
 
 \pnum
 \complexity
 Linear in $N$, where $N$ is \tcode{size()} after the operation.
-
-\pnum
-\remarks
-Since this operation performs an in-place merge, it may allocate memory.
 \end{itemdescr}
 
 \indexlibrarymember{insert_range}{flat_map}%
@@ -16927,7 +16906,7 @@ Equivalent to \tcode{insert(first, last)}.
 
 \pnum
 \complexity
-Linear.
+Linear in $N$, where $N$ is \tcode{size()} after the operation.
 \end{itemdescr}
 
 \indexlibrarymember{insert_range}{flat_set}%
@@ -17572,7 +17551,7 @@ Equivalent to \tcode{insert(first, last)}.
 
 \pnum
 \complexity
-Linear.
+Linear in $N$, where $N$ is \tcode{size()} after the operation.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{flat_multiset}%


### PR DESCRIPTION
If we can get away with the shorter wording in [flat.set.modifiers], we should also use it in [flat.map.modifiers]. Vice versa, the word "Linear" isn't terribly descriptive; let's take the more explicit wording for the Complexity element from [flat.map.modifiers].

The eliminated Remark element is accurate, but redundant, because `insert(first, last)` has the same Remark. Again this is just harmonizing [flat.map.modifiers] with the existing lack-of-Remark in [flat.set.modifiers].