### PR TITLE
[time.duration.cons] Fix redeclaration error in example

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -1313,7 +1313,7 @@ template<class Rep2>
 \begin{example}
 \begin{codeblock}
 duration<int, milli> d(3);          // OK
-duration<int, milli> d(3.5);        // error
+duration<int, milli> d2(3.5);       // error
 \end{codeblock}
 \end{example}
 


### PR DESCRIPTION
Does this change make sense?