### PR TITLE
[span.cons] Add `std::` for `data(arr)`

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -18450,7 +18450,7 @@ template<class T, size_t N> constexpr span(const array<T, N>& arr) noexcept;
 \begin{itemdescr}
 \pnum
 \constraints
-Let \tcode{U} be \tcode{remove_pointer_t<decltype(data(arr))>}.
+Let \tcode{U} be \tcode{remove_pointer_t<decltype(std::data(arr))>}.
 \begin{itemize}
 \item \tcode{extent == dynamic_extent || N == extent} is \tcode{true}, and
 \item \tcode{is_convertible_v<U(*)[], element_type(*)[]>} is \tcode{true}.
@@ -18469,7 +18469,7 @@ Constructs a \tcode{span} that is a view over the supplied array.
 
 \pnum
 \ensures
-\tcode{size() == N \&\& data() == data(arr)} is \tcode{true}.
+\tcode{size() == N \&\& data() == std::data(arr)} is \tcode{true}.
 \end{itemdescr}
 
 \indexlibraryctor{span}%


### PR DESCRIPTION
`std::span` has a member function `data`, which shadows `std::data`.

It is especially awkward that in `data() == data(arr)`, the first `data` refers to the member, while the second refers to `std::data`. The addition of `std::` helps to clarify that these two `data` belong to different scopes.