### PR TITLE
[over.ics.list] expand example 5, fix inconsistent spacing

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2448,19 +2448,21 @@ the context of a call to an initializer-list constructor.
 \begin{codeblock}
 void f(std::initializer_list<int>);
 f( {} );                        // OK, \tcode{f(initializer_list<int>)} identity conversion
-f( {1,2,3} );                   // OK, \tcode{f(initializer_list<int>)} identity conversion
-f( {'a','b'} );                 // OK, \tcode{f(initializer_list<int>)} integral promotion
+f( {1, 2, 3} );                 // OK, \tcode{f(initializer_list<int>)} identity conversion
+f( {'a', 'b'} );                // OK, \tcode{f(initializer_list<int>)} integral promotion
 f( {1.0} );                     // error: narrowing
 
 struct A {
   A(std::initializer_list<double>);                     // \#1
   A(std::initializer_list<std::complex<double>>);       // \#2
-  A(std::initializer_list<std::string>);                // \#3
+  A(std::initializer_list<A>);                          // \#3
+  A(std::initializer_list<std::string>);                // \#4
 };
-A a{ 1.0,2.0 };                 // OK, uses \#1
+A a{ 1.0, 2.0 };                // OK, uses \#1, not \#2
+A b{ a };                       // OK, uses \#3, not the implicitly-defined copy constructor
 
 void g(A);
-g({ "foo", "bar" });            // OK, uses \#3
+g({ "foo", "bar" });            // OK, uses \#4
 
 typedef int IA[3];
 void h(const IA&);


### PR DESCRIPTION
This edit expands the example to include the edge case where the `std::initializer_list` constructors competes with the copy constructor. This edge case has been the subject of some core issues:
- https://cplusplus.github.io/CWG/issues/1467.html
- https://cplusplus.github.io/CWG/issues/2137.html

It's also responsible for an LLVM bug where the copy constructor wins in overload resolution, and this is actively being worked on:
- https://github.com/llvm/llvm-project/issues/58520 (duplicate of)
- https://github.com/llvm/llvm-project/issues/24186

To raise awareness for this issue, and how the edge case should be handled, it would be wise to include it in the example.

Furthermore, this edit fixes inconsistent comma spacing towards the beginning of the example. While the style is up to the author of the examples, they should at least follow consistent style, and not space `1,2,3` in one place, but `1.0, 2.0` in another.