### PR TITLE
[lex.charset] Clarify normative reference to Unicode for UTF-x

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -449,9 +449,10 @@ The ordinary and wide literal encodings are otherwise
 \indextext{UTF-16}%
 \indextext{UTF-32}%
 For a UTF-8, UTF-16, or UTF-32 literal,
+the implementation shall encode
 the Unicode scalar value
 corresponding to each character of the translation character set
-is encoded as specified in the Unicode Standard
+as specified in the Unicode Standard
 for the respective Unicode encoding form.
 \indextext{character set|)}
 

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -247,7 +247,8 @@ needed for execution in its execution environment.%
 The \defnadj{translation}{character set} consists of the following elements:
 \begin{itemize}
 \item
-each abstract character assigned a code point in the Unicode codespace, and
+each abstract character assigned a code point in the Unicode codespace
+as specified in the Unicode Standard, and
 \item
 a distinct character for each Unicode scalar value
 not assigned to an abstract character.


### PR DESCRIPTION
Fixes ISO/CS 008 (C++23 DIS).

Fixes cplusplus/nbballot#550

Note: The first commit (adding another reference to the Unicode Standard) is probably not strictly necessary.
The second commit puts a "shall" near the reference, which is the suitable trigger word here.