### PR TITLE
[mem.res.private, mem.res.monotonic.buffer.mem, re.traits] Use `*this` instead of improper `this` in the library wording

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -5735,10 +5735,10 @@ virtual bool do_is_equal(const memory_resource& other) const noexcept = 0;
 \begin{itemdescr}
 \pnum
 \returns
-A derived class shall implement this function to return \tcode{true} if memory allocated from \keyword{this} can be deallocated from \tcode{other} and vice-versa,
+A derived class shall implement this function to return \tcode{true} if memory allocated from \tcode{*this} can be deallocated from \tcode{other} and vice-versa,
 otherwise \tcode{false}.
 \begin{note}
-It is possible that the most-derived type of \tcode{other} does not match the type of \keyword{this}.
+It is possible that the most-derived type of \tcode{other} does not match the type of \tcode{*this}.
 For a derived class \tcode{D}, an implementation of this function
 can immediately return \tcode{false}
 if \tcode{dynamic_cast<const D*>(\&other) == nullptr}.

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -6607,8 +6607,8 @@ to their initial values at construction.
 \pnum
 \begin{note}
 The memory is released back to \tcode{upstream_rsrc}
-even if some blocks that were allocated from \keyword{this}
-have not been deallocated from \keyword{this}.
+even if some blocks that were allocated from \tcode{*this}
+have not been deallocated from \tcode{*this}.
 \end{note}
 \end{itemdescr}
 

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -1260,7 +1260,7 @@ locale_type imbue(locale_type loc);
 \begin{itemdescr}
 \pnum
 \effects
-Imbues \keyword{this} with a copy of the
+Imbues \tcode{*this} with a copy of the
 locale \tcode{loc}.
 \begin{note}
 Calling \tcode{imbue} with a


### PR DESCRIPTION
Separated from #6748.