### PR TITLE
[string.view], [string.view.comparison] Refactor string_view comparis…

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -1613,11 +1613,6 @@ A sample conforming implementation for \tcode{operator==} would be:
 \begin{codeblock}
 template<class charT, class traits>
   constexpr bool operator==(basic_string_view<charT, traits> lhs,
-                            basic_string_view<charT, traits> rhs) noexcept {
-    return lhs.compare(rhs) == 0;
-  }
-template<class charT, class traits>
-  constexpr bool operator==(basic_string_view<charT, traits> lhs,
                             type_identity_t<basic_string_view<charT, traits>> rhs) noexcept {
     return lhs.compare(rhs) == 0;
   }


### PR DESCRIPTION
…ons, exploiting rewritten candidates

With the current semantics of rewritten candidates for the comparison operators, it is superfluous to specify both overloads

```
  operator==(basic_string_view, basic_string_view)
  operator==(basic_string_view, type_identity_t<basic_string_view>)
```

(ditto for `operator<=>`).

The second overload is necessary in order to implement the "sufficient additional overloads" part of [string.view.comparison], but it is also sufficient, as all the following cases

*  `sv == sv`
*  `sv == convertible_to_sv`
*  `convertible_to_sv == sv`

can in fact use it (directly, or after being rewritten with the arguments swapped).

The reason why we still do have both operators seems to be historical; there is an explanation offered here https://stackoverflow.com/a/70851101 .

Basically, there were _3_ overloads before a bunch of papers regarding `operator<=>` and `operator==` were merged:

1. `op==(sv, sv)` to deal with `sv == sv`;
2. `op==(sv, type_identity_t<sv>)` and
3. `op==(type_identity_t<sv>, sv)` to deal with `sv == convertible` and viceversa.

Overload n.1 was necessary because with only 2. and 3. a call like `sv == sv` would be ambiguous. With the adoption of the rewriting rules, overload n.3 has been dropped, without realizing that overload n.1 would then become redundant.

This commit removes `op==(sv,sv)` from the note that suggests how to implement the "sufficient additional overloads". I've left the overload in the synopsis untouched, however, under the assumption that its presence there doesn't mean that an implementation *must* provide it.