### PR TITLE
[intro.defs, dcl.init.list] Move definition of direct-non-list-init

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5755,7 +5755,7 @@ List-initialization can occur in direct-initialization or copy-initialization co
 list-initialization in a direct-initialization context is called
 \defn{direct-list-initialization} and list-initialization in a
 copy-initialization context is called \defn{copy-list-initialization}.
-Direct-initialization that is not direct-list-initialization is called
+Direct-initialization that is not list-initialization is called
 \defn{direct-non-list-initialization}.
 \begin{note}
 List-initialization can be used

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5755,6 +5755,8 @@ List-initialization can occur in direct-initialization or copy-initialization co
 list-initialization in a direct-initialization context is called
 \defn{direct-list-initialization} and list-initialization in a
 copy-initialization context is called \defn{copy-list-initialization}.
+Direct-initialization that is not direct-list-initialization is called
+\defn{direct-non-list-initialization}.
 \begin{note}
 List-initialization can be used
 \begin{itemize}

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -246,11 +246,6 @@ within the scope of the required behavior
 message belonging to an \impldef{diagnostic message} subset of the
 implementation's output messages
 
-\definition{direct-non-list-initialization}{defns.direct.non.list.init}
-\indexdefn{direct-non-list-initialization}%
-direct-initialization
-that is not list-initialization
-
 \indexdefn{type!dynamic}%
 \definition{dynamic type}{defns.dynamic.type}
 \defncontext{glvalue} type of the most derived object to which the

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -24,8 +24,9 @@
 
 % DIS comment **-011
 \removedxref{defns.arbitrary.stream}
-\removedxref{defns.repositional.stream}
+\removedxref{defns.direct.non.list.init}
 \removedxref{defns.iostream.templates}
+\removedxref{defns.repositional.stream}
 
 %%% Renamed sections.
 %%% Examples:


### PR DESCRIPTION
Partially fixes ISO/CS-11 (C++23 DIS).