### PR TITLE
[charconv.syn] Clarify what types match integer-type

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15215,7 +15215,7 @@ The header \libheader{execution} declares global objects associated with each ty
 When a function is specified
 with a type placeholder of \tcode{\placeholder{integer-type}},
 the implementation provides overloads
-for all cv-unqualified signed and unsigned integer types and \tcode{char}
+for \tcode{char} and all cv-unqualified signed and unsigned integer types
 in lieu of \tcode{\placeholder{integer-type}}.
 When a function is specified
 with a type placeholder of \tcode{\placeholder{floating-point-type}},


### PR DESCRIPTION
The current wording in [[charconv.syn]](https://eel.is/c++draft/charconv.syn) is confusing at a surface level, but this is purely an editorial problem:

> ... the implementation provides overloads for all cv-unqualified signed and unsigned integer types and `char` in lieu of *integer-types*

Firstly, the reader may ask whether this means:
- (signed and unsigned integer types) and `char`, or
- (signed and unsigned) (integer types and `char`)

In other words, does this include `signed char` and `unsigned char`, or does it include `char`? However, `signed char` and `unsigned char` are already signed/unsigned integer types, so mentioning `char` separately here would be totally redundant. Only the former interpretation is plausible to me.

Secondly, the reader may ask whether "cv-unqualified" applies to `char` as well, but this question is totally pointless since `char` is already cv-unqualified.

Overall, we can reduce mental complexity here by simply putting `char` in front. Each of these questions has a clear answer (which is why this edit is not normative), but it would be better if those questions were eliminated completely.