### PR TITLE
[lex.string] Format narrow string literals as definition

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1880,10 +1880,9 @@ is equivalent to \tcode{"x = \textbackslash "\textbackslash\textbackslash\textba
 \end{example}
 
 \pnum
-\indextext{literal!string!narrow}%
 \indextext{literal!narrow-character}%
 Ordinary string literals and UTF-8 string literals are
-also referred to as narrow string literals.
+also referred to as \defnx{narrow string literals}{literal!string!narrow}.
 
 \pnum
 \indextext{concatenation!string}%


### PR DESCRIPTION
This paragraph is obviously defining a term, but the definition is not formatted as such, contrary to definitions in [table 12](https://eel.is/c++draft/lex.string#tab:lex.string.literal).