### PR TITLE
[temp.param] Introduce term to xref structural type

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -6206,7 +6206,7 @@ one of these tables and
 for operations where there is additional semantic information.
 
 \pnum
-\tcode{array<T, N>} is a structural type\iref{temp.param} if
+\tcode{array<T, N>} is a structural type\iref{term.structural.type} if
 \tcode{T} is a structural type.
 Two values \tcode{a1} and \tcode{a2} of type \tcode{array<T, N>}
 are template-argument-equivalent\iref{temp.type} if and only if

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1868,7 +1868,7 @@ types of a \grammarterm{lambda-declarator} do not affect these associated namesp
 classes.
 \end{note}
 The closure type is not an aggregate type\iref{dcl.init.aggr} and
-not a structural type\iref{temp.param}.
+not a structural type\iref{term.structural.type}.
 An implementation may define the closure type differently from what
 is described below provided this does not alter the observable behavior of the program
 other than by changing:

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -392,6 +392,7 @@ on the
 are ignored when determining its type.
 
 \pnum
+\label{term.structural.type}%
 A \defnadj{structural}{type} is one of the following:
 \begin{itemize}
 \item a scalar type, or

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -797,7 +797,7 @@ If \tcode{(is_trivially_destructible_v<T1> \&\& is_trivially_destructible_v<T2>)
 is \tcode{true}, then the destructor of \tcode{pair} is trivial.
 
 \pnum
-\tcode{pair<T, U>} is a structural type\iref{temp.param}
+\tcode{pair<T, U>} is a structural type\iref{term.structural.type}
 if \tcode{T} and \tcode{U} are both structural types.
 Two values \tcode{p1} and \tcode{p2} of type \tcode{pair<T, U>}
 are template-argument-equivalent\iref{temp.type} if and only if


### PR DESCRIPTION
The current cross-references to [temp.param] appear confusing, as the structural type definition is buried a couple of pages below.  Also, this change looks clearer in the source.