### PR TITLE
[class.copy.assign] Remove a superfluous note.

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1679,7 +1679,7 @@ More than one form of copy assignment operator can be declared for a class.
 \begin{note}
 If a class
 \tcode{X}
-only has a copy assignment operator with a parameter of type
+only has a copy assignment operator with a non-object parameter of type
 \tcode{X\&},
 an expression of type const
 \tcode{X}
@@ -1719,12 +1719,12 @@ if
 \begin{itemize}
 \item
 each direct base class \tcode{B} of \tcode{X}
-has a copy assignment operator whose parameter is of type
+has a copy assignment operator whose non-object parameter is of type
 \tcode{const B\&}, \tcode{const volatile B\&}, or \tcode{B}, and
 \item
 for all the non-static data members of \tcode{X}
 that are of a class type \tcode{M} (or array thereof),
-each such class type has a copy assignment operator whose parameter is of type
+each such class type has a copy assignment operator whose non-object parameter is of type
 \tcode{const M\&}, \tcode{const volatile M\&},
 or \tcode{M}.
 \begin{footnote}

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1746,11 +1746,6 @@ a non-static non-template member function of class \tcode{X} with exactly
 one non-object parameter of type \tcode{X\&\&}, \tcode{const X\&\&}, \tcode{volatile X\&\&}, or
 \tcode{const volatile X\&\&}.
 \begin{note}
-An overloaded assignment operator must be
-declared to have only one parameter; see~\ref{over.ass}.
-\end{note}
-{}
-\begin{note}
 More than one form of move assignment operator can be declared for a class.
 \end{note}
 


### PR DESCRIPTION
Alternatively we could have added the word "non-object"; or changed it to say "An overloaded assignment operator must be a member function"; but it doesn't seem like it needs to be here at all.

(Clang, EDG, MSVC all agree that `B& operator=(this B, int);` is legal C++23.)