### PR TITLE
[diagnostics] Exposition-only formatting for `val_`, `cat_`, and `frames_`

### DIFF
--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -1088,8 +1088,8 @@ namespace std {
     explicit operator bool() const noexcept;
 
   private:
-    int val_;                   // \expos
-    const error_category* cat_; // \expos
+    int @\exposid{val_}@;                   // \expos
+    const error_category* @\exposid{cat_}@; // \expos
   };
 
   // \ref{syserr.errcode.nonmembers}, non-member functions
@@ -1111,8 +1111,8 @@ error_code() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{val_} with \tcode{0}
-and \tcode{cat_} with \tcode{\&system_category()}.
+Initializes \exposid{val_} with \tcode{0}
+and \exposid{cat_} with \tcode{\&system_category()}.
 \end{itemdescr}
 
 \indexlibraryctor{error_code}%
@@ -1123,8 +1123,8 @@ error_code(int val, const error_category& cat) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{val_} with \tcode{val}
-and \tcode{cat_} with \tcode{\&cat}.
+Initializes \exposid{val_} with \tcode{val}
+and \exposid{cat_} with \tcode{\&cat}.
 \end{itemdescr}
 
 \indexlibraryctor{error_code}%
@@ -1157,7 +1157,7 @@ void assign(int val, const error_category& cat) noexcept;
 \begin{itemdescr}
 \pnum
 \ensures
-\tcode{val_ == val} and \tcode{cat_ == \&cat}.
+\tcode{\exposid{val_} == val} and \tcode{\exposid{cat_} == \&cat}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{error_code}%
@@ -1206,7 +1206,7 @@ int value() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{val_}.
+\exposid{val_}.
 \end{itemdescr}
 
 \indexlibrarymember{category}{error_code}%
@@ -1217,7 +1217,7 @@ const error_category& category() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{*cat_}.
+\tcode{*\exposid{cat_}}.
 \end{itemdescr}
 
 \indexlibrarymember{default_error_condition}{error_code}%
@@ -1315,8 +1315,8 @@ namespace std {
     explicit operator bool() const noexcept;
 
   private:
-    int val_;                   // \expos
-    const error_category* cat_; // \expos
+    int @\exposid{val_}@;                   // \expos
+    const error_category* @\exposid{cat_}@; // \expos
   };
 }
 \end{codeblock}
@@ -1331,8 +1331,8 @@ error_condition() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{val_} with \tcode{0}
-and \tcode{cat_} with \tcode{\&generic_category()}.
+Initializes \exposid{val_} with \tcode{0}
+and \exposid{cat_} with \tcode{\&generic_category()}.
 \end{itemdescr}
 
 \indexlibraryctor{error_condition}%
@@ -1343,8 +1343,8 @@ error_condition(int val, const error_category& cat) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{val_} with \tcode{val}
-and \tcode{cat_} with \tcode{\&cat}.
+Initializes \exposid{val_} with \tcode{val}
+and \exposid{cat_} with \tcode{\&cat}.
 \end{itemdescr}
 
 \indexlibraryctor{error_condition}%
@@ -1378,7 +1378,7 @@ void assign(int val, const error_category& cat) noexcept;
 \begin{itemdescr}
 \pnum
 \ensures
-\tcode{val_ == val} and \tcode{cat_ == \&cat}.
+\tcode{\exposid{val_} == val} and \tcode{\exposid{cat_} == \&cat}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{error_condition}%
@@ -1426,7 +1426,7 @@ int value() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{val_}.
+\exposid{val_}.
 \end{itemdescr}
 
 \indexlibrarymember{category}{error_condition}%
@@ -1437,7 +1437,7 @@ const error_category& category() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{*cat_}.
+\tcode{*\exposid{cat_}}.
 \end{itemdescr}
 
 \indexlibrarymember{message}{error_condition}%
@@ -1998,7 +1998,7 @@ namespace std {
         allocator_traits<Allocator>::is_always_equal::value);
 
   private:
-    vector<value_type, allocator_type> frames_;         // \expos
+    vector<value_type, allocator_type> @\exposid{frames_}@;         // \expos
   };
 }
 \end{codeblock}
@@ -2030,17 +2030,17 @@ static basic_stacktrace current(const allocator_type& alloc = allocator_type()) 
 \pnum
 \returns
 A \tcode{basic_stacktrace} object
-with \tcode{frames_} storing
+with \exposid{frames_} storing
 the stacktrace of the current evaluation in the current thread of execution, or
 an empty \tcode{basic_stacktrace} object
-if the initialization of \tcode{frames_} failed.
-\tcode{alloc} is passed to the constructor of the \tcode{frames_} object.
+if the initialization of \exposid{frames_} failed.
+\tcode{alloc} is passed to the constructor of the \exposid{frames_} object.
 
 \begin{note}
 If the stacktrace was successfully obtained,
-then \tcode{frames_.front()} is the \tcode{stacktrace_entry}
+then \tcode{\exposid{frames_}.front()} is the \tcode{stacktrace_entry}
 representing approximately the current evaluation, and
-\tcode{frames_.back()} is the \tcode{stacktrace_entry}
+\tcode{\exposid{frames_}.back()} is the \tcode{stacktrace_entry}
 representing approximately the initial function of
 the current thread of execution.
 \end{note}
@@ -2061,10 +2061,10 @@ Let \tcode{n} be \tcode{t.size()}.
 \pnum
 \returns
 A \tcode{basic_stacktrace} object
-where \tcode{frames_} is direct-non-list-initialized from arguments
+where \exposid{frames_} is direct-non-list-initialized from arguments
 \tcode{t.begin() + min(n, skip)}, \tcode{t.end()}, and \tcode{alloc},
 or an empty \tcode{basic_stacktrace} object
-if the initialization of \tcode{frames_} failed.
+if the initialization of \exposid{frames_} failed.
 \end{itemdescr}
 
 \indexlibrarymember{current}{basic_stacktrace}%
@@ -2086,11 +2086,11 @@ Let \tcode{n} be \tcode{t.size()}.
 \pnum
 \returns
 A \tcode{basic_stacktrace} object
-where \tcode{frames_} is direct-non-list-initialized from arguments
+where \exposid{frames_} is direct-non-list-initialized from arguments
 \tcode{t.begin() + min(n, skip)}, \tcode{t.begin() + min(n, skip + max_depth)},
 and \tcode{alloc},
 or an empty \tcode{basic_stacktrace} object
-if the initialization of \tcode{frames_} failed.
+if the initialization of \exposid{frames_} failed.
 \end{itemdescr}
 
 \indexlibraryctor{basic_stacktrace}%
@@ -2112,7 +2112,7 @@ explicit basic_stacktrace(const allocator_type& alloc) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-\tcode{alloc} is passed to the \tcode{frames_} constructor.
+\tcode{alloc} is passed to the \exposid{frames_} constructor.
 
 \pnum
 \ensures
@@ -2162,7 +2162,7 @@ allocator_type get_allocator() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{frames_.get_allocator()}.
+\tcode{\exposid{frames_}.get_allocator()}.
 \end{itemdescr}
 
 \indexlibrarymember{begin}{basic_stacktrace}%
@@ -2175,7 +2175,7 @@ const_iterator cbegin() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-An iterator referring to the first element in \tcode{frames_}.
+An iterator referring to the first element in \exposid{frames_}.
 If \tcode{empty()} is \tcode{true},
 then it returns the same value as \tcode{end()}.
 \end{itemdescr}
@@ -2227,7 +2227,7 @@ const_reverse_iterator crend() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{frames_.empty()}.
+\tcode{\exposid{frames_}.empty()}.
 \end{itemdescr}
 
 \indexlibrarymember{size}{basic_stacktrace}%
@@ -2238,7 +2238,7 @@ size_type size() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{frames_.size()}.
+\tcode{\exposid{frames_}.size()}.
 \end{itemdescr}
 
 \indexlibrarymember{max_size}{basic_stacktrace}%
@@ -2249,7 +2249,7 @@ size_type max_size() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{frames_.max_size()}.
+\tcode{\exposid{frames_}.max_size()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator[]}{basic_stacktrace}%
@@ -2264,7 +2264,7 @@ const_reference operator[](size_type frame_no) const;
 
 \pnum
 \returns
-\tcode{frames_[frame_no]}.
+\tcode{\exposid{frames_}[frame_no]}.
 
 \pnum
 \throws
@@ -2279,7 +2279,7 @@ const_reference at(size_type frame_no) const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{frames_[frame_no]}.
+\tcode{\exposid{frames_}[frame_no]}.
 
 \pnum
 \throws


### PR DESCRIPTION
Towards #4702.