### PR TITLE
[expr.dynamic.cast] Add comma after conditional clause

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3827,7 +3827,8 @@ check logically executes as follows:
 \item If, in the most derived object pointed (referred) to by \tcode{v},
 \tcode{v} points (refers) to a public base class subobject of a
 \tcode{C} object, and if only one object of type \tcode{C} is derived
-from the subobject pointed (referred) to by \tcode{v} the result points (refers) to that \tcode{C} object.
+from the subobject pointed (referred) to by \tcode{v},
+the result points (refers) to that \tcode{C} object.
 
 \item Otherwise, if \tcode{v} points (refers) to a public base
 class subobject of the most derived object, and the type of the most


### PR DESCRIPTION
There is a conditional clause in this wording:

> ... and if only one object of type `C` is derived from the subobject pointed (referred) to by `v` the result ...

There should be a comma prior to "the".

There are further issues with [expr.dynamic.cast] as brought up in https://github.com/cplusplus/draft/issues/6799, though this PR is orthogonal.