### PR TITLE
[expr.call] Add further forward references

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3408,13 +3408,13 @@ An argument that has type \cv{}~\tcode{std::nullptr_t} is converted
 to type \tcode{\keyword{void}*}\iref{conv.ptr}.
 After these conversions, if the
 argument does not have arithmetic, enumeration, pointer, pointer-to-member,
-or class type, the program is ill-formed. Passing a potentially-evaluated
-argument
-of a scoped enumeration type or
-of a class type\iref{class} having an eligible non-trivial
-copy constructor, an eligible non-trivial move constructor,
-or a
-non-trivial destructor\iref{special},
+or class type, the program is ill-formed.
+Passing a potentially-evaluated argument
+of a scoped enumeration type\iref{dcl.enum} or
+of a class type\iref{class} having
+an eligible non-trivial copy constructor\iref{special,class.copy.ctor},
+an eligible non-trivial move constructor, or
+a non-trivial destructor\iref{class.dtor},
 with no corresponding parameter, is conditionally-supported with
 \impldef{passing argument of class type through ellipsis} semantics. If the argument has
 integral or enumeration type that is subject to the integral


### PR DESCRIPTION
This paragraph is reaching ahead quite a bit; talking about scoped enumerations, eligible special member functions, non-trivial special member functions, etc.

This edit adds the relevant forward references. What originally motivated me is that the current wording contains `non-trivial destructor\iref{special}`, which looked like a mistake. This forward reference is intended to apply to `eligible`.