### PR TITLE
[temp.pre] Add comma after introductory clause

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -123,7 +123,7 @@ declares a partial specialization\iref{temp.spec.partial}.
 \pnum
 In a
 \grammarterm{template-declaration},
-explicit specialization, or explicit instantiation the
+explicit specialization, or explicit instantiation, the
 \grammarterm{init-declarator-list}
 in the declaration shall contain at most one declarator.
 When such a declaration is used to declare a class template,


### PR DESCRIPTION
Gramatically, there should be a comma here. Sentences such as

> In case X, Y happens.

... read very strangely when removing the comma:

> In case X Y happens.

[temp.pre] p5 suffers.