### PR TITLE
[format.parse.ctx] add comma before consisting

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -17273,7 +17273,7 @@ namespace std {
 
 \pnum
 An instance of \tcode{basic_format_parse_context} holds
-the format string parsing state consisting of
+the format string parsing state, consisting of
 the format string range being parsed and
 the argument counter for automatic indexing.
 


### PR DESCRIPTION
It is more correct to write a comma here. The current wording suggests that

> An instance of `basic_fomat_parse_context` holds the one format string parsing state (of many parsing states) which happens to consist of ...

What the sentence is actually trying to express is

> An instance of `basic_format_parse_context` holds the the format string parsing state; this state consists of ...
