### PR TITLE
[stacktrace.format], [stacktrace.basic.hash] change rSec3 to rSec2

### DIFF
--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -2400,7 +2400,7 @@ template<class Allocator>
 Equivalent to: \tcode{return os << to_string(st);}
 \end{itemdescr}
 
-\rSec3[stacktrace.format]{Formatting support}
+\rSec2[stacktrace.format]{Formatting support}
 
 \begin{itemdecl}
 template<> struct formatter<stacktrace_entry>;
@@ -2442,7 +2442,7 @@ A \tcode{basic_stacktrace<Allocator>} object \tcode{s} is formatted as if by
 copying \tcode{to_string(s)} through the output iterator of the context.
 \end{itemdescr}
 
-\rSec3[stacktrace.basic.hash]{Hash support}
+\rSec2[stacktrace.basic.hash]{Hash support}
 
 \begin{itemdecl}
 template<> struct hash<stacktrace_entry>;


### PR DESCRIPTION
These should not be nested below `std::basic_stacktrace` because they apply to both `std::stacktrace_entry` and `std::basic_stacktrace`.