### PR TITLE
[class.conv.ctor] Fix missing space

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -2356,7 +2356,7 @@ Such a constructor is called a
 \begin{codeblock}
 struct X {
     X(int);
-    X(const char*, int =0);
+    X(const char*, int = 0);
     X(int, int);
 };
 


### PR DESCRIPTION
https://github.com/cplusplus/draft/blob/1c22d62180901069128b21daa2773d40566bd983/source/classes.tex#L2357-L2369

The author follows the ` = ` style in the rest of the example, so it is obvious that the missing space here is not intentional, but a typo.