### PR TITLE
[temp.deduct.type] Remove excessive spacing in example

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -8225,11 +8225,11 @@ This can lead to conflicts
 that cause type deduction to fail:
 
 \begin{codeblock}
-template <class T, class U> void f(  T (*)( T, U, U )  );
+template <class T, class U> void f(T (*)(T, U, U));
 
-int g1( int, float, float);
-char g2( int, float, float);
-int g3( int, char, float);
+int g1(int, float, float);
+char g2(int, float, float);
+int g3(int, char, float);
 
 void r() {
   f(g1);            // OK, \tcode{T} is \tcode{int} and \tcode{U} is \tcode{float}


### PR DESCRIPTION
Firstly, the leading space in the parameter list of `g1`, `g2`, and `g3` is obviously unintentional. This style isn't followed anywhere else in the example, and would be extremely unusual if intended.

Secondly, the spacing in `f` is quite excessive, and internally inconsistent with the remainder of the example. Just a few lines down, the example continues with:
```cpp
template<bool E> void f1(void (*)() noexcept(E));
template<bool> struct A { };
template<bool B> void f2(void (*)(A<B>) noexcept(B));
```
So everywhere but `f`, the author has no problem using a very conservative amount of spacing for function pointers.

This inconsistency tells me that the current declaration of `f` is some in-dev version which only made it into the standard by accident.