### PR TITLE
[string.view], [string.view.comparison] Refactor string_view comparisons, exploiting rewritten candidates

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -545,12 +545,12 @@ namespace std {
   template<class charT, class traits>
     constexpr bool ranges::enable_borrowed_range<basic_string_view<charT, traits>> = true;
 
-  // \ref{string.view.comparison}, non-member comparison functions
+  // \ref{string.view.comparison}, exposition-only non-member comparison functions
   template<class charT, class traits>
-    constexpr bool operator==(basic_string_view<charT, traits> x,
+    constexpr bool @\exposid{operator==}@(basic_string_view<charT, traits> x,
                               basic_string_view<charT, traits> y) noexcept;
   template<class charT, class traits>
-    constexpr @\seebelow@ operator<=>(basic_string_view<charT, traits> x,
+    constexpr @\seebelow@ @\exposid{operator<=>}@(basic_string_view<charT, traits> x,
               @\itcorr@                      basic_string_view<charT, traits> y) noexcept;
 
   // see \ref{string.view.comparison}, sufficient additional overloads of comparison functions
@@ -1586,7 +1586,7 @@ Determines \tcode{xpos}.
 Otherwise, returns \tcode{npos}.
 \end{itemdescr}
 
-\rSec2[string.view.comparison]{Non-member comparison functions}
+\rSec2[string.view.comparison]{Exposition-only non-member comparison functions}
 
 \pnum
 Let \tcode{S} be \tcode{basic_string_view<charT, traits>}, and \tcode{sv} be an instance of \tcode{S}.
@@ -1613,11 +1613,6 @@ A sample conforming implementation for \tcode{operator==} would be:
 \begin{codeblock}
 template<class charT, class traits>
   constexpr bool operator==(basic_string_view<charT, traits> lhs,
-                            basic_string_view<charT, traits> rhs) noexcept {
-    return lhs.compare(rhs) == 0;
-  }
-template<class charT, class traits>
-  constexpr bool operator==(basic_string_view<charT, traits> lhs,
                             type_identity_t<basic_string_view<charT, traits>> rhs) noexcept {
     return lhs.compare(rhs) == 0;
   }
@@ -1627,7 +1622,7 @@ template<class charT, class traits>
 \indexlibrarymember{operator==}{basic_string_view}%
 \begin{itemdecl}
 template<class charT, class traits>
-  constexpr bool operator==(basic_string_view<charT, traits> lhs,
+  constexpr bool @\exposid{operator==}@(basic_string_view<charT, traits> lhs,
                             basic_string_view<charT, traits> rhs) noexcept;
 \end{itemdecl}
 
@@ -1640,7 +1635,7 @@ template<class charT, class traits>
 \indexlibrarymember{operator<=>}{basic_string_view}%
 \begin{itemdecl}
 template<class charT, class traits>
-  constexpr @\seebelow@ operator<=>(basic_string_view<charT, traits> lhs,
+  constexpr @\seebelow@ @\exposid{operator<=>}@(basic_string_view<charT, traits> lhs,
             @\itcorr@                      basic_string_view<charT, traits> rhs) noexcept;
 \end{itemdecl}
 


### PR DESCRIPTION
With the current semantics of rewritten candidates for the comparison operators, it is superfluous to specify both overloads

```
  operator==(basic_string_view, basic_string_view)
  operator==(basic_string_view, type_identity_t<basic_string_view>)
```

(ditto for `operator<=>`).

The second overload is necessary in order to implement the "sufficient additional overloads" part of [string.view.comparison], but it is also sufficient, as all the following cases

*  `sv == sv`
*  `sv == convertible_to_sv`
*  `convertible_to_sv == sv`

will, in fact, end up using it (directly, or after being rewritten with the arguments swapped).

The reason why we still do have both operators seems to be historical; there is an explanation offered here https://stackoverflow.com/a/70851101 .

Basically, there were _3_ overloads before a bunch of papers regarding `operator<=>` and `operator==` were merged:

1. `op==(sv, sv)` to deal with `sv == sv`;
2. `op==(sv, type_identity_t<sv>)` and
3. `op==(type_identity_t<sv>, sv)` to deal with `sv == convertible` and viceversa.

Overload n.1 was necessary because with only 2. and 3. a call like `sv == sv` would be ambiguous. With the adoption of the rewriting rules, overload n.3 has been dropped, without realizing that overload n.1 would then become redundant.

This commit makes the operators in [string.view.comparison] exposition-only, and changes the implementation example for the "sufficient additional overloads" so that it only uses the strategy employing `type_identity_t`.