### PR TITLE
[dcl.ambig.res] fix double declaration of 'y' in example

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2441,9 +2441,9 @@ struct S {
 typedef struct BB { int C[2]; } *B, C;
 
 void foo(double a) {
-  S w(int(a));                  // function declaration
-  S x(int());                   // function declaration
-  S y((int(a)));                // object declaration
+  S v(int(a));                  // function declaration
+  S w(int());                   // function declaration
+  S x((int(a)));                // object declaration
   S y((int)a);                  // object declaration
   S z = int(a);                 // object declaration
   S a(B()->C);                  // object declaration


### PR DESCRIPTION
Fixes #6386 