### PR TITLE
[basic.scope.scope] add reference for equivalence to [temp.over.link]

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -908,7 +908,7 @@ exactly one is an implicit object member function
 with no \grammarterm{ref-qualifier} and
 the types of their object parameters,
 after removing any references,
-are equivalent, or
+are equivalent\iref{temp.over.link}, or
 \item
 the types of their object parameters are equivalent.
 \end{itemize}


### PR DESCRIPTION
Fixes https://github.com/cplusplus/draft/issues/6491.