### PR TITLE
[basic.life] Reflow text defining transparently replaceable

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3625,17 +3625,7 @@ well-defined. The program has undefined behavior if:
 \end{itemize}
 
 \pnum
-If, after the lifetime of an object has ended and before the storage
-which the object occupied is reused or released, a new object is created
-at the storage location which the original object occupied, a pointer
-that pointed to the original object, a reference that referred to the
-original object, or the name of the original object will automatically
-refer to the new object and, once the lifetime of the new object has
-started, can be used to manipulate the new object, if
-the original object is transparently replaceable (see below)
-by the new object.
-An object $o_1$ is \defn{transparently replaceable}
-by an object $o_2$ if:
+An object $o_1$ is \defn{transparently replaceable} by an object $o_2$ if:
 \begin{itemize}
 \item the storage that $o_2$ occupies exactly overlays
 the storage that $o_1$ occupied, and
@@ -3652,6 +3642,17 @@ is a potentially-overlapping subobject\iref{intro.object}, and
 $o_1$ and $o_2$ are direct subobjects of objects $p_1$ and $p_2$, respectively,
 and $p_1$ is transparently replaceable by $p_2$.
 \end{itemize}
+
+\pnum
+After the lifetime of an object has ended and before the storage which the
+object occupied is reused or released, if a new object is created at the
+storage location which the original object occupied and the original object was
+transparently replaceable by the new object, a pointer that pointed to the
+original object, a reference that referred to the original object, or the name
+of the original object will automatically refer to the new object and, once the
+lifetime of the new object has started, can be used to manipulate the new
+object.
+
 \begin{example}
 \begin{codeblock}
 struct C {


### PR DESCRIPTION
p8 is difficult to read as it defines transparently replaceable only after it has made all use of it.  The edit pulls the definition of transparently replaceable into its own preceding paragraph, and then simplifies the sentence that uses this term.