### PR TITLE
[meta.unary.prop.query, meta.trans.arr] Use `static_assert` instead of `assert` in example

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -1416,10 +1416,10 @@ static_assert(extent_v<int> == 0);
 static_assert(extent_v<int[2]> == 2);
 static_assert(extent_v<int[2][4]> == 2);
 static_assert(extent_v<int[][4]> == 0);
-static_assert((extent_v<int, 1>) == 0);
-static_assert((extent_v<int[2], 1>) == 0);
-static_assert((extent_v<int[2][4], 1>) == 4);
-static_assert((extent_v<int[][4], 1>) == 4);
+static_assert(extent_v<int, 1> == 0);
+static_assert(extent_v<int[2], 1> == 0);
+static_assert(extent_v<int[2][4], 1> == 4);
+static_assert(extent_v<int[][4], 1> == 4);
 \end{codeblock}
 \end{example}
 
@@ -1800,10 +1800,10 @@ For multidimensional arrays, only the first array dimension is
 \begin{example}
 \begin{codeblock}
 // the following assertions hold:
-static_assert((is_same_v<remove_extent_t<int>, int>));
-static_assert((is_same_v<remove_extent_t<int[2]>, int>));
-static_assert((is_same_v<remove_extent_t<int[2][3]>, int[3]>));
-static_assert((is_same_v<remove_extent_t<int[][3]>, int[3]>));
+static_assert(is_same_v<remove_extent_t<int>, int>);
+static_assert(is_same_v<remove_extent_t<int[2]>, int>);
+static_assert(is_same_v<remove_extent_t<int[2][3]>, int[3]>);
+static_assert(is_same_v<remove_extent_t<int[][3]>, int[3]>);
 \end{codeblock}
 \end{example}
 
@@ -1811,10 +1811,10 @@ static_assert((is_same_v<remove_extent_t<int[][3]>, int[3]>));
 \begin{example}
 \begin{codeblock}
 // the following assertions hold:
-static_assert((is_same_v<remove_all_extents_t<int>, int>));
-static_assert((is_same_v<remove_all_extents_t<int[2]>, int>));
-static_assert((is_same_v<remove_all_extents_t<int[2][3]>, int>));
-static_assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
+static_assert(is_same_v<remove_all_extents_t<int>, int>);
+static_assert(is_same_v<remove_all_extents_t<int[2]>, int>);
+static_assert(is_same_v<remove_all_extents_t<int[2][3]>, int>);
+static_assert(is_same_v<remove_all_extents_t<int[][3]>, int>);
 \end{codeblock}
 \end{example}
 

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -1402,9 +1402,9 @@ base characteristic of \tcode{integral_constant<size_t, Value>}.
 \begin{example}
 \begin{codeblock}
 // the following assertions hold:
-assert(rank_v<int> == 0);
-assert(rank_v<int[2]> == 1);
-assert(rank_v<int[][4]> == 2);
+static_assert(rank_v<int> == 0);
+static_assert(rank_v<int[2]> == 1);
+static_assert(rank_v<int[][4]> == 2);
 \end{codeblock}
 \end{example}
 
@@ -1412,14 +1412,14 @@ assert(rank_v<int[][4]> == 2);
 \begin{example}
 \begin{codeblock}
 // the following assertions hold:
-assert(extent_v<int> == 0);
-assert(extent_v<int[2]> == 2);
-assert(extent_v<int[2][4]> == 2);
-assert(extent_v<int[][4]> == 0);
-assert((extent_v<int, 1>) == 0);
-assert((extent_v<int[2], 1>) == 0);
-assert((extent_v<int[2][4], 1>) == 4);
-assert((extent_v<int[][4], 1>) == 4);
+static_assert(extent_v<int> == 0);
+static_assert(extent_v<int[2]> == 2);
+static_assert(extent_v<int[2][4]> == 2);
+static_assert(extent_v<int[][4]> == 0);
+static_assert((extent_v<int, 1>) == 0);
+static_assert((extent_v<int[2], 1>) == 0);
+static_assert((extent_v<int[2][4], 1>) == 4);
+static_assert((extent_v<int[][4], 1>) == 4);
 \end{codeblock}
 \end{example}
 
@@ -1800,10 +1800,10 @@ For multidimensional arrays, only the first array dimension is
 \begin{example}
 \begin{codeblock}
 // the following assertions hold:
-assert((is_same_v<remove_extent_t<int>, int>));
-assert((is_same_v<remove_extent_t<int[2]>, int>));
-assert((is_same_v<remove_extent_t<int[2][3]>, int[3]>));
-assert((is_same_v<remove_extent_t<int[][3]>, int[3]>));
+static_assert((is_same_v<remove_extent_t<int>, int>));
+static_assert((is_same_v<remove_extent_t<int[2]>, int>));
+static_assert((is_same_v<remove_extent_t<int[2][3]>, int[3]>));
+static_assert((is_same_v<remove_extent_t<int[][3]>, int[3]>));
 \end{codeblock}
 \end{example}
 
@@ -1811,10 +1811,10 @@ assert((is_same_v<remove_extent_t<int[][3]>, int[3]>));
 \begin{example}
 \begin{codeblock}
 // the following assertions hold:
-assert((is_same_v<remove_all_extents_t<int>, int>));
-assert((is_same_v<remove_all_extents_t<int[2]>, int>));
-assert((is_same_v<remove_all_extents_t<int[2][3]>, int>));
-assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
+static_assert((is_same_v<remove_all_extents_t<int>, int>));
+static_assert((is_same_v<remove_all_extents_t<int[2]>, int>));
+static_assert((is_same_v<remove_all_extents_t<int[2][3]>, int>));
+static_assert((is_same_v<remove_all_extents_t<int[][3]>, int>));
 \end{codeblock}
 \end{example}
 


### PR DESCRIPTION
Not sure why runtime `assert` was used on [meta] in the first place.