### PR TITLE
[basic.def.odr],[res.on.arguments],[futures] Fix hyphenation of "assignment operator"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -489,7 +489,7 @@ is a permissible implementation technique.
 \pnum
 An assignment operator function in a class is odr-used by an
 implicitly-defined
-copy-assignment or move-assignment function for another class as specified
+copy assignment or move assignment function for another class as specified
 in~\ref{class.copy.assign}.
 A constructor for a class is odr-used as specified
 in~\ref{dcl.init}. A destructor for a class is odr-used if it is potentially

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -3352,7 +3352,7 @@ pointer did point to the first element of such an array) are in fact valid.
 \item
 If a function argument is bound to an rvalue reference parameter, the implementation may
 assume that this parameter is a unique reference to this argument,
-except that the argument passed to a move-assignment operator may be
+except that the argument passed to a move assignment operator may be
 a reference to \tcode{*this}\iref{lib.types.movedfrom}.
 \begin{note}
 If the type of a parameter is a forwarding reference\iref{temp.deduct.call}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -10525,7 +10525,7 @@ member functions of \tcode{shared_future}.
 
 \pnum
 The effect of calling any member function other than the destructor, the
-move-assignment operator, \tcode{share}, or \tcode{valid} on a \tcode{future} object for which
+move assignment operator, \tcode{share}, or \tcode{valid} on a \tcode{future} object for which
 \tcode{valid() == false}
 is undefined.
 \begin{note}
@@ -10832,7 +10832,7 @@ but they synchronize with the shared state.
 
 \pnum
 The effect of calling any member function other than the destructor,
-the move-assignment operator, the copy-assignment operator, or
+the move assignment operator, the copy assignment operator, or
 \tcode{valid()} on a \tcode{shared_future} object for which \tcode{valid() == false} is undefined.
 \begin{note}
 It is valid to copy or move from a \tcode{shared_future}


### PR DESCRIPTION
Fixes https://github.com/cplusplus/draft/issues/6498 (in part).