### PR TITLE
Add memory order for atomic_flag_test_and_set and atomic_flag_clear.

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -5671,6 +5671,9 @@ bool atomic_flag::test_and_set(memory_order order = memory_order::seq_cst) noexc
 
 \begin{itemdescr}
 \pnum
+For \tcode{atomic_flag_test_and_set}, let \tcode{order} be \tcode{memory_order::seq_cst}.
+
+\pnum
 \effects
 Atomically sets the value pointed to by \tcode{object} or by \keyword{this} to \tcode{true}. Memory is affected according to the value of
 \tcode{order}. These operations are atomic read-modify-write operations\iref{intro.multithread}.
@@ -5693,6 +5696,9 @@ void atomic_flag::clear(memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+For \tcode{atomic_flag_clear}, let \tcode{order} be \tcode{memory_order::seq_cst}.
+
 \pnum
 \expects
 \tcode{order} is


### PR DESCRIPTION
The memory order for atomic_flag_test_and_set and atomic_flag_clear is not specified, it should be memory_order::seq_cst. (atomic_flag_test and atomic_flag_wait specify that)