### PR TITLE
[class.static.data] Fix - classes have no subobjects

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -2658,7 +2658,7 @@ A static member function cannot be qualified with \keyword{const},
 \indextext{member data!static}%
 
 \pnum
-A static data member is not part of the subobjects of a class. If a
+A static data member is not part of the subobjects of a class object. If a
 static data member is declared \keyword{thread_local} there is one copy of
 the member per thread. If a static data member is not declared
 \keyword{thread_local} there is one copy of the data member that is shared by all


### PR DESCRIPTION
To my understanding, a class cannot have any subobjects, only an object of class type can have subobjects. Therefore, the wording is incorrect, and should state `class object` instead of just `class`.