### PR TITLE
[class.friend] Fix a mistakenly monospaced "`friend` declaration"

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -4850,7 +4850,7 @@ A friend declaration can be the
 a \grammarterm{template-declaration}\iref{temp.pre,temp.friend}.
 \end{note}
 If the
-type specifier in a \keyword{friend} declaration designates a (possibly
+type specifier in a friend declaration designates a (possibly
 cv-qualified) class type, that class is declared as a friend; otherwise, the
 friend declaration is ignored.
 \begin{example}


### PR DESCRIPTION
Everywhere else has "friend declaration" without monospace.

Sidebar: Actually, I fail to find any definition of the term "friend declaration"; it clearly means "any kind of declaration involving the `friend` keyword," but I don't see that spelled out. The logical place for such a definition might be [[dcl.friend]](https://eel.is/c++draft/dcl.spec#dcl.friend).