### PR TITLE
[utility.intcmp] Simplify equivalences

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -541,14 +541,12 @@ extended integer types\iref{basic.fundamental}.
 \effects
 Equivalent to:
 \begin{codeblock}
-using UT = make_unsigned_t<T>;
-using UU = make_unsigned_t<U>;
 if constexpr (is_signed_v<T> == is_signed_v<U>)
   return t == u;
 else if constexpr (is_signed_v<T>)
-  return t < 0 ? false : UT(t) == u;
+  return t >= 0 && make_unsigned_t<T>(t) == u;
 else
-  return u < 0 ? false : t == UU(u);
+  return u >= 0 && make_unsigned_t<U>(u) == t;
 \end{codeblock}
 \end{itemdescr}
 
@@ -580,14 +578,12 @@ extended integer types\iref{basic.fundamental}.
 \effects
 Equivalent to:
 \begin{codeblock}
-using UT = make_unsigned_t<T>;
-using UU = make_unsigned_t<U>;
 if constexpr (is_signed_v<T> == is_signed_v<U>)
   return t < u;
 else if constexpr (is_signed_v<T>)
-  return t < 0 ? true : UT(t) < u;
+  return t < 0 || make_unsigned_t<T>(t) < u;
 else
-  return u < 0 ? false : t < UU(u);
+  return u >= 0 && t < make_unsigned_t<U>(u);
 \end{codeblock}
 \end{itemdescr}
 


### PR DESCRIPTION
This edit simplifies three equivalences, and makes them more practical from an implementation perspective:
1. the extra type aliases in `cmp_equal` and `cmp_less` are removed, since they are making the example longer and conceptually more complex, while not clearly improving readability
2. the logic in `cmp_equal` and `cmp_less` is simplified to not use the conditional operator, but instead use short circuiting logical operations
3. for the sake of symmetry, `cmp_less_equal` is directly defined in terms of `cmp_less`, instead of going through `cmp_greater` and lengthening the chain of equivalences