### PR TITLE
[dcl.init.string] Shorten example string

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5452,20 +5452,14 @@ with an integral conversion\iref{conv.integral}
 if necessary for the source and destination value.
 \begin{example}
 \begin{codeblock}
-char msg[] = "Syntax error on line %s\n";
+char msg[] = "Hi\n";
 \end{codeblock}
-shows a character array whose members are initialized
-with a
+shows a character array whose members are initialized with a
 \grammarterm{string-literal}.
 Note that because
-\tcode{'\textbackslash n'}
-is a single character and
-because a trailing
-\tcode{'\textbackslash 0'}
-is appended,
-\tcode{sizeof(msg)}
-is
-\tcode{25}.
+\tcode{'\textbackslash n'} is a single character, and because a trailing
+\tcode{'\textbackslash 0'} is appended,
+\tcode{sizeof(msg)} is \tcode{4}.
 \end{example}
 
 \pnum


### PR DESCRIPTION
Firstly, this edit shortens the string literal used in the example. This is necessary because the original author makes a point about why `sizeof(msg) == 25`. Due to the length of the old literal, it is not possible to estimate its length at first glance. Most readers cannot tell by intuition that `"Syntax error on line %s\n"` is 25 characters long, and might even make a mistake while counting. The new `"Hi\n"` literal has a length which serves the example much better.

Secondly, this edit adds a comma before at `is a single character, and because` because it is grammatically more appropriate.