### PR TITLE
[range.access.general] Use consistent "In addition to being available" form

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -600,7 +600,7 @@ of the same width as \tcode{X}.
 \pnum
 In addition to being available via inclusion of the \libheader{ranges}
 header, the customization point objects in \ref{range.access} are
-available when \libheaderrefx{iterator}{iterator.synopsis} is included.
+available when the header \libheaderrefx{iterator}{iterator.synopsis} is included.
 
 \pnum
 Within \ref{range.access},


### PR DESCRIPTION
Elsewhere we say "the header" or "any of the headers", e.g. [meta.trans.other], [tuple.helper], etc.