### PR TITLE
[over.call.func] Example 1 - Fix misleading indentation

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -492,18 +492,18 @@ struct C {
     a();                // OK, \tcode{(*this).a()}
   }
 
-void c(this const C&);      // \#1
-void c()&;                  // \#2
-static void c(int = 0);     // \#3
+  void c(this const C&);    // \#1
+  void c() &;               // \#2
+  static void c(int = 0);   // \#3
 
-void d() {
-  c();                  // error: ambiguous between \#2 and \#3
-  (C::c)();             // error: as above
-  (&(C::c))();          // error: cannot resolve address of overloaded \tcode{this->C::c}\iref{over.over}
-  (&C::c)(C{});         // selects \#1
-  (&C::c)(*this);       // error: selects \#2, and is ill-formed\iref{over.match.call.general}
-  (&C::c)();            // selects \#3
-}
+  void d() {
+    c();                // error: ambiguous between \#2 and \#3
+    (C::c)();           // error: as above
+    (&(C::c))();        // error: cannot resolve address of overloaded \tcode{this->C::c}\iref{over.over}
+    (&C::c)(C{});       // selects \#1
+    (&C::c)(*this);     // error: selects \#2, and is ill-formed\iref{over.match.call.general}
+    (&C::c)();          // selects \#3
+  }
 
   void f(this const C&);
   void g() const {


### PR DESCRIPTION
![grafik](https://github.com/cplusplus/draft/assets/22040976/019c237f-57ef-4123-a514-1ef58f3fe8e6)

The example is currently formatted as if `c` and `d` were free functions, not member functions of the surrounding `struct`.

Furthermore, the PR adds one space in `c()&` -> `c() &`. It is highly unusual to not separate cv-qualifiers or ref-qualifiers from the parameter list, and is a style that goes against almost every reference page. The example later uses `() const`, suggesting that this is merely a typo from the author, and not their preferred style.