### PR TITLE
[time.parse], [diff.cpp17.temp] Hyphenate argument-dependent lookup

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -984,11 +984,11 @@ that is followed by a \tcode{<}
 and for which name lookup
 finds nothing or finds a function
 will be treated as a \grammarterm{template-name}
-in order to potentially cause argument dependent lookup to be performed.
+in order to potentially cause argument-dependent lookup to be performed.
 \rationale
 It was problematic to call a function template
 with an explicit template argument list
-via argument dependent lookup
+via argument-dependent lookup
 because of the need to have a template with the same name
 visible via normal lookup.
 \effect

--- a/source/time.tex
+++ b/source/time.tex
@@ -11021,7 +11021,7 @@ return formatter<chrono::@\placeholder{local-time-format-t}@<Duration>, charT>::
 \pnum
 Each \tcode{parse} overload specified in this subclause
 calls \tcode{from_stream} unqualified,
-so as to enable argument dependent lookup\iref{basic.lookup.argdep}.
+so as to enable argument-dependent lookup\iref{basic.lookup.argdep}.
 In the following paragraphs,
 let \tcode{is} denote an object of type \tcode{basic_istream<charT, traits>} and
 let \tcode{I} be \tcode{basic_istream<charT, traits>\&},


### PR DESCRIPTION
Fixes #6712.