### PR TITLE
Remove section 2 from [sequence.reqmts]

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1254,24 +1254,6 @@ such as \tcode{stack}s,
 the basic sequence container kinds (or out of other program-defined sequence containers).
 
 \pnum
-\begin{note}
-The sequence containers
-offer the programmer different complexity trade-offs.
-\tcode{vector}
-is appropriate in most circumstances.
-\tcode{array}
-has a fixed size known during translation.
-\tcode{list} or \tcode{forward_list}
-support frequent insertions and deletions from the
-middle of the sequence.
-\tcode{deque}
-supports efficient insertions and deletions taking place at the beginning or at the
-end of the sequence.
-When choosing a container, remember \tcode{vector} is best;
-leave a comment to explain if you choose from the rest!
-\end{note}
-
-\pnum
 In this subclause,
 \begin{itemize}
 \item


### PR DESCRIPTION
I have been requested to make this a direct request rather than putting it in P0447.

Despite the cute poem, section 2 should be removed because the note is misleading and over-simplified. The section conflates time complexity and performance, and oddly recommends vector as a default without mentioning its time complexity, unlike the other containers. Time complexity's relevance to both performance and latency is subject to architectural differences. If the committee chose to re-include such a note, it should simply describe time complexity as below (being removed may be better as it creates less confusion):

[Note 1: The sequence containers offer the programmer different complexity trade-offs. vector has amortized constant time complexity for insertions at the end of the sequence, and constant time complexity for erasures at the end of the sequence. hive, list and forward_list have constant time complexity for insertions and erasures at any point in the sequence, however for hive the user cannot specify the insertion position. deque has constant time complexity for insertions and erasures at the beginning or end of the sequence. -end note]