### PR TITLE
[stmt.jump] Add reference to [stmt.dcl]

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -765,7 +765,7 @@ Jump statements unconditionally transfer control.
 \begin{note}
 On exit from a scope (however accomplished), objects with automatic storage
 duration\iref{basic.stc.auto} that have been constructed in that scope are destroyed
-in the reverse order of their construction.
+in the reverse order of their construction\iref{stmt.dcl}.
 For temporaries, see~\ref{class.temporary}.
 However, the program can be terminated (by calling
 \indextext{\idxcode{exit}}%


### PR DESCRIPTION
The other day, a few other C++ users and myself were trying to find the rules which forbid `goto` from crossing non-vacuous initialization.

To our surprise, neither [[stmt.jump]](https://eel.is/c++draft/stmt.jump) nor [[stmt.goto]](https://eel.is/c++draft/stmt.goto) describe these rules; they are found in [[stmt.dcl]](https://eel.is/c++draft/stmt.dcl).

It would make the rules easier to find if we had an `\iref{stmt.dcl}` here.