### PR TITLE
[intro.object] Make the storage in the example for storage providing properly aligned

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3221,7 +3221,7 @@ int f() {
 
 struct A { unsigned char a[32]; };
 struct B { unsigned char b[16]; };
-A a;
+alignas(int) A a;
 B *b = new (a.a + 8) B;                 // \tcode{a.a} provides storage for \tcode{*b}
 int *p = new (b->b + 4) int;            // \tcode{b->b} provides storage for \tcode{*p}
                                         // \tcode{a.a} does not provide storage for \tcode{*p} (directly),

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3207,6 +3207,8 @@ because its storage was reused\iref{basic.life}.
 \end{note}
 \begin{example}
 \begin{codeblock}
+// assumes that \tcode{sizeof(int)} is equal to 4
+
 template<typename ...T>
 struct AlignedUnion {
   alignas(T...) unsigned char data[max(sizeof(T)...)];


### PR DESCRIPTION
Fixes cplusplus/CWG#379.

The example seemingly assumes that the implementation-defined properties on common platforms (e.g., `sizeof(int)` is `4`) hold. I guess we can keep such assumptions implicit and avoid pedantically writing `sizeof(int)`.