### PR TITLE
[expr.call] Say "implicit object parameter" instead of "`this` parameter"

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3345,9 +3345,9 @@ int x = f<int>();               // error: no argument for second function parame
 If the function is an implicit object member
 function,
 the object expression of the class member access shall be a glvalue and
-the \keyword{this} parameter of the function\iref{expr.prim.this}
-is initialized with a pointer to the object of the call, converted
-as if by an explicit type conversion\iref{expr.cast}.
+the implicit object parameter of the function\iref{over.match.funcs}
+is initialized with that glvalue,
+converted as if by an explicit type conversion\iref{expr.cast}.
 \begin{note}
 There is no access or ambiguity checking on this conversion; the access
 checking and disambiguation are done as part of the (possibly implicit)


### PR DESCRIPTION
Separated from #6748.