### PR TITLE
[LWG motion 1] P3180R0 C++ Standard Library Issues to be moved in Tokyo, Mar. 2024

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -10773,11 +10773,9 @@ where the result of the division is truncated towards zero.
 \rSec3[numeric.sat.func]{Arithmetic functions}
 
 \pnum
-\begin{note}
 In the following descriptions, an arithmetic operation
 is performed as a mathematical operation with infinite range and then
 it is determined whether the mathematical result fits into the result type.
-\end{note}
 
 \indexlibraryglobal{add_sat}%
 \begin{itemdecl}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -18837,8 +18837,12 @@ constexpr reference operator[](size_type idx) const;
 \tcode{idx < size()} is \tcode{true}.
 
 \pnum
-\effects
-Equivalent to: \tcode{return *(data() + idx);}
+\returns
+\tcode{*(data() + idx)}.
+
+\pnum
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{span}{at}%
@@ -18867,8 +18871,12 @@ constexpr reference front() const;
 \tcode{empty()} is \tcode{false}.
 
 \pnum
-\effects
-Equivalent to: \tcode{return *data();}
+\returns
+\tcode{*data()}.
+
+\pnum
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{span}{back}%
@@ -18882,8 +18890,12 @@ constexpr reference back() const;
 \tcode{empty()} is \tcode{false}.
 
 \pnum
-\effects
-Equivalent to: \tcode{return *(data() + (size() - 1));}
+\returns
+\tcode{*(data() + (size() - 1))}.
+
+\pnum
+\throws
+Nothing.
 \end{itemdescr}
 
 \indexlibrarymember{span}{data}%
@@ -18893,8 +18905,8 @@ constexpr pointer data() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects
-Equivalent to: \tcode{return \exposid{data_};}
+\returns
+\exposid{data_}.
 \end{itemdescr}
 
 \rSec4[span.iterators]{Iterator support}

--- a/source/future.tex
+++ b/source/future.tex
@@ -2410,6 +2410,8 @@ in table \tref{locale.category.facets} of \ref{locale.category}.
 \begin{codeblock}
 codecvt<char16_t, char, mbstate_t>
 codecvt<char32_t, char, mbstate_t>
+codecvt<char16_t, char8_t, mbstate_t>
+codecvt<char32_t, char8_t, mbstate_t>
 \end{codeblock}
 
 \pnum
@@ -2420,6 +2422,8 @@ in table \tref{locale.spec} of \ref{locale.category}.
 \begin{codeblock}
 codecvt_byname<char16_t, char, mbstate_t>
 codecvt_byname<char32_t, char, mbstate_t>
+codecvt_byname<char16_t, char8_t, mbstate_t>
+codecvt_byname<char32_t, char8_t, mbstate_t>
 \end{codeblock}
 
 \pnum
@@ -2427,11 +2431,13 @@ The following class template specializations are required
 in addition to those specified in~\ref{locale.codecvt}.
 \indextext{UTF-8}%
 \indextext{UTF-16}%
-The specialization \tcode{codecvt<char16_t, char, mbstate_t>}
-converts between the UTF-16 and UTF-8 encoding forms, and
+The specializations \tcode{codecvt<char16_t, char, mbstate_t>} and
+\tcode{codecvt<char16_t, char8_t, mbstate_t>}
+convert between the UTF-16 and UTF-8 encoding forms, and
 \indextext{UTF-32}%
-the specialization \tcode{codecvt<char32_t, char, mbstate_t>}
-converts between the UTF-32 and UTF-8 encoding forms.
+the specializations \tcode{codecvt<char32_t, char, mbstate_t>} and
+\tcode{codecvt<char32_t, char8_t, mbstate_t>}
+convert between the UTF-32 and UTF-8 encoding forms.
 
 \rSec1[depr.fs.path.factory]{Deprecated filesystem path factory functions}
 

--- a/source/future.tex
+++ b/source/future.tex
@@ -232,6 +232,7 @@ The header \libheader{stdalign.h} has the following macro:
 \indexlibraryglobal{__alignas_is_defined}%
 \begin{codeblock}
 #define @\xname{alignas_is_defined}@ 1
+#define @\xname{alignof_is_defined}@ 1
 \end{codeblock}
 
 \pnum

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -3514,6 +3514,11 @@ void setg(char_type* gbeg, char_type* gnext, char_type* gend);
 
 \begin{itemdescr}
 \pnum
+\expects
+\range{gbeg}{gnext}, \range{gbeg}{gend}, and \range{gnext}{gend}
+are all valid ranges.
+
+\pnum
 \ensures
 \tcode{gbeg == eback()},
 \tcode{gnext == gptr()},
@@ -3573,6 +3578,10 @@ void setp(char_type* pbeg, char_type* pend);
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\expects
+\range{pbeg}{pend} is a valid range.
+
 \pnum
 \ensures
 \tcode{pbeg == pbase()},

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -4740,6 +4740,7 @@ has a set of zero or more \defnx{aliases}{encoding!registered character!alias}.
 The set of aliases of a known registered character encoding is an
 \impldef{set of aliases of a known registered character encoding}
 superset of the aliases specified in the IANA Character Sets registry.
+The set of aliases for US-ASCII includes ``ASCII''.
 No two aliases or primary names of distinct registered character encodings
 are equivalent when compared by \tcode{text_encoding::\exposid{comp-name}}.
 

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -974,18 +974,18 @@ namespace std {
     using mask = @\seebelow@;
 
     // numeric values are for exposition only.
-    static const mask space  = 1 << 0;
-    static const mask print  = 1 << 1;
-    static const mask cntrl  = 1 << 2;
-    static const mask upper  = 1 << 3;
-    static const mask lower  = 1 << 4;
-    static const mask alpha  = 1 << 5;
-    static const mask digit  = 1 << 6;
-    static const mask punct  = 1 << 7;
-    static const mask xdigit = 1 << 8;
-    static const mask blank  = 1 << 9;
-    static const mask alnum  = alpha | digit;
-    static const mask graph  = alnum | punct;
+    static constexpr mask space  = 1 << 0;
+    static constexpr mask print  = 1 << 1;
+    static constexpr mask cntrl  = 1 << 2;
+    static constexpr mask upper  = 1 << 3;
+    static constexpr mask lower  = 1 << 4;
+    static constexpr mask alpha  = 1 << 5;
+    static constexpr mask digit  = 1 << 6;
+    static constexpr mask punct  = 1 << 7;
+    static constexpr mask xdigit = 1 << 8;
+    static constexpr mask blank  = 1 << 9;
+    static constexpr mask alnum  = alpha | digit;
+    static constexpr mask graph  = alnum | punct;
   };
 }
 \end{codeblock}

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -320,8 +320,6 @@ including at least those shown in \tref{locale.category.facets}.
 collate     &   \tcode{collate<char>}, \tcode{collate<wchar_t>}                 \\ \rowsep
 ctype       &   \tcode{ctype<char>}, \tcode{ctype<wchar_t>}                     \\
             &   \tcode{codecvt<char, char, mbstate_t>}                            \\
-            &   \tcode{codecvt<char16_t, char8_t, mbstate_t>}        \\
-            &   \tcode{codecvt<char32_t, char8_t, mbstate_t>}        \\
             &   \tcode{codecvt<wchar_t, char, mbstate_t>}                         \\ \rowsep
 monetary    &   \tcode{moneypunct<char>}, \tcode{moneypunct<wchar_t>}           \\
             &   \tcode{moneypunct<char, true>}, \tcode{moneypunct<wchar_t, true>} \\
@@ -356,8 +354,6 @@ for those shown in \tref{locale.spec}.
 collate     &   \tcode{collate_byname<char>}, \tcode{collate_byname<wchar_t>}       \\ \rowsep
 ctype       &   \tcode{ctype_byname<char>}, \tcode{ctype_byname<wchar_t>}           \\
             &   \tcode{codecvt_byname<char, char, mbstate_t>}                       \\
-            &   \tcode{codecvt_byname<char16_t, char8_t, mbstate_t>}                   \\
-            &   \tcode{codecvt_byname<char32_t, char8_t, mbstate_t>}                   \\
             &   \tcode{codecvt_byname<wchar_t, char, mbstate_t>}                    \\ \rowsep
 monetary    &   \tcode{moneypunct_byname<char, International>}                      \\
             &   \tcode{moneypunct_byname<wchar_t, International>}                   \\
@@ -1684,13 +1680,6 @@ in \tref{locale.category.facets}\iref{locale.category}
 convert the implementation-defined native character set.
 \tcode{codecvt<char, char, mbstate_t>} implements a degenerate conversion;
 it does not convert at all.
-\indextext{UTF-8}%
-\indextext{UTF-16}%
-\indextext{UTF-32}%
-The specialization \tcode{codecvt<char16_t, char8_t, mbstate_t>}
-converts between the UTF-16 and UTF-8 encoding forms, and
-the specialization \tcode{codecvt<char32_t, char8_t, mbstate_t>}
-converts between the UTF-32 and UTF-8 encoding forms.
 \tcode{codecvt<wchar_t, char, mbstate_t>}
 converts between the native character sets for ordinary and wide characters.
 Specializations on \tcode{mbstate_t}

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -5062,6 +5062,11 @@ Both
 \tcode{ranges::range_value_t<text_encoding::aliases_view>} and
 \tcode{ranges::range_reference_t<text_encoding::aliases_view>}
 denote \tcode{const char*}.
+
+\pnum
+%FIXME: Is this supposed to be a remark or a requirement? Same above?
+\tcode{ranges::iterator_t<text_encoding::aliases_view>}
+is a constexpr iterator\iref{iterator.requirements.general}.
 \end{itemdescr}
 
 \rSec3[text.encoding.id]{Enumeration \tcode{text_encoding::id}}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2248,25 +2248,33 @@ constexpr bool @\exposid{reservable-container}@ =          // \expos
 \end{codeblock}
 
 \pnum
-Let \exposid{container-insertable} be defined as follows:
+Let \exposid{container-appendable} be defined as follows:
 \begin{codeblock}
 template<class Container, class Ref>
-constexpr bool @\exposid{container-insertable}@ =          // \expos
+constexpr bool @\exposid{container-appendable}@ =          // \expos
   requires(Container& c, Ref&& ref) {
-    requires (requires { c.push_back(std::forward<Ref>(ref)); } ||
+    requires (requires { c.emplace_back(std::forward<Ref>(ref)); } ||
+              requires { c.push_back(std::forward<Ref>(ref)); } ||
+              requires { c.emplace(c.end(), std::forward<Ref>(ref)); } ||
               requires { c.insert(c.end(), std::forward<Ref>(ref)); });
   };
 \end{codeblock}
 
 \pnum
-Let \exposid{container-inserter} be defined as follows:
+Let \exposid{container-appendable} be defined as follows:
 \begin{codeblock}
 template<class Ref, class Container>
-constexpr auto @\exposid{container-inserter}@(Container& c) {                // \expos
-  if constexpr (requires { c.push_back(declval<Ref>()); })
-    return back_inserter(c);
-  else
-    return inserter(c, c.end());
+constexpr auto @\exposid{container-appendable}@(Container& c) {                // \expos
+  return [&c]<class Ref>(Ref&& ref) {
+    if constexpr (requires { c.emplace_back(declval<Ref>()); })
+      c.emplace_back(std::forward<Ref>(ref));
+    else if constexpr (requires { c.push_back(declval<Ref>()); })
+      c.push_back(std::forward<Ref>(ref));
+    else if constexpr (requires { c.emplace(c.end(), declval<Ref>()); })
+      c.emplace(c.end(), std::forward<Ref>(ref));
+    else
+      c.insert(c.end(), std::forward<Ref>(ref));
+  };
 }
 \end{codeblock}
 
@@ -2328,13 +2336,13 @@ Otherwise, if
 \item
 \tcode{\libconcept{constructible_from}<C, Args...>} is \tcode{true}, and
 \item
-\tcode{\exposid{container-insertable}<C, range_reference_t<R>>} is \tcode{true}:
+\tcode{\exposid{container-appendable}<C, range_reference_t<R>>} is \tcode{true}:
 \end{itemize}
 \begin{codeblock}
 C c(std::forward<Args>(args)...);
 if constexpr (@\libconcept{sized_range}@<R> && @\exposid{reservable-container}@<C>)
   c.reserve(static_cast<range_size_t<C>>(ranges::size(r)));
-ranges::copy(r, @\exposid{container-inserter}@<range_reference_t<R>>(c));
+ranges::for_each(r, @\exposid{container-append}@(c));
 \end{codeblock}
 \item
 Otherwise, the program is ill-formed.

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -3476,8 +3476,8 @@ namespace std::ranges {
     constexpr auto size() const requires (!@\libconcept{same_as}@<Bound, unreachable_sentinel_t>);
   };
 
-  template<class T, class Bound>
-    repeat_view(T, Bound) -> repeat_view<T, Bound>;
+  template<class T, class Bound = unreachable_sentinel_t>
+    repeat_view(T, Bound = Bound()) -> repeat_view<T, Bound>;
 }
 \end{codeblock}
 

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -7909,10 +7909,9 @@ namespace std::ranges {
   private:
     @\exposid{outer-iterator}@ @\exposid{i_}@ = @\exposid{outer-iterator}@();               // \expos
 
-  public:
-    value_type() = default;
-    constexpr explicit value_type(@\exposid{outer-iterator}@ i);
+    constexpr explicit value_type(@\exposid{outer-iterator}@ i);    // \expos
 
+  public:
     constexpr @\exposid{inner-iterator}@<Const> begin() const;
     constexpr default_sentinel_t end() const noexcept;
   };

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -9539,13 +9539,13 @@ namespace std::ranges {
     { return @\exposid{iterator}@<true>(ranges::begin(@\exposid{base_}@), 0); }
 
     constexpr auto end() requires (!@\exposconcept{simple-view}@<V>) {
-      if constexpr (@\libconcept{common_range}@<V> && @\libconcept{sized_range}@<V>)
+      if constexpr (@\libconcept{forward_range}@<V> && @\libconcept{common_range}@<V> && @\libconcept{sized_range}@<V>)
         return @\exposid{iterator}@<false>(ranges::end(@\exposid{base_}@), ranges::distance(@\exposid{base_}@));
       else
         return @\exposid{sentinel}@<false>(ranges::end(@\exposid{base_}@));
     }
     constexpr auto end() const requires @\exposconcept{range-with-movable-references}@<const V> {
-      if constexpr (@\libconcept{common_range}@<const V> && @\libconcept{sized_range}@<const V>)
+      if constexpr (@\libconcept{forward_range}@<const V> && @\libconcept{common_range}@<const V> && @\libconcept{sized_range}@<const V>)
         return @\exposid{iterator}@<true>(ranges::end(@\exposid{base_}@), ranges::distance(@\exposid{base_}@));
       else
         return @\exposid{sentinel}@<true>(ranges::end(@\exposid{base_}@));

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2344,7 +2344,7 @@ Otherwise, the program is ill-formed.
 Otherwise,
 if \tcode{\libconcept{input_range}<range_reference_t<R>>} is \tcode{true}:
 \begin{codeblock}
-to<C>(r | views::transform([](auto&& elem) {
+to<C>(ref_view(r) | views::transform([](auto&& elem) {
   return to<range_value_t<C>>(std::forward<decltype(elem)>(elem));
 }), std::forward<Args>(args)...);
 \end{codeblock}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -8542,7 +8542,7 @@ namespace std::ranges {
     constexpr V base() const & requires @\libconcept{copy_constructible}@<V> { return @\exposid{base_}@; }
     constexpr V base() && { return std::move(@\exposid{base_}@); }
 
-    constexpr auto begin() {
+    constexpr auto begin() requires (!@\exposconcept{simple-view}@<V>) {
       if constexpr (@\libconcept{random_access_range}@<V> && @\libconcept{sized_range}@<V>)
         return ranges::begin(@\exposid{base_}@);
       else
@@ -8556,7 +8556,7 @@ namespace std::ranges {
         return common_iterator<iterator_t<const V>, sentinel_t<const V>>(ranges::begin(@\exposid{base_}@));
     }
 
-    constexpr auto end() {
+    constexpr auto end() requires (!@\exposconcept{simple-view}@<V>) {
       if constexpr (@\libconcept{random_access_range}@<V> && @\libconcept{sized_range}@<V>)
         return ranges::begin(@\exposid{base_}@) + ranges::distance(@\exposid{base_}@);
       else

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2541,6 +2541,7 @@ namespace std::ranges {
     constexpr const T* begin() const noexcept;
     constexpr T* end() noexcept;
     constexpr const T* end() const noexcept;
+    static constexpr bool empty() noexcept;
     static constexpr size_t size() noexcept;
     constexpr T* data() noexcept;
     constexpr const T* data() const noexcept;
@@ -2609,6 +2610,17 @@ constexpr const T* end() const noexcept;
 \pnum
 \effects
 Equivalent to: \tcode{return data() + 1;}
+\end{itemdescr}
+
+\indexlibrarymember{empty}{single_view}%
+\begin{itemdecl}
+static constexpr bool empty() noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return false;}
 \end{itemdescr}
 
 \indexlibrarymember{size}{single_view}%

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -3426,7 +3426,7 @@ a customization point object\iref{customization.point.object}.
 Given subexpressions \tcode{E} and \tcode{F},
 the expressions \tcode{views::repeat(E)} and \tcode{views::repeat(E, F)}
 are expression-equivalent to
-\tcode{repeat_view(E)} and \tcode{repeat_view(E, F)}, respectively.
+\tcode{repeat_view<decay_t<decltype((E))>>(E)} and \tcode{repeat_view(E, F)}, respectively.
 
 \pnum
 \begin{example}

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -549,12 +549,11 @@ namespace std {
   // \ref{string.view.comparison}, non-member comparison functions
   template<class charT, class traits>
     constexpr bool operator==(basic_string_view<charT, traits> x,
-                              basic_string_view<charT, traits> y) noexcept;
+                              type_identity_t<basic_string_view<charT, traits>> y) noexcept;
   template<class charT, class traits>
     constexpr @\seebelow@ operator<=>(basic_string_view<charT, traits> x,
-              @\itcorr@                      basic_string_view<charT, traits> y) noexcept;
-
-  // see \ref{string.view.comparison}, sufficient additional overloads of comparison functions
+              @\itcorr@                      type_identity_t<basic_string_view<charT,
+              @\itcorr@                                      traits>> y) noexcept;
 
   // \ref{string.view.io}, inserters and extractors
   template<class charT, class traits>
@@ -1600,47 +1599,11 @@ Otherwise, returns \tcode{npos}.
 
 \rSec2[string.view.comparison]{Non-member comparison functions}
 
-\pnum
-Let \tcode{S} be \tcode{basic_string_view<charT, traits>}, and \tcode{sv} be an instance of \tcode{S}.
-Implementations shall provide sufficient additional overloads marked \keyword{constexpr} and \keyword{noexcept}
-so that an object \tcode{t} with an implicit conversion to \tcode{S} can be compared according to \tref{string.view.comparison.overloads}.
-\begin{libtab2}{Additional \tcode{basic_string_view} comparison overloads}{string.view.comparison.overloads}{cc}{Expression}{Equivalent to}
-\tcode{t == sv} & \tcode{S(t) == sv} \\
-\tcode{sv == t} & \tcode{sv == S(t)} \\
-\tcode{t != sv} & \tcode{S(t) != sv} \\
-\tcode{sv != t} & \tcode{sv != S(t)} \\
-\tcode{t < sv}  & \tcode{S(t) < sv}  \\
-\tcode{sv < t}  & \tcode{sv < S(t)}  \\
-\tcode{t > sv}  & \tcode{S(t) > sv}  \\
-\tcode{sv > t}  & \tcode{sv > S(t)}  \\
-\tcode{t <= sv} & \tcode{S(t) <= sv} \\
-\tcode{sv <= t} & \tcode{sv <= S(t)} \\
-\tcode{t >= sv} & \tcode{S(t) >= sv} \\
-\tcode{sv >= t} & \tcode{sv >= S(t)} \\
-\tcode{t <=> sv} & \tcode{S(t) <=> sv} \\
-\tcode{sv <=> t} & \tcode{sv <=> S(t)} \\
-\end{libtab2}
-\begin{example}
-A sample conforming implementation for \tcode{operator==} would be:
-\begin{codeblock}
-template<class charT, class traits>
-  constexpr bool operator==(basic_string_view<charT, traits> lhs,
-                            basic_string_view<charT, traits> rhs) noexcept {
-    return lhs.compare(rhs) == 0;
-  }
-template<class charT, class traits>
-  constexpr bool operator==(basic_string_view<charT, traits> lhs,
-                            type_identity_t<basic_string_view<charT, traits>> rhs) noexcept {
-    return lhs.compare(rhs) == 0;
-  }
-\end{codeblock}
-\end{example}
-
 \indexlibrarymember{operator==}{basic_string_view}%
 \begin{itemdecl}
 template<class charT, class traits>
   constexpr bool operator==(basic_string_view<charT, traits> lhs,
-                            basic_string_view<charT, traits> rhs) noexcept;
+                            type_identity_t<basic_string_view<charT, traits>> rhs) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1653,7 +1616,7 @@ template<class charT, class traits>
 \begin{itemdecl}
 template<class charT, class traits>
   constexpr @\seebelow@ operator<=>(basic_string_view<charT, traits> lhs,
-            @\itcorr@                      basic_string_view<charT, traits> rhs) noexcept;
+            @\itcorr@                      type_identity_t<basic_string_view<charT, traits>> rhs) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1669,6 +1632,15 @@ otherwise \tcode{R} is \tcode{weak_ordering}.
 \pnum
 \returns
 \tcode{static_cast<R>(lhs.compare(rhs) <=> 0)}.
+
+\pnum
+\begin{note}
+The usage of \tcode{type_identity_t} as parameter
+ensures that an object of type \tcode{basic_string_view<charT, traits>}
+can always be compared with an object of a type \tcode{T} with
+an implicit conversion to \tcode{basic_string_view<charT, traits>}, and
+vice versa, as per \ref{over.match.oper}.
+\end{note}
 \end{itemdescr}
 
 \rSec2[string.view.io]{Inserters and extractors}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -9127,6 +9127,11 @@ constexpr expected& operator=(expected&& rhs) noexcept(@\seebelow@);
 
 \begin{itemdescr}
 \pnum
+\constraints
+\tcode{is_move_constructible_v<E>} is \tcode{true} and
+\tcode{is_move_assignable_v<E>} is \tcode{true}.
+
+\pnum
 \effects
 \begin{itemize}
 \item
@@ -9152,11 +9157,6 @@ Otherwise, equivalent to \tcode{\exposid{unex} = std::move(rhs.error())}.
 \remarks
 The exception specification is equivalent to
 \tcode{is_nothrow_move_constructible_v<E> \&\& is_nothrow_move_assignable_v<E>}.
-
-\pnum
-This operator is defined as deleted unless
-\tcode{is_move_constructible_v<E>} is \tcode{true} and
-\tcode{is_move_assignable_v<E>} is \tcode{true}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{expected<void>}%

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7305,10 +7305,10 @@ namespace std {
   class bad_expected_access<void> : public exception {
   protected:
     bad_expected_access() noexcept;
-    bad_expected_access(const bad_expected_access&);
-    bad_expected_access(bad_expected_access&&);
-    bad_expected_access& operator=(const bad_expected_access&);
-    bad_expected_access& operator=(bad_expected_access&&);
+    bad_expected_access(const bad_expected_access&) noexcept;
+    bad_expected_access(bad_expected_access&&) noexcept;
+    bad_expected_access& operator=(const bad_expected_access& noexcept);
+    bad_expected_access& operator=(bad_expected_access&&) noexcept;
     ~bad_expected_access();
 
   public:

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2049,6 +2049,12 @@ The expression inside \tcode{explicit} is equivalent to:
 \begin{codeblock}
 !(is_convertible_v<decltype(get<I>(std::forward<UTuple>(u))), Types> && ...)
 \end{codeblock}
+The constructor is defined as deleted if
+\begin{codeblock}
+(reference_constructs_from_temporary_v<Types, decltype(get<I>(std::forward<UTuple>(u)))>
+ || ...)
+\end{codeblock}
+is \tcode{true}.
 \end{itemdescr}
 
 \indexlibraryctor{tuple}%

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -17276,6 +17276,11 @@ the format string parsing state, consisting of
 the format string range being parsed and
 the argument counter for automatic indexing.
 
+\pnum
+If a program declares an explicit or partial specialization of
+\tcode{basic_format_parse_context},
+the program is ill-formed, no diagnostic required.
+
 \indexlibraryctor{basic_format_parse_context}%
 \begin{itemdecl}
 constexpr explicit basic_format_parse_context(basic_string_view<charT> fmt) noexcept;
@@ -17486,6 +17491,11 @@ namespace std {
 \pnum
 An instance of \tcode{basic_format_context} holds formatting state
 consisting of the formatting arguments and the output iterator.
+
+\pnum
+If a program declares an explicit or partial specialization of
+\tcode{basic_format_context},
+the program is ill-formed, no diagnostic required.
 
 \pnum
 \tcode{Out} shall model \tcode{\libconcept{output_iterator}<const charT\&>}.


### PR DESCRIPTION
Fixes #6872.

Also fixes #6765
Also fixes #6270 

Edit notes:
* LWG4016 [range.utility.conv.general]p5 Template parameters are reversed from what the paper has; resolution applied to body but not to remove Ref.