### PR TITLE
[expos.only.entity] Add missing \expos for two exposition-only names

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -499,11 +499,11 @@ to aid in the specification of the library:
 namespace std {
   template<class T>
     requires @\libconcept{convertible_to}@<T, decay_t<T>>
-      constexpr decay_t<T> @\placeholdernc{decay-copy}@(T&& v)
+      constexpr decay_t<T> @\placeholdernc{decay-copy}@(T&& v)       // \expos
         noexcept(is_nothrow_convertible_v<T, decay_t<T>>)
       { return std::forward<T>(v); }
 
-  constexpr auto @\placeholdernc{synth-three-way}@ =
+  constexpr auto @\placeholdernc{synth-three-way}@ =                 // \expos
     []<class T, class U>(const T& t, const U& u)
       requires requires {
         { t < u } -> @\exposconcept{boolean-testable}@;
@@ -520,7 +520,8 @@ namespace std {
     };
 
   template<class T, class U=T>
-  using @\placeholdernc{synth-three-way-result}@ = decltype(@\placeholdernc{synth-three-way}@(declval<T&>(), declval<U&>()));
+  using @\placeholdernc{synth-three-way-result}@ =                  // \expos
+    decltype(@\placeholdernc{synth-three-way}@(declval<T&>(), declval<U&>()));
 }
 \end{codeblock}
 

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -500,7 +500,7 @@ namespace std {
   template<class T>
     requires @\libconcept{convertible_to}@<T, decay_t<T>>
       constexpr decay_t<T> @\placeholdernc{decay-copy}@(T&& v)
-        noexcept(is_nothrow_convertible_v<T, decay_t<T>>)       // \expos
+        noexcept(is_nothrow_convertible_v<T, decay_t<T>>)
       { return std::forward<T>(v); }
 
   constexpr auto @\placeholdernc{synth-three-way}@ =


### PR DESCRIPTION
..Also fixed an issue where the first exposition-only comment wasn't quite aligned.