### PR TITLE
[allocator.requirements.general] Fix the misuse of `launder`

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2324,7 +2324,7 @@ and such an object is created
 but array elements are not constructed.
 \begin{example}
 When reusing storage denoted by some pointer value \tcode{p},
-\tcode{launder(reinterpret_cast<T*>(new (p) byte[n * sizeof(T)]))}
+\tcode{start_lifetime_as_array<T>(new (p) byte[n * sizeof(T)], n)}
 can be used to implicitly create a suitable array object
 and obtain a pointer to it.
 \end{example}


### PR DESCRIPTION
Fixes #4553.

I think the new-expression can render the contents in the storage indeterminate, and the `start_lifetime_as_array` call can obtain the pointer to the first element even if the element is not within its lifetime.