### PR TITLE
[dcl.constexpr] Modernize example of constexpr-usable functions

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -879,33 +879,26 @@ non-templated constexpr functions shall be constexpr-suitable.
 
 \begin{example}
 \begin{codeblock}
-constexpr int square(int x)
-  { return x * x; }             // OK
-constexpr long long_max()
-  { return 2147483647; }        // OK
-constexpr int abs(int x) {
-  if (x < 0)
-    x = -x;
-  return x;                     // OK
+constexpr int square(int x) {           // OK
+  return x * x;
 }
-constexpr int constant_non_42(int n) {  // OK
-  if (n == 42) {
-    static int value = n;
-    return value;
-  }
-  return n;
+constexpr std::generator<int> iota(int n = 0) {
+    while (true) co_yield n++;          // error: \tcode{co_yield} cannot be used in a constexpr function
 }
-constexpr int uninit() {
-  struct { int a; } s;
-  return s.a;                   // error: uninitialized read of \tcode{s.a}
+constexpr int stinit(int n) {           // \tcode{stinit} is constexpr-usable, but \tcode{stinit}
+  static int value = n;                 // may not be called in a constant expression
+  return value;
 }
-constexpr int prev(int x)
-  { return --x; }               // OK
-constexpr int g(int x, int n) { // OK
-  int r = 1;
-  while (--n > 0) r *= x;
-  return r;
+constexpr int uninit() {                // \tcode{uninit} is constexpr-usable, but a program which calls
+  struct { int a; } s;                  // \tcode{uninit} in a constant expression is ill-formed
+  return s.a;
 }
+struct Base {
+  constexpr Base() = default;           // OK
+};
+struct Derived : virtual Base {
+  constexpr Derived() = default;        // error: constructor cannot be constexpr in a
+};                                      // class or struct with virtual base classes
 \end{codeblock}
 \end{example}
 


### PR DESCRIPTION
Fixes https://github.com/cplusplus/draft/issues/5718.

![image](https://github.com/cplusplus/draft/assets/22040976/69db9771-6426-4ea8-b627-6aaea70b4398)

As explained in the issue, the example has become largely noise because of how many restrictions have been lifted in `constexpr` functions. The intuition of most users is probably that `abs`, `long_max`, `prev` and others *should* be `constexpr`, unless proven otherwise. This shift in mentality calls for examples which demonstrate what *isn't* constexpr-usable, rather than what is.