### PR TITLE
[alg.ends.with]: drop_view should be views::drop

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -4682,7 +4682,7 @@ Let \tcode{N1} be \tcode{ranges::distance(r1)} and
 \returns
 \tcode{false} if $\tcode{N1} < \tcode{N2}$, otherwise
 \begin{codeblock}
-ranges::equal(ranges::drop_view(ranges::ref_view(r1), N1 - N2), r2, pred, proj1, proj2)
+ranges::equal(views::drop(ranges::ref_view(r1), N1 - N2), r2, pred, proj1, proj2)
 \end{codeblock}
 \end{itemdescr}
 


### PR DESCRIPTION
We don't want programmers doing CTAD on `ranges::drop_view(args...)`, so we shouldn't put it in the as-if-by code either. What we expect people to do (and what we intend vendors to do here) is `views::drop`.

(Compare #6373. I'm also pinging the LWG reflector for an opinion on whether this is handleable without an LWG issue.)