### PR TITLE
typo fix appeartain -> appertain

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -8651,7 +8651,7 @@ entity or statement, the program is ill-formed. If an \grammarterm{attribute-spe
 appertains to a friend declaration\iref{class.friend}, that declaration shall be a
 definition.
 \begin{note}
-An \grammarterm{attribute-specifier-seq} cannot appeartain to
+An \grammarterm{attribute-specifier-seq} cannot appertain to
 an explicit instantiation\iref{temp.explicit}.
 \end{note}
 


### PR DESCRIPTION
There is a typo in the word appertain in [dcl.attr.grammar]p5 (in note 3).