### PR TITLE
[algorithm.syn] refactors _`indirectly-binary-left-foldable`_

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -1235,20 +1235,21 @@ namespace std {
       invoke_result_t<F&, U, T> operator()(T&&, U&&);
     };
 
-    template<class F, class T, class I, class U>
+    template<class F, class T, class I, class R, class U = decay_t<R>>
       concept @\defexposconcept{indirectly-binary-left-foldable-impl}@ =  // \expos
-        @\libconcept{movable}@<T> && @\libconcept{movable}@<U> &&
-        @\libconcept{convertible_to}@<T, U> && @\libconcept{invocable}@<F&, U, iter_reference_t<I>> &&
+        @\libconcept{convertible_to}@<R, U> &&
+        @\libconcept{movable}@<T> &&
+        @\libconcept{movable}@<U> &&
+        @\libconcept{convertible_to}@<T, U> &&
+        @\libconcept{invocable}@<F&, U, iter_reference_t<I>> &&
         @\libconcept{assignable_from}@<U&, invoke_result_t<F&, U, iter_reference_t<I>>>;
 
     template<class F, class T, class I>
       concept @\defexposconcept{indirectly-binary-left-foldable}@ =      // \expos
-        @\libconcept{copy_constructible}@<F> && @\libconcept{indirectly_readable}@<I> &&
+        @\libconcept{copy_constructible}@<F> &&
         @\libconcept{invocable}@<F&, T, iter_reference_t<I>> &&
-        @\libconcept{convertible_to}@<invoke_result_t<F&, T, iter_reference_t<I>>,
-               decay_t<invoke_result_t<F&, T, iter_reference_t<I>>>> &&
         @\exposconcept{indirectly-binary-left-foldable-impl}@<F, T, I,
-                        decay_t<invoke_result_t<F&, T, iter_reference_t<I>>>>;
+                        invoke_result_t<F&, T, iter_reference_t<I>>>;
 
     template<class F, class T, class I>
       concept @\defexposconcept{indirectly-binary-right-foldable}@ =    // \expos


### PR DESCRIPTION
* removes `indirectly_readable`, which is already checked by all of the algorithms using this exposition-only concept
* pushes `convertible_to<>` into the impl concept to deduplicate information.