### PR TITLE
[intro.execution] "Sequenced before" should be a strict partial order

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5846,9 +5846,10 @@ by the call (such as the I/O itself) or by the \keyword{volatile} access
 may not have completed yet.
 
 \pnum
-\defnx{Sequenced before}{sequenced before} is an asymmetric, transitive, pair-wise relation between
+\defnx{Sequenced before}{sequenced before} is an
+irreflexive, asymmetric, transitive, pair-wise relation between
 evaluations executed by a single thread\iref{intro.multithread}, which induces
-a partial order among those evaluations. Given any two evaluations \placeholder{A} and
+a strict partial order among those evaluations. Given any two evaluations \placeholder{A} and
 \placeholder{B}, if \placeholder{A} is sequenced before \placeholder{B}
 (or, equivalently, \placeholder{B} is \defn{sequenced after} \placeholder{A}),
 then the execution of


### PR DESCRIPTION
A relation which is asymmetric must also be irreflexive. Asymmetry is defined as:
```cpp
A sequenced before B  =>  !(A sequenced before B)
```
If any evaluation **E** was sequenced before itself, this would yield:
```cpp
E sequenced-before E  =>  !(E sequenced before E)
true                  =>  false
```
This is a contradiction of the asymmetry requirement, meaning that *sequenced before* is implied to be irreflexive. Ideally, this should be clearly stated, and it should be stated that it is a [strict partial order](https://en.wikipedia.org/wiki/Partially_ordered_set#Strict_partial_orders) since it fulfills all requirements of one.