### PR TITLE
[dcl.fct.default] Correct note on 'this' in default arguments

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4229,9 +4229,8 @@ void f() {
 
 \pnum
 \begin{note}
-The keyword
-\keyword{this}
-cannot appear in a default argument of a member function;
+\keyword{this} cannot appear as a subexpression of
+a default argument of a member function;
 see~\ref{expr.prim.this}.
 \begin{example}
 \begin{codeblock}


### PR DESCRIPTION
Fixes #6558.

This implements the wording suggested by @jensmaurer.