### PR TITLE
[atomics.ref.ops], [atomics.types.operations], [util.smartptr.atomic.…

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -2968,10 +2968,8 @@ void store(T desired, memory_order order = memory_order::seq_cst) const noexcept
 \begin{itemdescr}
 \pnum
 \expects
-The \tcode{order} argument is neither
-\tcode{memory_order::consume},
-\tcode{memory_order::acquire}, nor
-\tcode{memory_order::acq_rel}.
+The \tcode{order} parameter is \tcode{memory_order::relaxed},
+\tcode{memory_order::release}, or \tcode{memory_order::seq_cst}.
 
 \pnum
 \effects
@@ -3009,8 +3007,9 @@ T load(memory_order order = memory_order::seq_cst) const noexcept;
 \begin{itemdescr}
 \pnum
 \expects
-The \tcode{order} argument is neither
-\tcode{memory_order::release} nor \tcode{memory_order::acq_rel}.
+The \tcode{order} parameter is \tcode{memory_order::relaxed},
+\tcode{memory_order::consume}, \tcode{memory_order::acquire},
+or \tcode{memory_order::seq_cst}.
 
 \pnum
 \effects
@@ -3082,8 +3081,9 @@ bool compare_exchange_strong(T& expected, T desired,
 \begin{itemdescr}
 \pnum
 \expects
-The \tcode{failure} argument is neither
-\tcode{memory_order::release} nor \tcode{memory_order::acq_rel}.
+The \tcode{failure} parameter is \tcode{memory_order::relaxed},
+\tcode{memory_order::consume}, \tcode{memory_order::acquire},
+or \tcode{memory_order::seq_cst}.
 
 \pnum
 \effects
@@ -3146,8 +3146,9 @@ void wait(T old, memory_order order = memory_order::seq_cst) const noexcept;
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{order} is
-neither \tcode{memory_order::release} nor \tcode{memory_order::acq_rel}.
+The \tcode{order} parameter is \tcode{memory_order::relaxed},
+\tcode{memory_order::consume}, \tcode{memory_order::acquire},
+or \tcode{memory_order::seq_cst}.
 
 \pnum
 \effects
@@ -3814,8 +3815,8 @@ For the \tcode{volatile} overload of this function,
 
 \pnum
 \expects
-The \tcode{order} argument is neither \tcode{memory_order::consume},
-\tcode{memory_order::acquire}, nor \tcode{memory_order::acq_rel}.
+The \tcode{order} parameter is \tcode{memory_order::relaxed},
+\tcode{memory_order::release}, or \tcode{memory_order::seq_cst}.
 
 \pnum
 \effects
@@ -3867,7 +3868,9 @@ For the \tcode{volatile} overload of this function,
 
 \pnum
 \expects
-The \tcode{order} argument is neither \tcode{memory_order::release} nor \tcode{memory_order::acq_rel}.
+The \tcode{order} parameter is \tcode{memory_order::relaxed},
+\tcode{memory_order::consume}, \tcode{memory_order::acquire},
+or \tcode{memory_order::seq_cst}.
 
 \pnum
 \effects
@@ -3967,8 +3970,9 @@ For the \tcode{volatile} overload of this function,
 
 \pnum
 \expects
-The \tcode{failure} argument is neither \tcode{memory_order::release} nor
-\tcode{memory_order::acq_rel}.
+The \tcode{failure} parameter is \tcode{memory_order::relaxed},
+\tcode{memory_order::consume}, \tcode{memory_order::acquire},
+or \tcode{memory_order::seq_cst}.
 
 \pnum
 \effects
@@ -4119,7 +4123,9 @@ void wait(T old, memory_order order = memory_order::seq_cst) const noexcept;
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{order} is neither \tcode{memory_order::release} nor \tcode{memory_order::acq_rel}.
+The \tcode{order} parameter is \tcode{memory_order::relaxed},
+\tcode{memory_order::consume}, \tcode{memory_order::acquire},
+or \tcode{memory_order::seq_cst}.
 
 \pnum
 \effects
@@ -4970,10 +4976,8 @@ void store(shared_ptr<T> desired, memory_order order = memory_order::seq_cst) no
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{order} is neither
-\tcode{memory_order::consume},
-\tcode{memory_order::acquire}, nor
-\tcode{memory_order::acq_rel}.
+The \tcode{order} parameter is \tcode{memory_order::relaxed},
+\tcode{memory_order::release}, or \tcode{memory_order::seq_cst}.
 
 \pnum
 \effects
@@ -5012,8 +5016,9 @@ shared_ptr<T> load(memory_order order = memory_order::seq_cst) const noexcept;
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{order} is neither
-\tcode{memory_order::release} nor \tcode{memory_order::acq_rel}.
+The \tcode{order} parameter is \tcode{memory_order::relaxed},
+\tcode{memory_order::consume}, \tcode{memory_order::acquire},
+or \tcode{memory_order::seq_cst}.
 
 \pnum
 \effects
@@ -5065,8 +5070,9 @@ bool compare_exchange_strong(shared_ptr<T>& expected, shared_ptr<T> desired,
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{failure} is neither
-\tcode{memory_order::release} nor \tcode{memory_order::acq_rel}.
+The \tcode{failure} parameter is \tcode{memory_order::relaxed},
+\tcode{memory_order::consume}, \tcode{memory_order::acquire},
+or \tcode{memory_order::seq_cst}.
 
 \pnum
 \effects
@@ -5150,8 +5156,9 @@ void wait(shared_ptr<T> old, memory_order order = memory_order::seq_cst) const n
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{order} is
-neither \tcode{memory_order::release} nor \tcode{memory_order::acq_rel}.
+The \tcode{order} parameter is \tcode{memory_order::relaxed},
+\tcode{memory_order::consume}, \tcode{memory_order::acquire},
+or \tcode{memory_order::seq_cst}.
 
 \pnum
 \effects
@@ -5289,10 +5296,8 @@ void store(weak_ptr<T> desired, memory_order order = memory_order::seq_cst) noex
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{order} is neither
-\tcode{memory_order::consume},
-\tcode{memory_order::acquire}, nor
-\tcode{memory_order::acq_rel}.
+The \tcode{order} parameter is \tcode{memory_order::relaxed},
+\tcode{memory_order::release}, or \tcode{memory_order::seq_cst}.
 
 \pnum
 \effects
@@ -5320,8 +5325,9 @@ weak_ptr<T> load(memory_order order = memory_order::seq_cst) const noexcept;
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{order} is neither
-\tcode{memory_order::release} nor \tcode{memory_order::acq_rel}.
+The \tcode{order} parameter is \tcode{memory_order::relaxed},
+\tcode{memory_order::consume}, \tcode{memory_order::acquire},
+or \tcode{memory_order::seq_cst}.
 
 \pnum
 \effects
@@ -5372,8 +5378,9 @@ bool compare_exchange_strong(weak_ptr<T>& expected, weak_ptr<T> desired,
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{failure} is neither
-\tcode{memory_order::release} nor \tcode{memory_order::acq_rel}.
+The \tcode{failure} parameter is \tcode{memory_order::relaxed},
+\tcode{memory_order::consume}, \tcode{memory_order::acquire},
+or \tcode{memory_order::seq_cst}.
 
 \pnum
 \effects
@@ -5457,8 +5464,9 @@ void wait(weak_ptr<T> old, memory_order order = memory_order::seq_cst) const noe
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{order} is
-neither \tcode{memory_order::release} nor \tcode{memory_order::acq_rel}.
+The \tcode{order} parameter is \tcode{memory_order::relaxed},
+\tcode{memory_order::consume}, \tcode{memory_order::acquire},
+or \tcode{memory_order::seq_cst}.
 
 \pnum
 \effects
@@ -5602,8 +5610,9 @@ For \tcode{atomic_flag_test}, let \tcode{order} be \tcode{memory_order::seq_cst}
 
 \pnum
 \expects
-\tcode{order} is
-neither \tcode{memory_order::release} nor \tcode{memory_order::acq_rel}.
+The \tcode{order} parameter is \tcode{memory_order::relaxed},
+\tcode{memory_order::consume}, \tcode{memory_order::acquire},
+or \tcode{memory_order::seq_cst}.
 
 \pnum
 \effects
@@ -5652,8 +5661,8 @@ void atomic_flag::clear(memory_order order = memory_order::seq_cst) noexcept;
 \begin{itemdescr}
 \pnum
 \expects
-The \tcode{order} argument is neither \tcode{memory_order::consume},
-\tcode{memory_order::acquire}, nor \tcode{memory_order::acq_rel}.
+The \tcode{order} parameter is \tcode{memory_order::relaxed},
+\tcode{memory_order::release}, or \tcode{memory_order::seq_cst}.
 
 \pnum
 \effects
@@ -5686,8 +5695,9 @@ Let \tcode{flag} be \tcode{object} for the non-member functions and
 
 \pnum
 \expects
-\tcode{order} is
-neither \tcode{memory_order::release} nor \tcode{memory_order::acq_rel}.
+The \tcode{order} parameter is \tcode{memory_order::relaxed},
+\tcode{memory_order::consume}, \tcode{memory_order::acquire},
+or \tcode{memory_order::seq_cst}.
 
 \pnum
 \effects


### PR DESCRIPTION
…shared], [util.smartptr.atomic.weak], [atomics.flag]: Reword Preconditions on memory_order values in a positive form