### PR TITLE
[pairs.pair] Replace `std::forward` with `std::move` where equivalent

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1076,8 +1076,8 @@ constexpr pair& operator=(pair&& p) noexcept(@\seebelow@);
 
 \pnum
 \effects
-Assigns \tcode{std::forward<T1>(p.first)} to \tcode{first} and
-\tcode{std::forward<T2>(p.second)} to \tcode{second}.
+Assigns \tcode{std::move(p.first)} to \tcode{first} and
+\tcode{std::move(p.second)} to \tcode{second}.
 
 \pnum
 \returns
@@ -1108,8 +1108,8 @@ constexpr const pair& operator=(pair&& p) const;
 
 \pnum
 \effects
-Assigns \tcode{std::forward<T1>(p.first)} to \tcode{first} and
-\tcode{std::forward<T2>(p.second)} to \tcode{second}.
+Assigns \tcode{std::move(p.first)} to \tcode{first} and
+\tcode{std::move(p.second)} to \tcode{second}.
 
 \pnum
 \returns


### PR DESCRIPTION
The use of `std::forward` for the following assignment operators is unnecessary:
- `operator=(pair&& p)`
- `operator=(pair&& p) const`.

In both cases, we know 100% that the types of `this->first` and `p.first` and the type of `this->second` and `p.second` match, and we are working with an rvalue reference, not a forwarding reference.

In such cases, it's not necessary to use `std::forward`, and it arguably misleads the reader into thinking that this is ever copying instead of moving, which isn't the case (unless the two are equivalent).