### PR TITLE
[dcl.attr.noreturn] Remove redundant note

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -9279,10 +9279,6 @@ translation unit, the program is ill-formed, no diagnostic required.
 \pnum
 If a function \tcode{f} is called where \tcode{f} was previously declared with the \tcode{noreturn}
 attribute and \tcode{f} eventually returns, the behavior is undefined.
-\begin{note}
-The function may
-terminate by throwing an exception.
-\end{note}
 
 \pnum
 \recommended


### PR DESCRIPTION
This note is completely unnecessary, because just a few lines down, example 1 demonstrates:
```cpp
[[ noreturn ]] void f() {
  throw "error";                // OK
}
```
There is no good motivation for the reader to be informed in prose that throwing in a `[[noreturn]]` function is okay, if the example demonstrates that.