### PR TITLE
[memory.syn][ranges.syn] Remove redundant `// freestanding` marks for freestanding class members

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -104,9 +104,7 @@ namespace std {
 	                                      size_t n) noexcept;
 
   // \ref{allocator.tag}, allocator argument tag
-  struct allocator_arg_t {                                                          // freestanding
-      explicit allocator_arg_t() = default;                                         // freestanding
-  };
+  struct allocator_arg_t { explicit allocator_arg_t() = default; };                 // freestanding
   inline constexpr allocator_arg_t allocator_arg{};                                 // freestanding
 
   // \ref{allocator.uses}, \tcode{uses_allocator}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -552,19 +552,19 @@ namespace std {
     : integral_constant<size_t, 2> {};
   template<class I, class S, ranges::subrange_kind K>
   struct tuple_element<0, ranges::subrange<I, S, K>> {                              // freestanding
-    using type = I;                                                                 // freestanding
+    using type = I;
   };
   template<class I, class S, ranges::subrange_kind K>
   struct tuple_element<1, ranges::subrange<I, S, K>> {                              // freestanding
-    using type = S;                                                                 // freestanding
+    using type = S;
   };
   template<class I, class S, ranges::subrange_kind K>
   struct tuple_element<0, const ranges::subrange<I, S, K>> {                        // freestanding
-    using type = I;                                                                 // freestanding
+    using type = I;
   };
   template<class I, class S, ranges::subrange_kind K>
   struct tuple_element<1, const ranges::subrange<I, S, K>> {                        // freestanding
-    using type = S;                                                                 // freestanding
+    using type = S;
   };
 
   struct from_range_t { explicit from_range_t() = default; };                       // freestanding


### PR DESCRIPTION
See LWG3753. Also makes definition of `allocator_arg_t` shown in one line, like `from_range_t`.

Fixes #5723.