### PR TITLE
[basic][expr] Declare but not define typedef-names declared in standard headers

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5199,7 +5199,7 @@ If the implementation supports an extended floating-point type\iref{basic.fundam
 whose properties are specified by
 the ISO/IEC/IEEE 60559 floating-point interchange format binary16,
 then the \grammarterm{typedef-name} \tcode{std::float16_t}
-is defined in the header \libheaderref{stdfloat} and names such a type,
+is declared in the header \libheaderref{stdfloat} and names such a type,
 the macro \mname{STDCPP_FLOAT16_T} is defined\iref{cpp.predefined}, and
 the floating-point literal suffixes \tcode{f16} and \tcode{F16}
 are supported\iref{lex.fcon}.
@@ -5209,7 +5209,7 @@ If the implementation supports an extended floating-point type
 whose properties are specified by
 the ISO/IEC/IEEE 60559 floating-point interchange format binary32,
 then the \grammarterm{typedef-name} \tcode{std::float32_t}
-is defined in the header \libheader{stdfloat} and names such a type,
+is declared in the header \libheader{stdfloat} and names such a type,
 the macro \mname{STDCPP_FLOAT32_T} is defined, and
 the floating-point literal suffixes \tcode{f32} and \tcode{F32} are supported.
 
@@ -5218,7 +5218,7 @@ If the implementation supports an extended floating-point type
 whose properties are specified by
 the ISO/IEC/IEEE 60559 floating-point interchange format binary64,
 then the \grammarterm{typedef-name} \tcode{std::float64_t}
-is defined in the header \libheader{stdfloat} and names such a type,
+is declared in the header \libheader{stdfloat} and names such a type,
 the macro \mname{STDCPP_FLOAT64_T} is defined, and
 the floating-point literal suffixes \tcode{f64} and \tcode{F64} are supported.
 
@@ -5227,7 +5227,7 @@ If the implementation supports an extended floating-point type
 whose properties are specified by
 the ISO/IEC/IEEE 60559 floating-point interchange format binary128,
 then the \grammarterm{typedef-name} \tcode{std::float128_t}
-is defined in the header \libheader{stdfloat} and names such a type,
+is declared in the header \libheader{stdfloat} and names such a type,
 the macro \mname{STDCPP_FLOAT128_T} is defined, and
 the floating-point literal suffixes \tcode{f128} and \tcode{F128} are supported.
 
@@ -5240,7 +5240,7 @@ precision in bits ($p$) of 8,
 maximum exponent ($emax$) of 127, and
 exponent field width in bits ($w$) of 8, then
 the \grammarterm{typedef-name} \tcode{std::bfloat16_t}
-is defined in the header \libheader{stdfloat} and names such a type,
+is declared in the header \libheader{stdfloat} and names such a type,
 the macro \mname{STDCPP_BFLOAT16_T} is defined, and
 the floating-point literal suffixes \tcode{bf16} and \tcode{BF16} are supported.
 
@@ -5270,7 +5270,7 @@ $w$, exponent field width in bits & 5 & 8 & 11 & 15 & 8 \\
 \recommended
 Any names that the implementation provides for
 the extended floating-point types described in this subsection
-that are in addition to the names defined in the \libheader{stdfloat} header
+that are in addition to the names declared in the \libheader{stdfloat} header
 should be chosen to increase compatibility and interoperability
 with the interchange types
 \tcode{_Float16}, \tcode{_Float32}, \tcode{_Float64}, and \tcode{_Float128}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6273,7 +6273,7 @@ or a complete object results in undefined behavior.
 \indextext{comparison!undefined pointer}%
 When two pointer expressions \tcode{P} and \tcode{Q} are subtracted,
 the type of the result is an \impldef{type of \tcode{ptrdiff_t}} signed
-integral type; this type shall be the same type that is defined as
+integral type; this type shall be the same type that is named by
 \tcode{std::ptrdiff_t} in the \libheader{cstddef}
 header\iref{support.types.layout}.
 \begin{itemize}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5010,7 +5010,7 @@ The result of \keyword{sizeof} and \tcode{\keyword{sizeof}...} is a prvalue of t
 \begin{note}
 A \keyword{sizeof} expression
 is an integral constant expression\iref{expr.const}.
-The type \tcode{std::size_t} is defined in the standard header
+The \grammarterm{typedef-name} \tcode{std::size_t} is declared in the standard header
 \libheader{cstddef}\iref{cstddef.syn,support.types.layout}.
 \end{note}
 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5029,7 +5029,7 @@ The result is a prvalue of type \tcode{std::size_t}.
 \begin{note}
 An \keyword{alignof} expression
 is an integral constant expression\iref{expr.const}.
-The type \tcode{std::size_t} is defined in the standard header
+The \grammarterm{typedef-name} \tcode{std::size_t} is declared in the standard header
 \libheader{cstddef}\iref{cstddef.syn,support.types.layout}.
 \end{note}
 


### PR DESCRIPTION
Since (non-template) typedef-names are declared but not defined ([[basic.def]/2.9](https://eel.is/c++draft/basic.def#2.9), [[basic.def]/2.10](https://eel.is/c++draft/basic.def#2.10)).