### PR TITLE
Fix remaining references to container requirements, and adjust subclause naming

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -69,12 +69,12 @@ means, for example, that a node-based container would need to construct nodes co
 aligned buffers and call \tcode{construct} to place the element into the buffer.
 \end{note}
 
-\rSec2[container.gen.reqmts]{General containers}
+\rSec2[container.requirements.general]{General containers}
 
-\rSec3[container.requirements.general]{General}
+\rSec3[container.intro.reqmts]{Introduction}
 
 \pnum
-In subclause \ref{container.gen.reqmts},
+In subclause \ref{container.requirements.general},
 \begin{itemize}
 \item
 \tcode{X} denotes a container class containing objects of type \tcode{T},
@@ -103,7 +103,7 @@ concept @\defexposconcept{container-compatible-range}@ =    // \expos
   ranges::@\libconcept{input_range}@<R> && @\libconcept{convertible_to}@<ranges::range_reference_t<R>, T>;
 \end{codeblock}
 
-\rSec3[container.reqmts]{Containers}
+\rSec3[container.reqmts]{Container requirements}
 
 % Local command to index names as members of all containers.
 \newcommand{\indexcont}[1]{%

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -2132,7 +2132,7 @@ by the member functions of class template \tcode{match_results}.
 \indextext{requirements!sequence}%
 The class template \tcode{match_results} meets the requirements of an
 allocator-aware container and of
-a sequence container\iref{container.requirements.general,sequence.reqmts}
+a sequence container\iref{container.alloc.reqmts,sequence.reqmts}
 except that only
 copy assignment,
 move assignment, and

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -2725,7 +2725,7 @@ constexpr basic_string& operator=(basic_string&& str)
 \begin{itemdescr}
 \pnum
 \effects
-Move assigns as a sequence container\iref{container.requirements},
+Move assigns as a sequence container\iref{sequence.reqmts},
 except that iterators, pointers and references may be invalidated.
 
 \pnum

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -30,6 +30,9 @@
 %   \movedxrefiii{old.label}{new.label.1}{new.label.2}{new.label.3}
 %   \movedxrefs{old.label}{new place (e.g., \tref{blah})}
 
+% https://github.com/cplusplus/draft/pull/6255
+\movedxref{container.gen.reqmts}{container.requirements.general}
+
 %%% Deprecated features.
 %%% Example:
 %


### PR DESCRIPTION
Related to #6184

I missed the [re.results.general] one in #6253 because I searched for `{container.requirements.general}`. The [string.cons] one is to the top-level of container requirements, but should be to the sequence requirements.

After fixing those, we can retitle/relabel some of the container requirements subclauses, as discussed in #6184