### PR TITLE
[except.terminate] Fix missing introductory comma

### DIFF
--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -1015,7 +1015,7 @@ capture the currently handled exception.
 \pnum
 \indextext{\idxcode{terminate}}%
 % FIXME: What does it mean to abandon exception handling?
-In some situations exception handling is abandoned
+In some situations, exception handling is abandoned
 for less subtle error handling techniques.
 \begin{note}
 These situations are:


### PR DESCRIPTION
There is a missing comma after the conditional clause *"In some situations,"*.