### PR TITLE
[iterator.requirements.general] Clarify that "constexpr iterator" is …

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -709,12 +709,12 @@ is undefined.
 
 \pnum
 \indextext{iterator!constexpr}%
-Iterators are called \defn{constexpr iterators}
+Iterators meet the \defn{constexpr iterator} requirements
 if all operations provided to meet iterator category requirements
 are constexpr functions.
 \begin{note}
 For example, the types ``pointer to \tcode{int}'' and
-\tcode{reverse_iterator<int*>} are constexpr iterators.
+\tcode{reverse_iterator<int*>} meet the constexpr iterator requirements.
 \end{note}
 
 \rSec2[iterator.assoc.types]{Associated types}


### PR DESCRIPTION
…a requirement to be met

[iterator.requirements.general] p16 says "Iterators are called _constexpr iterators_ [..]", but all referencing sections say "meet the constexpr iterator requirements". For clarity, we should reword the definition to make it clear that this is a named requirement.