### PR TITLE
[expr.prim.lambda.closure] insert an extra pnum

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1867,6 +1867,8 @@ classes associated with the closure type\iref{basic.lookup.argdep}. The paramete
 types of a \grammarterm{lambda-declarator} do not affect these associated namespaces and
 classes.
 \end{note}
+
+\pnum
 The closure type is not an aggregate type\iref{dcl.init.aggr} and
 not a structural type\iref{temp.param}.
 An implementation may define the closure type differently from what


### PR DESCRIPTION
Paragraph 2 does two things.  The part before the note specifies the scope where the closure type is defined.  The part after the note places constraints on how the closure type can be implemented.  Adding a paragraph number after the note seems to be more readable, and referencable in the future.