### PR TITLE
[version.syn] New feature test macro __cpp_lib_freestanding_numeric

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -637,8 +637,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_format_uchar}@                      202311L // also in \libheader{format}
 #define @\defnlibxname{cpp_lib_formatters}@                        202302L // also in \libheader{stacktrace}, \libheader{thread}
 #define @\defnlibxname{cpp_lib_forward_like}@                      202207L // freestanding, also in \libheader{utility}
-#define @\defnlibxname{cpp_lib_freestanding_algorithm}@            202311L
-  // freestanding, also in \libheader{algorithm}, \libheader{numeric}
+#define @\defnlibxname{cpp_lib_freestanding_algorithm}@            202311L // freestanding, also in \libheader{algorithm}
 #define @\defnlibxname{cpp_lib_freestanding_array}@                202311L // freestanding, also in \libheader{array}
 #define @\defnlibxname{cpp_lib_freestanding_char_traits}@          202306L // freestanding, also in \libheader{string}
 #define @\defnlibxname{cpp_lib_freestanding_charconv}@             202306L // freestanding, also in \libheader{charconv}
@@ -653,6 +652,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_freestanding_iterator}@             202306L // freestanding, also in \libheader{iterator}
 #define @\defnlibxname{cpp_lib_freestanding_mdspan}@               202311L // freestanding, also in \libheader{mdspan}
 #define @\defnlibxname{cpp_lib_freestanding_memory}@               202306L // freestanding, also in \libheader{memory}
+#define @\defnlibxname{cpp_lib_freestanding_numeric}@              202311L // freestanding, also in \libheader{numeric}
 #define @\defnlibxname{cpp_lib_freestanding_operator_new}@         @\seebelow@ // freestanding, also in \libheader{new}
 #define @\defnlibxname{cpp_lib_freestanding_optional}@             202311L // freestanding, also in \libheader{optional}
 #define @\defnlibxname{cpp_lib_freestanding_ranges}@               202306L // freestanding, also in \libheader{ranges}


### PR DESCRIPTION
This macro indicates that freestanding support for "saturation arithmetic" is available, which was added in motion LWG-2 (via P0543R3). This reverts the previous change
148e03a16d53ff8cffd219384df37efad5fd386d, which I had made subsequent to motion LWG-3 (P2407R5), on advice of LWG. A separate macro is preferable to mixing both headers under "algorithm".