### PR TITLE
[thread.once.callonce] INVOKE is evaluated, not called

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -8220,7 +8220,7 @@ template<class Callable, class... Args>
 \effects
 An execution of \tcode{call_once} that does not call its \tcode{func} is a
 \term{passive} execution. An execution of \tcode{call_once} that calls its \tcode{func}
-is an \term{active} execution. An active execution calls
+is an \term{active} execution. An active execution evaluates
 \tcode{\placeholdernc{INVOKE}(\brk{}%
 std::forward<Callable>(func),
 std::forward<Args>(args)...)}\iref{func.require}. If such a call to \tcode{func}


### PR DESCRIPTION
`INVOKE` is not a function, it's a magic expression rewriter. So we don't "call" `INVOKE`, we evaluate the rewritten expression.