### PR TITLE
[atomics.order] Make out-of-thin-air prevention Recommended practice

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -2600,6 +2600,7 @@ with respect to other atomic operations performed by the same thread.
 \end{note}
 
 \pnum
+\recommended
 Implementations should ensure that no ``out-of-thin-air'' values are computed that
 circularly depend on their own computation.
 


### PR DESCRIPTION
The wording heavily suggests that this paragraph is merely a recommendation. The following example even says "this recommendation".

Therefore, the paragraph should be formatted as *Recommended Practice*.