### PR TITLE
[dcl.attr.nodiscard] Add example of nodiscard with message

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -9238,7 +9238,7 @@ as the rationale for why the result should not be discarded.
 \pnum
 \begin{example}
 \begin{codeblock}
-struct [[nodiscard]] my_scopeguard { @\commentellip@ };
+struct [[nodiscard("discarding guards is a bug")]] my_scopeguard { @\commentellip@ };
 struct my_unique {
   my_unique() = default;                                // does not acquire resource
   [[nodiscard]] my_unique(int fd) { @\commentellip@ }         // acquires resource
@@ -9249,7 +9249,7 @@ struct [[nodiscard]] error_info { @\commentellip@ };
 error_info enable_missile_safety_mode();
 void launch_missiles();
 void test_missiles() {
-  my_scopeguard();              // warning encouraged
+  my_scopeguard();              // warning encouraged; should include "discarding guards is a bug"
   (void)my_scopeguard(),        // warning not encouraged, cast to \keyword{void}
     launch_missiles();          // comma operator, statement continues
   my_unique(42);                // warning encouraged


### PR DESCRIPTION
The current example does not, but could include a use of `[[nodiscard("reason")]]`. This edit fixes this wasted potential, and adds such a case to the existing example.