### PR TITLE
[temp.spec.general] Instantiated definitions

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -5582,21 +5582,29 @@ a member template is referred to as
 \defn{template instantiation}.
 
 \pnum
-A function instantiated from a function template is called an instantiated
-function.
-A class instantiated from a class template is called an instantiated class.
-A member function, a member class, a member enumeration, or a static data member of a class template
-instantiated from the member definition of the class template is called,
-respectively, an instantiated member function, member class, member enumeration, or static data
-member.
-A member function instantiated from a member function template is called an
-instantiated member function.
-A member class instantiated from a member class template is called an
-instantiated member class.
-A variable instantiated from a variable template is called an
-instantiated variable.
-A static data member instantiated from a static data member template
-is called an instantiated static data member.
+An instantiated template specialization is called as follows:
+\begin{itemize}
+\item A function instantiated from a function template is called an
+\defn{instantiated function}.
+\item A class instantiated from a class template is called an
+\defn{instantiated class}.
+\item A member function instantiated from a member function template is called an
+\defn{instantiated member function}.
+\item A member class instantiated from a member class template is called an
+\defn{instantiated member class}.
+\item A variable instantiated from a variable template is called an
+\defn{instantiated variable}.
+\item A static data member instantiated from a static data member template is called an
+\defn{instantiated static data member}.
+\item The members of a class template instantiated from the
+member definition of the class template are called:
+\begin{itemize}
+  \item \defn{instantiated member function} if the member is a member function;
+  \item \defn{instantiated member class} if the member is a member class;
+  \item \defn{instantiated member enumeration} if the member is a member enumeration; and
+  \item \defn{instantiated static data member} if the member is a static data member.
+\end{itemize}
+\end{itemize}
 
 \pnum
 An explicit specialization may be declared for a function template,

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -5596,14 +5596,6 @@ An instantiated template specialization is called as follows:
 \defn{instantiated variable}.
 \item A static data member instantiated from a static data member template is called an
 \defn{instantiated static data member}.
-\item The members of a class template instantiated from the
-member definition of the class template are called:
-\begin{itemize}
-  \item \defn{instantiated member function} if the member is a member function;
-  \item \defn{instantiated member class} if the member is a member class;
-  \item \defn{instantiated member enumeration} if the member is a member enumeration; and
-  \item \defn{instantiated static data member} if the member is a static data member.
-\end{itemize}
 \end{itemize}
 
 \pnum


### PR DESCRIPTION
![image](https://github.com/cplusplus/draft/assets/22040976/d8e1b0ee-497c-43d4-92a7-9103f8b610d5)

This first commit itemizes the paragraph, and formats the defined names as `\defn`.

The second commit deletes the last bullet and thus some nonsensical contents in this paragraph. The problem used to be that some terms were literally defined twice with different meaning. For example, the term *instantiated member function* is defined twice:
- as an instantiated member function template
- as a member function of an instantiated class

Most definitions aren't used anywhere in this document, so a reasonable solution to this duplicate definition is to not give any term to the members instantiated from a class template.