### PR TITLE
[flat.map.cons] etc.: zip_view should be views::zip

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -15073,7 +15073,7 @@ Initializes
 sorts the range \range{begin()}{end()} with respect to \tcode{value_comp()}; and
 finally erases the duplicate elements as if by:
 \begin{codeblock}
-auto zv = ranges::zip_view(c.keys, c.values);
+auto zv = views::zip(c.keys, c.values);
 auto it = ranges::unique(zv, key_equiv(compare)).begin();
 auto dist = distance(zv.begin(), it);
 c.keys.erase(c.keys.begin() + dist, c.keys.end());
@@ -15400,7 +15400,7 @@ merges the resulting sorted range and
 the sorted range of pre-existing elements into a single sorted range; and
 finally erases the duplicate elements as if by:
 \begin{codeblock}
-auto zv = ranges::zip_view(c.keys, c.values);
+auto zv = views::zip(c.keys, c.values);
 auto it = ranges::unique(zv, key_equiv(compare)).begin();
 auto dist = distance(zv.begin(), it);
 c.keys.erase(c.keys.begin() + dist, c.keys.end());
@@ -15439,7 +15439,7 @@ Then, merges the sorted range of newly added elements and
 the sorted range of pre-existing elements into a single sorted range; and
 finally erases the duplicate elements as if by:
 \begin{codeblock}
-auto zv = ranges::zip_view(c.keys, c.values);
+auto zv = views::zip(c.keys, c.values);
 auto it = ranges::unique(zv, key_equiv(compare)).begin();
 auto dist = distance(zv.begin(), it);
 c.keys.erase(c.keys.begin() + dist, c.keys.end());
@@ -15477,7 +15477,7 @@ merges the resulting sorted range and
 the sorted range of pre-existing elements into a single sorted range; and
 finally erases the duplicate elements as if by:
 \begin{codeblock}
-auto zv = ranges::zip_view(c.keys, c.values);
+auto zv = views::zip(c.keys, c.values);
 auto it = ranges::unique(zv, key_equiv(compare)).begin();
 auto dist = distance(zv.begin(), it);
 c.keys.erase(c.keys.begin() + dist, c.keys.end());


### PR DESCRIPTION
We don't want programmers doing CTAD on `ranges::zip_view(args...)`, so we shouldn't put it in the as-if-by code either. What we expect people to do (and what we intend vendors to do here) is `views::zip`.