### PR TITLE
[basic.scope.scope] Avoid hard-to-read except...unless construction.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -931,7 +931,11 @@ enumerator,
 function, or
 function template, or
 \item
-each declares a function or function template, except when
+each declares a function or function template
+and they do not declare corresponding overloads.
+\end{itemize}
+Two function or function template declarations declare
+\defn{corresponding overloads} if:
 \begin{itemize}
 \item
 both declare functions with the same non-object-parameter-type-list,
@@ -947,7 +951,6 @@ they have corresponding object parameters, or
 both declare function templates with corresponding signatures and equivalent
 \grammarterm{template-head}s and
 trailing \grammarterm{requires-clause}s (if any).
-\end{itemize}
 \end{itemize}
 \begin{note}
 Declarations can correspond even if neither binds a name.


### PR DESCRIPTION
Factor out a name for the "unless" condition to avoid the double-negative.