### PR TITLE
[dcl.init.general],[dcl.init.list],[over.ics.list] Array of characters isn't defined

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5831,7 +5831,10 @@ the object is initialized from that element (by copy-initialization for
 copy-list-initialization, or by direct-initialization for
 direct-list-initialization).
 
-\item Otherwise, if \tcode{T} is a character array and the initializer list has a
+\item Otherwise, if \tcode{T}
+is an array of ordinary character type\iref{basic.fundamental}
+or an array of character type,
+and the initializer list has a
 single element that is an appropriately-typed \grammarterm{string-literal}\iref{dcl.init.string},
 initialization is performed as described in that subclause.
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4611,12 +4611,9 @@ is list-initialized\iref{dcl.init.list}.
 \item
 If the destination type is a reference type, see~\ref{dcl.init.ref}.
 \item
-If the destination type is an array of characters,
-an array of \keyword{char8_t},
-an array of \keyword{char16_t},
-an array of \keyword{char32_t},
-or an array of
-\keyword{wchar_t},
+If the destination type
+is an array of ordinary character type\iref{basic.fundamental}
+or an array of character type,
 and the initializer is a \grammarterm{string-literal}, see~\ref{dcl.init.string}.
 \item If the initializer is \tcode{()}, the object is value-initialized.
 \indextext{ambiguity!function declaration}%

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2398,7 +2398,9 @@ or a class derived from \tcode{X}, the implicit conversion sequence is the one
 required to convert the element to the parameter type.
 
 \pnum
-Otherwise, if the parameter type is a character array
+Otherwise, if the parameter type
+is an array of ordinary character type\iref{basic.fundamental}
+or an array of character type,
 \begin{footnote}
 Since there are no parameters of array type,
 this will only occur as the referenced type of a reference parameter.


### PR DESCRIPTION
The term "character" isn't defined anywhere.

The intent is obviously to say *ordinary character type*, since arrays of such type can be initialized as in the referenced section. Furthermore, it is wasteful to enumerate all character types in this bullet. There is the defined term *character type* for that.