### PR TITLE
[container.requirements] Fix malformed Result specifications

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -339,8 +339,8 @@ b.begin()
 \begin{itemdescr}
 \pnum
 \result
-\tcode{iterator};
-\tcode{const_iterator} for constant \tcode{b}.
+\tcode{const_iterator} if \tcode{b} is of type \tcode{const X};
+\tcode{iterator} otherwise.
 
 \pnum
 \returns
@@ -359,8 +359,8 @@ b.end()
 \begin{itemdescr}
 \pnum
 \result
-\tcode{iterator};
-\tcode{const_iterator} for constant \tcode{b}.
+\tcode{const_iterator} if \tcode{b} is of type \tcode{const X};
+\tcode{iterator} otherwise.
 
 \pnum
 \returns
@@ -822,8 +822,8 @@ a.rbegin()
 \begin{itemdescr}
 \pnum
 \result
-\tcode{reverse_iterator};
-\tcode{const_reverse_iterator} for constant \tcode{a}.
+\tcode{const_reverse_iterator} if \tcode{a} is of type \tcode{const X};
+\tcode{reverse_iterator} otherwise.
 
 \pnum
 \returns
@@ -842,8 +842,8 @@ a.rend()
 \begin{itemdescr}
 \pnum
 \result
-\tcode{reverse_iterator};
-\tcode{const_reverse_iterator} for constant \tcode{a}.
+\tcode{const_reverse_iterator} if \tcode{a} is of type \tcode{const X};
+\tcode{reverse_iterator} otherwise.
 
 \pnum
 \returns
@@ -1919,7 +1919,8 @@ a.front()
 \begin{itemdescr}
 \pnum
 \result
-\tcode{reference; const_reference} for constant \tcode{a}.
+\tcode{const_reference} if \tcode{a} is of type \tcode{const X};
+\tcode{reference} otherwise.
 
 \pnum
 \hardexpects
@@ -1948,7 +1949,8 @@ a.back()
 \begin{itemdescr}
 \pnum
 \result
-\tcode{reference; const_reference} for constant \tcode{a}.
+\tcode{const_reference} if \tcode{a} is of type \tcode{const X};
+\tcode{reference} otherwise.
 
 \pnum
 \hardexpects
@@ -2267,7 +2269,8 @@ a[n]
 \begin{itemdescr}
 \pnum
 \result
-\tcode{reference; const_reference} for constant \tcode{a}.
+\tcode{const_reference} if \tcode{a} is of type \tcode{const X};
+\tcode{reference} otherwise.
 
 \pnum
 \hardexpects
@@ -2294,7 +2297,8 @@ a.at(n)
 \begin{itemdescr}
 \pnum
 \result
-\tcode{reference; const_reference} for constant \tcode{a}.
+\tcode{const_reference} if \tcode{a} is of type \tcode{const X};
+\tcode{reference} otherwise.
 
 \pnum
 \returns
@@ -3783,7 +3787,8 @@ b.find(k)
 \begin{itemdescr}
 \pnum
 \result
-\tcode{iterator}; \tcode{const_iterator} for constant \tcode{b}.
+\tcode{const_iterator} if \tcode{b} is of type \tcode{const X};
+\tcode{iterator} otherwise.
 
 \pnum
 \returns
@@ -3803,7 +3808,8 @@ a_tran.find(ke)
 \begin{itemdescr}
 \pnum
 \result
-\tcode{iterator}; \tcode{const_iterator} for constant \tcode{a_tran}.
+\tcode{const_iterator} if \tcode{a_tran} is of type \tcode{const X};
+\tcode{iterator} otherwise.
 
 \pnum
 \returns
@@ -3893,7 +3899,8 @@ b.lower_bound(k)
 \begin{itemdescr}
 \pnum
 \result
-\tcode{iterator}; \tcode{const_iterator} for constant \tcode{b}.
+\tcode{const_iterator} if \tcode{b} is of type \tcode{const X};
+\tcode{iterator} otherwise.
 
 \pnum
 \returns
@@ -3913,7 +3920,8 @@ a_tran.lower_bound(kl)
 \begin{itemdescr}
 \pnum
 \result
-\tcode{iterator}; \tcode{const_iterator} for constant \tcode{a_tran}.
+\tcode{const_iterator} if \tcode{a_tran} is of type \tcode{const X};
+\tcode{iterator} otherwise.
 
 \pnum
 \returns
@@ -3934,7 +3942,8 @@ b.upper_bound(k)
 \begin{itemdescr}
 \pnum
 \result
-\tcode{iterator}; \tcode{const_iterator} for constant \tcode{b}.
+\tcode{const_iterator} if \tcode{b} is of type \tcode{const X};
+\tcode{iterator} otherwise.
 
 \pnum
 \returns
@@ -3954,7 +3963,8 @@ a_tran.upper_bound(ku)
 \begin{itemdescr}
 \pnum
 \result
-\tcode{iterator}; \tcode{const_iterator} for constant \tcode{a_tran}.
+\tcode{const_iterator} if \tcode{a_tran} is of type \tcode{const X};
+\tcode{iterator} otherwise.
 
 \pnum
 \returns
@@ -3975,8 +3985,9 @@ b.equal_range(k)
 \begin{itemdescr}
 \pnum
 \result
-\tcode{pair<iterator, iterator>};
-\tcode{pair<const_iterator, const_iterator>} for constant \tcode{b}.
+\tcode{pair<const_iterator, const_iterator>}
+if \tcode{b} is of type \tcode{const X};
+\tcode{pair<iter\-ator, iter\-ator>} otherwise.
 
 \pnum
 \effects
@@ -3995,8 +4006,9 @@ a_tran.equal_range(ke)
 \begin{itemdescr}
 \pnum
 \result
-\tcode{pair<iterator, iterator>};
-\tcode{pair<const_iterator, const_iterator>} for constant \tcode{a_tran}.
+\tcode{pair<const_iterator, const_iterator>}
+if \tcode{a_tran} is of type \tcode{const X};
+\tcode{pair<iter\-ator, iter\-ator>} otherwise.
 
 \pnum
 \effects
@@ -5470,7 +5482,8 @@ b.find(k)
 \begin{itemdescr}
 \pnum
 \result
-\tcode{iterator}; \tcode{const_iterator} for constant \tcode{b}.
+\tcode{const_iterator} if \tcode{b} is of type \tcode{const X};
+\tcode{iterator} otherwise.
 
 \pnum
 \returns
@@ -5490,7 +5503,8 @@ a_tran.find(ke)
 \begin{itemdescr}
 \pnum
 \result
-\tcode{iterator}; \tcode{const_iterator} for constant \tcode{a_tran}.
+\tcode{const_iterator} if \tcode{a_tran} is of type \tcode{const X};
+\tcode{iterator} otherwise.
 
 \pnum
 \returns
@@ -5571,8 +5585,9 @@ b.equal_range(k)
 \begin{itemdescr}
 \pnum
 \result
-\tcode{pair<iterator, iterator>};
-\tcode{pair<const_iterator, const_iterator>} for constant \tcode{b}.
+\tcode{pair<const_iterator, const_iterator>}
+if \tcode{b} is of type \tcode{const X};
+\tcode{pair<iter\-ator, iter\-ator>} otherwise.
 
 \pnum
 \returns
@@ -5592,8 +5607,9 @@ a_tran.equal_range(ke)
 \begin{itemdescr}
 \pnum
 \result
-\tcode{pair<iterator, iterator>};
-\tcode{pair<const_iterator, const_iterator>} for constant \tcode{a_tran}.
+\tcode{pair<const_iterator, const_iterator>}
+if \tcode{a_tran} is of type \tcode{const X};
+\tcode{pair<iter\-ator, iter\-ator>} otherwise.
 
 \pnum
 \returns
@@ -5730,7 +5746,8 @@ b.begin(n)
 \begin{itemdescr}
 \pnum
 \result
-\tcode{local_iterator}; \tcode{const_local_iterator} for constant \tcode{b}.
+\tcode{const_local_iterator} if \tcode{b} is of type \tcode{const X};
+\tcode{local_iterator} otherwise.
 
 \pnum
 \expects
@@ -5754,7 +5771,8 @@ b.end(n)
 \begin{itemdescr}
 \pnum
 \result
-\tcode{local_iterator}; \tcode{const_local_iterator} for constant \tcode{b}.
+\tcode{const_local_iterator} if \tcode{b} is of type \tcode{const X};
+\tcode{local_iterator} otherwise.
 
 \pnum
 \expects


### PR DESCRIPTION
The *Result* specifications for `a.front()`, `a.back()`, `a[n]`, and `a.at(n)` are formatted as:

> `reference; const_reference` for constant `a`.

In other words, the result of `a.front()` is the C++ type `reference; const_reference` in the event that `a` is constant. Otherwise, the standard imposes no requirements on the result type of the expression.

Seeing that `reference; const_reference` cannot be a type and that it would be surprising if no requirements were imposed on non-`const` `a`, this is presumably an editorial issue and should be rephrased.