### PR TITLE
[dcl.meaning.general] Remove `extern` in one case to make example 3 more informative

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2668,7 +2668,7 @@ namespace X {
   void p() {
     q();                        // error: \tcode{q} not yet declared
     extern void q();            // \tcode{q} is a member of namespace \tcode{X}
-    extern void r();            // \tcode{r} is a member of namespace \tcode{X}
+    void r();                   // \tcode{r} is a member of namespace \tcode{X}
   }
 
   void middle() {


### PR DESCRIPTION
The paragraph mentions that if the declaration declares a function, or uses the `extern` specifier, then ...

However, the example only shows declarations which are both functions and use the `extern` specifier, making it less informative. This PR removes `extern` in one of the two declarations, to make it clear that `extern` isn't required, and declaring a local function in itself is enough for the paragraph to apply.