### PR TITLE
P0732R2 Add `__cpp_nontype_template_parameter_class`

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1850,6 +1850,7 @@ an \impldef{text of \mname{TIME} when time of translation is not available} vali
 \defnxname{cpp_noexcept_function_type}            & \tcode{201510L} \\ \rowsep
 \defnxname{cpp_nontype_template_args}             & \tcode{201911L} \\ \rowsep
 \defnxname{cpp_nontype_template_parameter_auto}   & \tcode{201606L} \\ \rowsep
+\defnxname{cpp_nontype_template_parameter_class}  & \tcode{201911L} \\ \rowsep
 \defnxname{cpp_nsdmi}                             & \tcode{200809L} \\ \rowsep
 \defnxname{cpp_pack_indexing}                     & \tcode{202311L} \\ \rowsep
 \defnxname{cpp_placeholder_variables}             & \tcode{202306L} \\ \rowsep


### PR DESCRIPTION
See https://github.com/cplusplus/CWG/issues/508 for discussion.

[[P0732R2]](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0732r2.pdf) proposed to add a `__cpp_nontype_template_parameter_class` predefined macro, and this has been accepted into C++20.

According to @jensmaurer, it's an editorial oversight that it wasn't added to the working draft.