### PR TITLE
[expr.prim.lambda.general] Added missing definition for the term "lambda".

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1843,8 +1843,9 @@ auto x3 = [&]()->auto&& { return j; };  // OK, return type is \tcode{int\&}
 \end{example}
 
 \pnum
-A lambda is a \defn{generic lambda}
-if the \grammarterm{lambda-expression}
+A \grammarterm{lambda-expression} is a \defn{lambda}.
+A lambda is \defnx{generic}{lambda!generic}
+if the \grammarterm{parameter-declaration-clause}
 has any generic parameter type placeholders\iref{dcl.spec.auto}, or
 if the lambda has a \grammarterm{template-parameter-list}.
 \begin{example}
@@ -2059,7 +2060,7 @@ auto f = []<typename T1, C1 T2> requires C2<sizeof(T1) + sizeof(T2)>
 \end{note}
 
 \pnum
-The closure type for a non-generic \grammarterm{lambda-expression} with no
+The closure type for a non-generic lambda with no
 \grammarterm{lambda-capture}
 whose constraints (if any) are satisfied
 has a conversion function to pointer to


### PR DESCRIPTION
The unadorned term "lambda" is used interchangeably with _lambda-expression_ in a few places, but is never actually defined.  The term "generic lambda" is defined in terms of "lambda".  Adding the missing definition seemed like the simplest approach to resolving the issue.