### PR TITLE
[class.copy.assign] Remove note obsoleted by CWG2586

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1675,10 +1675,6 @@ participate in overload resolution with other assignment operators, including
 copy assignment operators, and, if selected, will be used to assign an object.
 \end{footnote}
 \begin{note}
-An overloaded assignment operator must be declared to have only one parameter;
-see~\ref{over.ass}.
-\end{note}
-\begin{note}
 More than one form of copy assignment operator can be declared for a class.
 \end{note}
 \begin{note}


### PR DESCRIPTION
Found by @Quuxplusone .