### PR TITLE
[atomics.order] Memory operations should be definitions

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -2483,10 +2483,10 @@ enumerated values and their meanings are as follows:
 \item \tcode{memory_order::relaxed}: no operation orders memory.
 
 \item \tcode{memory_order::release}, \tcode{memory_order::acq_rel}, and
-\tcode{memory_order::seq_cst}: a store operation performs a release operation on the
+\tcode{memory_order::seq_cst}: a store operation performs a \defn{release operation} on the
 affected memory location.
 
-\item \tcode{memory_order::consume}: a load operation performs a consume operation on the
+\item \tcode{memory_order::consume}: a load operation performs a \defn{consume operation} on the
 affected memory location.
 \begin{note}
 Prefer \tcode{memory_order::acquire}, which provides stronger guarantees
@@ -2496,7 +2496,7 @@ Specification revisions are under consideration.
 \end{note}
 
 \item \tcode{memory_order::acquire}, \tcode{memory_order::acq_rel}, and
-\tcode{memory_order::seq_cst}: a load operation performs an acquire operation on the
+\tcode{memory_order::seq_cst}: a load operation performs an \defn{acquire operation} on the
 affected memory location.
 \end{itemize}
 


### PR DESCRIPTION
Related: [Stack Overflow / Where is the definition of the acquire operation in the C++ 20?](https://stackoverflow.com/q/77132246/5740428)

OP in this Q&A was confused by operations involving `memory_order::acquire` referring to "acquire operation", but this term isn't defined anywhere. It is indeed confusing because "acquire operation" is colloquially used throughout the standard (e.g. [[intro.races] p3](https://eel.is/c++draft/intro.races#3)).

I believe the proper resolution is to tie the definition to the listing of memory orders.