### PR TITLE
[intro.execution] Fix bad function call in example

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5716,7 +5716,7 @@ void f() {
   if (S(3).v())                 // full-expression includes lvalue-to-rvalue and \tcode{int} to \tcode{bool} conversions,
                                 // performed before temporary is deleted at end of full-expression
   { }
-  bool b = noexcept(S());       // exception specification of destructor of \tcode{S} considered for \keyword{noexcept}
+  bool b = noexcept(S(4));      // exception specification of destructor of \tcode{S} considered for \keyword{noexcept}
 
   // full-expression is destruction of \tcode{s2} at end of block
 }


### PR DESCRIPTION
`S` does not have a default constructor.