### PR TITLE
[basic.align] Fix non-mathematical wording of p7

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4225,12 +4225,12 @@ underlying type for an aligned memory area\iref{dcl.align}.
 \end{note}
 
 \pnum
-Comparing alignments is meaningful and provides the obvious results:
+Comparing two alignments $A$ and $B$ is meaningful and provides the obvious results:
 
 \begin{itemize}
-\item Two alignments are equal when their numeric values are equal.
-\item Two alignments are different when their numeric values are not equal.
-\item When an alignment is larger than another it represents a stricter alignment.
+\item $A$ and $B$ are equal when their numeric values are equal.
+\item $A$ and $B$ are different when their numeric values are not equal.
+\item When the numeric value of $A$ is greater than that of $B$, $A$ represents a stricter alignment.
 \end{itemize}
 
 \pnum


### PR DESCRIPTION
The previous wording had some issues which this PR resolves:
1. The first two bullets talk about the numeric values of the alignment. The last bullet breaks this convention, which is surprising.
2. The proper wording is "greater", not "larger", when comparing numerical values.
3. The last bullet is missing a comma two separate the conditional clause from the rest of the sentence.
4. *It* is always somewhat problematic when two items are named. Using `$A$` and `$B$` is clearer.