### PR TITLE
[introduction] A minimal "Introduction" clause

### DIFF
--- a/source/preface.tex
+++ b/source/preface.tex
@@ -1,4 +1,19 @@
 %!TEX root = std.tex
+
 \chapter{Foreword}
 
 [This page is intentionally left blank.]
+
+\chapter{Introduction}
+
+Clauses and subclauses in this document are annotated
+with a so-called stable name,
+presented in square brackets next to the (sub)clause heading
+(such as ``[lex.token]'' for subclause \ref{lex.token}, ``Tokens'').
+Stable names aid in the discussion and evolution of this document
+by serving as stable references to subclauses across editions
+that are unaffected by changes of subclause numbering.
+
+Aspects of the language syntax of \Cpp{} are distinguished typographically
+by the use of \fakegrammarterm{italic, sans-serif} type
+or \tcode{constant width} type to avoid ambiguities; see \ref{syntax}.


### PR DESCRIPTION
This clause explains our conventions regarding stable labels and choice of fonts.

It is based on a similar, minimal Introduction used by the Library Fundamentals TS for similar purposes.

This is the initial contribution to #6271, and for C++26 we should expand this material considerably.