### PR TITLE
[array.zero] Fix triple comparison and improve wording consistency

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -6405,7 +6405,7 @@ the effect of calling \tcode{front()} or \tcode{back()} undefined.
 
 \pnum
 In the case that \tcode{N} equals \tcode{0},
-member function \tcode{swap()} shall have a
+the member function \tcode{swap} has a
 non-throwing exception specification.
 
 \rSec3[array.creation]{Array creation functions}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -6395,18 +6395,17 @@ Linear in \tcode{N}.
 
 \indextext{\idxcode{array}!zero sized}%
 \pnum
-\tcode{array} shall provide support for the special case \tcode{N == 0}.
+In the case that \tcode{N} equals \tcode{0},
+\tcode{begin()} equals \tcode{end()} and
+the return value of \tcode{data()} is unspecified.
 
 \pnum
-In the case that \tcode{N == 0}, \tcode{begin() == end() ==} unique value.
-The return value of \tcode{data()} is unspecified.
+In the case that \tcode{N} equals \tcode{0},
+the effect of calling \tcode{front()} or \tcode{back()} undefined.
 
 \pnum
-The effect of calling \tcode{front()} or \tcode{back()} for a zero-sized array is
-undefined.
-
-\pnum
-Member function \tcode{swap()} shall have a
+In the case that \tcode{N} equals \tcode{0},
+member function \tcode{swap()} shall have a
 non-throwing exception specification.
 
 \rSec3[array.creation]{Array creation functions}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -6401,7 +6401,7 @@ the return value of \tcode{data()} is unspecified.
 
 \pnum
 In the case that \tcode{N} equals \tcode{0},
-the effect of calling \tcode{front()} or \tcode{back()} undefined.
+the effect of calling \tcode{front()} or \tcode{back()} is undefined.
 
 \pnum
 In the case that \tcode{N} equals \tcode{0},


### PR DESCRIPTION
### [array.zero] p1

This paragraph is not normative and basically pointless. The existence of a section called "Zero-sized arrays" in itself implies that there is some special support for zero-sized arrays. It's also entirely unclear what it means to "provide support"; no concrete demand is being made here. Therefore, this paragraph should be deleted.

### [array.zero] p2

This paragraph contains the broken expression `begin() == end() ==` unique value. Such a triple comparison would work in mathematical notation, but in C++, this implies nothing for `begin() == end()`, only that "unique value" is being equality-compared to an expression of type `bool`.

In general, the convention is to write "`x == y` is `true`" or "`x` equals `y`" when something normative is expressed, since a C++ expression does not have any such implication, even if it is of type `bool`.

Furthermore, it is entirely unclear what "unique value" is in this context. Does it mean that every invocation of `begin()` and `end()` produces a unique value, and `begin()` and `end()` compare equal? Does it mean that the result of the expression of `begin() == end()` is a unique value for each comparison?

I'm not even sure if anything normative is being expressed here, and the intent is clearly just to say that `begin()` equals `end()` for empty arrays. Even if it said "`begin()` returns a unique value", what would that actually mean? A value "being unique" does not have any obvious standard meaning, so it could be seen as fluff.

### [array.zero] p3

This paragraph is the least problematic, but uses language inconsistent with p2. It would be more consistent if all paragraphs began with the same prefix.

### [array.zero] p4

This paragraph has a similar issue as p4. The intent is obviously not that `swap()` is always `noexcept` because otherwise, it would be `noexcept` in the synopsis. This paragraph is located in [array.zero] so presumably, it is only meant to apply to zero-length arrays. Let's prefix it and make this clear.