### PR TITLE
[class.conv.ctor] Turn last paragraph into a note

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -2403,10 +2403,9 @@ Z a6 = { 3, 4 };                // error: no implicit conversion
 
 \pnum
 \begin{note}
-A non-explicit copy/move constructor\iref{class.copy.ctor} is
-a converting constructor.
-An implicitly-declared copy/move constructor is not an explicit constructor;
-it can be called for implicit type conversions.
+A non-explicit copy/move constructor\iref{class.copy.ctor},
+including one implicitly declared,
+is a converting constructor.
 \end{note}
 
 \rSec3[class.conv.fct]{Conversion functions}%

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -2402,9 +2402,9 @@ Z a6 = { 3, 4 };                // error: no implicit conversion
 \end{note}
 
 \pnum
+\begin{note}
 A non-explicit copy/move constructor\iref{class.copy.ctor} is
 a converting constructor.
-\begin{note}
 An implicitly-declared copy/move constructor is not an explicit constructor;
 it can be called for implicit type conversions.
 \end{note}


### PR DESCRIPTION
Paragraph 1 already states:
https://github.com/cplusplus/draft/blob/1c22d62180901069128b21daa2773d40566bd983/source/classes.tex#L2347-L2353

The reader has no reason to believe that a copy/move constructor is excluded from the rule, and it certainly doesn't need to be stated in normative wording. The whole paragraph can and should be a note.