### PR TITLE
[basic.stc.dynamic.allocation] Remove redundant 'address of'

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3988,7 +3988,7 @@ An allocation function that fails to allocate storage can invoke the
 currently installed new-handler function\iref{new.handler}, if any.
 \begin{note}
 \indextext{\idxcode{new_handler}}%
-A program-supplied allocation function can obtain the address of the
+A program-supplied allocation function can obtain the
 currently installed \tcode{new_handler} using the
 \tcode{std::get_new_handler} function\iref{get.new.handler}.
 \end{note}


### PR DESCRIPTION
As per https://github.com/cplusplus/draft/pull/6174#discussion_r1192795712.