### PR TITLE
[range.drop.overview] Remove redundant \iref for subrange

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -6171,7 +6171,7 @@ if \tcode{T} is a specialization of \tcode{span} and \tcode{T} otherwise.
 \item
 Otherwise,
 if \tcode{T} is
-a specialization of \tcode{subrange}\iref{range.subrange}
+a specialization of \tcode{subrange}
 that models \libconcept{random_access_range} and \libconcept{sized_range},
 then
 \tcode{T(ranges::begin(E) + std::min<D>(ranges::distance(E), F), ranges::\linebreak{}end(E),


### PR DESCRIPTION
..which already existed in the previous bullet.