### PR TITLE
[basic.def.odr] Add serial comma

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -632,7 +632,7 @@ do not satisfy the following requirements,
 \end{itemize}
 the program is ill-formed;
 a diagnostic is required only
-if the definable item is attached to a named module and
+if the definable item is attached to a named module, and
 a prior definition is reachable at the point where a later definition occurs.
 Given such an item,
 for all definitions of \tcode{D}, or,


### PR DESCRIPTION
It would be more appropriate in American English to use a comma in this place.

Without the comma, the sentence reads as:
> [...] is attached to a named module and [to something else]

With the comma, the sentence reads as:
> [...] is attached to a named module, and [there is another requirement]

The second reading is correct here, given the rest of the sentence.