### PR TITLE
[expr.mul] Add missing commas after conditional and introductory phrases

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6133,9 +6133,9 @@ The binary \tcode{/} operator yields the quotient, and the binary
 \tcode{\%} operator yields the remainder from the division of the first
 expression by the second.
 \indextext{zero!undefined division by}%
-If the second operand of \tcode{/} or \tcode{\%} is zero the behavior is
+If the second operand of \tcode{/} or \tcode{\%} is zero, the behavior is
 undefined.
-For integral operands the \tcode{/} operator yields the algebraic quotient with
+For integral operands, the \tcode{/} operator yields the algebraic quotient with
 any fractional part discarded;
 \begin{footnote}
 This is often called truncation towards zero.


### PR DESCRIPTION
The use of comma is generally recommended after a conditional phrase or introductory phrase, such as `if something, ...` or `for something, ...`.