### PR TITLE
P2874R2 Mandating Annex D

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -1,8 +1,6 @@
 %!TEX root = std.tex
 \normannex{depr}{Compatibility features}
 
-\newcommand{\requires}{\Fundesc{Requires}}
-
 \rSec1[depr.general]{General}
 
 \pnum
@@ -204,20 +202,6 @@ The use of the keyword \keyword{template}
 before the qualified name of a class or alias template
 without a template argument list is deprecated\iref{temp.names}.
 
-\rSec1[depr.res.on.required]{Requires paragraph}
-
-\pnum
-In addition to the elements specified in \ref{structure.specifications},
-descriptions of function semantics may also contain a \requires element
-to denote the preconditions for calling a function.
-
-\pnum
-\indextext{restriction}%
-Violation of any preconditions specified in a function's \requires element
-results in undefined behavior
-unless the function's \throws element
-specifies throwing an exception when the precondition is violated.
-
 \rSec1[depr.numeric.limits.has.denorm]{\tcode{has_denorm} members in \tcode{numeric_limits}}
 
 \pnum
@@ -306,8 +290,8 @@ template<class T> bool operator!=(const T& x, const T& y);
 
 \begin{itemdescr}
 \pnum
-\requires
-Type \tcode{T} is \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable}).
+\expects
+\tcode{T} meets the \oldconcept{EqualityComparable} requirements (\tref{cpp17.equalitycomparable}).
 
 \pnum
 \returns
@@ -321,8 +305,8 @@ template<class T> bool operator>(const T& x, const T& y);
 
 \begin{itemdescr}
 \pnum
-\requires
-Type \tcode{T} is \oldconcept{LessThanComparable} (\tref{cpp17.lessthancomparable}).
+\expects
+\tcode{T} meets the \oldconcept{LessThanComparable} requirements (\tref{cpp17.lessthancomparable}).
 
 \pnum
 \returns
@@ -336,8 +320,8 @@ template<class T> bool operator<=(const T& x, const T& y);
 
 \begin{itemdescr}
 \pnum
-\requires
-Type \tcode{T} is \oldconcept{LessThanComparable} (\tref{cpp17.lessthancomparable}).
+\expects
+\tcode{T} meets the \oldconcept{LessThanComparable} requirements (\tref{cpp17.lessthancomparable}).
 
 \pnum
 \returns
@@ -351,8 +335,8 @@ template<class T> bool operator>=(const T& x, const T& y);
 
 \begin{itemdescr}
 \pnum
-\requires
-Type \tcode{T} is \oldconcept{LessThanComparable} (\tref{cpp17.lessthancomparable}).
+\expects
+\tcode{T} meets the \oldconcept{LessThanComparable} requirements (\tref{cpp17.lessthancomparable}).
 
 \pnum
 \returns
@@ -1490,6 +1474,13 @@ The behavior of a program that adds specializations for
 any of the templates defined in this subclause is undefined,
 unless explicitly permitted by the specification of the corresponding template.
 
+\pnum
+\indextext{POD}%
+A \term{POD class} is a class that is both a trivial class and a
+standard-layout class, and has no non-static data members of type non-POD class
+(or array thereof). A \term{POD type} is a scalar type, a POD class, an array
+of such a type, or a cv-qualified version of one of these types.
+
 \indexlibraryglobal{is_pod}%
 \begin{itemdecl}
 template<class T> struct is_pod;
@@ -1497,19 +1488,15 @@ template<class T> struct is_pod;
 
 \begin{itemdescr}
 \pnum
-\requires
+\expects
 \tcode{remove_all_extents_t<T>} shall be a complete type or \cv{} \keyword{void}.
 
 \pnum
+\remarks
 \tcode{is_pod<T>} is a \oldconcept{UnaryTypeTrait}\iref{meta.rqmts}
 with a base characteristic of \tcode{true_type}
 if \tcode{T} is a POD type,
 and \tcode{false_type} otherwise.
-\indextext{POD}%
-A POD class is a class that is both a trivial class and a standard-layout class,
-and has no non-static data members of type non-POD class (or array thereof).
-A POD type is a scalar type, a POD class, an array of such a type,
-or a cv-qualified version of one of these types.
 
 \pnum
 \begin{note}
@@ -1832,7 +1819,8 @@ template<class T> bool atomic_is_lock_free(const shared_ptr<T>* p);
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{p} shall not be null.
+\expects
+\tcode{p} is not null.
 
 \pnum
 \returns
@@ -1850,7 +1838,8 @@ template<class T> shared_ptr<T> atomic_load(const shared_ptr<T>* p);
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{p} shall not be null.
+\expects
+\tcode{p} is not null.
 
 \pnum
 \returns
@@ -1868,10 +1857,9 @@ template<class T> shared_ptr<T> atomic_load_explicit(const shared_ptr<T>* p, mem
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{p} shall not be null.
-
-\pnum
-\requires \tcode{mo} shall not be \tcode{memory_order::release} or \tcode{memory_order::acq_rel}.
+\expects
+\tcode{p} is not null.
+\tcode{mo} is neither \tcode{memory_order::release} nor \tcode{memory_order::acq_rel}.
 
 \pnum
 \returns
@@ -1889,7 +1877,8 @@ template<class T> void atomic_store(shared_ptr<T>* p, shared_ptr<T> r);
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{p} shall not be null.
+\expects
+\tcode{p} is not null.
 
 \pnum
 \effects
@@ -1907,10 +1896,9 @@ template<class T> void atomic_store_explicit(shared_ptr<T>* p, shared_ptr<T> r, 
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{p} shall not be null.
-
-\pnum
-\requires \tcode{mo} shall not be \tcode{memory_order::acquire} or \tcode{memory_order::acq_rel}.
+\expects
+\tcode{p} is not null.
+\tcode{mo} is neither \tcode{memory_order::acquire} nor \tcode{memory_order::acq_rel}.
 
 \pnum
 \effects
@@ -1928,7 +1916,8 @@ template<class T> shared_ptr<T> atomic_exchange(shared_ptr<T>* p, shared_ptr<T> 
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{p} shall not be null.
+\expects
+\tcode{p} is not null.
 
 \pnum
 \returns
@@ -1947,7 +1936,8 @@ template<class T>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{p} shall not be null.
+\expects
+\tcode{p} is not null.
 
 \pnum
 \effects
@@ -1970,7 +1960,8 @@ template<class T>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{p} shall not be null and \tcode{v} shall not be null.
+\expects
+\tcode{p} is not null and \tcode{v} is not null.
 
 \pnum
 \returns
@@ -2013,8 +2004,9 @@ template<class T>
 
 \begin{itemdescr}
 \pnum
-\requires \tcode{p} shall not be null and \tcode{v} shall not be null.
-The \tcode{failure} argument shall not be \tcode{memory_order::release} nor
+\expects
+\tcode{p} is not null and \tcode{v} is not null.
+The \tcode{failure} argument is neither \tcode{memory_order::release} nor
 \tcode{memory_order::acq_rel}.
 
 \pnum
@@ -2226,7 +2218,7 @@ conversion facet \tcode{codecvt_utf8} to output to \tcode{cout} a UTF-8
 multibyte sequence corresponding to a wide string, but you don't want to
 alter the locale for \tcode{cout}, you can write something like:
 \begin{codeblock}
-wstring_convert<std::codecvt_utf8<wchar_t>> myconv;
+std::wstring_convert<std::codecvt_utf8<wchar_t>> myconv;
 std::string mbstring = myconv.to_bytes(L"Hello\n");
 std::cout << mbstring;
 \end{codeblock}
@@ -2329,11 +2321,11 @@ wide_string from_bytes(const char* first, const char* last);
 \begin{itemdescr}
 \pnum
 \effects
-The first member function shall convert the single-element sequence \tcode{byte} to a
-wide string. The second member function shall convert the null-terminated
+The first member function converts the single-element sequence \tcode{byte} to a
+wide string. The second member function converts the null-terminated
 sequence beginning at \tcode{ptr} to a wide string. The third member function
-shall convert the sequence stored in \tcode{str} to a wide string. The fourth member
-function shall convert the sequence defined by the range \range{first}{last} to a
+converts the sequence stored in \tcode{str} to a wide string. The fourth member
+function converts the sequence defined by the range \range{first}{last} to a
 wide string.
 
 \pnum
@@ -2341,17 +2333,17 @@ In all cases:
 
 \begin{itemize}
 \item If the \tcode{cvtstate} object was not constructed with an explicit value, it
-shall be set to its default value (the initial conversion state) before the
-conversion begins. Otherwise it shall be left unchanged.
+is set to its default value (the initial conversion state) before the
+conversion begins. Otherwise it is left unchanged.
 
-\item The number of input elements successfully converted shall be stored in \tcode{cvtcount}.
+\item The number of input elements successfully converted is stored in \tcode{cvtcount}.
 \end{itemize}
 
 \pnum
 \returns
-If no conversion error occurs, the member function shall return the converted wide string.
+If no conversion error occurs, the member function returns the converted wide string.
 Otherwise, if the object was constructed with a wide-error string, the
-member function shall return the wide-error string.
+member function returns the wide-error string.
 Otherwise, the member function throws an object of class \tcode{range_error}.
 \end{itemdescr}
 
@@ -2377,30 +2369,29 @@ byte_string to_bytes(const Elem* first, const Elem* last);
 \begin{itemdescr}
 \pnum
 \effects
-The first member function shall convert the single-element sequence \tcode{wchar} to a byte string.
-The second member function shall convert the null-terminated sequence beginning at \tcode{wptr} to
-a byte string. The third member function shall convert the sequence stored in \tcode{wstr} to a
-byte string. The fourth member function shall convert the sequence defined by the
+The first member function converts the single-element sequence \tcode{wchar} to a byte string.
+The second member function converts the null-terminated sequence beginning at \tcode{wptr} to
+a byte string. The third member function converts the sequence stored in \tcode{wstr} to a
+byte string. The fourth member function converts the sequence defined by the
 range \range{first}{last} to a byte string.
 
 \pnum
 In all cases:
 
 \begin{itemize}
-\item If the \tcode{cvtstate} object was not constructed with an explicit value, it
-shall be
-set to its default value (the initial conversion state) before the
-conversion begins. Otherwise it shall be left unchanged.
-\item The number of input elements successfully converted shall be stored
+\item If the \tcode{cvtstate} object was not constructed with an explicit value,
+it is set to its default value (the initial conversion state) before the
+conversion begins. Otherwise it is left unchanged.
+\item The number of input elements successfully converted is stored
 in \tcode{cvtcount}.
 \end{itemize}
 
 \pnum
 \returns
-If no conversion error occurs, the member function shall return the converted byte string.
+If no conversion error occurs, the member function returns the converted byte string.
 Otherwise, if the object was constructed with a byte-error string, the
-member function shall return the byte-error string.
-Otherwise, the member function shall throw an object of class \tcode{range_error}.
+member function returns the byte-error string.
+Otherwise, the member function throws an object of class \tcode{range_error}.
 \end{itemdescr}
 
 \indexlibraryctor{wstring_convert}%
@@ -2413,20 +2404,20 @@ explicit wstring_convert(const byte_string& byte_err,
 
 \begin{itemdescr}
 \pnum
-\requires
-For the first and second constructors, \tcode{pcvt != nullptr}.
+\expects
+For the first and second constructors, \tcode{pcvt} is not null.
 
 \pnum
 \effects
-The first constructor shall store \tcode{pcvt} in \tcode{cvtptr} and
+The first constructor stores \tcode{pcvt} in \tcode{cvtptr} and
 default values in \tcode{cvtstate}, \tcode{byte_err_string}, and
 \tcode{wide_err_string}.
-The second constructor shall store \tcode{pcvt} in \tcode{cvtptr},
+The second constructor stores \tcode{pcvt} in \tcode{cvtptr},
 \tcode{state} in \tcode{cvtstate}, and default values in
 \tcode{byte_err_string} and \tcode{wide_err_string}; moreover the
-stored state shall be retained between calls to \tcode{from_bytes} and
+stored state is retained between calls to \tcode{from_bytes} and
 \tcode{to_bytes}.
-The third constructor shall store \tcode{new Codecvt} in \tcode{cvtptr},
+The third constructor stores \tcode{new Codecvt} in \tcode{cvtptr},
 \tcode{state_type()} in \tcode{cvtstate}, \tcode{byte_err}
 in \tcode{byte_err_string}, and \tcode{wide_err} in
 \tcode{wide_err_string}.
@@ -2440,7 +2431,7 @@ in \tcode{byte_err_string}, and \tcode{wide_err} in
 \begin{itemdescr}
 \pnum
 \effects
-The destructor shall delete \tcode{cvtptr}.
+\tcode{delete cvtptr}.
 \end{itemdescr}
 
 \rSec2[depr.conversions.buffer]{Class template \tcode{wbuffer_convert}}
@@ -2550,8 +2541,8 @@ explicit wbuffer_convert(
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{pcvt != nullptr}.
+\expects
+\tcode{pcvt} is not null.
 
 \pnum
 \effects
@@ -2568,7 +2559,7 @@ to \tcode{pcvt}, and initializes \tcode{cvtstate} to \tcode{state}.
 \begin{itemdescr}
 \pnum
 \effects
-The destructor shall delete \tcode{cvtptr}.
+\tcode{delete cvtptr}.
 \end{itemdescr}
 
 \rSec1[depr.locale.category]{Deprecated locale category facets}
@@ -2606,6 +2597,9 @@ converts between the UTF-32 and UTF-8 encoding forms.
 
 \rSec1[depr.fs.path.factory]{Deprecated filesystem path factory functions}
 
+\pnum
+The header \libheaderrefx{filesystem}{fs.filesystem.syn} has the following additions:
+
 \indexlibraryglobal{u8path}%
 \begin{itemdecl}
 template<class Source>
@@ -2616,23 +2610,27 @@ template<class InputIterator>
 
 \begin{itemdescr}
 \pnum
-\requires The \tcode{source} and \range{first}{last}
-  sequences are UTF-8 encoded. The value type of \tcode{Source}
-  and \tcode{InputIterator} is \tcode{char} or \keyword{char8_t}.
-  \tcode{Source} meets the requirements specified in \ref{fs.path.req}.
+\mandates
+The value type of \tcode{Source} and \tcode{InputIterator} is
+\tcode{char} or \keyword{char8_t}.
+
+\pnum
+\expects
+The \tcode{source} and \range{first}{last} sequences are UTF-8 encoded.
+\tcode{Source} meets the requirements specified in \ref{fs.path.req}.
 
 \pnum
 \returns
 \begin{itemize}
-\item If \tcode{value_type} is \tcode{char} and the current native
+\item If \tcode{path::value_type} is \tcode{char} and the current native
       narrow encoding\iref{fs.path.type.cvt} is UTF-8,
       return \tcode{path(source)} or \tcode{path(first, last)};
       otherwise,
-\item if \tcode{value_type} is \keyword{wchar_t} and the
+\item if \tcode{path::value_type} is \keyword{wchar_t} and the
       native wide encoding is UTF-16, or
-      if \tcode{value_type} is \keyword{char16_t} or \keyword{char32_t},
+      if \tcode{path::value_type} is \keyword{char16_t} or \keyword{char32_t},
       convert \tcode{source} or \range{first}{last}
-      to a temporary, \tcode{tmp}, of type \tcode{string_type} and
+      to a temporary, \tcode{tmp}, of type \tcode{path::string_type} and
       return \tcode{path(tmp)};
       otherwise,
 \item convert \tcode{source} or \range{first}{last}

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -114,5 +114,8 @@
 \movedxref{denorm.style}{depr.numeric.limits.has.denorm}
 \removedxref{fp.style}
 
+% P2874R2 Mandating Annex D
+\removedxref{depr.res.on.required}
+
 % Deprecated features.
 %\deprxref{old.label}  (if moved to depr.old.label, otherwise use \movedxref)


### PR DESCRIPTION
Applies all changes to replace 'requires' clauses in Annex D with more modern wording, per LWG Poll 19 at Varna 2023 meeting, paper P2874R2.

Fixes #6305
Fixes cplusplus/papers#1557