### PR TITLE
[class.access.general] Fix improper `\keyword{private}`

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -4229,9 +4229,7 @@ and local classes.
 \indextext{access control!default}%
 Members of a class defined with the keyword
 \keyword{class}
-are
-\keyword{private}
-by default.
+are private by default.
 Members of a class defined with the keywords
 \keyword{struct} or \keyword{union}
 are public by default.


### PR DESCRIPTION
The [[class.access]](https://eel.is/c++draft/class.access) section generally only uses `private` or `public` when talking about the access specifiers in the language syntax.

The use of `\keyword{private}` is inconsistent with the rest of the subclause, and even with the rest of the paragraph.