### PR TITLE
[basic.lval] Turn reference paragraph into note

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -272,9 +272,11 @@ temporary materialization conversion\iref{conv.rval} is
 applied to convert the expression to an xvalue.
 
 \pnum
+\begin{note}
 The discussion of reference initialization in~\ref{dcl.init.ref} and of
 temporaries in~\ref{class.temporary} indicates the behavior of lvalues
 and rvalues in other significant contexts.
+\end{note}
 
 \pnum
 Unless otherwise indicated\iref{dcl.type.decltype},


### PR DESCRIPTION
This paragraph should not be normative. It's essentially a "see also" paragraph.