### PR TITLE
P0493R5 Atomic minimum/maximum

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -572,6 +572,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_atomic_float}@                      201711L // freestanding, also in \libheader{atomic}
 #define @\defnlibxname{cpp_lib_atomic_is_always_lock_free}@        201603L // freestanding, also in \libheader{atomic}
 #define @\defnlibxname{cpp_lib_atomic_lock_free_type_aliases}@     201907L // also in \libheader{atomic}
+#define @\defnlibxname{cpp_lib_atomic_min_max}@                    202403L // freestanding, also in \libheader{atomic}
 #define @\defnlibxname{cpp_lib_atomic_ref}@                        201806L // freestanding, also in \libheader{atomic}
 #define @\defnlibxname{cpp_lib_atomic_shared_ptr}@                 201711L // also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_atomic_value_initialization}@       201911L // freestanding, also in \libheader{atomic}, \libheader{memory}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -2265,7 +2265,34 @@ namespace std {
   template<class T>
     T atomic_fetch_xor_explicit(atomic<T>*, typename atomic<T>::value_type,         // freestanding
                                 memory_order) noexcept;
-
+  template<class T>
+    T atomic_fetch_max(volatile atomic<T>*,                                         // freestanding
+                       typename atomic<T>::value_type) noexcept;
+  template<class T>
+    T atomic_fetch_max(atomic<T>*,                                                  // freestanding
+                       typename atomic<T>::value_type) noexcept;
+  template<class T>
+    T atomic_fetch_max_explicit(volatile atomic<T>*,                                // freestanding
+                                typename atomic<T>::value_type,
+                                memory_order) noexcept;
+  template<class T>
+    T atomic_fetch_max_explicit(atomic<T>*,                                         // freestanding
+                                typename atomic<T>::value_type,
+                                memory_order) noexcept;
+  template<class T>
+    T atomic_fetch_min(volatile atomic<T>*,                                         // freestanding
+                       typename atomic<T>::value_type) noexcept;
+  template<class T>
+    T atomic_fetch_min(atomic<T>*,                                                  // freestanding
+                       typename atomic<T>::value_type) noexcept;
+  template<class T>
+    T atomic_fetch_min_explicit(volatile atomic<T>*,                                // freestanding
+                                typename atomic<T>::value_type,
+                                memory_order) noexcept;
+  template<class T>
+    T atomic_fetch_min_explicit(atomic<T>*,                                         // freestanding
+                                typename atomic<T>::value_type,
+                                memory_order) noexcept;
   template<class T>
     void atomic_wait(const volatile atomic<T>*,                                     // freestanding
 	             typename atomic<T>::value_type) noexcept;
@@ -3289,6 +3316,10 @@ namespace std {
                             memory_order = memory_order::seq_cst) const noexcept;
     @\placeholdernc{integral-type}@ fetch_xor(@\placeholdernc{integral-type}@,
                             memory_order = memory_order::seq_cst) const noexcept;
+    @\placeholdernc{integral-type}@ fetch_max(@\placeholdernc{integral-type}@,
+                            memory_order = memory_order::seq_cst) const noexcept;
+    @\placeholdernc{integral-type}@ fetch_min(@\placeholdernc{integral-type}@,
+                            memory_order = memory_order::seq_cst) const noexcept;
 
     @\placeholdernc{integral-type}@ operator++(int) const noexcept;
     @\placeholdernc{integral-type}@ operator--(int) const noexcept;
@@ -3318,6 +3349,8 @@ in \tref{atomic.types.int.comp}.
 
 \indexlibrarymember{fetch_add}{atomic_ref<\placeholder{integral-type}>}%
 \indexlibrarymember{fetch_and}{atomic_ref<\placeholder{integral-type}>}%
+\indexlibrarymember{fetch_max}{atomic_ref<\placeholder{integral-type}>}%
+\indexlibrarymember{fetch_min}{atomic_ref<\placeholder{integral-type}>}%
 \indexlibrarymember{fetch_or}{atomic_ref<\placeholder{integral-type}>}%
 \indexlibrarymember{fetch_sub}{atomic_ref<\placeholder{integral-type}>}%
 \indexlibrarymember{fetch_xor}{atomic_ref<\placeholder{integral-type}>}%
@@ -3343,7 +3376,7 @@ immediately before the effects.
 \pnum
 \indextext{signed integer representation!two's complement}%
 \remarks
-For signed integer types,
+Except for \tcode{fetch_max} and \tcode{fetch_min}, for signed integer types
 the result is as if the object value and parameters
 were converted to their corresponding unsigned types,
 the computation performed on those types, and
@@ -3351,6 +3384,12 @@ the result converted back to the signed type.
 \begin{note}
 There are no undefined results arising from the computation.
 \end{note}
+
+\pnum
+For \tcode{fetch_max} and \tcode{fetch_min}, the maximum and minimum
+computation is performed as if by \tcode{max} and \tcode{min} algorithms
+\iref{alg.min.max}, respectively, with the object value and the first
+parameter as the arguments.
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{atomic_ref<\placeholder{integral-type}>}%
@@ -3522,6 +3561,8 @@ namespace std {
 
     T* fetch_add(difference_type, memory_order = memory_order::seq_cst) const noexcept;
     T* fetch_sub(difference_type, memory_order = memory_order::seq_cst) const noexcept;
+    T* fetch_max(T*, memory_order = memory_order::seq_cst) const noexcept;
+    T* fetch_min(T*, memory_order = memory_order::seq_cst) const noexcept;
 
     T* operator++(int) const noexcept;
     T* operator--(int) const noexcept;
@@ -3548,6 +3589,8 @@ in \tref{atomic.types.pointer.comp}.
 
 \indexlibrarymember{fetch_add}{atomic_ref<T*>}%
 \indexlibrarymember{fetch_sub}{atomic_ref<T*>}%
+\indexlibrarymember{fetch_max}{atomic_ref<T*>}%
+\indexlibrarymember{fetch_min}{atomic_ref<T*>}%
 \begin{itemdecl}
 T* fetch_@\placeholdernc{key}@(difference_type operand, memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
@@ -3574,7 +3617,21 @@ immediately before the effects.
 \remarks
 The result may be an undefined address,
 but the operations otherwise have no undefined behavior.
+
+\pnum
+For \tcode{fetch_max} and \tcode{fetch_min}, the maximum and minimum
+computation is performed as if by \tcode{max} and \tcode{min}
+algorithms\iref{alg.min.max}, respectively, with the object value and the first
+parameter as the arguments.
+
+\begin{note}
+If the pointers point to different complete objects (or subobjects thereof),
+the \tcode{<} operator does not establish a strict weak ordering
+(\tref{cpp17.lessthancomparable}, \ref{expr.rel}).
+\end{note}
 \end{itemdescr}
+
+
 
 \indexlibrarymember{operator+=}{atomic_ref<T*>}%
 \indexlibrarymember{operator-=}{atomic_ref<T*>}%
@@ -4301,6 +4358,14 @@ namespace std {
                             memory_order = memory_order::seq_cst) volatile noexcept;
     @\placeholdernc{integral-type}@ fetch_xor(@\placeholdernc{integral-type}@,
                             memory_order = memory_order::seq_cst) noexcept;
+    @\placeholdernc{integral-type}@ fetch_max( @\placeholdernc{integral-type}@,
+                            memory_order = memory_order::seq_cst) volatile noexcept;
+    @\placeholdernc{integral-type}@ fetch_max( @\placeholdernc{integral-type}@,
+                            memory_order = memory_order::seq_cst) noexcept;
+    @\placeholdernc{integral-type}@ fetch_min( @\placeholdernc{integral-type}@,
+                            memory_order = memory_order::seq_cst) volatile noexcept;
+    @\placeholdernc{integral-type}@ fetch_min( @\placeholdernc{integral-type}@,
+                            memory_order = memory_order::seq_cst) noexcept;
 
     @\placeholdernc{integral-type}@ operator++(int) volatile noexcept;
     @\placeholdernc{integral-type}@ operator++(int) noexcept;
@@ -4357,32 +4422,44 @@ in \tref{atomic.types.int.comp}.
 \tcode{add}       &
   \tcode{+}       &
   addition        &
+\tcode{and}       &
+  \tcode{\&}      &
+  bitwise and     \\
 \tcode{sub}       &
   \tcode{-}       &
-  subtraction     \\
+  subtraction     &
 \tcode{or}        &
   \tcode{|}       &
-  bitwise inclusive or  &
+  bitwise inclusive or  \\
+\tcode{max}       &
+                  &
+  maximum         &
 \tcode{xor}       &
   \tcode{\caret}        &
   bitwise exclusive or  \\
-\tcode{and}       &
-  \tcode{\&}      &
-  bitwise and     &&&\\
+\tcode{min}       &
+                  &
+  minimum         &&&\\
 \end{floattable}
 
 \indexlibraryglobal{atomic_fetch_add}%
 \indexlibraryglobal{atomic_fetch_and}%
+\indexlibraryglobal{atomic_fetch_max}%
+\indexlibraryglobal{atomic_fetch_min}%
 \indexlibraryglobal{atomic_fetch_or}%
 \indexlibraryglobal{atomic_fetch_sub}%
 \indexlibraryglobal{atomic_fetch_xor}%
 \indexlibraryglobal{atomic_fetch_add_explicit}%
 \indexlibraryglobal{atomic_fetch_and_explicit}%
+\indexlibraryglobal{atomic_fetch_max_explicit}%
+\indexlibraryglobal{atomic_fetch_min_explicit}%
 \indexlibraryglobal{atomic_fetch_or_explicit}%
 \indexlibraryglobal{atomic_fetch_sub_explicit}%
 \indexlibraryglobal{atomic_fetch_xor_explicit}%
 \indexlibrarymember{fetch_add}{atomic<\placeholder{integral-type}>}%
 \indexlibrarymember{fetch_and}{atomic<\placeholder{integral-type}>}%
+\indexlibrarymember{fetch_max}{atomic<\placeholder{integral-type}>}%
+\indexlibrarymember{fetch_min}{atomic<\placeholder{integral-type}>}%
 \indexlibrarymember{fetch_or}{atomic<\placeholder{integral-type}>}%
 \indexlibrarymember{fetch_sub}{atomic<\placeholder{integral-type}>}%
 \indexlibrarymember{fetch_xor}{atomic<\placeholder{integral-type}>}%
@@ -4412,7 +4489,7 @@ Atomically, the value pointed to by \keyword{this} immediately before the effect
 \pnum
 \indextext{signed integer representation!two's complement}%
 \remarks
-For signed integer types,
+Except for \tcode{fetch_max} and \tcode{fetch_min}, for signed integer types
 the result is as if the object value and parameters
 were converted to their corresponding unsigned types,
 the computation performed on those types, and
@@ -4421,6 +4498,11 @@ the result converted back to the signed type.
 There are no undefined results arising from the computation.
 \end{note}
 
+\pnum
+For \tcode{fetch_max} and \tcode{fetch_min}, the maximum and minimum
+computation is performed as if by \tcode{max} and \tcode{min} algorithms
+\iref{alg.min.max}, respectively, with the object value and the first parameter
+as the arguments.
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{atomic<T*>}%
@@ -4659,6 +4741,10 @@ namespace std {
     T* fetch_add(ptrdiff_t, memory_order = memory_order::seq_cst) noexcept;
     T* fetch_sub(ptrdiff_t, memory_order = memory_order::seq_cst) volatile noexcept;
     T* fetch_sub(ptrdiff_t, memory_order = memory_order::seq_cst) noexcept;
+    T* fetch_max(T*, memory_order = memory_order::seq_cst) volatile noexcept;
+    T* fetch_max(T*, memory_order = memory_order::seq_cst) noexcept;
+    T* fetch_min(T*, memory_order = memory_order::seq_cst) volatile noexcept;
+    T* fetch_min(T*, memory_order = memory_order::seq_cst) noexcept;
 
     T* operator++(int) volatile noexcept;
     T* operator++(int) noexcept;
@@ -4712,13 +4798,25 @@ in \tref{atomic.types.pointer.comp}.
 \tcode{sub}       &
   \tcode{-}       &
   subtraction     \\
+\tcode{max}       &
+                  &
+  maximum         &
+\tcode{min}       &
+                  &
+  minimum         \\
 \end{floattable}
 
 \indexlibraryglobal{atomic_fetch_add}%
+\indexlibraryglobal{atomic_fetch_max}%
+\indexlibraryglobal{atomic_fetch_min}%
 \indexlibraryglobal{atomic_fetch_sub}%
 \indexlibraryglobal{atomic_fetch_add_explicit}%
+\indexlibraryglobal{atomic_fetch_max_explicit}%
+\indexlibraryglobal{atomic_fetch_min_explicit}%
 \indexlibraryglobal{atomic_fetch_sub_explicit}%
 \indexlibrarymember{fetch_add}{atomic<T*>}%
+\indexlibrarymember{fetch_max}{atomic<T*>}%
+\indexlibrarymember{fetch_min}{atomic<T*>}%
 \indexlibrarymember{fetch_sub}{atomic<T*>}%
 \begin{itemdecl}
 T* fetch_@\placeholdernc{key}@(ptrdiff_t operand, memory_order order = memory_order::seq_cst) volatile noexcept;
@@ -4754,6 +4852,18 @@ Atomically, the value pointed to by \keyword{this} immediately before the effect
 \remarks
 The result may be an undefined address,
 but the operations otherwise have no undefined behavior.
+
+\pnum
+For \tcode{fetch_max} and \tcode{fetch_min}, the maximum and minimum
+computation is performed as if by \tcode{max} and \tcode{min}
+algorithms\iref{alg.min.max}, respectively, with the object value and the first
+parameter as the arguments.
+
+\begin{note}
+If the pointers point to different complete objects (or subobjects thereof),
+the \tcode{<} operator does not establish a strict weak ordering
+(\tref{cpp17.lessthancomparable}, \ref{expr.rel}).
+\end{note}
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{atomic<T*>}%


### PR DESCRIPTION
Fixes https://github.com/cplusplus/draft/issues/6880
Fixes https://github.com/cplusplus/papers/issues/866

Editorial changes:
Applied value 202403L to feature macro
Added freestanding to feature macro
Used _intergral-type_ rather than `integer` when naming generic template parameters Removed a couple of existing commas where new preceding commas were introduced