### PR TITLE
[intro.races] Remove unclear uses of "shall"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -6251,7 +6251,7 @@ happens before $X$ and $X$ happens before $B$.
 \end{itemize}
 
 The value of a non-atomic scalar object or bit-field $M$, as determined by
-evaluation $B$, shall be the value stored by the
+evaluation $B$, is the value stored by the
 \indextext{side effects!visible}%
 visible side effect $A$.
 \begin{note}
@@ -6269,7 +6269,7 @@ races in a simple interleaved (sequentially consistent) execution.
 
 \pnum
 The value of an
-atomic object $M$, as determined by evaluation $B$, shall be the value
+atomic object $M$, as determined by evaluation $B$, is the value
 stored by some unspecified
 side effect $A$ that modifies $M$, where $B$ does not happen
 before $A$.
@@ -6281,7 +6281,7 @@ described here, and in particular, by the coherence requirements below.
 \pnum
 \indextext{coherence!write-write}%
 If an operation $A$ that modifies an atomic object $M$ happens before
-an operation $B$ that modifies $M$, then $A$ shall be earlier
+an operation $B$ that modifies $M$, then $A$ is earlier
 than $B$ in the modification order of $M$.
 \begin{note}
 This requirement is known as write-write coherence.
@@ -6293,7 +6293,7 @@ If a
 \indextext{value computation}%
 value computation $A$ of an atomic object $M$ happens before a
 value computation $B$ of $M$, and $A$ takes its value from a side
-effect $X$ on $M$, then the value computed by $B$ shall either be
+effect $X$ on $M$, then the value computed by $B$ is either
 the value stored by $X$ or the value stored by a
 \indextext{side effects}%
 side effect $Y$ on $M$,
@@ -6307,7 +6307,7 @@ This requirement is known as read-read coherence.
 If a
 \indextext{value computation}%
 value computation $A$ of an atomic object $M$ happens before an
-operation $B$ that modifies $M$, then $A$ shall take its value from a side
+operation $B$ that modifies $M$, then $A$ takes its value from a side
 effect $X$ on $M$, where $X$ precedes $B$ in the
 modification order of $M$.
 \begin{note}
@@ -6320,7 +6320,7 @@ read-write coherence.
 If a
 \indextext{side effects}%
 side effect $X$ on an atomic object $M$ happens before a value
-computation $B$ of $M$, then the evaluation $B$ shall take its
+computation $B$ of $M$, then the evaluation $B$ takes its
 value from $X$ or from a
 \indextext{side effects}%
 side effect $Y$ that follows $X$ in the modification order of $M$.


### PR DESCRIPTION
This PR currently removes all occurences of "shall" in [intro.races], except for the explicitly stated use in "implementation shall".

Fixes cplusplus/CWG#373.