### PR TITLE
[class.copy.elision] Improve reference and replace informal term

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6234,8 +6234,8 @@ can be omitted and references to that copy replaced with references to the
 corresponding parameter if the meaning of the program will be unchanged except for
 the execution of a constructor and destructor for the parameter copy object
 
-\item when the \grammarterm{exception-declaration} of an
-exception handler\iref{except.pre} declares an object of the same
+\item when the \grammarterm{exception-declaration} of a
+\grammarterm{handler}\iref{except.handle} declares an object of the same
 type (except for cv-qualification) as the exception
 object\iref{except.throw}, the copy operation can be omitted by treating
 the \grammarterm{exception-declaration} as an alias for the exception


### PR DESCRIPTION
The term "exception handler" isn't defined anywhere, so it is a mistake to refer to it.

Just a few bullets up, the wording refers to the term in the grammar, making the subsequent bullet inconsistent
https://github.com/cplusplus/draft/blob/1339fdd98ed04a5077e7dad9ed356eb0302be8aa/source/classes.tex#L6213-L6216

Also, `except.handle` is a more accurate reference than `except.pre`.