### PR TITLE
[charconv.from.chars] Clarify the role of a `0x` prefix in `from_chars`

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15535,7 +15535,7 @@ but not \tcode{chars_format::scientific},
 the optional exponent part shall not appear; and
 \item
 if \tcode{fmt} is \tcode{chars_format::hex},
-the prefix \tcode{"0x"} or \tcode{"0X"} is assumed.
+the prefix \tcode{"0x"} or \tcode{"0X"} shall not appear.
 \begin{example}
 The string \tcode{0x123}
 is parsed to have the value


### PR DESCRIPTION
The current wording

> ... the prefix `"0x"` or `"0X"` is assumed.

... is ambiguous. It could either mean
- the prefix is assumed to be at the start of the string (inclusive prefix), or
- the prefix is assumed to precede the string (exclusive prefix).

In the English language, I don't believe that the inclusive/exclusive nature of prefixes is undisputed.

However, the following example with `0x123` disambiguates this, and this example has been present in [P0067R5](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0067r5.html) (which was accepted). 

Therefore, I believe intent is clear, and this issue is editorial. However, it would be better for the normative wording to be clear in itself instead of relying on a clarifying example.