### PR TITLE
[optional.optional] Remove qualified destructor calls, refactor postconditions of `swap`

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -3955,17 +3955,22 @@ See \tref{optional.swap}.
 calls \tcode{swap(*(*this), *rhs)} &
 direct-non-list-initializes the contained value of \tcode{*this}
 with \tcode{std::move(*rhs)},
-then destroys the contained value of \tcode{rhs};
-postcondition is that \tcode{*this} contains a value and \tcode{rhs} does not contain a value \\
+then destroys the contained value of \tcode{rhs} \\
 \rowsep
 
 \rowhdr{\tcode{rhs} does not contain a value} &
 direct-non-list-initializes the contained value of \tcode{rhs}
 with \tcode{std::move(*(*this))},
-then destroys the contained value of \tcode{*this};
-postcondition is that \tcode{*this} does not contain a value and \tcode{rhs} contains a value &
+then destroys the contained value of \tcode{*this} &
 no effect \\
 \end{lib2dtab2}
+
+\pnum
+\ensures
+\tcode{*this} contains a value if and only if
+\tcode{rhs} contained a value before the call.
+\tcode{rhs} contains a value if and only if
+\tcode{*this} contained a value before the call.
 
 \pnum
 \throws

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -3592,10 +3592,8 @@ constexpr ~optional();
 \begin{itemdescr}
 \pnum
 \effects
-If \tcode{is_trivially_destructible_v<T> != true} and \tcode{*this} contains a value, calls
-\begin{codeblock}
-val->T::~T()
-\end{codeblock}
+If \tcode{is_trivially_destructible_v<T> != true} and \tcode{*this} contains a value,
+destroys the contained value.
 
 \pnum
 \remarks
@@ -3612,7 +3610,7 @@ constexpr optional<T>& operator=(nullopt_t) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-If \tcode{*this} contains a value, calls \tcode{val->T::\~T()} to destroy the contained value; otherwise no effect.
+If \tcode{*this} contains a value, destroys the contained value; otherwise no effect.
 
 \pnum
 \ensures
@@ -3642,7 +3640,7 @@ direct-non-list-initializes the contained value with \tcode{*rhs} \\
 \rowsep
 
 \rowhdr{\tcode{rhs} does not contain a value} &
-destroys the contained value by calling \tcode{val->T::\~T()} &
+destroys the contained value &
 no effect \\
 \end{lib2dtab2}
 
@@ -3694,7 +3692,7 @@ direct-non-list-initializes the contained value with \tcode{std::move(*rhs)} \\
 \rowsep
 
 \rowhdr{\tcode{rhs} does not contain a value} &
-destroys the contained value by calling \tcode{val->T::\~T()} &
+destroys the contained value &
 no effect \\
 \end{lib2dtab2}
 
@@ -3786,7 +3784,7 @@ direct-non-list-initializes the contained value with \tcode{*rhs} \\
 \rowsep
 
 \rowhdr{\tcode{rhs} does not contain a value} &
-destroys the contained value by calling \tcode{val->T::\~T()} &
+destroys the contained value &
 no effect \\
 \end{lib2dtab2}
 
@@ -3842,7 +3840,7 @@ direct-non-list-initializes the contained value with \tcode{std::move(*rhs)} \\
 \rowsep
 
 \rowhdr{\tcode{rhs} does not contain a value} &
-destroys the contained value by calling \tcode{val->T::\~T()} &
+destroys the contained value &
 no effect \\
 \end{lib2dtab2}
 
@@ -3957,14 +3955,14 @@ See \tref{optional.swap}.
 calls \tcode{swap(*(*this), *rhs)} &
 direct-non-list-initializes the contained value of \tcode{*this}
 with \tcode{std::move(*rhs)},
-followed by \tcode{rhs.val->T::\~T()};
+then destroys the contained value of \tcode{rhs};
 postcondition is that \tcode{*this} contains a value and \tcode{rhs} does not contain a value \\
 \rowsep
 
 \rowhdr{\tcode{rhs} does not contain a value} &
 direct-non-list-initializes the contained value of \tcode{rhs}
 with \tcode{std::move(*(*this))},
-followed by \tcode{val->T::\~T()};
+then destroys the contained value of \tcode{*this};
 postcondition is that \tcode{*this} does not contain a value and \tcode{rhs} contains a value &
 no effect \\
 \end{lib2dtab2}
@@ -4324,7 +4322,7 @@ constexpr void reset() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-If \tcode{*this} contains a value, calls \tcode{val->T::\~T()} to destroy the contained value;
+If \tcode{*this} contains a value, destroys the contained value;
 otherwise no effect.
 
 \pnum


### PR DESCRIPTION
`val->T::~T()` should be `val->~T()` (the former breaks if `T` has a member named `T`), but considering that '[destroys](https://eel.is/c++draft/dcl.init.general#22) the contained value' is already sufficiently clear in its meaning, I don't see why explicitly specifying the syntax for a (pseudo-)destructor call is necessary at all.

This PR also changes the presentation of postconditions in [[optional.swap]](https://eel.is/c++draft/optional.swap) by moving them out of the 'Effects' table.