### PR TITLE
[input.output] Fix non-compliance Effects: Equivalent to format

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4460,7 +4460,7 @@ basic_istream& operator=(basic_istream&& rhs);
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{swap(rhs)}.
+Equivalent to \tcode{swap(rhs)}.
 
 \pnum
 \returns
@@ -5857,7 +5857,7 @@ basic_iostream& operator=(basic_iostream&& rhs);
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{swap(rhs)}.
+Equivalent to \tcode{swap(rhs)}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{basic_iostream}%
@@ -6130,7 +6130,7 @@ basic_ostream& operator=(basic_ostream&& rhs);
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{swap(rhs)}.
+Equivalent to \tcode{swap(rhs)}.
 
 \pnum
 \returns
@@ -8267,7 +8267,7 @@ and \tcode{rhs}.
 \remarks
 The exception specification is equivalent to:\\
 \tcode{allocator_traits<Allocator>::propagate_on_container_swap::value ||}\\
-\tcode{allocator_traits<Allocator>::is_always_equal::value}.
+\tcode{allocator_traits<Allocator>::is_always_equal::value}
 \end{itemdescr}
 
 \indexlibrarymember{swap}{basic_stringbuf}%
@@ -8280,7 +8280,7 @@ template<class charT, class traits, class Allocator>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{x.swap(y)}.
+Equivalent to \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec3[stringbuf.members]{Member functions}
@@ -9031,7 +9031,7 @@ template<class charT, class traits, class Allocator>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{x.swap(y)}.
+Equivalent to \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec3[istringstream.members]{Member functions}
@@ -9403,7 +9403,7 @@ template<class charT, class traits, class Allocator>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{x.swap(y)}.
+Equivalent to \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec3[ostringstream.members]{Member functions}
@@ -9781,7 +9781,7 @@ template<class charT, class traits, class Allocator>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{x.swap(y)}.
+Equivalent to \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec3[stringstream.members]{Member functions}
@@ -10384,7 +10384,7 @@ is \tcode{true}.
 \pnum
 \effects
 Let \tcode{sp} be \tcode{std::span<const charT>(std::forward<ROS>(s))}.
-Equivalent to
+Equivalent to:
 \begin{codeblock}
 basic_ispanstream(std::span<charT>(const_cast<charT*>(sp.data()), sp.size()))
 \end{codeblock}
@@ -10473,7 +10473,7 @@ is \tcode{true}.
 Let \tcode{sp} be \tcode{std::span<const charT>(std::forward<ROS>(s))}.
 Equivalent to:
 \begin{codeblock}
-this->span(std::span<charT>(const_cast<charT*>(sp.data()), sp.size()))
+this->span(std::span<charT>(const_cast<charT*>(sp.data()), sp.size()));
 \end{codeblock}
 \end{itemdescr}
 
@@ -11086,7 +11086,7 @@ template<class charT, class traits>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{x.swap(y)}.
+Equivalent to \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec3[filebuf.members]{Member functions}
@@ -11769,7 +11769,7 @@ explicit basic_ifstream(const string& s,
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{basic_ifstream(s.c_str(), mode)}.
+Equivalent to \tcode{basic_ifstream(s.c_str(), mode)}.
 \end{itemdescr}
 
 \indexlibraryctor{basic_ifstream}%
@@ -11785,7 +11785,7 @@ template<class T>
 
 \pnum
 \effects
-Equivalent to: \tcode{basic_ifstream(s.c_str(), mode)}.
+Equivalent to \tcode{basic_ifstream(s.c_str(), mode)}.
 \end{itemdescr}
 
 \indexlibraryctor{basic_ifstream}%
@@ -11826,7 +11826,7 @@ template<class charT, class traits>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{x.swap(y)}.
+Equivalent to \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec3[ifstream.members]{Member functions}
@@ -12028,7 +12028,7 @@ explicit basic_ofstream(const string& s,
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{basic_ofstream(s.c_str(), mode)}.
+Equivalent to \tcode{basic_ofstream(s.c_str(), mode)}.
 \end{itemdescr}
 
 \indexlibraryctor{basic_ofstream}%
@@ -12044,7 +12044,7 @@ template<class T>
 
 \pnum
 \effects
-Equivalent to: \tcode{basic_ofstream(s.c_str(), mode)}.
+Equivalent to \tcode{basic_ofstream(s.c_str(), mode)}.
 \end{itemdescr}
 
 \indexlibraryctor{basic_ofstream}%
@@ -12085,7 +12085,7 @@ template<class charT, class traits>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{x.swap(y)}.
+Equivalent to \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec3[ofstream.members]{Member functions}
@@ -12298,7 +12298,7 @@ explicit basic_fstream(
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{basic_fstream(s.c_str(), mode)}.
+Equivalent to \tcode{basic_fstream(s.c_str(), mode)}.
 \end{itemdescr}
 
 \indexlibraryctor{basic_fstream}%
@@ -12314,7 +12314,7 @@ template<class T>
 
 \pnum
 \effects
-Equivalent to: \tcode{basic_fstream(s.c_str(), mode)}.
+Equivalent to \tcode{basic_fstream(s.c_str(), mode)}.
 \end{itemdescr}
 
 \indexlibraryctor{basic_fstream}%
@@ -12356,7 +12356,7 @@ template<class charT, class traits>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{x.swap(y)}.
+Equivalent to \tcode{x.swap(y)}.
 \end{itemdescr}
 
 \rSec3[fstream.members]{Member functions}


### PR DESCRIPTION
This is the follow-up of #6254.
Not sure if this is 100% spec-compliant, corrections are welcome.