### PR TITLE
[charconv.to.chars] Itemize mapping of `chars_format` onto conversion specifiers

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15335,15 +15335,22 @@ resolving any remaining ties using rounding according to
 \tcode{round_to_nearest}\iref{round.style}.
 
 \pnum
-The functions taking a \tcode{chars_format} parameter
-determine the conversion specifier for \tcode{printf} as follows:
-The conversion specifier is
-\tcode{f} if \tcode{fmt} is \tcode{chars_format::fixed},
-\tcode{e} if \tcode{fmt} is \tcode{chars_format::scientific},
+In the functions taking a \tcode{chars_format} parameter,
+the conversion specifier for \tcode{printf} is
+\begin{itemize}
+\item
+\tcode{f}
+if \tcode{fmt} is \tcode{chars_format::fixed},
+\item
+\tcode{e}
+if \tcode{fmt} is \tcode{chars_format::scientific},
+\item
 \tcode{a} (without leading \tcode{"0x"} in the result)
-if \tcode{fmt} is \tcode{chars_format::hex},
-and
-\tcode{g} if \tcode{fmt} is \tcode{chars_format::general}.
+if \tcode{fmt} is \tcode{chars_format::hex}, and
+\item
+\tcode{g}
+if \tcode{fmt} is \tcode{chars_format::general}.
+\end{itemize}
 
 \indexlibraryglobal{to_chars}%
 \begin{itemdecl}


### PR DESCRIPTION
![image](https://github.com/cplusplus/draft/assets/22040976/e507974f-6051-4452-94e7-9a9913353991)

I find this paragraph to be a lot more readable when itemized. The old wording is also somewhat verbose:

> The functions taking a chars_format parameter determine the conversion specifier for `printf` as follows: The conversion specifier is ...

We don't need to tell the reader twice that we're determining conversion specifiers here.