### PR TITLE
[expr.unary.op] remove redundant value category wording

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4603,7 +4603,6 @@ Each of the following unary operators yields a prvalue.
 \indextext{expression!pointer-to-member constant}%
 The operand of the unary \tcode{\&} operator
 shall be an lvalue of some type \tcode{T}.
-The result is a prvalue.
 \begin{itemize}
 \item
 If the operand is a \grammarterm{qualified-id} naming a non-static or variant member \tcode{m}


### PR DESCRIPTION
https://github.com/cplusplus/draft/blob/8c8e05d7ff6cda6329ca898e7a270547a85675d7/source/expressions.tex#L4598-L4606

The paragraph above already states that *all* unary operators yield a prvalue. We can remove this redundant wording from the `&` operator.