### PR TITLE
CWG motion 2: P2748R5 Disallow Binding a Returned Glvalue to a Temporary

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4532,8 +4532,6 @@ a parenthesized \grammarterm{expression-list}\iref{dcl.init}
 persists until the completion of the full-expression
 containing the \grammarterm{expression-list}.
 
-\item The lifetime of a temporary bound to the returned value in a function \tcode{return} statement\iref{stmt.return} is not extended; the temporary is destroyed at the end of the full-expression in the \tcode{return} statement.
-
 \item A temporary bound to a reference in a \grammarterm{new-initializer}\iref{expr.new} persists until the completion of the full-expression containing the \grammarterm{new-initializer}.
 \begin{note}
 This might introduce a dangling reference.

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -905,6 +905,29 @@ by the operand of the \tcode{return} statement, which, in turn, is sequenced
 before the destruction of local variables\iref{stmt.jump} of the block
 enclosing the \tcode{return} statement.
 
+\pnum
+In a function whose return type is a reference,
+other than an invented function for \tcode{std::is_convertible}\iref{meta.rel},
+a \tcode{return} statement that binds the returned reference to
+a temporary expression\iref{class.temporary} is ill-formed.
+\begin{example}
+\begin{codeblock}
+auto&& f1() {
+  return 42;            // ill-formed
+}
+const double& f2() {
+  static int x = 42;
+  return x;             // ill-formed
+}
+auto&& id(auto&& r) {
+  return static_cast<decltype(r)&&>(r);
+}
+auto&& f3() {
+  return id(42);        // OK, but probably a bug
+}
+\end{codeblock}
+\end{example}
+
 \rSec2[stmt.return.coroutine]{The \keyword{co_return} statement}%
 \indextext{\idxcode{co_return}}%
 \indextext{coroutine return|see{\tcode{co_return}}}%


### PR DESCRIPTION
Fixes #6864 
Fixes cplusplus/papers#1439