### PR TITLE
[expr.mul] Reword 'truncation towards zero' in footnote

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6228,14 +6228,14 @@ expression by the second.
 \indextext{zero!undefined division by}%
 If the second operand of \tcode{/} or \tcode{\%} is zero, the behavior is
 undefined.
-For integral operands, the \tcode{/} operator yields the algebraic quotient with
-any fractional part discarded;
-\begin{footnote}
-This is often called truncation towards zero.
-\end{footnote}
-if the quotient \tcode{a/b} is representable in the type of the result,
-\tcode{(a/b)*b + a\%b} is equal to \tcode{a}; otherwise, the behavior
-of both \tcode{a/b} and \tcode{a\%b} is undefined.
+For integral operands, the \tcode{/} operator yields the algebraic quotient
+rounded towards zero.
+\begin{note}
+If the quotient \tcode{a/b} is representable in the type of the result,
+\tcode{(a/b)*b + a\%b} is equal to \tcode{a};
+otherwise, the behavior of both
+\tcode{a/b} and \tcode{a\%b} is undefined\iref{expr.pre}.
+\end{note}
 
 \rSec2[expr.add]{Additive operators}%
 \indextext{expression!additive operators}%


### PR DESCRIPTION
Fixes #6790.

I agree with @Tevemadar; *"truncation towards zero"* sounds redundant. However, I have frequently heard
- rounding towards zero
- truncation

The new footnote mentions both.