### PR TITLE
[depr.static.constexpr] Cross-reference core clauses 

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -182,7 +182,7 @@ definition\iref{class.mem,class.static},
 \item
 it declares a static data member outside a class definition
 and the variable was defined within the class with the \keyword{constexpr}
-specifier (this usage is deprecated; see \ref{depr.static.constexpr}),
+specifier\iref{class.static.data} (this usage is deprecated; see \ref{depr.static.constexpr}),
 \item
 \indextext{declaration!class name}%
 it is an \grammarterm{elaborated-type-specifier}\iref{class.name},

--- a/source/future.tex
+++ b/source/future.tex
@@ -140,7 +140,8 @@ void park(linhenykus alvarezsauroid) {
 
 \pnum
 For compatibility with prior revisions of \Cpp{}, a \keyword{constexpr}
-static data member may be redundantly redeclared outside the class with no initializer.
+static data member may be redundantly redeclared outside the class with no
+initializer\iref{basic.def}\iref{class.static.data}.
 This usage is deprecated.
 \begin{example}
 \begin{codeblock}

--- a/source/future.tex
+++ b/source/future.tex
@@ -141,7 +141,7 @@ void park(linhenykus alvarezsauroid) {
 \pnum
 For compatibility with prior revisions of \Cpp{}, a \keyword{constexpr}
 static data member may be redundantly redeclared outside the class with no
-initializer\iref{basic.def}\iref{class.static.data}.
+initializer\iref{basic.def,class.static.data}.
 This usage is deprecated.
 \begin{example}
 \begin{codeblock}


### PR DESCRIPTION
There is no back-link from the Annex D wording to the  feature that is deprecated.  The deprecation is mentioned in two places, so this PR links to both of them, and adds the corresponding missing link to the list item in [basic.def]