### PR TITLE
[expr.const] Clarify example on when evaluation takes place

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -7948,8 +7948,8 @@ execution.
 \begin{example}
 \begin{codeblock}
 bool f() {
-    char array[1 + int(1 + 0.2 - 0.1 - 0.1)];   // Must be evaluated during translation
-    int size = 1 + int(1 + 0.2 - 0.1 - 0.1);    // May be evaluated at runtime
+    char array[1 + int(1 + 0.2 - 0.1 - 0.1)];   // Arithmetic is evaluated during translation
+    int size = 1 + int(1 + 0.2 - 0.1 - 0.1);    // Arithmetic is evaluated during execution
     return sizeof(array) == size;
 }
 \end{codeblock}


### PR DESCRIPTION
I believe that [[expr.const] Example 8](https://eel.is/c++draft/expr.const#example-8) is at best unclear, and at worst misleading in its current form:
> ```cpp
> char array[1 + int(1 + 0.2 - 0.1 - 0.1)];   // Must be evaluated during translation
> int size = 1 + int(1 + 0.2 - 0.1 - 0.1);    // May be evaluated at runtime
> ```

Firstly, I think "must" is pretty strong language for an example. Don't we have style guides against "must" and "may" in examples?

Secondly, the initialization of an array `array` doesn't take place during translation. The "during translation" clearly refers to the *constant-expression* in the array size, not to the entire statement. 

Thirdly, there is no such thing as "runtime" in C++. In a C++ sense, the second line has to be evaluated during program execution, and I don't believe that the compiler is free to manifestly constant-evaluate the initializer of `size` as it pleases here. However, evaluation during program execution may actually take place during compilation, according to the "as-if rule". In short:
- `int size = ...` is evaluated during program execution
  - with optimizations, this could mean "at compile-time"
  - without optimizations, this could mean "at run-time"

Mixing standardese terms like "during translation" with "at runtime" in two consecutive lines is simply confusing.

It's also worth noting that [Note 10](https://eel.is/c++draft/expr.const#note-10) (right above) uses the terminology "during program execution" already; so it makes sense for the example to use this terminology as well.
