### PR TITLE
[temp.point] Itemize some paragraphs

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -5313,11 +5313,15 @@ its terminal name is dependent.
 For a function template specialization, a member function template
 specialization, or a specialization for a member function or static data member
 of a class template,
-if the specialization is implicitly instantiated because it is referenced
-from within another template specialization and
-the context from which it is referenced depends on a template parameter,
 the point of instantiation of the specialization is the point of instantiation
-of the enclosing specialization.
+of the enclosing specialization if
+\begin{itemize}
+\item the specialization is implicitly instantiated because it is referenced
+from within another template specialization, and
+
+\item the context from which it is referenced depends on a template parameter.
+\end{itemize}
+
 Otherwise, the point of instantiation for such a specialization immediately
 follows the namespace scope declaration
 or definition that refers to the specialization.
@@ -5331,29 +5335,39 @@ instantiation of the function template or member function specialization.
 
 \pnum
 For a \grammarterm{noexcept-specifier} of a function template
-specialization or specialization of a member function of a class template, if
-the \grammarterm{noexcept-specifier} is implicitly instantiated because
-it is needed by another template specialization and the context that requires
-it depends on a template parameter, the point of instantiation of the
+specialization or specialization of a member function of a class template,
+the point of instantiation of the
 \grammarterm{noexcept-specifier} is the point of instantiation of the
-specialization that requires it. Otherwise, the point of instantiation for such
+specialization that requires it if
+\begin{itemize}
+\item the \grammarterm{noexcept-specifier} is implicitly instantiated because
+it is needed by another template specialization, and
+
+\item the context that requires
+it depends on a template parameter.
+\end{itemize}
+
+Otherwise, the point of instantiation for such
 a \grammarterm{noexcept-specifier} immediately follows the namespace
 scope declaration or definition that requires the
 \grammarterm{noexcept-specifier}.
 
-
-
 \pnum
 For a class template specialization, a class member template specialization,
 or a specialization for a class member of a class template,
-if the specialization is implicitly instantiated because it is referenced
-from within another template specialization,
-if the context from which the specialization is referenced depends on a
-template parameter,
-and if the specialization is not instantiated previous to the instantiation of
-the enclosing template,
 the point of instantiation is immediately before the point of instantiation of
+the enclosing template if
+\begin{itemize}
+\item the specialization is implicitly instantiated because it is referenced
+from within another template specialization, and
+
+\item the context from which the specialization is referenced depends on a
+template parameter, and
+
+\item the specialization is not instantiated previous to the instantiation of
 the enclosing template.
+\end{itemize}
+
 Otherwise, the point of instantiation for such a specialization immediately
 precedes the namespace scope declaration
 or definition that refers to the specialization.


### PR DESCRIPTION
Paragraphs in [[temp.point]](https://eel.is/c++draft/temp.point) (p1, p3, p4) are notorious in the C++ community for being long and hard to read.

This edit itemizes them, turning them from one huge prose sentence into something more organized. The actual text is almost the same 1:1, just reordered so that it makes sense as a list.

![grafik](https://github.com/cplusplus/draft/assets/22040976/30a35dd6-a34d-43c0-a46a-fc2365087b94)
![grafik](https://github.com/cplusplus/draft/assets/22040976/d4b1765d-5a59-427c-865b-fad1b5323f96)
![grafik](https://github.com/cplusplus/draft/assets/22040976/088dc0bf-ac59-4b86-a2b6-58e1379376ff)

I've asked for feedback from users familiar with the C++ standard on a programming Discord:
- One user said that this edit is *"reasonable"*.
- Another has said that it's *"definitely"* easier to read after the edit.