### PR TITLE
[ranges] Introduce `bidirectional-common` and `random-access-sized` to simplify concept spelling

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -10060,7 +10060,7 @@ namespace std::ranges {
   concept @\defexposconcept{zip-is-common}@ =                             // \expos
     (sizeof...(Rs) == 1 && (@\libconcept{common_range}@<Rs> && ...)) ||
     (!(@\libconcept{bidirectional_range}@<Rs> && ...) && (@\libconcept{common_range}@<Rs> && ...)) ||
-    (@\exposconcept{random-access-sized}@<Rs> && ...);
+    ((@\libconcept{random_access_range}@<Rs> && ...) && (@\libconcept{sized_range}@<Rs> && ...));
 
   template<@\libconcept{input_range}@... Views>
     requires (@\libconcept{view}@<Views> && ...) && (sizeof...(Views) > 0)

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1642,6 +1642,14 @@ template<class R>
   concept @\defexposconceptnc{range-with-movable-references}@ =                   // \expos
     @\libconcept{input_range}@<R> && @\libconcept{move_constructible}@<range_reference_t<R>> &&
     @\libconcept{move_constructible}@<range_rvalue_reference_t<R>>;
+
+template<class R>
+  concept @\defexposconcept{bidirectional-common}@ =                           // \expos
+    @\libconcept{bidirectional_range}@<R> && @\libconcept{common_range}@<R>;
+
+template<class R>
+  concept @\defexposconcept{random-access-sized}@ =                            // \expos
+    @\libconcept{random_access_range}@<R> && @\libconcept{sized_range}@<R>;
 \end{codeblock}
 
 \rSec2[view.interface]{View interface}
@@ -1723,9 +1731,8 @@ namespace std::ranges {
     constexpr decltype(auto) front() requires @\libconcept{forward_range}@<D>;
     constexpr decltype(auto) front() const requires @\libconcept{forward_range}@<const D>;
 
-    constexpr decltype(auto) back() requires @\libconcept{bidirectional_range}@<D> && @\libconcept{common_range}@<D>;
-    constexpr decltype(auto) back() const
-      requires @\libconcept{bidirectional_range}@<const D> && @\libconcept{common_range}@<const D>;
+    constexpr decltype(auto) back() requires @\exposconcept{bidirectional-common}@<D>;
+    constexpr decltype(auto) back() const requires @\exposconcept{bidirectional-common}@<const D>;
 
     template<@\libconcept{random_access_range}@ R = D>
       constexpr decltype(auto) operator[](range_difference_t<R> n) {
@@ -1766,9 +1773,8 @@ Equivalent to: \tcode{return *ranges::begin(\exposid{derived}());}
 
 \indexlibrarymember{back}{view_interface}%
 \begin{itemdecl}
-constexpr decltype(auto) back() requires @\libconcept{bidirectional_range}@<D> && @\libconcept{common_range}@<D>;
-constexpr decltype(auto) back() const
-  requires @\libconcept{bidirectional_range}@<const D> && @\libconcept{common_range}@<const D>;
+constexpr decltype(auto) back() requires @\exposconcept{bidirectional-common}@<D>;
+constexpr decltype(auto) back() const requires @\exposconcept{bidirectional-common}@<const D>;;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5677,14 +5683,14 @@ are indeterminately sequenced.
 
 \item
 Otherwise, if \tcode{T} models
-\libconcept{random_access_range} and \libconcept{sized_range}
+\exposconcept{random-access-sized}
 and is a specialization of
 \tcode{span}\iref{views.span},
 \tcode{basic_string_view}\iref{string.view}, or
 \tcode{subrange}\iref{range.subrange},
 then
 \tcode{U(ranges::begin(E),
-ranges::be\-gin(E) + std::min<D>(ranges::distance(E), F))},
+ranges::be\-gin(E) + std::\linebreak{}min<D>(ranges::distance(E), F))},
 except that \tcode{E} is evaluated only once,
 where \tcode{U} is a type determined as follows:
 
@@ -5700,10 +5706,10 @@ then \tcode{U} is \tcode{T};
 \item
 otherwise, if \tcode{T} is
 a specialization of \tcode{iota_view}\iref{range.iota.view}
-that models \libconcept{random_access_range} and \libconcept{sized_range},
+that models \exposconcept{random-access-sized},
 then
 \tcode{iota_view(*ranges::begin(E),
-*(ranges::begin(E) + std::\linebreak{}min<D>(ranges::distance(E), F)))},
+*(ranges::begin(E) + std::min<D>(ranges::distance(E), \linebreak{}F)))},
 except that \tcode{E} is evaluated only once.
 
 \item
@@ -6142,7 +6148,7 @@ are indeterminately sequenced.
 
 \item
 Otherwise, if \tcode{T} models
-\libconcept{random_access_range} and \libconcept{sized_range}
+\exposconcept{random-access-sized}
 and is
 \begin{itemize}
 \item a specialization of \tcode{span}\iref{views.span},
@@ -6160,9 +6166,9 @@ if \tcode{T} is a specialization of \tcode{span} and \tcode{T} otherwise.
 Otherwise,
 if \tcode{T} is
 a specialization of \tcode{subrange}\iref{range.subrange}
-that models \libconcept{random_access_range} and \libconcept{sized_range},
+that models \exposconcept{random-access-sized},
 then
-\tcode{T(ranges::begin(E) + std::min<D>(ranges::distance(E), F), ranges::\linebreak{}end(E),
+\tcode{T(ranges::begin(E) + std::min<D>(ranges::distance(E), F), ranges::end(E), \linebreak{}
 \exposid{to-unsigned-like}(ranges::distance(E) -
 std::min<D>(ranges::distance(E), F)))},
 except that \tcode{E} and \tcode{F} are each evaluated only once.
@@ -6215,10 +6221,8 @@ namespace std::ranges {
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
     constexpr auto begin()
-      requires (!(@\exposconcept{simple-view}@<V> &&
-                  @\libconcept{random_access_range}@<const V> && @\libconcept{sized_range}@<const V>));
-    constexpr auto begin() const
-      requires @\libconcept{random_access_range}@<const V> && @\libconcept{sized_range}@<const V>;
+      requires (!(@\exposconcept{simple-view}@<V> && @\exposconcept{random-access-sized}@<const V>));
+    constexpr auto begin() const requires @\exposconcept{random-access-sized}@<const V>;
 
     constexpr auto end() requires (!@\exposconcept{simple-view}@<V>)
     { return ranges::end(@\exposid{base_}@); }
@@ -6267,10 +6271,8 @@ Initializes \exposid{base_} with \tcode{std::move(base)} and
 \indexlibrarymember{begin}{drop_view}%
 \begin{itemdecl}
 constexpr auto begin()
-  requires (!(@\exposconcept{simple-view}@<V> &&
-              @\libconcept{random_access_range}@<const V> && @\libconcept{sized_range}@<const V>));
-constexpr auto begin() const
-  requires @\libconcept{random_access_range}@<const V> && @\libconcept{sized_range}@<const V>;
+  requires (!(@\exposconcept{simple-view}@<V> && @\exposconcept{random-access-sized}@<const V>));
+constexpr auto begin() const requires @\exposconcept{random-access-sized}@<const V>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6578,13 +6580,11 @@ namespace std::ranges {
 
     constexpr @\exposid{iterator}@& operator--()
       requires @\exposid{ref-is-glvalue}@ && @\libconcept{bidirectional_range}@<@\exposid{Base}@> &&
-               @\libconcept{bidirectional_range}@<range_reference_t<@\exposid{Base}@>> &&
-               @\libconcept{common_range}@<range_reference_t<@\exposid{Base}@>>;
+               @\exposconcept{bidirectional-common}@<range_reference_t<@\exposid{Base}@>>;
 
     constexpr @\exposid{iterator}@ operator--(int)
       requires @\exposid{ref-is-glvalue}@ && @\libconcept{bidirectional_range}@<@\exposid{Base}@> &&
-               @\libconcept{bidirectional_range}@<range_reference_t<@\exposid{Base}@>> &&
-               @\libconcept{common_range}@<range_reference_t<@\exposid{Base}@>>;
+               @\exposconcept{bidirectional-common}@<range_reference_t<@\exposid{Base}@>>;
 
     friend constexpr bool operator==(const @\exposid{iterator}@& x, const @\exposid{iterator}@& y)
       requires @\exposid{ref-is-glvalue}@ && @\libconcept{forward_range}@<@\exposid{Base}@> &&
@@ -6607,8 +6607,7 @@ namespace std::ranges {
 \begin{itemize}
 \item If \exposid{ref-is-glvalue} is \tcode{true},
   \exposid{Base} models \libconcept{bidirectional_range}, and
-  \tcode{range_reference_t<\exposid{Base}>} models
-  both \libconcept{bidirectional_range} and \libconcept{common_range},
+  \tcode{range_reference_t<\exposid{Base}>} models \exposconcept{bidirectional-common},
   then \tcode{iterator_concept} denotes \tcode{bidirectio\-nal_iterator_tag}.
 \item Otherwise, if \exposid{ref-is-glvalue} is \tcode{true} and
   \exposid{Base} and \tcode{range_reference_t<\exposid{Base}>}
@@ -6811,8 +6810,7 @@ return tmp;
 \begin{itemdecl}
 constexpr @\exposid{iterator}@& operator--()
   requires @\exposid{ref-is-glvalue}@ && @\libconcept{bidirectional_range}@<@\exposid{Base}@> &&
-           @\libconcept{bidirectional_range}@<range_reference_t<@\exposid{Base}@>> &&
-           @\libconcept{common_range}@<range_reference_t<@\exposid{Base}@>>;
+           @\exposconcept{bidirectional-common}@<range_reference_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6833,8 +6831,7 @@ return *this;
 \begin{itemdecl}
 constexpr @\exposid{iterator}@ operator--(int)
   requires @\exposid{ref-is-glvalue}@ && @\libconcept{bidirectional_range}@<@\exposid{Base}@> &&
-           @\libconcept{bidirectional_range}@<range_reference_t<@\exposid{Base}@>> &&
-           @\libconcept{common_range}@<range_reference_t<@\exposid{Base}@>>;
+           @\exposconcept{bidirectional-common}@<range_reference_t<@\exposid{Base}@>>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6978,9 +6975,6 @@ namespace std::ranges {
       @\libconcept{common_with}@<range_value_t<R>, range_value_t<P>> &&
       @\libconcept{common_reference_with}@<range_reference_t<R>, range_reference_t<P>> &&
       @\libconcept{common_reference_with}@<range_rvalue_reference_t<R>, range_rvalue_reference_t<P>>;
-
-  template<class R>
-  concept @\defexposconcept{bidirectional-common}@ = @\libconcept{bidirectional_range}@<R> && @\libconcept{common_range}@<R>;    // \expos
 
   template<@\libconcept{input_range}@ V, @\libconcept{forward_range}@ Pattern>
     requires @\libconcept{view}@<V> && @\libconcept{input_range}@<range_reference_t<V>>
@@ -8531,28 +8525,28 @@ namespace std::ranges {
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
     constexpr auto begin() {
-      if constexpr (@\libconcept{random_access_range}@<V> && @\libconcept{sized_range}@<V>)
+      if constexpr (@\exposconcept{random-access-sized}@<V>)
         return ranges::begin(@\exposid{base_}@);
       else
         return common_iterator<iterator_t<V>, sentinel_t<V>>(ranges::begin(@\exposid{base_}@));
     }
 
     constexpr auto begin() const requires @\libconcept{range}@<const V> {
-      if constexpr (@\libconcept{random_access_range}@<const V> && @\libconcept{sized_range}@<const V>)
+      if constexpr (@\exposconcept{random-access-sized}@<const V>)
         return ranges::begin(@\exposid{base_}@);
       else
         return common_iterator<iterator_t<const V>, sentinel_t<const V>>(ranges::begin(@\exposid{base_}@));
     }
 
     constexpr auto end() {
-      if constexpr (@\libconcept{random_access_range}@<V> && @\libconcept{sized_range}@<V>)
+      if constexpr (@\exposconcept{random-access-sized}@<V>)
         return ranges::begin(@\exposid{base_}@) + ranges::distance(@\exposid{base_}@);
       else
         return common_iterator<iterator_t<V>, sentinel_t<V>>(ranges::end(@\exposid{base_}@));
     }
 
     constexpr auto end() const requires @\libconcept{range}@<const V> {
-      if constexpr (@\libconcept{random_access_range}@<const V> && @\libconcept{sized_range}@<const V>)
+      if constexpr (@\exposconcept{random-access-sized}@<const V>)
         return ranges::begin(@\exposid{base_}@) + ranges::distance(@\exposid{base_}@);
       else
         return common_iterator<iterator_t<const V>, sentinel_t<const V>>(ranges::end(@\exposid{base_}@));
@@ -10066,7 +10060,7 @@ namespace std::ranges {
   concept @\defexposconcept{zip-is-common}@ =                             // \expos
     (sizeof...(Rs) == 1 && (@\libconcept{common_range}@<Rs> && ...)) ||
     (!(@\libconcept{bidirectional_range}@<Rs> && ...) && (@\libconcept{common_range}@<Rs> && ...)) ||
-    ((@\libconcept{random_access_range}@<Rs> && ...) && (@\libconcept{sized_range}@<Rs> && ...));
+    (@\exposconcept{random-access-sized}@<Rs> && ...);
 
   template<@\libconcept{input_range}@... Views>
     requires (@\libconcept{view}@<Views> && ...) && (sizeof...(Views) > 0)
@@ -13359,11 +13353,11 @@ for (auto i : v | views::slide(2)) {
 \begin{codeblock}
 namespace std::ranges {
   template<class V>
-  concept @\defexposconcept{slide-caches-nothing}@ = @\libconcept{random_access_range}@<V> && @\libconcept{sized_range}@<V>;       // \expos
+  concept @\defexposconcept{slide-caches-nothing}@ = @\exposconcept{random-access-sized}@<V>;                 // \expos
 
   template<class V>
   concept @\defexposconcept{slide-caches-last}@ =                                            // \expos
-    !@\exposconcept{slide-caches-nothing}@<V> && @\libconcept{bidirectional_range}@<V> && @\libconcept{common_range}@<V>;
+    !@\exposconcept{slide-caches-nothing}@<V> && @\exposconcept{bidirectional-common}@<V>;
 
   template<class V>
   concept @\defexposconcept{slide-caches-first}@ =                                           // \expos
@@ -14969,12 +14963,11 @@ namespace std::ranges {
   template<bool Const, class First, class... Vs>
   concept @\defexposconcept{cartesian-product-is-random-access}@ =          // \expos
     (@\libconcept{random_access_range}@<@\exposid{maybe-const}@<Const, First>> && ... &&
-      (@\libconcept{random_access_range}@<@\exposid{maybe-const}@<Const, Vs>>
-        && @\libconcept{sized_range}@<@\exposid{maybe-const}@<Const, Vs>>));
+      @\exposconcept{random-access-sized}@<@\exposid{maybe-const}@<Const, Vs>>);
 
   template<class R>
   concept @\defexposconcept{cartesian-product-common-arg}@ =                // \expos
-    @\libconcept{common_range}@<R> || (@\libconcept{sized_range}@<R> && @\libconcept{random_access_range}@<R>);
+    @\libconcept{common_range}@<R> || @\exposconcept{random-access-sized}@<R>;
 
   template<bool Const, class First, class... Vs>
   concept @\defexposconcept{cartesian-product-is-bidirectional}@ =          // \expos

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1644,11 +1644,11 @@ template<class R>
     @\libconcept{move_constructible}@<range_rvalue_reference_t<R>>;
 
 template<class R>
-  concept @\defexposconcept{bidirectional-common}@ =                           // \expos
+  concept @\defexposconcept{bidirectional-common}@ =                               // \expos
     @\libconcept{bidirectional_range}@<R> && @\libconcept{common_range}@<R>;
 
 template<class R>
-  concept @\defexposconcept{random-access-sized}@ =                            // \expos
+  concept @\defexposconcept{random-access-sized}@ =                                // \expos
     @\libconcept{random_access_range}@<R> && @\libconcept{sized_range}@<R>;
 \end{codeblock}
 

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -6168,10 +6168,10 @@ if \tcode{T} is
 a specialization of \tcode{subrange}\iref{range.subrange}
 that models \exposconcept{random-access-sized},
 then
-\tcode{T(ranges::begin(E) + std::min<D>(ranges::distance(E), F), ranges::end(E), \linebreak{}
+\tcode{T(ranges::begin(E) + std::min<D>(ranges::distance(E), F), ranges::end(E),\linebreak{}
 \exposid{to-unsigned-like}(ranges::distance(E) -
 std::min<D>(ranges::distance(E), F)))},
-except that \tcode{E} and \tcode{F} are each evaluated only once.
+except\linebreak{} that \tcode{E} and \tcode{F} are each evaluated only once.
 
 \item
 Otherwise, if \tcode{T} is


### PR DESCRIPTION
This is the resolution for #6633.
This PR moves [_`bidirectional-common`_](https://eel.is/c++draft/range.join.with.view#concept:bidirectional-common)  to [[range.utility.helpers]](https://eel.is/c++draft/range.utility.helpers) also with [_`slide-caches-nothing`_](https://eel.is/c++draft/ranges#concept:slide-caches-nothing) which renames it to _`random-access-sized`_:

```cpp
template<class R>
  concept bidirectional-common = // exposition only
    bidirectional_range<R> && common_range<R>;
template<class R>
  concept random-access-sized = // exposition only
    random_access_range<R> && sized_range<R>;
```
Then replace them where they are used in [ranges].
I believe this is editorial, and it simplifies the spelling of a number of concepts without reducing readability, which is an improvement in my opinion. 

And I think this also helps with the concept spelling for newly-introduced range adaptors.


Comments are welcome.