### PR TITLE
Dehyphenate trivially-copyable

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -902,7 +902,7 @@ as follows:
 The object representation of \placeholder{a}
 is the contents of the storage prior to the call to \tcode{start_lifetime_as}.
 The value of each created object \placeholder{o}
-of trivially-copyable type \tcode{U}
+of trivially copyable type\iref{term.trivially.copyable.type} \tcode{U}
 is determined in the same manner as for a call
 to \tcode{bit_cast<U>(E)}\iref{bit.cast},
 where \tcode{E} is an lvalue of type \tcode{U} denoting \placeholder{o},

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -194,7 +194,7 @@ The effect of instantiating the template \tcode{complex} for any type
 that is not a cv-unqualified floating-point type\iref{basic.fundamental}
 is unspecified.
 Specializations of \tcode{complex} for cv-unqualified floating-point types
-are trivially-copyable literal types\iref{term.literal.type}.
+are trivially copyable literal types\iref{term.literal.type}.
 
 \pnum
 If the result of a function is not mathematically defined or not in


### PR DESCRIPTION
Trivially copyable is (almost) never hyphenated, so remove the hyphens from the two extant cases.  Add one cross-reference
to the term for good measure.