### PR TITLE
[rand.req.seedeq], [rand.req.dist], [char.traits.require] Eliminate "compile-time" complexity

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -1711,7 +1711,7 @@ In \tref{rand.req.seedseq} and throughout this subclause:
   & \tcode{T}
   & \tcode{T} is an unsigned integer type\iref{basic.fundamental}
     of at least 32 bits.
-  & compile-time
+  &
   \\ \rowsep
 \tcode{S()}%
   &

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -2320,12 +2320,12 @@ according to \ref{strings} and \ref{input.output}.
 \tcode{D::result_type}
   & \tcode{T}
   & \tcode{T} is an arithmetic type\iref{basic.fundamental}.
-  & compile-time
+  &
   \\ \rowsep
 \tcode{D::param_type}
   & \tcode{P}
   &
-  & compile-time
+  &
   \\ \rowsep
 \tcode{D()}%
   &

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -122,15 +122,15 @@ shall exit via an exception.
                         &                       &   \chdr{pre-/post-condition}   &               \\ \capsep
 \endhead
 \tcode{X::char_type}    &   \tcode{C}       &
-   &   compile-time    \\ \rowsep
+   &    \\ \rowsep
 \tcode{X::int_type} &                       &
-(described in~\ref{char.traits.typedefs})   &   compile-time    \\ \rowsep
+(described in~\ref{char.traits.typedefs})   &    \\ \rowsep
 \tcode{X::off_type} &                       &
-(described in~\ref{iostreams.limits.pos} and \ref{iostream.forward})   &   compile-time    \\ \rowsep
+(described in~\ref{iostreams.limits.pos} and \ref{iostream.forward})   &    \\ \rowsep
 \tcode{X::pos_type} &                       &
-(described in~\ref{iostreams.limits.pos} and \ref{iostream.forward})   &   compile-time    \\ \rowsep
+(described in~\ref{iostreams.limits.pos} and \ref{iostream.forward})   &    \\ \rowsep
 \tcode{X::state_type}   &                       &
-(described in~\ref{char.traits.typedefs})   &   compile-time    \\ \rowsep
+(described in~\ref{char.traits.typedefs})   &    \\ \rowsep
 \tcode{X::eq(c,d)}      &   \tcode{bool}        &
  \returns
 whether \tcode{c} is to be treated as equal to \tcode{d}.   &   constant    \\ \rowsep


### PR DESCRIPTION
Related to https://github.com/cplusplus/draft/issues/5641.

In short, the C++ standard doesn't have a clearly-defined notion of "compile-time" or "run-time".

Instead of specifying that these type aliases have "compile-time complexity" (whatever that's supposed to mean) we can just leave the cell empty. No evaluation takes place here, so it's meaningless to talk about complexity.