### PR TITLE
[res.on.data.races] Use "object parameter" instead of `this` or "argument"

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -3666,14 +3666,14 @@ Implementations may prevent data races in cases other than those specified below
 \pnum
 A \Cpp{} standard library function shall not directly or indirectly access
 objects\iref{intro.multithread} accessible by threads other than the current thread
-unless the objects are accessed directly or indirectly via the function's arguments,
-including \keyword{this}.
+unless the objects are accessed directly or indirectly via the function's parameters,
+including the object parameter (if any).
 
 \pnum
 A \Cpp{} standard library function shall not directly or indirectly modify
 objects\iref{intro.multithread} accessible by threads other than the current thread
 unless the objects are accessed directly or indirectly via the function's non-const
-arguments, including \keyword{this}.
+parameters, including the object parameter (if any).
 
 \pnum
 \begin{note}


### PR DESCRIPTION
We should say "implicit object parameter", "implied object argument", or "`*this`" instead.

Fixes #6731.