### PR TITLE
[alg.min.max] Reword min/max/minmax in modern style

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -8725,18 +8725,19 @@ template<class T, class Proj = identity,
 
 \begin{itemdescr}
 \pnum
+Let \tcode{comp} be \tcode{less\{\}}
+and \tcode{proj} be \tcode{identity\{\}}
+for the overloads with no parameters by those names.
+
+\pnum
 \expects
 For the first form, \tcode{T} meets the
 \oldconcept{LessThanComparable} requirements (\tref{cpp17.lessthancomparable}).
 
 \pnum
-\returns
-The smaller value.
-Returns the first argument when the arguments are equivalent.
-
-\pnum
-\complexity
-Exactly one comparison and two applications of the projection, if any.
+\effects
+Equivalent to:
+\tcode{return invoke(comp, invoke(proj, b), invoke(proj, a)) ? b : a;}
 
 \pnum
 \remarks
@@ -8764,6 +8765,11 @@ template<@\libconcept{input_range}@ R, class Proj = identity,
 
 \begin{itemdescr}
 \pnum
+Let \tcode{comp} be \tcode{less\{\}}
+and \tcode{proj} be \tcode{identity\{\}}
+for the overloads with no parameters by those names.
+
+\pnum
 \expects
 \tcode{ranges::distance(r) > 0}.
 For the overloads in namespace \tcode{std},
@@ -8773,14 +8779,14 @@ requirements (\tref{cpp17.lessthancomparable}).
 
 \pnum
 \returns
-The smallest value in the input range.
-Returns a copy of the leftmost element
-when several elements are equivalent to the smallest.
+Returns a copy of the leftmost element \tcode{e} in the input range \tcode{r}
+for which \tcode{bool(invoke(comp, invoke(proj, x), invoke(proj, e)))}
+is \tcode{false} for all elements \tcode{x} in \tcode{r}.
 
 \pnum
 \complexity
 Exactly \tcode{ranges::distance(r) - 1} comparisons
-and twice as many applications of the projection, if any.
+and twice as many applications of the projection.
 
 \pnum
 \remarks
@@ -8803,18 +8809,19 @@ template<class T, class Proj = identity,
 
 \begin{itemdescr}
 \pnum
+Let \tcode{comp} be \tcode{less\{\}}
+and \tcode{proj} be \tcode{identity\{\}}
+for the overloads with no parameters by those names.
+
+\pnum
 \expects
 For the first form, \tcode{T} meets the
 \oldconcept{LessThanComparable} requirements (\tref{cpp17.lessthancomparable}).
 
 \pnum
-\returns
-The larger value.
-Returns the first argument when the arguments are equivalent.
-
-\pnum
-\complexity
-Exactly one comparison and two applications of the projection, if any.
+\effects
+Equivalent to:
+\tcode{return invoke(comp, invoke(proj, a), invoke(proj, b)) ? b : a;}
 
 \pnum
 \remarks
@@ -8842,6 +8849,11 @@ template<@\libconcept{input_range}@ R, class Proj = identity,
 
 \begin{itemdescr}
 \pnum
+Let \tcode{comp} be \tcode{less\{\}}
+and \tcode{proj} be \tcode{identity\{\}}
+for the overloads with no parameters by those names.
+
+\pnum
 \expects
 \tcode{ranges::distance(r) > 0}.
 For the overloads in namespace \tcode{std},
@@ -8851,14 +8863,14 @@ requirements (\tref{cpp17.lessthancomparable}).
 
 \pnum
 \returns
-The largest value in the input range.
-Returns a copy of the leftmost element
-when several elements are equivalent to the largest.
+Returns a copy of the leftmost element \tcode{e} in the input range \tcode{r}
+for which \tcode{bool(invoke(comp, invoke(proj, e), invoke(proj, x)))}
+is \tcode{false} for all elements \tcode{x} in \tcode{r}.
 
 \pnum
 \complexity
 Exactly \tcode{ranges::distance(r) - 1} comparisons
-and twice as many applications of the projection, if any.
+and twice as many applications of the projection.
 
 \pnum
 \remarks
@@ -8883,18 +8895,24 @@ template<class T, class Proj = identity,
 
 \begin{itemdescr}
 \pnum
+Let \tcode{comp} be \tcode{less\{\}}
+and \tcode{proj} be \tcode{identity\{\}}
+for the overloads with no parameters by those names.
+
+\pnum
 \expects
 For the first form, \tcode{T} meets the
 \oldconcept{LessThanComparable} requirements (\tref{cpp17.lessthancomparable}).
 
 \pnum
 \returns
-\tcode{\{b, a\}} if \tcode{b} is smaller than \tcode{a}, and
-\tcode{\{a, b\}} otherwise.
+\tcode{\{b, a\}} if
+\tcode{bool(invoke(comp, invoke(proj, b), invoke(proj, a)))} is \tcode{true},
+and \tcode{\{a, b\}} otherwise.
 
 \pnum
 \complexity
-Exactly one comparison and two applications of the projection, if any.
+Exactly one comparison and two applications of the projection.
 
 \pnum
 \remarks
@@ -8923,6 +8941,11 @@ template<@\libconcept{input_range}@ R, class Proj = identity,
 
 \begin{itemdescr}
 \pnum
+Let \tcode{comp} be \tcode{less\{\}}
+and \tcode{proj} be \tcode{identity\{\}}
+for the overloads with no parameters by those names.
+
+\pnum
 \expects
 \tcode{ranges::distance(r) > 0}.
 For the overloads in namespace \tcode{std},
@@ -8934,15 +8957,19 @@ requirements (\tref{cpp17.lessthancomparable}).
 \returns
 Let \tcode{X} be the return type.
 Returns \tcode{X\{x, y\}},
-where \tcode{x} is a copy of the leftmost element with the smallest value and
-\tcode{y} a copy of the rightmost element with the largest value
-in the input range.
+where \tcode{x} is a copy of
+the leftmost element in the input range \tcode{r} for which
+\tcode{bool(invoke(comp, invoke(proj, e), invoke(proj, x)))}
+is \tcode{false} for all elements \tcode{e} in \tcode{r}
+and \tcode{y} is a copy of
+the rightmost element in \tcode{r} for which
+\tcode{bool(invoke(comp, invoke(proj, y), invoke(proj, e)))}
+is \tcode{false} for all elements \tcode{e} in \tcode{r}.
 
 \pnum
 \complexity
-At most $(3/2)\tcode{ranges::distance(r)}$ applications
-of the corresponding predicate
-and twice as many applications of the projection, if any.
+At most $(3/2)\tcode{ranges::distance(r)}$ comparisons
+and twice as many applications of the projection.
 
 \pnum
 \remarks


### PR DESCRIPTION
... to clarify the meaning of "smaller"/"smallest"/"larger"/"largest" with a custom comparison predicate and/or projection by effectively replacing those terms with code.

Closes #6747.
Closes #6752.
