### PR TITLE
[temp.res.general] Fix misleading example related to syntax errors

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -4534,7 +4534,7 @@ template<class T> class X {
     X<T>::h();      // may be diagnosed even if \tcode{X::f} is not instantiated
   }
   void g(T t) {
-    +;              // may be diagnosed even if \tcode{X::g} is not instantiated
+    +;              // must be diagnosed even if \tcode{X::g} is not instantiated
   }
 };
 


### PR DESCRIPTION
The use of the word "may" suggests that an implementation isn't required to diagnose `+;` if it's in a template, but this is not true. Diagnostics are always required for syntax errors.

- `+;` is not a valid *[statement]*; therefore
- `{ +; }` is not a valid *[compound-statement]* and not a valid *[function-body]*; therefore
- `void g() { +; }` is not a valid *[function-definition]* and not a valid *[member-declaration]*; therefore
- the definition of `X` is not a valid *[template-declaration]* and not an element of the *[declaration-seq]* of the TU; therefore
- the entire *[translation-unit]* is invalid

As you can see, a syntax error inevitably "bubbles upwards" in the grammar, and also means that any containing template isn't a template in the first place. If there is no containing template, and there isn't even a valid *[translation-unit]*, then diagnostics are required because syntax errors fall under the umbrella of [diagnosable rules].

Unless "no diagnostic required" was explicitly stated, the following applies:

> [...] if a program contains a violation of any diagnosable rule or an occurrence of a construct described in this document as “conditionally-supported” when the implementation does not support that construct, **a conforming implementation shall issue at least one diagnostic message**.

\- [[intro.compliance.general] p2.3](https://eel.is/c++draft/intro.compliance.general#2.3)

[statement]: https://eel.is/c++draft/stmt.pre#nt:statement
[compound-statement]: https://eel.is/c++draft/stmt.block#nt:compound-statement
[function-body]: https://eel.is/c++draft/dcl.fct.def.general#nt:function-body
[function-definition]: https://eel.is/c++draft/dcl.fct.def.general#nt:function-definition
[member-declaration]: https://eel.is/c++draft/class.mem.general#nt:member-declaration
[template-declaration]: https://eel.is/c++draft/temp.pre#nt:template-declaration
[declaration-seq]: https://eel.is/c++draft/dcl.pre#nt:declaration-seq
[translation-unit]: https://eel.is/c++draft/basic.link#nt:translation-unit

[diagnosable rules]: https://eel.is/c++draft/intro.compliance.general#def:diagnosable_rules