### PR TITLE
[mdspan.layout.stride.cons] Fix cross-reference

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -20564,7 +20564,7 @@ template<class StridedLayoutMapping>
 \expects
 \begin{itemize}
 \item
-\tcode{StridedLayoutMapping} meets the layout mapping requirements\iref{mdspan.layout.policy.reqmts},
+\tcode{StridedLayoutMapping} meets the layout mapping requirements\iref{mdspan.layout.reqmts},
 \item
 \tcode{other.stride($r$) > 0} is \tcode{true}
 for every rank index $r$ of \tcode{extents()},


### PR DESCRIPTION
The text says that "`StridedLayoutMapping` meets the layout mapping requirements" but the cross-reference is to the layout mapping _policy_ requirements.