### PR TITLE
[basic.types.general] Create a term for implicit-lifetime type

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3338,7 +3338,7 @@ Some operations are described as
 within a specified region of storage.
 For each operation that is specified as implicitly creating objects,
 that operation implicitly creates and starts the lifetime of
-zero or more objects of implicit-lifetime types\iref{basic.types.general}
+zero or more objects of implicit-lifetime types\iref{term.implicit.lifetime.type}
 in its specified region of storage
 if doing so would result in the program having defined behavior.
 If no such set of objects would give the program defined behavior,
@@ -4835,6 +4835,7 @@ Scalar types, standard-layout class
 types\iref{class.prop}, arrays of such types, and
 cv-qualified versions of these types
 are collectively called \defnadjx{standard-layout}{types}{type}.
+\label{term.implicit.lifetime.type}%
 Scalar types, implicit-lifetime class types\iref{class.prop},
 array types, and cv-qualified versions of these types
 are collectively called \defnadjx{implicit-lifetime}{types}{type}.

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -881,7 +881,7 @@ template<class T>
 \begin{itemdescr}
 \pnum
 \mandates
-\tcode{T} is an implicit-lifetime type\iref{basic.types.general}
+\tcode{T} is an implicit-lifetime type\iref{term.implicit.lifetime.type}
 and not an incomplete type\iref{term.incomplete.type}.
 
 \pnum

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -1207,7 +1207,7 @@ The compilation of the
 \indexlibraryglobal{is_implicit_lifetime}%
 \tcode{template<class T>}\br
   \tcode{struct is_implicit_lifetime;} &
-  \tcode{T} is an implicit-lifetime type\iref{basic.types.general}. &
+  \tcode{T} is an implicit-lifetime type\iref{term.implicit.lifetime.type}. &
   \tcode{T} shall be an array type,
   a complete type, or \cv{}~\keyword{void}.  \\ \rowsep
 


### PR DESCRIPTION
All the other terms defined in this paragraph have a term.xxx.type name.  An iref using the term name, rather than the section name, will create a hyperlink to the specific paragraph, rather than the top of the clause.