### PR TITLE
[dcl.init.ref] Clarify "related type"

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5720,9 +5720,10 @@ struct A { operator volatile int&(); } a;
 const int& r3 = a;                  // error: cv-qualifier dropped
                                     // from result of conversion function
 double d2 = 1.0;
-double&& rrd2 = d2;                 // error: initializer is lvalue of related type
+double&& rrd2 = d2;                 // error: initializer is lvalue of reference-related type
 struct X { operator int&(); };
-int&& rri2 = X();                   // error: result of conversion function is lvalue of related type
+int&& rri2 = X();                   // error: result of conversion function is
+                                    // lvalue of reference-related type
 int i3 = 2;
 double&& rrd3 = i3;                 // \tcode{rrd3} refers to temporary with value \tcode{2.0}
 \end{codeblock}


### PR DESCRIPTION
"Related type" is not a term, and it might be clearer to use "reference-related type".

Should close cplusplus/CWG#461, which is not a defect IMO. Towards #6651.