### PR TITLE
Refer to library exposition-only function templates as templates

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -10768,7 +10768,8 @@ are destroyed in an unspecified order
 before allowing the exception to propagate.
 
 \pnum
-Some algorithms specified in \ref{specialized.algorithms} make use of the exposition-only function
+Some algorithms specified in \ref{specialized.algorithms}
+make use of the exposition-only function template
 \tcode{\placeholdernc{voidify}}:
 \begin{codeblock}
 template<class T>

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1170,7 +1170,7 @@ that exchanges the values\iref{concept.swappable} denoted by its
 arguments.
 
 \pnum
-Let \exposid{iter-exchange-move} be the exposition-only function:
+Let \exposid{iter-exchange-move} be the exposition-only function template:
 \begin{itemdecl}
 template<class X, class Y>
   constexpr iter_value_t<X> @\exposid{iter-exchange-move}@(X&& x, Y&& y)

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2639,7 +2639,7 @@ template<class F, @\exposconcept{tuple-like}@ Tuple>
 \begin{itemdescr}
 \pnum
 \effects
-Given the exposition-only function:
+Given the exposition-only function template:
 \begin{codeblock}
 namespace std {
   template<class F, @\exposconcept{tuple-like}@ Tuple, size_t... I>
@@ -2681,7 +2681,7 @@ is \tcode{false}.
 
 \pnum
 \effects
-Given the exposition-only function:
+Given the exposition-only function template:
 \begin{codeblock}
 namespace std {
   template<class T, @\exposconcept{tuple-like}@ Tuple, size_t... I>
@@ -7735,7 +7735,7 @@ then this destructor is a trivial destructor.
 \rSec3[expected.object.assign]{Assignment}
 
 \pnum
-This subclause makes use of the following exposition-only function:
+This subclause makes use of the following exposition-only function template:
 \begin{codeblock}
 template<class T, class U, class... Args>
 constexpr void @\exposid{reinit-expected}@(T& newval, U& oldval, Args&&... args) {  // \expos


### PR DESCRIPTION
As opposed to functions.