### PR TITLE
Fix a few small bugs in submdspan

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -21741,11 +21741,11 @@ template<class IndexType, class... Extents, class... SliceSpecifiers>
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{sizeof...(slices)} equals \tcode{Extents::rank()}.
+\tcode{sizeof...(slices)} equals \tcode{decltype(src)::rank()}.
 
 \pnum
 \mandates
-For each rank index $k$ of \tcode{src.extents()},
+For each rank index $k$ of \tcode{src},
 exactly one of the following is true:
 \begin{itemize}
 \item $S_k$ models \tcode{\libconcept{convertible_to}<IndexType>},
@@ -21756,7 +21756,7 @@ exactly one of the following is true:
 
 \pnum
 \expects
-For each rank index $k$ of \tcode{src.extents()},
+For each rank index $k$ of \tcode{src},
 all of the following are \tcode{true}:
 \begin{itemize}
 \item
@@ -21889,9 +21889,9 @@ if $S_k$ is a specialization of \tcode{strided_slice}
   \item $\tcode{$s_k$.stride} > 0$
   \end{itemize}
 \item
-$0            \le \tcode{\exposid{first_}<index_type, $k$>(slices...)} \\
-\hphantom{0 } \le \tcode{\exposid{last_}<$k$>(extents(), slices...)} \\
-\hphantom{0 } \le \tcode{extents().extent($k$)}$
+$0 \le \tcode{\exposid{first_}<index_type, $k$>(slices...)}$
+$\le \tcode{\exposid{last_}<$k$>(extents(), slices...)}$
+$\le \tcode{extents().extent($k$)}$
 \end{itemize}
 
 \pnum


### PR DESCRIPTION
This fixes a couple bugs in `subdmspan`.  Some of the wording for constraints/mandates/preconditions of `submdspan_extents` was straight copied from `submdspan_mapping` but the names of the things it refers to are not quite right (`src` is actually the equivalent of `extents()` and `decltype(src)` the equivalent of `Extents`). Also fixes the last precondition in `submdspan_mapping` which should be essentially the same as in `submdspan_extents` i.e. a strict ordering of the values, not comparing to 0 each of them. 