### PR TITLE
[container.reqmts] Fix stray semicolon in description of expression

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -267,7 +267,7 @@ Linear for \tcode{array} and constant for all other standard containers.
 
 \indexcont{operator=}%
 \begin{itemdecl}
-t = v;
+t = v
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
According to [[structure.specifications] p3.7](https://eel.is/c++draft/structure.specifications#3.7), a *Result* is meaningful for expressions, but not statements.

The statement in question is `t = v;`, which has a *Result* specification below, which seems erroneous.

Removing the *Result* specification would have normative effect and doesn't seem like the right resolution anyway, so the semicolon should be removed. This also brings the `t = v;` in line with the next item, which is `t = rv` (no semicolon).