### PR TITLE
[Motion cwg 7] P2915R0 (Proposed resolution for CWG1223)

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2371,6 +2371,11 @@ the resolution is to consider any construct,
 such as the potential parameter declaration,
 that could possibly be a declaration
 to be a declaration.
+However, a construct that can syntactically be a \grammarterm{declaration}
+whose outermost \grammarterm{declarator}
+would match the grammar of a \grammarterm{declarator}
+with a \grammarterm{trailing-return-type}
+is a declaration only if it starts with \keyword{auto}.
 \begin{note}
 A declaration can be explicitly disambiguated by adding parentheses
 around the argument.
@@ -2382,6 +2387,7 @@ list-initialization syntax, or by use of a non-function-style cast.
 struct S {
   S(int);
 };
+typedef struct BB { int C[2]; } *B, C;
 
 void foo(double a) {
   S w(int(a));                  // function declaration
@@ -2389,6 +2395,8 @@ void foo(double a) {
   S y((int(a)));                // object declaration
   S y((int)a);                  // object declaration
   S z = int(a);                 // object declaration
+  S a(B()->C);                  // object declaration
+  S b(auto()->C);               // function declaration
 }
 \end{codeblock}
 \end{example}
@@ -2401,6 +2409,11 @@ The resolution is that any construct that could possibly be a
 \grammarterm{type-id}
 in its syntactic context shall be considered a
 \grammarterm{type-id}.
+However, a construct that can syntactically be a \grammarterm{type-id}
+whose outermost \grammarterm{abstract-declarator}
+would match the grammar of an \grammarterm{abstract-declarator}
+with a \grammarterm{trailing-return-type}
+is a \grammarterm{type-id} only if it starts with \keyword{auto}.
 \begin{example}
 \begin{codeblock}
 template <class T> struct X {};
@@ -2418,6 +2431,12 @@ void foo(signed char a) {
   (int())+1;                    // type-id (ill-formed)
   (int(a))+1;                   // expression
   (int(unsigned(a)))+1;         // type-id (ill-formed)
+}
+
+typedef struct BB { int C[2]; } *B, C;
+void g() {
+  sizeof(B()->C[1]);            // OK, \tcode{\keyword{sizeof}(}expression\tcode{)}
+  sizeof(auto()->C[1]);         // error: \keyword{sizeof} of a function returning an array
 }
 \end{codeblock}
 \end{example}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2413,7 +2413,7 @@ However, a construct that can syntactically be a \grammarterm{type-id}
 whose outermost \grammarterm{abstract-declarator}
 would match the grammar of an \grammarterm{abstract-declarator}
 with a \grammarterm{trailing-return-type}
-is a \grammarterm{type-id} only if it starts with \keyword{auto}.
+is considered a \grammarterm{type-id} only if it starts with \keyword{auto}.
 \begin{example}
 \begin{codeblock}
 template <class T> struct X {};

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -1081,7 +1081,7 @@ There is an ambiguity in the grammar involving
 conversion\iref{expr.type.conv} as its leftmost subexpression can be
 indistinguishable from a \grammarterm{declaration} where the first
 \grammarterm{declarator} starts with a \tcode{(}. In those cases the
-\grammarterm{statement} is a \grammarterm{declaration},
+\grammarterm{statement} is considered a \grammarterm{declaration},
 except as specified below.
 
 \pnum
@@ -1169,7 +1169,7 @@ void f() {
 A syntactically ambiguous statement that can syntactically be
 a \grammarterm{declaration} with an outermost \grammarterm{declarator}
 with a \grammarterm{trailing-return-type}
-is a \grammarterm{declaration} only if it starts with \keyword{auto}.
+is considered a \grammarterm{declaration} only if it starts with \keyword{auto}.
 \begin{example}
 \begin{codeblock}
 struct M;

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -1081,7 +1081,8 @@ There is an ambiguity in the grammar involving
 conversion\iref{expr.type.conv} as its leftmost subexpression can be
 indistinguishable from a \grammarterm{declaration} where the first
 \grammarterm{declarator} starts with a \tcode{(}. In those cases the
-\grammarterm{statement} is a \grammarterm{declaration}.
+\grammarterm{statement} is a \grammarterm{declaration},
+except as specified below.
 
 \pnum
 \begin{note}
@@ -1160,6 +1161,37 @@ void f() {
   T2(4),                        // \tcode{T2} will be declared as a variable of type \tcode{T1}, but this will not
   (*(*b)(T2(c)))(int(d));       // allow the last part of the declaration to parse properly,
                                 // since it depends on \tcode{T2} being a type-name
+}
+\end{codeblock}
+\end{example}
+
+\pnum
+A syntactically ambiguous statement that can syntactically be
+a \grammarterm{declaration} with an outermost \grammarterm{declarator}
+with a \grammarterm{trailing-return-type}
+is a \grammarterm{declaration} only if it starts with \keyword{auto}.
+\begin{example}
+\begin{codeblock}
+struct M;
+struct S {
+  S* operator()();
+  int N;
+  int M;
+
+  void mem(S s) {
+    auto(s)()->M;               // expression, \tcode{S::M} hides \tcode{::M}
+  }
+};
+
+void f(S s) {
+  {
+    auto(s)()->N;               // expression
+    auto(s)()->M;               // function declaration
+  }
+  {
+    S(s)()->N;                  // expression
+    S(s)()->M;                  // expression
+  }
 }
 \end{codeblock}
 \end{example}


### PR DESCRIPTION
Fixes #6282.

Notes:
* The wording for this paper is problematic, both for type-id and for declaration (e.g. trying to redefine grammar production rules). I did my best to improve it editorially with the changes you see, and inserted FIXMEs to point out the remaining badness.