### PR TITLE
[expr.prim.lambda.closure] Improve some parallel grammar

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2130,7 +2130,7 @@ has the same effect as invoking the closure type's function call operator
 on a default-constructed instance of the closure type.
 \tcode{F} is a constexpr function
 if the function call operator is a constexpr function
-and is an immediate function
+and an immediate function
 if the function call operator is an immediate function.
 
 \pnum
@@ -2206,8 +2206,8 @@ effect as invoking the generic lambda's corresponding function call operator
 template specialization on a default-constructed instance of the closure type.
 \tcode{F} is a constexpr function
 if the corresponding specialization is a constexpr function and
-\tcode{F} is an immediate function
-if the function call operator template specialization is an immediate function.
+an immediate function
+if the corresponding specialization is an immediate function.
 \begin{note}
 This will result in the implicit instantiation of the generic lambda's body.
 The instantiated generic lambda's return type and parameter types need to match


### PR DESCRIPTION
I noticed that we say "F is... and..." in two parallel places, but one says "and is" and the other says "and F is" when really they should both just say "and". The further parallelism of "the corresponding specialization" is just a drive-by but I think also an improvement.