### PR TITLE
[basic.def.odr] Greatly expand example 6

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -775,32 +775,72 @@ might still denote different types in different translation units.
 \pnum
 \begin{example}
 \begin{codeblock}
+static int local = 0;
+inline int a(int = local) {
+  return 0;
+}
+inline int b = a(0);
+\end{codeblock}
+If the definition of \tcode{a} or \tcode{b} appears in multiple translation units,
+the behavior of the program is as if
+there is only one definition of \tcode{a} or \tcode{b}, respectively.
+
+\begin{codeblock}
+inline int c = a();
+\end{codeblock}
+If the definition of \tcode{c} appears in multiple translation units,
+the program is ill-formed (no diagnostic required) because
+each such definition calls \tcode{a} with a different function argument.
+
+\begin{codeblock}
 inline void f(bool cond, void (*p)()) {
   if (cond) f(false, []{});
 }
+\end{codeblock}
+If the definition of \tcode{f} appears in multiple translation units,
+the behavior of the program is as if
+there is only one definition of \tcode{f}.
+
+\begin{codeblock}
 inline void g(bool cond, void (*p)() = []{}) {
   if (cond) g(false);
 }
+\end{codeblock}
+If the definition of \tcode{g} appears in multiple translation units,
+the program is ill-formed (no diagnostic required) because
+each such definition uses a default argument that
+refers to a distinct \grammarterm{lambda-expression} closure type.
+
+\begin{codeblock}
 struct X {
   void h(bool cond, void (*p)() = []{}) {
     if (cond) h(false);
   }
 };
 \end{codeblock}
-
-If the definition of \tcode{f} appears in multiple translation units,
-the behavior of the program is as if
-there is only one definition of \tcode{f}.
-If the definition of \tcode{g} appears in multiple translation units,
-the program is ill-formed (no diagnostic required) because
-each such definition uses a default argument that
-refers to a distinct \grammarterm{lambda-expression} closure type.
 The definition of \tcode{X} can appear
 in multiple translation units of a valid program;
 the \grammarterm{lambda-expression}{s} defined within
 the default argument of \tcode{X::h} within the definition of \tcode{X}
 denote the same closure type in each translation unit.
+
+\begin{codeblock}
+inline decltype([]{}) u = {};
+\end{codeblock}
+If the declaration of \tcode{u} appears in multiple translation units,
+the program is ill-formed (no diagnostic required) because each such declaration
+declares an object of distinct type.
+
+\begin{codeblock}
+inline auto v = []{};
+inline auto w = decltype([]{}){};
+\end{codeblock}
+If the definition of \tcode{v} or \tcode{w} appears in multiple translation units,
+the behavior is as if there is only one definition of \tcode{v} or \tcode{w}
+because the definition of its closure type is considered to be part of the
+token sequence of the definition of \tcode{v} or \tcode{w} respectively.
 \end{example}
+
 
 \pnum
 If, at any point in the program,


### PR DESCRIPTION
![image](https://github.com/cplusplus/draft/assets/22040976/6f563a8c-02d6-43e7-a214-e3c6f962ad26)

The ODR is fairly complex, and deserving of examples which elaborate on intent and behavior in more detail. Firstly, the new style interleaves explanations and code blocks, which is necessary due to the scale of the example.

## First Addition
```cpp
static int local = 0; // OK
inline int a(int = local) { // OK
  return 0;
}
inline int b = a(0); // OK
inline int c = a(); // IFNDR
```
This example demonstrates three important mechanisms:
- semantic differences can violate the ODR, even if the syntax is the same in every TU
- using entities with internal linkage is dangerous
- default arguments in the parameter list are not subject to the requirements of the ODR
- however, uses of such default arguments are subject to the ODR

This part is much simpler than the subsequent part involving lambda-expressions, and establishes the knowledge necessary to understand the second part.

## Second Addition
The new (third) part of the example is as follows:
```cpp
inline decltype([]{}) u = {}; // IFNDR
inline auto v = []{}; // OK
inline auto w = decltype([]{}){}; // OK
```
This demonstrates that:
- using lambda expressions in declarations is a major footgun, and can violate the ODR in a more direct way
- lambda-expressions can appear in a definition, even without being contained within a block scope, and this doesn't violate the ODR

This part of the example is actually related to implementation divergence: https://godbolt.org/z/749Tf53hG / https://github.com/llvm/llvm-project/issues/64811.