### PR TITLE
[time.format] Make reference to ISO 8601 more precise

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -10793,7 +10793,7 @@ The modified command \tcode{\%EY} produces
 the locale's alternative full year representation.
 \\ \rowsep
 \tcode{\%z} &
-The offset from UTC in the ISO 8601:2004 format.
+The offset from UTC as specified in ISO 8601:2004, subclause 4.2.5.2.
 For example \tcode{-0430} refers to 4 hours 30 minutes behind UTC\@.
 If the offset is zero, \tcode{+0000} is used.
 The modified commands \tcode{\%Ez} and  \tcode{\%Oz}


### PR DESCRIPTION
Fixes ISO/CS 003 (C++23 DIS).

Fixes cplusplus/nbballot#545