### PR TITLE
[LWG 16] P2833R2 Freestanding Library: inout expected span

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -18223,13 +18223,14 @@ other facilities for interacting with these multidimensional views.
 \begin{codeblock}
 #include <initializer_list>     // see \ref{initializer.list.syn}
 
+// mostly freestanding
 namespace std {
   // constants
   inline constexpr size_t @\libglobal{dynamic_extent}@ = numeric_limits<size_t>::max();
 
   // \ref{views.span}, class template \tcode{span}
   template<class ElementType, size_t Extent = dynamic_extent>
-    class span;
+    class span;                                                             // partially freestanding
 
   template<class ElementType, size_t Extent>
     constexpr bool ranges::@\libspec{enable_view}{span}@<span<ElementType, Extent>> = true;
@@ -19037,6 +19038,7 @@ in the interval $[L_i, U_i)$ of $S$.
 
 \indexheader{mdspan}%
 \begin{codeblock}
+// all freestanding
 namespace std {
   // \ref{mdspan.extents}, class template \tcode{extents}
   template<class IndexType, size_t... Extents>

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1525,6 +1525,7 @@ include at least the headers shown in \tref{headers.cpp.fs}.
 \ref{tuple}              & Tuples                    & \tcode{<tuple>}            \\ \rowsep
 \ref{optional}           & Optional objects          & \tcode{<optional>}         \\ \rowsep
 \ref{variant}            & Variants                  & \tcode{<variant>}          \\ \rowsep
+\ref{expected}           & Expected objects          & \tcode{<expected>}         \\ \rowsep
 \ref{function.objects}   & Function objects          & \tcode{<functional>}       \\ \rowsep
 \ref{charconv}           & Primitive numeric conversions & \tcode{<charconv>}     \\ \rowsep
 \ref{bit}                & Bit manipulation          & \tcode{<bit>}              \\ \rowsep
@@ -1532,6 +1533,8 @@ include at least the headers shown in \tref{headers.cpp.fs}.
 \ref{string.classes}     & String classes            & \tcode{<string>}           \\ \rowsep
 \ref{c.strings}          & Null-terminated sequence utilities & \tcode{<cstring>}, \tcode{<cwchar>} \\ \rowsep
 \ref{array}              & Class template \tcode{array} & \tcode{<array>}         \\ \rowsep
+\ref{views.contiguous}   & Contiguous access         & \tcode{<span>}             \\ \rowsep
+\ref{views.multidim}     & Multidimensional access   & \tcode{<mdspan>}           \\ \rowsep
 \ref{iterators}          & Iterators library         & \tcode{<iterator>}         \\ \rowsep
 \ref{ranges}             & Ranges library            & \tcode{<ranges>}           \\ \rowsep
 \ref{algorithms}         & Algorithms library        & \tcode{<algorithm>}, \tcode{<numeric>} \\ \rowsep

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -570,19 +570,19 @@ namespace std {
 
   // \ref{out.ptr.t}, class template \tcode{out_ptr_t}
   template<class Smart, class Pointer, class... Args>
-    class out_ptr_t;
+    class out_ptr_t;                                                                // freestanding
 
   // \ref{out.ptr}, function template \tcode{out_ptr}
   template<class Pointer = void, class Smart, class... Args>
-    auto out_ptr(Smart& s, Args&&... args);
+    auto out_ptr(Smart& s, Args&&... args);                                         // freestanding
 
   // \ref{inout.ptr.t}, class template \tcode{inout_ptr_t}
   template<class Smart, class Pointer, class... Args>
-    class inout_ptr_t;
+    class inout_ptr_t;                                                              // freestanding
 
   // \ref{inout.ptr}, function template \tcode{inout_ptr}
   template<class Pointer = void, class Smart, class... Args>
-    auto inout_ptr(Smart& s, Args&&... args);
+    auto inout_ptr(Smart& s, Args&&... args);                                       // freestanding
 }
 \end{codeblock}
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -647,9 +647,11 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_freestanding_cwchar}@               202306L // freestanding, also in \libheader{cwchar}
 #define @\defnlibxname{cpp_lib_freestanding_errc}@                 202306L
   // freestanding, also in \libheader{cerrno}, \libheader{system_error}
+#define @\defnlibxname{cpp_lib_freestanding_expected}@             202311L // freestanding, also in \libheader{expected}
 #define @\defnlibxname{cpp_lib_freestanding_feature_test_macros}@  202306L // freestanding
 #define @\defnlibxname{cpp_lib_freestanding_functional}@           202306L // freestanding, also in \libheader{functional}
 #define @\defnlibxname{cpp_lib_freestanding_iterator}@             202306L // freestanding, also in \libheader{iterator}
+#define @\defnlibxname{cpp_lib_freestanding_mdspan}@               202311L // freestanding, also in \libheader{mdspan}
 #define @\defnlibxname{cpp_lib_freestanding_memory}@               202306L // freestanding, also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_freestanding_operator_new}@         @\seebelow@ // freestanding, also in \libheader{new}
 #define @\defnlibxname{cpp_lib_freestanding_optional}@             202311L // freestanding, also in \libheader{optional}
@@ -716,7 +718,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_not_fn}@                            202306L // freestanding, also in \libheader{functional}
 #define @\defnlibxname{cpp_lib_null_iterators}@                    201304L // freestanding, also in \libheader{iterator}
 #define @\defnlibxname{cpp_lib_optional}@                          202110L // also in \libheader{optional}
-#define @\defnlibxname{cpp_lib_out_ptr}@                           202106L // also in \libheader{memory}
+#define @\defnlibxname{cpp_lib_out_ptr}@                           202311L // freestanding, also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_parallel_algorithm}@                201603L // also in \libheader{algorithm}, \libheader{numeric}
 #define @\defnlibxname{cpp_lib_polymorphic_allocator}@             201902L // also in \libheader{memory_resource}
 #define @\defnlibxname{cpp_lib_print}@                             202207L // also in \libheader{print}, \libheader{ostream}
@@ -761,7 +763,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_smart_ptr_for_overwrite}@           202002L // also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_smart_ptr_owner_equality}@          202306L // also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_source_location}@                   201907L // freestanding, also in \libheader{source_location}
-#define @\defnlibxname{cpp_lib_span}@                              202311L // also in \libheader{span}
+#define @\defnlibxname{cpp_lib_span}@                              202311L // freestanding, also in \libheader{span}
 #define @\defnlibxname{cpp_lib_span_initializer_list}@             202311L // also in \libheader{span}
 #define @\defnlibxname{cpp_lib_spanstream}@                        202106L // also in \libheader{spanstream}
 #define @\defnlibxname{cpp_lib_ssize}@                             201902L // freestanding, also in \libheader{iterator}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6995,6 +6995,7 @@ manages the lifetime of the contained objects.
 \indexlibraryglobal{unexpect_t}%
 \indexlibraryglobal{unexpect}%
 \begin{codeblock}
+// mostly freestanding
 namespace std {
   // \ref{expected.unexpected}, class template \tcode{unexpected}
   template<class E> class unexpected;
@@ -7012,10 +7013,10 @@ namespace std {
   inline constexpr unexpect_t unexpect{};
 
   // \ref{expected.expected}, class template \tcode{expected}
-  template<class T, class E> class expected;
+  template<class T, class E> class expected;                                // partially freestanding
 
   // \ref{expected.void}, partial specialization of \tcode{expected} for \tcode{void} types
-  template<class T, class E> requires is_void_v<T> class expected<T, E>;
+  template<class T, class E> requires is_void_v<T> class expected<T, E>;    // partially freestanding
 }
 \end{codeblock}
 
@@ -7398,10 +7399,10 @@ namespace std {
     constexpr T&& operator*() && noexcept;
     constexpr explicit operator bool() const noexcept;
     constexpr bool has_value() const noexcept;
-    constexpr const T& value() const &;
-    constexpr T& value() &;
-    constexpr const T&& value() const &&;
-    constexpr T&& value() &&;
+    constexpr const T& value() const &;                                     // freestanding-deleted
+    constexpr T& value() &;                                                 // freestanding-deleted
+    constexpr const T&& value() const &&;                                   // freestanding-deleted
+    constexpr T&& value() &&;                                               // freestanding-deleted
     constexpr const E& error() const & noexcept;
     constexpr E& error() & noexcept;
     constexpr const E&& error() const && noexcept;
@@ -8792,8 +8793,8 @@ public:
   constexpr explicit operator bool() const noexcept;
   constexpr bool has_value() const noexcept;
   constexpr void operator*() const noexcept;
-  constexpr void value() const &;
-  constexpr void value() &&;
+  constexpr void value() const &;                                           // freestanding-deleted
+  constexpr void value() &&;                                                // freestanding-deleted
   constexpr const E& error() const & noexcept;
   constexpr E& error() & noexcept;
   constexpr const E&& error() const && noexcept;


### PR DESCRIPTION
Partially fixes #6674.

Note:
* See #6692 for change to [views.span] after [P2821] "span.at()" merged:  "append a // freestanding-deleted comment to every overload of at". I only saw one such "overload" - should there be more?