### PR TITLE
[dcl.init] Fix brace spacing inconsistencies

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5112,9 +5112,9 @@ struct A;
 extern A a;
 struct A {
   const A& a1 { A{ a, a } };    // OK
-  const A& a2 { A{ } };          // error
+  const A& a2 { A{ } };         // error
 };
-A a{a,a};                       // OK
+A a{ a, a };                    // OK
 
 struct B {
   int n = B{}.n;                // error
@@ -5703,13 +5703,17 @@ List-initialization can be used
 \begin{example}
 \begin{codeblock}
 int a = {1};
-std::complex<double> z{1,2};
-new std::vector<std::string>{"once", "upon", "a", "time"};  // 4 string elements
+std::complex<double> z{ 1, 2 };
+new std::vector<std::string>{ "once", "upon", "a", "time" };  // 4 string elements
 f( {"Nicholas","Annemarie"} );  // pass list of two elements
 return { "Norah" };             // return list of one element
-int* e {};                      // initialization to zero / null pointer
-x = double{1};                  // explicitly construct a \tcode{double}
-std::map<std::string,int> anim = { {"bear",4}, {"cassowary",2}, {"tiger",7} };
+int* e{ };                      // initialization to zero / null pointer
+x = double{ 1 };                // explicitly construct a \tcode{double}
+std::map<std::string,int> anim = {
+    { "bear", 4 },
+    { "cassowary", 2 },
+    { "tiger", 7 }
+};
 \end{codeblock}
 \end{example}
 \end{note}
@@ -5781,8 +5785,8 @@ struct S2 {
   double m2, m3;
 };
 S2 s21 = { 1, 2, 3.0 };             // OK
-S2 s22 { 1.0, 2, 3 };               // error: narrowing
-S2 s23 { };                         // OK, default to 0,0,0
+S2 s22{ 1.0, 2, 3 };                // error: narrowing
+S2 s23{ };                          // OK, default to 0,0,0
 \end{codeblock}
 \end{example}
 
@@ -5831,7 +5835,7 @@ struct S {
 };
 S s1 = { 1, 2, 3.0 };               // OK, invoke \#1
 S s2 { 1.0, 2, 3 };                 // error: narrowing
-S s3 { };                           // OK, invoke \#2
+S s3{ };                            // OK, invoke \#2
 \end{codeblock}
 \end{example}
 
@@ -5846,10 +5850,10 @@ to \tcode{U}, the program is ill-formed.
 \begin{example}
 \begin{codeblock}
 enum byte : unsigned char { };
-byte b { 42 };                      // OK
+byte b{ 42 };                       // OK
 byte c = { 42 };                    // error
 byte d = byte{ 42 };                // OK; same value as \tcode{b}
-byte e { -1 };                      // error
+byte e{ -1 };                       // error
 
 struct A { byte b; };
 A a1 = { { 42 } };                  // error
@@ -5859,7 +5863,7 @@ void f(byte);
 f({ 42 });                          // error
 
 enum class Handle : uint32_t { Invalid = 0 };
-Handle h { 42 };                    // OK
+Handle h{ 42 };                     // OK
 \end{codeblock}
 \end{example}
 
@@ -5876,8 +5880,8 @@ to convert the element to \tcode{T}, the program is ill-formed.
 
 \begin{example}
 \begin{codeblock}
-int x1 {2};                         // OK
-int x2 {2.0};                       // error: narrowing
+int x1{ 2 };                        // OK
+int x2{ 2.0 };                      // error: narrowing
 \end{codeblock}
 \end{example}
 
@@ -5922,7 +5926,7 @@ value-initialized.
 
 \begin{example}
 \begin{codeblock}
-int** pp { };                       // initialized to null pointer
+int** pp{ };                        // initialized to null pointer
 \end{codeblock}
 \end{example}
 
@@ -5931,21 +5935,21 @@ int** pp { };                       // initialized to null pointer
 \begin{example}
 \begin{codeblock}
 struct A { int i; int j; };
-A a1 { 1, 2 };                      // aggregate initialization
-A a2 { 1.2 };                       // error: narrowing
+A a1{ 1, 2 };                       // aggregate initialization
+A a2{ 1.2 };                        // error: narrowing
 struct B {
   B(std::initializer_list<int>);
 };
-B b1 { 1, 2 };                      // creates \tcode{initializer_list<int>} and calls constructor
-B b2 { 1, 2.0 };                    // error: narrowing
+B b1{ 1, 2 };                       // creates \tcode{initializer_list<int>} and calls constructor
+B b2{ 1, 2.0 };                     // error: narrowing
 struct C {
   C(int i, double j);
 };
 C c1 = { 1, 2.2 };                  // calls constructor with arguments (1, 2.2)
 C c2 = { 1.1, 2 };                  // error: narrowing
 
-int j { 1 };                        // initialize to 1
-int k { };                          // initialize to 0
+int j{ 1 };                         // initialize to 1
+int k{ };                           // initialize to 0
 \end{codeblock}
 \end{example}
 
@@ -6077,17 +6081,17 @@ int x = 999;                    // \tcode{x} is not a constant expression
 const int y = 999;
 const int z = 99;
 char c1 = x;                    // OK, though it potentially narrows (in this case, it does narrow)
-char c2 { x };                  // error: potentially narrows
-char c3 { y };                  // error: narrows (assuming \tcode{char} is 8 bits)
-char c4 { z };                  // OK, no narrowing needed
+char c2{ x };                   // error: potentially narrows
+char c3{ y };                   // error: narrows (assuming \tcode{char} is 8 bits)
+char c4{ z };                   // OK, no narrowing needed
 unsigned char uc1 = { 5 };      // OK, no narrowing needed
 unsigned char uc2 = { -1 };     // error: narrows
 unsigned int ui1 = { -1 };      // error: narrows
 signed int si1 =
   { (unsigned int)-1 };         // error: narrows
 int ii = { 2.0 };               // error: narrows
-float f1 { x };                 // error: potentially narrows
-float f2 { 7 };                 // OK, 7 can be exactly represented as a \tcode{float}
+float f1{ x };                  // error: potentially narrows
+float f2{ 7 };                  // OK, 7 can be exactly represented as a \tcode{float}
 bool b = { "meow" };            // error: narrows
 int f(int);
 int a[] = { 2, f(2), f(2.0) };  // OK, the \tcode{double}-to-\tcode{int} conversion is not at the top level

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4647,11 +4647,11 @@ struct A {
 int f();
 int n = 10;
 
-A a1{1, f()};                   // OK, lifetime is extended
-A a2(1, f());                   // well-formed, but dangling reference
-A a3{1.0, 1};                   // error: narrowing conversion
-A a4(1.0, 1);                   // well-formed, but dangling reference
-A a5(1.0, std::move(n));        // OK
+A a1{ 1, f() };                 // OK, lifetime is extended
+A a2( 1, f() );                 // well-formed, but dangling reference
+A a3{ 1.0, 1 };                 // error: narrowing conversion
+A a4( 1.0, 1 );                 // well-formed, but dangling reference
+A a5( 1.0, std::move(n) );      // OK
 \end{codeblock}
 \end{example}
 \end{note}
@@ -4922,8 +4922,8 @@ struct derived : base1, base2 {
   int d;
 };
 
-derived d1{{1, 2}, {}, 4};
-derived d2{{}, {}, 4};
+derived d1{ { 1, 2 }, { }, 4 };
+derived d2{ { }, { }, 4 };
 \end{codeblock}
 initializes
 \tcode{d1.b1} with 1,
@@ -4992,7 +4992,7 @@ struct A {
 };
 \end{codeblock}
 
-\tcode{A\{.c=21\}} has the following steps:
+\tcode{A\{ .c=21 \}} has the following steps:
 \begin{itemize}
 \item Initialize \tcode{a} with \tcode{\{\}}
 \item Initialize \tcode{b} with \tcode{= 42}
@@ -5111,8 +5111,8 @@ the program is ill-formed.
 struct A;
 extern A a;
 struct A {
-  const A& a1 { A{a,a} };       // OK
-  const A& a2 { A{} };          // error
+  const A& a1 { A{ a, a } };    // OK
+  const A& a2 { A{ } };          // error
 };
 A a{a,a};                       // OK
 
@@ -5752,8 +5752,8 @@ Aggregate initialization is performed\iref{dcl.init.aggr}.
 \begin{example}
 \begin{codeblock}
 struct A { int x; int y; int z; };
-A a{.y = 2, .x = 1};                // error: designator order does not match declaration order
-A b{.x = 1, .z = 2};                // OK, \tcode{b.y} initialized to \tcode{0}
+A a{ .y = 2, .x = 1 };              // error: designator order does not match declaration order
+A b{ .x = 1, .z = 2 };              // OK, \tcode{b.y} initialized to \tcode{0}
 \end{codeblock}
 \end{example}
 
@@ -5922,7 +5922,7 @@ value-initialized.
 
 \begin{example}
 \begin{codeblock}
-int** pp {};                        // initialized to null pointer
+int** pp { };                       // initialized to null pointer
 \end{codeblock}
 \end{example}
 
@@ -5986,12 +5986,12 @@ If a narrowing conversion is required to initialize any of the elements, the pro
 struct X {
   X(std::initializer_list<double> v);
 };
-X x{ 1,2,3 };
+X x{ 1, 2, 3 };
 \end{codeblock}
 
 The initialization will be implemented in a way roughly equivalent to this:
 \begin{codeblock}
-const double __a[3] = {double{1}, double{2}, double{3}};
+const double __a[3] = { double{ 1 }, double{ 2 }, double{ 3 } };
 X x(std::initializer_list<double>(__a, __a+3));
 \end{codeblock}
 assuming that the implementation can construct an \tcode{initializer_list} object with a pair of pointers.
@@ -6077,18 +6077,18 @@ int x = 999;                    // \tcode{x} is not a constant expression
 const int y = 999;
 const int z = 99;
 char c1 = x;                    // OK, though it potentially narrows (in this case, it does narrow)
-char c2{x};                     // error: potentially narrows
-char c3{y};                     // error: narrows (assuming \tcode{char} is 8 bits)
-char c4{z};                     // OK, no narrowing needed
-unsigned char uc1 = {5};        // OK, no narrowing needed
-unsigned char uc2 = {-1};       // error: narrows
-unsigned int ui1 = {-1};        // error: narrows
+char c2 { x };                  // error: potentially narrows
+char c3 { y };                  // error: narrows (assuming \tcode{char} is 8 bits)
+char c4 { z };                  // OK, no narrowing needed
+unsigned char uc1 = { 5 };      // OK, no narrowing needed
+unsigned char uc2 = { -1 };     // error: narrows
+unsigned int ui1 = { -1 };      // error: narrows
 signed int si1 =
   { (unsigned int)-1 };         // error: narrows
-int ii = {2.0};                 // error: narrows
+int ii = { 2.0 };               // error: narrows
 float f1 { x };                 // error: potentially narrows
 float f2 { 7 };                 // OK, 7 can be exactly represented as a \tcode{float}
-bool b = {"meow"};              // error: narrows
+bool b = { "meow" };            // error: narrows
 int f(int);
 int a[] = { 2, f(2), f(2.0) };  // OK, the \tcode{double}-to-\tcode{int} conversion is not at the top level
 \end{codeblock}


### PR DESCRIPTION
[dcl.init] involves many uses of list initialization, and the style isn't consistent. Sometimes it isn't even consistent within the same example.

This PR makes the style consistent within the same section, where the chosen style is:
- spaces after `{` and before `}`
- empty brace pairs formatted as `{}`
- direct list initialization formatted as `T var{ a, b, c };`
- copy list initialization formatted as `T var = { a, b, c };`