### PR TITLE
[cmath.syn] Fix misaligned parameter lists

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -9193,13 +9193,13 @@ namespace std {
   constexpr long double fminl(long double x, long double y);
 
   constexpr @\placeholder{floating-point-type}@ fma(@\placeholder{floating-point-type}@ x, @\placeholder{floating-point-type}@ y,
-                                  @\placeholder{floating-point-type}@ z);
+                                    @\placeholder{floating-point-type}@ z);
   constexpr float fmaf(float x, float y, float z);
   constexpr long double fmal(long double x, long double y, long double z);
 
   // \ref{c.math.lerp}, linear interpolation
   constexpr @\placeholder{floating-point-type}@ lerp(@\placeholder{floating-point-type}@ a, @\placeholder{floating-point-type}@ b,
-                                    @\placeholder{floating-point-type}@ t) noexcept;
+                                     @\placeholder{floating-point-type}@ t) noexcept;
 
   // \ref{c.math.fpclass}, classification / comparison functions
   constexpr int fpclassify(@\placeholder{floating-point-type}@ x);


### PR DESCRIPTION
`fma` and `lerp` have multi-line parameter lists which are not vertically aligned like `hypot`.
![image](https://github.com/cplusplus/draft/assets/22040976/dbb7da6e-c671-47ab-99e8-c0e6965d67ad)

This looks goofy, and the edit fixes these issues.