### PR TITLE
[basic.compound] Clarify a pointer to a non-first element object of an array

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5383,6 +5383,8 @@ or the first byte in memory
 after the end of the storage occupied by the object,
 respectively.
 \begin{note}
+A pointer to an actual array element object is categorized as a pointer to an object,
+even though it also points past the end of the previous array element, if any.
 A pointer past the end of an object\iref{expr.add}
 is not considered to point to an unrelated object
 of the object's type,


### PR DESCRIPTION
Such a pointer is categorized a pointer to an object, even if it may also point past the end of the previous array element. That is, [[basic.compound]/3.1](https://eel.is/c++draft/basic.compound#3.1) applies first whenever possible.

I think we can just make clarification in the note.

Fixes #4784.
Fixes cplusplus/CWG#385.