### PR TITLE
[bit.cast] simplify "unsigned ordinary character type" to `unsigned char`

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -18792,7 +18792,7 @@ has an indeterminate value\iref{basic.indet}.
 For each bit in the value representation of the result that is indeterminate,
 the smallest object containing that bit has an indeterminate value;
 the behavior is undefined unless that object is
-of unsigned ordinary character type or \tcode{std::byte} type.
+of type \tcode{unsigned char} or \tcode{std::byte}.
 The result does not otherwise contain any indeterminate values.
 
 \pnum


### PR DESCRIPTION
[Ordinary character types](https://eel.is/c++draft/basic.fundamental#7) include `char`, `signed char`, and `unsigned char`.

Saying *unsigned ordinary character type* is just an obscure way of saying `unsigned char`, and should be simplified.