### PR TITLE
[std] Reword "cannot" in notes to not sound like negative permission

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -407,8 +407,8 @@ Unless otherwise stated, implementations may make arbitrary copies of elements
 where \tcode{is_trivially_copy_constructible_v<T>}
 and \tcode{is_trivially_destructible_v<T>} are \tcode{true}.
 \begin{note}
-This implies that user-supplied function objects cannot rely on
-object identity of arguments for such input sequences.
+This implies that the object identity of arguments
+in user-supplied function objects is not reliable for such input sequences.
 If object identity of the arguments to these function objects
 is important, a wrapping iterator
 that returns a non-copied implementation object
@@ -541,7 +541,7 @@ The semantics of invocation with
 \tcode{execution::parallel_policy}, or
 \tcode{execution::parallel_unsequenced_policy}
 allow the implementation to fall back to sequential execution
-if the system cannot parallelize an algorithm invocation,
+if the system is unable to parallelize an algorithm invocation,
 e.g., due to lack of resources.
 \end{note}
 

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1220,7 +1220,7 @@ template<class T
 The locus of a \grammarterm{concept-definition}
 is immediately after its \grammarterm{concept-name}\iref{temp.concept}.
 \begin{note}
-The \grammarterm{constraint-expression} cannot use
+It is not possible for the \grammarterm{constraint-expression} to use
 the \grammarterm{concept-name}.
 \end{note}
 
@@ -1324,7 +1324,7 @@ else {
 A \grammarterm{parameter-declaration-clause} $P$ introduces
 a \defnadj{function parameter}{scope} that includes $P$.
 \begin{note}
-A function parameter cannot be used for its value
+It is not possible for a function parameter to be used for its value
 within the \grammarterm{parameter-declaration-clause}\iref{dcl.fct.default}.
 \end{note}
 \begin{itemize}
@@ -4121,7 +4121,7 @@ is of type \tcode{std::destroying_delete_t}.
 A destroying operator delete
 shall be a class member function named \tcode{\keyword{operator} \keyword{delete}}.
 \begin{note}
-Array deletion cannot use a destroying operator delete.
+It is not possible for array deletion to use a destroying operator delete.
 \end{note}
 
 \pnum
@@ -4773,7 +4773,7 @@ object type is unknown.
 Incompletely-defined object types and \cv{}~\keyword{void} are
 \defnadjx{incomplete}{types}{type}\iref{basic.fundamental}.
 \begin{note}
-Objects cannot be defined to have an incomplete type\iref{basic.def}.
+It is not possibe to define objects of incomplete type\iref{basic.def}.
 \end{note}
 
 \pnum
@@ -4793,7 +4793,7 @@ The type of a pointer or reference to array of unknown bound
 permanently points to or refers to an incomplete type.
 An array of unknown bound named by a \keyword{typedef} declaration
 permanently refers to an incomplete type.
-In either case, the array type cannot be completed.
+In either case, it is not possible to complete the array type.
 \end{note}
 \begin{example}
 \indextext{type!example of incomplete}%
@@ -5007,7 +5007,7 @@ Each set of values for any padding bits\iref{basic.types.general}
 in the object representation are
 alternative representations of the value specified by the value representation.
 \begin{note}
-Padding bits have unspecified value, but cannot cause traps.
+Padding bits have unspecified value, but do not cause traps.
 In contrast, see ISO C 6.2.6.2.
 \end{note}
 \begin{note}
@@ -5892,7 +5892,7 @@ Evaluations \placeholder{A} and \placeholder{B} are
 \defn{indeterminately sequenced} when either \placeholder{A} is sequenced before
 \placeholder{B} or \placeholder{B} is sequenced before \placeholder{A}, but it is unspecified which.
 \begin{note}
-Indeterminately sequenced evaluations cannot overlap, but either
+Indeterminately sequenced evaluations never overlap, but either
 can be executed first.
 \end{note}
 An expression \placeholder{X}
@@ -6087,7 +6087,7 @@ $A$ forces prior
 side effects on other memory locations to become visible
 to other threads that later perform a consume or an acquire operation on
 $A$. ``Relaxed'' atomic operations are not synchronization operations even
-though, like synchronization operations, they cannot contribute to data races.
+though, like synchronization operations, they never contribute to data races.
 \end{note}
 
 \pnum
@@ -6399,7 +6399,7 @@ object being taken from the last
 side effect on that object in that
 interleaving. This is normally referred to as ``sequential consistency''.
 However, this applies only to data-race-free programs, and data-race-free
-programs cannot observe most program transformations that do not change
+programs are not able to observe most program transformations that do not change
 single-threaded program semantics. In fact, most single-threaded program
 transformations remain possible, since any program that behaves
 differently as a result has undefined behavior.

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -700,7 +700,7 @@ incomplete type\iref{term.incomplete.type},
 an abstract class type\iref{class.abstract},
 or a (possibly multidimensional) array thereof.
 \begin{note}
-In particular, a class \tcode{C} cannot contain
+In particular, it is not possible for a class \tcode{C} to contain
 a non-static member of class \tcode{C},
 but it can contain a pointer or reference to an object of class \tcode{C}.
 \end{note}
@@ -1218,7 +1218,7 @@ The address of a constructor shall not be taken.
 \indextext{restriction!constructor}%
 \begin{note}
 A \tcode{return} statement in the body of a constructor
-cannot specify a return value\iref{stmt.return}.
+never specifies a return value\iref{stmt.return}.
 \end{note}
 
 \pnum
@@ -1425,7 +1425,7 @@ an initializer of type
 or
 \tcode{volatile}
 \tcode{X}
-cannot initialize an object of type
+is not able to initialize an object of type
 \cv{}~\tcode{X}.
 \begin{example}
 \begin{codeblock}
@@ -1434,7 +1434,7 @@ struct X {
   X(X&);            // copy constructor with a non-const parameter
 };
 const X cx;
-X x = cx;           // error: \tcode{X::X(X\&)} cannot copy \tcode{cx} into \tcode{x}
+X x = cx;           // error: \tcode{X::X(X\&)} unable to copy \tcode{cx} into \tcode{x}
 \end{codeblock}
 \end{example}
 \end{note}
@@ -1684,10 +1684,8 @@ If a class
 \tcode{X}
 only has a copy assignment operator with a non-object parameter of type
 \tcode{X\&},
-an expression of type const
-\tcode{X}
-cannot be assigned to an object of type
-\tcode{X}.
+it is not possible to assign an expression of type const \tcode{X}
+to an object of type \tcode{X}.
 \begin{example}
 \begin{codeblock}
 struct X {
@@ -1697,7 +1695,7 @@ struct X {
 const X cx;
 X x;
 void f() {
-  x = cx;           // error: \tcode{X::operator=(X\&)} cannot assign \tcode{cx} into \tcode{x}
+  x = cx;           // error: \tcode{X::operator=(X\&)} unable to assign \tcode{cx} into \tcode{x}
 }
 \end{codeblock}
 \end{example}
@@ -2026,7 +2024,7 @@ The address of a destructor shall not be taken.
 \indextext{restriction!destructor}%
 \begin{note}
 A \tcode{return} statement in the body of a destructor
-cannot specify a return value\iref{stmt.return}.
+never specifies a return value\iref{stmt.return}.
 \end{note}
 \indextext{\idxcode{const}!destructor and}%
 \indextext{\idxcode{volatile}!destructor and}%
@@ -2631,7 +2629,7 @@ member, the \keyword{static} specifier shall only be used in the member
 declarations that appear within the \grammarterm{member-specification} of
 the class definition.
 \begin{note}
-It cannot be specified in member declarations that appear in namespace scope.
+It is not possible to specify member declarations that appear in namespace scope with \keyword{static}.
 \end{note}
 
 \rSec3[class.static.mfct]{Static member functions}
@@ -2647,7 +2645,7 @@ functions.
 \begin{note}
 A static member function does not have a \keyword{this}
 pointer\iref{expr.prim.this}.
-A static member function cannot be qualified with \keyword{const},
+It is not possible to qualify a static member function with \keyword{const},
 \tcode{volatile}, or \keyword{virtual}\iref{dcl.fct}.
 \end{note}
 
@@ -3317,11 +3315,9 @@ union U {
 A class can be declared within a function definition; such a class is
 called a \defnadj{local}{class}.
 \begin{note}
-A declaration in a local class
-cannot odr-use\iref{term.odr.use}
-a local entity
-from an
-enclosing scope.
+It is not possible for a declaration in a local class
+to odr-use\iref{term.odr.use} a local entity
+from an enclosing scope.
 \end{note}
 \begin{example}
 \begin{codeblock}
@@ -3369,7 +3365,7 @@ a local class is a local class.
 \pnum
 \indextext{restriction!static member local class}%
 \begin{note}
-A local class cannot have static data members\iref{class.static.data}.
+It is not possible for a local class to have static data members\iref{class.static.data}.
 \end{note}
 
 \rSec1[class.derived]{Derived classes}%
@@ -3541,7 +3537,7 @@ subobject can have a polymorphic behavior\iref{class.cdtor}
 different from the polymorphic behavior of a most derived object of the
 same type. A base class subobject can be of zero size;
 however, two subobjects that have the same class type and that belong to
-the same most derived object cannot be allocated at the same
+the same most derived object are never allocated at the same
 address\iref{intro.object}.
 \end{note}
 
@@ -3932,7 +3928,7 @@ type)\iref{expr.call}.
 \pnum
 \begin{note}
 The \keyword{virtual} specifier implies membership, so a virtual function
-cannot be a non-member\iref{dcl.fct.spec} function. Nor can a virtual
+is never a non-member\iref{dcl.fct.spec} function. Nor can a virtual
 function be a static member, since a virtual function call relies on a
 specific object for determining which function to invoke. A virtual
 function declared in one class can be declared a friend\iref{class.friend} in
@@ -4108,8 +4104,8 @@ public:
 \end{codeblock}
 \end{example}
 \begin{note}
-A function declaration cannot provide both a \grammarterm{pure-specifier}
-and a definition.
+A function declaration can only provide either a \grammarterm{pure-specifier}
+or a definition, but not both.
 \end{note}
 \begin{example}
 \begin{codeblock}
@@ -4121,11 +4117,11 @@ struct C {
 
 \pnum
 \begin{note}
-An abstract class type cannot be used
+It is not possible to use an abstract class type
 as a parameter or return type of
 a function being defined\iref{dcl.fct} or called\iref{expr.call},
 except as specified in \ref{dcl.type.simple}.
-Further, an abstract class type cannot be used as
+Further, it is not possible to use an abstract class type as
 the type of an explicit type conversion\iref{expr.static.cast,
 expr.reinterpret.cast,expr.const.cast},
 because the resulting prvalue would be of abstract class type\iref{basic.lval}.
@@ -6265,8 +6261,8 @@ object if the meaning of the program will be unchanged except for the execution
 of constructors and destructors for the object declared by the
 \grammarterm{exception-declaration}.
 \begin{note}
-There cannot be a move from the exception object because it is
-always an lvalue.
+Since the exception object because is always an lvalue,
+it is never moved from, which would potentially be incorrect.
 \end{note}
 \end{itemize}
 Copy elision is not permitted

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -6261,8 +6261,7 @@ object if the meaning of the program will be unchanged except for the execution
 of constructors and destructors for the object declared by the
 \grammarterm{exception-declaration}.
 \begin{note}
-Since the exception object because is always an lvalue,
-it is never moved from, which would potentially be incorrect.
+The exception object is always an lvalue, thus it is not implicitly moved from."
 \end{note}
 \end{itemize}
 Copy elision is not permitted

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -4320,8 +4320,8 @@ An iterator type
 whose category, value type, difference type, and pointer and reference types
 are the same as \tcode{X::iterator}'s.
 \begin{note}
-A \tcode{local_iterator} object can be used to iterate through a single bucket,
-but cannot be used to iterate across buckets.
+A \tcode{local_iterator} object is usable for iteration through a single bucket,
+but not for iteration across buckets.
 \end{note}
 \end{itemdescr}
 
@@ -4337,9 +4337,8 @@ An iterator type
 whose category, value type, difference type, and pointer and reference types
 are the same as \tcode{X::const_iterator}'s.
 \begin{note}
-A \tcode{const_local_iterator} object can be used to iterate
-through a single bucket,
-but cannot be used to iterate across buckets.
+A \tcode{const_local_iterator} object is usable for iteration through a single bucket,
+but not for iteration across buckets.
 \end{note}
 \end{itemdescr}
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -823,7 +823,7 @@ An explicit specialization can differ from the template declaration
 with respect to the \keyword{constexpr} or \keyword{consteval} specifier.
 \end{note}
 \begin{note}
-Function parameters cannot be declared \keyword{constexpr}.
+It is not possible for a function parameter to be declared \keyword{constexpr}.
 \end{note}
 \begin{example}
 \begin{codeblock}
@@ -1020,8 +1020,8 @@ the other rules for inline functions specified in this subclause shall
 still be respected.
 \begin{note}
 The \keyword{inline} keyword has no effect on the linkage of a function.
-In certain cases, an inline function cannot use names with internal linkage;
-see~\ref{basic.link}.
+In certain cases, it is not possible for an inline function
+to use names with internal linkage; see~\ref{basic.link}.
 \end{note}
 
 \pnum
@@ -1836,7 +1836,7 @@ shall be defined in the translation unit
 containing its exported declaration,
 outside the \grammarterm{private-module-fragment} (if any).
 \begin{note}
-The deduced return type cannot have
+This avoids having a deduced return type with
 a name with internal linkage\iref{basic.link}.
 \end{note}
 
@@ -3072,12 +3072,12 @@ or is the declaration of a parameter or a return type\iref{dcl.fct}; see~\ref{ba
 A reference shall be initialized to refer to a valid object or function.
 \begin{note}
 \indextext{reference!null}%
-In particular, a null reference cannot exist in a well-defined program,
+In particular, a well-defined program does not contain null references,
 because the only way to create such a reference would be to bind it to
 the ``object'' obtained by indirection through a null pointer,
 which causes undefined behavior.
-As described in~\ref{class.bit}, a reference cannot be bound directly
-to a bit-field.
+As described in~\ref{class.bit}, it is not possible for a bit-field
+to bind directly to a reference.
 \end{note}
 
 \pnum
@@ -4103,8 +4103,8 @@ supplied in this or a previous declaration,
 unless the parameter was expanded from a parameter pack,
 or shall be a function parameter pack.
 \begin{note}
-A default argument
-cannot be redefined by a later declaration
+It is not possible for a default argument
+to be redefined by a later declaration
 (not even to the same value)\iref{basic.def.odr}.
 \end{note}
 \begin{example}
@@ -4213,8 +4213,8 @@ void C::g(int i = 88, int j) {} // in this translation unit, \tcode{C::g} can be
 
 \pnum
 \begin{note}
-A local variable cannot be odr-used\iref{term.odr.use}
-in a default argument.
+It is not possible for a default argument
+to odr-use\iref{term.odr.use} a local variable.
 \end{note}
 \begin{example}
 \begin{codeblock}
@@ -4229,9 +4229,8 @@ void f() {
 
 \pnum
 \begin{note}
-The keyword
-\keyword{this}
-cannot appear in a default argument of a member function;
+It is not possible for the keyword \keyword{this}
+to appear in a default argument of a member function;
 see~\ref{expr.prim.this}.
 \begin{example}
 \begin{codeblock}
@@ -5392,7 +5391,7 @@ brace elision is assumed and the
 \grammarterm{assignment-expression}
 is considered for the initialization of the first element of the subaggregate.
 \begin{note}
-As specified above, brace elision cannot apply to
+As specified above, brace elision does not apply to
 subaggregates with no elements; an
 \grammarterm{initializer-clause} for the entire subobject is needed.
 \end{note}
@@ -8119,7 +8118,7 @@ either is reachable from the other, and
 they do not both declare functions or function templates,
 the program is ill-formed.
 \begin{note}
-Overload resolution possibly cannot distinguish
+It is possible that overload resolution is unable to distinguish
 between conflicting function declarations.
 \end{note}
 \begin{example}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -105,7 +105,7 @@ a = ((a + b) + 32765);
 \end{codeblock}
 since if the values for \tcode{a} and \tcode{b} were, respectively,
 $-32754$ and $-15$, the sum \tcode{a + b} would produce an exception while
-the original expression would not; nor can the expression be rewritten
+the original expression would not; similarly, it is precluded from rewriting the expression
 as either
 \begin{codeblock}
 a = ((a + 32765) + b);
@@ -117,9 +117,8 @@ a = (a + (b + 32765));
 since the values for \tcode{a} and \tcode{b} might have been,
 respectively, 4 and $-8$ or $-17$ and 12. However on a machine in which
 overflows do not produce an exception and in which the results of
-overflows are reversible, the above expression statement can be
-rewritten by the implementation in any of the above ways because the
-same result will occur.
+overflows are reversible, rewriting the above expression statement is possible
+in any of the above ways because the same result will occur.
 \end{note}
 
 \pnum

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -98,7 +98,7 @@ result of the sum \tcode{(a + 32760)} is next added to \tcode{b}, and
 that result is then added to 5 which results in the value assigned to
 \tcode{a}. On a machine in which overflows produce an exception and in
 which the range of values representable by an \tcode{int} is
-\crange{-32768}{+32767}, the implementation cannot rewrite this
+\crange{-32768}{+32767}, an implementation is precluded from rewriting this
 expression as
 \begin{codeblock}
 a = ((a + b) + 32765);
@@ -1091,7 +1091,7 @@ an object pointer or a function pointer
 and the rules for conversions
 of such pointers do not apply to pointers to members.
 \indextext{conversion!pointer-to-member!\idxcode{void*}}%
-In particular, a pointer to member cannot be converted to a
+In particular, it is not possible to convert a pointer to member to a
 \tcode{\keyword{void}*}.
 \end{footnote}
 
@@ -1821,7 +1821,7 @@ In such cases,
 any attributes are treated as
 \grammarterm{attribute-specifier-seq} in \grammarterm{lambda-expression}.
 \begin{note}
-Such ambiguous cases cannot have valid semantics
+Such ambiguous cases would not have valid semantics
 because the constraint expression would not have type \keyword{bool}.
 \begin{example}
 \begin{codeblock}
@@ -2548,8 +2548,8 @@ struct s2 {
 \begin{note}
 Because local entities are not
 odr-usable within a default argument\iref{basic.def.odr},
-a \grammarterm{lambda-expression} appearing in a default argument
-cannot implicitly or explicitly capture any local entity.
+it is not possible for a \grammarterm{lambda-expression} appearing in a default argument
+to capture any local entity, implicitly or explicitly.
 Such a \grammarterm{lambda-expression}
 can still have an \grammarterm{init-capture} if
 any full-expression in its \grammarterm{initializer}
@@ -3402,7 +3402,7 @@ converted to the return type of the statically chosen function.
 \indextext{reference!call by}%
 \indextext{argument!reference}%
 A function can change the values of its non-const parameters, but these
-changes cannot affect the values of the arguments except where a
+changes do not affect the values of the arguments except where a
 parameter is of a reference type\iref{dcl.ref}; if the reference is to
 a const-qualified type, \keyword{const_cast} needs to be used to
 cast away the constness in order to modify the argument's value. Where a
@@ -3726,7 +3726,7 @@ indeterminately-sequenced function call, the operation of postfix
 \tcode{++} is
 a single evaluation.
 \begin{note}
-Therefore, a function call cannot intervene between the
+Therefore, there is never an intervening function call between the
 lvalue-to-rvalue conversion and the side effect associated with any
 single postfix \tcode{++} operator.
 \end{note}
@@ -3948,7 +3948,7 @@ to a possibly cv-qualified type, the result of the
 \keyword{typeid} expression refers to a \tcode{std::type_info} object
 representing the cv-unqualified referenced type.
 \begin{note}
-The \grammarterm{type-id} cannot denote a function type with
+The \grammarterm{type-id} never denotes a function type with
 a \grammarterm{cv-qualifier-seq} or a \grammarterm{ref-qualifier}\iref{dcl.fct}.
 \end{note}
 
@@ -4279,9 +4279,8 @@ A value of type \tcode{std::nullptr_t} can be converted to an integral
 type; the conversion has the same meaning and validity as a conversion of
 \tcode{(\keyword{void}*)0} to the integral type.
 \begin{note}
-A \keyword{reinterpret_cast}
-cannot be used to convert a value of any type to the type
-\tcode{std::nullptr_t}.
+It is not possible to use a \keyword{reinterpret_cast}
+to convert a value of any type to the type \tcode{std::nullptr_t}.
 \end{note}
 
 \pnum
@@ -4351,7 +4350,8 @@ pointer value.
 The null pointer value\iref{basic.compound} is converted to the null pointer value
 of the destination type.
 \begin{note}
-A null pointer constant of type \tcode{std::nullptr_t} cannot be converted to a
+It is not possible for a null pointer constant of type \tcode{std::nullptr_t}
+to be converted to a
 pointer type, and a null pointer constant of integral type is not necessarily
 converted to a null pointer value.
 \end{note}
@@ -4512,8 +4512,8 @@ casts away constness if a cast from a prvalue of type ``pointer to \tcode{T1}'' 
 
 \pnum
 \begin{note}
-Some conversions which involve only changes in cv-qualification cannot
-be done using \keyword{const_cast}. For instance, conversions between
+Some conversions which involve only changes in cv-qualification are not possible
+with \keyword{const_cast}. For instance, conversions between
 pointers to functions are not covered because such conversions lead to
 values whose use causes undefined behavior. For the same reasons,
 conversions between pointers to member functions, and in particular, the
@@ -5125,8 +5125,7 @@ This type shall be a complete object type\iref{term.incomplete.type},
 but not an abstract class type\iref{class.abstract} or array
 thereof\iref{intro.object}.
 \begin{note}
-Because references are not objects, references cannot be created by
-\grammarterm{new-expression}{s}.
+Because references are not objects, \grammarterm{new-expression}{s} never create references.
 \end{note}
 \begin{note}
 The \grammarterm{type-id} can be a cv-qualified type, in which case the
@@ -7217,7 +7216,7 @@ With
 respect to an indeterminately-sequenced function call, the operation of
 a compound assignment is a single evaluation.
 \begin{note}
-Therefore, a function call cannot intervene between the
+Therefore, a function call never intervenes between the
 lvalue-to-rvalue conversion and the side effect associated with any
 single compound assignment operator.
 \end{note}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -2811,7 +2811,7 @@ Calls \tcode{str.setf(ios_base::fixed | ios_base::scientific,
 
 \pnum
 \begin{note}
-\tcode{ios_base::hex} cannot be used to specify
+It is not possible to use \tcode{ios_base::hex} to specify
 a hexadecimal floating-point format,
 because it is not part of \tcode{ios_base::floatfield}
 (\tref{ios.fmtflags.const}).
@@ -17419,7 +17419,7 @@ As specified in~\ref{fs.err.report}.
 Some operating systems require symlink creation to
 identify that the link is to a directory.
 Thus, \tcode{create_symlink()} (instead of \tcode{create_directory_symlink()})
-cannot be used reliably to create directory symlinks.
+is not a reliable way to create directory symlinks.
 \end{note}
 
 \pnum

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -500,7 +500,7 @@ used as an index for lookup and to encapsulate initialization.
 \begin{note}
 Because facets are used by iostreams,
 potentially while static constructors are running,
-their initialization cannot depend on programmed static initialization.
+it is not possible for their initialization to depend on programmed static initialization.
 One initialization strategy is for \tcode{locale}
 to initialize each facet's \tcode{id} member
 the first time an instance of the facet is installed into a locale.

--- a/source/modules.tex
+++ b/source/modules.tex
@@ -491,7 +491,7 @@ permitted within a header unit despite all
 declarations being implicitly exported\iref{module.interface}.
 \begin{note}
 A definition that appears in multiple translation units
-cannot in general refer to such names\iref{basic.def.odr}.
+is not able to refer to such names\iref{basic.def.odr} in general.
 \end{note}
 A header unit shall not contain
 a definition of a non-inline function or variable

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2349,7 +2349,7 @@ other than a reference to a non-volatile \keyword{const} type
 to an rvalue
 or binding an rvalue reference to an lvalue other than a function lvalue.
 \begin{note}
-This means, for example, that a candidate function cannot be a viable
+This means, for example, that a candidate function is not a viable
 function if it has a non-\keyword{const} lvalue reference parameter (other than
 the implicit object parameter) and the corresponding argument
 would require a temporary to be created to initialize the lvalue
@@ -3237,7 +3237,7 @@ can be overloaded.
 \pnum
 \begin{note}
 \indextext{restriction!operator overloading}%
-The following operators cannot be overloaded:
+It is not possible to overload the following operators:
 \begin{ncsimplebnf}\obeyspaces
 \terminal{.      .*     ::     ?:}
 \end{ncsimplebnf}
@@ -3942,9 +3942,7 @@ and
 \begin{note}
 As with all these descriptions of candidate functions, this declaration serves
 only to describe the built-in operator for purposes of overload resolution.
-The operator
-``\tcode{?:}''
-cannot be overloaded.
+It is not possible to overload the operator ``\tcode{?:}''.
 \end{note}
 
 \pnum

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -1044,7 +1044,7 @@ If control enters the declaration concurrently while the variable is
 being initialized, the concurrent execution shall wait for completion
 of the initialization.
 \begin{note}
-A conforming implementation cannot introduce
+A conforming implementation never introduces
 any deadlock around execution of the initializer.
 Deadlocks might still be caused by the program logic;
 the implementation need only avoid deadlocks

--- a/source/support.tex
+++ b/source/support.tex
@@ -2203,9 +2203,9 @@ the function \tcode{std::terminate} is invoked\iref{except.terminate}.%
 \begin{note}
 A function registered via \tcode{at_quick_exit}
 is invoked by the thread that calls \tcode{quick_exit},
-which can be a different thread
-than the one that registered it, so registered functions cannot rely on the identity
-of objects with thread storage duration.
+which can be a different thread than the one that registered it,
+so it is not guaranteed which identity of objects with thread storage duration
+a registered function observes during its execution.
 \end{note}
 After calling registered functions, \tcode{quick_exit} shall call \tcode{_Exit(status)}.
 

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -143,7 +143,7 @@ instantiation\iref{temp.decls} and must obey the one-definition rule\iref{basic.
 
 \pnum
 \begin{note}
-A template cannot have the same name as any other
+It is not possible for a template to have the same name as any other
 name bound in the same scope\iref{basic.scope.scope}, except
 that a function template can share a name with non-template
 functions\iref{dcl.fct} and/or function templates\iref{temp.over}.
@@ -442,9 +442,9 @@ template<const X& x, int i, A a> void f() {
 
 \pnum
 \begin{note}
-A non-type
+It is not possible to declare a non-type
 \grammarterm{template-parameter}
-cannot be declared to have type \cv{} \keyword{void}.
+to have type \cv{} \keyword{void}.
 \begin{example}
 \begin{codeblock}
 template<void v> class X;       // error
@@ -760,9 +760,9 @@ The latter case is deprecated\iref{depr.template.template}.
 The keyword \keyword{template} shall not appear immediately
 before a \tcode{\~} token (as to name a destructor).
 \begin{note}
-The keyword
+It is not possible to apply the keyword
 \keyword{template}
-cannot be applied to non-template members of class templates.
+to non-template members of class templates.
 \end{note}
 \begin{note}
 As is the case with the
@@ -3345,7 +3345,7 @@ of the partial specialization.
 \begin{note}
 The template arguments can be private types or
 objects that would normally not be accessible.
-Dependent names cannot be checked when declaring the partial specialization,
+Dependent names are not checked when declaring the partial specialization,
 but will be checked when substituting into the partial specialization.
 \end{note}
 
@@ -4250,7 +4250,7 @@ A concept shall not have associated constraints\iref{temp.constr.decl}.
 A concept is not instantiated\iref{temp.spec}.
 \begin{note}
 A concept-id\iref{temp.names} is evaluated as an expression.
-A concept cannot be
+It is not possible for a concept to be
 explicitly instantiated\iref{temp.explicit},
 explicitly specialized\iref{temp.expl.spec},
 or partially specialized\iref{temp.spec.partial}.
@@ -5832,8 +5832,8 @@ a potentially-constant variable\iref{expr.const}, or
 a specialization of a templated class.
 \end{itemize}
 \begin{note}
-An implicit instantiation in an importing translation unit
-cannot use names with internal linkage
+It is not possible for an implicit instantiation in an importing translation unit
+to use names with internal linkage
 from an imported translation unit\iref{basic.link}.
 \end{note}
 
@@ -7750,11 +7750,10 @@ the type deduction fails.
 If a
 \grammarterm{template-parameter}
 is not used in any of the function parameters of a function template,
-or is used only in a non-deduced context, its corresponding
-\grammarterm{template-argument}
-cannot be deduced from a function call and the
-\grammarterm{template-argument}
-must be explicitly specified.
+or is used only in a non-deduced context, then it is not possible for its corresponding
+\grammarterm{template-argument} to be deduced from a function call, and
+thus the program is ill-formed
+unless the \grammarterm{template-argument} is explicitly specified.
 \end{note}
 
 \pnum
@@ -8638,7 +8637,7 @@ void g() {
 \pnum
 \begin{note}
 Except for reference and pointer types, a major array bound is not part of a
-function parameter type and cannot be deduced from an argument:
+function parameter type and is not possible to be deduced from an argument:
 \begin{codeblock}
 template<int i> void f1(int a[10][i]);
 template<int i> void f2(int a[i][20]);

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -651,7 +651,7 @@ return cmp_greater_equal(t, numeric_limits<R>::min()) &&
 
 \pnum
 \begin{note}
-These function templates cannot be used to compare
+These function templates are not usable for comparing
 \tcode{byte},
 \tcode{char},
 \keyword{char8_t},
@@ -687,7 +687,7 @@ template<class T>
 \expects
 \tcode{false} is \tcode{true}.
 \begin{note}
-This precondition cannot be satisfied, thus the behavior
+This precondition is never satisfied, thus the behavior
 of calling \tcode{unreachable} is undefined.
 \end{note}
 
@@ -2715,9 +2715,8 @@ return @\placeholdernc{make-from-tuple-impl}@<T>(
            make_index_sequence<tuple_size_v<remove_reference_t<Tuple>>>{});
 \end{codeblock}
 \begin{note}
-The type of \tcode{T} must be supplied
-as an explicit template parameter,
-as it cannot be deduced from the argument list.
+As the type \tcode{T} cannot be deduced from the argument list,
+it is necessary for it to be supplied as an explicit template argument.
 \end{note}
 \end{itemdescr}
 
@@ -15827,7 +15826,7 @@ argument indices 0, 1, 2, \ldots{} will automatically be used in that order.
 If some \fmtgrammarterm{arg-id}s are omitted and some are present,
 the string is not a format string.
 \begin{note}
-A format string cannot contain a
+It is not possible for a format string to contain a
 mixture of automatic and manual indexing.
 \end{note}
 \begin{example}


### PR DESCRIPTION
Notes shall not contain permissions. Even though "cannot" is allowed to express negative possibility, ISO has requested that we avoid it when it might be ambiguous and could be mistaken as permission.