### PR TITLE
[flat.multiset.defn] Fix erroneous duplication of `iter-value-type<InputIterator>`

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -17357,11 +17357,11 @@ namespace std {
 
   template<class InputIterator, class Compare = less<@\placeholder{iter-value-type}@<InputIterator>>>
     flat_multiset(InputIterator, InputIterator, Compare = Compare())
-      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>, Compare>;
+      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, Compare>;
 
   template<class InputIterator, class Compare = less<@\placeholder{iter-value-type}@<InputIterator>>>
     flat_multiset(sorted_equivalent_t, InputIterator, InputIterator, Compare = Compare())
-      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>, Compare>;
+      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, Compare>;
 
   template<ranges::@\libconcept{input_range}@ R, class Compare = less<ranges::range_value_t<R>>,
            class Allocator = allocator<ranges::range_value_t<R>>>


### PR DESCRIPTION
`iter-value-type<InputIterator>` should appear only once in both deduction guides.