### PR TITLE
[streambuf.general] Strike "abstract" from "basic_streambuf serves as an abstract base class"

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -3096,7 +3096,7 @@ namespace std {
 \pnum
 The class template
 \tcode{basic_streambuf}
-serves as an abstract base class for deriving various
+serves as a base class for deriving various
 \term{stream buffers}
 whose objects each control two
 \term{character sequences}:


### PR DESCRIPTION
Fixes #6629.