### PR TITLE
[headers] Strike 'C standard library headers' and turn paragraph into note

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1313,7 +1313,7 @@ standard header \libheader{iso646.h} has no effect.
 \end{footnote}
 
 \pnum
-\ref{support.c.headers}, C standard library headers, describes the effects of using
+Subclause \ref{support.c.headers} describes the effects of using
 the \tcode{\placeholder{name}.h} (C header) form in a \Cpp{} program.
 \begin{footnote}
  The


### PR DESCRIPTION
Fixes #6789.

Furthermore, this paragraph has no normative effect and can be turned into a note. It's merely a *"this other section specifies ..."* paragraph.