### PR TITLE
[vector.data],[array.members] Clarify C++ boolean expression

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -6331,7 +6331,7 @@ constexpr const T* data() const noexcept;
 \pnum
 \returns
 A pointer such that \range{data()}{data() + size()} is a valid range. For a
-non-empty array, \tcode{data()} \tcode{==} \tcode{addressof(front())}.
+non-empty array, \tcode{data() == addressof(front())} is \keyword{true}.
 \end{itemdescr}
 
 \indexlibrarymember{array}{fill}%
@@ -9068,7 +9068,7 @@ constexpr const T*   data() const noexcept;
 \pnum
 \returns
 A pointer such that \range{data()}{data() + size()} is a valid range. For a
-non-empty vector, \tcode{data()} \tcode{==} \tcode{addressof(front())}.
+non-empty vector, \tcode{data() == addressof(front())} is \keyword{true}.
 
 \pnum
 \complexity


### PR DESCRIPTION
As far as I know, it is not enough to say
> For a non-empty array, [C++ boolean expression]

It is not obvious that this should be automatically interpreted as [C++ boolean expression] is `true` in all cases.

This edit fixes it by explicitly saying that the expression is `true`, which looks to be the intention here.