### PR TITLE
[flat.map, flat.multimap, flat.set, flat.multiset] Exposition-only formatting for `c`, `comp`, `compare`, and `key-equiv`

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -15884,12 +15884,12 @@ namespace std {
 
     class value_compare {
     private:
-      key_compare comp;                                 // \expos
-      value_compare(key_compare c) : comp(c) { }        // \expos
+      key_compare @\exposid{comp}@;                                 // \expos
+      value_compare(key_compare c) : @\exposid{comp}@(c) { }        // \expos
 
     public:
       bool operator()(const_reference x, const_reference y) const {
-        return comp(x.first, y.first);
+        return @\exposid{comp}@(x.first, y.first);
       }
     };
 
@@ -15902,7 +15902,7 @@ namespace std {
     flat_map() : flat_map(key_compare()) { }
 
     explicit flat_map(const key_compare& comp)
-      : c(), compare(comp) { }
+      : @\exposid{c}@(), @\exposid{compare}@(comp) { }
 
     flat_map(key_container_type key_cont, mapped_container_type mapped_cont,
              const key_compare& comp = key_compare());
@@ -15912,12 +15912,12 @@ namespace std {
 
     template<class InputIterator>
       flat_map(InputIterator first, InputIterator last, const key_compare& comp = key_compare())
-        : c(), compare(comp) { insert(first, last); }
+        : @\exposid{c}@(), @\exposid{compare}@(comp) { insert(first, last); }
 
     template<class InputIterator>
       flat_map(sorted_unique_t s, InputIterator first, InputIterator last,
                const key_compare& comp = key_compare())
-        : c(), compare(comp) { insert(s, first, last); }
+        : @\exposid{c}@(), @\exposid{compare}@(comp) { insert(s, first, last); }
 
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       flat_map(from_range_t fr, R&& rg)
@@ -16082,8 +16082,8 @@ namespace std {
     key_compare key_comp() const;
     value_compare value_comp() const;
 
-    const key_container_type& keys() const noexcept      { return c.keys; }
-    const mapped_container_type& values() const noexcept { return c.values; }
+    const key_container_type& keys() const noexcept      { return @\exposid{c}@.keys; }
+    const mapped_container_type& values() const noexcept { return @\exposid{c}@.values; }
 
     // map operations
     iterator find(const key_type& x);
@@ -16121,11 +16121,11 @@ namespace std {
       { x.swap(y); }
 
   private:
-    containers c;               // \expos
-    key_compare compare;        // \expos
+    containers @\exposid{c}@;               // \expos
+    key_compare @\exposid{compare}@;        // \expos
 
-    struct key_equiv {  // \expos
-      key_equiv(key_compare c) : comp(c) { }
+    struct @\exposid{key-equiv}@ {  // \expos
+      @\exposid{key-equiv}@(key_compare c) : comp(c) { }
       bool operator()(const_reference x, const_reference y) const {
         return !comp(x.first, y.first) && !comp(y.first, x.first);
       }
@@ -16217,17 +16217,17 @@ flat_map(key_container_type key_cont, mapped_container_type mapped_cont,
 \pnum
 \effects
 Initializes
-\tcode{c.keys} with \tcode{std::move(key_cont)},
-\tcode{c.values} with \tcode{std::move(mapped_cont)}, and
-\tcode{compare} with \tcode{comp};
+\tcode{\exposid{c}.keys} with \tcode{std::move(key_cont)},
+\tcode{\exposid{c}.values} with \tcode{std::move(mapped_cont)}, and
+\exposid{compare} with \tcode{comp};
 sorts the range \range{begin()}{end()} with respect to \tcode{value_comp()}; and
 finally erases the duplicate elements as if by:
 \begin{codeblock}
-auto zv = views::zip(c.keys, c.values);
-auto it = ranges::unique(zv, key_equiv(compare)).begin();
+auto zv = views::zip(@\exposid{c}@.keys, @\exposid{c}@.values);
+auto it = ranges::unique(zv, @\exposid{key-equiv}@(@\exposid{compare}@)).begin();
 auto dist = distance(zv.begin(), it);
-c.keys.erase(c.keys.begin() + dist, c.keys.end());
-c.values.erase(c.values.begin() + dist, c.values.end());
+@\exposid{c}@.keys.erase(@\exposid{c}@.keys.begin() + dist, @\exposid{c}@.keys.end());
+@\exposid{c}@.values.erase(@\exposid{c}@.values.begin() + dist, @\exposid{c}@.values.end());
 \end{codeblock}
 
 \pnum
@@ -16247,9 +16247,9 @@ flat_map(sorted_unique_t, key_container_type key_cont, mapped_container_type map
 \pnum
 \effects
 Initializes
-\tcode{c.keys} with \tcode{std::move(key_cont)},
-\tcode{c.values} with \tcode{std::move(mapped_cont)}, and
-\tcode{compare} with \tcode{comp}.
+\tcode{\exposid{c}.keys} with \tcode{std::move(key_cont)},
+\tcode{\exposid{c}.values} with \tcode{std::move(mapped_cont)}, and
+\exposid{compare} with \tcode{comp}.
 
 \pnum
 \complexity
@@ -16278,7 +16278,7 @@ template<class Alloc>
 \effects
 Equivalent to \tcode{flat_map(key_cont, mapped_cont)} and
 \tcode{flat_map(key_cont, mapped_cont, comp)}, respectively,
-except that \tcode{c.keys} and \tcode{c.values} are constructed with
+except that \tcode{\exposid{c}.keys} and \tcode{\exposid{c}.values} are constructed with
 uses-allocator construction\iref{allocator.uses.construction}.
 
 \pnum
@@ -16303,7 +16303,7 @@ template<class Alloc>
 \effects
 Equivalent to \tcode{flat_map(s, key_cont, mapped_cont)} and
 \tcode{flat_map(s, key_cont, \linebreak{}mapped_cont, comp)}, respectively,
-except that \tcode{c.keys} and \tcode{c.values} are constructed
+except that \tcode{\exposid{c}.keys} and \tcode{\exposid{c}.values} are constructed
 with uses-allocator construction\iref{allocator.uses.construction}.
 
 \pnum
@@ -16349,7 +16349,7 @@ template<class Alloc>
 \pnum
 \effects
 Equivalent to the corresponding non-allocator constructors
-except that \tcode{c.keys} and \tcode{c.values} are constructed
+except that \tcode{\exposid{c}.keys} and \tcode{\exposid{c}.values} are constructed
 with uses-allocator construction\iref{allocator.uses.construction}.
 \end{itemdescr}
 
@@ -16363,7 +16363,7 @@ size_type size() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{c.keys.size()}.
+\tcode{\exposid{c}.keys.size()}.
 \end{itemdescr}
 
 \indexlibrarymember{max_size}{flat_map}%
@@ -16374,7 +16374,7 @@ size_type max_size() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{min<size_type>(c.keys.max_size(), c.values.max_size())}.
+\tcode{min<size_type>(\exposid{c}.keys.max_size(), \exposid{c}.values.max_size())}.
 \end{itemdescr}
 
 \rSec3[flat.map.access]{Access}
@@ -16491,10 +16491,10 @@ whose key is equivalent to \tcode{t.first},
 \tcode{*this} is unchanged.
 Otherwise, equivalent to:
 \begin{codeblock}
-auto key_it = ranges::upper_bound(c.keys, t.first, compare);
-auto value_it = c.values.begin() + distance(c.keys.begin(), key_it);
-c.keys.insert(key_it, std::move(t.first));
-c.values.insert(value_it, std::move(t.second));
+auto key_it = ranges::upper_bound(@\exposid{c}@.keys, t.first, @\exposid{compare}@);
+auto value_it = @\exposid{c}@.values.begin() + distance(@\exposid{c}@.keys.begin(), key_it);
+@\exposid{c}@.keys.insert(key_it, std::move(t.first));
+@\exposid{c}@.values.insert(value_it, std::move(t.second));
 \end{codeblock}
 
 \pnum
@@ -16532,12 +16532,12 @@ template<class InputIterator>
 \begin{itemdescr}
 \pnum
 \effects
-Adds elements to \tcode{c} as if by:
+Adds elements to \exposid{c} as if by:
 \begin{codeblock}
 for (; first != last; ++first) {
   value_type value = *first;
-  c.keys.insert(c.keys.end(), std::move(value.first));
-  c.values.insert(c.values.end(), std::move(value.second));
+  @\exposid{c}@.keys.insert(@\exposid{c}@.keys.end(), std::move(value.first));
+  @\exposid{c}@.values.insert(@\exposid{c}@.values.end(), std::move(value.second));
 }
 \end{codeblock}
 Then, sorts the range of newly inserted elements
@@ -16546,11 +16546,11 @@ merges the resulting sorted range and
 the sorted range of pre-existing elements into a single sorted range; and
 finally erases the duplicate elements as if by:
 \begin{codeblock}
-auto zv = views::zip(c.keys, c.values);
-auto it = ranges::unique(zv, key_equiv(compare)).begin();
+auto zv = views::zip(@\exposid{c}@.keys, @\exposid{c}@.values);
+auto it = ranges::unique(zv, @\exposid{key-equiv}@(@\exposid{compare}@)).begin();
 auto dist = distance(zv.begin(), it);
-c.keys.erase(c.keys.begin() + dist, c.keys.end());
-c.values.erase(c.values.begin() + dist, c.values.end());
+@\exposid{c}@.keys.erase(@\exposid{c}@.keys.begin() + dist, @\exposid{c}@.keys.end());
+@\exposid{c}@.values.erase(@\exposid{c}@.values.begin() + dist, @\exposid{c}@.values.end());
 \end{codeblock}
 
 \pnum
@@ -16573,23 +16573,23 @@ template<class InputIterator>
 \begin{itemdescr}
 \pnum
 \effects
-Adds elements to \tcode{c} as if by:
+Adds elements to \exposid{c} as if by:
 \begin{codeblock}
 for (; first != last; ++first) {
   value_type value = *first;
-  c.keys.insert(c.keys.end(), std::move(value.first));
-  c.values.insert(c.values.end(), std::move(value.second));
+  @\exposid{c}@.keys.insert(@\exposid{c}@.keys.end(), std::move(value.first));
+  @\exposid{c}@.values.insert(@\exposid{c}@.values.end(), std::move(value.second));
 }
 \end{codeblock}
 Then, merges the sorted range of newly added elements and
 the sorted range of pre-existing elements into a single sorted range; and
 finally erases the duplicate elements as if by:
 \begin{codeblock}
-auto zv = views::zip(c.keys, c.values);
-auto it = ranges::unique(zv, key_equiv(compare)).begin();
+auto zv = views::zip(@\exposid{c}@.keys, @\exposid{c}@.values);
+auto it = ranges::unique(zv, @\exposid{key-equiv}@(@\exposid{compare}@)).begin();
 auto dist = distance(zv.begin(), it);
-c.keys.erase(c.keys.begin() + dist, c.keys.end());
-c.values.erase(c.values.begin() + dist, c.values.end());
+@\exposid{c}@.keys.erase(@\exposid{c}@.keys.begin() + dist, @\exposid{c}@.keys.end());
+@\exposid{c}@.values.erase(@\exposid{c}@.values.begin() + dist, @\exposid{c}@.values.end());
 \end{codeblock}
 
 \pnum
@@ -16610,11 +16610,11 @@ template<@\exposconcept{container-compatible-range}@<value_type> R>
 \begin{itemdescr}
 \pnum
 \effects
-Adds elements to \tcode{c} as if by:
+Adds elements to \exposid{c} as if by:
 \begin{codeblock}
 for (const auto& e : rg) {
-  c.keys.insert(c.keys.end(), e.first);
-  c.values.insert(c.values.end(), e.second);
+  @\exposid{c}@.keys.insert(@\exposid{c}@.keys.end(), e.first);
+  @\exposid{c}@.values.insert(@\exposid{c}@.values.end(), e.second);
 }
 \end{codeblock}
 Then, sorts the range of newly inserted elements
@@ -16623,11 +16623,11 @@ merges the resulting sorted range and
 the sorted range of pre-existing elements into a single sorted range; and
 finally erases the duplicate elements as if by:
 \begin{codeblock}
-auto zv = views::zip(c.keys, c.values);
-auto it = ranges::unique(zv, key_equiv(compare)).begin();
+auto zv = views::zip(@\exposid{c}@.keys, @\exposid{c}@.values);
+auto it = ranges::unique(zv, @\exposid{key-equiv}@(@\exposid{compare}@)).begin();
 auto dist = distance(zv.begin(), it);
-c.keys.erase(c.keys.begin() + dist, c.keys.end());
-c.values.erase(c.values.begin() + dist, c.values.end());
+@\exposid{c}@.keys.erase(@\exposid{c}@.keys.begin() + dist, @\exposid{c}@.keys.end());
+@\exposid{c}@.values.erase(@\exposid{c}@.values.begin() + dist, @\exposid{c}@.values.end());
 \end{codeblock}
 
 \pnum
@@ -16664,10 +16664,10 @@ If the map already contains an element whose key is equivalent to \tcode{k},
 \tcode{*this} and \tcode{args...} are unchanged.
 Otherwise equivalent to:
 \begin{codeblock}
-auto key_it = ranges::upper_bound(c.keys, k, compare);
-auto value_it = c.values.begin() + distance(c.keys.begin(), key_it);
-c.keys.insert(key_it, std::forward<decltype(k)>(k));
-c.values.emplace(value_it, std::forward<Args>(args)...);
+auto key_it = ranges::upper_bound(@\exposid{c}@.keys, k, @\exposid{compare}@);
+auto value_it = @\exposid{c}@.values.begin() + distance(@\exposid{c}@.keys.begin(), key_it);
+@\exposid{c}@.keys.insert(key_it, std::forward<decltype(k)>(k));
+@\exposid{c}@.values.emplace(value_it, std::forward<Args>(args)...);
 \end{codeblock}
 
 \pnum
@@ -16721,10 +16721,10 @@ If the map already contains an element whose key is equivalent to \tcode{k},
 \tcode{*this} and \tcode{args...} are unchanged.
 Otherwise equivalent to:
 \begin{codeblock}
-auto key_it = ranges::upper_bound(c.keys, k, compare);
-auto value_it = c.values.begin() + distance(c.keys.begin(), key_it);
-c.keys.emplace(key_it, std::forward<K>(k));
-c.values.emplace(value_it, std::forward<Args>(args)...);
+auto key_it = ranges::upper_bound(@\exposid{c}@.keys, k, @\exposid{compare}@);
+auto value_it = @\exposid{c}@.values.begin() + distance(@\exposid{c}@.keys.begin(), key_it);
+@\exposid{c}@.keys.emplace(key_it, std::forward<K>(k));
+@\exposid{c}@.values.emplace(value_it, std::forward<Args>(args)...);
 \end{codeblock}
 
 \pnum
@@ -16851,9 +16851,9 @@ void swap(flat_map& y) noexcept;
 \effects
 Equivalent to:
 \begin{codeblock}
-ranges::swap(compare, y.compare);
-ranges::swap(c.keys, y.c.keys);
-ranges::swap(c.values, y.c.values);
+ranges::swap(@\exposid{compare}@, y.@\exposid{compare}@);
+ranges::swap(@\exposid{c}@.keys, y.@\exposid{c}@.keys);
+ranges::swap(@\exposid{c}@.values, y.@\exposid{c}@.values);
 \end{codeblock}
 \end{itemdescr}
 
@@ -16869,7 +16869,7 @@ containers extract() &&;
 
 \pnum
 \returns
-\tcode{std::move(c)}.
+\tcode{std::move(\exposid{c})}.
 \end{itemdescr}
 
 \indexlibrarymember{replace}{flat_map}%
@@ -16881,15 +16881,15 @@ void replace(key_container_type&& key_cont, mapped_container_type&& mapped_cont)
 \pnum
 \expects
 \tcode{key_cont.size() == mapped_cont.size()} is \tcode{true},
-the elements of \tcode{key_cont} are sorted with respect to \tcode{compare}, and
+the elements of \tcode{key_cont} are sorted with respect to \exposid{compare}, and
 \tcode{key_cont} contains no equal elements.
 
 \pnum
 \effects
 Equivalent to:
 \begin{codeblock}
-c.keys = std::move(key_cont);
-c.values = std::move(mapped_cont);
+@\exposid{c}@.keys = std::move(key_cont);
+@\exposid{c}@.values = std::move(mapped_cont);
 \end{codeblock}
 \end{itemdescr}
 
@@ -17067,12 +17067,12 @@ namespace std {
 
     class value_compare {
     private:
-      key_compare comp;                                 // \expos
-      value_compare(key_compare c) : comp(c) { }        // \expos
+      key_compare @\exposid{comp}@;                                 // \expos
+      value_compare(key_compare c) : @\exposid{comp}@(c) { }        // \expos
 
     public:
       bool operator()(const_reference x, const_reference y) const {
-        return comp(x.first, y.first);
+        return @\exposid{comp}@(x.first, y.first);
       }
     };
 
@@ -17085,7 +17085,7 @@ namespace std {
     flat_multimap() : flat_multimap(key_compare()) { }
 
     explicit flat_multimap(const key_compare& comp)
-      : c(), compare(comp) { }
+      : @\exposid{c}@(), @\exposid{compare}@(comp) { }
 
     flat_multimap(key_container_type key_cont, mapped_container_type mapped_cont,
                   const key_compare& comp = key_compare());
@@ -17097,13 +17097,13 @@ namespace std {
     template<class InputIterator>
       flat_multimap(InputIterator first, InputIterator last,
                     const key_compare& comp = key_compare())
-        : c(), compare(comp)
+        : @\exposid{c}@(), @\exposid{compare}@(comp)
         { insert(first, last); }
 
     template<class InputIterator>
       flat_multimap(sorted_equivalent_t s, InputIterator first, InputIterator last,
                     const key_compare& comp = key_compare())
-        : c(), compare(comp) { insert(s, first, last); }
+        : @\exposid{c}@(), @\exposid{compare}@(comp) { insert(s, first, last); }
 
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       flat_multimap(from_range_t fr, R&& rg)
@@ -17236,8 +17236,8 @@ namespace std {
     key_compare key_comp() const;
     value_compare value_comp() const;
 
-    const key_container_type& keys() const noexcept { return c.keys; }
-    const mapped_container_type& values() const noexcept { return c.values; }
+    const key_container_type& keys() const noexcept { return @\exposid{c}@.keys; }
+    const mapped_container_type& values() const noexcept { return @\exposid{c}@.values; }
 
     // map operations
     iterator find(const key_type& x);
@@ -17277,8 +17277,8 @@ namespace std {
       { x.swap(y); }
 
   private:
-    containers c;               // \expos
-    key_compare compare;        // \expos
+    containers @\exposid{c}@;               // \expos
+    key_compare @\exposid{compare}@;        // \expos
   };
 
   template<class KeyContainer, class MappedContainer,
@@ -17370,9 +17370,9 @@ flat_multimap(key_container_type key_cont, mapped_container_type mapped_cont,
 \pnum
 \effects
 Initializes
-\tcode{c.keys} with \tcode{std::move(key_cont)},
-\tcode{c.values} with \tcode{std::move(mapped_cont)}, and
-\tcode{compare} with \tcode{comp};
+\tcode{\exposid{c}.keys} with \tcode{std::move(key_cont)},
+\tcode{\exposid{c}.values} with \tcode{std::move(mapped_cont)}, and
+\exposid{compare} with \tcode{comp};
 sorts the range \range{begin()}{end()} with respect to \tcode{value_comp()}.
 
 \pnum
@@ -17392,9 +17392,9 @@ flat_multimap(sorted_equivalent_t, key_container_type key_cont, mapped_container
 \pnum
 \effects
 Initializes
-\tcode{c.keys} with \tcode{std::move(key_cont)},
-\tcode{c.values} with \tcode{std::move(mapped_cont)}, and
-\tcode{compare} with \tcode{comp}.
+\tcode{\exposid{c}.keys} with \tcode{std::move(key_cont)},
+\tcode{\exposid{c}.values} with \tcode{std::move(mapped_cont)}, and
+\exposid{compare} with \tcode{comp}.
 
 \pnum
 \complexity
@@ -17423,7 +17423,7 @@ template<class Alloc>
 \effects
 Equivalent to \tcode{flat_multimap(key_cont, mapped_cont)} and
 \tcode{flat_multimap(key_cont, \linebreak{}mapped_cont, comp)}, respectively,
-except that \tcode{c.keys} and \tcode{c.values} are constructed
+except that \tcode{\exposid{c}.keys} and \tcode{\exposid{c}.values} are constructed
 with uses-allocator construction\iref{allocator.uses.construction}.
 
 \pnum
@@ -17448,7 +17448,7 @@ template<class Alloc>
 \effects
 Equivalent to \tcode{flat_multimap(s, key_cont, mapped_cont)} and
 \tcode{flat_multimap(s, key_cont, mapped_cont, comp)}, respectively,
-except that \tcode{c.keys} and \tcode{c.val\-ues} are constructed
+except that \tcode{\exposid{c}.keys} and \tcode{\exposid{c}.val\-ues} are constructed
 with uses-allocator construction\iref{allocator.uses.construction}.
 
 \pnum
@@ -17496,7 +17496,7 @@ template<class Alloc>
 \pnum
 \effects
 Equivalent to the corresponding non-allocator constructors
-except that \tcode{c.keys} and \tcode{c.values} are constructed
+except that \tcode{\exposid{c}.keys} and \tcode{\exposid{c}.values} are constructed
 with uses-allocator construction\iref{allocator.uses.construction}.
 \end{itemdescr}
 
@@ -18682,8 +18682,8 @@ First, initializes an object \tcode{t} of type \tcode{value_type}
 with \tcode{std::forward<Args>(args)...},
 then inserts \tcode{t} as if by:
 \begin{codeblock}
-auto it = ranges::upper_bound(c, t, compare);
-c.insert(it, std::move(t));
+auto it = ranges::upper_bound(@\exposid{c}@, t, @\exposid{compare}@);
+@\exposid{c}@.insert(it, std::move(t));
 \end{codeblock}
 
 \pnum
@@ -18702,7 +18702,7 @@ template<class InputIterator>
 \effects
 Adds elements to \exposid{c} as if by:
 \begin{codeblock}
-c.insert(c.end(), first, last);
+@\exposid{c}@.insert(@\exposid{c}@.end(), first, last);
 \end{codeblock}
 Then, sorts the range of newly inserted elements with respect to \exposid{compare},
 and merges the resulting sorted range and
@@ -18744,8 +18744,8 @@ void swap(flat_multiset& y) noexcept;
 \effects
 Equivalent to:
 \begin{codeblock}
-ranges::swap(compare, y.compare);
-ranges::swap(c, y.c);
+ranges::swap(@\exposid{compare}@, y.@\exposid{compare}@);
+ranges::swap(@\exposid{c}@, y.@\exposid{c}@);
 \end{codeblock}
 \end{itemdescr}
 
@@ -18761,7 +18761,7 @@ container_type extract() &&;
 
 \pnum
 \returns
-\tcode{std::move(c)}.
+\tcode{std::move(\exposid{c})}.
 \end{itemdescr}
 
 \indexlibrarymember{replace}{flat_multiset}%
@@ -18776,7 +18776,7 @@ The elements of \tcode{cont} are sorted with respect to \exposid{compare}.
 
 \pnum
 \effects
-Equivalent to: \tcode{c = std::move(cont);}
+Equivalent to: \tcode{\exposid{c} = std::move(cont);}
 \end{itemdescr}
 
 \rSec3[flat.multiset.erasure]{Erasure}


### PR DESCRIPTION
Also changes `key_equiv` to _`key-equiv`_.

I think it's OK to keep the member `comp` of `key_equiv` not marked `\exposid`, since the identifier `comp` is already reserved by `priority_queue::comp`. Implementations can use the name `comp` as-is or use another name.

`key_equiv` and `value_compare`'s exposition-only constructors are less than ideal to me. But I think they should be handled in an LWG issue because additional copy of comparator seems to be observable. Edit: now this is LWG3959.

Follows up #5914. Fixes #5812. Fixes #7380.