### PR TITLE
[class.default.ctor, class.copy.ctor, class.copy.assign] No code font for "is constexpr"

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1350,8 +1350,7 @@ constructor for that class with no
 \grammarterm{compound-statement}.
 If that user-written default constructor would be ill-formed,
 the program is ill-formed.
-The implicitly-defined
-default constructor is \keyword{constexpr}.
+The implicitly-defined default constructor is constexpr.
 Before the defaulted default constructor for a class is
 implicitly defined,
 all the non-user-provided default constructors for its base classes and
@@ -1636,8 +1635,7 @@ otherwise the copy/move constructor is
 The copy/move constructor is implicitly defined even if the implementation elided
 its odr-use\iref{term.odr.use,class.temporary}.
 \end{note}
-The implicitly-defined\iref{dcl.fct.def.default}
-constructor is \keyword{constexpr}.
+The implicitly-defined\iref{dcl.fct.def.default} constructor is constexpr.
 
 \pnum
 Before the defaulted copy/move constructor for a class is
@@ -1913,7 +1911,7 @@ otherwise the copy/move assignment operator is
 \defnx{non-trivial}{assignment operator!copy!non-trivial}.
 
 \pnum
-An implicitly-defined\iref{dcl.fct.def.default} copy/move assignment operator is \keyword{constexpr}.
+An implicitly-defined\iref{dcl.fct.def.default} copy/move assignment operator is constexpr.
 
 \pnum
 Before the defaulted copy/move assignment operator for a class is


### PR DESCRIPTION
Just throwing this over the wall, in hopes that if any of these are editorial improvements they'll be taken up individually.
Right now the text is pretty inconsistent about "X is constexpr"/"X is `constexpr`", but I think the former is better. I'm also pretty sure that a function that isn't constexpr-suitable cannot possibly be constexpr, hence the biggest diff below.