### PR TITLE
[bit.pow.two] Remove redundant Remarks specification

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -18961,12 +18961,6 @@ $N$.
 \pnum
 \throws
 Nothing.
-
-\pnum
-\remarks
-A function call expression
-that violates the precondition in the \expects element
-is not a core constant expression\iref{expr.const}.
 \end{itemdescr}
 
 \indexlibraryglobal{bit_floor}%


### PR DESCRIPTION
This paragraph is useless and should be removed.

[[structure.specifications] p3.3](https://eel.is/c++draft/structure.specifications#3.3) already states that precondition violations are undefined behavior. Evaluations with undefined behavior are not core constant expressions as per [[expr.const] p5.8](https://eel.is/c++draft/expr.const#5.8).

It could be argued that this paragraph is not only pointless but also harmful because it suggests that the precondition violations don't *generally* disqualify expressions from being constant expressions, only in this case, and this is surely not intended.

Even if we read this paragraph as
> If a precondition is violated, the behavior is undefined, but it's not allowed for the undefined behavior to be a core constant expression.

... then what's the point of that? It just seems confusing.