### PR TITLE
[mdspan.submdspan] Add missing definitions for full_extent_t and full_extent

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -18997,6 +18997,11 @@ namespace std {
     class mdspan;
 
   // \ref{mdspan.submdspan}, \tcode{submdspan} creation
+  struct full_extent_t {
+    explicit full_extent() = default;
+  };
+  inline constexpr full_extent_t full_extent{};
+
   template<class OffsetType, class LengthType, class StrideType>
     struct strided_slice;
 


### PR DESCRIPTION
This attempt to fix an oversight in [P2630R4](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2630r4.html) (submdspan) that was voted into the draft in Varna.

* `full_extent_t` is the tag type that represents all indices.
* `full_extent` is a constant of type `const full_extent_t` which can be passed as a slice specifier argument to `submdspan()`.

`full_extent_t` is used 8x in [[mdspan.submdspan]](https://eel.is/c++draft/views.multidim#mdspan.submdspan).
`full_extent` is used in the code snippet (Example 1) in the last paragraph.
Neither is ever defined.

These can be found in the wording of [P0009R16](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0009r16.html#wording) but were removed in R17 for the sake of `mdspan` making it into C++23.

@jwakely 
@crtrott 
@tkoeppe 