### PR TITLE
[common.iter.const] Add missing periods for Returns

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -5581,7 +5581,7 @@ where $i$ is \tcode{x.v_.index()}.
 
 \pnum
 \returns
-\tcode{*this}
+\tcode{*this}.
 \end{itemdescr}
 
 \rSec3[common.iter.access]{Accessors}


### PR DESCRIPTION
That's a tough one.