### PR TITLE
[cmp.categories] Exposition-only formatting for comparison category types

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -4331,14 +4331,14 @@ That is, \tcode{a < b}, \tcode{a == b}, and \tcode{a > b} might all be \tcode{fa
 \begin{codeblock}
 namespace std {
   class partial_ordering {
-    int value;          // \expos
-    bool is_ordered;    // \expos
+    int @\exposid{value}@;          // \expos
+    bool @\exposid{is-ordered}@;    // \expos
 
     // exposition-only constructors
     constexpr explicit
-      partial_ordering(@\placeholder{ord}@ v) noexcept : value(int(v)), is_ordered(true) {}     // \expos
+      partial_ordering(@\placeholder{ord}@ v) noexcept : @\exposid{value}@(int(v)), @\exposid{is-ordered}@(true) {}     // \expos
     constexpr explicit
-      partial_ordering(@\placeholder{ncmp}@ v) noexcept : value(int(v)), is_ordered(false) {}   // \expos
+      partial_ordering(@\placeholder{ncmp}@ v) noexcept : @\exposid{value}@(int(v)), @\exposid{is-ordered}@(false) {}   // \expos
 
   public:
     // valid values
@@ -4386,7 +4386,7 @@ constexpr bool operator>=(partial_ordering v, @\unspec@) noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-For \tcode{operator@}, \tcode{v.is_ordered \&\& v.value @ 0}.
+For \tcode{operator@}, \tcode{v.\exposid{is-ordered} \&\& v.\exposid{value} @ 0}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<}{partial_ordering}%
@@ -4403,7 +4403,7 @@ constexpr bool operator>=(@\unspec@, partial_ordering v) noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-For \tcode{operator@}, \tcode{v.is_ordered \&\& 0 @ v.value}.
+For \tcode{operator@}, \tcode{v.\exposid{is-ordered} \&\& 0 @ v.\exposid{value}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{partial_ordering}%
@@ -4444,10 +4444,10 @@ and for which equality need not imply substitutability.
 \begin{codeblock}
 namespace std {
   class weak_ordering {
-    int value;  // \expos
+    int @\exposid{value}@;  // \expos
 
     // exposition-only constructors
-    constexpr explicit weak_ordering(@\placeholder{ord}@ v) noexcept : value(int(v)) {} // \expos
+    constexpr explicit weak_ordering(@\placeholder{ord}@ v) noexcept : @\exposid{value}@(int(v)) {} // \expos
 
   public:
     // valid values
@@ -4489,8 +4489,8 @@ constexpr operator partial_ordering() const noexcept;
 \pnum
 \returns
 \begin{codeblock}
-value == 0 ? partial_ordering::equivalent :
-value < 0  ? partial_ordering::less :
+@\exposid{value}@ == 0 ? partial_ordering::equivalent :
+@\exposid{value}@ < 0  ? partial_ordering::less :
              partial_ordering::greater
 \end{codeblock}
 \end{itemdescr}
@@ -4511,7 +4511,7 @@ constexpr bool operator>=(weak_ordering v, @\unspec@) noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{v.value @ 0} for \tcode{operator@}.
+\tcode{v.\exposid{value} @ 0} for \tcode{operator@}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<}{weak_ordering}%
@@ -4528,7 +4528,7 @@ constexpr bool operator>=(@\unspec@, weak_ordering v) noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{0 @ v.value} for \tcode{operator@}.
+\tcode{0 @ v.\exposid{value}} for \tcode{operator@}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{weak_ordering}%
@@ -4570,10 +4570,10 @@ and for which equality does imply substitutability.
 \begin{codeblock}
 namespace std {
   class strong_ordering {
-    int value;  // \expos
+    int @\exposid{value}@;  // \expos
 
     // exposition-only constructors
-    constexpr explicit strong_ordering(@\placeholder{ord}@ v) noexcept : value(int(v)) {}   // \expos
+    constexpr explicit strong_ordering(@\placeholder{ord}@ v) noexcept : @\exposid{value}@(int(v)) {}   // \expos
 
   public:
     // valid values
@@ -4618,8 +4618,8 @@ constexpr operator partial_ordering() const noexcept;
 \pnum
 \returns
 \begin{codeblock}
-value == 0 ? partial_ordering::equivalent :
-value < 0  ? partial_ordering::less :
+@\exposid{value}@ == 0 ? partial_ordering::equivalent :
+@\exposid{value}@ < 0  ? partial_ordering::less :
              partial_ordering::greater
 \end{codeblock}
 \end{itemdescr}
@@ -4633,8 +4633,8 @@ constexpr operator weak_ordering() const noexcept;
 \pnum
 \returns
 \begin{codeblock}
-value == 0 ? weak_ordering::equivalent :
-value < 0  ? weak_ordering::less :
+@\exposid{value}@ == 0 ? weak_ordering::equivalent :
+@\exposid{value}@ < 0  ? weak_ordering::less :
              weak_ordering::greater
 \end{codeblock}
 \end{itemdescr}
@@ -4655,7 +4655,7 @@ constexpr bool operator>=(strong_ordering v, @\unspec@) noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{v.value @ 0} for \tcode{operator@}.
+\tcode{v.\exposid{value} @ 0} for \tcode{operator@}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<}{strong_ordering}%
@@ -4672,7 +4672,7 @@ constexpr bool operator>=(@\unspec@, strong_ordering v) noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{0 @ v.value} for \tcode{operator@}.
+\tcode{0 @ v.\exposid{value}} for \tcode{operator@}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{strong_ordering}%


### PR DESCRIPTION
Towards #4702 and #5940.