### PR TITLE
[mem.res.pool.options] Replace `field` with `member`

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -6310,7 +6310,7 @@ If the value of \tcode{max_blocks_per_chunk} is zero or
 is greater than an \impldef{largest supported value to configure the maximum number of blocks to replenish a pool}
 limit, that limit is used instead.
 The implementation
-may choose to use a smaller value than is specified in this field and
+may choose to use a smaller value than is specified in this member and
 may use different values for different pools.
 \end{itemdescr}
 
@@ -6329,7 +6329,7 @@ If \tcode{largest_required_pool_block} is zero or
 is greater than an \impldef{largest supported value to configure the largest allocation satisfied directly by a pool}
 limit, that limit is used instead.
 The implementation may choose a pass-through threshold
-larger than specified in this field.
+larger than specified in this member.
 \end{itemdescr}
 
 \rSec3[mem.res.pool.ctor]{Constructors and destructors}


### PR DESCRIPTION
Fixes https://github.com/cplusplus/draft/issues/5544 (in part)