### PR TITLE
[dcl.init.list] Eliminate a case of "specialization of X<Y>"

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5984,7 +5984,7 @@ S2 s23 { };                         // OK, default to 0,0,0
 \item Otherwise, if the initializer list has no elements and \tcode{T} is a class type with a
 default constructor, the object is value-initialized.
 
-\item Otherwise, if \tcode{T} is a specialization of \tcode{std::initializer_list<E>},
+\item Otherwise, if \tcode{T} is a specialization of \tcode{std::initializer_list},
 the object is constructed as described below.
 
 \item Otherwise, if \tcode{T} is a class type, constructors are considered.


### PR DESCRIPTION
This and #6257 are the only instance of this solecism.