### PR TITLE
[charconv.from.chars] Clarify effect of from_chars

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15543,9 +15543,14 @@ is parsed to have the value
 with remaining characters \tcode{x123}.
 \end{example}
 \end{itemize}
-In any case, the resulting \tcode{value} is one of
-at most two floating-point values
-closest to the value of the string matching the pattern.
+In any case, let $x$ be the numeric value obtained by parsing the subject sequence.
+If $x$ can be exactly represented in \placeholder{floating-point-type},
+\tcode{value} has value $x$.
+Otherwise, if $x$ is between two adjacent values
+of type \placeholder{floating-point-type},
+\tcode{value} is an implementation-defined choice of either of those values.
+Otherwise, \tcode{value} is the value closest to $x$ and representable in
+\placeholder{floating-point-type}.
 
 \pnum
 \throws


### PR DESCRIPTION
Fixes #6730.

![image](https://github.com/cplusplus/draft/assets/22040976/340c1430-2af6-4c8c-87eb-78ce9a4f8c23)

Drafting the wording has revealed an asymmetry with how `static_cast` works. Say we have a floating-point type `T` which cannot represent infinity and which can represent `[-1, 1]` in increments of `0.1`.

In that case, `static_cast<T>(1.1)` is undefined behavior. However, `from_chars("1.1")` in the current wording is `1.0`. My proposed change is editorial only and doesn't change that behavior, but perhaps it should be revisited whether `static_cast` and `from_chars` should have matching behavior in this event.