### PR TITLE
[dcl.init.string] Reword character array initialization

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5425,27 +5425,22 @@ union is a member of another aggregate.
 \indextext{UTF-8}%
 \indextext{UTF-16}%
 \indextext{UTF-32}%
-An array of ordinary character type\iref{basic.fundamental},
-\keyword{char8_t} array,
-\keyword{char16_t} array,
-\keyword{char32_t} array,
-or \keyword{wchar_t} array
-may be initialized by
-an ordinary string literal,
-UTF-8 string literal,
-UTF-16 string literal,
-UTF-32 string literal, or
-wide string literal,
-respectively, or by an appropriately-typed \grammarterm{string-literal} enclosed in
-braces\iref{lex.string}.
-Additionally, an array of \keyword{char} or
-\tcode{\keyword{unsigned} \keyword{char}}
-may be initialized by
-a UTF-8 string literal, or by
-such a string literal enclosed in braces.
+An object
+of type ``array of \tcode{T}''
+may be initialized by an optionally brace-enclosed \grammarterm{string-literal}
+of type ``array of \tcode{\keyword{const} U}'' if:
+\begin{itemize}
+\item
+\tcode{T} and \tcode{U} are the same type;
+\item
+\tcode{T} is an ordinary character type\iref{basic.fundamental}, and
+\tcode{U} is \keyword{char}; or
+\item
+\tcode{T} is \keyword{char} or \tcode{\keyword{unsigned} \keyword{char}},
+and \tcode{U} is \keyword{char8_t}.
+\end{itemize}
 \indextext{initialization!character array}%
-Successive
-characters of the
+Successive characters of the
 value of the \grammarterm{string-literal}
 initialize the elements of the array,
 with an integral conversion\iref{conv.integral}


### PR DESCRIPTION
![image](https://github.com/cplusplus/draft/assets/22040976/38fc2ce0-d623-4915-9b4f-b37f6e3cedf4)

This edit greatly compactifies the current wording. The issue with the status quo is that it contains a massive clause of:
> X, Y, Z, or W may be initialized by A, B, C, or D respectively

Such a clause is difficult for the reader to follow, and it's easy to make a mistake when matching `B` to `Y` etc. What the paragraph is saying, in essence, is that an array may be initialized by a string literal of the same type. These types are clearly defined in [[lex.string.literal]](https://eel.is/c++draft/tab:lex.string.literal), and could be used in this paragraph.

We can simply say that
> X is initialized by a string-literal of type X

Some care is required due to the string-literals being arrays of `const` characters.

Furthermore, the wording of
> or by an appropriately-typed *string-literal* enclosed in braces

is quite verbose, and could be simplified to "optionally brace-enclosed". This is just as clear, but much more concise.