### PR TITLE
[format.parse.ctx] add comma before 'which'

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -17353,8 +17353,10 @@ return next_arg_id_++;
 
 \pnum
 \throws
-\tcode{format_error} if \tcode{indexing_ == manual} is \tcode{true}
-which indicates mixing of automatic and manual argument indexing.
+\tcode{format_error} if \tcode{indexing_ == manual} is \tcode{true}.
+\begin{note}
+This indicates mixing of automatic and manual argument indexing.
+\end{note}
 
 \pnum
 \remarks
@@ -17380,8 +17382,10 @@ if (indexing_ == unknown)
 \pnum
 \throws
 \tcode{format_error} if
-\tcode{indexing_ == automatic} is \tcode{true}
-which indicates mixing of automatic and manual argument indexing.
+\tcode{indexing_ == automatic} is \tcode{true}.
+\begin{note}
+This indicates mixing of automatic and manual argument indexing.
+\end{note}
 
 \pnum
 \remarks


### PR DESCRIPTION
Normally, you would write a comma here.

Saying
> `indexing == manual` is `true` which

suggests that `index == manual` is the `true` which ...

This wouldn't make sense since there is only one `true`, which makes it more correct to write a comma here. Of course, the sentence is unambiguous one way or the other; this is purely a readability improvement.