### PR TITLE
[expr.call] Turn recursive call wording into note

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3425,8 +3425,10 @@ the \defnx{default argument promotions}{promotion!default argument promotion}.
 
 \pnum
 \indextext{function call!recursive}%
+\begin{note}
 Recursive calls are permitted, except to the \tcode{main}
 function\iref{basic.start.main}.
+\end{note}
 
 \pnum
 A function call is an lvalue


### PR DESCRIPTION
This paragraph doesn't have to be normative. [basic.start.main] already explains that the `main` function can't be used.

The reader also has no reason to believe that recursive calls are not allowed, and no wording forbids them generally, making this paragraph unnecessary from a normative POV.