### PR TITLE
[tab:headers.cpp] Rebalance table columns

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1143,8 +1143,8 @@ shown in \tref{headers.cpp}.
 \tcode{<sstream>} \\
 \tcode{<stack>} \\
 \tcode{<stacktrace>} \\
-\tcode{<stdexcept>} \\
 \columnbreak
+\tcode{<stdexcept>} \\
 \tcode{<stdfloat>} \\
 \tcode{<stop_token>} \\
 \tcode{<streambuf>} \\


### PR DESCRIPTION
The third column had one more entry than any other, while the fourth column was conincidentally one entry short.