### PR TITLE
[stmt.while] Add grammar

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -558,7 +558,11 @@ substatement.
 
 \pnum
 \indextext{statement!declaration in \tcode{while}}%
-A \keyword{while} statement is equivalent to
+A \keyword{while} statement
+\begin{ncsimplebnf}
+\keyword{while} \terminal{(} condition \terminal{)} statement
+\end{ncsimplebnf}
+is equivalent to
 \begin{ncsimplebnf}
 \exposid{label} \terminal{:}\br
 \terminal{\{}\br
@@ -569,8 +573,8 @@ A \keyword{while} statement is equivalent to
 \terminal{\}}
 \end{ncsimplebnf}
 \begin{note}
-The variable created in the condition is destroyed and created with each
-iteration of the loop.
+The variable created in the \grammarterm{condition}
+is destroyed and created with each iteration of the loop.
 \begin{example}
 \begin{codeblock}
 struct A {
@@ -586,8 +590,8 @@ while (A a = i) {
 }
 \end{codeblock}
 In the while-loop, the constructor and destructor are each called twice,
-once for the condition that succeeds and once for the condition that
-fails.
+once for the \grammarterm{condition} that succeeds and
+once for the \grammarterm{condition} that fails.
 \end{example}
 \end{note}
 


### PR DESCRIPTION
Fixes #6493.

![image](https://github.com/cplusplus/draft/assets/22040976/b88da345-81ea-45e1-a35d-de499a9895e2)

Similar to [stmt.for], the grammar necessary to understand the equivalence is now included.