### PR TITLE
[conv.mem] Itemize p2

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1063,18 +1063,20 @@ A prvalue of type ``pointer to member of \tcode{B} of type \cv{}
 \tcode{T}'', where \tcode{B} is a class type, can be converted to
 a prvalue of type ``pointer to member of \tcode{D} of type \cv{}
 \tcode{T}'', where \tcode{D} is a complete class derived\iref{class.derived}
-from \tcode{B}. If \tcode{B} is an
-inaccessible\iref{class.access},
+from \tcode{B}, as follows:
+\begin{itemize}
+\item If \tcode{B} is an inaccessible\iref{class.access},
 ambiguous\iref{class.member.lookup}, or virtual\iref{class.mi} base
 class of \tcode{D}, or a base class of a virtual base class of
 \tcode{D}, a program that necessitates this conversion is ill-formed.
-If class \tcode{D} does not contain the original member and
+\item If class \tcode{D} does not contain the original member and
 is not a base class of the class containing the original member,
-the behavior is undefined. Otherwise,
-the result of the conversion refers to the same member as the pointer to
+the behavior is undefined.
+\item Otherwise, the result of the conversion refers to the same member as the pointer to
 member before the conversion took place, but it refers to the base class
 member as if it were a member of the derived class. The result refers to
-the member in \tcode{D}'s instance of \tcode{B}. Since the result has
+the member in \tcode{D}'s instance of \tcode{B}.
+Since the result has
 type ``pointer to member of \tcode{D} of type \cv{} \tcode{T}'',
 indirection through it with a \tcode{D} object is valid. The result is the same
 as if indirecting through the pointer to member of \tcode{B} with the
@@ -1094,6 +1096,7 @@ of such pointers do not apply to pointers to members.
 In particular, a pointer to member cannot be converted to a
 \tcode{\keyword{void}*}.
 \end{footnote}
+\end{itemize}
 
 \rSec2[conv.fctptr]{Function pointer conversions}
 

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1063,24 +1063,29 @@ A prvalue of type ``pointer to member of \tcode{B} of type \cv{}
 \tcode{T}'', where \tcode{B} is a class type, can be converted to
 a prvalue of type ``pointer to member of \tcode{D} of type \cv{}
 \tcode{T}'', where \tcode{D} is a complete class derived\iref{class.derived}
-from \tcode{B}. If \tcode{B} is an
-inaccessible\iref{class.access},
+from \tcode{B}, as follows:
+\begin{itemize}
+\item
+If \tcode{B} is an inaccessible\iref{class.access},
 ambiguous\iref{class.member.lookup}, or virtual\iref{class.mi} base
 class of \tcode{D}, or a base class of a virtual base class of
 \tcode{D}, a program that necessitates this conversion is ill-formed.
-If class \tcode{D} does not contain the original member and
+\item
+Otherwise, if the operand is the null member pointer value,
+the result is the null member pointer value of the destination type.
+\item
+Otherwise, if class \tcode{D} does not contain the original member and
 is not a base class of the class containing the original member,
-the behavior is undefined. Otherwise,
-the result of the conversion refers to the same member as the pointer to
+the behavior is undefined.
+\item
+Otherwise, the result of the conversion refers to the same member as the pointer to
 member before the conversion took place, but it refers to the base class
 member as if it were a member of the derived class. The result refers to
 the member in \tcode{D}'s instance of \tcode{B}. Since the result has
 type ``pointer to member of \tcode{D} of type \cv{} \tcode{T}'',
 indirection through it with a \tcode{D} object is valid. The result is the same
 as if indirecting through the pointer to member of \tcode{B} with the
-\tcode{B} subobject of \tcode{D}. The null member pointer value is
-converted to the null member pointer value of the destination
-type.
+\tcode{B} subobject of \tcode{D}.
 \begin{footnote}
 The rule for conversion of pointers to members (from pointer to member
 of base to pointer to member of derived) appears inverted compared to
@@ -1094,6 +1099,7 @@ of such pointers do not apply to pointers to members.
 In particular, a pointer to member cannot be converted to a
 \tcode{\keyword{void}*}.
 \end{footnote}
+\end{itemize}
 
 \rSec2[conv.fctptr]{Function pointer conversions}
 


### PR DESCRIPTION
This is meant to improve readability and make it possible to cite each bullet separately. This paragraph is quite a massive block of text otherwise.