### PR TITLE
[class.eq] Fix the return value of a defaulted == operator function

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6511,8 +6511,8 @@ in the expanded lists of subobjects for \tcode{x} and \tcode{y}
 until the first index $i$
 where $\tcode{x}_i\tcode{ == }\tcode{y}_i$ yields a result value which,
 when contextually converted to \tcode{bool}, yields \tcode{false}.
-The return value is \tcode{true} if such an index exists
-and \tcode{false} otherwise.
+The return value is \tcode{false} if such an index exists
+and \tcode{true} otherwise.
 
 \pnum
 \begin{example}


### PR DESCRIPTION
The last sentence of [class.eq]p3 says the opposite after the refactor done in #6035.