### PR TITLE
[expr.sizeof] Use constexpr member in example

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4995,7 +4995,7 @@ A \tcode{\keyword{sizeof}...} expression is a pack expansion\iref{temp.variadic}
 \begin{codeblock}
 template<class... Types>
 struct count {
-  static const std::size_t value = sizeof...(Types);
+  static constexpr std::size_t value = sizeof...(Types);
 };
 \end{codeblock}
 \end{example}


### PR DESCRIPTION
Using `constexpr` in this context is how users would implement the trait typically, in modern C++.

This also improves the example because it demonstrates that `sizeof...` is a constant expression, which `const` in itself doesn't.