### PR TITLE
[class.base.init] use defnadj to introduce delegating and target constructor

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -5461,8 +5461,8 @@ constructor of the constructor's class using any
 \grammarterm{class-or-decltype} that denotes the constructor's class itself. If a
 \grammarterm{mem-initializer-id} designates the constructor's class,
 it shall be the only \grammarterm{mem-initializer}; the constructor
-is a \term{delegating constructor}, and the constructor selected by the
-\grammarterm{mem-initializer} is the \term{target constructor}.
+is a \defnadj{delegating}{constructor}, and the constructor selected by the
+\grammarterm{mem-initializer} is the \defnadj{target}{constructor}.
 The target constructor is selected by overload resolution.
 Once the target constructor returns, the body of the delegating constructor
 is executed. If a constructor delegates to itself directly or indirectly,


### PR DESCRIPTION
so that they are indexed