### PR TITLE
[text.encoding.overview] Use same parameter names as detailed description

### DIFF
--- a/source/locales.tex
+++ b/source/locales.tex
@@ -4701,8 +4701,8 @@ namespace std {
     struct aliases_view;
     constexpr aliases_view aliases() const noexcept;
 
-    friend constexpr bool operator==(const text_encoding& encoding,
-                                     const text_encoding& other) noexcept;
+    friend constexpr bool operator==(const text_encoding& a,
+                                     const text_encoding& b) noexcept;
     friend constexpr bool operator==(const text_encoding& encoding, id i) noexcept;
 
     static consteval text_encoding literal() noexcept;


### PR DESCRIPTION
[text.encoding.cmp] calls these parameters `a` and `b` so the synopsis should either not name them, or use the same names.

https://github.com/cplusplus/draft/blob/74433025763f83bbccfb001dab8aa084647ffb2f/source/locales.tex#L5021-L5033

Partially addresses #3255