### PR TITLE
[stdfloat.syn] Add typedefs to library index

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -1966,6 +1966,11 @@ the optional extended floating-point types that are specified in
 \ref{basic.extended.fp}.
 
 \indexheader{stdfloat}%
+\indexlibraryglobal{float16_t}%
+\indexlibraryglobal{float32_t}%
+\indexlibraryglobal{float64_t}%
+\indexlibraryglobal{float128_t}%
+\indexlibraryglobal{bfloat16_t}%
 \begin{codeblock}
 namespace std {
   #if defined(__STDCPP_FLOAT16_T__)


### PR DESCRIPTION
I've noticed that for some reason, the typedefs in this header aren't indexed. By comparison, `std::int8_t` etc. are indexed here:
https://github.com/cplusplus/draft/blob/be07cd4e87c693fb9749c1e5e7c07ee0cf9e0084/source/support.tex#L1820-L1824

I've added the floating point typedefs to the index in the same style.