### PR TITLE
[stmt.while], [stmt.do] Add commas after introductory phrases

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -598,7 +598,7 @@ The expression is contextually converted to \tcode{bool}\iref{conv};
 if that conversion is ill-formed, the program is ill-formed.
 
 \pnum
-In the \keyword{do} statement the substatement is executed repeatedly
+In the \keyword{do} statement, the substatement is executed repeatedly
 until the value of the expression becomes \tcode{false}. The test takes
 place after each execution of the statement.
 

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -550,7 +550,7 @@ Thus after the \keyword{while} statement, \tcode{i} is no longer in scope.
 \indextext{statement!\idxcode{while}}
 
 \pnum
-In the \keyword{while} statement the substatement is executed repeatedly
+In the \keyword{while} statement, the substatement is executed repeatedly
 until the value of the condition\iref{stmt.pre} becomes
 \tcode{false}. The test takes place before each execution of the
 substatement.


### PR DESCRIPTION
The current wording is:
> In the `...` statement the substatement is executed repeatedly

It would be more correct to have a comma after the introductory phrase, i.e. prior to "the".

While we're at it, I'd also like to draw some attention to https://github.com/cplusplus/draft/issues/6492.