### PR TITLE
[span.cons][range.slide.iterator][text.encoding.members] Simplify `\tcode{\exposid{name}}` to `\exposid{name}`

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -18389,8 +18389,8 @@ then \tcode{count} is equal to \tcode{extent}.
 
 \pnum
 \effects
-Initializes \tcode{\exposid{data_}} with \tcode{to_address(first)} and
-\tcode{\exposid{size_}} with \tcode{count}.
+Initializes \exposid{data_} with \tcode{to_address(first)} and
+\exposid{size_} with \tcode{count}.
 
 \pnum
 \throws
@@ -18432,8 +18432,8 @@ then \tcode{last - first} is equal to \tcode{extent}.
 
 \pnum
 \effects
-Initializes \tcode{\exposid{data_}} with \tcode{to_address(first)} and
-\tcode{\exposid{size_}} with \tcode{last - first}.
+Initializes \exposid{data_} with \tcode{to_address(first)} and
+\exposid{size_} with \tcode{last - first}.
 
 \pnum
 \throws
@@ -18510,8 +18510,8 @@ then \tcode{ranges::size(r)} is equal to \tcode{extent}.
 
 \pnum
 \effects
-Initializes \tcode{\exposid{data_}} with \tcode{ranges::data(r)} and
-\tcode{\exposid{size_}} with \tcode{ranges::size(r)}.
+Initializes \exposid{data_} with \tcode{ranges::data(r)} and
+\exposid{size_} with \tcode{ranges::size(r)}.
 
 \pnum
 \throws

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -4855,7 +4855,7 @@ constexpr id mib() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{\exposid{mib_}}.
+\exposid{mib_}.
 \end{itemdescr}
 
 \indexlibrarymember{name}{text_encoding}%
@@ -4866,7 +4866,7 @@ constexpr const char* name() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{\exposid{name_}} if \tcode{(\exposid{name_}[0] != '\textbackslash 0')}
+\exposid{name_} if \tcode{(\exposid{name_}[0] != '\textbackslash 0')}
 is \tcode{true}, and
 \keyword{nullptr} otherwise.
 
@@ -4874,7 +4874,7 @@ is \tcode{true}, and
 \remarks
 If \tcode{name() == nullptr} is \tcode{false},
 \tcode{name()} is an \ntbs{} and
-accessing elements of \tcode{\exposid{name_}}
+accessing elements of \exposid{name_}
 outside of the range \countedrange{name()}{strlen(name()) + 1}
 is undefined behavior.
 \end{itemdescr}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -13529,7 +13529,7 @@ namespace std::ranges {
     using @\exposid{Base}@ = @\exposid{maybe-const}@<Const, V>;                 // \expos
     iterator_t<@\exposid{Base}@> @\exposid{current_}@   = iterator_t<@\exposid{Base}@>();   // \expos
     iterator_t<@\exposid{Base}@> @\exposid{last_ele_}@  = iterator_t<@\exposid{Base}@>();   // \expos,
-                                               // present only if \tcode{\exposid{Base}} models \tcode{\exposconcept{slide-caches-first}}
+                                               // present only if \exposid{Base} models \tcode{\exposconcept{slide-caches-first}}
     range_difference_t<@\exposid{Base}@> @\exposid{n_}@ = 0;                    // \expos
 
     constexpr @\exposid{iterator}@(iterator_t<@\exposid{Base}@> current, range_difference_t<@\exposid{Base}@> n) // \expos

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -13529,7 +13529,7 @@ namespace std::ranges {
     using @\exposid{Base}@ = @\exposid{maybe-const}@<Const, V>;                 // \expos
     iterator_t<@\exposid{Base}@> @\exposid{current_}@   = iterator_t<@\exposid{Base}@>();   // \expos
     iterator_t<@\exposid{Base}@> @\exposid{last_ele_}@  = iterator_t<@\exposid{Base}@>();   // \expos,
-                                               // present only if \exposid{Base} models \tcode{\exposconcept{slide-caches-first}}
+                                               // present only if \exposid{Base} models \exposconcept{slide-caches-first}
     range_difference_t<@\exposid{Base}@> @\exposid{n_}@ = 0;                    // \expos
 
     constexpr @\exposid{iterator}@(iterator_t<@\exposid{Base}@> current, range_difference_t<@\exposid{Base}@> n) // \expos


### PR DESCRIPTION
As suggested by @JohelEGP. Follows up #5918 and #6359.