### PR TITLE
[ostream.formatted.print] Use \impldef macro.

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -6838,8 +6838,8 @@ the function initializes an automatic variable via
 string out = vformat(os.getloc(), fmt, args);
 \end{codeblock}
 If the function is \tcode{vprint_unicode} and
-\tcode{os} is a stream that refers to a terminal capable of displaying Unicode
-which is determined in an implementation-defined manner,
+\tcode{os} is a stream that refers to \impldef{a terminal capable of displaying
+Unicode} which is determined in an implementation-defined manner,
 writes \tcode{out} to the terminal using the native Unicode API;
 if \tcode{out} contains invalid code units,
 \indextext{undefined}%


### PR DESCRIPTION
The text defines implementation-defined behavior, but it doesn't use the appropriate macro. So the text is not available in "Index of implementation-defined behavior".