### PR TITLE
[structure.specifications] clarify description of Results element

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -389,7 +389,7 @@ established by the function.
 \result
 for a \grammarterm{typename-specifier}, a description of the named type;
 for an \grammarterm{expression},
-a description of the type of the expression;
+a description of the type and value category of the expression;
 the expression is an lvalue if the type is an lvalue reference type,
 an xvalue if the type is an rvalue reference type, and
 a prvalue otherwise.


### PR DESCRIPTION
The text "... the expression is an lvalue if the type is an lvalue reference type, an xvalue if the type is an rvalue reference type, and a prvalue otherwise" clearly indicates that a Result element describes the type and value category of an expression, yet we summarize it as only "a description of the type of the expression".