### PR TITLE
P2767R0 §3 as seen by LWG in Varna

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -16957,79 +16957,81 @@ namespace std {
     // \ref{flat.set.cons}, constructors
     flat_set() : flat_set(key_compare()) { }
 
-    template<class Allocator>
-      flat_set(const flat_set&, const Allocator& a);
-    template<class Allocator>
-      flat_set(flat_set&&, const Allocator& a);
-
     explicit flat_set(container_type cont, const key_compare& comp = key_compare());
-    template<class Allocator>
-      flat_set(const container_type& cont, const Allocator& a);
-    template<class Allocator>
-      flat_set(const container_type& cont, const key_compare& comp, const Allocator& a);
 
     flat_set(sorted_unique_t, container_type cont, const key_compare& comp = key_compare())
       : @\exposid{c}@(std::move(cont)), @\exposid{compare}@(comp) { }
-    template<class Allocator>
-      flat_set(sorted_unique_t, const container_type& cont, const Allocator& a);
-    template<class Allocator>
-      flat_set(sorted_unique_t, const container_type& cont,
-               const key_compare& comp, const Allocator& a);
 
     explicit flat_set(const key_compare& comp)
       : @\exposid{c}@(), @\exposid{compare}@(comp) { }
-    template<class Allocator>
-      flat_set(const key_compare& comp, const Allocator& a);
-    template<class Allocator>
-      explicit flat_set(const Allocator& a);
 
     template<class InputIterator>
       flat_set(InputIterator first, InputIterator last, const key_compare& comp = key_compare())
         : @\exposid{c}@(), @\exposid{compare}@(comp)
         { insert(first, last); }
-    template<class InputIterator, class Allocator>
-      flat_set(InputIterator first, InputIterator last,
-               const key_compare& comp, const Allocator& a);
-    template<class InputIterator, class Allocator>
-      flat_set(InputIterator first, InputIterator last, const Allocator& a);
 
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       flat_set(from_range_t fr, R&& rg)
         : flat_set(fr, std::forward<R>(rg), key_compare()) { }
-    template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-      flat_set(from_range_t, R&& rg, const Allocator& a);
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       flat_set(from_range_t, R&& rg, const key_compare& comp)
         : flat_set(comp)
         { insert_range(std::forward<R>(rg)); }
-    template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-       flat_set(from_range_t, R&& rg, const key_compare& comp, const Allocator& a);
 
     template<class InputIterator>
       flat_set(sorted_unique_t, InputIterator first, InputIterator last,
                const key_compare& comp = key_compare())
         : @\exposid{c}@(first, last), @\exposid{compare}@(comp) { }
-    template<class InputIterator, class Allocator>
-      flat_set(sorted_unique_t, InputIterator first, InputIterator last,
-               const key_compare& comp, const Allocator& a);
-    template<class InputIterator, class Allocator>
-      flat_set(sorted_unique_t, InputIterator first, InputIterator last, const Allocator& a);
 
     flat_set(initializer_list<value_type> il, const key_compare& comp = key_compare())
         : flat_set(il.begin(), il.end(), comp) { }
-    template<class Allocator>
-      flat_set(initializer_list<value_type> il, const key_compare& comp, const Allocator& a);
-    template<class Allocator>
-      flat_set(initializer_list<value_type> il, const Allocator& a);
 
     flat_set(sorted_unique_t s, initializer_list<value_type> il,
              const key_compare& comp = key_compare())
         : flat_set(s, il.begin(), il.end(), comp) { }
-    template<class Allocator>
+
+    // \ref{flat.set.cons.alloc}, constructors with allocators
+
+    template<class Alloc>
+      flat_set(const flat_set&, const Alloc& a);
+    template<class Alloc>
+      flat_set(flat_set&&, const Alloc& a);
+    template<class Alloc>
+      flat_set(const container_type& cont, const Alloc& a);
+    template<class Alloc>
+      flat_set(const container_type& cont, const key_compare& comp, const Alloc& a);
+    template<class Alloc>
+      flat_set(sorted_unique_t, const container_type& cont, const Alloc& a);
+    template<class Alloc>
+      flat_set(sorted_unique_t, const container_type& cont,
+               const key_compare& comp, const Alloc& a);
+    template<class Alloc>
+      flat_set(const key_compare& comp, const Alloc& a);
+    template<class Alloc>
+      explicit flat_set(const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_set(InputIterator first, InputIterator last,
+               const key_compare& comp, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_set(InputIterator first, InputIterator last, const Alloc& a);
+    template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+      flat_set(from_range_t, R&& rg, const Alloc& a);
+    template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+       flat_set(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_set(sorted_unique_t, InputIterator first, InputIterator last,
+               const key_compare& comp, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_set(sorted_unique_t, InputIterator first, InputIterator last, const Alloc& a);
+    template<class Alloc>
+      flat_set(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
+    template<class Alloc>
+      flat_set(initializer_list<value_type> il, const Alloc& a);
+    template<class Alloc>
       flat_set(sorted_unique_t, initializer_list<value_type> il,
-               const key_compare& comp, const Allocator& a);
-    template<class Allocator>
-      flat_set(sorted_unique_t, initializer_list<value_type> il, const Allocator& a);
+               const key_compare& comp, const Alloc& a);
+    template<class Alloc>
+      flat_set(sorted_unique_t, initializer_list<value_type> il, const Alloc& a);
 
     flat_set& operator=(initializer_list<value_type>);
 
@@ -17214,23 +17216,25 @@ from each group of consecutive equivalent elements.
 
 \pnum
 \complexity
-Linear in $N$ if \tcode{cont} is sorted with respect to \exposid{compare} and
+Linear in $N$ if \tcode{cont} is already sorted with respect to \exposid{compare} and
 otherwise $N \log N$, where $N$ is the value of \tcode{cont.size()} before this call.
 \end{itemdescr}
 
+\rSec3[flat.set.cons.alloc]{Constructors with allocators}
+
+\pnum
+The constructors in this subclause shall not participate in overload resolution
+unless \tcode{uses_allocator_v<container_type, Alloc>} is \tcode{true}.
+
 \indexlibraryctor{flat_set}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_set(const container_type& cont, const Allocator& a);
-template<class Allocator>
-  flat_set(const container_type& cont, const key_compare& comp, const Allocator& a);
+template<class Alloc>
+  flat_set(const container_type& cont, const Alloc& a);
+template<class Alloc>
+  flat_set(const container_type& cont, const key_compare& comp, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\constraints
-\tcode{uses_allocator_v<container_type, Allocator>} is \tcode{true}.
-
 \pnum
 \effects
 Equivalent to
@@ -17245,18 +17249,14 @@ Same as \tcode{flat_set(cont)} and \tcode{flat_set(cont, comp)}, respectively.
 
 \indexlibraryctor{flat_set}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_set(sorted_unique_t s, const container_type& cont, const Allocator& a);
-template<class Allocator>
+template<class Alloc>
+  flat_set(sorted_unique_t s, const container_type& cont, const Alloc& a);
+template<class Alloc>
   flat_set(sorted_unique_t s, const container_type& cont,
-           const key_compare& comp, const Allocator& a);
+           const key_compare& comp, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\constraints
-\tcode{uses_allocator_v<container_type, Allocator>} is \tcode{true}.
-
 \pnum
 \effects
 Equivalent to
@@ -17271,43 +17271,39 @@ Linear.
 
 \indexlibraryctor{flat_set}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_set(const flat_set&, const Allocator& a);
-template<class Allocator>
-  flat_set(flat_set&&, const Allocator& a);
-template<class Allocator>
-  flat_set(const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  explicit flat_set(const Allocator& a);
-template<class InputIterator, class Allocator>
-  flat_set(InputIterator first, InputIterator last, const key_compare& comp, const Allocator& a);
-template<class InputIterator, class Allocator>
-  flat_set(InputIterator first, InputIterator last, const Allocator& a);
-template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-  flat_set(from_range_t, R&& rg, const Allocator& a);
-template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-  flat_set(from_range_t, R&& rg, const key_compare& comp, const Allocator& a);
-template<class InputIterator, class Allocator>
+template<class Alloc>
+  flat_set(const flat_set&, const Alloc& a);
+template<class Alloc>
+  flat_set(flat_set&&, const Alloc& a);
+template<class Alloc>
+  flat_set(const key_compare& comp, const Alloc& a);
+template<class Alloc>
+  explicit flat_set(const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_set(InputIterator first, InputIterator last, const key_compare& comp, const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_set(InputIterator first, InputIterator last, const Alloc& a);
+template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+  flat_set(from_range_t, R&& rg, const Alloc& a);
+template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+  flat_set(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
+template<class InputIterator, class Alloc>
   flat_set(sorted_unique_t, InputIterator first, InputIterator last,
-           const key_compare& comp, const Allocator& a);
-template<class InputIterator, class Allocator>
-  flat_set(sorted_unique_t, InputIterator first, InputIterator last, const Allocator& a);
-template<class Allocator>
-  flat_set(initializer_list<value_type> il, const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  flat_set(initializer_list<value_type> il, const Allocator& a);
-template<class Allocator>
+           const key_compare& comp, const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_set(sorted_unique_t, InputIterator first, InputIterator last, const Alloc& a);
+template<class Alloc>
+  flat_set(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
+template<class Alloc>
+  flat_set(initializer_list<value_type> il, const Alloc& a);
+template<class Alloc>
   flat_set(sorted_unique_t, initializer_list<value_type> il,
-           const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  flat_set(sorted_unique_t, initializer_list<value_type> il, const Allocator& a);
+           const key_compare& comp, const Alloc& a);
+template<class Alloc>
+  flat_set(sorted_unique_t, initializer_list<value_type> il, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\constraints
-\tcode{uses_allocator_v<container_type, Allocator>} is \tcode{true}.
-
 \pnum
 \effects
 Equivalent to the corresponding non-allocator constructors

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -15210,18 +15210,23 @@ namespace std {
     // \ref{flat.map.cons}, constructors
     flat_map() : flat_map(key_compare()) { }
 
+    explicit flat_map(const key_compare& comp)
+      : c(), compare(comp) { }
+
     flat_map(key_container_type key_cont, mapped_container_type mapped_cont,
              const key_compare& comp = key_compare());
 
     flat_map(sorted_unique_t, key_container_type key_cont, mapped_container_type mapped_cont,
              const key_compare& comp = key_compare());
 
-    explicit flat_map(const key_compare& comp)
-      : c(), compare(comp) { }
-
     template<class InputIterator>
       flat_map(InputIterator first, InputIterator last, const key_compare& comp = key_compare())
         : c(), compare(comp) { insert(first, last); }
+
+    template<class InputIterator>
+      flat_map(sorted_unique_t s, InputIterator first, InputIterator last,
+               const key_compare& comp = key_compare())
+        : c(), compare(comp) { insert(s, first, last); }
 
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       flat_map(from_range_t fr, R&& rg)
@@ -15229,11 +15234,6 @@ namespace std {
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       flat_map(from_range_t, R&& rg, const key_compare& comp)
         : flat_map(comp) { insert_range(std::forward<R>(rg)); }
-
-    template<class InputIterator>
-      flat_map(sorted_unique_t s, InputIterator first, InputIterator last,
-               const key_compare& comp = key_compare())
-        : c(), compare(comp) { insert(s, first, last); }
 
     flat_map(initializer_list<value_type> il, const key_compare& comp = key_compare())
         : flat_map(il.begin(), il.end(), comp) { }
@@ -15245,9 +15245,9 @@ namespace std {
     // \ref{flat.map.cons.alloc}, constructors with allocators
 
     template<class Alloc>
-      flat_map(const flat_map&, const Alloc& a);
+      explicit flat_map(const Alloc& a);
     template<class Alloc>
-      flat_map(flat_map&&, const Alloc& a);
+      flat_map(const key_compare& comp, const Alloc& a);
     template<class Alloc>
       flat_map(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
                const Alloc& a);
@@ -15262,32 +15262,32 @@ namespace std {
                const mapped_container_type& mapped_cont,
                const key_compare& comp, const Alloc& a);
     template<class Alloc>
-      flat_map(const key_compare& comp, const Alloc& a);
+      flat_map(const flat_map&, const Alloc& a);
     template<class Alloc>
-      explicit flat_map(const Alloc& a);
+      flat_map(flat_map&&, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_map(InputIterator first, InputIterator last, const Alloc& a);
     template<class InputIterator, class Alloc>
       flat_map(InputIterator first, InputIterator last,
                const key_compare& comp, const Alloc& a);
     template<class InputIterator, class Alloc>
-      flat_map(InputIterator first, InputIterator last, const Alloc& a);
+      flat_map(sorted_unique_t, InputIterator first, InputIterator last, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_map(sorted_unique_t, InputIterator first, InputIterator last,
+               const key_compare& comp, const Alloc& a);
     template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
       flat_map(from_range_t, R&& rg, const Alloc& a);
     template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
       flat_map(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
-    template<class InputIterator, class Alloc>
-      flat_map(sorted_unique_t, InputIterator first, InputIterator last,
-               const key_compare& comp, const Alloc& a);
-    template<class InputIterator, class Alloc>
-      flat_map(sorted_unique_t, InputIterator first, InputIterator last, const Alloc& a);
-    template<class Alloc>
-      flat_map(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
     template<class Alloc>
       flat_map(initializer_list<value_type> il, const Alloc& a);
     template<class Alloc>
-      flat_map(sorted_unique_t, initializer_list<value_type> il,
-               const key_compare& comp, const Alloc& a);
+      flat_map(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
     template<class Alloc>
       flat_map(sorted_unique_t, initializer_list<value_type> il, const Alloc& a);
+    template<class Alloc>
+      flat_map(sorted_unique_t, initializer_list<value_type> il,
+               const key_compare& comp, const Alloc& a);
 
     flat_map& operator=(initializer_list<value_type>);
 
@@ -15623,35 +15623,35 @@ Linear.
 \indexlibraryctor{flat_map}%
 \begin{itemdecl}
 template<class Alloc>
-  flat_map(const flat_map&, const Alloc& a);
-template<class Alloc>
-  flat_map(flat_map&&, const Alloc& a);
+  explicit flat_map(const Alloc& a);
 template<class Alloc>
   flat_map(const key_compare& comp, const Alloc& a);
 template<class Alloc>
-  explicit flat_map(const Alloc& a);
+  flat_map(const flat_map&, const Alloc& a);
+template<class Alloc>
+  flat_map(flat_map&&, const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_map(InputIterator first, InputIterator last, const Alloc& a);
 template<class InputIterator, class Alloc>
   flat_map(InputIterator first, InputIterator last, const key_compare& comp, const Alloc& a);
 template<class InputIterator, class Alloc>
-  flat_map(InputIterator first, InputIterator last, const Alloc& a);
+  flat_map(sorted_unique_t, InputIterator first, InputIterator last, const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_map(sorted_unique_t, InputIterator first, InputIterator last,
+           const key_compare& comp, const Alloc& a);
 template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
   flat_map(from_range_t, R&& rg, const Alloc& a);
 template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
   flat_map(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
-template<class InputIterator, class Alloc>
-  flat_map(sorted_unique_t, InputIterator first, InputIterator last,
-           const key_compare& comp, const Alloc& a);
-template<class InputIterator, class Alloc>
-  flat_map(sorted_unique_t, InputIterator first, InputIterator last, const Alloc& a);
-template<class Alloc>
-  flat_map(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
 template<class Alloc>
   flat_map(initializer_list<value_type> il, const Alloc& a);
 template<class Alloc>
-  flat_map(sorted_unique_t, initializer_list<value_type> il,
-           const key_compare& comp, const Alloc& a);
+  flat_map(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
 template<class Alloc>
   flat_map(sorted_unique_t, initializer_list<value_type> il, const Alloc& a);
+template<class Alloc>
+  flat_map(sorted_unique_t, initializer_list<value_type> il,
+           const key_compare& comp, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -16390,92 +16390,94 @@ namespace std {
       mapped_container_type values;
     };
 
-    // \ref{flat.multimap.cons}, construct/copy/destroy
+    // \ref{flat.multimap.cons}, constructors
     flat_multimap() : flat_multimap(key_compare()) { }
-
-    template<class Allocator>
-      flat_multimap(const flat_multimap&, const Allocator& a);
-    template<class Allocator>
-      flat_multimap(flat_multimap&&, const Allocator& a);
 
     flat_multimap(key_container_type key_cont, mapped_container_type mapped_cont,
                   const key_compare& comp = key_compare());
-    template<class Allocator>
-      flat_multimap(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
-                    const Allocator& a);
-    template<class Allocator>
-      flat_multimap(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
-                    const key_compare& comp, const Allocator& a);
 
     flat_multimap(sorted_equivalent_t,
                   key_container_type key_cont, mapped_container_type mapped_cont,
                   const key_compare& comp = key_compare());
-    template<class Allocator>
-      flat_multimap(sorted_equivalent_t, const key_container_type& key_cont,
-                    const mapped_container_type& mapped_cont, const Allocator& a);
-    template<class Allocator>
-      flat_multimap(sorted_equivalent_t, const key_container_type& key_cont,
-                    const mapped_container_type& mapped_cont,
-                    const key_compare& comp, const Allocator& a);
 
     explicit flat_multimap(const key_compare& comp)
       : c(), compare(comp) { }
-    template<class Allocator>
-      flat_multimap(const key_compare& comp, const Allocator& a);
-    template<class Allocator>
-      explicit flat_multimap(const Allocator& a);
 
     template<class InputIterator>
       flat_multimap(InputIterator first, InputIterator last,
                     const key_compare& comp = key_compare())
         : c(), compare(comp)
         { insert(first, last); }
-    template<class InputIterator, class Allocator>
-      flat_multimap(InputIterator first, InputIterator last,
-                    const key_compare& comp, const Allocator& a);
-    template<class InputIterator, class Allocator>
-      flat_multimap(InputIterator first, InputIterator last, const Allocator& a);
 
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       flat_multimap(from_range_t fr, R&& rg)
         : flat_multimap(fr, std::forward<R>(rg), key_compare()) { }
-    template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-      flat_multimap(from_range_t, R&& rg, const Allocator& a);
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       flat_multimap(from_range_t, R&& rg, const key_compare& comp)
         : flat_multimap(comp) { insert_range(std::forward<R>(rg)); }
-    template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-      flat_multimap(from_range_t, R&& rg, const key_compare& comp, const Allocator& a);
 
     template<class InputIterator>
       flat_multimap(sorted_equivalent_t s, InputIterator first, InputIterator last,
                     const key_compare& comp = key_compare())
         : c(), compare(comp) { insert(s, first, last); }
-    template<class InputIterator, class Allocator>
-      flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
-                    const key_compare& comp, const Allocator& a);
-    template<class InputIterator, class Allocator>
-      flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
-                    const Allocator& a);
 
     flat_multimap(initializer_list<value_type> il, const key_compare& comp = key_compare())
         : flat_multimap(il.begin(), il.end(), comp) { }
-    template<class Allocator>
-      flat_multimap(initializer_list<value_type> il, const key_compare& comp,
-                    const Allocator& a);
-    template<class Allocator>
-      flat_multimap(initializer_list<value_type> il, const Allocator& a);
 
     flat_multimap(sorted_equivalent_t s, initializer_list<value_type> il,
                   const key_compare& comp = key_compare())
         : flat_multimap(s, il.begin(), il.end(), comp) { }
-    template<class Allocator>
-      flat_multimap(sorted_equivalent_t, initializer_list<value_type> il,
-                    const key_compare& comp, const Allocator& a);
-    template<class Allocator>
-      flat_multimap(sorted_equivalent_t, initializer_list<value_type> il, const Allocator& a);
 
-    flat_multimap& operator=(initializer_list<value_type> il);
+    // \ref{flat.multimap.cons.alloc}, constructors with allocators
+
+    template<class Alloc>
+      flat_multimap(const flat_multimap&, const Alloc& a);
+    template<class Alloc>
+      flat_multimap(flat_multimap&&, const Alloc& a);
+    template<class Alloc>
+      flat_multimap(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
+                    const Alloc& a);
+    template<class Alloc>
+      flat_multimap(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
+                    const key_compare& comp, const Alloc& a);
+    template<class Alloc>
+      flat_multimap(sorted_equivalent_t, const key_container_type& key_cont,
+                    const mapped_container_type& mapped_cont, const Alloc& a);
+    template<class Alloc>
+      flat_multimap(sorted_equivalent_t, const key_container_type& key_cont,
+                    const mapped_container_type& mapped_cont,
+                    const key_compare& comp, const Alloc& a);
+    template<class Alloc>
+      flat_multimap(const key_compare& comp, const Alloc& a);
+    template<class Alloc>
+      explicit flat_multimap(const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_multimap(InputIterator first, InputIterator last,
+                    const key_compare& comp, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_multimap(InputIterator first, InputIterator last, const Alloc& a);
+    template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+      flat_multimap(from_range_t, R&& rg, const Alloc& a);
+    template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+      flat_multimap(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
+                    const key_compare& comp, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
+                    const Alloc& a);
+    template<class Alloc>
+      flat_multimap(initializer_list<value_type> il, const key_compare& comp,
+                    const Alloc& a);
+    template<class Alloc>
+      flat_multimap(initializer_list<value_type> il, const Alloc& a);
+    template<class Alloc>
+      flat_multimap(sorted_equivalent_t, initializer_list<value_type> il,
+                    const key_compare& comp, const Alloc& a);
+    template<class Alloc>
+      flat_multimap(sorted_equivalent_t, initializer_list<value_type> il, const Alloc& a);
+
+    flat_multimap& operator=(initializer_list<value_type>);
 
     // iterators
     iterator               begin() noexcept;
@@ -16691,35 +16693,6 @@ where $N$ is the value of \tcode{key_cont.size()} before this call.
 
 \indexlibraryctor{flat_multimap}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_multimap(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
-                const Allocator& a);
-template<class Allocator>
-  flat_multimap(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
-                const key_compare& comp, const Allocator& a);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\constraints
-\tcode{uses_allocator_v<key_container_type, Allocator>} is \tcode{true} and
-\tcode{uses_allocator_v<mapped_container_type, Allocator>} is \tcode{true}.
-
-\pnum
-\effects
-Equivalent to \tcode{flat_multimap(key_cont, mapped_cont)} and
-\tcode{flat_multimap(key_cont, \linebreak{}mapped_cont, comp)}, respectively,
-except that \tcode{c.keys} and \tcode{c.values} are constructed
-with uses-allocator construction\iref{allocator.uses.construction}.
-
-\pnum
-\complexity
-Same as \tcode{flat_multimap(key_cont, mapped_cont)} and
-\tcode{flat_multimap(key_cont, \linebreak{}mapped_cont, comp)}, respectively.
-\end{itemdescr}
-
-\indexlibraryctor{flat_multimap}%
-\begin{itemdecl}
 flat_multimap(sorted_equivalent_t, key_container_type key_cont, mapped_container_type mapped_cont,
               const key_compare& comp = key_compare());
 \end{itemdecl}
@@ -16737,23 +16710,49 @@ Initializes
 Constant.
 \end{itemdescr}
 
+\rSec3[flat.multimap.cons.alloc]{Constructors with allocators}
+
+\pnum
+The constructors in this subclause shall not participate in overload resolution
+unless \tcode{uses_allocator_v<key_container_type, Alloc>} is \tcode{true}
+and \tcode{uses_allocator_v<mapped_container_type, Alloc>} is \tcode{true}.
+
 \indexlibraryctor{flat_multimap}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_multimap(sorted_equivalent_t s, const key_container_type& key_cont,
-                const mapped_container_type& mapped_cont, const Allocator& a);
-template<class Allocator>
-  flat_multimap(sorted_equivalent_t s, const key_container_type& key_cont,
-                const mapped_container_type& mapped_cont, const key_compare& comp,
-                const Allocator& a);
+template<class Alloc>
+  flat_multimap(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
+                const Alloc& a);
+template<class Alloc>
+  flat_multimap(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
+                const key_compare& comp, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\constraints
-\tcode{uses_allocator_v<key_container_type, Allocator>} is \tcode{true} and
-\tcode{uses_allocator_v<mapped_container_type, Allocator>} is \tcode{true}.
+\effects
+Equivalent to \tcode{flat_multimap(key_cont, mapped_cont)} and
+\tcode{flat_multimap(key_cont, \linebreak{}mapped_cont, comp)}, respectively,
+except that \tcode{c.keys} and \tcode{c.values} are constructed
+with uses-allocator construction\iref{allocator.uses.construction}.
 
+\pnum
+\complexity
+Same as \tcode{flat_multimap(key_cont, mapped_cont)} and
+\tcode{flat_multimap(key_cont, \linebreak{}mapped_cont, comp)}, respectively.
+\end{itemdescr}
+
+\indexlibraryctor{flat_multimap}%
+\begin{itemdecl}
+template<class Alloc>
+  flat_multimap(sorted_equivalent_t s, const key_container_type& key_cont,
+                const mapped_container_type& mapped_cont, const Alloc& a);
+template<class Alloc>
+  flat_multimap(sorted_equivalent_t s, const key_container_type& key_cont,
+                const mapped_container_type& mapped_cont, const key_compare& comp,
+                const Alloc& a);
+\end{itemdecl}
+
+\begin{itemdescr}
 \pnum
 \effects
 Equivalent to \tcode{flat_multimap(s, key_cont, mapped_cont)} and
@@ -16768,46 +16767,41 @@ Linear.
 
 \indexlibraryctor{flat_multimap}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_multimap(const flat_multimap&, const Allocator& a);
-template<class Allocator>
-  flat_multimap(flat_multimap&&, const Allocator& a);
-template<class Allocator>
-  flat_multimap(const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  explicit flat_multimap(const Allocator& a);
-template<class InputIterator, class Allocator>
+template<class Alloc>
+  flat_multimap(const flat_multimap&, const Alloc& a);
+template<class Alloc>
+  flat_multimap(flat_multimap&&, const Alloc& a);
+template<class Alloc>
+  flat_multimap(const key_compare& comp, const Alloc& a);
+template<class Alloc>
+  explicit flat_multimap(const Alloc& a);
+template<class InputIterator, class Alloc>
   flat_multimap(InputIterator first, InputIterator last, const key_compare& comp,
-                const Allocator& a);
-template<class InputIterator, class Allocator>
-  flat_multimap(InputIterator first, InputIterator last, const Allocator& a);
-template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-  flat_multimap(from_range_t, R&& rg, const Allocator& a);
-template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-  flat_multimap(from_range_t, R&& rg, const key_compare& comp, const Allocator& a);
-template<class InputIterator, class Allocator>
+                const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_multimap(InputIterator first, InputIterator last, const Alloc& a);
+template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+  flat_multimap(from_range_t, R&& rg, const Alloc& a);
+template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+  flat_multimap(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
+template<class InputIterator, class Alloc>
   flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
-                const key_compare& comp, const Allocator& a);
-template<class InputIterator, class Allocator>
+                const key_compare& comp, const Alloc& a);
+template<class InputIterator, class Alloc>
   flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
-                const Allocator& a);
-template<class Allocator>
-  flat_multimap(initializer_list<value_type> il, const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  flat_multimap(initializer_list<value_type> il, const Allocator& a);
-template<class Allocator>
+                const Alloc& a);
+template<class Alloc>
+  flat_multimap(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
+template<class Alloc>
+  flat_multimap(initializer_list<value_type> il, const Alloc& a);
+template<class Alloc>
   flat_multimap(sorted_equivalent_t, initializer_list<value_type> il,
-                const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  flat_multimap(sorted_equivalent_t, initializer_list<value_type> il, const Allocator& a);
+                const key_compare& comp, const Alloc& a);
+template<class Alloc>
+  flat_multimap(sorted_equivalent_t, initializer_list<value_type> il, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\constraints
-\tcode{uses_allocator_v<key_container_type, Allocator>} is \tcode{true} and
-\tcode{uses_allocator_v<mapped_container_type, Allocator>} is \tcode{true}.
-
 \pnum
 \effects
 Equivalent to the corresponding non-allocator constructors

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -15207,87 +15207,89 @@ namespace std {
       mapped_container_type values;
     };
 
-    // \ref{flat.map.cons}, construct/copy/destroy
+    // \ref{flat.map.cons}, constructors
     flat_map() : flat_map(key_compare()) { }
-
-    template<class Allocator>
-      flat_map(const flat_map&, const Allocator& a);
-    template<class Allocator>
-      flat_map(flat_map&&, const Allocator& a);
 
     flat_map(key_container_type key_cont, mapped_container_type mapped_cont,
              const key_compare& comp = key_compare());
-    template<class Allocator>
-      flat_map(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
-               const Allocator& a);
-    template<class Allocator>
-      flat_map(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
-               const key_compare& comp, const Allocator& a);
 
     flat_map(sorted_unique_t, key_container_type key_cont, mapped_container_type mapped_cont,
              const key_compare& comp = key_compare());
-    template<class Allocator>
-      flat_map(sorted_unique_t, const key_container_type& key_cont,
-               const mapped_container_type& mapped_cont, const Allocator& a);
-    template<class Allocator>
-      flat_map(sorted_unique_t, const key_container_type& key_cont,
-               const mapped_container_type& mapped_cont,
-               const key_compare& comp, const Allocator& a);
 
     explicit flat_map(const key_compare& comp)
       : c(), compare(comp) { }
-    template<class Allocator>
-      flat_map(const key_compare& comp, const Allocator& a);
-    template<class Allocator>
-      explicit flat_map(const Allocator& a);
 
     template<class InputIterator>
       flat_map(InputIterator first, InputIterator last, const key_compare& comp = key_compare())
         : c(), compare(comp) { insert(first, last); }
-    template<class InputIterator, class Allocator>
-      flat_map(InputIterator first, InputIterator last,
-               const key_compare& comp, const Allocator& a);
-    template<class InputIterator, class Allocator>
-      flat_map(InputIterator first, InputIterator last, const Allocator& a);
 
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       flat_map(from_range_t fr, R&& rg)
         : flat_map(fr, std::forward<R>(rg), key_compare()) { }
-    template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-      flat_map(from_range_t, R&& rg, const Allocator& a);
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       flat_map(from_range_t, R&& rg, const key_compare& comp)
         : flat_map(comp) { insert_range(std::forward<R>(rg)); }
-    template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-      flat_map(from_range_t, R&& rg, const key_compare& comp, const Allocator& a);
 
     template<class InputIterator>
       flat_map(sorted_unique_t s, InputIterator first, InputIterator last,
                const key_compare& comp = key_compare())
         : c(), compare(comp) { insert(s, first, last); }
-    template<class InputIterator, class Allocator>
-      flat_map(sorted_unique_t, InputIterator first, InputIterator last,
-               const key_compare& comp, const Allocator& a);
-    template<class InputIterator, class Allocator>
-      flat_map(sorted_unique_t, InputIterator first, InputIterator last, const Allocator& a);
 
     flat_map(initializer_list<value_type> il, const key_compare& comp = key_compare())
         : flat_map(il.begin(), il.end(), comp) { }
-    template<class Allocator>
-      flat_map(initializer_list<value_type> il, const key_compare& comp, const Allocator& a);
-    template<class Allocator>
-      flat_map(initializer_list<value_type> il, const Allocator& a);
 
     flat_map(sorted_unique_t s, initializer_list<value_type> il,
              const key_compare& comp = key_compare())
         : flat_map(s, il.begin(), il.end(), comp) { }
-    template<class Allocator>
-      flat_map(sorted_unique_t, initializer_list<value_type> il,
-               const key_compare& comp, const Allocator& a);
-    template<class Allocator>
-      flat_map(sorted_unique_t, initializer_list<value_type> il, const Allocator& a);
 
-    flat_map& operator=(initializer_list<value_type> il);
+    // \ref{flat.map.cons.alloc}, constructors with allocators
+
+    template<class Alloc>
+      flat_map(const flat_map&, const Alloc& a);
+    template<class Alloc>
+      flat_map(flat_map&&, const Alloc& a);
+    template<class Alloc>
+      flat_map(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
+               const Alloc& a);
+    template<class Alloc>
+      flat_map(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
+               const key_compare& comp, const Alloc& a);
+    template<class Alloc>
+      flat_map(sorted_unique_t, const key_container_type& key_cont,
+               const mapped_container_type& mapped_cont, const Alloc& a);
+    template<class Alloc>
+      flat_map(sorted_unique_t, const key_container_type& key_cont,
+               const mapped_container_type& mapped_cont,
+               const key_compare& comp, const Alloc& a);
+    template<class Alloc>
+      flat_map(const key_compare& comp, const Alloc& a);
+    template<class Alloc>
+      explicit flat_map(const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_map(InputIterator first, InputIterator last,
+               const key_compare& comp, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_map(InputIterator first, InputIterator last, const Alloc& a);
+    template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+      flat_map(from_range_t, R&& rg, const Alloc& a);
+    template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+      flat_map(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_map(sorted_unique_t, InputIterator first, InputIterator last,
+               const key_compare& comp, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_map(sorted_unique_t, InputIterator first, InputIterator last, const Alloc& a);
+    template<class Alloc>
+      flat_map(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
+    template<class Alloc>
+      flat_map(initializer_list<value_type> il, const Alloc& a);
+    template<class Alloc>
+      flat_map(sorted_unique_t, initializer_list<value_type> il,
+               const key_compare& comp, const Alloc& a);
+    template<class Alloc>
+      flat_map(sorted_unique_t, initializer_list<value_type> il, const Alloc& a);
+
+    flat_map& operator=(initializer_list<value_type>);
 
     // iterators
     iterator               begin() noexcept;
@@ -15546,35 +15548,6 @@ where $N$ is the value of \tcode{key_cont.size()} before this call.
 
 \indexlibraryctor{flat_map}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_map(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
-           const Allocator& a);
-template<class Allocator>
-  flat_map(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
-           const key_compare& comp, const Allocator& a);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\constraints
-\tcode{uses_allocator_v<key_container_type, Allocator>} is \tcode{true} and
-\tcode{uses_allocator_v<mapped_container_type, Allocator>} is \tcode{true}.
-
-\pnum
-\effects
-Equivalent to \tcode{flat_map(key_cont, mapped_cont)} and
-\tcode{flat_map(key_cont, mapped_cont, comp)}, respectively,
-except that \tcode{c.keys} and \tcode{c.values} are constructed with
-uses-allocator construction\iref{allocator.uses.construction}.
-
-\pnum
-\complexity
-Same as \tcode{flat_map(key_cont, mapped_cont)} and
-\tcode{flat_map(key_cont, mapped_cont, comp)}, respectively.
-\end{itemdescr}
-
-\indexlibraryctor{flat_map}%
-\begin{itemdecl}
 flat_map(sorted_unique_t, key_container_type key_cont, mapped_container_type mapped_cont,
          const key_compare& comp = key_compare());
 \end{itemdecl}
@@ -15592,23 +15565,49 @@ Initializes
 Constant.
 \end{itemdescr}
 
+\rSec3[flat.map.cons.alloc]{Constructors with allocators}
+
+\pnum
+The constructors in this subclause shall not participate in overload resolution
+unless \tcode{uses_allocator_v<key_container_type, Alloc>} is \tcode{true}
+and \tcode{uses_allocator_v<mapped_container_type, Alloc>} is \tcode{true}.
+
 \indexlibraryctor{flat_map}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_map(sorted_unique_t s, const key_container_type& key_cont,
-           const mapped_container_type& mapped_cont, const Allocator& a);
-template<class Allocator>
-  flat_map(sorted_unique_t s, const key_container_type& key_cont,
-           const mapped_container_type& mapped_cont, const key_compare& comp,
-           const Allocator& a);
+template<class Alloc>
+  flat_map(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
+           const Alloc& a);
+template<class Alloc>
+  flat_map(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
+           const key_compare& comp, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\constraints
-\tcode{uses_allocator_v<key_container_type, Allocator>} is \tcode{true} and
-\tcode{uses_allocator_v<mapped_container_type, Allocator>} is \tcode{true}.
+\effects
+Equivalent to \tcode{flat_map(key_cont, mapped_cont)} and
+\tcode{flat_map(key_cont, mapped_cont, comp)}, respectively,
+except that \tcode{c.keys} and \tcode{c.values} are constructed with
+uses-allocator construction\iref{allocator.uses.construction}.
 
+\pnum
+\complexity
+Same as \tcode{flat_map(key_cont, mapped_cont)} and
+\tcode{flat_map(key_cont, mapped_cont, comp)}, respectively.
+\end{itemdescr}
+
+\indexlibraryctor{flat_map}%
+\begin{itemdecl}
+template<class Alloc>
+  flat_map(sorted_unique_t s, const key_container_type& key_cont,
+           const mapped_container_type& mapped_cont, const Alloc& a);
+template<class Alloc>
+  flat_map(sorted_unique_t s, const key_container_type& key_cont,
+           const mapped_container_type& mapped_cont, const key_compare& comp,
+           const Alloc& a);
+\end{itemdecl}
+
+\begin{itemdescr}
 \pnum
 \effects
 Equivalent to \tcode{flat_map(s, key_cont, mapped_cont)} and
@@ -15623,44 +15622,39 @@ Linear.
 
 \indexlibraryctor{flat_map}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_map(const flat_map&, const Allocator& a);
-template<class Allocator>
-  flat_map(flat_map&&, const Allocator& a);
-template<class Allocator>
-  flat_map(const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  explicit flat_map(const Allocator& a);
-template<class InputIterator, class Allocator>
-  flat_map(InputIterator first, InputIterator last, const key_compare& comp, const Allocator& a);
-template<class InputIterator, class Allocator>
-  flat_map(InputIterator first, InputIterator last, const Allocator& a);
-template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-  flat_map(from_range_t, R&& rg, const Allocator& a);
-template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-  flat_map(from_range_t, R&& rg, const key_compare& comp, const Allocator& a);
-template<class InputIterator, class Allocator>
+template<class Alloc>
+  flat_map(const flat_map&, const Alloc& a);
+template<class Alloc>
+  flat_map(flat_map&&, const Alloc& a);
+template<class Alloc>
+  flat_map(const key_compare& comp, const Alloc& a);
+template<class Alloc>
+  explicit flat_map(const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_map(InputIterator first, InputIterator last, const key_compare& comp, const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_map(InputIterator first, InputIterator last, const Alloc& a);
+template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+  flat_map(from_range_t, R&& rg, const Alloc& a);
+template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+  flat_map(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
+template<class InputIterator, class Alloc>
   flat_map(sorted_unique_t, InputIterator first, InputIterator last,
-           const key_compare& comp, const Allocator& a);
-template<class InputIterator, class Allocator>
-  flat_map(sorted_unique_t, InputIterator first, InputIterator last, const Allocator& a);
-template<class Allocator>
-  flat_map(initializer_list<value_type> il, const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  flat_map(initializer_list<value_type> il, const Allocator& a);
-template<class Allocator>
+           const key_compare& comp, const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_map(sorted_unique_t, InputIterator first, InputIterator last, const Alloc& a);
+template<class Alloc>
+  flat_map(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
+template<class Alloc>
+  flat_map(initializer_list<value_type> il, const Alloc& a);
+template<class Alloc>
   flat_map(sorted_unique_t, initializer_list<value_type> il,
-           const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  flat_map(sorted_unique_t, initializer_list<value_type> il, const Allocator& a);
+           const key_compare& comp, const Alloc& a);
+template<class Alloc>
+  flat_map(sorted_unique_t, initializer_list<value_type> il, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\constraints
-\tcode{uses_allocator_v<key_container_type, Allocator>} is \tcode{true} and
-\tcode{uses_allocator_v<mapped_container_type, Allocator>} is \tcode{true}.
-
 \pnum
 \effects
 Equivalent to the corresponding non-allocator constructors

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -16393,6 +16393,9 @@ namespace std {
     // \ref{flat.multimap.cons}, constructors
     flat_multimap() : flat_multimap(key_compare()) { }
 
+    explicit flat_multimap(const key_compare& comp)
+      : c(), compare(comp) { }
+
     flat_multimap(key_container_type key_cont, mapped_container_type mapped_cont,
                   const key_compare& comp = key_compare());
 
@@ -16400,14 +16403,16 @@ namespace std {
                   key_container_type key_cont, mapped_container_type mapped_cont,
                   const key_compare& comp = key_compare());
 
-    explicit flat_multimap(const key_compare& comp)
-      : c(), compare(comp) { }
-
     template<class InputIterator>
       flat_multimap(InputIterator first, InputIterator last,
                     const key_compare& comp = key_compare())
         : c(), compare(comp)
         { insert(first, last); }
+
+    template<class InputIterator>
+      flat_multimap(sorted_equivalent_t s, InputIterator first, InputIterator last,
+                    const key_compare& comp = key_compare())
+        : c(), compare(comp) { insert(s, first, last); }
 
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       flat_multimap(from_range_t fr, R&& rg)
@@ -16415,11 +16420,6 @@ namespace std {
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       flat_multimap(from_range_t, R&& rg, const key_compare& comp)
         : flat_multimap(comp) { insert_range(std::forward<R>(rg)); }
-
-    template<class InputIterator>
-      flat_multimap(sorted_equivalent_t s, InputIterator first, InputIterator last,
-                    const key_compare& comp = key_compare())
-        : c(), compare(comp) { insert(s, first, last); }
 
     flat_multimap(initializer_list<value_type> il, const key_compare& comp = key_compare())
         : flat_multimap(il.begin(), il.end(), comp) { }
@@ -16431,9 +16431,9 @@ namespace std {
     // \ref{flat.multimap.cons.alloc}, constructors with allocators
 
     template<class Alloc>
-      flat_multimap(const flat_multimap&, const Alloc& a);
+      explicit flat_multimap(const Alloc& a);
     template<class Alloc>
-      flat_multimap(flat_multimap&&, const Alloc& a);
+      flat_multimap(const key_compare& comp, const Alloc& a);
     template<class Alloc>
       flat_multimap(const key_container_type& key_cont, const mapped_container_type& mapped_cont,
                     const Alloc& a);
@@ -16448,34 +16448,34 @@ namespace std {
                     const mapped_container_type& mapped_cont,
                     const key_compare& comp, const Alloc& a);
     template<class Alloc>
-      flat_multimap(const key_compare& comp, const Alloc& a);
+      flat_multimap(const flat_multimap&, const Alloc& a);
     template<class Alloc>
-      explicit flat_multimap(const Alloc& a);
+      flat_multimap(flat_multimap&&, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_multimap(InputIterator first, InputIterator last, const Alloc& a);
     template<class InputIterator, class Alloc>
       flat_multimap(InputIterator first, InputIterator last,
                     const key_compare& comp, const Alloc& a);
     template<class InputIterator, class Alloc>
-      flat_multimap(InputIterator first, InputIterator last, const Alloc& a);
+      flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
+                    const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
+                    const key_compare& comp, const Alloc& a);
     template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
       flat_multimap(from_range_t, R&& rg, const Alloc& a);
     template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
       flat_multimap(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
-    template<class InputIterator, class Alloc>
-      flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
-                    const key_compare& comp, const Alloc& a);
-    template<class InputIterator, class Alloc>
-      flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
-                    const Alloc& a);
+    template<class Alloc>
+      flat_multimap(initializer_list<value_type> il, const Alloc& a);
     template<class Alloc>
       flat_multimap(initializer_list<value_type> il, const key_compare& comp,
                     const Alloc& a);
     template<class Alloc>
-      flat_multimap(initializer_list<value_type> il, const Alloc& a);
+      flat_multimap(sorted_equivalent_t, initializer_list<value_type> il, const Alloc& a);
     template<class Alloc>
       flat_multimap(sorted_equivalent_t, initializer_list<value_type> il,
                     const key_compare& comp, const Alloc& a);
-    template<class Alloc>
-      flat_multimap(sorted_equivalent_t, initializer_list<value_type> il, const Alloc& a);
 
     flat_multimap& operator=(initializer_list<value_type>);
 
@@ -16768,37 +16768,37 @@ Linear.
 \indexlibraryctor{flat_multimap}%
 \begin{itemdecl}
 template<class Alloc>
-  flat_multimap(const flat_multimap&, const Alloc& a);
-template<class Alloc>
-  flat_multimap(flat_multimap&&, const Alloc& a);
+  explicit flat_multimap(const Alloc& a);
 template<class Alloc>
   flat_multimap(const key_compare& comp, const Alloc& a);
 template<class Alloc>
-  explicit flat_multimap(const Alloc& a);
+  flat_multimap(const flat_multimap&, const Alloc& a);
+template<class Alloc>
+  flat_multimap(flat_multimap&&, const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_multimap(InputIterator first, InputIterator last, const Alloc& a);
 template<class InputIterator, class Alloc>
   flat_multimap(InputIterator first, InputIterator last, const key_compare& comp,
                 const Alloc& a);
 template<class InputIterator, class Alloc>
-  flat_multimap(InputIterator first, InputIterator last, const Alloc& a);
+  flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
+                const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
+                const key_compare& comp, const Alloc& a);
 template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
   flat_multimap(from_range_t, R&& rg, const Alloc& a);
 template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
   flat_multimap(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
-template<class InputIterator, class Alloc>
-  flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
-                const key_compare& comp, const Alloc& a);
-template<class InputIterator, class Alloc>
-  flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
-                const Alloc& a);
-template<class Alloc>
-  flat_multimap(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
 template<class Alloc>
   flat_multimap(initializer_list<value_type> il, const Alloc& a);
 template<class Alloc>
-  flat_multimap(sorted_equivalent_t, initializer_list<value_type> il,
-                const key_compare& comp, const Alloc& a);
+  flat_multimap(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
 template<class Alloc>
   flat_multimap(sorted_equivalent_t, initializer_list<value_type> il, const Alloc& a);
+template<class Alloc>
+  flat_multimap(sorted_equivalent_t, initializer_list<value_type> il,
+                const key_compare& comp, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -16957,18 +16957,23 @@ namespace std {
     // \ref{flat.set.cons}, constructors
     flat_set() : flat_set(key_compare()) { }
 
+    explicit flat_set(const key_compare& comp)
+      : @\exposid{c}@(), @\exposid{compare}@(comp) { }
+
     explicit flat_set(container_type cont, const key_compare& comp = key_compare());
 
     flat_set(sorted_unique_t, container_type cont, const key_compare& comp = key_compare())
       : @\exposid{c}@(std::move(cont)), @\exposid{compare}@(comp) { }
 
-    explicit flat_set(const key_compare& comp)
-      : @\exposid{c}@(), @\exposid{compare}@(comp) { }
-
     template<class InputIterator>
       flat_set(InputIterator first, InputIterator last, const key_compare& comp = key_compare())
         : @\exposid{c}@(), @\exposid{compare}@(comp)
         { insert(first, last); }
+
+    template<class InputIterator>
+      flat_set(sorted_unique_t, InputIterator first, InputIterator last,
+               const key_compare& comp = key_compare())
+        : @\exposid{c}@(first, last), @\exposid{compare}@(comp) { }
 
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       flat_set(from_range_t fr, R&& rg)
@@ -16977,11 +16982,6 @@ namespace std {
       flat_set(from_range_t, R&& rg, const key_compare& comp)
         : flat_set(comp)
         { insert_range(std::forward<R>(rg)); }
-
-    template<class InputIterator>
-      flat_set(sorted_unique_t, InputIterator first, InputIterator last,
-               const key_compare& comp = key_compare())
-        : @\exposid{c}@(first, last), @\exposid{compare}@(comp) { }
 
     flat_set(initializer_list<value_type> il, const key_compare& comp = key_compare())
         : flat_set(il.begin(), il.end(), comp) { }
@@ -16993,9 +16993,9 @@ namespace std {
     // \ref{flat.set.cons.alloc}, constructors with allocators
 
     template<class Alloc>
-      flat_set(const flat_set&, const Alloc& a);
+      explicit flat_set(const Alloc& a);
     template<class Alloc>
-      flat_set(flat_set&&, const Alloc& a);
+      flat_set(const key_compare& comp, const Alloc& a);
     template<class Alloc>
       flat_set(const container_type& cont, const Alloc& a);
     template<class Alloc>
@@ -17006,32 +17006,32 @@ namespace std {
       flat_set(sorted_unique_t, const container_type& cont,
                const key_compare& comp, const Alloc& a);
     template<class Alloc>
-      flat_set(const key_compare& comp, const Alloc& a);
+      flat_set(const flat_set&, const Alloc& a);
     template<class Alloc>
-      explicit flat_set(const Alloc& a);
+      flat_set(flat_set&&, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_set(InputIterator first, InputIterator last, const Alloc& a);
     template<class InputIterator, class Alloc>
       flat_set(InputIterator first, InputIterator last,
                const key_compare& comp, const Alloc& a);
     template<class InputIterator, class Alloc>
-      flat_set(InputIterator first, InputIterator last, const Alloc& a);
+      flat_set(sorted_unique_t, InputIterator first, InputIterator last, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_set(sorted_unique_t, InputIterator first, InputIterator last,
+               const key_compare& comp, const Alloc& a);
     template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
       flat_set(from_range_t, R&& rg, const Alloc& a);
     template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
        flat_set(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
-    template<class InputIterator, class Alloc>
-      flat_set(sorted_unique_t, InputIterator first, InputIterator last,
-               const key_compare& comp, const Alloc& a);
-    template<class InputIterator, class Alloc>
-      flat_set(sorted_unique_t, InputIterator first, InputIterator last, const Alloc& a);
-    template<class Alloc>
-      flat_set(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
     template<class Alloc>
       flat_set(initializer_list<value_type> il, const Alloc& a);
     template<class Alloc>
-      flat_set(sorted_unique_t, initializer_list<value_type> il,
-               const key_compare& comp, const Alloc& a);
+      flat_set(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
     template<class Alloc>
       flat_set(sorted_unique_t, initializer_list<value_type> il, const Alloc& a);
+    template<class Alloc>
+      flat_set(sorted_unique_t, initializer_list<value_type> il,
+               const key_compare& comp, const Alloc& a);
 
     flat_set& operator=(initializer_list<value_type>);
 
@@ -17272,35 +17272,35 @@ Linear.
 \indexlibraryctor{flat_set}%
 \begin{itemdecl}
 template<class Alloc>
-  flat_set(const flat_set&, const Alloc& a);
-template<class Alloc>
-  flat_set(flat_set&&, const Alloc& a);
+  explicit flat_set(const Alloc& a);
 template<class Alloc>
   flat_set(const key_compare& comp, const Alloc& a);
 template<class Alloc>
-  explicit flat_set(const Alloc& a);
+  flat_set(const flat_set&, const Alloc& a);
+template<class Alloc>
+  flat_set(flat_set&&, const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_set(InputIterator first, InputIterator last, const Alloc& a);
 template<class InputIterator, class Alloc>
   flat_set(InputIterator first, InputIterator last, const key_compare& comp, const Alloc& a);
 template<class InputIterator, class Alloc>
-  flat_set(InputIterator first, InputIterator last, const Alloc& a);
+  flat_set(sorted_unique_t, InputIterator first, InputIterator last, const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_set(sorted_unique_t, InputIterator first, InputIterator last,
+           const key_compare& comp, const Alloc& a);
 template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
   flat_set(from_range_t, R&& rg, const Alloc& a);
 template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
   flat_set(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
-template<class InputIterator, class Alloc>
-  flat_set(sorted_unique_t, InputIterator first, InputIterator last,
-           const key_compare& comp, const Alloc& a);
-template<class InputIterator, class Alloc>
-  flat_set(sorted_unique_t, InputIterator first, InputIterator last, const Alloc& a);
-template<class Alloc>
-  flat_set(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
 template<class Alloc>
   flat_set(initializer_list<value_type> il, const Alloc& a);
 template<class Alloc>
-  flat_set(sorted_unique_t, initializer_list<value_type> il,
-           const key_compare& comp, const Alloc& a);
+  flat_set(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
 template<class Alloc>
   flat_set(sorted_unique_t, initializer_list<value_type> il, const Alloc& a);
+template<class Alloc>
+  flat_set(sorted_unique_t, initializer_list<value_type> il,
+           const key_compare& comp, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -17620,20 +17620,25 @@ namespace std {
     // \ref{flat.multiset.cons}, constructors
     flat_multiset() : flat_multiset(key_compare()) { }
 
+    explicit flat_multiset(const key_compare& comp)
+      : @\exposid{c}@(), @\exposid{compare}@(comp) { }
+
     explicit flat_multiset(container_type cont, const key_compare& comp = key_compare());
 
     flat_multiset(sorted_equivalent_t, container_type cont,
                   const key_compare& comp = key_compare())
       : @\exposid{c}@(std::move(cont)), @\exposid{compare}@(comp) { }
 
-    explicit flat_multiset(const key_compare& comp)
-      : @\exposid{c}@(), @\exposid{compare}@(comp) { }
-
     template<class InputIterator>
       flat_multiset(InputIterator first, InputIterator last,
                     const key_compare& comp = key_compare())
         : @\exposid{c}@(), @\exposid{compare}@(comp)
         { insert(first, last); }
+
+    template<class InputIterator>
+      flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
+                    const key_compare& comp = key_compare())
+        : @\exposid{c}@(first, last), @\exposid{compare}@(comp) { }
 
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       flat_multiset(from_range_t fr, R&& rg)
@@ -17642,11 +17647,6 @@ namespace std {
       flat_multiset(from_range_t, R&& rg, const key_compare& comp)
         : flat_multiset(comp)
         { insert_range(std::forward<R>(rg)); }
-
-    template<class InputIterator>
-      flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
-                    const key_compare& comp = key_compare())
-        : @\exposid{c}@(first, last), @\exposid{compare}@(comp) { }
 
     flat_multiset(initializer_list<value_type> il, const key_compare& comp = key_compare())
       : flat_multiset(il.begin(), il.end(), comp) { }
@@ -17658,9 +17658,9 @@ namespace std {
     // \ref{flat.multiset.cons.alloc}, constructors with allocators
 
     template<class Alloc>
-      flat_multiset(const flat_multiset&, const Alloc& a);
+      explicit flat_multiset(const Alloc& a);
     template<class Alloc>
-      flat_multiset(flat_multiset&&, const Alloc& a);
+      flat_multiset(const key_compare& comp, const Alloc& a);
     template<class Alloc>
       flat_multiset(const container_type& cont, const Alloc& a);
     template<class Alloc>
@@ -17671,34 +17671,34 @@ namespace std {
       flat_multiset(sorted_equivalent_t, const container_type& cont,
                     const key_compare& comp, const Alloc& a);
     template<class Alloc>
-      flat_multiset(const key_compare& comp, const Alloc& a);
+      flat_multiset(const flat_multiset&, const Alloc& a);
     template<class Alloc>
-      explicit flat_multiset(const Alloc& a);
+      flat_multiset(flat_multiset&&, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_multiset(InputIterator first, InputIterator last, const Alloc& a);
     template<class InputIterator, class Alloc>
       flat_multiset(InputIterator first, InputIterator last,
                     const key_compare& comp, const Alloc& a);
     template<class InputIterator, class Alloc>
-      flat_multiset(InputIterator first, InputIterator last, const Alloc& a);
+      flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
+                    const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
+                    const key_compare& comp, const Alloc& a);
     template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
       flat_multiset(from_range_t, R&& rg, const Alloc& a);
     template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
       flat_multiset(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
-    template<class InputIterator, class Alloc>
-      flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
-                    const key_compare& comp, const Alloc& a);
-    template<class InputIterator, class Alloc>
-      flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
-                    const Alloc& a);
+    template<class Alloc>
+      flat_multiset(initializer_list<value_type> il, const Alloc& a);
     template<class Alloc>
       flat_multiset(initializer_list<value_type> il, const key_compare& comp,
                     const Alloc& a);
     template<class Alloc>
-      flat_multiset(initializer_list<value_type> il, const Alloc& a);
+      flat_multiset(sorted_equivalent_t, initializer_list<value_type> il, const Alloc& a);
     template<class Alloc>
       flat_multiset(sorted_equivalent_t, initializer_list<value_type> il,
                     const key_compare& comp, const Alloc& a);
-    template<class Alloc>
-      flat_multiset(sorted_equivalent_t, initializer_list<value_type> il, const Alloc& a);
 
     flat_multiset& operator=(initializer_list<value_type>);
 
@@ -17937,36 +17937,36 @@ Linear.
 \indexlibraryctor{flat_multiset}%
 \begin{itemdecl}
 template<class Alloc>
-  flat_multiset(const flat_multiset&, const Alloc& a);
-template<class Alloc>
-  flat_multiset(flat_multiset&&, const Alloc& a);
+  explicit flat_multiset(const Alloc& a);
 template<class Alloc>
   flat_multiset(const key_compare& comp, const Alloc& a);
 template<class Alloc>
-  explicit flat_multiset(const Alloc& a);
+  flat_multiset(const flat_multiset&, const Alloc& a);
+template<class Alloc>
+  flat_multiset(flat_multiset&&, const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_multiset(InputIterator first, InputIterator last, const Alloc& a);
 template<class InputIterator, class Alloc>
   flat_multiset(InputIterator first, InputIterator last,
                 const key_compare& comp, const Alloc& a);
 template<class InputIterator, class Alloc>
-  flat_multiset(InputIterator first, InputIterator last, const Alloc& a);
+  flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last, const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
+                const key_compare& comp, const Alloc& a);
 template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
   flat_multiset(from_range_t, R&& rg, const Alloc& a);
 template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
   flat_multiset(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
-template<class InputIterator, class Alloc>
-  flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
-                const key_compare& comp, const Alloc& a);
-template<class InputIterator, class Alloc>
-  flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last, const Alloc& a);
-template<class Alloc>
-  flat_multiset(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
 template<class Alloc>
   flat_multiset(initializer_list<value_type> il, const Alloc& a);
 template<class Alloc>
-  flat_multiset(sorted_equivalent_t, initializer_list<value_type> il,
-                const key_compare& comp, const Alloc& a);
+  flat_multiset(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
 template<class Alloc>
   flat_multiset(sorted_equivalent_t, initializer_list<value_type> il, const Alloc& a);
+template<class Alloc>
+  flat_multiset(sorted_equivalent_t, initializer_list<value_type> il,
+                const key_compare& comp, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -17620,83 +17620,85 @@ namespace std {
     // \ref{flat.multiset.cons}, constructors
     flat_multiset() : flat_multiset(key_compare()) { }
 
-    template<class Allocator>
-      flat_multiset(const flat_multiset&, const Allocator& a);
-    template<class Allocator>
-      flat_multiset(flat_multiset&&, const Allocator& a);
-
     explicit flat_multiset(container_type cont, const key_compare& comp = key_compare());
-    template<class Allocator>
-      flat_multiset(const container_type& cont, const Allocator& a);
-    template<class Allocator>
-      flat_multiset(const container_type& cont, const key_compare& comp, const Allocator& a);
 
     flat_multiset(sorted_equivalent_t, container_type cont,
                   const key_compare& comp = key_compare())
       : @\exposid{c}@(std::move(cont)), @\exposid{compare}@(comp) { }
-    template<class Allocator>
-      flat_multiset(sorted_equivalent_t, const container_type& cont, const Allocator& a);
-    template<class Allocator>
-      flat_multiset(sorted_equivalent_t, const container_type& cont,
-                    const key_compare& comp, const Allocator& a);
 
     explicit flat_multiset(const key_compare& comp)
       : @\exposid{c}@(), @\exposid{compare}@(comp) { }
-    template<class Allocator>
-      flat_multiset(const key_compare& comp, const Allocator& a);
-    template<class Allocator>
-      explicit flat_multiset(const Allocator& a);
 
     template<class InputIterator>
       flat_multiset(InputIterator first, InputIterator last,
                     const key_compare& comp = key_compare())
         : @\exposid{c}@(), @\exposid{compare}@(comp)
         { insert(first, last); }
-    template<class InputIterator, class Allocator>
-      flat_multiset(InputIterator first, InputIterator last,
-                    const key_compare& comp, const Allocator& a);
-    template<class InputIterator, class Allocator>
-      flat_multiset(InputIterator first, InputIterator last, const Allocator& a);
 
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       flat_multiset(from_range_t fr, R&& rg)
         : flat_multiset(fr, std::forward<R>(rg), key_compare()) { }
-    template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-      flat_multiset(from_range_t, R&& rg, const Allocator& a);
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       flat_multiset(from_range_t, R&& rg, const key_compare& comp)
         : flat_multiset(comp)
         { insert_range(std::forward<R>(rg)); }
-    template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-      flat_multiset(from_range_t, R&& rg, const key_compare& comp, const Allocator& a);
 
     template<class InputIterator>
       flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
                     const key_compare& comp = key_compare())
         : @\exposid{c}@(first, last), @\exposid{compare}@(comp) { }
-    template<class InputIterator, class Allocator>
-      flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
-                    const key_compare& comp, const Allocator& a);
-    template<class InputIterator, class Allocator>
-      flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
-                    const Allocator& a);
 
     flat_multiset(initializer_list<value_type> il, const key_compare& comp = key_compare())
       : flat_multiset(il.begin(), il.end(), comp) { }
-    template<class Allocator>
-      flat_multiset(initializer_list<value_type> il, const key_compare& comp,
-                    const Allocator& a);
-    template<class Allocator>
-      flat_multiset(initializer_list<value_type> il, const Allocator& a);
 
     flat_multiset(sorted_equivalent_t s, initializer_list<value_type> il,
                   const key_compare& comp = key_compare())
         : flat_multiset(s, il.begin(), il.end(), comp) { }
-    template<class Allocator>
+
+    // \ref{flat.multiset.cons.alloc}, constructors with allocators
+
+    template<class Alloc>
+      flat_multiset(const flat_multiset&, const Alloc& a);
+    template<class Alloc>
+      flat_multiset(flat_multiset&&, const Alloc& a);
+    template<class Alloc>
+      flat_multiset(const container_type& cont, const Alloc& a);
+    template<class Alloc>
+      flat_multiset(const container_type& cont, const key_compare& comp, const Alloc& a);
+    template<class Alloc>
+      flat_multiset(sorted_equivalent_t, const container_type& cont, const Alloc& a);
+    template<class Alloc>
+      flat_multiset(sorted_equivalent_t, const container_type& cont,
+                    const key_compare& comp, const Alloc& a);
+    template<class Alloc>
+      flat_multiset(const key_compare& comp, const Alloc& a);
+    template<class Alloc>
+      explicit flat_multiset(const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_multiset(InputIterator first, InputIterator last,
+                    const key_compare& comp, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_multiset(InputIterator first, InputIterator last, const Alloc& a);
+    template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+      flat_multiset(from_range_t, R&& rg, const Alloc& a);
+    template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+      flat_multiset(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
+                    const key_compare& comp, const Alloc& a);
+    template<class InputIterator, class Alloc>
+      flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
+                    const Alloc& a);
+    template<class Alloc>
+      flat_multiset(initializer_list<value_type> il, const key_compare& comp,
+                    const Alloc& a);
+    template<class Alloc>
+      flat_multiset(initializer_list<value_type> il, const Alloc& a);
+    template<class Alloc>
       flat_multiset(sorted_equivalent_t, initializer_list<value_type> il,
-                    const key_compare& comp, const Allocator& a);
-    template<class Allocator>
-      flat_multiset(sorted_equivalent_t, initializer_list<value_type> il, const Allocator& a);
+                    const key_compare& comp, const Alloc& a);
+    template<class Alloc>
+      flat_multiset(sorted_equivalent_t, initializer_list<value_type> il, const Alloc& a);
 
     flat_multiset& operator=(initializer_list<value_type>);
 
@@ -17878,23 +17880,25 @@ sorts the range \range{begin()}{end()} with respect to \exposid{compare}.
 
 \pnum
 \complexity
-Linear in $N$ if \tcode{cont} is sorted with respect to \exposid{compare} and
+Linear in $N$ if \tcode{cont} is already sorted with respect to \exposid{compare} and
 otherwise $N \log N$, where $N$ is the value of \tcode{cont.size()} before this call.
 \end{itemdescr}
 
+\rSec3[flat.multiset.cons.alloc]{Constructors with allocators}
+
+\pnum
+The constructors in this subclause shall not participate in overload resolution
+unless \tcode{uses_allocator_v<container_type, Alloc>} is \tcode{true}.
+
 \indexlibraryctor{flat_multiset}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_multiset(const container_type& cont, const Allocator& a);
-template<class Allocator>
-  flat_multiset(const container_type& cont, const key_compare& comp, const Allocator& a);
+template<class Alloc>
+  flat_multiset(const container_type& cont, const Alloc& a);
+template<class Alloc>
+  flat_multiset(const container_type& cont, const key_compare& comp, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\constraints
-\tcode{uses_allocator_v<container_type, Allocator>} is \tcode{true}.
-
 \pnum
 \effects
 Equivalent to \tcode{flat_multiset(cont)} and
@@ -17910,18 +17914,14 @@ Same as \tcode{flat_multiset(cont)} and
 
 \indexlibraryctor{flat_multiset}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_multiset(sorted_equivalent_t s, const container_type& cont, const Allocator& a);
-template<class Allocator>
+template<class Alloc>
+  flat_multiset(sorted_equivalent_t s, const container_type& cont, const Alloc& a);
+template<class Alloc>
   flat_multiset(sorted_equivalent_t s, const container_type& cont,
-                const key_compare& comp, const Allocator& a);
+                const key_compare& comp, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\constraints
-\tcode{uses_allocator_v<container_type, Allocator>} is \tcode{true}.
-
 \pnum
 \effects
 Equivalent to \tcode{flat_multiset(s, cont)} and
@@ -17936,44 +17936,40 @@ Linear.
 
 \indexlibraryctor{flat_multiset}%
 \begin{itemdecl}
-template<class Allocator>
-  flat_multiset(const flat_multiset&, const Allocator& a);
-template<class Allocator>
-  flat_multiset(flat_multiset&&, const Allocator& a);
-template<class Allocator>
-  flat_multiset(const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  explicit flat_multiset(const Allocator& a);
-template<class InputIterator, class Allocator>
+template<class Alloc>
+  flat_multiset(const flat_multiset&, const Alloc& a);
+template<class Alloc>
+  flat_multiset(flat_multiset&&, const Alloc& a);
+template<class Alloc>
+  flat_multiset(const key_compare& comp, const Alloc& a);
+template<class Alloc>
+  explicit flat_multiset(const Alloc& a);
+template<class InputIterator, class Alloc>
   flat_multiset(InputIterator first, InputIterator last,
-                const key_compare& comp, const Allocator& a);
-template<class InputIterator, class Allocator>
-  flat_multiset(InputIterator first, InputIterator last, const Allocator& a);
-template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-  flat_multiset(from_range_t, R&& rg, const Allocator& a);
-template<@\exposconcept{container-compatible-range}@<value_type> R, class Allocator>
-  flat_multiset(from_range_t, R&& rg, const key_compare& comp, const Allocator& a);
-template<class InputIterator, class Allocator>
+                const key_compare& comp, const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_multiset(InputIterator first, InputIterator last, const Alloc& a);
+template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+  flat_multiset(from_range_t, R&& rg, const Alloc& a);
+template<@\exposconcept{container-compatible-range}@<value_type> R, class Alloc>
+  flat_multiset(from_range_t, R&& rg, const key_compare& comp, const Alloc& a);
+template<class InputIterator, class Alloc>
   flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
-                const key_compare& comp, const Allocator& a);
-template<class InputIterator, class Allocator>
-  flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last, const Allocator& a);
-template<class Allocator>
-  flat_multiset(initializer_list<value_type> il, const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  flat_multiset(initializer_list<value_type> il, const Allocator& a);
-template<class Allocator>
+                const key_compare& comp, const Alloc& a);
+template<class InputIterator, class Alloc>
+  flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last, const Alloc& a);
+template<class Alloc>
+  flat_multiset(initializer_list<value_type> il, const key_compare& comp, const Alloc& a);
+template<class Alloc>
+  flat_multiset(initializer_list<value_type> il, const Alloc& a);
+template<class Alloc>
   flat_multiset(sorted_equivalent_t, initializer_list<value_type> il,
-                const key_compare& comp, const Allocator& a);
-template<class Allocator>
-  flat_multiset(sorted_equivalent_t, initializer_list<value_type> il, const Allocator& a);
+                const key_compare& comp, const Alloc& a);
+template<class Alloc>
+  flat_multiset(sorted_equivalent_t, initializer_list<value_type> il, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\constraints
-\tcode{uses_allocator_v<container_type, Allocator>} is \tcode{true}.
-
 \pnum
 \effects
 Equivalent to the corresponding non-allocator constructors


### PR DESCRIPTION
LWG reviewed this wording in Varna, approved it as suitably editorial ([poll 7–0–1](https://wiki.edg.com/bin/view/Wg21varna/P2767-20230616-LM)), and we agreed that I should now submit it as a PR for @jwakely to look at.

This PR right now is structured as eight commits: two commits per container adaptor. For each adaptor, the first commit is literally the wording published in [P2767R0 §3](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2767r0.html#editorial-cons-alloc) and reviewed live in Varna. The second commit is amendments requested by LWG, to put the constructor overload sets in the traditional order (e.g. default constructor at the top). These second commits are editorial, and they're improvements over the status quo, and they were explicitly requested by LWG, but they _have not been published in a P-paper, and have not been reviewed yet._ Please see if they match your expectation!

Also, of course, I may have made typos in my transcription of even the first commits, so someone (@jwakely presumably) should still look through this and not just merge it blindly. Duh. :)

I expect this PR will be squash-merged with an updated commit message of some sort, and am happy to let whoever merges it figure that part out. Please let me know if you want me on my side to squash it and/or reword the commit message.