### PR TITLE
[dcl.init.ref, over.ics.ref, over.ics.rank] Avoid saying function lvalue

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -5620,13 +5620,14 @@ double& rd3 = i;                // error: type mismatch and reference not \keywo
 
 \item Otherwise, if the initializer expression
 \begin{itemize}
-\item is an rvalue (but not a bit-field) or function lvalue and
+\item is an rvalue (but not a bit-field) or an lvalue of function type and
 ``\cvqual{cv1} \tcode{T1}'' is
 reference-compatible with ``\cvqual{cv2} \tcode{T2}'', or
 
 \item has a class type (i.e., \tcode{T2} is a class type), where \tcode{T1}
 is not reference-related to \tcode{T2}, and can be converted to
-an rvalue or function lvalue of type ``\cvqual{cv3} \tcode{T3}'',
+an rvalue of type ``\cvqual{cv3} \tcode{T3}'' or
+an lvalue of function type ``\cvqual{cv3} \tcode{T3}'',
 where ``\cvqual{cv1} \tcode{T1}'' is
 reference-compatible with ``\cvqual{cv3} \tcode{T3}'' (see~\ref{over.match.ref}),
 \end{itemize}

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2716,8 +2716,8 @@ or, if not that,
 
 \item
 \tcode{S1} and \tcode{S2} include reference bindings\iref{dcl.init.ref} and
-\tcode{S1} binds an lvalue reference to a function lvalue and \tcode{S2} binds
-an rvalue reference to a function lvalue
+\tcode{S1} binds an lvalue reference to an lvalue of function type and
+\tcode{S2} binds an rvalue reference to an lvalue of function type
 \begin{example}
 \begin{codeblock}
 int f(void(&)());               // \#1

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2318,7 +2318,7 @@ an implicit conversion sequence cannot be formed if it requires
 binding an lvalue reference
 other than a reference to a non-volatile \keyword{const} type
 to an rvalue
-or binding an rvalue reference to an lvalue other than a function lvalue.
+or binding an rvalue reference to an lvalue of object type.
 \begin{note}
 This means, for example, that a candidate function cannot be a viable
 function if it has a non-\keyword{const} lvalue reference parameter (other than


### PR DESCRIPTION
Fixes cplusplus/CWG#469.

Note that we can simplify the wording in [[over.ics.ref] p3](https://eel.is/c++draft/over.ics.ref#3) by the fact that an lvalue is of either an object type or a function type.