### PR TITLE
[func.wrap.func.cons] [any.assign] Harmonize operator= wording

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6643,16 +6643,11 @@ any& operator=(const any& rhs);
 \begin{itemdescr}
 \pnum
 \effects
-As if by \tcode{any(rhs).swap(*this)}.
-No effects if an exception is thrown.
+Equivalent to: \tcode{any(rhs).swap(*this);}
 
 \pnum
 \returns
 \tcode{*this}.
-
-\pnum
-\throws
-Any exceptions arising from the copy constructor for the contained value.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{any}%
@@ -6663,11 +6658,7 @@ any& operator=(any&& rhs) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-As if by \tcode{any(std::move(rhs)).swap(*this)}.
-
-\pnum
-\ensures
-The state of \tcode{*this} is equivalent to the original state of \tcode{rhs}.
+Equivalent to: \tcode{any(std::move(rhs)).swap(*this);}
 
 \pnum
 \returns
@@ -13115,7 +13106,7 @@ function& operator=(const function& f);
 \begin{itemdescr}
 \pnum
 \effects
-As if by \tcode{function(f).swap(*this);}
+Equivalent to: \tcode{function(f).swap(*this);}
 
 \pnum
 \returns
@@ -13130,8 +13121,7 @@ function& operator=(function&& f);
 \begin{itemdescr}
 \pnum
 \effects
-Replaces the target of \tcode{*this}
-with the target of \tcode{f}.
+Equivalent to: \tcode{function(std::move(f)).swap(*this);}
 
 \pnum
 \returns


### PR DESCRIPTION
This harmonizes the wording of `operator=` semantics for all four type-erasure types (function, any, move_only_function, copyable_function) by bringing the former two into line with the latter (newer) two.

Using "Equivalent to" instead of "As if by" allows us to omit some wording about what exceptions might be thrown. [func.wrap.func.con] also had a typo "As if by `x;`" that should have been "As if by `x`."

The one borderline-editorial part is `function`'s move-constructor ([[func.wrap.func.cons]/21](https://eel.is/c++draft/func.wrap.func.con#21)). The old wording is
"Replaces the target of `*this` with the target of `f`," which a sufficiently smart vendor could take as giving permission to use the contained object's assignment operator (if `f`'s contained object is assignable to `*this`'s contained object) and/or to destroy `*this`'s contained object _before_ copying `f`'s contained object. My impression is that no vendor (ab)uses that permission today, but please correct me if I'm wrong.