### PR TITLE
[meta.unary.op] Expand note for has_unique_object_representations

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -1354,8 +1354,14 @@ if they have the same active member and the corresponding members have the same 
 The set of scalar types for which this condition holds is
 \impldef{which scalar types have unique object representations}.
 \begin{note}
-If a type has padding bits, the condition does not hold;
-otherwise, the condition holds true for integral types.
+If a type \tcode{T} has padding bits, the condition does not hold for \tcode{T}.
+If \tcode{T} is an integral type other than \keyword{bool}, the condition
+holds for \tcode{T}.
+The condition might not hold for \keyword{bool} because
+\keyword{true} or \keyword{false} can have multiple object representations.
+If \tcode{std::numeric_limits<T>::is_iec559} is \keyword{true}, the
+condition does not hold for \tcode{T} because there are multiple object
+representations for some values, such as zero.
 \end{note}
 
 \rSec2[meta.unary.prop.query]{Type property queries}


### PR DESCRIPTION
It's a common question in the community for what types `std::has_unique_object_representations_v` yields `false`, and why that happens.

I think it's worth expanding this note so that it mentions two very common failure cases:
- IEC 559 floating-point numbers, which have multiple representations for zero and NaN
- `bool` on ARM, which allows for more representations of `true` than just `0x01`