### PR TITLE
[std] Remove problematic phrases from notes

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -6538,7 +6538,7 @@ For a thread of execution providing \defn{concurrent forward progress guarantees
 the implementation ensures that the thread will eventually make progress for as
 long as it has not terminated.
 \begin{note}
-This is required regardless of whether or not other threads of execution (if any)
+This is regardless of whether or not other threads of execution (if any)
 have been or are making progress. To eventually fulfill this requirement means that
 this will happen in an unspecified but finite amount of time.
 \end{note}

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -6202,15 +6202,15 @@ if
 The ``inter-thread happens before'' relation describes arbitrary
 concatenations of ``sequenced before'', ``synchronizes with'' and
 ``dependency-ordered before'' relationships, with two exceptions. The first
-exception is that a concatenation is not permitted to end with
+exception is that a concatenation never ends with
 ``dependency-ordered before'' followed by ``sequenced before''. The reason for
 this limitation is that a consume operation participating in a
 ``dependency-ordered before'' relationship provides ordering only with respect
 to operations to which this consume operation actually carries a dependency. The
 reason that this limitation applies only to the end of such a concatenation is
 that any subsequent release operation will provide the required ordering for a
-prior consume operation. The second exception is that a concatenation is not
-permitted to consist entirely of ``sequenced before''. The reasons for this
+prior consume operation. The second exception is that a concatenation never
+consist entirely of ``sequenced before''. The reasons for this
 limitation are (1) to permit ``inter-thread happens before'' to be transitively
 closed and (2) the ``happens before'' relation, defined below, provides for
 relationships consisting entirely of ``sequenced before''.
@@ -6290,7 +6290,7 @@ unspecified or undefined.
 \begin{note}
 This states that operations on
 ordinary objects are not visibly reordered. This is not actually detectable
-without data races, but it is necessary to ensure that data races, as defined
+without data races, but is needed to ensure that data races, as defined
 below, and with suitable restrictions on the use of atomics, correspond to data
 races in a simple interleaved (sequentially consistent) execution.
 \end{note}
@@ -6401,7 +6401,7 @@ interleaving. This is normally referred to as ``sequential consistency''.
 However, this applies only to data-race-free programs, and data-race-free
 programs cannot observe most program transformations that do not change
 single-threaded program semantics. In fact, most single-threaded program
-transformations continue to be allowed, since any program that behaves
+transformations remain possible, since any program that behaves
 differently as a result has undefined behavior.
 \end{note}
 
@@ -6538,7 +6538,7 @@ For a thread of execution providing \defn{concurrent forward progress guarantees
 the implementation ensures that the thread will eventually make progress for as
 long as it has not terminated.
 \begin{note}
-This is regardless of whether or not other threads of execution (if any)
+This applies regardless of whether or not other threads of execution (if any)
 have been or are making progress. To eventually fulfill this requirement means that
 this will happen in an unspecified but finite amount of time.
 \end{note}

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3074,8 +3074,7 @@ simplify the use of unions: If a standard-layout union contains several standard
 structs that share a common initial sequence\iref{class.mem}, and
 if a non-static data member of an object of this standard-layout union type
 is active and is one of the standard-layout structs,
-it is permitted to inspect the common initial sequence
-of any of the standard-layout struct members;
+the common initial sequence of any of the standard-layout struct members can be inspected;
 see~\ref{class.mem}.
 \end{note}
 

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1330,7 +1330,7 @@ implicit exception specification, see~\ref{dcl.fct.def}.
 \indextext{constructor!implicitly invoked}%
 A default constructor is implicitly invoked to initialize
 a class object when no initializer is specified\iref{dcl.init.general}.
-Such a default constructor is required to be accessible\iref{class.access}.
+Such a default constructor needs to be accessible\iref{class.access}.
 \end{note}
 
 \pnum

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2719,7 +2719,7 @@ in \ref{container.alloc.reqmts} apply instead to \tcode{key_type}
 and \tcode{mapped_type}.
 \begin{note}
 For example, in some cases \tcode{key_type} and \tcode{mapped_type}
-are required to be \oldconcept{CopyAssignable} even though the associated
+need to be \oldconcept{CopyAssignable} even though the associated
 \tcode{value_type}, \tcode{pair<const key_type, mapped_type>}, is not
 \oldconcept{CopyAssignable}.
 \end{note}
@@ -4217,7 +4217,7 @@ the requirements placed on \tcode{value_type} in \ref{container.alloc.reqmts}
 apply instead to \tcode{key_type} and \tcode{mapped_type}.
 \begin{note}
 For example, \tcode{key_type} and \tcode{mapped_type}
-are sometimes required to be \oldconcept{CopyAssignable}
+sometimes need to be \oldconcept{CopyAssignable}
 even though the associated \tcode{value_type},
 \tcode{pair<const key_type, mapped_type>},
 is not \oldconcept{CopyAssignable}.

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1558,7 +1558,7 @@ This implies that, within a class template with a template
 \begin{codeblock}
 friend class T;
 \end{codeblock}
-is ill-formed. However, the similar declaration \tcode{friend T;} is allowed\iref{class.friend}.
+is ill-formed. However, the similar declaration \tcode{friend T;} is well-formed.\iref{class.friend}.
 \end{note}
 
 \pnum
@@ -4684,7 +4684,7 @@ but the declaration of a function taking no arguments and returning an
 \tcode{X}.
 The form
 \tcode{()}
-is permitted in certain other initialization contexts\iref{expr.new,
+can appear in certain other initialization contexts\iref{expr.new,
 expr.type.conv,class.base.init}.
 \end{note}
 
@@ -4752,7 +4752,7 @@ associated with the initialization of $e_i$
 is sequenced before those associated with the initialization of $e_j$.
 \begin{note}
 By contrast with direct-list-initialization,
-narrowing conversions\iref{dcl.init.list} are permitted,
+narrowing conversions\iref{dcl.init.list} can appear,
 designators are not permitted,
 a temporary object bound to a reference
 does not have its lifetime extended\iref{class.temporary}, and
@@ -9332,7 +9332,7 @@ translation unit, the program is ill-formed, no diagnostic required.
 If a function \tcode{f} is called where \tcode{f} was previously declared with the \tcode{noreturn}
 attribute and \tcode{f} eventually returns, the behavior is undefined.
 \begin{note}
-The function may
+The function can
 terminate by throwing an exception.
 \end{note}
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1268,10 +1268,10 @@ the behavior is undefined.
 \indextext{\idxcode{volatile}!implementation-defined}%
 \begin{note}
 \tcode{volatile} is a hint to the implementation to avoid aggressive
-optimization involving the object because the value of the object might
-be changed by means undetectable by an implementation.
-Furthermore, for some implementations, \tcode{volatile} might indicate that
-special hardware instructions are required to access the object.
+optimization involving the object because it is possible for the value of the object
+to change by means undetectable by an implementation.
+Furthermore, for some implementations, \tcode{volatile} can indicate that
+special hardware instructions are needed to access the object.
 See~\ref{intro.execution} for detailed semantics. In general, the
 semantics of \tcode{volatile} are intended to be the same in \Cpp{} as
 they are in C.
@@ -5394,8 +5394,7 @@ is considered for the initialization of the first element of the subaggregate.
 \begin{note}
 As specified above, brace elision cannot apply to
 subaggregates with no elements; an
-\grammarterm{initializer-clause} for the entire subobject is
-required.
+\grammarterm{initializer-clause} for the entire subobject is needed.
 \end{note}
 
 \begin{example}
@@ -6084,7 +6083,7 @@ Each element of the backing array is copy-initialized with the
 corresponding element of the initializer list, and the
 \tcode{std::initializer_list<E>} object is constructed to refer to that array.
 \begin{note}
-A constructor or conversion function selected for the copy is required to be
+A constructor or conversion function selected for the copy needs to be
 accessible\iref{class.access} in the context of the initializer list.
 \end{note}
 If a narrowing conversion is required to initialize any of the elements,

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1412,7 +1412,7 @@ void g() {
 \end{codeblock}
 In each case, the constraints of \tcode{f} are not satisfied.
 In the declaration of \tcode{p2},
-those constraints are required to be satisfied
+those constraints need to be satisfied
 even though
 \tcode{f} is an unevaluated operand\iref{term.unevaluated.operand}.
 \end{example}
@@ -2182,7 +2182,7 @@ if the corresponding specialization is a constexpr function and
 if the function call operator template specialization is an immediate function.
 \begin{note}
 This will result in the implicit instantiation of the generic lambda's body.
-The instantiated generic lambda's return type and parameter types are required to match
+The instantiated generic lambda's return type and parameter types need to match
 the return type and parameter types of the pointer to function.
 \end{note}
 \begin{example}
@@ -3404,7 +3404,7 @@ converted to the return type of the statically chosen function.
 A function can change the values of its non-const parameters, but these
 changes cannot affect the values of the arguments except where a
 parameter is of a reference type\iref{dcl.ref}; if the reference is to
-a const-qualified type, \keyword{const_cast} is required to be used to
+a const-qualified type, \keyword{const_cast} needs to be used to
 cast away the constness in order to modify the argument's value. Where a
 parameter is of \keyword{const} reference type a temporary object is
 introduced if
@@ -5378,7 +5378,7 @@ allocation function's name is
 and the deallocation function's name is
 \tcode{\keyword{operator} \keyword{delete}[]}.
 \begin{note}
-An implementation is required to provide default definitions for the global
+An implementation is expected to provide default definitions for the global
 allocation
 functions\iref{basic.stc.dynamic,new.delete.single,new.delete.array}.
 A \Cpp{} program can provide alternative definitions of

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6080,7 +6080,7 @@ are incomplete, it is unspecified whether the \keyword{static_cast} or the
 inheritance relationship between the two classes.
 \begin{note}
 For example, if the classes were defined later in the translation unit,
-a multi-pass compiler would be permitted to interpret a cast between
+a multi-pass compiler could validly interpret a cast between
 pointers to the classes as if the class types were complete at the point
 of the cast.
 \end{note}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -13839,8 +13839,8 @@ as a native path.
 \begin{note}
 Some operating systems have no unambiguous way to distinguish between native format and generic format arguments.
 This is by design as it simplifies use for operating systems that do not require
-disambiguation. An implementation for an operating system where disambiguation
-is required is permitted to distinguish between the formats.
+disambiguation. It is possible that an implementation for an operating system
+where disambiguation is needed distinguishes between the formats.
 \end{note}
 
 \pnum

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -918,7 +918,7 @@ as a synonym for a class with equivalent functionality
 to class \tcode{ios_base::failure} shown in this subclause.
 \begin{note}
 When \tcode{ios_base::failure} is a synonym for another type,
-that type is required to provide a nested type \tcode{failure}
+that type needs to provide a nested type \tcode{failure}
 to emulate the injected-class-name.
 \end{note}
 The class
@@ -14384,7 +14384,7 @@ path& make_preferred();
 \effects
 Each \grammarterm{directory-separator}
 of the pathname in the generic format
-  is converted to \grammarterm{preferred-separator}.
+is converted to \grammarterm{preferred-separator}.
 
 \pnum
 \returns
@@ -15161,8 +15161,8 @@ the forward traversal order is as follows:
 \item The \grammarterm{root-name} element, if present.
 \item The \grammarterm{root-directory} element, if present.
 \begin{note}
-The generic format is required to ensure lexicographical
-comparison works correctly.
+It is possible that the use of the generic format is needed
+to ensure correct lexicographical comparison.
 \end{note}
 \item Each successive \grammarterm{filename} element, if present.
 \item An empty element, if a trailing non-root \grammarterm{directory-separator}

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -665,8 +665,7 @@ Blanks, horizontal and vertical tabs, newlines, formfeeds, and comments
 (collectively, ``whitespace''), as described below, are ignored except
 as they serve to separate tokens.
 \begin{note}
-Some whitespace is
-required to separate otherwise adjacent identifiers, keywords, numeric
+Whitespace can separate otherwise adjacent identifiers, keywords, numeric
 literals, and alternative tokens containing alphabetic characters.
 \end{note}
 \indextext{token|)}
@@ -1851,7 +1850,7 @@ shall consist of at most 16 characters.
 
 \pnum
 \begin{note}
-The characters \tcode{'('} and \tcode{')'} are permitted in a
+The characters \tcode{'('} and \tcode{')'} can appear in a
 \grammarterm{raw-string}. Thus, \tcode{R"delimiter((a|b))delimiter"} is equivalent to
 \tcode{"(a|b)"}.
 \end{note}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -3605,8 +3605,8 @@ the only declaration of that function or function template
 provided by an implementation.
 \begin{note}
 In particular,
-an implementation is not allowed to provide
-an additional declaration of that function or function template
+a conforming implementation does not provide
+any additional declarations of that function or function template
 at namespace scope.
 \end{note}
 \begin{note}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1455,7 +1455,7 @@ described in \ref{support.c.headers.other}.
 It is unspecified to which module a declaration in the standard library
 is attached.
 \begin{note}
-Implementations are required to ensure that mixing
+Conforming implementations ensure that mixing
 \tcode{\#include} and \tcode{import} does not result in
 conflicting attachments\iref{basic.link}.
 \end{note}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -9472,7 +9472,8 @@ for which \tcode{is_unsigned_v<X>} is \tcode{true} and
 if \tcode{X} cannot be converted to \tcode{int}
 by integral promotion\iref{conv.prom}, the program is ill-formed.
 \begin{note}
-Arguments that can be promoted to \tcode{int} are permitted for compatibility with C.
+Allowing arguments that can be promoted to \tcode{int}
+provides compatibility with C.
 \end{note}
 \end{itemdescr}
 

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2141,8 +2141,8 @@ In all contexts, when converting to the implicit object parameter
 or when converting to the left operand of an assignment operation
 only standard conversion sequences are allowed.
 \begin{note}
-When converting to the explicit object parameter, if any,
-user-defined conversion sequences are allowed.
+When a conversion to the explicit object parameter occurs,
+it can include user-defined conversion sequences.
 \end{note}
 
 \pnum

--- a/source/support.tex
+++ b/source/support.tex
@@ -3915,10 +3915,9 @@ If the attempt to copy the current exception object throws an exception, the fun
 returns an \tcode{exception_ptr} object that refers to the thrown exception or,
 if this is not possible, to an instance of \tcode{bad_exception}.
 \begin{note}
-The
-copy constructor of the thrown exception can also fail, so the implementation is allowed
-to substitute a \tcode{bad_exception} object to avoid infinite
-recursion.
+The copy constructor of the thrown exception can also fail,
+so the implementation can substitute a \tcode{bad_exception} object
+to avoid infinite recursion.
 \end{note}
 \end{itemdescr}
 

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6317,7 +6317,7 @@ the \grammarterm{declaration} produced by the corresponding substitution
 into the templated function, variable, or class
 are two declarations of the same entity.
 \begin{note}
-These declarations are required to have matching types as specified in~\ref{basic.link}, except as specified in~\ref{except.spec}.
+These declarations need to have matching types as specified in~\ref{basic.link}, except as specified in~\ref{except.spec}.
 \begin{example}
 \begin{codeblock}
 template<typename T> T var = {};
@@ -6367,7 +6367,7 @@ template void sort<>(Array<int>&);
 
 \pnum
 \begin{note}
-An explicit instantiation of a constrained template is required
+An explicit instantiation of a constrained template needs
 to satisfy that template's associated constraints\iref{temp.constr.decl}.
 The satisfaction of constraints is determined
 % FIXME: What is a "template name"? Does this mean "simple-template-id"?
@@ -6514,10 +6514,9 @@ may be defined\iref{dcl.meaning,class.mem,temp.mem}.
 An explicit specialization does not introduce a name\iref{basic.scope.scope}.
 A declaration of a function template, class template, or variable template being explicitly
 specialized shall be reachable from the declaration of
-the explicit
-specialization.
+the explicit specialization.
 \begin{note}
-A declaration, but not a definition of the template is required.
+A declaration, but not a definition of the template is needed.
 \end{note}
 The definition of a class or class template shall be reachable from the
 declaration of an explicit specialization for a member template of the class
@@ -6708,7 +6707,7 @@ template<> void sort(Array<int>&);
 
 \pnum
 \begin{note}
-An explicit specialization of a constrained template is required
+An explicit specialization of a constrained template needs
 to satisfy that template's associated constraints\iref{temp.constr.decl}.
 The satisfaction of constraints is determined
 when forming the template name of an explicit specialization
@@ -7305,10 +7304,8 @@ If a substitution results in an invalid type or expression, type deduction fails
 invalid type or expression is one that would be ill-formed, with a diagnostic
 required, if written in the same context using the substituted arguments.
 \begin{note}
-If no
-diagnostic is required, the program is still ill-formed. Access checking is done
-as part of the substitution
-process.
+If no diagnostic is required, the program is still ill-formed.
+Access checking is done as part of the substitution process.
 \end{note}
 Invalid types and expressions can result in a deduction failure
 only in the immediate context of the deduction substitution loci.

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -769,7 +769,7 @@ As is the case with the
 \keyword{typename}
 prefix, the
 \keyword{template}
-prefix is allowed
+prefix is well-formed
 even when lookup for the name would already find a template.
 \end{note}
 \begin{example}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -6305,8 +6305,8 @@ ownership of that object will fail (for \tcode{try_lock()}) or block (for
 \begin{note}
 After a thread \tcode{A} has called \tcode{unlock()}, releasing a mutex, it is possible for another
 thread \tcode{B} to lock the same mutex, observe that it is no longer in use, unlock it, and
-destroy it, before thread \tcode{A} appears to have returned from its unlock call. Implementations
-are required to handle such scenarios correctly, as long as thread \tcode{A} doesn't access the
+destroy it, before thread \tcode{A} appears to have returned from its unlock call. Conforming implementations
+handle such scenarios correctly, as long as thread \tcode{A} does not access the
 mutex after the unlock call returns. These cases typically occur when a reference-counted object
 contains a mutex that is used to protect the reference count.
 \end{note}

--- a/source/time.tex
+++ b/source/time.tex
@@ -7923,7 +7923,7 @@ The year, month, and day are accepted in any of the following 3 orders:
 @\tcode{\placeholder{day}}@/@\tcode{\placeholder{month}}@/@\tcode{\placeholder{year}}@
 \end{codeblock}
 
-Anywhere a \tcode{\placeholder{day}} is required, any of the following can also be specified:
+Anywhere a \tcode{\placeholder{day}} is needed, any of the following can also be specified:
 
 \begin{codeblock}
 last

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -3002,7 +3002,7 @@ The above definition does not require \tcode{t$_{\mathrm{tail}}$}
 (or \tcode{u$_{\mathrm{tail}}$}) to be constructed. It might not
 even be possible, as \tcode{t} and \tcode{u} are not required to be copy
 constructible. Also, all comparison operator functions are short circuited;
-they do not perform element accesses beyond what is required to determine the
+they do not perform element accesses beyond what is needed to determine the
 result of the comparison.
 \end{note}
 


### PR DESCRIPTION
Only specific phrases involving the word "required" are problematic, namely when they appear to establish a normative requirement. They have been reworded, often by replacing "is required" with "needs", sometimes with slightly larger edits.

Also reword "necessary", "permitted", "allowed" in notes, so that they do not (inappropriately) state requirements or
permissions.

On request of ISO.