### PR TITLE
[tuple.cnstr] Do not use code font for cardinal number 1

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2032,7 +2032,7 @@ is\linebreak{} % Overfull
 \tcode{true}, and
 
 \item
-either \tcode{sizeof...(Types)} is not \tcode{1}, or
+either \tcode{sizeof...(Types)} is not 1, or
 (when \tcode{Types...} expands to \tcode{T})
 \tcode{is_convertible_v<UTuple, T>} and
 \tcode{is_constructible_v<T, UTuple>} are both \tcode{false}.


### PR DESCRIPTION
Consistent with '2' on line 1977 above.

https://github.com/cplusplus/draft/blob/4fe9190fa05c4fb4e83c1a1ba68aa12aa49542e9/source/utilities.tex#L1977