### PR TITLE
[format.parse.ctx] improve readability of paragraphs 12 and 14

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -17385,8 +17385,8 @@ which indicates mixing of automatic and manual argument indexing.
 
 \pnum
 \remarks
-Call expressions where \tcode{id >= num_args_} is \tcode{true} are not
-core constant expressions\iref{expr.const}.
+A call to this function is a core constant expression\iref{expr.const} only if
+\tcode{id < num_args_} is \tcode{true}.
 \end{itemdescr}
 
 \indexlibrarymember{check_dynamic_spec}{basic_format_parse_context}%
@@ -17415,12 +17415,14 @@ Each type in \tcode{Ts...} is one of
 
 \pnum
 \remarks
-Call expressions where
-\tcode{id >= num_args_} or
+A call to this function is a core constant expression only if
+\begin{itemize}
+\item
+\tcode{id < num_args_} is \tcode{true} and
+\item
 the type of the corresponding format argument
-(after conversion to \tcode{basic_format_arg<Context>})
-is not one of the types in \tcode{Ts...}
-are not core constant expressions\iref{expr.const}.
+(after conversion to \tcode{basic_format_args<Context>}) is one of the types in \tcode{Ts...}.
+\end{itemize}
 \end{itemdescr}
 
 \indexlibrarymember{check_dynamic_spec_integral}{basic_format_parse_context}%

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -17421,7 +17421,7 @@ A call to this function is a core constant expression only if
 \tcode{id < num_args_} is \tcode{true} and
 \item
 the type of the corresponding format argument
-(after conversion to \tcode{basic_format_args<Context>}) is one of the types in \tcode{Ts...}.
+(after conversion to \tcode{basic_format_arg<Context>}) is one of the types in \tcode{Ts...}.
 \end{itemize}
 \end{itemdescr}
 


### PR DESCRIPTION
Fixes #6801.

![image](https://github.com/cplusplus/draft/assets/22040976/f75f328b-f255-41a7-9dab-14a104147781)

I have had great difficulty reading paragraph 14 prior to this edit. There are multiple reasons for that:
1. It was 1AM when I've opened the issue.
2. I was unfamiliar with the wording "Call expressions". "Calls to this function" is commonly found in the standard and it's much more obvious that it refers to *this* function, not some call expressions in general.
3. The old wording is a huge grammatical sandwich of the form "Call expressions where ... are not core constant expressions.". The sentence goes on for quite a while and connecting the beginning to the end is mentally challenging.
4. The whole sentence is a double negation of the form "Call expressions where ... **is not** one of the types ... **are not** ...". This double negation makes it hard to comprehend what the condition actually is, especially within this sandwich structure.
5. The sentence starts with "Call expressions where ... or ...". Until one has read the sentence completely, it's unclear how far the "or" will go. It basically requires the reader to properly apply "operator precedence" to make sense of this sentence solely because of the sandwich structure. If all conditions were at the end, this wouldn't be an issue.

Here's a visualization of the old structure:
```
Call expressions where
        id >= num_args_ or
        the type of the corresponding format argument
                (after conversion to basic_format_arg<Context>)
                is not one of the types in Ts...
are not core constant expressions ([expr.const]).
```
It should be obvious that navigating this sentence structure is fairly complex.

This edit resolves all these issues and makes corresponding changes to paragraph 12.