### PR TITLE
[algorithms.parallel.defns] Insert new paragraph number for example

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -312,6 +312,8 @@ See~\ref{algorithms.requirements}.
 \end{note}
 \end{itemize}
 These functions are herein called \defn{element access functions}.
+
+\pnum
 \begin{example}
 The \tcode{sort} function may invoke the following element access functions:
 \begin{itemize}


### PR DESCRIPTION
The example currently in paragraph 3 has its own list, whole numbering extends that of the normative list preceding it.  This can be confusing at first sight, with a one-line defintion apparently inserted into the middle of the list.  By adding a new pnum for the example, the list numbering in the example restarts at 4.1, reducing confusion.