### PR TITLE
[basic.fundamental] Clarify that table of minimum integral type widths applies only to standard integral types

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4970,7 +4970,7 @@ the largest value of the corresponding unsigned type.
 \end{floattable}
 
 \pnum
-The width of each signed integer type
+The width of each standard signed integer type
 shall not be less than the values specified in \tref{basic.fundamental.width}.
 The value representation of a signed or unsigned integer type
 comprises $N$ bits, where N is the respective width.


### PR DESCRIPTION
Per https://github.com/cplusplus/CWG/issues/365#issuecomment-1637162904