### PR TITLE
[class.conv.fct] Fix reference to 'ref-qualifier-seq'

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -2438,7 +2438,7 @@ its \grammarterm{declarator} shall be
 a function declarator\iref{dcl.fct} of the form
 \begin{ncsimplebnf}
 ptr-declarator \terminal{(} parameter-declaration-clause \terminal{)} \opt{cv-qualifier-seq}\br
-\bnfindent \opt{ref-qualifier-seq} \opt{noexcept-specifier} \opt{attribute-specifier-seq}
+\bnfindent \opt{ref-qualifier} \opt{noexcept-specifier} \opt{attribute-specifier-seq}
 \end{ncsimplebnf}
 where the \grammarterm{ptr-declarator} consists solely of
 an \grammarterm{id-expression},


### PR DESCRIPTION
There is no such thing as a _ref-qualifier-seq_. The fix here is obvious.