### PR TITLE
[stmt.expr] use grammarterm for expression

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -188,7 +188,7 @@ All
 side effects from an expression statement
 are completed before the next statement is executed.
 \indextext{statement!empty}%
-An expression statement with the expression missing is called
+An expression statement with the \grammarterm{expression} missing is called
 a \defnadj{null}{statement}.
 \begin{note}
 Most statements are expression statements --- usually assignments or


### PR DESCRIPTION
In this paragraph, *expression* literally refers to when the *expresssion* grammar term is missing in the syntax (included in the same paragraph):
> *expression*<sub>opt</sub>`;`

It feels more appropriate to style it as a `grammarterm` due to this strong connection, instead of simple prose.