### PR TITLE
[tuple.helper] paragraph one not universally true

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2730,7 +2730,8 @@ template<class T> struct tuple_size;
 
 \begin{itemdescr}
 \pnum
-All specializations of \tcode{tuple_size} meet the
+Except where specified otherwise,
+all specializations of \tcode{tuple_size} meet the
 \oldconcept{UnaryTypeTrait} requirements\iref{meta.rqmts} with a
 base characteristic of \tcode{integral_constant<size_t, N>}
 for some \tcode{N}.


### PR DESCRIPTION
[tuple.helper] p1 defines a general requirement that all specializations of `tuple_size` shall meet the *Cpp17UnaryTypeTrait* requirements but p4 actually defines a special situation where this requirement is not met ("Otherwise, it has no member value"). We have the same seemingly contradiction in [depr.tuple] p2. For clarity, we should point out that this provision is not universal.