### PR TITLE
[container.reqmts] Avoid dependency of `size`/`max_size` on `distance(begin(), end())`

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -504,8 +504,12 @@ c.size()
 
 \pnum
 \returns
-\tcode{distance(c.begin(), c.end())},
-i.e., the number of elements in the container.
+The number of elements in the container.
+
+\begin{note}
+\tcode{distance(c.begin(), c.end())}, whenever well-defined,
+is equal to the number of elements.
+\end{note}
 
 \pnum
 \complexity
@@ -529,7 +533,7 @@ c.max_size()
 
 \pnum
 \returns
-\tcode{distance(begin(), end())} for the largest possible container.
+\tcode{c.size()} for the largest possible container.
 
 \pnum
 \complexity


### PR DESCRIPTION
`c.size()` and `c.max_size()` should be always well-defined, and thus shouldn't be dependent on `std::distance`. Related to #6822.