### PR TITLE
[strings] Consistently use shorter forms of return types

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -1035,7 +1035,7 @@ constexpr bool empty() const noexcept;
 
 \indexlibrarymember{operator[]}{basic_string_view}%
 \begin{itemdecl}
-constexpr const_reference operator[](size_type pos) const;
+constexpr const char& operator[](size_type pos) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1057,7 +1057,7 @@ Nothing.
 
 \indexlibrarymember{at}{basic_string_view}%
 \begin{itemdecl}
-constexpr const_reference at(size_type pos) const;
+constexpr const char& at(size_type pos) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1072,7 +1072,7 @@ constexpr const_reference at(size_type pos) const;
 
 \indexlibrarymember{front}{basic_string_view}%
 \begin{itemdecl}
-constexpr const_reference front() const;
+constexpr const char& front() const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1091,7 +1091,7 @@ Nothing.
 
 \indexlibrarymember{back}{basic_string_view}%
 \begin{itemdecl}
-constexpr const_reference back() const;
+constexpr const char& back() const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1110,7 +1110,7 @@ Nothing.
 
 \indexlibrarymember{data}{basic_string_view}%
 \begin{itemdecl}
-constexpr const_pointer data() const noexcept;
+constexpr const char* data() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -2238,7 +2238,7 @@ namespace std {
     // \ref{string.ops}, string operations
     constexpr const charT* c_str() const noexcept;
     constexpr const charT* data() const noexcept;
-    constexpr charT* data() noexcept;
+    constexpr charT*       data() noexcept;
     constexpr operator basic_string_view<charT, traits>() const noexcept;
     constexpr allocator_type get_allocator() const noexcept;
 

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -2126,10 +2126,10 @@ namespace std {
     constexpr bool empty() const noexcept;
 
     // \ref{string.access}, element access
-    constexpr const_reference operator[](size_type pos) const;
-    constexpr reference       operator[](size_type pos);
-    constexpr const_reference at(size_type n) const;
-    constexpr reference       at(size_type n);
+    constexpr const charT& operator[](size_type pos) const;
+    constexpr charT&       operator[](size_type pos);
+    constexpr const charT& at(size_type n) const;
+    constexpr charT&       at(size_type n);
 
     constexpr const charT& front() const;
     constexpr charT&       front();

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -3090,8 +3090,8 @@ Equivalent to:
 
 \indexlibrarymember{operator[]}{basic_string}%
 \begin{itemdecl}
-constexpr const_reference operator[](size_type pos) const;
-constexpr reference       operator[](size_type pos);
+constexpr const charT& operator[](size_type pos) const;
+constexpr charT&       operator[](size_type pos);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3117,8 +3117,8 @@ Constant time.
 
 \indexlibrarymember{at}{basic_string}%
 \begin{itemdecl}
-constexpr const_reference at(size_type pos) const;
-constexpr reference       at(size_type pos);
+constexpr const charT& at(size_type pos) const;
+constexpr charT&       at(size_type pos);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -661,11 +661,11 @@ Because \tcode{basic_string_view} refers to a constant sequence, \tcode{iterator
     constexpr bool empty() const noexcept;
 
     // \ref{string.view.access}, element access
-    constexpr const_reference operator[](size_type pos) const;
-    constexpr const_reference at(size_type pos) const;                  // freestanding-deleted
-    constexpr const_reference front() const;
-    constexpr const_reference back() const;
-    constexpr const_pointer data() const noexcept;
+    constexpr const charT& operator[](size_type pos) const;
+    constexpr const charT& at(size_type pos) const;                     // freestanding-deleted
+    constexpr const charT& front() const;
+    constexpr const charT& back() const;
+    constexpr const charT* data() const noexcept;
 
     // \ref{string.view.modifiers}, modifiers
     constexpr void remove_prefix(size_type n);
@@ -734,7 +734,7 @@ Because \tcode{basic_string_view} refers to a constant sequence, \tcode{iterator
     constexpr size_type find_last_not_of(const charT* s, size_type pos = npos) const;
 
   private:
-    const_pointer @\exposid{data_}@;        // \expos
+    const charT* @\exposid{data_}@;         // \expos
     size_type @\exposid{size_}@;            // \expos
   };
 


### PR DESCRIPTION
Currently, `const_reference` and `const charT&` are mixedly used in the return types of some functions in [strings] (same for non-const versions).

This PR consistently
- spells the return types in the short aliased forms, as the shorter forms are clearer, and
- aligns non-const and const overloads of `basic_string::data`, and
- spells the shorter form for the type of `basic_string_view::data_`.