### PR TITLE
Fix typo in [allocator.requirements.general] wording for `a.construct(c, args)`

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2572,7 +2572,7 @@ Nothing.
 \end{itemdescr}
 
 \begin{itemdecl}
-a.construct(c, args)
+a.construct(c, args...)
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Add missing ellipsis, changing to `a.construct(c, args...)`.

Hopefully this fix can be made editorially.

CC: @jwakely 