### PR TITLE
[func.wrap.func.general], [func.wrap.move.class] Remove redundant declaration

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -12594,8 +12594,6 @@ An
 \indexlibrarymember{result_type}{function}%
 \begin{codeblock}
 namespace std {
-  template<class> class function;       // \notdef
-
   template<class R, class... ArgTypes>
   class function<R(ArgTypes...)> {
   public:
@@ -13067,8 +13065,6 @@ otherwise, let \placeholder{inv-quals} be \cv{} \placeholder{ref}.
 \indexlibraryglobal{move_only_function}%
 \begin{codeblock}
 namespace std {
-  template<class... S> class move_only_function;                // \notdef
-
   template<class R, class... ArgTypes>
   class move_only_function<R(ArgTypes...) @\cv{}@ @\placeholder{ref}@ noexcept(@\placeholder{noex}@)> {
   public:


### PR DESCRIPTION
We don't need to repeat the declarations of the incomplete primary template, they are already present in the `<functional>` synopsis.