### PR TITLE
[lex.icon] Itemize extended integer choice

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1325,16 +1325,17 @@ Except for \grammarterm{integer-literal}{s} containing
 a \grammarterm{size-suffix},
 if the value of an \grammarterm{integer-literal}
 cannot be represented by any type in its list and
-an extended integer type\iref{basic.fundamental} can represent its value,
-it may have that extended integer type.
-If all of the types in the list for the \grammarterm{integer-literal}
-are signed,
-the extended integer type is signed.
-If all of the types in the list for the \grammarterm{integer-literal}
-are unsigned,
-the extended integer type is unsigned.
-If the list contains both signed and unsigned types,
-the extended integer type may be signed or unsigned.
+an extended integer type\iref{basic.fundamental} \tcode{T} can represent its value,
+it may have type \tcode{T}.
+\tcode{T} has the following signedness:
+\begin{itemize}
+\item If all types in the list for the \grammarterm{integer-literal}
+are signed, \tcode{T} is signed.
+\item If all types in the list for the \grammarterm{integer-literal}
+are unsigned, \tcode{T} is unsigned.
+\item If the list contains both signed and unsigned types,
+\tcode{T} may be signed or unsigned.
+\end{itemize}
 If an \grammarterm{integer-literal}
 cannot be represented by any of the allowed types,
 the program is ill-formed.


### PR DESCRIPTION
![image](https://github.com/cplusplus/draft/assets/22040976/ae7a42bb-4eed-4e18-b544-e95ce63aef78)

This edit slightly improves readability of the three possible choices for the signedness of the extended integer type.

Furthermore, it conceptually separates the last `If ...` sentence from the previous ones, which is good, because otherwise it reads like just another bullet in a list.

Furthermore, the last bullet in the list is abbreviated to an `Otherwise,` bullet, since the list is exhaustive anyway.