### PR TITLE
[dcl.inline] p2 - Make it recommended practice

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1010,13 +1010,12 @@ of a variable or function.
 \indextext{inline function}%
 A function declaration\iref{dcl.fct,class.mfct,class.friend}
 with an \keyword{inline} specifier declares an
-\defnadj{inline}{function}. The inline specifier indicates to
+\defnadj{inline}{function}.
+
+\recommended
+The \keyword{inline} specifier indicates to
 the implementation that inline substitution of the function body at the
 point of call is to be preferred to the usual function call mechanism.
-An implementation is not required to perform this inline substitution at
-the point of call; however, even if this inline substitution is omitted,
-the other rules for inline functions specified in this subclause shall
-still be respected.
 \begin{note}
 The \keyword{inline} keyword has no effect on the linkage of a function.
 In certain cases, an inline function cannot use names with internal linkage;


### PR DESCRIPTION
I believe this should be a recommended practice paragraph because what the paragraph demands is an optional compiler hint.

Furthermore, p1 uses `\keyword{inline} specifier`, whereas p2 uses `inline specifier`, which is inconsistent.