### PR TITLE
[LWG 11] P2868 Remove deprecated typedef from std::allocator

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -107,6 +107,28 @@ auto s = std::to_string(1e-7);  // \tcode{"1e-07"}
                                 // changed according to the global C locale
 \end{codeblock}
 
+\rSec2[diff.cpp23.depr]{\ref{depr}: compatibility features}
+
+\nodiffref
+\change
+Remove the type alias \tcode{allocator<T>::is_always_equal}.
+\rationale
+Non-empty allocator classes derived from \tcode{allocator} needed to explicitly
+define an \tcode{is_always_equal} member type so that \tcode{allocator_traits}
+would not use the one from the allocator base class.
+\effect
+It is simpler to correctly define an allocator class with an allocator base
+class. For example:
+\begin{codeblock}
+template <class T>
+struct MyAlloc : allocator<T> {
+  int tag;
+};
+
+static_assert(!allocator_traits<MyAlloc<int>>::is_always_equal);        // Error in \CppXXIII{},
+                                                                        // OK in \CppXXVI{}
+\end{codeblock}
+
 \rSec2[diff.cpp23.containers]{\ref{containers}: containers library}
 
 \diffref{span.overview}

--- a/source/future.tex
+++ b/source/future.tex
@@ -1383,22 +1383,6 @@ The value of each \tcode{enum errc} enumerator above
 is the same as the value of the \libheader{cerrno} macro
 shown in the above synopsis.
 
-\rSec1[depr.default.allocator]{The default allocator}
-
-\pnum
-The following member is defined in addition to those
-specified in \ref{default.allocator}:
-
-\indexlibrarymember{is_always_equal}{allocator}%
-\begin{codeblock}
-namespace std {
-  template<class T> class allocator {
-  public:
-    using is_always_equal = true_type;
-  };
-}
-\end{codeblock}
-
 \rSec1[depr.mem.poly.allocator.mem]{Deprecated \tcode{polymorphic_allocator} member function}
 
 \pnum

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -22,6 +22,9 @@
 % P2864R2 Remove deprecated arithmetic conversions
 \removedxref{depr.arith.conv.enum}
 
+% P2870R3 Remove deprecated typedef from `std::allocator`
+\removedxref{depr.default.allocator}
+
 % P2874R2 Mandating Annex D
 \removedxref{depr.res.on.required}
 


### PR DESCRIPTION
Fixes #6669
Fixes cplusplus/papers#1524