### PR TITLE
[intro.defs] Remove mention of symbols from ISO 80000-2

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -76,9 +76,7 @@ Available from: \url{https://www.unicode.org/versions/latest/}
 \indextext{definitions|(}%
 For the purposes of this document,
 the terms and definitions
-given in ISO/IEC 2382,
-the terms, definitions, and symbols
-given in ISO 80000-2:2009,
+given in ISO/IEC 2382 and ISO 80000-2:2009
 and the following apply.
 
 \pnum


### PR DESCRIPTION
According to ISO/CS, symbols cannot be imported by reference.