### PR TITLE
[string.capacity] Remove parentheses from "reserve()"

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -3009,8 +3009,8 @@ constexpr void reserve(size_type res_arg);
 \effects
 A directive that informs a \tcode{basic_string} of a planned change in size,
 so that the storage allocation can be managed accordingly.
-After
-\tcode{reserve()},
+Following a call to
+\tcode{reserve},
 \tcode{capacity()}
 is greater or equal to the argument of
 \tcode{reserve}
@@ -3019,7 +3019,7 @@ equal to the previous value of
 \tcode{capacity()}
 otherwise.
 Reallocation happens at this point if and only if
-the current capacity is less than the argument of \tcode{reserve()}.
+the current capacity is less than the argument of \tcode{reserve}.
 
 \pnum
 \throws


### PR DESCRIPTION
It's very confusing to talk about `reserve()` when describing a call to `reserve(size_type)`, given that the overload `reserve()` also exists.