### PR TITLE
[LWG 12] P2870R3 Remove deprecated basic_string::reserve() with no parameters

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -107,6 +107,31 @@ auto s = std::to_string(1e-7);  // \tcode{"1e-07"}
                                 // changed according to the global C locale
 \end{codeblock}
 
+\rSec2[diff.cpp23.containers]{\ref{containers}: containers library}
+
+\diffref{span.overview}
+\change
+\tcode{span<const T>} is constructible from \tcode{initializer_list<T>}.
+\rationale
+Permit passing a braced initializer list to a function taking \tcode{span}.
+\effect
+Valid \CppXXIII{} code that relies on the lack of this constructor
+may refuse to compile, or change behavior in this revision of \Cpp{}.
+For example:
+\begin{codeblock}
+void one(pair<int, int>);       // \#1
+void one(span<const int>);      // \#2
+void t1() { one({1, 2}); }      // ambiguous between \#1 and \#2; previously called \#1
+
+void two(span<const int, 2>);
+void t2() { two({{1, 2}}); }    // ill-formed; previously well-formed
+
+void *a[10];
+int x = span<void* const>{a, 0}.size();     // \tcode{x} is \tcode{2}; previously \tcode{0}
+any b[10];
+int y = span<const any>{b, b + 10}.size();  // \tcode{y} is \tcode{2}; previously \tcode{10}
+\end{codeblock}
+
 \rSec2[diff.cpp23.depr]{\ref{depr}: compatibility features}
 
 \nodiffref
@@ -140,31 +165,6 @@ A valid \CppXXIII{} program that calls \tcode{reserve()}
 on a \tcode{basic_string} object may fail to compile.
 The old functionality can be achieved by calling \tcode{shrink_to_fit()} instead,
 or the function call can be safely eliminated with no side effects.
-
-\rSec2[diff.cpp23.containers]{\ref{containers}: containers library}
-
-\diffref{span.overview}
-\change
-\tcode{span<const T>} is constructible from \tcode{initializer_list<T>}.
-\rationale
-Permit passing a braced initializer list to a function taking \tcode{span}.
-\effect
-Valid \CppXXIII{} code that relies on the lack of this constructor
-may refuse to compile, or change behavior in this revision of \Cpp{}.
-For example:
-\begin{codeblock}
-void one(pair<int, int>);       // \#1
-void one(span<const int>);      // \#2
-void t1() { one({1, 2}); }      // ambiguous between \#1 and \#2; previously called \#1
-
-void two(span<const int, 2>);
-void t2() { two({{1, 2}}); }    // ill-formed; previously well-formed
-
-void *a[10];
-int x = span<void* const>{a, 0}.size();     // \tcode{x} is \tcode{2}; previously \tcode{0}
-any b[10];
-int y = span<const any>{b, b + 10}.size();  // \tcode{y} is \tcode{2}; previously \tcode{10}
-\end{codeblock}
 
 \rSec1[diff.cpp20]{\Cpp{} and ISO \CppXX{}}
 

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -129,6 +129,18 @@ static_assert(!allocator_traits<MyAlloc<int>>::is_always_equal);        // Error
                                                                         // OK in \CppXXVI{}
 \end{codeblock}
 
+\nodiffref
+\change
+Remove the \tcode{basic_string::reserve()} overload with no parameters.
+\rationale
+The overload of \tcode{reserve} with no parameters is redundant.
+The \tcode{shrink_to_fit} member function can be used instead.
+\effect
+A valid \CppXXIII{} program that calls \tcode{reserve()}
+on a \tcode{basic_string} object may fail to compile.
+The old functionality can be achieved by calling \tcode{shrink_to_fit()} instead,
+or the function call can be safely eliminated with no side effects.
+
 \rSec2[diff.cpp23.containers]{\ref{containers}: containers library}
 
 \diffref{span.overview}

--- a/source/future.tex
+++ b/source/future.tex
@@ -1995,39 +1995,6 @@ pointer value and share ownership.
 The weak form may fail spuriously. See~\ref{atomics.types.operations}.
 \end{itemdescr}
 
-\rSec1[depr.string.capacity]{Deprecated \tcode{basic_string} capacity}
-
-\pnum
-The following member is declared in addition to those members specified
-in \ref{string.capacity}:
-
-\indexlibraryglobal{basic_string}%
-\begin{codeblock}
-namespace std {
-  template<class charT, class traits = char_traits<charT>,
-           class Allocator = allocator<charT>>
-  class basic_string {
-  public:
-    void reserve();
-  };
-}
-\end{codeblock}
-
-\indexlibrarymember{reserve}{basic_string}%
-\begin{itemdecl}
-void reserve();
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-After this call, \tcode{capacity()} has an unspecified value
-greater than or equal to \tcode{size()}.
-\begin{note}
-This is a non-binding shrink to fit request.
-\end{note}
-\end{itemdescr}
-
 \rSec1[depr.format]{Deprecated formatting}
 
 \rSec2[depr.format.syn]{Header \tcode{<format>} synopsis}

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -28,6 +28,9 @@
 % P2874R2 Mandating Annex D
 \removedxref{depr.res.on.required}
 
+% P2870R3 Remove `basic_string::reserve()` with no parameters
+\removedxref{depr.string.capacity}
+
 %%% Renamed sections.
 %%% Examples:
 %


### PR DESCRIPTION
Fixes #6670 
Fixes cplusplus/papers#1526