### PR TITLE
[dcl.attr.unused] Add static keyword to function in example

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -9159,8 +9159,8 @@ if the attribute does not cause suppression of such warnings.
 \pnum
 \begin{example}
 \begin{codeblock}
-[[maybe_unused]] void f([[maybe_unused]] bool thing1,
-                        [[maybe_unused]] bool thing2) {
+[[maybe_unused]] static void f([[maybe_unused]] bool thing1,
+                               [[maybe_unused]] bool thing2) {
   [[maybe_unused]] bool b = thing1 && thing2;
   assert(b);
 }


### PR DESCRIPTION
The current example has a function `f` with external linkage. Such a function definition would normally not be marked as unused anyway, because it could be used from another TU.

Using `static` or `inline` makes the example meaningful, because functions with internal linkage and inline functions would be marked as unused in practice.