### PR TITLE
[expr.log.and],[expr.log.or] improve wording symmetry and quality

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6810,20 +6810,21 @@ The result is the bitwise inclusive \logop{or} function of the operands.
 \end{bnf}
 
 \pnum
-The \tcode{\&\&} operator groups left-to-right. The operands are both
-contextually converted to \keyword{bool}\iref{conv}.
-The
-result is \keyword{true} if both operands are \keyword{true} and
-\keyword{false} otherwise. Unlike \tcode{\&}, \tcode{\&\&} guarantees
-left-to-right evaluation: the second operand is not evaluated if the
-first operand is \keyword{false}.
+The \tcode{\&\&} operator groups left-to-right.
+The operands are both contextually converted to \keyword{bool}\iref{conv}.
+The result is a prvalue of type \keyword{bool}.
+The result is
+\keyword{true} if both operands are \keyword{true} and
+\keyword{false} otherwise.
 
 \pnum
-The result is a \tcode{bool}.
 \indextext{operator!side effects and logical AND}%
-If the second expression is evaluated,
-the first expression is sequenced before
-the second expression\iref{intro.execution}.
+The right operand is not evaluated if the left operand evaluates to \keyword{false}.
+The left operand is sequenced before\iref{intro.execution} the right operand.
+\begin{note}
+The former behavior is sometimes called "short-circuiting".
+The \tcode{\&} operator guarantees neither short-circuiting nor left-to-right evaluation.
+\end{note}
 
 \rSec2[expr.log.or]{Logical OR operator}%
 \indextext{expression!logical OR}%
@@ -6837,20 +6838,21 @@ the second expression\iref{intro.execution}.
 \end{bnf}
 
 \pnum
-The \tcode{||} operator groups left-to-right. The operands are both
-contextually converted to \keyword{bool}\iref{conv}.
+The \tcode{||} operator groups left-to-right.
+The operands are both contextually converted to \keyword{bool}\iref{conv}.
+The result is a prvalue of type \keyword{bool}.
 The result is
 \keyword{true} if either of its operands is \keyword{true}, and
-\keyword{false} otherwise. Unlike \tcode{|}, \tcode{||} guarantees
-left-to-right evaluation; moreover, the second operand is not evaluated
-if the first operand evaluates to \keyword{true}.
+\keyword{false} otherwise.
 
 \pnum
-The result is a \keyword{bool}.
 \indextext{operator!side effects and logical OR}%
-If the second expression is evaluated,
-the first expression is sequenced before
-the second expression\iref{intro.execution}.
+The right operand is not evaluated if the left operand evaluates to \keyword{true}.
+The left operand is sequenced before\iref{intro.execution} the right operand.
+\begin{note}
+The former behavior is sometimes called "short-circuiting".
+The \tcode{|} operator guarantees neither short-circuiting nor left-to-right evaluation.
+\end{note}
 
 \rSec2[expr.cond]{Conditional operator}%
 \indextext{expression!conditional operator}%


### PR DESCRIPTION
The wording for `&&` and `||` had a number of issues which this PR resolves.

1. The wording of `&&` and `||` is oddly asymmetric in a number of places. Specific wording choices like using `:` in one paragraph, and `; morever,` are asymmetric with no good reason.
2. There are notes regarding `&` left in normative wording. These are extracted into an actual note.
3. In both subclauses, the first and second paragraph contain a mixture of describing the result (type) and describing evaluation. This is fixed by clearly separating it so that:
   - the first paragraph talks about the result
   - the second paragraph talks about left-to-right evaluation and short-circuiting
4. The second paragraph needlessly says that the result is `bool`. The first paragraph already states that the result is `true` or `false`, so this information is redundant.
5. The wording contains the phrase "the expression is sequenced" which doesn't make any sense because an expression is a syntactical construct and cannot be sequenced. Only an evaluation can be sequenced.
6. The paragraphs contain a mixture of first/second terminology and left/right terminology. The PR uses left/right terminology in all places.
7. Other places in the standard contain notes about "the short-circuiting behavior" of the `&&` operator. However, this is not noted in the description of the `&&` and `||` operator. This information is added to a note.