### PR TITLE
[cpp] `\grammarterm` overhaul

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -134,10 +134,11 @@
 \end{bnf}
 
 \pnum
-A \defn{preprocessing directive} consists of a sequence of preprocessing tokens
+A \defn{preprocessing directive} consists of a sequence of
+\grammarterm{preprocessing-token}s
 that satisfies the following constraints:
 At the start of translation phase 4,
-the first token in the sequence,
+the first \grammarterm{preprocessing-token} in the sequence,
 referred to as a \defnadj{directive-introducing}{token},
 begins with the first character in the source file
 (optionally after whitespace containing no new-line characters) or
@@ -146,28 +147,28 @@ and is
 
 \begin{itemize}
 \item
-a \tcode{\#} preprocessing token, or
+a \tcode{\#} \grammarterm{preprocessing-token}, or
 
 \item
-an \keyword{import} preprocessing token
+an \keyword{import} \grammarterm{preprocessing-token}
 immediately followed on the same logical line by a
 \grammarterm{header-name},
 \tcode{<},
 \grammarterm{identifier},
 \grammarterm{string-literal}, or
 \tcode{:}
-preprocessing token, or
+\grammarterm{preprocessing-token}, or
 
 \item
-a \keyword{module} preprocessing token
+a \keyword{module} \grammarterm{preprocessing-token}
 immediately followed on the same logical line by an
 \grammarterm{identifier},
 \tcode{:}, or
 \tcode{;}
-preprocessing token, or
+\grammarterm{preprocessing-token}, or
 
 \item
-an \keyword{export} preprocessing token
+an \keyword{export} \grammarterm{preprocessing-token}
 immediately followed on the same logical line by
 one of the two preceding forms.
 \end{itemize}
@@ -214,9 +215,11 @@ import ->               // not a preprocessing directive
 \end{example}
 
 \pnum
-A sequence of preprocessing tokens is only a \grammarterm{text-line}
+A sequence of \grammarterm{preprocessing-token}s
+is only a \grammarterm{text-line}
 if it does not begin with a directive-introducing token.
-A sequence of preprocessing tokens is only a \grammarterm{conditionally-supported-directive}
+A sequence of \grammarterm{preprocessing-token}s is only a
+\grammarterm{conditionally-supported-directive}
 if it does not begin with any of the directive names
 appearing after a \tcode{\#} in the syntax.
 A \grammarterm{conditionally-supported-directive} is
@@ -230,13 +233,13 @@ the \grammarterm{group} of a \grammarterm{pp-global-module-fragment} shall
 contain neither a \grammarterm{text-line} nor a \grammarterm{pp-import}.
 
 \pnum
-When in a group that is skipped\iref{cpp.cond}, the directive
-syntax is relaxed to allow any sequence of preprocessing tokens to occur between
-the directive name and the following new-line character.
+When in a \grammarterm{group} that is skipped\iref{cpp.cond}, the directive
+syntax is relaxed to allow any sequence of \grammarterm{preprocessing-token}s
+to occur between the directive name and the following new-line character.
 
 \pnum
 The only whitespace characters that shall appear
-between preprocessing tokens
+between \grammarterm{preprocessing-token}s
 within a preprocessing directive
 (from just after the directive-introducing token
 through just before the terminating new-line character)
@@ -257,7 +260,7 @@ because conceptually they occur
 before translation of the resulting translation unit.
 
 \pnum
-The preprocessing tokens within a preprocessing directive
+The \grammarterm{preprocessing-token}s within a preprocessing directive
 are not subject to macro expansion unless otherwise stated.
 
 \begin{example}
@@ -266,7 +269,7 @@ In:
 #define EMPTY
 EMPTY   #   include <file.h>
 \end{codeblock}
-the sequence of preprocessing tokens on the second line is \textit{not}
+the sequence of \grammarterm{preprocessing-token}s on the second line is \textit{not}
 a preprocessing directive, because it does not begin with a \tcode{\#} at the start of
 translation phase 4, even though it will do so after the macro \tcode{EMPTY}
 has been replaced.
@@ -316,13 +319,13 @@ has been replaced.
 \pnum
 The expression that controls conditional inclusion
 shall be an integral constant expression except that
-identifiers
+\grammarterm{identifier}s
 (including those lexically identical to keywords)
 are interpreted as described below
 \begin{footnote}
 Because the controlling constant expression is evaluated
 during translation phase 4,
-all identifiers either are or are not macro names ---
+all \grammarterm{identifier}s either are or are not macro names ---
 there simply are no keywords, enumeration constants, etc.
 \end{footnote}
 and it may contain zero or more \grammarterm{defined-macro-expression}{s} and/or
@@ -331,7 +334,7 @@ and it may contain zero or more \grammarterm{defined-macro-expression}{s} and/or
 
 \pnum
 A \grammarterm{defined-macro-expression} evaluates to \tcode{1}
-if the identifier is currently defined
+if the \grammarterm{identifier} is currently defined
 as a macro name
 (that is, if it is predefined
 or if it has one or more active macro definitions\iref{cpp.import},
@@ -341,18 +344,19 @@ it has been the subject of a
 preprocessing directive
 without an intervening
 \tcode{\#undef}
-directive with the same subject identifier), \tcode{0} if it is not.
+directive with the same subject \grammarterm{identifier}),
+\tcode{0} if it is not.
 
 \pnum
 The second form of \grammarterm{has-include-expression}
 is considered only if the first form does not match,
-in which case the preprocessing tokens are processed just as in normal text.
+in which case the \grammarterm{preprocessing-token}s are processed just as in normal text.
 
 \pnum
 The header or source file identified by
-the parenthesized preprocessing token sequence
+the parenthesized \grammarterm{preprocessing-token} sequence
 in each contained \grammarterm{has-include-expression}
-is searched for as if that preprocessing token sequence
+is searched for as if that \grammarterm{preprocessing-token} sequence
 were the \grammarterm{pp-tokens} in a \tcode{\#include} directive,
 except that no further macro expansion is performed.
 If such a directive would not satisfy the syntactic requirements
@@ -411,11 +415,12 @@ directives, and
 the \tcode{defined} conditional inclusion operator,
 shall treat \xname{has_include} and \xname{has_cpp_attribute}
 as if they were the names of defined macros.
-The identifiers \xname{has_include} and \xname{has_cpp_attribute}
+The \grammarterm{identifier}s \xname{has_include} and \xname{has_cpp_attribute}
 shall not appear in any context not mentioned in this subclause.
 
 \pnum
-Each preprocessing token that remains (in the list of preprocessing tokens that
+Each \grammarterm{preprocessing-token} that remains
+(in the list of \grammarterm{preprocessing-token}s that
 will become the controlling expression)
 after all macro replacements have occurred
 shall be in the lexical form of a token\iref{lex.token}.
@@ -432,7 +437,7 @@ check whether the controlling constant expression evaluates to nonzero.
 
 \pnum
 Prior to evaluation,
-macro invocations in the list of preprocessing tokens
+macro invocations in the list of \grammarterm{preprocessing-token}s
 that will become the controlling constant expression
 are replaced
 (except for those macro names modified by the
@@ -455,17 +460,17 @@ evaluations of
 \grammarterm{has-include-expression}s, and
 \grammarterm{has-attribute-expression}s
 have been performed,
-all remaining identifiers and keywords,
+all remaining \grammarterm{identifier}s and keywords,
 except for
 \tcode{true}
 and
 \tcode{false},
 are replaced with the \grammarterm{pp-number}
 \tcode{0},
-and then each preprocessing token is converted into a token.
+and then each \grammarterm{preprocessing-token} is converted into a token.
 \begin{note}
 An alternative
-token\iref{lex.digraph} is not an identifier,
+token\iref{lex.digraph} is not an \grammarterm{identifier},
 even when its spelling consists entirely of letters and underscores.
 Therefore it is not subject to this replacement.
 \end{note}
@@ -482,7 +487,8 @@ act as if they have the same representation as, respectively,
 Thus on an
 implementation where \tcode{std::numeric_limits<int>::max()} is \tcode{0x7FFF}
 and \tcode{std::numeric_limits<unsigned int>::max()} is \tcode{0xFFFF},
-the integer literal \tcode{0x8000} is signed and positive within a \tcode{\#if}
+the \grammarterm{integer-literal} \tcode{0x8000}
+is signed and positive within a \tcode{\#if}
 expression even though it is unsigned in translation phase
 7\iref{lex.phases}.
 \end{note}
@@ -508,7 +514,8 @@ Preprocessing directives of the forms
 \terminal{\# elifndef} identifier new-line \opt{group}
 \indextext{\idxcode{\#elifndef}}%
 \end{ncsimplebnf}
-check whether the identifier is or is not currently defined as a macro name.
+check whether the \grammarterm{identifier}
+is or is not currently defined as a macro name.
 Their conditions are equivalent to
 \tcode{\#if} \tcode{defined} \grammarterm{identifier},
 \tcode{\#if} \tcode{!defined} \grammarterm{identifier},
@@ -518,33 +525,34 @@ respectively.
 
 \pnum
 Each directive's condition is checked in order.
-If it evaluates to false (zero),
-the group that it controls is skipped:
+If it evaluates to \tcode{false} (zero),
+the \grammarterm{group} that it controls is skipped:
 directives are processed only through the name that determines
 the directive in order to keep track of the level
 of nested conditionals;
-the rest of the directives' preprocessing tokens are ignored,
-as are the other preprocessing tokens in the group.
-Only the first group
-whose control condition evaluates to true (nonzero) is processed;
-any following groups are skipped and their controlling directives
-are processed as if they were in a group that is skipped.
-If none of the conditions evaluates to true,
+the rest of the directives' \grammarterm{preprocessing-token}s are ignored,
+as are the other \grammarterm{preprocessing-token}s in the
+\grammarterm{group}.
+Only the first \grammarterm{group}
+whose control condition evaluates to \tcode{true} (nonzero) is processed;
+any following \grammarterm{group}s are skipped and their controlling directives
+are processed as if they were in a \grammarterm{group} that is skipped.
+If none of the conditions evaluates to \tcode{true},
 and there is a
 \tcode{\#else}
 \indextext{\idxcode{\#else}}%
 directive,
-the group controlled by the
+the \grammarterm{group} controlled by the
 \tcode{\#else}
 is processed; lacking a
 \tcode{\#else}
-directive, all the groups until the
+directive, all the \grammarterm{group}s until the
 \tcode{\#endif}
 \indextext{\idxcode{\#endif}}%
 are skipped.%
 \begin{footnote}
 As indicated by the syntax,
-a preprocessing token cannot follow a
+a \grammarterm{preprocessing-token} cannot follow a
 \tcode{\#else}
 or
 \tcode{\#endif}
@@ -653,11 +661,12 @@ A preprocessing directive of the form
 \terminal{\# include} pp-tokens new-line
 \end{ncsimplebnf}
 (that does not match one of the two previous forms) is permitted.
-The preprocessing tokens after
+The \grammarterm{preprocessing-token}s after
 \tcode{include}
 in the directive are processed just as in normal text
-(i.e., each identifier currently defined as a macro name is replaced by its
-replacement list of preprocessing tokens).
+(i.e., each \grammarterm{identifier} currently defined as a macro name is
+replaced by its \grammarterm{replacement-list} of
+\grammarterm{preprocessing-token}s, if any).
 If the directive resulting after all replacements does not match
 one of the two previous forms, the behavior is
 undefined.
@@ -668,14 +677,15 @@ a single \grammarterm{string-literal}
 thus, an expansion that results in two \grammarterm{string-literal}s is an
 invalid directive.
 \end{footnote}
-The method by which a sequence of preprocessing tokens between a
+The method by which a sequence of \grammarterm{preprocessing-token}s between a
 \tcode{<}
 and a
 \tcode{>}
-preprocessing token pair or a pair of
+\grammarterm{preprocessing-token} pair or a pair of
 \tcode{"}
 characters is combined into a single header name
-preprocessing token is \impldef{search locations for \tcode{""""} header}.
+\grammarterm{preprocessing-token} is
+\impldef{search locations for \tcode{""""} header}.
 
 \pnum
 The implementation shall provide unique mappings for
@@ -757,20 +767,23 @@ directives:
 A \grammarterm{pp-module} shall not
 appear in a context where \tcode{module}
 or (if it is the first token of the \grammarterm{pp-module}) \tcode{export}
-is an identifier defined as an object-like macro.
+is an \grammarterm{identifier} defined as an object-like macro.
 
 \pnum
-Any preprocessing tokens after the \tcode{module} preprocessing token
+Any \grammarterm{preprocessing-token}s after the \tcode{module}
+\grammarterm{preprocessing-token}
 in the \tcode{module} directive are processed just as in normal text.
 \begin{note}
-Each identifier currently defined as a macro name
-is replaced by its replacement list of preprocessing tokens.
+Each \grammarterm{identifier} currently defined as a macro name
+is replaced by its \grammarterm{replacement-list} of
+\grammarterm{preprocessing-token}s, if any.
 \end{note}
 
 \pnum
-The \tcode{module} and \tcode{export} (if it exists) preprocessing tokens
+The \tcode{module} and \tcode{export} (if it exists)
+\grammarterm{preprocessing-token}s
 are replaced by the \grammarterm{module-keyword} and
-\grammarterm{export-keyword} preprocessing tokens respectively.
+\grammarterm{export-keyword} \grammarterm{preprocessing-token}s respectively.
 \begin{note}
 This makes the line no longer a directive
 so it is not removed at the end of phase 4.
@@ -792,14 +805,16 @@ so it is not removed at the end of phase 4.
 A \grammarterm{pp-import} shall not
 appear in a context where \tcode{import}
 or (if it is the first token of the \grammarterm{pp-import}) \tcode{export}
-is an identifier defined as an object-like macro.
+is an \grammarterm{identifier} defined as an object-like macro.
 
 \pnum
-The preprocessing tokens after the \tcode{import} preprocessing token
+The \grammarterm{preprocessing-token}s after the
+\tcode{import} \grammarterm{preprocessing-token}
 in the \tcode{import} \grammarterm{control-line}
 are processed just as in normal text
-(i.e., each identifier currently defined as a macro name
-is replaced by its replacement list of preprocessing tokens).
+(i.e., each \grammarterm{identifier} currently defined as a macro name
+is replaced by its \grammarterm{replacement-list} of
+\grammarterm{pp-tokens}, if any).
 \begin{note}
 An \tcode{import} directive
 matching the first two forms of a \grammarterm{pp-import}
@@ -826,9 +841,10 @@ the program is ill-formed.
 
 \pnum
 In all three forms of \grammarterm{pp-import},
-the \tcode{import} and \tcode{export} (if it exists) preprocessing tokens
+the \tcode{import} and \tcode{export} (if it exists)
+\grammarterm{preprocessing-token}s
 are replaced by the \grammarterm{import-keyword} and
-\grammarterm{export-keyword} preprocessing tokens respectively.
+\grammarterm{export-keyword} \grammarterm{preprocessing-token}s respectively.
 \begin{note}
 This makes the line no longer a directive
 so it is not removed at the end of phase 4.
@@ -955,27 +971,27 @@ int x = Y;      // error: \tcode{Y} is neither a defined macro nor a declared na
 
 \pnum
 \indextext{macro!replacement list}%
-Two replacement lists are identical if and only if
-the preprocessing tokens in both have
+Two \grammarterm{replacement-list}s are identical if and only if
+the \grammarterm{preprocessing-token}s in both have
 the same number, ordering, spelling, and whitespace separation,
 where all whitespace separations are considered identical.
 
 \pnum
-An identifier currently defined as an
+An \grammarterm{identifier} currently defined as an
 \indextext{macro!object-like}%
 object-like macro (see below) may be redefined by another
 \tcode{\#define}
 preprocessing directive provided that the second definition is an
-object-like macro definition and the two replacement lists
+object-like macro definition and the two \grammarterm{replacement-list}s
 are identical, otherwise the program is ill-formed.
-Likewise, an identifier currently defined as a
+Likewise, an \grammarterm{identifier} currently defined as a
 \indextext{macro!function-like}%
 function-like macro (see below) may be redefined by another
 \tcode{\#define}
 preprocessing directive provided that the second definition is a
 function-like macro definition that has the same number and spelling
 of parameters,
-and the two replacement lists are identical,
+and the two \grammarterm{replacement-list}s are identical,
 otherwise the program is ill-formed.
 
 \pnum
@@ -1000,52 +1016,53 @@ But the following redefinitions are invalid:
 
 \pnum
 \indextext{macro!replacement list}%
-There shall be whitespace between the identifier and the replacement list
+There shall be whitespace between the \grammarterm{identifier} and
+the \grammarterm{replacement-list}
 in the definition of an object-like macro.
 
 \pnum
 If the \grammarterm{identifier-list} in the macro definition does not end with
 an ellipsis, the number of arguments (including those arguments consisting
-of no preprocessing tokens)
+of no \grammarterm{preprocessing-token}s)
 in an invocation of a function-like macro shall
 equal the number of parameters in the macro definition.
 Otherwise, there shall be at least as many arguments in the invocation as there are
 parameters in the macro definition (excluding the \tcode{...}). There
 shall exist a
 \tcode{)}
-preprocessing token that terminates the invocation.
+\grammarterm{preprocessing-token} that terminates the invocation.
 
 \pnum
 \indextext{__va_args__@\mname{VA_ARGS}}%
 \indextext{__va_opt__@\mname{VA_OPT}}%
-The identifiers \mname{VA_ARGS} and \mname{VA_OPT}
+The \grammarterm{identifier}s \mname{VA_ARGS} and \mname{VA_OPT}
 shall occur only in the \grammarterm{replacement-list}
 of a function-like macro that uses the ellipsis notation in the parameters.
 
 \pnum
-A parameter identifier in a function-like macro
+A parameter \grammarterm{identifier} in a function-like macro
 shall be uniquely declared within its scope.
 
 \pnum
-The identifier immediately following the
+The \grammarterm{identifier} immediately following the
 \tcode{define}
 is called the
 \indextext{name!macro|see{macro, name}}%
 \defnx{macro name}{macro!name}.
 There is one name space for macro names.
 Any whitespace characters preceding or following the
-replacement list of preprocessing tokens are not considered
-part of the replacement list for either form of macro.
+\grammarterm{replacement-list} of \grammarterm{pp-tokens} are not considered
+part of the \grammarterm{replacement-list} for either form of macro.
 
 \pnum
 If a
 \indextext{\#\#0 operator@\tcode{\#} operator}
 \tcode{\#}
-preprocessing token,
-followed by an identifier,
+\grammarterm{preprocessing-token},
+followed by an \grammarterm{identifier},
 occurs lexically
 at the point at which a preprocessing directive can begin,
-the identifier is not subject to macro replacement.
+the \grammarterm{identifier} is not subject to macro replacement.
 
 \pnum
 A preprocessing directive of the form
@@ -1058,20 +1075,22 @@ defines an
 causes each subsequent instance of the macro name
 \begin{footnote}
 Since, by macro-replacement time,
-all \grammarterm{character-literal}s and \grammarterm{string-literal}s are preprocessing tokens,
-not sequences possibly containing identifier-like subsequences
+all \grammarterm{character-literal}s and \grammarterm{string-literal}s are
+\grammarterm{preprocessing-token}s,
+not sequences possibly containing \grammarterm{identifier}-like subsequences
 (see \ref{lex.phases}, translation phases),
 they are never scanned for macro names or parameters.
 \end{footnote}
-to be replaced by the replacement list of preprocessing tokens
+to be replaced by the \grammarterm{replacement-list} of
+\grammarterm{pp-tokens}
 that constitute the remainder of the directive.
 \begin{footnote}
-An alternative token\iref{lex.digraph} is not an identifier,
+An alternative token\iref{lex.digraph} is not an \grammarterm{identifier},
 even when its spelling consists entirely of letters and underscores.
 Therefore it is not possible to define a macro
 whose name is the same as that of an alternative token.
 \end{footnote}
-The replacement list is then rescanned for more macro names as
+The \grammarterm{replacement-list} is then rescanned for more macro names as
 specified below.
 
 \pnum
@@ -1096,32 +1115,32 @@ with parameters, whose use is
 similar syntactically to a function call.
 The parameters
 \indextext{parameter!macro}%
-are specified by the optional list of identifiers.
+are specified by the optional list of \grammarterm{identifier}s.
 Each subsequent instance of the function-like macro name followed by a
 \tcode{(}
-as the next preprocessing token
-introduces the sequence of preprocessing tokens that is replaced
-by the replacement list in the definition
+as the next \grammarterm{preprocessing-token}
+introduces the sequence of \grammarterm{preprocessing-token}s that is replaced
+by the \grammarterm{replacement-list} in the definition
 (an invocation of the macro).
 \indextext{invocation!macro}%
-The replaced sequence of preprocessing tokens is terminated by the matching
+The replaced sequence of \grammarterm{preprocessing-token}s is terminated by the matching
 \tcode{)}
-preprocessing token, skipping intervening matched pairs of left and
-right parenthesis preprocessing tokens.
-Within the sequence of preprocessing tokens making up an invocation
+\grammarterm{preprocessing-token}, skipping intervening matched pairs of left and
+right parenthesis \grammarterm{preprocessing-token}s.
+Within the sequence of \grammarterm{preprocessing-token}s making up an invocation
 of a function-like macro,
 new-line is considered a normal whitespace character.
 
 \pnum
 \indextext{macro!function-like!arguments}%
-The sequence of preprocessing tokens
+The sequence of \grammarterm{preprocessing-token}s
 bounded by the outside-most matching parentheses
 forms the list of arguments for the function-like macro.
 The individual arguments within the list
-are separated by comma preprocessing tokens,
-but comma preprocessing tokens between matching
+are separated by comma \grammarterm{preprocessing-token}s,
+but comma \grammarterm{preprocessing-token}s between matching
 inner parentheses do not separate arguments.
-If there are sequences of preprocessing tokens within the list of
+If there are sequences of \grammarterm{preprocessing-token}s within the list of
 arguments that would otherwise act as preprocessing directives,
 \begin{footnote}
 A \grammarterm{conditionally-supported-directive} is a preprocessing directive regardless of whether the implementation supports it.
@@ -1173,23 +1192,24 @@ one more than the number of parameters in the macro definition (excluding the
 \pnum
 After the arguments for the invocation of a function-like macro have
 been identified, argument substitution takes place.
-For each parameter in the replacement list that is neither
-preceded by a \tcode{\#} or \tcode{\#\#} preprocessing token nor
-followed by a \tcode{\#\#} preprocessing token, the preprocessing tokens
+For each parameter in the \grammarterm{replacement-list} that is neither
+preceded by a \tcode{\#} or \tcode{\#\#} \grammarterm{preprocessing-token} nor
+followed by a \tcode{\#\#} \grammarterm{preprocessing-token},
+the \grammarterm{preprocessing-token}s
 naming the parameter are replaced by a token sequence determined as follows:
 \begin{itemize}
 \item
   If the parameter is of the form \grammarterm{va-opt-replacement},
-  the replacement preprocessing tokens are the
-  preprocessing token sequence for the corresponding argument,
+  the replacement \grammarterm{preprocessing-token}s are the
+  \grammarterm{preprocessing-token} sequence for the corresponding argument,
   as specified below.
 \item
-  Otherwise, the replacement preprocessing tokens are the
-  preprocessing tokens of corresponding argument after all
+  Otherwise, the replacement \grammarterm{preprocessing-token}s are the
+  \grammarterm{preprocessing-token}s of corresponding argument after all
   macros contained therein have been expanded. The argument's
-  preprocessing tokens are completely macro replaced before
+  \grammarterm{preprocessing-token}s are completely macro replaced before
   being substituted as if they formed the rest of the preprocessing
-  file with no other preprocessing tokens being available.
+  file with no other \grammarterm{preprocessing-token}s being available.
 \end{itemize}
 \begin{example}
 \begin{codeblock}
@@ -1202,9 +1222,10 @@ int x = F(LPAREN(), 0, <:-);    // replaced by \tcode{int x = 42;}
 
 \pnum
 \indextext{__va_args__@\mname{VA_ARGS}}%
-An identifier \mname{VA_ARGS} that occurs in the replacement list
-shall be treated as if it were a parameter, and the variable arguments shall form
-the preprocessing tokens used to replace it.
+An \grammarterm{identifier} \mname{VA_ARGS} that occurs in the
+\grammarterm{replacement-list}
+shall be treated as if it were a parameter, and the variable arguments shall
+form the \grammarterm{preprocessing-token}s used to replace it.
 
 \pnum
 \begin{example}
@@ -1228,8 +1249,8 @@ puts("The first, second, and third items.");
 
 \pnum
 \indextext{__va_opt__@\mname{VA_OPT}}%
-The identifier \mname{VA_OPT}
-shall always occur as part of the preprocessing token sequence
+The \grammarterm{identifier} \mname{VA_OPT}
+shall always occur as part of the \grammarterm{preprocessing-token} sequence
 \grammarterm{va-opt-replacement};
 its closing \tcode{)} is determined by skipping
 intervening pairs of matching left and right parentheses
@@ -1237,18 +1258,20 @@ in its \grammarterm{pp-tokens}.
 The \grammarterm{pp-tokens} of a \grammarterm{va-opt-replacement}
 shall not contain \mname{VA_OPT}.
 If the \grammarterm{pp-tokens} would be ill-formed
-as the replacement list of the current function-like macro,
+as the \grammarterm{replacement-list} of the current function-like macro,
 the program is ill-formed.
 A \grammarterm{va-opt-replacement} is treated as if it were a parameter,
-and the preprocessing token sequence for the corresponding
+and the \grammarterm{preprocessing-token} sequence for the corresponding
 argument is defined as follows.
 If the substitution of \mname{VA_ARGS} as neither an operand
-of \tcode{\#} nor \tcode{\#\#} consists of no preprocessing tokens,
+of \tcode{\#} nor \tcode{\#\#} consists of no
+\grammarterm{preprocessing-token}s,
 the argument consists of
-a single placemarker preprocessing token\iref{cpp.concat,cpp.rescan}.
+a single placemarker
+\grammarterm{preprocessing-token}\iref{cpp.concat,cpp.rescan}.
 Otherwise, the argument consists of
 the results of the expansion of the contained \grammarterm{pp-tokens}
-as the replacement list of the current function-like macro
+as the \grammarterm{replacement-list} of the current function-like macro
 before removal of placemarker tokens, rescanning, and further replacement.
 \begin{note}
 The placemarker tokens are removed before stringization\iref{cpp.stringize},
@@ -1273,7 +1296,7 @@ SDEF(foo);          // replaced by \tcode{S foo;}
 SDEF(bar, 1, 2);    // replaced by \tcode{S bar = \{ 1, 2 \};}
 
 #define H1(X, ...) X __VA_OPT__(##) __VA_ARGS__ // error: \tcode{\#\#} may not appear at
-                                                // the beginning of a replacement list\iref{cpp.concat}
+                                                // the beginning of a \grammarterm{replacement-list}\iref{cpp.concat}
 
 #define H2(X, Y, ...) __VA_OPT__(X ## Y,) __VA_ARGS__
 H2(a, b, c, d)      // replaced by \tcode{ab, c, d}
@@ -1298,26 +1321,30 @@ H5C(H5A())          // replaced by \tcode{ab}
 \pnum
 Each
 \tcode{\#}
-preprocessing token in the replacement list for a function-like
-macro shall be followed by a parameter as the next preprocessing
-token in the replacement list.
+\grammarterm{preprocessing-token} in the
+\grammarterm{replacement-list} for a function-like
+macro shall be followed by a parameter as the next
+\grammarterm{preprocessing-token} in the \grammarterm{replacement-list}.
 
 \pnum
 A \defn{character string literal} is a \grammarterm{string-literal} with no prefix.
-If, in the replacement list, a parameter is immediately
+If, in the \grammarterm{replacement-list}, a parameter is immediately
 preceded by a
 \tcode{\#}
-preprocessing token,
-both are replaced by a single character string literal preprocessing token that
-contains the spelling of the preprocessing token sequence for the
+\grammarterm{preprocessing-token},
+both are replaced by a single character \grammarterm{string-literal}
+\grammarterm{preprocessing-token} that
+contains the spelling of the \grammarterm{preprocessing-token} sequence for the
 corresponding argument (excluding placemarker tokens).
-Let the \defn{stringizing argument} be the preprocessing token sequence
+Let the \defn{stringizing argument} be the
+\grammarterm{preprocessing-token} sequence
 for the corresponding argument with placemarker tokens removed.
-Each occurrence of whitespace between the stringizing argument's preprocessing
-tokens becomes a single space character in the character string literal.
-Whitespace before the first preprocessing token and after the last
-preprocessing token comprising the stringizing argument is deleted.
-Otherwise, the original spelling of each preprocessing token in the
+Each occurrence of whitespace between the stringizing argument's
+\grammarterm{preprocessing-token} becomes a single space character in the
+character string literal.
+Whitespace before the first \grammarterm{preprocessing-token} and after the last
+\grammarterm{preprocessing-token} comprising the stringizing argument is deleted.
+Otherwise, the original spelling of each \grammarterm{preprocessing-token} in the
 stringizing argument is retained in the character string literal,
 except for special handling for producing the spelling of
 \grammarterm{string-literal}s and \grammarterm{character-literal}s:
@@ -1347,40 +1374,45 @@ operators is unspecified.
 \pnum
 A
 \tcode{\#\#}
-preprocessing token shall not occur at the beginning or
-at the end of a replacement list for either form
+\grammarterm{preprocessing-token} shall not occur at the beginning or
+at the end of a \grammarterm{replacement-list} for either form
 of macro definition.
 
 \pnum
-If, in the replacement list of a function-like macro, a parameter is
+If, in the \grammarterm{replacement-list} of a function-like macro, a parameter is
 immediately preceded or followed by a
 \tcode{\#\#}
-preprocessing token, the parameter is replaced by the
-corresponding argument's preprocessing token sequence; however, if an argument consists of no preprocessing tokens, the parameter is
-replaced by a placemarker preprocessing token instead.
+\grammarterm{preprocessing-token}, the parameter is replaced by the
+corresponding argument's \grammarterm{preprocessing-token} sequence;
+however, if an argument consists of no \grammarterm{preprocessing-token},
+the parameter is replaced by a
+placemarker \grammarterm{preprocessing-token} instead.
 \begin{footnote}
-Placemarker preprocessing tokens do not appear in the syntax
+Placemarker \grammarterm{preprocessing-token}s do not appear in the syntax
 because they are temporary entities that exist only within translation phase 4.
 \end{footnote}
 
 \pnum
 For both object-like and function-like macro invocations, before the
-replacement list is reexamined for more macro names to replace,
+\grammarterm{replacement-list} is reexamined for more macro names to replace,
 each instance of a
 \tcode{\#\#}
-preprocessing token in the replacement list
+\grammarterm{preprocessing-token} in the \grammarterm{replacement-list}
 (not from an argument) is deleted and the
-preceding preprocessing token is concatenated
-with the following preprocessing token.
-Placemarker preprocessing tokens are handled specially: concatenation
-of two placemarkers results in a single placemarker preprocessing token, and
-concatenation of a placemarker with a non-placemarker preprocessing token results
-in the non-placemarker preprocessing token.
+preceding \grammarterm{preprocessing-token} is concatenated
+with the following \grammarterm{preprocessing-token}.
+Placemarker \grammarterm{preprocessing-token}s are handled specially:
+concatenation
+of two placemarkers results in a single
+placemarker \grammarterm{preprocessing-token}, and
+concatenation of a placemarker
+with a non-placemarker \grammarterm{preprocessing-token} results
+in the non-placemarker \grammarterm{preprocessing-token}.
 \begin{note}
 Concatenation can form
 a \grammarterm{universal-character-name}\iref{lex.charset}.
 \end{note}
-If the result is not a valid preprocessing token,
+If the result is not a valid \grammarterm{preprocessing-token},
 the behavior is undefined.
 The resulting token is available for further macro replacement.
 The order of evaluation of
@@ -1458,7 +1490,8 @@ consisting of two adjacent sharp signs, but this new token is not the
 
 \pnum
 \begin{example}
-To illustrate the rules for placemarker preprocessing tokens, the sequence
+To illustrate the rules for placemarker \grammarterm{preprocessing-token}s,
+the sequence
 \begin{codeblock}
 #define t(x,y,z) x ## y ## z
 int j[] = { t(1,2,3), t(,4,5), t(6,,7), t(8,9,),
@@ -1476,11 +1509,12 @@ int j[] = { 123, 45, 67, 89,
 \indextext{rescanning and replacement|see{macro, rescanning and replacement}}
 
 \pnum
-After all parameters in the replacement list have been substituted and \tcode{\#} and \tcode{\#\#} processing has taken
-place, all placemarker preprocessing tokens are removed. Then
-the resulting preprocessing token sequence is rescanned, along with all
-subsequent preprocessing tokens of the source file, for more macro names
-to replace.
+After all parameters in the \grammarterm{replacement-list} have been substituted
+and \tcode{\#} and \tcode{\#\#} processing has taken
+place, all placemarker \grammarterm{preprocessing-token}s are removed.
+Then the resulting \grammarterm{preprocessing-token} sequence is rescanned,
+along with all subsequent \grammarterm{preprocessing-token}s of the source file,
+for more macro names to replace.
 
 \pnum
 \begin{example}
@@ -1518,20 +1552,21 @@ char c[2][6] = { "hello", "" };
 
 \pnum
 If the name of the macro being replaced is found during this scan of
-the replacement list
-(not including the rest of the source file's preprocessing tokens),
+the \grammarterm{replacement-list}
+(not including the rest of the source file's \grammarterm{preprocessing-token}s),
 it is not replaced.
 Furthermore,
 if any nested replacements encounter the name of the macro being replaced,
 it is not replaced.
-These nonreplaced macro name preprocessing tokens are no longer available
+These nonreplaced macro name \grammarterm{preprocessing-token}s
+are no longer available
 for further replacement even if they are later (re)examined in contexts
-in which that macro name preprocessing token would otherwise have been
-replaced.
+in which that macro name \grammarterm{preprocessing-token}
+would otherwise have been replaced.
 
 \pnum
-The resulting completely macro-replaced preprocessing token sequence
-is not processed as a preprocessing directive even if it resembles one,
+The resulting completely macro-replaced \grammarterm{preprocessing-token}
+sequence is not processed as a preprocessing directive even if it resembles one,
 but all pragma unary operator expressions within it are then processed as
 specified in~\ref{cpp.pragma.op} below.
 
@@ -1555,8 +1590,8 @@ A preprocessing directive of the form
 \terminal{\# undef} identifier new-line
 \indextext{\idxcode{\#undef}}%
 \end{ncsimplebnf}
-causes the specified identifier no longer to be defined as a macro name.
-It is ignored if the specified identifier is not currently defined as
+causes the specified \grammarterm{identifier} no longer to be defined as a macro name.
+It is ignored if the specified \grammarterm{identifier} is not currently defined as
 a macro name.
 
 \indextext{macro!replacement|)}
@@ -1608,11 +1643,11 @@ A preprocessing directive of the form
 \end{ncsimplebnf}
 (that does not match one of the two previous forms)
 is permitted.
-The preprocessing tokens after
+The \grammarterm{preprocessing-token}s after
 \tcode{line}
 on the directive are processed just as in normal text
-(each identifier currently defined as a macro name is replaced by its
-replacement list of preprocessing tokens).
+(each \grammarterm{identifier} currently defined as a macro name is replaced by
+its \grammarterm{replacement-list} of \grammarterm{preprocessing-token}s).
 If the directive resulting after all replacements does not match
 one of the two previous forms, the behavior is undefined;
 otherwise, the result is processed as appropriate.
@@ -1630,7 +1665,8 @@ A preprocessing directive of either of the following forms
 \terminal{\# warning} \opt{pp-tokens} new-line
 \end{ncsimplebnf}
 causes the implementation to produce
-a diagnostic message that should include the specified sequence of preprocessing tokens;
+a diagnostic message that should include the specified sequence of
+\grammarterm{preprocessing-token}s;
 the \tcode{\# error} directive renders the program ill-formed.
 
 \rSec1[cpp.pragma]{Pragma directive}%
@@ -1670,7 +1706,7 @@ The following macro names shall be defined by the implementation:
 \item
 \indextext{\idxxname{cplusplus}}%
 \xname{cplusplus}\\
-The integer literal \tcode{\cppver}.
+The \grammarterm{integer-literal} \tcode{\cppver}.
 \begin{note}
 Future revisions of \Cpp{} will
 replace the value of this macro with a greater value.
@@ -1678,7 +1714,7 @@ replace the value of this macro with a greater value.
 
 \item The names listed in \tref{cpp.predefined.ft}.\\
 The macros defined in \tref{cpp.predefined.ft} shall be defined to
-the corresponding integer literal.
+the corresponding \grammarterm{integer-literal}.
 \begin{note}
 Future revisions of \Cpp{} might replace
 the values of these macros with greater values.
@@ -1714,7 +1750,7 @@ The presumed source file name can be changed by the \tcode{\#line} directive.
 \indextext{__line__@\mname{LINE}}%
 \mname{LINE}\\
 The presumed line number (within the current source file) of the current source line
-(an integer literal).
+(an \grammarterm{integer-literal}).
 \begin{footnote}
 The presumed line number can be changed by the \tcode{\#line} directive.
 \end{footnote}
@@ -1724,15 +1760,15 @@ The presumed line number can be changed by the \tcode{\#line} directive.
 \indextext{implementation!hosted}%
 \indextext{implementation!freestanding}%
 \mname{STDC_HOSTED}\\
-The integer literal \tcode{1}
+The \grammarterm{integer-literal} \tcode{1}
 if the implementation is a hosted implementation or
-the integer literal \tcode{0}
+the \grammarterm{integer-literal} \tcode{0}
 if it is a freestanding implementation\iref{intro.compliance}.
 
 \item
 \indextext{__stdcpp_default_new_alignment__@\mname{STDCPP_DEFAULT_NEW_ALIGNMENT}}%
 \mname{STDCPP_DEFAULT_NEW_ALIGNMENT}\\
-An integer literal of type \tcode{std::size_t}
+An \grammarterm{integer-literal} of type \tcode{std::size_t}
 whose value is the alignment guaranteed
 by a call to \tcode{operator new(std::size_t)}
 or \tcode{operator new[](std::size_t)}.
@@ -1744,7 +1780,7 @@ Larger alignments will be passed to
 \item
 \indextext{__stdcpp_float16_t__@\mname{STDCPP_FLOAT16_T}}%
 \mname{STDCPP_FLOAT16_T}\\
-Defined as the integer literal \tcode{1}
+Defined as the \grammarterm{integer-literal} \tcode{1}
 if and only if the implementation supports
 the ISO/IEC/IEEE 60559 floating-point interchange format binary16
 as an extended floating-point type\iref{basic.extended.fp}.
@@ -1752,7 +1788,7 @@ as an extended floating-point type\iref{basic.extended.fp}.
 \item
 \indextext{__stdcpp_float32_t__@\mname{STDCPP_FLOAT32_T}}%
 \mname{STDCPP_FLOAT32_T}\\
-Defined as the integer literal \tcode{1}
+Defined as the \grammarterm{integer-literal} \tcode{1}
 if and only if the implementation supports
 the ISO/IEC/IEEE 60559 floating-point interchange format binary32
 as an extended floating-point type.
@@ -1760,7 +1796,7 @@ as an extended floating-point type.
 \item
 \indextext{__stdcpp_float64_t__@\mname{STDCPP_FLOAT64_T}}%
 \mname{STDCPP_FLOAT64_T}\\
-Defined as the integer literal \tcode{1}
+Defined as the \grammarterm{integer-literal} \tcode{1}
 if and only if the implementation supports
 the ISO/IEC/IEEE 60559 floating-point interchange format binary64
 as an extended floating-point type.
@@ -1768,7 +1804,7 @@ as an extended floating-point type.
 \item
 \indextext{__stdcpp_float128_t__@\mname{STDCPP_FLOAT128_T}}%
 \mname{STDCPP_FLOAT128_T}\\
-Defined as the integer literal \tcode{1}
+Defined as the \grammarterm{integer-literal} \tcode{1}
 if and only if the implementation supports
 the ISO/IEC/IEEE 60559 floating-point interchange format binary128
 as an extended floating-point type.
@@ -1776,7 +1812,7 @@ as an extended floating-point type.
 \item
 \indextext{__stdcpp_bfloat16_t__@\mname{STDCPP_BFLOAT16_T}}%
 \mname{STDCPP_BFLOAT16_T}\\
-Defined as the integer literal \tcode{1}
+Defined as the \grammarterm{integer-literal} \tcode{1}
 if and only if the implementation supports an extended floating-point type
 with the properties of the \grammarterm{typedef-name} \tcode{std::bfloat16_t}
 as described in \ref{basic.extended.fp}.
@@ -1884,7 +1920,7 @@ are \impldef{definition and meaning of \mname{STDC}}.
 \item
 \indextext{__stdc_mb_might_neq_wc__@\mname{STDC_MB_MIGHT_NEQ_WC}}%
 \mname{STDC_MB_MIGHT_NEQ_WC}\\
-The integer literal \tcode{1}, intended to indicate that, in the encoding for
+The \grammarterm{integer-literal} \tcode{1}, intended to indicate that, in the encoding for
 \keyword{wchar_t}, a member of the basic character set need not have a code value equal to
 its value when used as the lone character in an ordinary character literal.
 
@@ -1897,7 +1933,7 @@ are \impldef{definition and meaning of \mname{STDC_VERSION}}.
 \item
 \indextext{__stdc_iso_10646__@\mname{STDC_ISO_10646}}%
 \mname{STDC_ISO_10646}\\
-An integer literal of the form \tcode{yyyymmL}
+An \grammarterm{integer-literal} of the form \tcode{yyyymmL}
 (for example, \tcode{199712L}).
 Whether \mname{STDC_ISO_10646} is predefined and
 if so, what its value is,
@@ -1906,7 +1942,8 @@ are \impldef{presence and value of \mname{STDC_ISO_10646}}.
 \item
 \indextext{__stdcpp_threads__@\mname{STDCPP_THREADS}}%
 \mname{STDCPP_THREADS}\\
-Defined, and has the value integer literal 1, if and only if a program
+Defined, and has the value \grammarterm{integer-literal} \tcode{1},
+if and only if a program
 can have more than one thread of execution\iref{intro.multithread}.
 
 \end{description}
@@ -1921,7 +1958,7 @@ remain constant throughout the translation unit.
 
 \pnum
 If any of the pre-defined macro names in this subclause,
-or the identifier
+or the \grammarterm{identifier}
 \tcode{defined},
 is the subject of a
 \tcode{\#define}
@@ -1947,7 +1984,8 @@ by deleting the \tcode{L} prefix, if present, deleting the leading and trailing
 double-quotes, replacing each escape sequence \tcode{\textbackslash"} by a double-quote, and
 replacing each escape sequence \tcode{\textbackslash\textbackslash} by a single
 backslash. The resulting sequence of characters is processed through translation phase 3
-to produce preprocessing tokens that are executed as if they were the
+to produce \grammarterm{preprocessing-token}s that are executed
+as if they were the
 \grammarterm{pp-tokens} in a pragma directive. The original four preprocessing
 tokens in the unary operator expression are removed.
 


### PR DESCRIPTION
Fixes https://github.com/cplusplus/draft/issues/6524.

This edit consistently uses `\grammarterm` formatting for:
- *identifier*
- *preprocessing-token*
- *replacement-list*
- *group*
- *string-literal*
- *integer-literal*

No normative wording changes are made.