### PR TITLE
[stack.syn, queue.syn] Show `formatter` specializations in the synopses

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -13734,6 +13734,10 @@ namespace std {
     void swap(stack<T, Container>& x, stack<T, Container>& y) noexcept(noexcept(x.swap(y)));
   template<class T, class Container, class Alloc>
     struct uses_allocator<stack<T, Container>, Alloc>;
+
+  // \ref{container.adaptors.format}, formatter specialization for \tcode{stack}
+  template<class charT, class T, @\libconcept{formattable}@<charT> Container>
+    struct formatter<stack<T, Container>, charT>;
 }
 \end{codeblock}
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -13682,6 +13682,10 @@ namespace std {
   template<class T, class Container, class Alloc>
     struct uses_allocator<queue<T, Container>, Alloc>;
 
+  // \ref{container.adaptors.format}, formatter specialization for \tcode{queue}
+  template<class charT, class T, @\libconcept{formattable}@<charT> Container>
+    struct formatter<queue<T, Container>, charT>;
+
   // \ref{priority.queue}, class template \tcode{priority_queue}
   template<class T, class Container = vector<T>,
            class Compare = less<typename Container::value_type>>
@@ -13692,6 +13696,10 @@ namespace std {
               priority_queue<T, Container, Compare>& y) noexcept(noexcept(x.swap(y)));
   template<class T, class Container, class Compare, class Alloc>
     struct uses_allocator<priority_queue<T, Container, Compare>, Alloc>;
+
+  // \ref{container.adaptors.format}, formatter specialization for \tcode{priority_queue}
+  template<class charT, class T, @\libconcept{formattable}@<charT> Container, class Compare>
+    struct formatter<priority_queue<T, Container, Compare>, charT>;
 }
 \end{codeblock}
 


### PR DESCRIPTION
Currently it is a bit unclear in which headers these specializations are provided.

I'm trying to make clarification editorially since @Dani-Hub told me that the changes seemed almost editorial to him.