### PR TITLE
[mdspan.extents.cons] Fix typo (`dynamic_rank` => `rank_dynamic`)

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -19349,7 +19349,7 @@ is representable as a value of type \tcode{index_type} for every rank index $r$.
 \effects
 \begin{itemize}
 \item
-If \tcode{N} equals \tcode{dynamic_rank()},
+If \tcode{N} equals \tcode{rank_dynamic()},
 for all $d$ in the range $[0, \tcode{rank_dynamic()})$,
 direct-non-list-initializes \tcode{\exposidnc{dynamic-extents}[$d$]}
 with \tcode{as_const(exts[$d$])}.


### PR DESCRIPTION
There's no definition of `dynamic_rank`. Based on the context, it seems that `rank_dynamic` is meant.

cc @crtrott 