### PR TITLE
[conv.ptr], [conv.mem] Remove redundant text on null pointer comparisons

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1012,8 +1012,7 @@ distinguishable from every other value of
 object pointer or function pointer
 type.
 Such a conversion is called a \defnx{null pointer conversion}{conversion!null pointer}.
-Two null pointer values of the same type shall compare
-equal. The conversion of a null pointer constant to a pointer to
+The conversion of a null pointer constant to a pointer to
 cv-qualified type is a single conversion, and not the sequence of a
 pointer conversion followed by a qualification
 conversion\iref{conv.qual}. A null pointer constant of integral type
@@ -1052,8 +1051,7 @@ type; the result is the \defnx{null member pointer value}{value!null member poin
 of that type and is distinguishable from any pointer to member not
 created from a null pointer constant.
 Such a conversion is called a \defnx{null member pointer conversion}{conversion!null member pointer}.
-Two null member pointer values of
-the same type shall compare equal. The conversion of a null pointer
+The conversion of a null pointer
 constant to a pointer to member of cv-qualified type is a single
 conversion, and not the sequence of a pointer-to-member conversion
 followed by a qualification conversion\iref{conv.qual}.


### PR DESCRIPTION
(Member) pointer equality is specified in [[expr.eq]](https://eel.is/c++draft/expr.eq).