### PR TITLE
[temp.arg.template] Clean up wording for template template argument matching

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1351,84 +1351,12 @@ C<A> c;             // \tcode{V<int>} within \tcode{C<A>} uses the primary templ
 \end{example}
 
 \pnum
-A \grammarterm{template-argument} matches a template
+A template \grammarterm{template-argument} \tcode{A} matches a template
 \grammarterm{template-parameter} \tcode{P} when
-\tcode{P} is at least as specialized as the \grammarterm{template-argument} \tcode{A}.
-In this comparison, if \tcode{P} is unconstrained,
-the constraints on \tcode{A} are not considered.
-If \tcode{P} contains a template parameter pack, then \tcode{A} also matches \tcode{P}
-if each of \tcode{A}'s template parameters
-matches the corresponding template parameter in the
-\grammarterm{template-head} of \tcode{P}.
-Two template parameters match if they are of the same kind (type, non-type, template),
-for non-type \grammarterm{template-parameter}{s}, their types are
-equivalent\iref{temp.over.link}, and for template \grammarterm{template-parameter}{s},
-each of their corresponding \grammarterm{template-parameter}{s} matches, recursively.
-When \tcode{P}'s \grammarterm{template-head} contains a template parameter
-pack\iref{temp.variadic}, the template parameter pack will match zero or more template
-parameters or template parameter packs in the \grammarterm{template-head} of
-\tcode{A} with the same type and form as the template parameter pack in \tcode{P}
-(ignoring whether those template parameters are template parameter packs).
-
-\begin{example}
-\begin{codeblock}
-template<class T> class A { @\commentellip@ };
-template<class T, class U = T> class B { @\commentellip@ };
-template<class ... Types> class C { @\commentellip@ };
-template<auto n> class D { @\commentellip@ };
-template<template<class> class P> class X { @\commentellip@ };
-template<template<class ...> class Q> class Y { @\commentellip@ };
-template<template<int> class R> class Z { @\commentellip@ };
-
-X<A> xa;            // OK
-X<B> xb;            // OK
-X<C> xc;            // OK
-Y<A> ya;            // OK
-Y<B> yb;            // OK
-Y<C> yc;            // OK
-Z<D> zd;            // OK
-\end{codeblock}
-\end{example}
-\begin{example}
-\begin{codeblock}
-template <class T> struct eval;
-
-template <template <class, class...> class TT, class T1, class... Rest>
-struct eval<TT<T1, Rest...>> { };
-
-template <class T1> struct A;
-template <class T1, class T2> struct B;
-template <int N> struct C;
-template <class T1, int N> struct D;
-template <class T1, class T2, int N = 17> struct E;
-
-eval<A<int>> eA;                // OK, matches partial specialization of \tcode{eval}
-eval<B<int, float>> eB;         // OK, matches partial specialization of \tcode{eval}
-eval<C<17>> eC;                 // error: \tcode{C} does not match \tcode{TT} in partial specialization
-eval<D<int, 17>> eD;            // error: \tcode{D} does not match \tcode{TT} in partial specialization
-eval<E<int, float>> eE;         // error: \tcode{E} does not match \tcode{TT} in partial specialization
-\end{codeblock}
-\end{example}
-\begin{example}
-\begin{codeblock}
-template<typename T> concept C = requires (T t) { t.f(); };
-template<typename T> concept D = C<T> && requires (T t) { t.g(); };
-
-template<template<C> class P> struct S { };
-
-template<C> struct X { };
-template<D> struct Y { };
-template<typename T> struct Z { };
-
-S<X> s1;            // OK, \tcode{X} and \tcode{P} have equivalent constraints
-S<Y> s2;            // error: \tcode{P} is not at least as specialized as \tcode{Y}
-S<Z> s3;            // OK, \tcode{P} is at least as specialized as \tcode{Z}
-\end{codeblock}
-\end{example}
-
-\pnum
-A template \grammarterm{template-parameter} \tcode{P} is
-at least as specialized as a template \grammarterm{template-argument} \tcode{A}
+\tcode{P} is at least as specialized as \tcode{A},
+ignoring constraints on \tcode{A}
+if \tcode{P} is unconstrained.
+\tcode{P} is at least as specialized as \tcode{A}
 if, given the following rewrite to two function templates,
 the function template corresponding to \tcode{P}
 is at least as specialized as
@@ -1458,6 +1386,84 @@ otherwise, \tcode{AA} is the \grammarterm{id-expression} \tcode{PP}.
 \end{itemize}
 If the rewrite produces an invalid type,
 then \tcode{P} is not at least as specialized as \tcode{A}.
+
+\pnum
+If \tcode{P} contains a template parameter pack\iref{temp.variadic}, then
+\tcode{A} also matches \tcode{P}
+if each of \tcode{A}'s template parameters
+matches the corresponding template parameter in the
+\grammarterm{template-head} of \tcode{P}.
+Two template parameters match if they are of the same kind (type, non-type, template),
+for non-type \grammarterm{template-parameter}{s}, their types are
+equivalent\iref{temp.over.link}, and for template \grammarterm{template-parameter}{s},
+each of their corresponding \grammarterm{template-parameter}{s} matches, recursively.
+A template parameter pack
+in the \grammarterm{template-head} of \tcode{P}
+will match zero or more template
+parameters or template parameter packs in the \grammarterm{template-head} of
+\tcode{A} with the same type and form as the template parameter pack in \tcode{P}
+(ignoring whether those template parameters are template parameter packs).
+
+\pnum
+\begin{example}
+\begin{codeblock}
+template<class T> class A { @\commentellip@ };
+template<class T, class U = T> class B { @\commentellip@ };
+template<class ... Types> class C { @\commentellip@ };
+template<auto n> class D { @\commentellip@ };
+template<template<class> class P> class X { @\commentellip@ };
+template<template<class ...> class Q> class Y { @\commentellip@ };
+template<template<int> class R> class Z { @\commentellip@ };
+
+X<A> xa;            // OK
+X<B> xb;            // OK
+X<C> xc;            // OK
+Y<A> ya;            // OK
+Y<B> yb;            // OK
+Y<C> yc;            // OK
+Z<D> zd;            // OK
+\end{codeblock}
+\end{example}
+
+\pnum
+\begin{example}
+\begin{codeblock}
+template <class T> struct eval;
+
+template <template <class, class...> class TT, class T1, class... Rest>
+struct eval<TT<T1, Rest...>> { };
+
+template <class T1> struct A;
+template <class T1, class T2> struct B;
+template <int N> struct C;
+template <class T1, int N> struct D;
+template <class T1, class T2, int N = 17> struct E;
+
+eval<A<int>> eA;                // OK, matches partial specialization of \tcode{eval}
+eval<B<int, float>> eB;         // OK, matches partial specialization of \tcode{eval}
+eval<C<17>> eC;                 // error: \tcode{C} does not match \tcode{TT} in partial specialization
+eval<D<int, 17>> eD;            // error: \tcode{D} does not match \tcode{TT} in partial specialization
+eval<E<int, float>> eE;         // error: \tcode{E} does not match \tcode{TT} in partial specialization
+\end{codeblock}
+\end{example}
+
+\pnum
+\begin{example}
+\begin{codeblock}
+template<typename T> concept C = requires (T t) { t.f(); };
+template<typename T> concept D = C<T> && requires (T t) { t.g(); };
+
+template<template<C> class P> struct S { };
+
+template<C> struct X { };
+template<D> struct Y { };
+template<typename T> struct Z { };
+
+S<X> s1;            // OK, \tcode{X} and \tcode{P} have equivalent constraints
+S<Y> s2;            // error: \tcode{P} is not at least as specialized as \tcode{Y}
+S<Z> s3;            // OK, \tcode{P} is at least as specialized as \tcode{Z}
+\end{codeblock}
+\end{example}
 
 \rSec1[temp.constr]{Template constraints}
 


### PR DESCRIPTION
I've rearranged the paragraphs describing matching in terms of partial ordering vs component-wise matching to more clearly separate the concepts.  I've also cleaned up some resulting redundant wording and moved the examples into separate paragraphs as they're fairly general within the context of this section (with the exception of the last example, which could reasonably be pulled into the paragraph on matching in terms of partial ordering).