### PR TITLE
[type.traits] Strike 'at compile time'

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -76,7 +76,7 @@ The type \tcode{make_integer_sequence<T, N>} is an alias for the type
 Subclause \ref{type.traits} describes components used by \Cpp{} programs, particularly in
 templates, to support the widest possible range of types, optimize
 template code usage, detect type related user errors, and perform
-type inference and transformation at compile time. It includes type
+type inference and transformation. It includes type
 classification traits, type property inspection traits, and type
 transformations. The type classification traits describe a complete taxonomy
 of all possible \Cpp{} types, and state where in that taxonomy a given

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -622,7 +622,7 @@ the interface for various type traits.
 
 \pnum
 Subclause \ref{meta.unary} contains templates that may be used to query the
-properties of a type at compile time.
+properties of a type.
 
 \pnum
 Each of these templates shall be a

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -1432,7 +1432,7 @@ static_assert(extent_v<int[][4], 1> == 4);
 
 \pnum
 The templates specified in \tref{meta.rel}
-may be used to query relationships between types at compile time.
+may be used to query relationships between types.
 
 \pnum
 Each of these templates shall be a

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -1364,7 +1364,7 @@ otherwise, the condition holds true for integral types.
 
 \pnum
 The templates specified in \tref{meta.unary.prop.query}
-may be used to query properties of types at compile time.
+may be used to query properties of types.
 
 \begin{libreqtab2a}{Type property queries}{meta.unary.prop.query}
 \\ \topline


### PR DESCRIPTION
Related to #5641.

C++ doesn't have a notion of "compile-time" or "run-time". We can simply say that type traits query the properties of a type, period.

If we really wanted to, we could say something about constant expression here. However, I see this as pointless; these paragraphs are informative anyway.