### PR TITLE
[mdspan.mdspan.overview] Don't use "requires(" for non-requires-expressions

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -21030,17 +21030,17 @@ namespace std {
   };
 
   template<class CArray>
-    requires(is_array_v<CArray> && rank_v<CArray> == 1)
+    requires (is_array_v<CArray> && rank_v<CArray> == 1)
     mdspan(CArray&)
       -> mdspan<remove_all_extents_t<CArray>, extents<size_t, extent_v<CArray, 0>>>;
 
   template<class Pointer>
-    requires(is_pointer_v<remove_reference_t<Pointer>>)
+    requires (is_pointer_v<remove_reference_t<Pointer>>)
     mdspan(Pointer&&)
       -> mdspan<remove_pointer_t<remove_reference_t<Pointer>>, extents<size_t>>;
 
   template<class ElementType, class... Integrals>
-    requires((is_convertible_v<Integrals, size_t> && ...) && sizeof...(Integrals) > 0)
+    requires ((is_convertible_v<Integrals, size_t> && ...) && sizeof...(Integrals) > 0)
     explicit mdspan(ElementType*, Integrals...)
       -> mdspan<ElementType, dextents<size_t, sizeof...(Integrals)>>;
 


### PR DESCRIPTION
The Library spec uses `requires(` (no space before `(`) to introduce *requires-expression*s, and inserts a space to visually distinguish *requires-clause*s.