### PR TITLE
[gram.key] Replace 'context-dependent keywords' with 'names'

### DIFF
--- a/source/grammar.tex
+++ b/source/grammar.tex
@@ -18,7 +18,7 @@ to weed out syntactically valid but meaningless constructs.
 
 \pnum
 \indextext{keyword}%
-New context-dependent keywords are introduced into a program by
+New names are introduced into a program by
 \tcode{typedef}\iref{dcl.typedef},
 \tcode{namespace}\iref{namespace.def},
 class\iref{class}, enumeration\iref{dcl.enum}, and


### PR DESCRIPTION
Fixes #6486.

@jwakely  commented that all these declarations introduce "names". That's the wording I am familiar with and find less confusing.

As already noted, the wording "context-dependent keywords" dates back to C++98. I think it's safe to assume that this is simply immature/antiquated wording that's more common in the original standard.