### PR TITLE
Updated templates.tex to make program ill formed when the set of func…

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -8740,6 +8740,9 @@ or the type of the deallocation function that would match the placement
 deduction is done as described in~\ref{temp.deduct.type}.
 
 \pnum
+If the set of function templates so considered is empty, the program is ill-formed.
+
+\pnum
 If, for the set of function templates so considered, there is either no match or
 more than one match after partial ordering has been considered\iref{temp.func.order},
 deduction fails and, in the declaration cases, the


### PR DESCRIPTION
…tion templates considered is empty

Related to [CWG-issue-465](https://github.com/cplusplus/CWG/issues/465) that notes that currently there is [implementation divergence](https://godbolt.org/z/v86Ga7Mrj) for the friend declaration `friend void fun2<T>(typename Ext<T>::Inner&);` when there is no forward declaration of any such `func2` function template. The edit is suppose to clarify that [temp.deduct.decl#2](https://timsong-cpp.github.io/cppwp/n4868/temp.deduct.decl#2) clause makes the program ill-formed.