### PR TITLE
[basic.types.general] Apply Oxford comma consistently

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4827,12 +4827,12 @@ arrays of such types, and cv-qualified versions of these
 types are collectively called \defnadjx{trivially copyable}{types}{type}.
 \label{term.trivial.type}%
 Scalar types, trivial class types\iref{class.prop},
-arrays of such types and cv-qualified versions of these
+arrays of such types, and cv-qualified versions of these
 types are collectively called
 \defnadjx{trivial}{types}{type}.
 \label{term.standard.layout.type}%
 Scalar types, standard-layout class
-types\iref{class.prop}, arrays of such types and
+types\iref{class.prop}, arrays of such types, and
 cv-qualified versions of these types
 are collectively called \defnadjx{standard-layout}{types}{type}.
 Scalar types, implicit-lifetime class types\iref{class.prop},


### PR DESCRIPTION
Three of the 5 sentences in this paragraph correctly use the Oxford comma, so apply to the other two lists for consistency within the same paragraph.