### PR TITLE
[res.on.exception.handling] Use `\grammarterm` instead of informal term

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -3772,7 +3772,7 @@ Any of the functions defined in the \Cpp{} standard library
 can report a failure by throwing an exception of a type
 described in its \throws paragraph,
 or of a type derived from a type named in the \throws paragraph
-that would be caught by an exception handler for the base type.
+that would be caught by a \grammarterm{handler}\iref{except.handle} for the base type.
 
 \pnum
 Functions from the C standard library shall not throw exceptions%


### PR DESCRIPTION
The term "exception handler" isn't formally defined anywhere. It would be better to use the grammatical term *handler*, which is defined.