### PR TITLE
[rand.dist.samp.plinear] Fix copy & paste error in Mandates

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -6395,7 +6395,12 @@ template<class InputIteratorB, class InputIteratorW>
 \begin{itemdescr}
 \pnum
 \mandates
-\tcode{is_invocable_r_v<double, UnaryOperation\&, double>} is \tcode{true}.
+Both of
+\begin{itemize}
+\item{\tcode{is_convertible_v<iterator_traits<InputIteratorB>::value_type, double>}}
+\item{\tcode{is_convertible_v<iterator_traits<InputIteratorW>::value_type, double>}}
+\end{itemize}
+are \tcode{true}.
 
 \pnum
 \expects


### PR DESCRIPTION
This error was present in the incoming [P1719R2](https://wg21.link/p1719r2) paper (Mandating the Standard Library: Clause 26 - Numerics Library), but is obviously bogus. There is no UnaryOperation type in that constructor. The correct requirement is taken from the corresponding constructor in [rand.dist.samp.pconst].