### PR TITLE
[tuple.swap] change weird 'call x with y' wording

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2503,7 +2503,7 @@ For all $i$, \tcode{get<$i$>(*this)} is swappable with\iref{swappable.requiremen
 
 \pnum
 \effects
-For each $i$, calls \tcode{swap} for \tcode{get<$i$>(*this)} with \tcode{get<$i$>(rhs)}.
+For each $i$, calls \tcode{swap} for \tcode{get<$i$>(*this)} and \tcode{get<$i$>(rhs)}.
 
 \pnum
 \throws


### PR DESCRIPTION
Fixes https://github.com/cplusplus/draft/issues/6020.
First suggested here https://github.com/cplusplus/draft/pull/5978#discussion_r1044446006.