### PR TITLE
[intro.object] Fix cross-references for implicit object creation in the library

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3393,7 +3393,7 @@ implicitly creates objects in the returned region of storage and
 returns a pointer to a suitable created object.
 \begin{note}
 Some functions in the \Cpp{} standard library implicitly create objects%
-\iref{obj.lifetime,allocator.traits.members,c.malloc,cstring.syn,bit.cast}.
+\iref{obj.lifetime,c.malloc,mem.res.public,bit.cast,cstring.syn}.
 \end{note}
 \indextext{object model|)}
 


### PR DESCRIPTION
* Remove reference to [[allocator.traits.members]](https://eel.is/c++draft/allocator.traits.members)
* Add reference to [[mem.res.public]](https://eel.is/c++draft/mem.res.public#2)
* Reorder references to [[bit.cast]](https://eel.is/c++draft/bit.cast) and [[cstring.syn]](https://eel.is/c++draft/cstring.syn) to match subclause order