### PR TITLE
[LWG 18] P2264R7 Make assert() macro user friendly for C and C++

### DIFF
--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -451,25 +451,57 @@ underflow_error(const char* what_arg);
 \pnum
 The header \libheaderdef{cassert}
 provides a macro for documenting \Cpp{} program assertions and a mechanism
-for disabling the assertion checks.
+for disabling the assertion checks through defining the macro \tcode{NDEBUG}.
 
 \rSec2[cassert.syn]{Header \tcode{<cassert>} synopsis}
 
 \indexlibraryglobal{assert}%
 \begin{codeblock}
-#define assert(E) @\seebelow@
+#define assert(...) @\seebelow@
+\end{codeblock}
+
+\rSec2[assertions.assert]{The \tcode{assert} macro}
+
+\pnum
+If \tcode{NDEBUG} is defined as a macro name
+at the point in the source file where \tcode{<cassert>} is included,
+the \tcode{assert} macro is defined as
+\begin{codeblock}
+#define assert(...) ((void)0)
 \end{codeblock}
 
 \pnum
-\indextext{static_assert@\tcode{static_assert}!not macro}%
-The contents are the same as the C standard library header
-\libheader{assert.h},
-except that a macro named \keyword{static_assert}
-is not defined.
+Otherwise, the \tcode{assert} macro puts a diagnostic test into programs;
+it expands to an expression of type \keyword{void} which
+has the following effects:
 
-\xrefc{7.2}
+\begin{itemize}
+\item
+\mname{VA_ARGS} is evaluated and contextually converted to \tcode{bool}.
+\item
+If the evaluation yields \tcode{true} there are no further effects.
+\item
+Otherwise, the \tcode{assert} macro's expression
+creates a diagnostic on the standard error stream in an
+\impldef{format of diagnostic created by \tcode{assert} macro's expression}
+format and calls \tcode{abort()}.
+The diagnostic contains \tcode{\#}\mname{VA_ARGS} and
+information on
+the name of the source file,
+the source line number, and
+the name of the enclosing function
+(such as provided by \tcode{source_location::current()}).
+\end{itemize}
 
-\rSec2[assertions.assert]{The \tcode{assert} macro}
+\pnum
+If \mname{VA_ARGS} does not expand to
+an \grammarterm{assignment-expression},
+the program is ill-formed.
+
+\pnum
+The macro \tcode{assert} is redefined according to
+the current state of \tcode{NDEBUG} each time that
+\tcode{<cassert>} is included.
 
 \pnum
 An expression \tcode{assert(E)}


### PR DESCRIPTION
Fixes #6676.
Fixes cplusplus/papers#957

Question: Was the red wording in [cassert.syn] intended to be deleted?
- Update: Thomas says no; added back and force-pushed.