### PR TITLE
tools: Use grep -F instead of fgrep

### DIFF
--- a/tools/check-source.sh
+++ b/tools/check-source.sh
@@ -76,7 +76,7 @@ grep -n '^[^%]*[^{"]C++[^"}]' $texfiles |
     fail 'use \\Cpp{} instead' || failed=1
 
 # Use \caret instead of \^
-fgrep -n '\^' $texfiles |
+grep -F -n '\^' $texfiles |
     fail 'use \\caret instead' || failed=1
 
 # Use \unicode instead of U+nnnn
@@ -137,7 +137,7 @@ done |
     fail 'No namespace around class definition' || failed=1
 
 # ref-qualifier on member functions with no space, e.g. "const&"
-fgrep -ne ') const&' $texlib |
+grep -F -ne ') const&' $texlib |
     fail 'no space between cv-qualifier and ref-qualifier' || failed=1
 
 # \begin{example/note} with non-whitespace in front on the same line.


### PR DESCRIPTION
POSIX only defines grep, not fgrep and egrep (the latter two were already marked as LEGACY in SUSv2 in 1997, and are not present in POSIX-2001 or any later POSIX standards). Recent versions of GNU grep warn when fgrep and egrep are used: https://lists.gnu.org/archive/html/info-gnu/2022-09/msg00001.html