### PR TITLE
[dcl.stc] rearrange wording, turn typedef restriction into note

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -446,20 +446,23 @@ The storage class specifiers are
     \keyword{mutable}
 \end{bnf}
 
-At most one \grammarterm{storage-class-specifier} shall appear in a given
-\grammarterm{decl-specifier-seq}, except that \keyword{thread_local} may appear with \keyword{static} or
-\keyword{extern}. If \keyword{thread_local} appears in any declaration of
-a variable it shall be present in all declarations of that entity. If a
-\grammarterm{storage-class-specifier}
-appears in a \grammarterm{decl-specifier-seq}, there can be no
-\tcode{typedef} specifier in the same \grammarterm{decl-specifier-seq} and
-the \grammarterm{init-declarator-list} or \grammarterm{member-declarator-list}
-of the declaration shall not be
-empty (except for an anonymous union declared in a namespace scope\iref{class.union.anon}). The
-\grammarterm{storage-class-specifier} applies to the name declared by each
+The \grammarterm{storage-class-specifier} applies to the name declared by each
 \grammarterm{init-declarator} in the list and not to any names declared by
 other specifiers.
+At most one \grammarterm{storage-class-specifier} shall appear in a given
+\grammarterm{decl-specifier-seq}, except that
+\keyword{thread_local} may appear with \keyword{static} or \keyword{extern}.
+If \keyword{thread_local} appears in any declaration of
+a variable, it shall be present in all declarations of that entity.
+If a \grammarterm{storage-class-specifier}
+appears in a \grammarterm{decl-specifier-seq},
+the \grammarterm{init-declarator-list} or \grammarterm{member-declarator-list}
+of the declaration shall not be empty, except for an anonymous union
+declared in a namespace scope\iref{class.union.anon}.
 \begin{note}
+A \keyword{typedef} specifier cannot appear in a
+\grammarterm{decl-specifier-seq} that contains a
+\grammarterm{storage-class-specifier}\iref{dcl.typedef}.
 See \ref{temp.expl.spec} and \ref{temp.explicit} for restrictions
 in explicit specializations and explicit instantiations, respectively.
 \end{note}


### PR DESCRIPTION
![image](https://github.com/cplusplus/draft/assets/22040976/80c2b697-4c8a-4057-b9da-6f51d6f7bbc9)

This edit changes a few things:
- It adds a missing comma after the conditional clause "if `thread_local` appears ..."
- Fixes https://github.com/cplusplus/draft/issues/6081. This is done by turning the normative wording into a note at the bottom. The restriction on `typedef` is already defined in [dcl.typedef], and does not need to be stated here.
- It turns the last sentence into the first sentence, which seems more logical. What a *storage-class-specifier* applies to is more important than the list of restrictions.