### PR TITLE
[ranges] Make the "Effects: Equivalent to" format consistent

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -8320,7 +8320,7 @@ constexpr iterator_t<V> base() const;
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to \tcode{return \exposid{cur_};}
+Equivalent to: \tcode{return \exposid{cur_};}
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -8330,7 +8330,7 @@ constexpr value_type operator*() const;
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to \tcode{return \{\exposid{cur_}, \exposid{next_}.begin()\};}
+Equivalent to: \tcode{return \{\exposid{cur_}, \exposid{next_}.begin()\};}
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -10645,7 +10645,7 @@ friend constexpr common_type_t<range_difference_t<@\exposid{maybe-const}@<OtherC
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to \tcode{return -(x - y);}
+Equivalent to: \tcode{return -(x - y);}
 \end{itemdescr}
 
 \rSec2[range.zip.transform]{Zip transform view}
@@ -12309,7 +12309,7 @@ friend constexpr bool operator==(const @\exposid{iterator}@<OtherConst>& x, cons
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to \tcode{return x.\exposid{inner_} == y.\exposid{inner_};}
+Equivalent to: \tcode{return x.\exposid{inner_} == y.\exposid{inner_};}
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -12327,7 +12327,7 @@ friend constexpr range_difference_t<@\exposid{maybe-const}@<OtherConst, @\exposi
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to \tcode{return x.\exposid{inner_} - y.\exposid{inner_};}
+Equivalent to: \tcode{return x.\exposid{inner_} - y.\exposid{inner_};}
 \end{itemdescr}
 
 \rSec2[range.chunk]{Chunk view}


### PR DESCRIPTION
- When "_Effects_: Equivalent to" is followed by a " ", the subsequent expression ends with a ".";
- When "_Effects_: Equivalent to" is followed by a ":", the subsequent expression ends with a ";".