### PR TITLE
[dcl.type.elab] Don't start a paragraph with a note

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1533,17 +1533,20 @@ does not consider scopes that contain the target scope; no name is bound.
 \begin{note}
 A \grammarterm{using-directive} in the target scope is ignored
 if it refers to a namespace not contained by that scope.
-\ref{basic.lookup.elab} describes how name lookup proceeds
-in an \grammarterm{elaborated-type-specifier}.
 \end{note}
 
 \pnum
 \begin{note}
+\ref{basic.lookup.elab} describes how name lookup proceeds
+in an \grammarterm{elaborated-type-specifier}.
 An \grammarterm{elaborated-type-specifier} can be used to refer to
 a previously declared \grammarterm{class-name} or \grammarterm{enum-name}
 even if the name has been hidden by a non-type declaration.
 \end{note}
+
+\pnum
 If the \grammarterm{identifier} or \grammarterm{simple-template-id}
+in an \grammarterm{elaborated-type-specifier}
 resolves to a \grammarterm{class-name} or
 \grammarterm{enum-name}, the \grammarterm{elaborated-type-specifier}
 introduces it into the declaration the same way a
@@ -1563,7 +1566,7 @@ is ill-formed. However, the similar declaration \tcode{friend T;} is well-formed
 
 \pnum
 The \grammarterm{class-key} or \keyword{enum} keyword
-present in the
+present in an
 \grammarterm{elaborated-type-specifier} shall agree in kind with the
 declaration to which the name in the
 \grammarterm{elaborated-type-specifier} refers. This rule also applies to


### PR DESCRIPTION
Currently looks like this: https://eel.is/c++draft/dcl.type.elab#4

I *think* the note "obviously" belongs to the previous paragraph.
Possible alternative solution: move Note 2 to the bottom of paragraph 5 instead.
