### PR TITLE
[preprocessor] [version.syn] Add index entries for "feature-test macro" in the two places they're defined

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1794,6 +1794,8 @@ If the time of translation is not available,
 an \impldef{text of \mname{TIME} when time of translation is not available} valid time shall be supplied.
 \end{description}
 
+\indextext{macro!feature-test}%
+\indextext{feature-test macro|see{macro, feature-test}}%
 \begin{LongTable}{Feature-test macros}{cpp.predefined.ft}{ll}
 \\ \topline
 \lhdr{Macro name} & \rhdr{Value} \\ \capsep

--- a/source/support.tex
+++ b/source/support.tex
@@ -541,6 +541,7 @@ about the \Cpp{} standard library
 (e.g., version number and release date).
 
 \pnum
+\indextext{macro!feature-test}%
 Each of the macros defined in \libheader{version} is also defined
 after inclusion of any member of the set of library headers
 indicated in the corresponding comment in this synopsis.


### PR DESCRIPTION
I always find it difficult to locate these tables. Having an index entry will help a lot.