### PR TITLE
[stmt.return] format operand as `\term`

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -851,7 +851,8 @@ A function returns to its caller by the \tcode{return} statement.
 
 \pnum
 The \grammarterm{expr-or-braced-init-list}
-of a \tcode{return} statement is called its operand. A \tcode{return} statement with
+of a \tcode{return} statement is called its \term{operand}.
+A \tcode{return} statement with
 no operand shall be used only in a function whose return type is
 \cv{}~\keyword{void}, a constructor\iref{class.ctor}, or a
 destructor\iref{class.dtor}.


### PR DESCRIPTION
`operand` is a definition in this context, but isn't formatted as such.

The use of `\term` over `\defn` is intentional, since the [Q&A](https://github.com/cplusplus/draft/wiki/Q-&-A) suggests to use `\term` for definitions that shouldn't be indexed, and I don't believe it's necessary to index *operand*