### PR TITLE
[unord.hash] [format.formatter.spec] Rephrase "specialization of X<Y>"

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -13749,14 +13749,17 @@ disabled specializations do not.
 Each header that declares the template \tcode{hash}
 provides enabled specializations of \tcode{hash} for \tcode{nullptr_t} and
 all cv-unqualified arithmetic, enumeration, and pointer types.
+
+\pnum
+For any type \tcode{Key} for which the library provides
+an explicit or partial specialization of the class template \tcode{hash},
+\tcode{hash<Key>} is enabled except as noted otherwise,
+and its member functions are \keyword{noexcept} except as noted otherwise.
+
+\pnum
 For any type \tcode{Key} for which neither the library nor the user provides
 an explicit or partial specialization of the class template \tcode{hash},
 \tcode{hash<Key>} is disabled.
-
-\pnum
-If the library provides an explicit or partial specialization of \tcode{hash<Key>},
-that specialization is enabled except as noted otherwise,
-and its member functions are \keyword{noexcept} except as noted otherwise.
 
 \pnum
 If \tcode{H} is a disabled specialization of \tcode{hash},
@@ -15947,16 +15950,19 @@ multibyte / wide string or character conversion are disabled.
 
 \pnum
 For any types \tcode{T} and \tcode{charT} for which
+the library provides
+an explicit or partial specialization of
+the class template \tcode{formatter},
+\tcode{formatter<T, charT>} is enabled
+and meets the \newoldconcept{Formatter} requirements
+except as noted otherwise.
+
+\pnum
+For any types \tcode{T} and \tcode{charT} for which
 neither the library nor the user provides
 an explicit or partial specialization of
 the class template \tcode{formatter},
 \tcode{formatter<T, charT>} is disabled.
-
-\pnum
-If the library provides an explicit or partial specialization of
-\tcode{formatter<T, charT>}, that specialization is enabled
-and meets the \newoldconcept{Formatter} requirements
-except as noted otherwise.
 
 \pnum
 If \tcode{F} is a disabled specialization of \tcode{formatter}, these


### PR DESCRIPTION
Both instances here have the same form: The first paragraph is phrased correctly as "for any type Y for which the library provides a specialization of X," and talks about disabling; the second paragraph talks about enabling in terms of "a specialization of X<Y>," which is incorrect. Flip it around so we talk enabling first, and use parallel construction in the two paragraphs.

Question: Can we replace the words "explicit or partial specialization" with the one word "specialization"? Would that be wrong or confusing somehow?