### PR TITLE
[alg.min.max] Replace small/large terminology with less/greater

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -8731,7 +8731,7 @@ For the first form, \tcode{T} meets the
 
 \pnum
 \returns
-The smaller value.
+The lesser value.
 Returns the first argument when the arguments are equivalent.
 
 \pnum
@@ -8773,9 +8773,9 @@ requirements (\tref{cpp17.lessthancomparable}).
 
 \pnum
 \returns
-The smallest value in the input range.
+The least value in the input range.
 Returns a copy of the leftmost element
-when several elements are equivalent to the smallest.
+when several elements are equivalent to the least.
 
 \pnum
 \complexity
@@ -8809,7 +8809,7 @@ For the first form, \tcode{T} meets the
 
 \pnum
 \returns
-The larger value.
+The greater value.
 Returns the first argument when the arguments are equivalent.
 
 \pnum
@@ -8851,9 +8851,9 @@ requirements (\tref{cpp17.lessthancomparable}).
 
 \pnum
 \returns
-The largest value in the input range.
+The greatest value in the input range.
 Returns a copy of the leftmost element
-when several elements are equivalent to the largest.
+when several elements are equivalent to the greatest.
 
 \pnum
 \complexity
@@ -8889,7 +8889,7 @@ For the first form, \tcode{T} meets the
 
 \pnum
 \returns
-\tcode{\{b, a\}} if \tcode{b} is smaller than \tcode{a}, and
+\tcode{\{b, a\}} if \tcode{b} is lesser than \tcode{a}, and
 \tcode{\{a, b\}} otherwise.
 
 \pnum
@@ -8934,8 +8934,8 @@ requirements (\tref{cpp17.lessthancomparable}).
 \returns
 Let \tcode{X} be the return type.
 Returns \tcode{X\{x, y\}},
-where \tcode{x} is a copy of the leftmost element with the smallest value and
-\tcode{y} a copy of the rightmost element with the largest value
+where \tcode{x} is a copy of the leftmost element with the least value and
+\tcode{y} a copy of the rightmost element with the greatest value
 in the input range.
 
 \pnum
@@ -9080,12 +9080,12 @@ template<@\libconcept{forward_range}@ R, class Proj = identity,
 \tcode{\{first, first\}} if \range{first}{last} is empty, otherwise
 \tcode{\{m, M\}}, where \tcode{m} is
 the first iterator in \range{first}{last} such that no iterator in the range refers
-to a smaller element, and where \tcode{M} is the last iterator
+to a lesser element, and where \tcode{M} is the last iterator
 \begin{footnote}
 This behavior
 intentionally differs from \tcode{max_element}.
 \end{footnote}
-in \range{first}{last} such that no iterator in the range refers to a larger element.
+in \range{first}{last} such that no iterator in the range refers to a greater element.
 
 \pnum
 \complexity


### PR DESCRIPTION
Fixes #6747 in part.

The motivation for this edit is already stated in the linked edit. [alg.min.max] is the best place to start with implementing these changes because any terminology but less/greater is misleading.

For example, `std::min` is implemented in terms of `<`. Saying it returns the "smaller" value has seemingly nothing to do with the *less-than* operator, which is poor wording.