### PR TITLE
[string.view.synop,string.syn] Fix indentation

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -578,14 +578,14 @@ namespace std {
   template<> struct hash<wstring_view>;
 
   inline namespace literals {
-  inline namespace string_view_literals {
-    // \ref{string.view.literals}, suffix for \tcode{basic_string_view} literals
-    constexpr string_view    operator""sv(const char* str, size_t len) noexcept;
-    constexpr u8string_view  operator""sv(const char8_t* str, size_t len) noexcept;
-    constexpr u16string_view operator""sv(const char16_t* str, size_t len) noexcept;
-    constexpr u32string_view operator""sv(const char32_t* str, size_t len) noexcept;
-    constexpr wstring_view   operator""sv(const wchar_t* str, size_t len) noexcept;
-  }
+    inline namespace string_view_literals {
+      // \ref{string.view.literals}, suffix for \tcode{basic_string_view} literals
+      constexpr string_view    operator""sv(const char* str, size_t len) noexcept;
+      constexpr u8string_view  operator""sv(const char8_t* str, size_t len) noexcept;
+      constexpr u16string_view operator""sv(const char16_t* str, size_t len) noexcept;
+      constexpr u32string_view operator""sv(const char32_t* str, size_t len) noexcept;
+      constexpr wstring_view   operator""sv(const wchar_t* str, size_t len) noexcept;
+    }
   }
 }
 \end{codeblock}
@@ -1987,14 +1987,14 @@ namespace std {
   template<class A> struct hash<basic_string<wchar_t, char_traits<wchar_t>, A>>;
 
   inline namespace literals {
-  inline namespace string_literals {
-    // \ref{basic.string.literals}, suffix for \tcode{basic_string} literals
-    constexpr string    operator""s(const char* str, size_t len);
-    constexpr u8string  operator""s(const char8_t* str, size_t len);
-    constexpr u16string operator""s(const char16_t* str, size_t len);
-    constexpr u32string operator""s(const char32_t* str, size_t len);
-    constexpr wstring   operator""s(const wchar_t* str, size_t len);
-  }
+    inline namespace string_literals {
+      // \ref{basic.string.literals}, suffix for \tcode{basic_string} literals
+      constexpr string    operator""s(const char* str, size_t len);
+      constexpr u8string  operator""s(const char8_t* str, size_t len);
+      constexpr u16string operator""s(const char16_t* str, size_t len);
+      constexpr u32string operator""s(const char32_t* str, size_t len);
+      constexpr wstring   operator""s(const wchar_t* str, size_t len);
+    }
   }
 }
 \end{codeblock}


### PR DESCRIPTION
[string.view.synop] 23.3.2 // 23.3.7, suffix for basic_string_view literals
[string.syn] 23.4.2 // 23.4.7, suffix for basic_string literals