### PR TITLE
[class.compare.default] Say subobjects of an object instead of a class

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6610,11 +6610,11 @@ is defined as deleted.
 \end{note}
 
 \pnum
-The direct base class subobjects of \tcode{C},
+The direct base class subobjects of an object \tcode{x} of class \tcode{C},
 in the order of their declaration in the \grammarterm{base-specifier-list} of \tcode{C},
-followed by the non-static data members of \tcode{C},
+followed by the direct member subobjects of \tcode{x},
 in the order of their declaration in the \grammarterm{member-specification} of \tcode{C},
-form a list of subobjects.
+form a list of subobjects for \tcode{x}.
 In that list, any subobject of array type is recursively expanded
 to the sequence of its elements, in the order of increasing subscript.
 Let $\tcode{x}_i$ be an lvalue denoting the $i^\text{th}$ element


### PR DESCRIPTION
Fixes #5339.