### PR TITLE
[intro.races] Drop a possibly misleading sentence in p20

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -6327,8 +6327,6 @@ guarantee provided by most hardware available to \Cpp{} atomic operations.
 
 \pnum
 \begin{note}
-The value observed by a load of an atomic depends on the ``happens
-before'' relation, which depends on the values observed by loads of atomics.
 The intended reading is that there must exist an
 association of atomic loads with modifications they observe that, together with
 suitably chosen modification orders and the ``happens before'' relation derived


### PR DESCRIPTION
The sentence being removed doesn't seem very helpful, and possibly misleading.

Fixes cplusplus/CWG#369.