### PR TITLE
[expr.prim.req.nested][expr.prim.id.general] Say the normal form of the constraint-expression

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1488,8 +1488,8 @@ overload resolution is performed
 to select a unique function\iref{over.match,over.over}.
 \begin{note}
 A program cannot refer to a function
-with a trailing \grammarterm{requires-clause}
-whose \grammarterm{constraint-expression} is not satisfied,
+with a trailing \grammarterm{requires-clause} if the normal form of
+its \grammarterm{constraint-expression} is not satisfied,
 because such functions are never selected by overload resolution.
 \begin{example}
 \begin{codeblock}
@@ -3494,7 +3494,7 @@ that \tcode{g(x)} is non-throwing.
 \pnum
 A \grammarterm{nested-requirement} can be used
 to specify additional constraints in terms of local parameters.
-The \grammarterm{constraint-expression}
+The normal form\iref{temp.constr.normal} of the \grammarterm{constraint-expression}
 shall be satisfied\iref{temp.constr.decl}
 by the substituted template arguments, if any.
 Substitution of template arguments into a \grammarterm{nested-requirement}


### PR DESCRIPTION
... instead the constraint-expression itself.

Fixes #5460.
Fixes cplusplus/CWG#330.