### PR TITLE
[basic.fundamental] Itemize uses of `void` expressions

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5169,13 +5169,18 @@ type for functions that do not return a value. Any expression can be
 explicitly converted to type
 \cv{}~\keyword{void}\iref{expr.type.conv,expr.static.cast,expr.cast}.
 An expression of type \cv{}~\keyword{void} shall
-be used only as an expression statement\iref{stmt.expr}, as an operand
-of a comma expression\iref{expr.comma}, as a second or third operand
-of \tcode{?:}\iref{expr.cond}, as the operand of
-\keyword{typeid}, \keyword{noexcept}, or \keyword{decltype}, as
-the expression in a \keyword{return} statement\iref{stmt.return} for a function
-with the return type \cv{}~\keyword{void}, or as the operand of an explicit conversion
-to type \cv{}~\keyword{void}.
+be used only as
+\begin{itemize}
+\item an expression statement\iref{stmt.expr},
+\item the expression in a \keyword{return} statement\iref{stmt.return}
+for a function with the return type \cv{}~\keyword{void},
+\item an operand of a comma expression\iref{expr.comma},
+\item the second or third operand of \tcode{?:}\iref{expr.cond},
+\item the operand of a \keyword{typeid} expression\iref{expr.typeid},
+\item the operand of a \keyword{noexcept} operator\iref{expr.unary.noexcept},
+\item the operand of a \keyword{decltype} specifier\iref{dcl.type.decltype}, or
+\item the operand of an explicit conversion to type \cv{}~\keyword{void}.
+\end{itemize}
 
 \pnum
 A value of type \tcode{std::nullptr_t} is a null pointer


### PR DESCRIPTION
![image](https://github.com/cplusplus/draft/assets/22040976/788995f1-eed2-453f-aa86-969dc425d060)

This edit improves readability of the paragraph by neatly splitting the list of uses into bullets. Furthermore, some (implicit) bullets are reordered, so that statements and expressions are grouped together.

Also, the enumeration "`typeid`, `noexcept`, or `decltype`" is split up. This helps clarify whether a `noexcept` specification, or a `noexcept` operator is referred to. Additional forward references to the relevant sections are added.