### PR TITLE
Change floating point wording from mantissa to significand

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5248,8 +5248,8 @@ the floating-point literal suffixes \tcode{bf16} and \tcode{BF16} are supported.
 \pnum
 \begin{note}
 A summary of the parameters for each type is given in \tref{basic.extended.fp}.
-The precision $p$ includes the implicit 1 bit at the beginning of the mantissa,
-so the storage used for the mantissa is $p-1$ bits.
+The precision $p$ includes the implicit 1 bit at the beginning of the significand,
+so the storage used for the significand is $p-1$ bits.
 ISO/IEC/IEEE 60559 does not assign a name for a type
 having the parameters specified for \tcode{std::bfloat16_t}.
 \end{note}

--- a/source/support.tex
+++ b/source/support.tex
@@ -1069,7 +1069,7 @@ For integer types, the number of non-sign bits in the representation.
 
 \pnum
 For floating-point types, the number of \tcode{radix} digits in the
-mantissa.
+significand.
 \begin{footnote}
 Equivalent to \tcode{FLT_MANT_DIG}, \tcode{DBL_MANT_DIG},
 \tcode{LDBL_MANT_DIG}.


### PR DESCRIPTION
Since ISO/IEC/IEEE 60559:2008 the word „mantissa“ has been superseded by „significand“.