### PR TITLE
[stmt.do] Add grammar equivalence and reorder paragraphs

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -595,13 +595,25 @@ fails.
 \indextext{statement!\idxcode{do}}
 
 \pnum
-The expression is contextually converted to \tcode{bool}\iref{conv};
-if that conversion is ill-formed, the program is ill-formed.
+In the \keyword{do} statement the substatement is executed repeatedly
+until the value of the \grammarterm{expression} becomes \tcode{false}.
+The test takes place after each execution of the statement.
 
 \pnum
-In the \keyword{do} statement the substatement is executed repeatedly
-until the value of the expression becomes \tcode{false}. The test takes
-place after each execution of the statement.
+The \keyword{do} statement
+\begin{ncsimplebnf}
+\keyword{do} statement \keyword{while} \terminal{(} expression \terminal{)} \terminal{;}
+\end{ncsimplebnf}
+is equivalent to
+\begin{ncsimplebnf}
+\exposid{label} \terminal{:}\br
+\terminal{\{}\br
+\bnfindent statement\br
+\bnfindent \keyword{if} \terminal{(} expression \terminal{)} \terminal{\{}\br
+\bnfindent \bnfindent \keyword{goto} \exposid{label} \terminal{;}\br
+\bnfindent \terminal{\}}\br
+\terminal{\}}
+\end{ncsimplebnf}
 
 \rSec2[stmt.for]{The \tcode{for} statement}%
 \indextext{statement!\idxcode{for}}


### PR DESCRIPTION
Fixes #6492 for the most part.

![image](https://github.com/cplusplus/draft/assets/22040976/2a25dce3-3ba8-40fc-b240-82c212d0e3a0)

This edit improves a few things:
1. The two paragraphs are swapped, which creates symmetry with how they are ordered in [stmt.while]
2. Similar to `while` and `for`, the equivalence to a `goto` construct is also provided.
  Note that the trailing semicolon issue is swept under the rug by defining the equivalence for `while (expression);` with a semicolon present
3. `\grammarterm` is used in a few more places.