### PR TITLE
[basic.link] fix unusual punctuation in p4

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2694,35 +2694,35 @@ The name of an entity that belongs to a namespace scope
 that has not been given internal linkage above
 and that is the name of
 \begin{itemize}
-\item a variable; or
-\item a function; or
+\item a variable, or
+\item a function, or
 \item
 \indextext{class!linkage of}%
 a named class\iref{class.pre}, or an unnamed class defined in a
 typedef declaration in which the class has the typedef name for linkage
-purposes\iref{dcl.typedef}; or
+purposes\iref{dcl.typedef}, or
 \item
 \indextext{enumeration!linkage of}%
 a named enumeration\iref{dcl.enum}, or an unnamed enumeration defined
 in a typedef declaration in which the enumeration has the typedef name
-for linkage purposes\iref{dcl.typedef}; or
+for linkage purposes\iref{dcl.typedef}, or
 \item an unnamed enumeration
-that has an enumerator as a name for linkage purposes\iref{dcl.enum}; or
+that has an enumerator as a name for linkage purposes\iref{dcl.enum}, or
 \item a template
 \end{itemize}
 has its linkage determined as follows:
 \begin{itemize}
 \item
-if the enclosing namespace has internal linkage,
-the name has internal linkage;
+If the enclosing namespace has internal linkage,
+the name has internal linkage.
 \item
-otherwise,
+Otherwise,
 if the declaration of the name is
 attached to a named module\iref{module.unit}
 and is not exported\iref{module.interface},
-the name has module linkage;
+the name has module linkage.
 \item
-otherwise,
+Otherwise,
 the name has external linkage.
 \end{itemize}
 


### PR DESCRIPTION
Paragraph 4 breaks convention by excessively using semicolons instead of serial commas. This is also inconsistent with the preceding p3.

Furthermore, even though the latter bullets 4.7 through 4.9 are complete sentences, and usually would be capitalized and punctuated as such elsewhere in the standard, they are also separated by semicolons.

This PR fixes this unconventional and surprising form of capitalization and punctuation.