### PR TITLE
[format.formattable] Add the second template argument for `basic_format_context` LWG3925

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15851,7 +15851,7 @@ template<class T, class Context,
 
 template<class T, class charT>
   concept @\deflibconcept{formattable}@ =
-    @\exposconcept{formattable-with}@<remove_reference_t<T>, basic_format_context<@\placeholder{fmt-iter-for}@<charT>>>;
+    @\exposconcept{formattable-with}@<remove_reference_t<T>, basic_format_context<@\placeholder{fmt-iter-for}@<charT>, charT>>;
 \end{codeblock}
 
 \pnum


### PR DESCRIPTION
`basic_format_context` has two template parameters:

https://github.com/cplusplus/draft/blob/4fac9f97a2c25d39a01f75cf198d0783bfa8deda/source/utilities.tex#L14511

But there's only one template argument in <code>basic_format_context<<i>fmt-iter-for</i>&lt;charT>></code>.

This seems to be a typo in the resolution of LWG3631.