### PR TITLE
[time.zone.leap.overview] Fix example

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -10133,7 +10133,7 @@ are constructed and stored in the time zone database when initialized.
 \begin{example}
 \begin{codeblock}
 for (auto& l : get_tzdb().leap_seconds)
-  if (l <= 2018y/March/17d)
+  if (l <= sys_days(2018y/March/17d))
     cout << l.date() << ": " << l.value() << '\n';
 \end{codeblock}
 

--- a/source/time.tex
+++ b/source/time.tex
@@ -10133,7 +10133,7 @@ are constructed and stored in the time zone database when initialized.
 \begin{example}
 \begin{codeblock}
 for (auto& l : get_tzdb().leap_seconds)
-  if (l <= sys_days(2018y/March/17d))
+  if (l <= sys_days{2018y/March/17d})
     cout << l.date() << ": " << l.value() << '\n';
 \end{codeblock}
 


### PR DESCRIPTION
`leap_seconds` can only be compared with `sys_time<Duration>`, so we are in nondeduced context here? 

Correct me if I'm wrong.