### PR TITLE
[dcl.enum] Fix double spaces in Example 4

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -7194,7 +7194,7 @@ Each unnamed enumeration with no enumerators is a distinct type.
 \begin{codeblock}
 enum direction { left='l', right='r' };
 
-void g()  {
+void g() {
   direction d;                  // OK
   d = left;                     // OK
   d = direction::right;         // OK
@@ -7202,7 +7202,7 @@ void g()  {
 
 enum class altitude { high='h', low='l' };
 
-void h()  {
+void h() {
   altitude a;                   // OK
   a = high;                     // error: \tcode{high} not in scope
   a = altitude::low;            // OK


### PR DESCRIPTION
Example 4 contains two instances where there are two spaces between the parameter list and the function body.

This code style is inconsistent with what is normally found in the standard.