### PR TITLE
[intro.races] Make reading atomic objects nondeterministic

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -6269,7 +6269,7 @@ races in a simple interleaved (sequentially consistent) execution.
 \pnum
 The value of an
 atomic object $M$, as determined by evaluation $B$, shall be the value
-stored by some
+stored by some unspecified
 side effect $A$ that modifies $M$, where $B$ does not happen
 before $A$.
 \begin{note}


### PR DESCRIPTION
[intro.abstract]/3:
> Certain other aspects and operations of the abstract machine are described in this document as **unspecified**... These define the nondeterministic aspects of the abstract machine[.](http://eel.is/c++draft/intro.abstract#3.sentence-3) An instance of the abstract machine can thus have more than one possible execution for a given program and a given input[.](http://eel.is/c++draft/intro.abstract#3.sentence-4)

Without «unspecified» in [intro.race]/14
> The value of an atomic object M, as determined by evaluation B, shall be the value stored by some side effect A that modifies M, where B does not happen before A[.](http://eel.is/c++draft/intro.races#14.sentence-1)

reading atomic objects is not nondeterministic