### PR TITLE
[strings], [unord.req.general], [stringbuf.members]: Fix xrefs to [co…

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2705,7 +2705,7 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \pnum
 A type \tcode{X} meets the \defnadj{associative}{container} requirements
 if \tcode{X} meets all the requirements of an allocator-aware
-container\iref{container.requirements.general} and
+container\iref{container.reqmts} and
 the following types, statements, and expressions are well-formed and
 have the specified semantics,
 except that for
@@ -4204,7 +4204,7 @@ that models \tcode{\exposconcept{container-compatible-range}<value_type>},
 A type \tcode{X} meets
 the \defnadj{unordered associative}{container} requirements
 if \tcode{X} meets all the requirements of
-an allocator-aware container\iref{container.requirements.general} and
+an allocator-aware container\iref{container.reqmts} and
 the following types, statements, and expressions are well-formed and
 have the specified semantics,
 except that for \tcode{unordered_map} and \tcode{unordered_multimap},
@@ -4675,7 +4675,7 @@ X(b)
 \begin{itemdescr}
 \pnum
 \effects
-In addition to the container requirements\iref{container.requirements.general},
+In addition to the container requirements\iref{container.reqmts},
 copies the hash function, predicate, and maximum load factor.
 
 \pnum

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -8333,7 +8333,7 @@ template<class SAlloc>
 \pnum
 \constraints
 \tcode{SAlloc} is a type that
-qualifies as an allocator\iref{container.requirements.general}.
+qualifies as an allocator\iref{container.reqmts}.
 
 \pnum
 \effects

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -2374,7 +2374,7 @@ as \tcode{charT}. Every object of type
 \tcode{basic_string<charT, traits, Allocator>} uses an object of type
 \tcode{Allocator} to allocate and free storage for the contained \tcode{charT}
 objects as needed. The \tcode{Allocator} object used is
-obtained as described in \ref{container.requirements.general}.
+obtained as described in \ref{container.reqmts}.
 In every specialization \tcode{basic_string<charT, traits, Allocator>},
 the type \tcode{traits} shall meet
 the character traits requirements\iref{char.traits}.
@@ -2382,7 +2382,7 @@ the character traits requirements\iref{char.traits}.
 Every specialization \tcode{basic_string<charT, traits, Allocator>} is
 an allocator-aware container,
 but does not use the allocator's \tcode{construct} and \tcode{destroy}
-member functions\iref{container.requirements.general}.
+member functions\iref{container.requirements.pre}.
 \end{note}
 \begin{note}
 The program is ill-formed if \tcode{traits::char_type}
@@ -2569,7 +2569,8 @@ constexpr basic_string(const charT* s, const Allocator& a = Allocator());
 \pnum
 \constraints
 \tcode{Allocator} is a type
-that qualifies as an allocator\iref{container.requirements.general}.
+
+that qualifies as an allocator\iref{container.reqmts}.
 \begin{note}
 This affects class template argument deduction.
 \end{note}
@@ -2588,7 +2589,7 @@ constexpr basic_string(size_type n, charT c, const Allocator& a = Allocator());
 \pnum
 \constraints
 \tcode{Allocator} is a type
-that qualifies as an allocator\iref{container.requirements.general}.
+that qualifies as an allocator\iref{container.reqmts}.
 \begin{note}
 This affects class template argument deduction.
 \end{note}
@@ -2608,7 +2609,7 @@ template<class InputIterator>
 \pnum
 \constraints
 \tcode{InputIterator} is a type that qualifies as an input
-iterator\iref{container.requirements.general}.
+iterator\iref{container.reqmts}.
 
 \pnum
 \effects
@@ -2672,7 +2673,7 @@ template<class InputIterator,
 \pnum
 \constraints
 \tcode{InputIterator} is a type that qualifies as an input iterator,
-and \tcode{Allocator} is a type that qualifies as an allocator\iref{container.requirements.general}.
+and \tcode{Allocator} is a type that qualifies as an allocator\iref{container.reqmts}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -2695,7 +2696,7 @@ template<class charT,
 \pnum
 \constraints
 \tcode{Allocator} is a type that qualifies as
-an allocator\iref{container.requirements.general}.
+an allocator\iref{container.reqmts}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{basic_string}%
@@ -3377,7 +3378,7 @@ template<class InputIterator>
 \pnum
 \constraints
 \tcode{InputIterator} is a type that qualifies as an input
-iterator\iref{container.requirements.general}.
+iterator\iref{container.reqmts}.
 
 \pnum
 \effects
@@ -3582,7 +3583,7 @@ template<class InputIterator>
 \pnum
 \constraints
 \tcode{InputIterator} is a type that qualifies as an input
-iterator\iref{container.requirements.general}.
+iterator\iref{container.reqmts}.
 
 \pnum
 \effects
@@ -3800,7 +3801,7 @@ template<class InputIterator>
 \pnum
 \constraints
 \tcode{InputIterator} is a type that qualifies as an input
-iterator\iref{container.requirements.general}.
+iterator\iref{container.reqmts}.
 
 \pnum
 \expects
@@ -4198,7 +4199,7 @@ template<class InputIterator>
 \pnum
 \constraints
 \tcode{InputIterator} is a type that qualifies as an input
-iterator\iref{container.requirements.general}.
+iterator\iref{container.reqmts}.
 
 \pnum
 \effects


### PR DESCRIPTION
…ntainer.requirements.general]

All the references for "qualifies as an input iterator" and "qualifies as an allocator" are supposed to be to [container.reqmts] p69 which begins:

> The behavior of certain container member functions and deduction
> guides depends on whether types qualify as input iterators or
> allocators.

The reference in [string.require] for obtaining an allocator should be to [container.reqmts] p64.

The reference in [string.require] Note 2 should be to [container.requirements.pre] p3.

Fixes #6184