### PR TITLE
mdspan/layout_stride: fix missed rename in use of template argument name

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -20087,9 +20087,9 @@ with \tcode{other.stride($d$)}.
 Remarks: The expression inside \tcode{explicit} is equivalent to:
 \begin{codeblock}
 !(is_convertible_v<typename StridedLayoutMapping::extents_type, extents_type> &&
-  (@\exposid{is-mapping-of}@<layout_left, LayoutStrideMapping> ||
-   @\exposid{is-mapping-of}@<layout_right, LayoutStrideMapping> ||
-   @\exposid{is-mapping-of}@<layout_stride, LayoutStrideMapping>))
+  (@\exposid{is-mapping-of}@<layout_left, StridedLayoutMapping> ||
+   @\exposid{is-mapping-of}@<layout_right, StridedLayoutMapping> ||
+   @\exposid{is-mapping-of}@<layout_stride, StridedLayoutMapping>))
 \end{codeblock}
 \end{itemdescr}
 


### PR DESCRIPTION
There is a typo where it says: LayoutStrideMapping, instead of StridedLayoutMapping. No other use of LayoutStrideMapping exists in the document.

This is in the constructor of `layout_stride::mapping` which takes a constrained other mapping and has remarks for the explicit condition:


```c++
template<class StridedLayoutMapping>
  explicit(see below)
  constexpr mapping(const StridedLayoutMapping& other) noexcept;
```

*Remarks:* The expression inside `explicit` is equivalent to:
  
```c++
   !(is_convertible_v<typename StridedLayoutMapping::extents_type, extents_type> && (
     is-mapping-of<layout_left, LayoutStrideMapping> || 
     is-mapping-of<layout_right, LayoutStrideMapping> ||
     is-mapping-of<layout_stride, LayoutStrideMapping>))
```

This needs to be:

```c++
   !(is_convertible_v<typename StridedLayoutMapping::extents_type, extents_type> && (
     is-mapping-of<layout_left, StridedLayoutMapping> || 
     is-mapping-of<layout_right, StridedLayoutMapping> ||
     is-mapping-of<layout_stride, StridedLayoutMapping>))
```

I am considering this an editorial fix.