### PR TITLE
[atomics] Make notify_one nondeterministic

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -3177,7 +3177,7 @@ void notify_one() const noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Unblocks the execution of at least one atomic waiting operation on \tcode{*ptr}
+Unblocks the execution of at least one unspecified atomic waiting operation on \tcode{*ptr}
 that is eligible to be unblocked\iref{atomics.wait} by this call,
 if any such atomic waiting operations exist.
 
@@ -4152,7 +4152,7 @@ void notify_one() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Unblocks the execution of at least one atomic waiting operation
+Unblocks the execution of at least one unspecified atomic waiting operation
 that is eligible to be unblocked\iref{atomics.wait} by this call,
 if any such atomic waiting operations exist.
 
@@ -5181,7 +5181,7 @@ void notify_one() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Unblocks the execution of at least one atomic waiting operation
+Unblocks the execution of at least one unspecified atomic waiting operation
 that is eligible to be unblocked\iref{atomics.wait} by this call,
 if any such atomic waiting operations exist.
 
@@ -5489,7 +5489,7 @@ void notify_one() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Unblocks the execution of at least one atomic waiting operation
+Unblocks the execution of at least one unspecified atomic waiting operation
 that is eligible to be unblocked\iref{atomics.wait} by this call,
 if any such atomic waiting operations exist.
 
@@ -5717,7 +5717,7 @@ void atomic_flag::notify_one() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Unblocks the execution of at least one atomic waiting operation
+Unblocks the execution of at least one unspecified atomic waiting operation
 that is eligible to be unblocked\iref{atomics.wait} by this call,
 if any such atomic waiting operations exist.
 


### PR DESCRIPTION
See #6501 for explanation

Affects:
[atomics.ref.ops]
[atomics.types.operations]
[util.smartptr.atomic.shared]
[util.smartptr.atomic.weak]
[atomics.flag]