### PR TITLE
[namespace.std] Convert unconventional (a) and (b) notation to items

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2837,10 +2837,11 @@ a program may add a template specialization for
 any standard library class template
 to namespace
 \tcode{std} provided that
-(a) the added declaration
-depends on at least one program-defined type
-and
-(b) the specialization meets the standard library requirements
+\begin{itemize}
+\item the added declaration
+depends on at least one program-defined type, and
+
+\item the specialization meets the standard library requirements
 for the original template.
 \begin{footnote}
 Any
@@ -2848,6 +2849,7 @@ library code that instantiates other library templates
 must be prepared to work adequately with any user-supplied specialization
 that meets the minimum requirements of this document.
 \end{footnote}
+\end{itemize}
 
 \pnum
 The behavior of a \Cpp{} program is undefined
@@ -2878,10 +2880,12 @@ of a standard library class or class template, or
 A program may explicitly instantiate
 a class template defined in the standard library
 only if the declaration
-(a) depends on the name of at least one program-defined type
-and
-(b) the instantiation meets the standard library requirements for the
+\begin{itemize}
+\item depends on the name of at least one program-defined type, and
+
+\item the instantiation meets the standard library requirements for the
 original template.
+\end{itemize}
 
 \pnum
 Let \tcode{\placeholder{F}} denote


### PR DESCRIPTION
It would be more appropriate in American English to use a comma in this place.

Without the comma, the sentence reads as:
> [...] depends on the name of at least one program-defined type and [on something else]

With the comma, the sentence reads as:
> [...] depends on the name of at least one program-defined type, and [there is another requirement]

The second reading is correct here, given the rest of the sentence.