### PR TITLE
[algorithms] reorders the fold family

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -1254,12 +1254,34 @@ namespace std {
       concept @\defexposconcept{indirectly-binary-right-foldable}@ =    // \expos
         @\exposconcept{indirectly-binary-left-foldable}@<@\exposid{flipped}@<F>, T, I>;
 
+    template<class I, class T>
+      using fold_left_with_iter_result = in_value_result<I, T>;
+    template<class I, class T>
+      using fold_left_first_with_iter_result = in_value_result<I, T>;
+
+    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T,
+             @\exposconcept{indirectly-binary-left-foldable}@<T, I> F>
+      constexpr @\seebelow@ fold_left_with_iter(I first, S last, T init, F f);
+
+    template<@\libconcept{input_range}@ R, class T, @\exposconcept{indirectly-binary-left-foldable}@<T, iterator_t<R>> F>
+      constexpr @\seebelow@ fold_left_with_iter(R&& r, T init, F f);
+
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T,
              @\exposconcept{indirectly-binary-left-foldable}@<T, I> F>
       constexpr auto fold_left(I first, S last, T init, F f);
 
     template<@\libconcept{input_range}@ R, class T, @\exposconcept{indirectly-binary-left-foldable}@<T, iterator_t<R>> F>
       constexpr auto fold_left(R&& r, T init, F f);
+
+      template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S,
+               @\exposconcept{indirectly-binary-left-foldable}@<iter_value_t<I>, I> F>
+        requires @\libconcept{constructible_from}@<iter_value_t<I>, iter_reference_t<I>>
+        constexpr @\seebelow@ fold_left_first_with_iter(I first, S last, F f);
+
+      template<@\libconcept{input_range}@ R,
+               @\exposconcept{indirectly-binary-left-foldable}@<range_value_t<R>, iterator_t<R>> F>
+        requires @\libconcept{constructible_from}@<range_value_t<R>, range_reference_t<R>>
+        constexpr @\seebelow@ fold_left_first_with_iter(R&& r, F f);
 
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S,
              @\exposconcept{indirectly-binary-left-foldable}@<iter_value_t<I>, I> F>
@@ -1287,28 +1309,6 @@ namespace std {
              @\exposconcept{indirectly-binary-right-foldable}@<range_value_t<R>, iterator_t<R>> F>
       requires @\libconcept{constructible_from}@<range_value_t<R>, range_reference_t<R>>
       constexpr auto fold_right_last(R&& r, F f);
-
-    template<class I, class T>
-      using fold_left_with_iter_result = in_value_result<I, T>;
-    template<class I, class T>
-      using fold_left_first_with_iter_result = in_value_result<I, T>;
-
-    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T,
-             @\exposconcept{indirectly-binary-left-foldable}@<T, I> F>
-      constexpr @\seebelow@ fold_left_with_iter(I first, S last, T init, F f);
-
-    template<@\libconcept{input_range}@ R, class T, @\exposconcept{indirectly-binary-left-foldable}@<T, iterator_t<R>> F>
-      constexpr @\seebelow@ fold_left_with_iter(R&& r, T init, F f);
-
-    template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S,
-             @\exposconcept{indirectly-binary-left-foldable}@<iter_value_t<I>, I> F>
-      requires @\libconcept{constructible_from}@<iter_value_t<I>, iter_reference_t<I>>
-      constexpr @\seebelow@ fold_left_first_with_iter(I first, S last, F f);
-
-    template<@\libconcept{input_range}@ R,
-             @\exposconcept{indirectly-binary-left-foldable}@<range_value_t<R>, iterator_t<R>> F>
-      requires @\libconcept{constructible_from}@<range_value_t<R>, range_reference_t<R>>
-      constexpr @\seebelow@ fold_left_first_with_iter(R&& r, F f);
   }
 
   // \ref{alg.modifying.operations}, mutating sequence operations
@@ -4632,6 +4632,39 @@ ranges::equal(ranges::drop_view(ranges::ref_view(r1), N1 - N2), r2, pred, proj1,
 
 \rSec2[alg.fold]{Fold}
 
+\indexlibraryglobal{fold_left_with_iter}%
+\begin{itemdecl}
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T,
+         @\exposconcept{indirectly-binary-left-foldable}@<T, I> F>
+  constexpr @\seebelow@ ranges::fold_left_with_iter(I first, S last, T init, F f);
+template<@\libconcept{input_range}@ R, class T, @\exposconcept{indirectly-binary-left-foldable}@<T, iterator_t<R>> F>
+  constexpr @\seebelow@ ranges::fold_left_with_iter(R&& r, T init, F f);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{U} be \tcode{decay_t<invoke_result_t<F\&, T, iter_reference_t<I>>>}.
+
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+if (first == last)
+  return {std::move(first), U(std::move(init))};
+U accum = invoke(f, std::move(init), *first);
+for (++first; first != last; ++first)
+  accum = invoke(f, std::move(accum), *first);
+return {std::move(first), std::move(accum)};
+\end{codeblock}
+
+\pnum
+\remarks
+The return type is
+\tcode{fold_left_with_iter_result<I, U>} for the first overload and
+\tcode{fold_left_with_iter_result<borrowed_iterator_t<R>, U>}
+for the second overload.
+\end{itemdescr}
+
 \indexlibraryglobal{fold_left}%
 \begin{itemdecl}
 template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T, @\exposconcept{indirectly-binary-left-foldable}@<T, I> F>
@@ -4646,6 +4679,45 @@ template<@\libconcept{input_range}@ R, class T, @\exposconcept{indirectly-binary
 \begin{codeblock}
 ranges::fold_left_with_iter(std::move(first), last, std::move(init), f).value
 \end{codeblock}
+\end{itemdescr}
+
+\indexlibraryglobal{fold_left_first_with_iter}%
+\begin{itemdecl}
+template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S,
+         @\exposconcept{indirectly-binary-left-foldable}@<iter_value_t<I>, I> F>
+  requires @\libconcept{constructible_from}@<iter_value_t<I>, iter_reference_t<I>>
+  constexpr @\seebelow@ ranges::fold_left_first_with_iter(I first, S last, F f);
+template<@\libconcept{input_range}@ R, @\exposconcept{indirectly-binary-left-foldable}@<range_value_t<R>, iterator_t<R>> F>
+  requires @\libconcept{constructible_from}@<range_value_t<R>, range_reference_t<R>>
+  constexpr @\seebelow@ ranges::fold_left_first_with_iter(R&& r, F f);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{U} be
+\begin{codeblock}
+decltype(ranges::fold_left(std::move(first), last, iter_value_t<I>(*first), f))
+\end{codeblock}
+
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+if (first == last)
+  return {std::move(first), optional<U>()};
+optional<U> init(in_place, *first);
+for (++first; first != last; ++first)
+  *init = invoke(f, std::move(*init), *first);
+return {std::move(first), std::move(init)};
+\end{codeblock}
+
+\pnum
+\remarks
+The return type is
+\tcode{fold_left_first_with_iter_result<I, optional<U>>}
+for the first overload and
+\tcode{fold_left_first_with_iter_result<borrowed_iterator_t<R>, optional<U>>}
+for the second overload.
 \end{itemdescr}
 
 \indexlibraryglobal{fold_left_first}%
@@ -4720,78 +4792,6 @@ I tail = ranges::prev(ranges::next(first, std::move(last)));
 return optional<U>(in_place,
   ranges::fold_right(std::move(first), tail, iter_value_t<I>(*tail), std::move(f)));
 \end{codeblock}
-\end{itemdescr}
-
-\indexlibraryglobal{fold_left_with_iter}%
-\begin{itemdecl}
-template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T,
-         @\exposconcept{indirectly-binary-left-foldable}@<T, I> F>
-  constexpr @\seebelow@ ranges::fold_left_with_iter(I first, S last, T init, F f);
-template<@\libconcept{input_range}@ R, class T, @\exposconcept{indirectly-binary-left-foldable}@<T, iterator_t<R>> F>
-  constexpr @\seebelow@ ranges::fold_left_with_iter(R&& r, T init, F f);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-Let \tcode{U} be \tcode{decay_t<invoke_result_t<F\&, T, iter_reference_t<I>>>}.
-
-\pnum
-\effects
-Equivalent to:
-\begin{codeblock}
-if (first == last)
-  return {std::move(first), U(std::move(init))};
-U accum = invoke(f, std::move(init), *first);
-for (++first; first != last; ++first)
-  accum = invoke(f, std::move(accum), *first);
-return {std::move(first), std::move(accum)};
-\end{codeblock}
-
-\pnum
-\remarks
-The return type is
-\tcode{fold_left_with_iter_result<I, U>} for the first overload and
-\tcode{fold_left_with_iter_result<borrowed_iterator_t<R>, U>}
-for the second overload.
-\end{itemdescr}
-
-\indexlibraryglobal{fold_left_first_with_iter}%
-\begin{itemdecl}
-template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S,
-         @\exposconcept{indirectly-binary-left-foldable}@<iter_value_t<I>, I> F>
-  requires @\libconcept{constructible_from}@<iter_value_t<I>, iter_reference_t<I>>
-  constexpr @\seebelow@ ranges::fold_left_first_with_iter(I first, S last, F f);
-template<@\libconcept{input_range}@ R, @\exposconcept{indirectly-binary-left-foldable}@<range_value_t<R>, iterator_t<R>> F>
-  requires @\libconcept{constructible_from}@<range_value_t<R>, range_reference_t<R>>
-  constexpr @\seebelow@ ranges::fold_left_first_with_iter(R&& r, F f);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-Let \tcode{U} be
-\begin{codeblock}
-decltype(ranges::fold_left(std::move(first), last, iter_value_t<I>(*first), f))
-\end{codeblock}
-
-\pnum
-\effects
-Equivalent to:
-\begin{codeblock}
-if (first == last)
-  return {std::move(first), optional<U>()};
-optional<U> init(in_place, *first);
-for (++first; first != last; ++first)
-  *init = invoke(f, std::move(*init), *first);
-return {std::move(first), std::move(init)};
-\end{codeblock}
-
-\pnum
-\remarks
-The return type is
-\tcode{fold_left_first_with_iter_result<I, optional<U>>}
-for the first overload and
-\tcode{fold_left_first_with_iter_result<borrowed_iterator_t<R>, optional<U>>}
-for the second overload.
 \end{itemdescr}
 
 \rSec1[alg.modifying.operations]{Mutating sequence operations}


### PR DESCRIPTION
I accidentally mixed up `fold_left_with_iter` with other fold algorithms multiple times while implementing it for libc++, and it might also be confusing reviewrs. This commit reorders them so that they appear in an order that they might be implemented.

* `fold_left_with_iter`
* `fold_left`
* `fold_left_first_with_iter`
* `fold_left_first`
* `fold_right`
* `fold_right_last`