### PR TITLE
[locale.categories] Promote remaining static const data members to `constexpr`

### DIFF
--- a/source/text.tex
+++ b/source/text.tex
@@ -480,7 +480,7 @@ namespace std {
     class id;
     // \ref{locale.category}, type \tcode{locale::category}
     using category = int;
-    static const category   // values assigned here are for exposition only
+    static constexpr category   // values assigned here are for exposition only
       none     = 0,
       collate  = 0x010, ctype    = 0x020,
       monetary = 0x040, numeric  = 0x080,
@@ -1724,7 +1724,7 @@ namespace std {
       const char* narrow(const char* low, const char* high, char dfault, char* to) const;
 
       static locale::id id;
-      static const size_t table_size = @\impdef@;
+      static constexpr size_t table_size = @\impdef@;
 
       const mask* table() const noexcept;
       static const mask* classic_table() noexcept;
@@ -4445,7 +4445,7 @@ namespace std {
       pattern     neg_format()    const;
 
       static locale::id id;
-      static const bool intl = International;
+      static constexpr bool intl = International;
 
     protected:
       ~moneypunct();


### PR DESCRIPTION
See also #4862. After the changes there's no static const data members that are guaranteed to be usable in constant expressions but not constexpr.

The changes seemingly require these static data members to be implicitly inline variables, but [[contents]/1](https://eel.is/c++draft/contents#1) has already required an implementation to provide definitions for them, so the difference between plain `const` and `constexpr` is unobservable.

The last remain pieces are static data members of `ctype_base` - it's not strictly required that these members are required to be usable in constant expressions since `mask` may be a class type. LWG4037 is opened for this. Edit: LWG4037 has been resolved.