### PR TITLE
[expr.sizeof] Turn identifier into a grammarterm

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4987,7 +4987,7 @@ the temporary materialization conversion\iref{conv.rval}
 is applied.
 
 \pnum
-The identifier in a \tcode{\keyword{sizeof}...} expression shall name a
+The \grammarterm{identifier} in a \tcode{\keyword{sizeof}...} expression shall name a
 pack. The \tcode{\keyword{sizeof}...} operator yields the number of elements
 in the pack\iref{temp.variadic}.
 A \tcode{\keyword{sizeof}...} expression is a pack expansion\iref{temp.variadic}.


### PR DESCRIPTION
Since `sizeof...` is literally applied to an *identifier* in the grammar, (see https://eel.is/c++draft/expr.unary.general#nt:unary-expression), and p1 talks about `sizeof` *type-id*, where *type-id* is also a grammar term, it feels more appropriate to format *identifier* as such too.