### PR TITLE
[basic.def.odr] Fix grammatical error in p17

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -804,8 +804,8 @@ denote the same closure type in each translation unit.
 
 \pnum
 If, at any point in the program,
-there is more than one
-reachable unnamed enumeration definition in the same scope
+there are multiple
+reachable unnamed enumeration definitions in the same scope
 that have the same first enumerator name and
 do not have typedef names for linkage purposes\iref{dcl.enum},
 those unnamed enumeration types shall be the same; no diagnostic required.


### PR DESCRIPTION
The paragraph presently uses:
- singular form in the first half "there is ..."
- plural form in the second half "that have the same first ..."

This PR fixes that grammatical error. Furthermore "there are more than one" is intuitively awkward wording, so it is replaced with "there are multiple".