### PR TITLE
[flat.multiset.defn] Fix minor errors and inconsistencies

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -17163,7 +17163,7 @@ namespace std {
                   const key_compare& comp = key_compare())
       : @\exposid{c}@(std::move(cont)), @\exposid{compare}@(comp) { }
     template<class Allocator>
-      flat_multiset(sorted_equivalent_t, const container_type&, const Allocator& a);
+      flat_multiset(sorted_equivalent_t, const container_type& cont, const Allocator& a);
     template<class Allocator>
       flat_multiset(sorted_equivalent_t, const container_type& cont,
                     const key_compare& comp, const Allocator& a);
@@ -17329,8 +17329,8 @@ namespace std {
       { x.swap(y); }
 
   private:
-    container_type @\exposid{c}@;       // \expos
-    key_compare @\exposid{compare}@;    // \expos
+    container_type @\exposid{c}@;           // \expos
+    key_compare @\exposid{compare}@;        // \expos
   };
 
   template<class KeyContainer, class Compare = less<typename KeyContainer::value_type>>
@@ -17357,11 +17357,11 @@ namespace std {
 
   template<class InputIterator, class Compare = less<@\placeholder{iter-value-type}@<InputIterator>>>
     flat_multiset(InputIterator, InputIterator, Compare = Compare())
-      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>, Compare>;
+      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, Compare>;
 
   template<class InputIterator, class Compare = less<@\placeholder{iter-value-type}@<InputIterator>>>
     flat_multiset(sorted_equivalent_t, InputIterator, InputIterator, Compare = Compare())
-      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>, Compare>;
+      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, Compare>;
 
   template<ranges::@\libconcept{input_range}@ R, class Compare = less<ranges::range_value_t<R>>,
            class Allocator = allocator<ranges::range_value_t<R>>>


### PR DESCRIPTION
[flat.set.defn] and [flat.multiset.defn] are now formatted identically.
Additionally removed erroneous template parameters in two deduction guides (the `Key` was provided twice).

CC: @tzlaine