### PR TITLE
[fs.filesystem.syn] Remove redundant inline

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -13366,14 +13366,14 @@ namespace std {
 
 namespace std::ranges {
   template<>
-    inline constexpr bool @\libspec{enable_borrowed_range}{directory_iterator}@<filesystem::directory_iterator> = true;
+    constexpr bool @\libspec{enable_borrowed_range}{directory_iterator}@<filesystem::directory_iterator> = true;
   template<>
-    inline constexpr bool @\libspec{enable_borrowed_range}{recursive_directory_iterator}@<filesystem::recursive_directory_iterator> = true;
+    constexpr bool @\libspec{enable_borrowed_range}{recursive_directory_iterator}@<filesystem::recursive_directory_iterator> = true;
 
   template<>
-    inline constexpr bool @\libspec{enable_view}{directory_iterator}@<filesystem::directory_iterator> = true;
+    constexpr bool @\libspec{enable_view}{directory_iterator}@<filesystem::directory_iterator> = true;
   template<>
-    inline constexpr bool @\libspec{enable_view}{recursive_directory_iterator}@<filesystem::recursive_directory_iterator> = true;
+    constexpr bool @\libspec{enable_view}{recursive_directory_iterator}@<filesystem::recursive_directory_iterator> = true;
 }
 \end{codeblock}
 


### PR DESCRIPTION
This is reasonable, right?