### PR TITLE
[zombie.names] Turn lists of zombie names into tables

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -3021,107 +3021,132 @@ undefined.%
 \indextext{brains!names that want to eat your}%
 
 \pnum
-In namespace \tcode{std}, the following names are reserved for previous standardization:
-\begin{itemize}
-\item \indexlibraryzombie{auto_ptr} \tcode{auto_ptr},
-\item \indexlibraryzombie{auto_ptr_ref} \tcode{auto_ptr_ref},
-\item \indexlibraryzombie{binary_function} \tcode{binary_function},
-\item \indexlibraryzombie{binary_negate} \tcode{binary_negate},
-\item \indexlibraryzombie{bind1st} \tcode{bind1st},
-\item \indexlibraryzombie{bind2nd} \tcode{bind2nd},
-\item \indexlibraryzombie{binder1st} \tcode{binder1st},
-\item \indexlibraryzombie{binder2nd} \tcode{binder2nd},
-\item \indexlibraryzombie{codecvt_mode} \tcode{codecvt_mode},
-\item \indexlibraryzombie{codecvt_utf16} \tcode{codecvt_utf16},
-\item \indexlibraryzombie{codecvt_utf8} \tcode{codecvt_utf8},
-\item \indexlibraryzombie{codecvt_utf8_utf16} \tcode{codecvt_utf8_utf16},
-\item \indexlibraryzombie{const_mem_fun1_ref_t} \tcode{const_mem_fun1_ref_t},
-\item \indexlibraryzombie{const_mem_fun1_t} \tcode{const_mem_fun1_t},
-\item \indexlibraryzombie{const_mem_fun_ref_t} \tcode{const_mem_fun_ref_t},
-\item \indexlibraryzombie{const_mem_fun_t} \tcode{const_mem_fun_t},
-\item \indexlibraryzombie{consume_header} \tcode{consume_header},
-\item \indexlibraryzombie{declare_no_pointers} \tcode{declare_no_pointers},
-\item \indexlibraryzombie{declare_reachable} \tcode{declare_reachable},
-\item \indexlibraryzombie{generate_header} \tcode{generate_header},
-\item \indexlibraryzombie{get_pointer_safety} \tcode{get_pointer_safety},
-\item \indexlibraryzombie{get_temporary_buffer} \tcode{get_temporary_buffer},
-\item \indexlibraryzombie{get_unexpected} \tcode{get_unexpected},
-\item \indexlibraryzombie{gets} \tcode{gets},
-\item \indexlibraryzombie{is_literal_type} \tcode{is_literal_type},
-\item \indexlibraryzombie{is_literal_type_v} \tcode{is_literal_type_v},
-\item \indexlibraryzombie{istrstream} \tcode{istrstream},
-\item \indexlibraryzombie{little_endian} \tcode{little_endian},
-\item \indexlibraryzombie{mem_fun1_ref_t} \tcode{mem_fun1_ref_t},
-\item \indexlibraryzombie{mem_fun1_t} \tcode{mem_fun1_t},
-\item \indexlibraryzombie{mem_fun_ref_t} \tcode{mem_fun_ref_t},
-\item \indexlibraryzombie{mem_fun_ref} \tcode{mem_fun_ref},
-\item \indexlibraryzombie{mem_fun_t} \tcode{mem_fun_t},
-\item \indexlibraryzombie{mem_fun} \tcode{mem_fun},
-\item \indexlibraryzombie{not1} \tcode{not1},
-\item \indexlibraryzombie{not2} \tcode{not2},
-\item \indexlibraryzombie{ostrstream} \tcode{ostrstream},
-\item \indexlibraryzombie{pointer_safety} \tcode{pointer_safety},
-\item \indexlibraryzombie{pointer_to_binary_function} \tcode{pointer_to_binary_function},
-\item \indexlibraryzombie{pointer_to_unary_function} \tcode{pointer_to_unary_function},
-\item \indexlibraryzombie{ptr_fun} \tcode{ptr_fun},
-\item \indexlibraryzombie{random_shuffle} \tcode{random_shuffle},
-\item \indexlibraryzombie{raw_storage_iterator} \tcode{raw_storage_iterator},
-\item \indexlibraryzombie{result_of} \tcode{result_of},
-\item \indexlibraryzombie{result_of_t} \tcode{result_of_t},
-\item \indexlibraryzombie{return_temporary_buffer} \tcode{return_temporary_buffer},
-\item \indexlibraryzombie{set_unexpected} \tcode{set_unexpected},
-\item \indexlibraryzombie{strstream} \tcode{strstream},
-\item \indexlibraryzombie{strstreambuf} \tcode{strstreambuf},
-\item \indexlibraryzombie{unary_function} \tcode{unary_function},
-\item \indexlibraryzombie{unary_negate} \tcode{unary_negate},
-\item \indexlibraryzombie{uncaught_exception} \tcode{uncaught_exception},
-\item \indexlibraryzombie{undeclare_no_pointers} \tcode{undeclare_no_pointers},
-\item \indexlibraryzombie{undeclare_reachable} \tcode{undeclare_reachable},
-\item \indexlibraryzombie{unexpected_handler} \tcode{unexpected_handler},
-\item \indexlibraryzombie{wbuffer_convert} \tcode{wbuffer_convert},
-and
-\item \indexlibraryzombie{wstring_convert} \tcode{wstring_convert}.
-\end{itemize}
+In namespace \tcode{std}, the names shown in \tref{zombie.names.std} are
+reserved for previous standardization:
+
+\begin{multicolfloattable}{Zombie names in namespace \tcode{std}}{zombie.names.std}
+{lll}
+\indexlibraryzombie{auto_ptr} \tcode{auto_ptr} \\
+\indexlibraryzombie{auto_ptr_ref} \tcode{auto_ptr_ref} \\
+\indexlibraryzombie{binary_function} \tcode{binary_function} \\
+\indexlibraryzombie{binary_negate} \tcode{binary_negate} \\
+\indexlibraryzombie{bind1st} \tcode{bind1st} \\
+\indexlibraryzombie{bind2nd} \tcode{bind2nd} \\
+\indexlibraryzombie{binder1st} \tcode{binder1st} \\
+\indexlibraryzombie{binder2nd} \tcode{binder2nd} \\
+\indexlibraryzombie{codecvt_mode} \tcode{codecvt_mode} \\
+\indexlibraryzombie{codecvt_utf16} \tcode{codecvt_utf16} \\
+\indexlibraryzombie{codecvt_utf8} \tcode{codecvt_utf8} \\
+\indexlibraryzombie{codecvt_utf8_utf16} \tcode{codecvt_utf8_utf16} \\
+\indexlibraryzombie{const_mem_fun1_ref_t} \tcode{const_mem_fun1_ref_t} \\
+\indexlibraryzombie{const_mem_fun1_t} \tcode{const_mem_fun1_t} \\
+\indexlibraryzombie{const_mem_fun_ref_t} \tcode{const_mem_fun_ref_t} \\
+\indexlibraryzombie{const_mem_fun_t} \tcode{const_mem_fun_t} \\
+\indexlibraryzombie{consume_header} \tcode{consume_header} \\
+\indexlibraryzombie{declare_no_pointers} \tcode{declare_no_pointers} \\
+\indexlibraryzombie{declare_reachable} \tcode{declare_reachable} \\
+\columnbreak
+\indexlibraryzombie{generate_header} \tcode{generate_header} \\
+\indexlibraryzombie{get_pointer_safety} \tcode{get_pointer_safety} \\
+\indexlibraryzombie{get_temporary_buffer} \tcode{get_temporary_buffer} \\
+\indexlibraryzombie{get_unexpected} \tcode{get_unexpected} \\
+\indexlibraryzombie{gets} \tcode{gets} \\
+\indexlibraryzombie{is_literal_type} \tcode{is_literal_type} \\
+\indexlibraryzombie{is_literal_type_v} \tcode{is_literal_type_v} \\
+\indexlibraryzombie{istrstream} \tcode{istrstream} \\
+\indexlibraryzombie{little_endian} \tcode{little_endian} \\
+\indexlibraryzombie{mem_fun1_ref_t} \tcode{mem_fun1_ref_t} \\
+\indexlibraryzombie{mem_fun1_t} \tcode{mem_fun1_t} \\
+\indexlibraryzombie{mem_fun_ref_t} \tcode{mem_fun_ref_t} \\
+\indexlibraryzombie{mem_fun_ref} \tcode{mem_fun_ref} \\
+\indexlibraryzombie{mem_fun_t} \tcode{mem_fun_t} \\
+\indexlibraryzombie{mem_fun} \tcode{mem_fun} \\
+\indexlibraryzombie{not1} \tcode{not1} \\
+\indexlibraryzombie{not2} \tcode{not2} \\
+\indexlibraryzombie{ostrstream} \tcode{ostrstream} \\
+\indexlibraryzombie{pointer_safety} \tcode{pointer_safety} \\
+\columnbreak
+\indexlibraryzombie{pointer_to_binary_function} \tcode{pointer_to_binary_function} \\
+\indexlibraryzombie{pointer_to_unary_function} \tcode{pointer_to_unary_function} \\
+\indexlibraryzombie{ptr_fun} \tcode{ptr_fun} \\
+\indexlibraryzombie{random_shuffle} \tcode{random_shuffle} \\
+\indexlibraryzombie{raw_storage_iterator} \tcode{raw_storage_iterator} \\
+\indexlibraryzombie{result_of} \tcode{result_of} \\
+\indexlibraryzombie{result_of_t} \tcode{result_of_t} \\
+\indexlibraryzombie{return_temporary_buffer} \tcode{return_temporary_buffer} \\
+\indexlibraryzombie{set_unexpected} \tcode{set_unexpected} \\
+\indexlibraryzombie{strstream} \tcode{strstream} \\
+\indexlibraryzombie{strstreambuf} \tcode{strstreambuf} \\
+\indexlibraryzombie{unary_function} \tcode{unary_function} \\
+\indexlibraryzombie{unary_negate} \tcode{unary_negate} \\
+\indexlibraryzombie{uncaught_exception} \tcode{uncaught_exception} \\
+\indexlibraryzombie{undeclare_no_pointers} \tcode{undeclare_no_pointers} \\
+\indexlibraryzombie{undeclare_reachable} \tcode{undeclare_reachable} \\
+\indexlibraryzombie{unexpected_handler} \tcode{unexpected_handler} \\
+\indexlibraryzombie{wbuffer_convert} \tcode{wbuffer_convert} \\
+\indexlibraryzombie{wstring_convert} \tcode{wstring_convert} \\
+\end{multicolfloattable}
+
 
 \pnum
-The following names are reserved as members for previous standardization,
-and may not be used as a name for object-like macros in portable code:
-\begin{itemize}
-\item \indexlibraryzombie{argument_type} \tcode{argument_type},
-\item \indexlibraryzombie{first_argument_type} \tcode{first_argument_type},
-\item \indexlibraryzombie{io_state} \tcode{io_state},
-\item \indexlibraryzombie{op} \tcode{op},
-\item \indexlibraryzombie{open_mode} \tcode{open_mode},
-\item \indexlibraryzombie{preferred} \tcode{preferred},
-\item \indexlibraryzombie{second_argument_type} \tcode{second_argument_type},
-\item \indexlibraryzombie{seek_dir} \tcode{seek_dir}, and
-\item \indexlibraryzombie{strict} \tcode{strict}.
-\end{itemize}
+The names shown in \tref{zombie.names.objmacro} are reserved as members for
+previous standardization, and may not be used as a name for object-like macros
+in portable code:
+
+\begin{multicolfloattable}{Zombie object-like macros}{zombie.names.objmacro}
+{lll}
+\indexlibraryzombie{argument_type} \tcode{argument_type} \\
+\indexlibraryzombie{first_argument_type} \tcode{first_argument_type} \\
+\indexlibraryzombie{io_state} \tcode{io_state} \\
+\columnbreak
+\indexlibraryzombie{op} \tcode{op} \\
+\indexlibraryzombie{open_mode} \tcode{open_mode} \\
+\indexlibraryzombie{preferred} \tcode{preferred} \\
+\columnbreak
+\indexlibraryzombie{second_argument_type} \tcode{second_argument_type} \\
+\indexlibraryzombie{seek_dir} \tcode{seek_dir} \\
+\indexlibraryzombie{strict} \tcode{strict} \\
+\end{multicolfloattable}
+
 
 \pnum
-The following names are reserved as member functions for previous
-standardization, and may not be used as a name for function-like macros in
-portable code:
-\begin{itemize}
-\item \indexlibraryzombie{converted} \tcode{converted},
-\item \indexlibraryzombie{from_bytes} \tcode{from_bytes},
-\item \indexlibraryzombie{freeze} \tcode{freeze},
-\item \indexlibraryzombie{pcount} \tcode{pcount},
-\item \indexlibraryzombie{stossc} \tcode{stossc}, and
-\item \indexlibraryzombie{to_bytes} \tcode{to_bytes}.
-\end{itemize}
+The names shown in \tref{zombie.names.fnmacro} are reserved as member functions
+for previous standardization, and may not be used as a name for function-like
+macros in portable code:
+
+\begin{multicolfloattable}{Zombie function-like macros}{zombie.names.fnmacro}
+{llllll}
+\indexlibraryzombie{converted} \tcode{converted} \\
+\columnbreak
+\indexlibraryzombie{freeze} \tcode{freeze} \\
+\columnbreak
+\indexlibraryzombie{from_bytes} \tcode{from_bytes} \\
+\columnbreak
+\indexlibraryzombie{pcount} \tcode{pcount} \\
+\columnbreak
+\indexlibraryzombie{stossc} \tcode{stossc} \\
+\columnbreak
+\indexlibraryzombie{to_bytes} \tcode{to_bytes} \\
+\end{multicolfloattable}
 
 \pnum
-The following header names are reserved for previous standardization:
-\begin{itemize}
-\item \libnoheader{ccomplex},
-\item \libnoheader{ciso646},
-\item \libnoheader{codecvt},
-\item \libnoheader{cstdalign},
-\item \libnoheader{cstdbool},
-\item \libnoheader{ctgmath}, and
-\item \libnoheader{strstream}.
-\end{itemize}
+The header names shown in \tref{zombie.names.header} are reserved for previous
+standardization:
+
+\begin{multicolfloattable}{Zombie headers}{zombie.names.header}
+{lllll}
+\libnoheader{ccomplex} \\
+\libnoheader{ciso646} \\
+\columnbreak
+\libnoheader{codecvt} \\
+\libnoheader{cstdalign} \\
+\columnbreak
+\libnoheader{cstdbool} \\
+\columnbreak
+\libnoheader{ctgmath} \\
+\columnbreak
+\libnoheader{strstream} \\
+\end{multicolfloattable}
 
 \rSec4[macro.names]{Macro names}
 


### PR DESCRIPTION
Fixes #6898

As the list of zombie names has grown so long, it is hard to check without scrolling.  Rendering as a table makes it easier to read in one place, as well as saving on our page count!

Pre-emptively turned all the other zombie name lists into tables too, for consistency.  We have precedent for such short tables with the table of contextual keywords.