### PR TITLE
[dlc.init.general] Fix wording of direct-initialization

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4581,17 +4581,15 @@ Copy-initialization can invoke a move\iref{class.copy.ctor}.
 \end{note}
 
 \pnum
-The initialization that occurs
+Initialization is called \defn{direct-initialization} if it occurs
 \begin{itemize}
 \item for an \grammarterm{initializer} that is a
 parenthesized \grammarterm{expression-list} or a \grammarterm{braced-init-list},
 \item for a \grammarterm{new-initializer}\iref{expr.new},
 \item in a \keyword{static_cast} expression\iref{expr.static.cast},
-\item in a functional notation type conversion\iref{expr.type.conv}, and
-\item in the \grammarterm{braced-init-list} form of a \grammarterm{condition}
+\item in a functional notation type conversion\iref{expr.type.conv}, or
+\item in the \grammarterm{braced-init-list} form of a \grammarterm{condition}.
 \end{itemize}
-is called
-\defn{direct-initialization}.
 
 \pnum
 The semantics of initializers are as follows.


### PR DESCRIPTION
Firstly, this paragraph should be combining its items with `or`, not `and`. Initialization is not called *direct-initialization* if it's taking place both in a `static_cast` expression *and* in a functional notation type conversion at the same time, but rather if one *or* the other case.

Secondly, it's a little unusual how short the part after the `\itemize` section is. I think readability if the paragraph started with the defined term instead.