### PR TITLE
[intro.memory] Remove stray bit definitions

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3066,11 +3066,10 @@ bits,
 The number of bits in a byte is reported by the macro
 \tcode{CHAR_BIT} in the header \libheaderref{climits}.
 \end{footnote}
-the number of which is \impldef{bits in a byte}. The least
-significant bit is called the \defn{low-order bit}; the most
-significant bit is called the \defn{high-order bit}. The memory
-available to a \Cpp{} program consists of one or more sequences of
-contiguous bytes. Every byte has a unique address.
+the number of which is \impldef{bits in a byte}.
+The memory available to a \Cpp{} program consists of one or more sequences of
+contiguous bytes.
+Every byte has a unique address.
 
 \pnum
 \begin{note}


### PR DESCRIPTION
This old paragraph defines two terms which aren't used anywhere else in the document. Maybe they have been used historically and someone forgot to remove them, or maybe they haven't ever been used.

On a personal note, I also have to say that I have never heard someone say *high-order bit* or *low-order bit*. The terminology *least significant* and *most significant* is much more popular in my experience, self-explanatory, and used in other places in the C++ standard.