### PR TITLE
[intro.defs, macros] Add cross-references among definitions

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -180,7 +180,7 @@ that provides the definitions specified in
 \defncontext{library}
 \indexdefn{type!character container}%
 class or a type used to
-represent a character
+represent a \termref{defns.character}{character}{}
 
 \begin{defnote}
 It is used for one of the template parameters of \tcode{char_traits}
@@ -190,13 +190,13 @@ such as the string, iostream, and regular expression class templates.
 
 \definition{collating element}{defns.regex.collating.element}
 \indexdefn{collating element}%
-sequence of one or more characters within the
+sequence of one or more \termref{defns.character}{character}{s} within the
 current locale that collate as if they were a single character
 
 \definition{component}{defns.component}
 \defncontext{library}
 \indexdefn{component}%
-group of library entities directly related as members, parameters, or
+group of library entities directly related as members, \termref{defns.parameter}{parameter}{s}, or
 return types
 
 \begin{defnote}
@@ -226,13 +226,13 @@ from being a core constant expression
 \indexdefn{deadlock}%
 situation wherein
 one or more threads are unable to continue execution because each is
-blocked waiting for one or more of the others to satisfy some condition
+\termref{defns.block}{block}{ed} waiting for one or more of the others to satisfy some condition
 
 \definition{default behavior}{defns.default.behavior.impl}
 \indexdefn{behavior!default}%
 \defncontext{library implementation}
 specific behavior provided by the implementation,
-within the scope of the required behavior
+within the scope of the \termref{defns.required.behavior}{required behavior}{}
 
 \indexdefn{message!diagnostic}%
 \definition{diagnostic message}{defns.diagnostic}
@@ -254,7 +254,7 @@ treated similarly.
 
 \indexdefn{type!dynamic}%
 \definition{dynamic type}{defns.dynamic.type.prvalue}
-\defncontext{prvalue} static type of the prvalue expression
+\defncontext{prvalue} \termref{defns.static.type}{static type}{} of the prvalue expression
 
 \definition{expression-equivalent}{defns.expression.equivalent}
 \defncontext{library}
@@ -265,7 +265,7 @@ are all potentially-throwing or
 are all not potentially-throwing,
 and
 either
-are all constant subexpressions or
+are all \termref{defns.const.subexpr}{constant subexpression}{s} or
 are all not constant subexpressions
 
 \begin{example}
@@ -283,14 +283,14 @@ are expression-equivalent.
 \defncontext{regular expression}
 \indexdefn{finite state machine}%
 unspecified data structure that is used to
-represent a regular expression, and which permits efficient matches
+represent a \termref{defns.regex.regular.expression}{regular expression}{}, and which permits efficient matches
 against the regular expression to be obtained
 
 \definition{format specifier}{defns.regex.format.specifier}
 \defncontext{regular expression}
 \indexdefn{format specifier}%
-sequence of one or more characters that is to be
-replaced with some part of a regular expression match
+sequence of one or more \termref{defns.character}{character}{s} that is to be
+replaced with some part of a \termref{defns.regex.regular.expression}{regular expression}{} match
 
 \definition{handler function}{defns.handler}
 \defncontext{library}
@@ -309,7 +309,7 @@ program that is not well-formed\iref{defns.well.formed}
 
 \indexdefn{behavior!implementation-defined}%
 \definition{implementation-defined behavior}{defns.impl.defined}
-behavior, for a well-formed program construct and correct data, that
+behavior, for a \termref{defns.well.formed}{well-formed program}{} construct and correct data, that
 depends on the implementation and that each implementation documents
 
 \definition{implementation-defined strict total order over pointers}
@@ -335,7 +335,7 @@ language that each implementation documents
 \defncontext{regular expression}
 \indexdefn{matched}%
 \indexdefn{regular expression!matched}%
-condition when a sequence of zero or more characters
+condition when a sequence of zero or more \termref{defns.character}{character}{s}
 correspond to a sequence of characters defined by the pattern
 
 \definition{modifier function}{defns.modifier}
@@ -366,7 +366,7 @@ prevents \tcode{E} from being a core constant expression
 \indexdefn{NTCTS}%
 \indexdefn{string!null-terminated character type}%
 sequence of values that have
-character type
+\termref{defns.character}{character}{} type
 that precede the terminating null character type
 value
 \tcode{charT()}
@@ -406,7 +406,7 @@ following the macro name
 \definition{primary equivalence class}{defns.regex.primary.equivalence.class}
 \defncontext{regular expression}
 \indexdefn{primary equivalence class}%
-set of one or more characters which
+set of one or more \termref{defns.character}{character}{s} which
 share the same primary sort key: that is the sort key weighting that
 depends only upon character shape, and not accents, case, or
 locale specific tailorings
@@ -425,7 +425,7 @@ non-closure class type or enumeration type
 that is not part of the \Cpp{} standard library and
 not defined by the implementation,
 or a closure type of a non-implementation-provided lambda expression,
-or an instantiation of a program-defined specialization
+or an instantiation of a \termref{defns.prog.def.spec}{program-defined specialization}{}
 
 \begin{defnote}
 Types defined by the implementation include
@@ -462,7 +462,7 @@ including reference types.
 
 \definition{regular expression}{defns.regex.regular.expression}
 pattern that selects specific strings
-from a set of character strings
+from a set of \termref{defns.character}{character}{} strings
 
 \definition{replacement function}{defns.replacement}
 \defncontext{library}
@@ -479,7 +479,8 @@ definitions of all translation units\iref{basic.link}.
 \definition{required behavior}{defns.required.behavior}
 \defncontext{library}
 \indexdefn{behavior!required}%
-description of replacement function and handler function semantics
+description of \termref{defns.replacement}{replacement function}{}
+and \termref{defns.handler}{handler function}{} semantics
 applicable to both the behavior provided by the implementation and
 the behavior of any such function definition in the program
 
@@ -528,7 +529,7 @@ name,
 parameter-type-list,
 enclosing namespace,
 return type,
-signature of the \grammarterm{template-head},
+\termref{defns.signature.template.head}{signature}{} of the \grammarterm{template-head},
 and
 trailing \grammarterm{requires-clause} (if any)
 
@@ -539,14 +540,14 @@ name,
 parameter-type-list,
 return type,
 enclosing class,
-signature of the \grammarterm{template-head},
+\termref{defns.signature.template.head}{signature}{} of the \grammarterm{template-head},
 and
 trailing \grammarterm{requires-clause} (if any)
 
 \indexdefn{signature}%
 \definition{signature}{defns.signature.spec}
-\defncontext{function template specialization} signature of the template of which it is a specialization
-and its template arguments (whether explicitly specified or deduced)
+\defncontext{function template specialization} \termref{defns.signature.templ}{signature}{} of the template of which it is a specialization
+and its template \termref{defns.argument.templ}{argument}{s} (whether explicitly specified or deduced)
 
 \indexdefn{signature}%
 \definition{signature}{defns.signature.member}
@@ -568,20 +569,20 @@ class of which the function is a member,
 \cv-qualifiers (if any),
 \grammarterm{ref-qualifier} (if any),
 return type (if any),
-signature of the \grammarterm{template-head},
+\termref{defns.signature.template.head}{signature}{} of the \grammarterm{template-head},
 and
 trailing \grammarterm{requires-clause} (if any)
 
 \indexdefn{signature}%
 \definition{signature}{defns.signature.member.spec}
-\defncontext{class member function template specialization} signature of the member function template
+\defncontext{class member function template specialization} \termref{defns.signature.member.templ}{signature}{} of the member function template
 of which it is a specialization and its template arguments (whether explicitly specified or deduced)
 
 \indexdefn{signature}%
 \definition{signature}{defns.signature.template.head}
 \defncontext{\grammarterm{template-head}}
-template parameter list,
-excluding template parameter names and default arguments,
+template \termref{defns.parameter.templ}{parameter}{} list,
+excluding template parameter names and default \termref{defns.argument.templ}{argument}{s},
 and
 \grammarterm{requires-clause} (if any)
 
@@ -610,7 +611,7 @@ executing.
 \definition{sub-expression}{defns.regex.subexpression}
 \defncontext{regular expression}
 \indexdefn{sub-expression!regular expression}%
-subset of a regular expression that has
+subset of a \termref{defns.regex.regular.expression}{regular expression}{} that has
 been marked by parentheses
 
 \definition{traits class}{defns.traits}
@@ -621,7 +622,7 @@ function templates to manipulate objects of types for which they are instantiate
 
 \indexdefn{unblock}%
 \definition{unblock}{defns.unblock}
-satisfy a condition that one or more blocked threads of execution are waiting for
+satisfy a condition that one or more \termref{defns.block}{block}{ed} threads of execution are waiting for
 
 \indexdefn{behavior!undefined}%
 \definition{undefined behavior}{defns.undefined}
@@ -636,7 +637,7 @@ Permissible undefined behavior ranges
 from ignoring the situation completely with unpredictable results, to
 behaving during translation or program execution in a documented manner
 characteristic of the environment (with or without the issuance of a
-diagnostic message), to terminating a translation or execution (with the
+\termref{defns.diagnostic}{diagnostic message}{}), to terminating a translation or execution (with the
 issuance of a diagnostic message). Many erroneous program constructs do
 not engender undefined behavior; they are required to be diagnosed.
 Evaluation of a constant expression\iref{expr.const} never exhibits behavior explicitly
@@ -645,7 +646,7 @@ specified as undefined in \ref{intro} through \ref{cpp}.
 
 \indexdefn{behavior!unspecified}%
 \definition{unspecified behavior}{defns.unspecified}
-behavior, for a well-formed program construct and correct data, that
+behavior, for a \termref{defns.well.formed}{well-formed program}{} construct and correct data, that
 depends on the implementation
 
 \begin{defnote}

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -368,6 +368,7 @@
 %% Cross-reference
 \newcommand{\xref}{\textsc{See also:}\space}
 \newcommand{\xrefc}[1]{\xref{} \IsoC{}, #1}
+\newcommand{\termref}[3]{\textit{#2}{#3}\iref{#1}} % in Clause 3
 
 %% Inline comma-separated parenthesized references
 \ExplSyntaxOn


### PR DESCRIPTION
Fixes ISO/CS 017 (C++23 DIS).