### PR TITLE
[mdspan] require conversion results to be nonnegative

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -20513,7 +20513,8 @@ template<class OtherIndexType>
 \expects
 \begin{itemize}
 \item
-\tcode{s[$i$] > 0} is \tcode{true}
+The result of converting \tcode{s[$i$]} to \tcode{index_type}
+is greater than \tcode{0}
 for all $i$ in the range $[0, \exposid{rank_})$.
 \item
 \tcode{\exposid{REQUIRED-SPAN-SIZE}(e, s)} is representable

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -19296,8 +19296,8 @@ either
 \item
 \tcode{sizeof...(exts) == 0} is \tcode{true}, or
 \item
-each element of \tcode{exts} is nonnegative and
-is representable as a value of type \tcode{index_type}.
+each element of \tcode{exts} is representable
+as a nonnegative value of type \tcode{index_type}.
 \end{itemize}
 \end{itemize}
 
@@ -19340,8 +19340,8 @@ either
 \item
 \tcode{N} is zero, or
 \item
-\tcode{exts[$r$]} is nonnegative and
-is representable as a value of type \tcode{index_type} for every rank index $r$.
+\tcode{exts[$r$]} is representable
+as a nonnegative value of type \tcode{index_type} for every rank index $r$.
 \end{itemize}
 \end{itemize}
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -20419,8 +20419,12 @@ Let \tcode{\exposid{REQUIRED-SPAN-SIZE}(e, strides)} be:
 \item
 otherwise \tcode{0}, if the size of the multidimensional index space \tcode{e} is 0,
 \item
-otherwise \tcode{1} plus the sum of products of \tcode{(e.extent($r$) - 1)} and \tcode{strides[$r$]}
-for all $r$ in the range $[0, \tcode{e.rank()})$.
+otherwise \tcode{1} plus the sum of products of
+\tcode{(e.extent($r$) - 1)} and
+\begin{codeblock}
+extents_type::@\exposid{index-cast}@(strides[@$r$@])
+\end{codeblock}
+  for all $r$ in the range $[0, \tcode{e.rank()})$.
 \end{itemize}
 
 \pnum


### PR DESCRIPTION
"nonnegative" is meaningless for a value of some arbitrary type which we've only required to be convertible to the integral type `index_type`, so this wording clearly intends to constrain the result of the conversion.