### PR TITLE
[mdspan.mdspan.overview] Rename parameter ptr to p

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -20974,7 +20974,7 @@ namespace std {
     constexpr mdspan(mdspan&& rhs) = default;
 
     template<class... OtherIndexTypes>
-      constexpr explicit mdspan(data_handle_type ptr, OtherIndexTypes... exts);
+      constexpr explicit mdspan(data_handle_type p, OtherIndexTypes... exts);
     template<class OtherIndexType, size_t N>
       constexpr explicit(N != rank_dynamic())
         mdspan(data_handle_type p, span<OtherIndexType, N> exts);


### PR DESCRIPTION
..which makes it consistent with other function declarations.