### PR TITLE
[expr.const] Check the result object of a prvalue

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -8200,7 +8200,7 @@ the conversion sequence contains only the conversions above.
 A \defnadj{constant}{expression} is either
 a glvalue core constant expression that refers to
 an object or a non-immediate function, or
-a prvalue core constant expression whose value
+a prvalue core constant expression whose result object\iref{basic.lval}
 satisfies the following constraints:
 \begin{itemize}
 \item


### PR DESCRIPTION
Fixes #5422.

The remain issue (modulo CWG2558) is that we shouldn't imply a prvalue is an object, which is not true since C++17.