### PR TITLE
[atomics.order] p11 - Make it recommended practice and rephrase

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -2645,8 +2645,10 @@ Atomic read-modify-write operations shall always read the last value
 the read-modify-write operation.
 
 \pnum
-Implementations should make atomic stores visible to atomic loads within a reasonable
-amount of time.
+\recommended
+The implementation should make atomic stores visible to atomic loads,
+and atomic loads should observe atomic stores,
+within a reasonable amount of time.
 
 \indexlibraryglobal{kill_dependency}%
 \begin{itemdecl}


### PR DESCRIPTION
Fixes #6376.

p11 should have been a recommended practice paragraph, and the current phrasing is slightly unclear on whether demands are made only towards atomic stores, or towards both loads and stores.

The proposed wording is a combination of my initial disambiguation, incorporating ideas from @jensmaurer.