### PR TITLE
[class.local] Add comma after introductory clause

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3358,7 +3358,7 @@ definition, if they are defined at all.
 
 \pnum
 \indextext{nested class!local class}%
-If class \tcode{X} is a local class a nested class \tcode{Y} may be
+If class \tcode{X} is a local class, a nested class \tcode{Y} may be
 declared in class \tcode{X} and later defined in the definition of class
 \tcode{X} or be later defined in the same scope as the definition of
 class \tcode{X}.


### PR DESCRIPTION
I personally find the absence of a comma quite annoying in this sentence, and it made me read the sentence twice.

Usually there should be a comma after an introductory clause, especially one as long as this.