### PR TITLE
[basic.lookup.qual.general] Ignore top-level cv-qualifiers for the purpose of lookup context

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2426,6 +2426,7 @@ the type of its associated object expression
 The lookup context of any other qualified name is
 the type, template, or namespace
 nominated by the preceding \grammarterm{nested-name-specifier}.
+The top-level cv-qualifiers of a type are ignored for the purpose of lookup context.
 \begin{note}
 When parsing a class member access,
 the name following the \tcode{->} or \tcode{.} is

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2461,6 +2461,7 @@ the type of its associated object expression
 The lookup context of any other qualified name is
 the type, template, or namespace
 nominated by the preceding \grammarterm{nested-name-specifier}.
+The top-level cv-qualifiers of a type are ignored for the purpose of lookup context.
 \begin{note}
 When parsing a class member access,
 the name following the \tcode{->} or \tcode{.} is


### PR DESCRIPTION
Fixes #5351.