### PR TITLE
[temp.func.order] Specify to only add extra first argument if needed CWG2834

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3904,7 +3904,7 @@ in the type of the value synthesized for a non-type template parameter
 is also a unique synthesized type.
 \end{note}
 Each function template $M$ that is a member function
-is considered to have
+with no explicit object parameter is considered to have
 a new first parameter of type $X(M)$, described below,
 inserted in its function parameter list.
 If exactly one of the function templates was considered by overload resolution


### PR DESCRIPTION
In [temp.func.order] paragraph 3, it is written that we need to add a new first parameter for all member functions for the purposes of template deduction. However, it only makes sense if we have an implicit object parameter.

If we don't have an implicit object parameter, we shouldn't add a new first parameter because all of our parameters explicitly are written.