### PR TITLE
P2592R3 Hashing support for std::chrono value classes

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -585,7 +585,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_byteswap}@                          202110L // also in \libheader{bit}
 #define @\defnlibxname{cpp_lib_char8_t}@                           201907L
   // also in \libheader{atomic}, \libheader{filesystem}, \libheader{istream}, \libheader{limits}, \libheader{locale}, \libheader{ostream}, \libheader{string}, \libheader{string_view}
-#define @\defnlibxname{cpp_lib_chrono}@                            201907L // also in \libheader{chrono}
+#define @\defnlibxname{cpp_lib_chrono}@                            202306L // also in \libheader{chrono}
 #define @\defnlibxname{cpp_lib_chrono_udls}@                       201304L // also in \libheader{chrono}
 #define @\defnlibxname{cpp_lib_clamp}@                             201603L // also in \libheader{algorithm}
 #define @\defnlibxname{cpp_lib_common_reference}@                  202302L // also in \libheader{type_traits}

--- a/source/time.tex
+++ b/source/time.tex
@@ -942,6 +942,31 @@ namespace std::inline literals::inline chrono_literals {
 namespace std::chrono {
   using namespace literals::chrono_literals;
 }
+
+namespace std {
+  // \ref{time.hash}, hash support
+  template<class T> struct hash;
+  template<class Rep, class Period> struct hash<chrono::duration<Rep, Period>>;
+  template<class Clock, class Duration> struct hash<chrono::time_point<Clock, Duration>>;
+  template<> struct hash<chrono::day>;
+  template<> struct hash<chrono::month>;
+  template<> struct hash<chrono::year>;
+  template<> struct hash<chrono::weekday>;
+  template<> struct hash<chrono::weekday_indexed>;
+  template<> struct hash<chrono::weekday_last>;
+  template<> struct hash<chrono::month_day>;
+  template<> struct hash<chrono::month_day_last>;
+  template<> struct hash<chrono::month_weekday>;
+  template<> struct hash<chrono::month_weekday_last>;
+  template<> struct hash<chrono::year_month>;
+  template<> struct hash<chrono::year_month_day>;
+  template<> struct hash<chrono::year_month_day_last>;
+  template<> struct hash<chrono::year_month_weekday>;
+  template<> struct hash<chrono::year_month_weekday_last>;
+  template<class Duration, class TimeZonePtr>
+    struct hash<chrono::zoned_time<Duration, TimeZonePtr>>;
+  template<> struct hash<chrono::leap_second>;
+}
 \end{codeblock}
 
 \rSec1[time.clock.req]{\oldconcept{Clock} requirements}
@@ -11448,6 +11473,101 @@ A \tcode{\%} character is extracted.
 \end{LongTable}
 
 \indexlibrary{\idxcode{parse}|)}
+
+\rSec1[time.hash]{Hash support}
+
+\indexlibrarymember{hash}{duration}%
+\begin{itemdecl}
+template<class Rep, class Period> struct hash<chrono::duration<Rep, Period>>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+The specialization \tcode{hash<chrono::duration<Rep, Period>>} is enabled\iref{unord.hash}
+if and only if \\% newline to fix overfull hbox
+\tcode{hash<Rep>} is enabled.
+The member functions are not guaranteed to be \keyword{noexcept}.
+\end{itemdescr}
+
+\indexlibrarymember{hash}{time_point}%
+\begin{itemdecl}
+template<class Clock, class Duration> struct hash<chrono::time_point<Clock, Duration>>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+The specialization \tcode{hash<chrono::time_point<Clock, Duration>>} is enabled\iref{unord.hash}
+if and only if \tcode{hash<Duration>} is enabled.
+The member functions are not guaranteed to be \keyword{noexcept}.
+\end{itemdescr}
+
+\indexlibrarymember{hash}{day}%
+\indexlibrarymember{hash}{month}%
+\indexlibrarymember{hash}{year}%
+\indexlibrarymember{hash}{weekday}%
+\indexlibrarymember{hash}{weekday_indexed}%
+\indexlibrarymember{hash}{weekday_last}%
+\indexlibrarymember{hash}{month_day}%
+\indexlibrarymember{hash}{month_day_last}%
+\indexlibrarymember{hash}{month_weekday}%
+\indexlibrarymember{hash}{month_weekday_last}%
+\indexlibrarymember{hash}{year_month}%
+\indexlibrarymember{hash}{year_month_day}%
+\indexlibrarymember{hash}{year_month_day_last}%
+\indexlibrarymember{hash}{year_month_weekday}%
+\indexlibrarymember{hash}{year_month_weekday_last}%
+\begin{itemdecl}
+template<> struct hash<chrono::day>;
+template<> struct hash<chrono::month>;
+template<> struct hash<chrono::year>;
+template<> struct hash<chrono::weekday>;
+template<> struct hash<chrono::weekday_indexed>;
+template<> struct hash<chrono::weekday_last>;
+template<> struct hash<chrono::month_day>;
+template<> struct hash<chrono::month_day_last>;
+template<> struct hash<chrono::month_weekday>;
+template<> struct hash<chrono::month_weekday_last>;
+template<> struct hash<chrono::year_month>;
+template<> struct hash<chrono::year_month_day>;
+template<> struct hash<chrono::year_month_day_last>;
+template<> struct hash<chrono::year_month_weekday>;
+template<> struct hash<chrono::year_month_weekday_last>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+The specializations are enabled\iref{unord.hash}.
+\begin{note}
+All the \tcode{hash<Key>} specializations listed above meet the
+\oldconcept{Cpp17Hash} requirements, even when called on objects \tcode{k}
+of type \tcode{Key} such that \tcode{k.ok()} is \tcode{false}.
+\end{note}
+\end{itemdescr}
+
+\indexlibrarymember{hash}{zoned_time}%
+\begin{itemdecl}
+template<class Duration, class TimeZonePtr>
+  struct hash<chrono::zoned_time<Duration, TimeZonePtr>>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+The specialization \tcode{hash<chrono::zoned_time<Durationm TimeZonePtr>>}
+is enabled\iref{unord.hash}
+if and only if \tcode{hash<Duration>} is enabled and
+\tcode{hash<TimeZonePtr>} is enabled.
+The member functions are not guaranteed to be \keyword{noexcept}.
+\end{itemdescr}
+
+\indexlibrarymember{hash}{leap_second}%
+\begin{itemdecl}
+template<> struct hash<chrono::leap_second>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+The specialization is enabled\iref{unord.hash}.
+\end{itemdescr}
 
 \rSec1[ctime.syn]{Header \tcode{<ctime>} synopsis}
 


### PR DESCRIPTION
Editorial: Added \ref from synopsis to [time.hash]

Fixes #6289
Fixes https://github.com/cplusplus/papers/issues/1250