### PR TITLE
[filebuf.virtuals] fix "if width if less than zero" typo

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -11276,7 +11276,7 @@ the put buffer is non-empty.
 ``Write any unshift sequence'' means,
 if
 \tcode{width}
-if less than zero then call
+is less than zero then call
 \tcode{a_codecvt.unshift(state, xbuf, xbuf+XSIZE, xbuf_end)}
 and output the resulting unshift sequence.
 The function determines one of three values for the


### PR DESCRIPTION
This typo has been present since C++98.