### PR TITLE
[support.initlist] Teletype font for `initializer_list`

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -4139,7 +4139,7 @@ objects of type \tcode{const E}.
 A pair of pointers or a pointer plus
 a length would be obvious representations for \tcode{initializer_list}.
 \tcode{initializer_list} is used to implement initializer lists as specified
-in~\ref{dcl.init.list}. Copying an initializer list does not copy the underlying
+in~\ref{dcl.init.list}. Copying an \tcode{initializer_list} does not copy the underlying
 elements.
 \end{note}
 


### PR DESCRIPTION
This note is talking about the class type, not the grammatical construct, so it should say `initializer_list`.