### PR TITLE
[handler.functions], [mem.res.global] Replace 'shall synchronize with' with 'synchronizes with'

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -3341,7 +3341,7 @@ functions:
 
 \pnum
 Calling the \tcode{set_*} and \tcode{get_*} functions shall not incur a data race\iref{intro.races}.
-A call to any of the \tcode{set_*} functions shall synchronize with subsequent calls to the same
+A call to any of the \tcode{set_*} functions synchronizes with subsequent calls to the same
 \tcode{set_*} function and to the corresponding \tcode{get_*} function.
 
 \rSec3[res.on.functions]{Other functions}

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -6156,7 +6156,7 @@ The previous value of the default memory resource pointer.
 Calling the \tcode{set_default_resource} and
 \tcode{get_default_resource} functions shall not incur a data race.
 A call to the \tcode{set_default_resource} function
-shall synchronize with subsequent calls to
+synchronizes with\iref{intro.races} subsequent calls to
 the \tcode{set_default_resource} and \tcode{get_default_resource} functions.
 \end{itemdescr}
 


### PR DESCRIPTION
Fixes https://github.com/cplusplus/draft/pull/6845#discussion_r1510205634, implementing the change suggested by @jensmaurer.

While we're at it, we can apply the same change to [mem.res.global] and add an `\iref{intro.races}` since this is the first and only mention of "synchronizes with" in [mem].