### PR TITLE
Replace "C Standard" with "ISO/IEC 9899:2018" and define "C standard library"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4728,9 +4728,8 @@ a set of bits in the object representation that determines a
 \defn{value}, which is one discrete element of an
 \impldef{values of a trivially copyable type} set of values.
 \begin{footnote}
-The
-intent is that the memory model of \Cpp{} is compatible
-with that of ISO/IEC 9899 Programming Language C.
+The intent is that the memory model of \Cpp{} is compatible
+with that of the C programming language.
 \end{footnote}
 
 \pnum
@@ -5276,7 +5275,7 @@ that are in addition to the names defined in the \libheader{stdfloat} header
 should be chosen to increase compatibility and interoperability
 with the interchange types
 \tcode{_Float16}, \tcode{_Float32}, \tcode{_Float64}, and \tcode{_Float128}
-defined in ISO/IEC TS 18661-3 and with future versions of the C standard.
+defined in ISO/IEC TS 18661-3 and with future versions of \IsoCUndated{}.
 
 \rSec2[basic.compound]{Compound types}
 

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -12,9 +12,8 @@ requirement appear at various places within this document.
 
 \pnum
 \Cpp{} is a general purpose programming language based on the C
-programming language as described in ISO/IEC 9899:2018
-\doccite{Programming languages --- C} (hereinafter referred to as the
-\defnx{C standard}{C!standard}). \Cpp{} provides many facilities
+programming language as described in \IsoC{}.
+\Cpp{} provides many facilities
 beyond those provided by C, including additional data types,
 classes, templates, exceptions, namespaces, operator
 overloading, function name overloading, references, free store
@@ -37,7 +36,7 @@ For undated references, the latest edition of the referenced document
 \item ISO/IEC 2382, \doccite{Information technology --- Vocabulary}
 \item ISO 8601:2004, \doccite{Data elements and interchange formats ---
 Information interchange --- Representation of dates and times}
-\item ISO/IEC 9899:2018, \doccite{Information technology --- Programming languages --- C}
+\item \IsoC{}, \doccite{Information technology --- Programming languages --- C}
 \item ISO/IEC/IEEE 9945:2009, \doccite{Information Technology --- Portable
 Operating System Interface (POSIX
 \begin{footnote}

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -71,16 +71,6 @@ Available from: \url{https://www.unicode.org/versions/latest/}
 \end{itemize}
 
 \pnum
-The library described in ISO/IEC 9899:2018, Clause 7,
-is hereinafter called the
-\defnx{C standard library}{C!standard library}.
-\begin{footnote}
-With the qualifications noted in \ref{\firstlibchapter}
-through \ref{\lastlibchapter} and in \ref{diff.library}, the C standard
-library is a subset of the \Cpp{} standard library.
-\end{footnote}
-
-\pnum
 The operating system interface described in ISO/IEC 9945:2009 is
 hereinafter called \defn{POSIX}.
 
@@ -163,6 +153,15 @@ continuing execution past the blocking operation
 \definition{block}{defns.block.stmt}
 \defncontext{statement}
 compound statement
+
+\indexdefn{C!standard library}%
+\definition{C standard library}{defns.c.lib}
+library described in \IsoC{}, Clause 7
+\begin{defnote}
+With the qualifications noted in \ref{\firstlibchapter}
+through \ref{\lastlibchapter} and in \ref{diff.library},
+the C standard library is a subset of the \Cpp{} standard library.
+\end{defnote}
 
 \definition{character}{defns.character}
 \indexdefn{character}%

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -150,9 +150,9 @@ a non-constant library call\iref{defns.nonconst.libcall}
 if it raises a floating-point exception other than \tcode{FE_INEXACT}.
 The semantics of a call to a C standard library function
 evaluated as a core constant expression
-are those specified in Annex F of the C standard
+are those specified in \IsoC{}, Annex F
 \begin{footnote}
-See also ISO/IEC 9899:2018 section 7.6.
+See also \IsoC{}, 7.6.
 \end{footnote}
 to the extent applicable to the floating-point types\iref{basic.fundamental}
 that are parameter types of the called function.
@@ -1281,7 +1281,7 @@ intended to be strictly compatible with C.
 \end{footnote}
 
 \pnum
-Annex K of the C standard describes a large number of functions,
+\IsoC{}, Annex K describes a large number of functions,
 with associated types and macros,
 which ``promote safer, more secure programming''
 than many of the traditional C library functions.
@@ -1302,7 +1302,7 @@ is declared in the global namespace.
 that may be declared in some header.
 These names are also subject to the restrictions of~\ref{macro.names}.
 
-\begin{multicolfloattable}{C standard Annex K names}{c.annex.k.names}
+\begin{multicolfloattable}{Names from \IsoC{}, Annex K}{c.annex.k.names}
 {llll}
 \tcode{abort_handler_s} \\
 \tcode{asctime_s} \\
@@ -1599,8 +1599,7 @@ linkage for this purpose.
 \begin{footnote}
 The only reliable way to declare an object or
 function signature from the C standard library is by including the header that
-declares it, notwithstanding the latitude granted in 7.1.4 of the C
-Standard.
+declares it, notwithstanding the latitude granted in \IsoC{}, 7.1.4.
 \end{footnote}
 
 \pnum
@@ -3715,8 +3714,7 @@ that would be caught by an exception handler for the base type.
 Functions from the C standard library shall not throw exceptions%
 \indextext{specifications!C standard library exception}%
 \begin{footnote}
-That is, the C
-library functions can all be treated as if they
+That is, the C standard library functions can all be treated as if they
 are marked \keyword{noexcept}.
 This allows implementations to make performance optimizations
 based on the absence of exceptions at runtime.

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -277,6 +277,8 @@
 \newcommand{\CppXX}{\Cpp{} 2020}
 \newcommand{\CppXXIII}{\Cpp{} 2023}
 \newcommand{\CppXXVI}{\Cpp{} 2026}
+\newcommand{\IsoCUndated}{ISO/IEC 9899}
+\newcommand{\IsoC}{\IsoCUndated{}:2018}
 \newcommand{\opt}[1]{#1\ensuremath{_\mathit{\color{black}opt}}}
 \newcommand{\bigoh}[1]{\ensuremath{\mathscr{O}(#1)}}
 
@@ -363,7 +365,7 @@
 
 %% Cross-reference
 \newcommand{\xref}{\textsc{See also:}\space}
-\newcommand{\xrefc}[1]{\xref{} ISO C #1}
+\newcommand{\xrefc}[1]{\xref{} \IsoC{}, #1}
 
 %% Inline comma-separated parenthesized references
 \ExplSyntaxOn

--- a/source/support.tex
+++ b/source/support.tex
@@ -6164,6 +6164,6 @@ global namespace.
 The header \libheader{stdlib.h}
 assuredly provides the same declarations and definitions within
 the global namespace,
-much as in the C Standard. It may also provide these names within
+much as in \IsoCUndated{}. It may also provide these names within
 the namespace \tcode{std}.
 \end{example}


### PR DESCRIPTION
Fixes ISO/CS 035 (C++23 DIS).

Partially addresses https://github.com/cplusplus/nbballot/issues/544.
Fixes https://github.com/cplusplus/nbballot/issues/577.