### PR TITLE
[temp.expl.spec] Turn paragraph into note

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6621,8 +6621,10 @@ when one or more trailing template arguments are left unspecified.
 \end{note}
 
 \pnum
+\begin{note}
 A function with the same name as a template and a type that exactly matches that
 of a template specialization is not an explicit specialization\iref{temp.fct}.
+\end{note}
 
 \pnum
 Whether an explicit specialization of a function or variable template


### PR DESCRIPTION
This paragraph can and should be a note. It provides no new normative information. Everything it says is already said in greater detail in the paragraph it refers to, [[temp.fct.general] p2](http://eel.is/c++draft/temp.fct.general#2).