### PR TITLE
[over.call.object] Refer to the static type of the object expression

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -532,8 +532,8 @@ struct C {
 
 \pnum
 If the \grammarterm{postfix-expression} \tcode{E}
-in the function call syntax evaluates
-to a class object of type ``\cv{}~\tcode{T}'',
+in the function call syntax
+is of class type ``\cv{}~\tcode{T}'',
 then the set of candidate functions
 includes at least the function call operators of \tcode{T}.
 The function call operators of \tcode{T}


### PR DESCRIPTION
'`E` evaluates to a class object' is something that happens at runtime, but the text here is clearly concerned with the static type of the expression.