### PR TITLE
[conv.general, expr.static.cast] Remove inappropriate "temporary"

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -550,14 +550,14 @@ See~\ref{dcl.init}, \ref{dcl.init.ref}.
 \pnum
 An expression $E$ can be
 \defnx{implicitly converted}{conversion!implicit} to a type \tcode{T} if and only if the
-declaration \tcode{T t=$E$;} is well-formed, for some invented temporary
+declaration \tcode{T t=$E$;} is well-formed, for some invented
 variable \tcode{t}\iref{dcl.init}.
 
 \pnum
 Certain language constructs require that an expression be converted to a Boolean
 value. An expression $E$ appearing in such a context is said to be
 \defnx{contextually converted to \tcode{bool}}{conversion!contextual to \tcode{bool}} and is well-formed if and only if
-the declaration \tcode{\keyword{bool} t($E$);} is well-formed, for some invented temporary
+the declaration \tcode{\keyword{bool} t($E$);} is well-formed, for some invented
 variable \tcode{t}\iref{dcl.init}.
 
 \pnum
@@ -577,7 +577,7 @@ There shall be exactly one such \tcode{T}.
 \pnum
 The effect of any implicit
 conversion is the same as performing the corresponding declaration and initialization
-and then using the temporary variable as the result of the conversion.
+and then using the invented variable as the result of the conversion.
 The result is an lvalue if \tcode{T} is an lvalue reference
 type or an rvalue reference to function type\iref{dcl.ref},
 an xvalue if \tcode{T} is an rvalue reference to object type,
@@ -4027,8 +4027,8 @@ the same as performing the declaration and initialization
 \begin{codeblock}
 T t(@$E$@);
 \end{codeblock}
-for some invented temporary variable \tcode{t}\iref{dcl.init}
-and then using the temporary variable as the result of the conversion.
+for some invented variable \tcode{t}\iref{dcl.init}
+and then using the variable as the result of the conversion.
 Otherwise, the result object is direct-initialized from $E$.
 \begin{note}
 The conversion is ill-formed when attempting to convert an

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -550,14 +550,14 @@ See~\ref{dcl.init}, \ref{dcl.init.ref}.
 \pnum
 An expression $E$ can be
 \defnx{implicitly converted}{conversion!implicit} to a type \tcode{T} if and only if the
-declaration \tcode{T t=$E$;} is well-formed, for some invented
+declaration \tcode{T t=$E$;} is well-formed for some invented
 variable \tcode{t}\iref{dcl.init}.
 
 \pnum
 Certain language constructs require that an expression be converted to a Boolean
 value. An expression $E$ appearing in such a context is said to be
 \defnx{contextually converted to \tcode{bool}}{conversion!contextual to \tcode{bool}} and is well-formed if and only if
-the declaration \tcode{\keyword{bool} t($E$);} is well-formed, for some invented
+the declaration \tcode{\keyword{bool} t($E$);} is well-formed for some invented
 variable \tcode{t}\iref{dcl.init}.
 
 \pnum


### PR DESCRIPTION
It's not clear in which sense the invented variables in question are "temporary". Since C++ already contains a notion of a "temporary (object)", and since variables are precisely _not_ temporary objects, it seems unnecessary to use the words "temporary variable" in the present sense.

See also http://thecodelesscode.com/case/234.