### PR TITLE
[format.string.std] Fix example

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15901,8 +15901,6 @@ are both absent.
 The \fmtgrammarterm{align} option applies to all argument types.
 The meaning of the various alignment options is as specified in \tref{format.align}.
 \begin{example}
-%FIXME: example is incomplete, sB and sC result in:
-%Error: Invalid UTF-8 byte sequence.
 \begin{codeblock}
 char c = 120;
 string s0 = format("{:6}", 42);             // value of \tcode{s0} is \tcode{"\ \ \ \ 42"}
@@ -15916,8 +15914,8 @@ string s7 = format("{:*<6.3}", "123456");   // value of \tcode{s7} is \tcode{"12
 string s8 = format("{:02}", 1234);          // value of \tcode{s8} is \tcode{"1234"}
 string s9 = format("{:*<}", "12");          // value of \tcode{s9} is \tcode{"12"}
 string sA = format("{:*<6}", "12345678");   // value of \tcode{sA} is \tcode{"12345678"}
-string sB = format("{:@\importexample[-2pt]{example_05}\caret{}@6}", "x");         // value of \tcode{sB} is \tcode{"\importexample[-2pt]{example_05}\importexample[-2pt]{example_05}x\importexample[-2pt]{example_05}\importexample[-2pt]{example_05}\importexample[-2pt]{example_05}"}
-string sC = format("{:*@\caret{}@6}", "@\importexample[-2pt]{example_05}@");         // value of \tcode{sC} is \tcode{"\importexample[-2pt]{example_05}\importexample[-2pt]{example_05}\importexample[-2pt]{example_05}"}
+string sB = format("{:@\importexample[-2pt]{example_05}\kern0.75pt\caret{}@6}", "x");         // value of \tcode{sB} is \tcode{"\importexample[-2pt]{example_05}\importexample[-2pt]{example_05}x\importexample[-2pt]{example_05}\importexample[-2pt]{example_05}\importexample[-2pt]{example_05}"}
+string sC = format("{:*@\caret{}@6}", "@\importexample[-2pt]{example_05}\kern0.75pt\importexample[-2pt]{example_05}\kern0.75pt\importexample[-2pt]{example_05}\kern0.75pt@");     // value of \tcode{sC} is \tcode{"\importexample[-2pt]{example_05}\importexample[-2pt]{example_05}\importexample[-2pt]{example_05}"}
 \end{codeblock}
 \end{example}
 \begin{note}
@@ -17139,9 +17137,6 @@ if \placeholder{C} is \unicode{0022}{quotation mark},
 then \placeholder{C} is appended unchanged.
 \end{itemize}
 
-%% FIXME: Example is incomplete; s2 and s6 from P2286R8
-%%        and s8 (which should be s9) from P2713R1 are missing below;
-%% FIXME: their Unicode characters are not available in our font (Latin Modern).
 \begin{example}
 \begin{codeblock}
 string s0 = format("[{}]", "h\tllo");                   // \tcode{s0} has value: \tcode{[h\ \ \ \ llo]}


### PR DESCRIPTION
Fixes #6474.

@timsong-cpp, @tahonermann FYI