### PR TITLE
[std] Update references from ISO 8601:2004 to ISO 8601-1:2019

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -34,8 +34,7 @@ For undated references, the latest edition of the referenced document
 \begin{itemize}
 % ISO documents in numerical order.
 \item ISO/IEC 2382, \doccite{Information technology --- Vocabulary}
-\item ISO 8601:2004, \doccite{Data elements and interchange formats ---
-Information interchange --- Representation of dates and times}
+\item ISO 8601-1:2019, \doccite{Date and time --- Representations for information interchange --- Part 1: Basic rules}
 \item \IsoC{}, \doccite{Information technology --- Programming languages --- C}
 \item ISO/IEC/IEEE 9945:2009, \doccite{Information Technology --- Portable
 Operating System Interface (POSIX

--- a/source/time.tex
+++ b/source/time.tex
@@ -10533,7 +10533,7 @@ the global locale.
 Each conversion specifier \fmtgrammarterm{conversion-spec}
 is replaced by appropriate characters
 as described in \tref{time.format.spec};
-the formats specified in ISO 8601:2004 shall be used where so described.
+the formats specified in ISO 8601-1:2019 shall be used where so described.
 Some of the conversion specifiers
 depend on the formatting locale.
 If the string literal encoding is a Unicode encoding form and
@@ -10793,7 +10793,7 @@ The modified command \tcode{\%EY} produces
 the locale's alternative full year representation.
 \\ \rowsep
 \tcode{\%z} &
-The offset from UTC as specified in ISO 8601:2004, subclause 4.2.5.2.
+The offset from UTC as specified in ISO 8601-1:2019, subclause 5.3.4.1.
 For example \tcode{-0430} refers to 4 hours 30 minutes behind UTC\@.
 If the offset is zero, \tcode{+0000} is used.
 The modified commands \tcode{\%Ez} and  \tcode{\%Oz}


### PR DESCRIPTION
As requested by ISO/CS for C++23 DIS.