### PR TITLE
[priqueue.members] [queue.mod] [stack.mod] Harmonize push_range wording

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -13630,9 +13630,9 @@ template<@\exposconcept{container-compatible-range}@<T> R>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to \tcode{c.append_range(std::forward<R>(rg))}
-if that is a valid expression,
-otherwise \tcode{ranges::copy(rg, back_inserter(c))}.
+Adds the elements of \tcode{rg} to \tcode{c}
+via \tcode{c.append_range(rg)} if that is a valid expression,
+or \tcode{ranges::copy(rg, back_inserter(c))} otherwise.
 \end{itemdescr}
 
 \rSec3[queue.ops]{Operators}
@@ -14187,9 +14187,9 @@ template<@\exposconcept{container-compatible-range}@<T> R>
 \begin{itemdescr}
 \pnum
 \effects
-Inserts all elements of \tcode{rg} in \tcode{c} via
-\tcode{c.append_range(std::forward<R>(rg))} if that is a valid expression, or
-\tcode{ranges::copy(rg, back_inserter(c))} otherwise.
+Adds the elements of \tcode{rg} to \tcode{c}
+via \tcode{c.append_range(rg)} if that is a valid expression,
+or \tcode{ranges::copy(rg, back_inserter(c))} otherwise.
 Then restores the heap property as if by
 \tcode{make_heap(c.begin(), c.end(), comp)}.
 
@@ -14497,9 +14497,9 @@ template<@\exposconcept{container-compatible-range}@<T> R>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to \tcode{c.append_range(std::forward<R>(rg))}
-if that is a valid expression,
-otherwise \tcode{ranges::copy(rg, back_inserter(c))}.
+Adds the elements of \tcode{rg} to \tcode{c}
+via \tcode{c.append_range(rg)} if that is a valid expression,
+or \tcode{ranges::copy(rg, back_inserter(c))} otherwise.
 \end{itemdescr}
 
 \rSec3[stack.ops]{Operators}


### PR DESCRIPTION
Discussion of P2767 raised the point that `forward` here is redundant (ranges are take-by-forwarding-reference but use-by-lvalue, since they can't possibly dangle at this point). Be consistent. Also, harmonize the English wording of all three container adaptors.

The flat container adaptors' `insert_range` functions are deliberately excluded from this editorial patch, because this harmonization would _not_ be editorial for them; they will be brought into line by [P2767 section 5](https://quuxplusone.github.io/draft/d2767-flat-omnibus.html#set-insert-range) once LWG has re-reviewed it.

(Attn @CaseyCarter @var-const)