### PR TITLE
[range.utility.conv.to] Add terminating condition for first bullet

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2336,6 +2336,8 @@ if constexpr (@\libconcept{sized_range}@<R> && @\exposid{reservable-container}@<
   c.reserve(static_cast<range_size_t<C>>(ranges::size(r)));
 ranges::copy(r, @\exposid{container-inserter}@<range_reference_t<R>>(c));
 \end{codeblock}
+\item
+Otherwise, the program is ill-formed.
 \end{itemize}
 
 \item


### PR DESCRIPTION
We currently fail to say what happens if the first bullet is true, but then none of its sub-bullets is true.