### PR TITLE
[exception] Paragraph two is no longer universally true

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -3635,7 +3635,8 @@ class for the types of objects thrown as exceptions by
 expressions, to report errors detected during program execution.
 
 \pnum
-Each standard library class \tcode{T} that derives from class \tcode{exception}
+Except where explicitly specified otherwise,
+each standard library class \tcode{T} that derives from class \tcode{exception}
 has the following publicly accessible member functions, each of them having
 a non-throwing exception specification\iref{except.spec}:
 \begin{itemize}


### PR DESCRIPTION
We recently added `bad_expected_access<void>` to the Standard Library, which derives from `exception`, but does not have "the following publicly accessible member functions, each of them having a non-throwing exception specification." For clarity, we should point out that this provision is not universal.