### PR TITLE
[format.formatter.spec] Add missing include to example

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16981,6 +16981,7 @@ An enabled specialization \tcode{formatter<T, charT>} meets the
 \begin{example}
 \begin{codeblock}
 #include <format>
+#include <string>
 
 enum color { red, green, blue };
 const char* color_names[] = { "red", "green", "blue" };


### PR DESCRIPTION
The example code refers to `std::string` directly so it should `#include<string>`.