### PR TITLE
P2836R1 std::basic_const_iterator should follow its underlying type's convertibility

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -4288,6 +4288,13 @@ namespace std {
     template<@\libconcept{sentinel_for}@<Iterator> S>
       constexpr bool operator==(const S& s) const;
 
+    template<@\exposconcept{not-a-const-iterator}@ CI>
+      requires @\exposconcept{constant-iterator}@<CI> && @\libconcept{convertible_to}@<Iterator const&, CI>
+    constexpr operator CI() const &;
+    template<@\exposconcept{not-a-const-iterator}@ CI>
+      requires @\exposconcept{constant-iterator}@<CI> && @\libconcept{convertible_to}@<Iterator, CI>
+    constexpr operator CI() &&;
+
     constexpr bool operator<(const basic_const_iterator& y) const
       requires @\libconcept{random_access_iterator}@<Iterator>;
     constexpr bool operator>(const basic_const_iterator& y) const
@@ -4588,6 +4595,30 @@ template<@\libconcept{sentinel_for}@<Iterator> S>
 \pnum
 \effects
 Equivalent to: \tcode{return \exposid{current_} == s;}
+\end{itemdescr}
+
+\begin{itemdecl}
+template<@\exposconcept{not-a-const-iterator}@ CI>
+  requires @\exposconcept{constant-iterator}@<CI> && @\libconcept{convertible_to}@<Iterator const&, CI>
+constexpr operator CI() const &;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\exposid{current_}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<@\exposconcept{not-a-const-iterator}@ CI>
+  requires @\exposconcept{constant-iterator}@<CI> && @\libconcept{convertible_to}@<Iterator, CI>
+constexpr operator CI() &&;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{std::move(\exposid{current_})}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<}{basic_const_iterator}%

--- a/source/support.tex
+++ b/source/support.tex
@@ -725,7 +725,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_quoted_string_io}@                  201304L // also in \libheader{iomanip}
 #define @\defnlibxname{cpp_lib_ranges}@                            202302L
   // also in \libheader{algorithm}, \libheader{functional}, \libheader{iterator}, \libheader{memory}, \libheader{ranges}
-#define @\defnlibxname{cpp_lib_ranges_as_const}@                   202207L // freestanding, also in \libheader{ranges}
+#define @\defnlibxname{cpp_lib_ranges_as_const}@                   202311L // freestanding, also in \libheader{ranges}
 #define @\defnlibxname{cpp_lib_ranges_as_rvalue}@                  202207L // freestanding, also in \libheader{ranges}
 #define @\defnlibxname{cpp_lib_ranges_cartesian_product}@          202207L // freestanding, also in \libheader{ranges}
 #define @\defnlibxname{cpp_lib_ranges_chunk}@                      202202L // freestanding, also in \libheader{ranges}


### PR DESCRIPTION
Fixes #6675
Fixes cplusplus/papers#1509