### PR TITLE
[dcl.meaning.general] Use 'declarator-id' instead of 'name'

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2754,7 +2754,8 @@ In a declaration
 \tcode{D}
 where
 \tcode{D}
-is an unadorned name, the type of the declared entity is
+is an unadorned \grammarterm{declarator-id},
+the type of the declared entity is
 ``\tcode{T}''.
 
 \pnum


### PR DESCRIPTION
A [*declarator-id*](https://eel.is/c++draft/dcl.decl.general#nt:declarator-id) is not necessarily a [name](https://eel.is/c++draft/basic.pre#def:name).