### PR TITLE
[basic.def.odr] Make example 6 much less confusing

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -768,15 +768,17 @@ might still denote different types in different translation units.
 \pnum
 \begin{example}
 \begin{codeblock}
-inline void f(bool cond, void (*p)()) {
-  if (cond) f(false, []{});
+inline void f() {
+  []{};                                   // OK, closure type will be declared inside of \tcode{f}.
 }
-inline void g(bool cond, void (*p)() = []{}) {
-  if (cond) g(false);
-}
+inline void g(void (*)() = []{}) { }
+inline void g2() {                        // Ill-formed if \tcode{g2} appears in multiple translation units because
+  g();                                    // the closure type of the default argument to \tcode{g()} will be
+}                                         // declared outside of \tcode{g}, and this type is unique in every translation unit.
 struct X {
-  void h(bool cond, void (*p)() = []{}) {
-    if (cond) h(false);
+  void h(void (*)() = []{}) { }
+  void h2() {                             // OK, the closure type of the default argument to \tcode{X::h()} will be
+    h();                                  // declared inside of \tcode{X}.
   }
 };
 \end{codeblock}


### PR DESCRIPTION
Related: #6364.

Let me start by saying that together with other members of the community whom I consider to be experts, we have spent *literally hours* trying to figure out the restrictions imposed by the ODR for lambda expressions.

Example 6 has greatly contributed to our confusion, for a number of reasons:
1. The example doesn't make it clear enough in what scope the closure types are defined. This is actually key to understanding when there is an ODR violation, and when there isn't.
2. The example is weirdly code-golfed and uses recursion. To produce an ODR violation like the example demonstrates, recursion isn't necessary, and neither is the `bool` parameter to the function. It took us a while to understand that the recursion has *nothing* to do with the ODR, and everything to do with the point of declaration of the closure type.
3. The recursion is significantly complicating `f`. `f` is the most simple example, and actually requires no parameters.
4. The example contains an excessively long explanation which could have been turned into explanatory comments at the location where they're relevant. This PR still needs work to trim and format everything.