### PR TITLE
[std.iterator.tags] Reword iterator tag description

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2741,11 +2741,12 @@ several classes and functions.
 It is often desirable for a
 function template specialization
 to find out what is the most specific category of its iterator
-argument, so that the function can select the most efficient algorithm at compile time.
+argument, so that a function call can select the most efficient algorithm
+during overload resolution.
 To facilitate this, the
 library introduces
 \defn{category tag}
-classes which are used as compile time tags for algorithm selection.
+classes which are used as overload resolution tags for algorithm selection.
 They are:
 \tcode{output_iterator_tag},
 \tcode{input_iterator_tag},


### PR DESCRIPTION
Related to #5641.

This section has a few issues:

1. It contains wording "so that the function can select". This doesn't make much sense, since a function simply exists and never selects in itself. The intent is presumably that a *function call* selects the most efficient algorithm. That's how tag dispatch works anyway.

2. The wording contains "compile time", which isn't a concept that really exists in C++. It is better to talk about overload resolution.

