### PR TITLE
[expr.unary.noexcept] Replace informative wording

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5052,13 +5052,13 @@ which is an unevaluated operand\iref{term.unevaluated.operand}.
 The \keyword{noexcept} operator yields \keyword{true}
 unless the full-expression of the operand
 is potentially-throwing\iref{except.spec}.
-
-\pnum
-The result of the \keyword{noexcept} operator is a prvalue of type \keyword{bool}.
 \begin{note}
 A \grammarterm{noexcept-expression}
 is an integral constant expression\iref{expr.const}.
 \end{note}
+
+\pnum
+The result of the \keyword{noexcept} operator is a prvalue of type \keyword{bool}.
 
 \pnum
 If the operand is a prvalue,

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5042,14 +5042,16 @@ element type.
 \pnum
 \indextext{\idxcode{noexcept}}%
 \indextext{expression!\idxcode{noexcept}}%
-The \keyword{noexcept} operator determines whether the evaluation of its operand,
-which is an unevaluated operand\iref{term.unevaluated.operand}, can throw an
-exception\iref{except.throw}.
-
+The \keyword{noexcept} operator
 \begin{bnf}
 \nontermdef{noexcept-expression}\br
   \keyword{noexcept} \terminal{(} expression \terminal{)}
 \end{bnf}
+has an \grammarterm{expression} \term{operand}
+which is an unevaluated operand\iref{term.unevaluated.operand}.
+The \keyword{noexcept} operator yields \keyword{true}
+unless the full-expression of the operand
+is potentially-throwing\iref{except.spec}.
 
 \pnum
 The result of the \keyword{noexcept} operator is a prvalue of type \keyword{bool}.
@@ -5061,9 +5063,6 @@ is an integral constant expression\iref{expr.const}.
 \pnum
 If the operand is a prvalue,
 the temporary materialization conversion\iref{conv.rval} is applied.
-The result of the \keyword{noexcept} operator is \keyword{true}
-unless the full-expression of the operand
-is potentially-throwing\iref{except.spec}.
 \indextext{expression!unary|)}
 
 \rSec3[expr.new]{New}


### PR DESCRIPTION
### Context and Problem with the Current Wording
I was briefly under the impression that `a + b` can throw for two `int`s `a` and `b`, because signed integer overflow is UB, and UB can result in throwing exceptions, and maybe the `noexcept` operator needs to consider that.

Paragraph 1 in its current form says:
> determines whether the evaluation of its operand [...] can throw an exception

An unsuspecting reader like me might assume that this includes exceptions thrown as the result of UB. However, this isn't actually possible, and this wording is purely informative. Paragraph 3 contains the *actual normative* wording, explaining that the `noexcept` operator checks whether an expression is potentially-throwing.

### Suggested Solution
This PR moves the *actual normative* wording from p3 up into p1 to avoid any future confusion. The informative wording is removed.