### PR TITLE
[cmath.syn] Align function declarations

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -9028,372 +9028,372 @@ namespace std {
 #define math_errhandling @\seebelow@
 
 namespace std {
-  constexpr @\placeholder{floating-point-type}@ acos(@\placeholder{floating-point-type}@ x);
-  constexpr float acosf(float x);
-  constexpr long double acosl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ acos(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               acosf(float x);
+  constexpr long double         acosl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ asin(@\placeholder{floating-point-type}@ x);
-  constexpr float asinf(float x);
-  constexpr long double asinl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ asin(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               asinf(float x);
+  constexpr long double         asinl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ atan(@\placeholder{floating-point-type}@ x);
-  constexpr float atanf(float x);
-  constexpr long double atanl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ atan(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               atanf(float x);
+  constexpr long double         atanl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ atan2(@\placeholder{floating-point-type}@ y, @\placeholder{floating-point-type}@ x);
-  constexpr float atan2f(float y, float x);
-  constexpr long double atan2l(long double y, long double x);
+  constexpr @\placeholdernc{floating-point-type}@ atan2(@\placeholdernc{floating-point-type}@ y, @\placeholdernc{floating-point-type}@ x);
+  constexpr float               atan2f(float y, float x);
+  constexpr long double         atan2l(long double y, long double x);
 
-  constexpr @\placeholder{floating-point-type}@ cos(@\placeholder{floating-point-type}@ x);
-  constexpr float cosf(float x);
-  constexpr long double cosl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ cos(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               cosf(float x);
+  constexpr long double         cosl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ sin(@\placeholder{floating-point-type}@ x);
-  constexpr float sinf(float x);
-  constexpr long double sinl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ sin(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               sinf(float x);
+  constexpr long double         sinl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ tan(@\placeholder{floating-point-type}@ x);
-  constexpr float tanf(float x);
-  constexpr long double tanl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ tan(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               tanf(float x);
+  constexpr long double         tanl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ acosh(@\placeholder{floating-point-type}@ x);
-  constexpr float acoshf(float x);
-  constexpr long double acoshl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ acosh(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               acoshf(float x);
+  constexpr long double         acoshl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ asinh(@\placeholder{floating-point-type}@ x);
-  constexpr float asinhf(float x);
-  constexpr long double asinhl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ asinh(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               asinhf(float x);
+  constexpr long double         asinhl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ atanh(@\placeholder{floating-point-type}@ x);
-  constexpr float atanhf(float x);
-  constexpr long double atanhl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ atanh(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               atanhf(float x);
+  constexpr long double         atanhl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ cosh(@\placeholder{floating-point-type}@ x);
-  constexpr float coshf(float x);
-  constexpr long double coshl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ cosh(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               coshf(float x);
+  constexpr long double         coshl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ sinh(@\placeholder{floating-point-type}@ x);
-  constexpr float sinhf(float x);
-  constexpr long double sinhl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ sinh(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               sinhf(float x);
+  constexpr long double         sinhl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ tanh(@\placeholder{floating-point-type}@ x);
-  constexpr float tanhf(float x);
-  constexpr long double tanhl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ tanh(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               tanhf(float x);
+  constexpr long double         tanhl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ exp(@\placeholder{floating-point-type}@ x);
-  constexpr float expf(float x);
-  constexpr long double expl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ exp(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               expf(float x);
+  constexpr long double         expl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ exp2(@\placeholder{floating-point-type}@ x);
-  constexpr float exp2f(float x);
-  constexpr long double exp2l(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ exp2(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               exp2f(float x);
+  constexpr long double         exp2l(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ expm1(@\placeholder{floating-point-type}@ x);
-  constexpr float expm1f(float x);
-  constexpr long double expm1l(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ expm1(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               expm1f(float x);
+  constexpr long double         expm1l(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ frexp(@\placeholder{floating-point-type}@ value, int* exp);
-  constexpr float frexpf(float value, int* exp);
-  constexpr long double frexpl(long double value, int* exp);
+  constexpr @\placeholdernc{floating-point-type}@ frexp(@\placeholdernc{floating-point-type}@ value, int* exp);
+  constexpr float               frexpf(float value, int* exp);
+  constexpr long double         frexpl(long double value, int* exp);
 
-  constexpr int ilogb(@\placeholder{floating-point-type}@ x);
+  constexpr int ilogb(@\placeholdernc{floating-point-type}@ x);
   constexpr int ilogbf(float x);
   constexpr int ilogbl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ ldexp(@\placeholder{floating-point-type}@ x, int exp);
-  constexpr float ldexpf(float x, int exp);
-  constexpr long double ldexpl(long double x, int exp);
+  constexpr @\placeholdernc{floating-point-type}@ ldexp(@\placeholdernc{floating-point-type}@ x, int exp);
+  constexpr float               ldexpf(float x, int exp);
+  constexpr long double         ldexpl(long double x, int exp);
 
-  constexpr @\placeholder{floating-point-type}@ log(@\placeholder{floating-point-type}@ x);
-  constexpr float logf(float x);
-  constexpr long double logl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ log(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               logf(float x);
+  constexpr long double         logl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ log10(@\placeholder{floating-point-type}@ x);
-  constexpr float log10f(float x);
-  constexpr long double log10l(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ log10(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               log10f(float x);
+  constexpr long double         log10l(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ log1p(@\placeholder{floating-point-type}@ x);
-  constexpr float log1pf(float x);
-  constexpr long double log1pl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ log1p(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               log1pf(float x);
+  constexpr long double         log1pl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ log2(@\placeholder{floating-point-type}@ x);
-  constexpr float log2f(float x);
-  constexpr long double log2l(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ log2(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               log2f(float x);
+  constexpr long double         log2l(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ logb(@\placeholder{floating-point-type}@ x);
-  constexpr float logbf(float x);
-  constexpr long double logbl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ logb(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               logbf(float x);
+  constexpr long double         logbl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ modf(@\placeholder{floating-point-type}@ value, @\placeholder{floating-point-type}@* iptr);
-  constexpr float modff(float value, float* iptr);
-  constexpr long double modfl(long double value, long double* iptr);
+  constexpr @\placeholdernc{floating-point-type}@ modf(@\placeholdernc{floating-point-type}@ value, @\placeholdernc{floating-point-type}@* iptr);
+  constexpr float               modff(float value, float* iptr);
+  constexpr long double         modfl(long double value, long double* iptr);
 
-  constexpr @\placeholder{floating-point-type}@ scalbn(@\placeholder{floating-point-type}@ x, int n);
-  constexpr float scalbnf(float x, int n);
-  constexpr long double scalbnl(long double x, int n);
+  constexpr @\placeholdernc{floating-point-type}@ scalbn(@\placeholdernc{floating-point-type}@ x, int n);
+  constexpr float               scalbnf(float x, int n);
+  constexpr long double         scalbnl(long double x, int n);
 
-  constexpr @\placeholder{floating-point-type}@ scalbln(@\placeholder{floating-point-type}@ x, long int n);
-  constexpr float scalblnf(float x, long int n);
-  constexpr long double scalblnl(long double x, long int n);
+  constexpr @\placeholdernc{floating-point-type}@ scalbln(@\placeholdernc{floating-point-type}@ x, long int n);
+  constexpr float               scalblnf(float x, long int n);
+  constexpr long double         scalblnl(long double x, long int n);
 
-  constexpr @\placeholder{floating-point-type}@ cbrt(@\placeholder{floating-point-type}@ x);
-  constexpr float cbrtf(float x);
-  constexpr long double cbrtl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ cbrt(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               cbrtf(float x);
+  constexpr long double         cbrtl(long double x);
 
   // \ref{c.math.abs}, absolute values
-  constexpr int abs(int j);                                             // freestanding
-  constexpr long int abs(long int j);                                   // freestanding
-  constexpr long long int abs(long long int j);                         // freestanding
-  constexpr @\placeholder{floating-point-type}@ abs(@\placeholder{floating-point-type}@ j);            // freestanding-deleted
+  constexpr int                 abs(int j);                             // freestanding
+  constexpr long int            abs(long int j);                        // freestanding
+  constexpr long long int       abs(long long int j);                   // freestanding
+  constexpr @\placeholdernc{floating-point-type}@ abs(@\placeholdernc{floating-point-type}@ j);            // freestanding-deleted
 
-  constexpr @\placeholder{floating-point-type}@ fabs(@\placeholder{floating-point-type}@ x);
-  constexpr float fabsf(float x);
-  constexpr long double fabsl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ fabs(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               fabsf(float x);
+  constexpr long double         fabsl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ hypot(@\placeholder{floating-point-type}@ x, @\placeholder{floating-point-type}@ y);
-  constexpr float hypotf(float x, float y);
-  constexpr long double hypotl(long double x, long double y);
+  constexpr @\placeholdernc{floating-point-type}@ hypot(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr float               hypotf(float x, float y);
+  constexpr long double         hypotl(long double x, long double y);
 
   // \ref{c.math.hypot3}, three-dimensional hypotenuse
-  constexpr @\placeholder{floating-point-type}@ hypot(@\placeholder{floating-point-type}@ x, @\placeholder{floating-point-type}@ y,
-                                      @\placeholder{floating-point-type}@ z);
+  constexpr @\placeholdernc{floating-point-type}@ hypot(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y,
+                                      @\placeholdernc{floating-point-type}@ z);
 
-  constexpr @\placeholder{floating-point-type}@ pow(@\placeholder{floating-point-type}@ x, @\placeholder{floating-point-type}@ y);
-  constexpr float powf(float x, float y);
-  constexpr long double powl(long double x, long double y);
+  constexpr @\placeholdernc{floating-point-type}@ pow(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr float               powf(float x, float y);
+  constexpr long double         powl(long double x, long double y);
 
-  constexpr @\placeholder{floating-point-type}@ sqrt(@\placeholder{floating-point-type}@ x);
-  constexpr float sqrtf(float x);
-  constexpr long double sqrtl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ sqrt(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               sqrtf(float x);
+  constexpr long double         sqrtl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ erf(@\placeholder{floating-point-type}@ x);
-  constexpr float erff(float x);
-  constexpr long double erfl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ erf(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               erff(float x);
+  constexpr long double         erfl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ erfc(@\placeholder{floating-point-type}@ x);
-  constexpr float erfcf(float x);
-  constexpr long double erfcl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ erfc(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               erfcf(float x);
+  constexpr long double         erfcl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ lgamma(@\placeholder{floating-point-type}@ x);
-  constexpr float lgammaf(float x);
-  constexpr long double lgammal(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ lgamma(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               lgammaf(float x);
+  constexpr long double         lgammal(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ tgamma(@\placeholder{floating-point-type}@ x);
-  constexpr float tgammaf(float x);
-  constexpr long double tgammal(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ tgamma(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               tgammaf(float x);
+  constexpr long double         tgammal(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ ceil(@\placeholder{floating-point-type}@ x);
-  constexpr float ceilf(float x);
-  constexpr long double ceill(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ ceil(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               ceilf(float x);
+  constexpr long double         ceill(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ floor(@\placeholder{floating-point-type}@ x);
-  constexpr float floorf(float x);
-  constexpr long double floorl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ floor(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               floorf(float x);
+  constexpr long double         floorl(long double x);
 
-  @\placeholder{floating-point-type}@ nearbyint(@\placeholder{floating-point-type}@ x);
-  float nearbyintf(float x);
-  long double nearbyintl(long double x);
+  @\placeholdernc{floating-point-type}@ nearbyint(@\placeholdernc{floating-point-type}@ x);
+  float               nearbyintf(float x);
+  long double         nearbyintl(long double x);
 
-  @\placeholder{floating-point-type}@ rint(@\placeholder{floating-point-type}@ x);
-  float rintf(float x);
-  long double rintl(long double x);
+  @\placeholdernc{floating-point-type}@ rint(@\placeholdernc{floating-point-type}@ x);
+  float               rintf(float x);
+  long double         rintl(long double x);
 
-  long int lrint(@\placeholder{floating-point-type}@ x);
+  long int lrint(@\placeholdernc{floating-point-type}@ x);
   long int lrintf(float x);
   long int lrintl(long double x);
 
-  long long int llrint(@\placeholder{floating-point-type}@ x);
+  long long int llrint(@\placeholdernc{floating-point-type}@ x);
   long long int llrintf(float x);
   long long int llrintl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ round(@\placeholder{floating-point-type}@ x);
-  constexpr float roundf(float x);
-  constexpr long double roundl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ round(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               roundf(float x);
+  constexpr long double         roundl(long double x);
 
-  constexpr long int lround(@\placeholder{floating-point-type}@ x);
+  constexpr long int lround(@\placeholdernc{floating-point-type}@ x);
   constexpr long int lroundf(float x);
   constexpr long int lroundl(long double x);
 
-  constexpr long long int llround(@\placeholder{floating-point-type}@ x);
+  constexpr long long int llround(@\placeholdernc{floating-point-type}@ x);
   constexpr long long int llroundf(float x);
   constexpr long long int llroundl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ trunc(@\placeholder{floating-point-type}@ x);
-  constexpr float truncf(float x);
-  constexpr long double truncl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ trunc(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               truncf(float x);
+  constexpr long double         truncl(long double x);
 
-  constexpr @\placeholder{floating-point-type}@ fmod(@\placeholder{floating-point-type}@ x, @\placeholder{floating-point-type}@ y);
-  constexpr float fmodf(float x, float y);
-  constexpr long double fmodl(long double x, long double y);
+  constexpr @\placeholdernc{floating-point-type}@ fmod(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr float               fmodf(float x, float y);
+  constexpr long double         fmodl(long double x, long double y);
 
-  constexpr @\placeholder{floating-point-type}@ remainder(@\placeholder{floating-point-type}@ x, @\placeholder{floating-point-type}@ y);
-  constexpr float remainderf(float x, float y);
-  constexpr long double remainderl(long double x, long double y);
+  constexpr @\placeholdernc{floating-point-type}@ remainder(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr float               remainderf(float x, float y);
+  constexpr long double         remainderl(long double x, long double y);
 
-  constexpr @\placeholder{floating-point-type}@ remquo(@\placeholder{floating-point-type}@ x, @\placeholder{floating-point-type}@ y, int* quo);
-  constexpr float remquof(float x, float y, int* quo);
-  constexpr long double remquol(long double x, long double y, int* quo);
+  constexpr @\placeholdernc{floating-point-type}@ remquo(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y, int* quo);
+  constexpr float               remquof(float x, float y, int* quo);
+  constexpr long double         remquol(long double x, long double y, int* quo);
 
-  constexpr @\placeholder{floating-point-type}@ copysign(@\placeholder{floating-point-type}@ x, @\placeholder{floating-point-type}@ y);
-  constexpr float copysignf(float x, float y);
-  constexpr long double copysignl(long double x, long double y);
+  constexpr @\placeholdernc{floating-point-type}@ copysign(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr float               copysignf(float x, float y);
+  constexpr long double         copysignl(long double x, long double y);
 
-  double nan(const char* tagp);
-  float nanf(const char* tagp);
+  double      nan(const char* tagp);
+  float       nanf(const char* tagp);
   long double nanl(const char* tagp);
 
-  constexpr @\placeholder{floating-point-type}@ nextafter(@\placeholder{floating-point-type}@ x, @\placeholder{floating-point-type}@ y);
-  constexpr float nextafterf(float x, float y);
-  constexpr long double nextafterl(long double x, long double y);
+  constexpr @\placeholdernc{floating-point-type}@ nextafter(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr float               nextafterf(float x, float y);
+  constexpr long double         nextafterl(long double x, long double y);
 
-  constexpr @\placeholder{floating-point-type}@ nexttoward(@\placeholder{floating-point-type}@ x, long double y);
-  constexpr float nexttowardf(float x, long double y);
-  constexpr long double nexttowardl(long double x, long double y);
+  constexpr @\placeholdernc{floating-point-type}@ nexttoward(@\placeholdernc{floating-point-type}@ x, long double y);
+  constexpr float               nexttowardf(float x, long double y);
+  constexpr long double         nexttowardl(long double x, long double y);
 
-  constexpr @\placeholder{floating-point-type}@ fdim(@\placeholder{floating-point-type}@ x, @\placeholder{floating-point-type}@ y);
-  constexpr float fdimf(float x, float y);
-  constexpr long double fdiml(long double x, long double y);
+  constexpr @\placeholdernc{floating-point-type}@ fdim(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr float               fdimf(float x, float y);
+  constexpr long double         fdiml(long double x, long double y);
 
-  constexpr @\placeholder{floating-point-type}@ fmax(@\placeholder{floating-point-type}@ x, @\placeholder{floating-point-type}@ y);
-  constexpr float fmaxf(float x, float y);
-  constexpr long double fmaxl(long double x, long double y);
+  constexpr @\placeholdernc{floating-point-type}@ fmax(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr float               fmaxf(float x, float y);
+  constexpr long double         fmaxl(long double x, long double y);
 
-  constexpr @\placeholder{floating-point-type}@ fmin(@\placeholder{floating-point-type}@ x, @\placeholder{floating-point-type}@ y);
-  constexpr float fminf(float x, float y);
-  constexpr long double fminl(long double x, long double y);
+  constexpr @\placeholdernc{floating-point-type}@ fmin(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr float               fminf(float x, float y);
+  constexpr long double         fminl(long double x, long double y);
 
-  constexpr @\placeholder{floating-point-type}@ fma(@\placeholder{floating-point-type}@ x, @\placeholder{floating-point-type}@ y,
-                                    @\placeholder{floating-point-type}@ z);
-  constexpr float fmaf(float x, float y, float z);
-  constexpr long double fmal(long double x, long double y, long double z);
+  constexpr @\placeholdernc{floating-point-type}@ fma(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y,
+                                    @\placeholdernc{floating-point-type}@ z);
+  constexpr float               fmaf(float x, float y, float z);
+  constexpr long double         fmal(long double x, long double y, long double z);
 
   // \ref{c.math.lerp}, linear interpolation
-  constexpr @\placeholder{floating-point-type}@ lerp(@\placeholder{floating-point-type}@ a, @\placeholder{floating-point-type}@ b,
-                                     @\placeholder{floating-point-type}@ t) noexcept;
+  constexpr @\placeholdernc{floating-point-type}@ lerp(@\placeholdernc{floating-point-type}@ a, @\placeholdernc{floating-point-type}@ b,
+                                     @\placeholdernc{floating-point-type}@ t) noexcept;
 
   // \ref{c.math.fpclass}, classification / comparison functions
-  constexpr int fpclassify(@\placeholder{floating-point-type}@ x);
-  constexpr bool isfinite(@\placeholder{floating-point-type}@ x);
-  constexpr bool isinf(@\placeholder{floating-point-type}@ x);
-  constexpr bool isnan(@\placeholder{floating-point-type}@ x);
-  constexpr bool isnormal(@\placeholder{floating-point-type}@ x);
-  constexpr bool signbit(@\placeholder{floating-point-type}@ x);
-  constexpr bool isgreater(@\placeholder{floating-point-type}@ x, @\placeholder{floating-point-type}@ y);
-  constexpr bool isgreaterequal(@\placeholder{floating-point-type}@ x, @\placeholder{floating-point-type}@ y);
-  constexpr bool isless(@\placeholder{floating-point-type}@ x, @\placeholder{floating-point-type}@ y);
-  constexpr bool islessequal(@\placeholder{floating-point-type}@ x, @\placeholder{floating-point-type}@ y);
-  constexpr bool islessgreater(@\placeholder{floating-point-type}@ x, @\placeholder{floating-point-type}@ y);
-  constexpr bool isunordered(@\placeholder{floating-point-type}@ x, @\placeholder{floating-point-type}@ y);
+  constexpr int fpclassify(@\placeholdernc{floating-point-type}@ x);
+  constexpr bool isfinite(@\placeholdernc{floating-point-type}@ x);
+  constexpr bool isinf(@\placeholdernc{floating-point-type}@ x);
+  constexpr bool isnan(@\placeholdernc{floating-point-type}@ x);
+  constexpr bool isnormal(@\placeholdernc{floating-point-type}@ x);
+  constexpr bool signbit(@\placeholdernc{floating-point-type}@ x);
+  constexpr bool isgreater(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr bool isgreaterequal(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr bool isless(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr bool islessequal(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr bool islessgreater(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr bool isunordered(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
 
   // \ref{sf.cmath}, mathematical special functions
 
   // \ref{sf.cmath.assoc.laguerre}, associated Laguerre polynomials
-  @\placeholder{floating-point-type}@ assoc_laguerre(unsigned n, unsigned m, @\placeholder{floating-point-type}@ x);
-  float        assoc_laguerref(unsigned n, unsigned m, float x);
-  long double  assoc_laguerrel(unsigned n, unsigned m, long double x);
+  @\placeholdernc{floating-point-type}@ assoc_laguerre(unsigned n, unsigned m, @\placeholdernc{floating-point-type}@ x);
+  float               assoc_laguerref(unsigned n, unsigned m, float x);
+  long double         assoc_laguerrel(unsigned n, unsigned m, long double x);
 
   // \ref{sf.cmath.assoc.legendre}, associated Legendre functions
-  @\placeholder{floating-point-type}@ assoc_legendre(unsigned l, unsigned m, @\placeholder{floating-point-type}@ x);
-  float        assoc_legendref(unsigned l, unsigned m, float x);
-  long double  assoc_legendrel(unsigned l, unsigned m, long double x);
+  @\placeholdernc{floating-point-type}@ assoc_legendre(unsigned l, unsigned m, @\placeholdernc{floating-point-type}@ x);
+  float               assoc_legendref(unsigned l, unsigned m, float x);
+  long double         assoc_legendrel(unsigned l, unsigned m, long double x);
 
   // \ref{sf.cmath.beta}, beta function
-  @\placeholder{floating-point-type}@ beta(@\placeholder{floating-point-type}@ x, @\placeholder{floating-point-type}@ y);
-  float        betaf(float x, float y);
-  long double  betal(long double x, long double y);
+  @\placeholdernc{floating-point-type}@ beta(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  float               betaf(float x, float y);
+  long double         betal(long double x, long double y);
 
   // \ref{sf.cmath.comp.ellint.1}, complete elliptic integral of the first kind
-  @\placeholder{floating-point-type}@ comp_ellint_1(@\placeholder{floating-point-type}@ k);
-  float        comp_ellint_1f(float k);
-  long double  comp_ellint_1l(long double k);
+  @\placeholdernc{floating-point-type}@ comp_ellint_1(@\placeholdernc{floating-point-type}@ k);
+  float               comp_ellint_1f(float k);
+  long double         comp_ellint_1l(long double k);
 
   // \ref{sf.cmath.comp.ellint.2}, complete elliptic integral of the second kind
-  @\placeholder{floating-point-type}@ comp_ellint_2(@\placeholder{floating-point-type}@ k);
-  float        comp_ellint_2f(float k);
-  long double  comp_ellint_2l(long double k);
+  @\placeholdernc{floating-point-type}@ comp_ellint_2(@\placeholdernc{floating-point-type}@ k);
+  float               comp_ellint_2f(float k);
+  long double         comp_ellint_2l(long double k);
 
   // \ref{sf.cmath.comp.ellint.3}, complete elliptic integral of the third kind
-  @\placeholder{floating-point-type}@ comp_ellint_3(@\placeholder{floating-point-type}@ k, @\placeholder{floating-point-type}@ nu);
-  float        comp_ellint_3f(float k, float nu);
-  long double  comp_ellint_3l(long double k, long double nu);
+  @\placeholdernc{floating-point-type}@ comp_ellint_3(@\placeholdernc{floating-point-type}@ k, @\placeholdernc{floating-point-type}@ nu);
+  float               comp_ellint_3f(float k, float nu);
+  long double         comp_ellint_3l(long double k, long double nu);
 
   // \ref{sf.cmath.cyl.bessel.i}, regular modified cylindrical Bessel functions
-  @\placeholder{floating-point-type}@ cyl_bessel_i(@\placeholder{floating-point-type}@ nu, @\placeholder{floating-point-type}@ x);
-  float        cyl_bessel_if(float nu, float x);
-  long double  cyl_bessel_il(long double nu, long double x);
+  @\placeholdernc{floating-point-type}@ cyl_bessel_i(@\placeholdernc{floating-point-type}@ nu, @\placeholdernc{floating-point-type}@ x);
+  float               cyl_bessel_if(float nu, float x);
+  long double         cyl_bessel_il(long double nu, long double x);
 
   // \ref{sf.cmath.cyl.bessel.j}, cylindrical Bessel functions of the first kind
-  @\placeholder{floating-point-type}@ cyl_bessel_j(@\placeholder{floating-point-type}@ nu, @\placeholder{floating-point-type}@ x);
-  float        cyl_bessel_jf(float nu, float x);
-  long double  cyl_bessel_jl(long double nu, long double x);
+  @\placeholdernc{floating-point-type}@ cyl_bessel_j(@\placeholdernc{floating-point-type}@ nu, @\placeholdernc{floating-point-type}@ x);
+  float               cyl_bessel_jf(float nu, float x);
+  long double         cyl_bessel_jl(long double nu, long double x);
 
   // \ref{sf.cmath.cyl.bessel.k}, irregular modified cylindrical Bessel functions
-  @\placeholder{floating-point-type}@ cyl_bessel_k(@\placeholder{floating-point-type}@ nu, @\placeholder{floating-point-type}@ x);
-  float        cyl_bessel_kf(float nu, float x);
-  long double  cyl_bessel_kl(long double nu, long double x);
+  @\placeholdernc{floating-point-type}@ cyl_bessel_k(@\placeholdernc{floating-point-type}@ nu, @\placeholdernc{floating-point-type}@ x);
+  float               cyl_bessel_kf(float nu, float x);
+  long double         cyl_bessel_kl(long double nu, long double x);
 
   // \ref{sf.cmath.cyl.neumann}, cylindrical Neumann functions
   // cylindrical Bessel functions of the second kind
-  @\placeholder{floating-point-type}@       cyl_neumann(@\placeholder{floating-point-type}@ nu, @\placeholder{floating-point-type}@ x);
-  float        cyl_neumannf(float nu, float x);
-  long double  cyl_neumannl(long double nu, long double x);
+  @\placeholdernc{floating-point-type}@       cyl_neumann(@\placeholdernc{floating-point-type}@ nu, @\placeholdernc{floating-point-type}@ x);
+  float               cyl_neumannf(float nu, float x);
+  long double         cyl_neumannl(long double nu, long double x);
 
   // \ref{sf.cmath.ellint.1}, incomplete elliptic integral of the first kind
-  @\placeholder{floating-point-type}@ ellint_1(@\placeholder{floating-point-type}@ k, @\placeholder{floating-point-type}@ phi);
-  float        ellint_1f(float k, float phi);
-  long double  ellint_1l(long double k, long double phi);
+  @\placeholdernc{floating-point-type}@ ellint_1(@\placeholdernc{floating-point-type}@ k, @\placeholdernc{floating-point-type}@ phi);
+  float               ellint_1f(float k, float phi);
+  long double         ellint_1l(long double k, long double phi);
 
   // \ref{sf.cmath.ellint.2}, incomplete elliptic integral of the second kind
-  @\placeholder{floating-point-type}@ ellint_2(@\placeholder{floating-point-type}@ k, @\placeholder{floating-point-type}@ phi);
-  float        ellint_2f(float k, float phi);
-  long double  ellint_2l(long double k, long double phi);
+  @\placeholdernc{floating-point-type}@ ellint_2(@\placeholdernc{floating-point-type}@ k, @\placeholdernc{floating-point-type}@ phi);
+  float               ellint_2f(float k, float phi);
+  long double         ellint_2l(long double k, long double phi);
 
   // \ref{sf.cmath.ellint.3}, incomplete elliptic integral of the third kind
-  @\placeholder{floating-point-type}@ ellint_3(@\placeholder{floating-point-type}@ k, @\placeholder{floating-point-type}@ nu,
-                                 @\placeholder{floating-point-type}@ phi);
-  float        ellint_3f(float k, float nu, float phi);
-  long double  ellint_3l(long double k, long double nu, long double phi);
+  @\placeholdernc{floating-point-type}@ ellint_3(@\placeholdernc{floating-point-type}@ k, @\placeholdernc{floating-point-type}@ nu,
+                                 @\placeholdernc{floating-point-type}@ phi);
+  float               ellint_3f(float k, float nu, float phi);
+  long double         ellint_3l(long double k, long double nu, long double phi);
 
   // \ref{sf.cmath.expint}, exponential integral
-  @\placeholder{floating-point-type}@ expint(@\placeholder{floating-point-type}@ x);
-  float        expintf(float x);
-  long double  expintl(long double x);
+  @\placeholdernc{floating-point-type}@ expint(@\placeholdernc{floating-point-type}@ x);
+  float               expintf(float x);
+  long double         expintl(long double x);
 
   // \ref{sf.cmath.hermite}, Hermite polynomials
-  @\placeholder{floating-point-type}@ hermite(unsigned n, @\placeholder{floating-point-type}@ x);
-  float        hermitef(unsigned n, float x);
-  long double  hermitel(unsigned n, long double x);
+  @\placeholdernc{floating-point-type}@ hermite(unsigned n, @\placeholdernc{floating-point-type}@ x);
+  float               hermitef(unsigned n, float x);
+  long double         hermitel(unsigned n, long double x);
 
   // \ref{sf.cmath.laguerre}, Laguerre polynomials
-  @\placeholder{floating-point-type}@ laguerre(unsigned n, @\placeholder{floating-point-type}@ x);
-  float        laguerref(unsigned n, float x);
-  long double  laguerrel(unsigned n, long double x);
+  @\placeholdernc{floating-point-type}@ laguerre(unsigned n, @\placeholdernc{floating-point-type}@ x);
+  float               laguerref(unsigned n, float x);
+  long double         laguerrel(unsigned n, long double x);
 
   // \ref{sf.cmath.legendre}, Legendre polynomials
-  @\placeholder{floating-point-type}@ legendre(unsigned l, @\placeholder{floating-point-type}@ x);
-  float        legendref(unsigned l, float x);
-  long double  legendrel(unsigned l, long double x);
+  @\placeholdernc{floating-point-type}@ legendre(unsigned l, @\placeholdernc{floating-point-type}@ x);
+  float               legendref(unsigned l, float x);
+  long double         legendrel(unsigned l, long double x);
 
   // \ref{sf.cmath.riemann.zeta}, Riemann zeta function
-  @\placeholder{floating-point-type}@ riemann_zeta(@\placeholder{floating-point-type}@ x);
-  float        riemann_zetaf(float x);
-  long double  riemann_zetal(long double x);
+  @\placeholdernc{floating-point-type}@ riemann_zeta(@\placeholdernc{floating-point-type}@ x);
+  float               riemann_zetaf(float x);
+  long double         riemann_zetal(long double x);
 
   // \ref{sf.cmath.sph.bessel}, spherical Bessel functions of the first kind
-  @\placeholder{floating-point-type}@ sph_bessel(unsigned n, @\placeholder{floating-point-type}@ x);
-  float        sph_besself(unsigned n, float x);
-  long double  sph_bessell(unsigned n, long double x);
+  @\placeholdernc{floating-point-type}@ sph_bessel(unsigned n, @\placeholdernc{floating-point-type}@ x);
+  float               sph_besself(unsigned n, float x);
+  long double         sph_bessell(unsigned n, long double x);
 
   // \ref{sf.cmath.sph.legendre}, spherical associated Legendre functions
-  @\placeholder{floating-point-type}@ sph_legendre(unsigned l, unsigned m, @\placeholder{floating-point-type}@ theta);
-  float        sph_legendref(unsigned l, unsigned m, float theta);
-  long double  sph_legendrel(unsigned l, unsigned m, long double theta);
+  @\placeholdernc{floating-point-type}@ sph_legendre(unsigned l, unsigned m, @\placeholdernc{floating-point-type}@ theta);
+  float               sph_legendref(unsigned l, unsigned m, float theta);
+  long double         sph_legendrel(unsigned l, unsigned m, long double theta);
 
   // \ref{sf.cmath.sph.neumann}, spherical Neumann functions;
   // spherical Bessel functions of the second kind
-  @\placeholder{floating-point-type}@ sph_neumann(unsigned n, @\placeholder{floating-point-type}@ x);
-  float        sph_neumannf(unsigned n, float x);
-  long double  sph_neumannl(unsigned n, long double x);
+  @\placeholdernc{floating-point-type}@ sph_neumann(unsigned n, @\placeholdernc{floating-point-type}@ x);
+  float               sph_neumannf(unsigned n, float x);
+  long double         sph_neumannl(unsigned n, long double x);
 }
 \end{codeblock}
 


### PR DESCRIPTION
Based on https://github.com/cplusplus/draft/pull/6542.

If you look at the [C++17 synopsis](https://timsong-cpp.github.io/cppwp/n4659/cmath.syn), you will notice that the mathematical special functions used to be beautifully aligned:
```cpp
  double       ellint_1(double k, double phi);
  float        ellint_1f(float k, float phi);
  long double  ellint_1l(long double k, long double phi);
```
Unfortunately, the current working draft uses a placeholder *`floating-point-type`* which breaks that alignment:
```cpp
  floating-point-type comp_ellint_1(floating-point-type k);
  float        comp_ellint_1f(float k);
  long double  comp_ellint_1l(long double k);
```

Also, the mathematical common functions have not yet been aligned, which makes them annoying to read in my opinion:
```cpp
  constexpr floating-point-type cos(floating-point-type x);
  constexpr float cosf(float x);
  constexpr long double cosl(long double x);
```

This edit aligns all functions in the synopsis:
```cpp
  constexpr floating-point-type cos(floating-point-type x);
  constexpr float               cosf(float x);
  constexpr long double         cosl(long double x);
```