### PR TITLE
[range.concat.view] Use \exposid for `is-const`

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -8658,12 +8658,12 @@ constexpr @\exposid{iterator}@<true> begin() const
 \begin{itemdescr}
 \pnum
 \effects
-Let \tcode{is-const} be
+Let \exposid{is-const} be
 \tcode{true} for the const-qualified overload, and
 \tcode{false} otherwise.
 Equivalent to:
 \begin{codeblock}
-@\exposid{iterator}@<is-const> it(this, in_place_index<0>, ranges::begin(std::get<0>(@\exposid{views_}@)));
+@\exposid{iterator}@<@\exposid{is-const}@> it(this, in_place_index<0>, ranges::begin(std::get<0>(@\exposid{views_}@)));
 it.template @\exposid{satisfy}@<0>();
 return it;
 \end{codeblock}
@@ -8679,14 +8679,14 @@ constexpr auto end() const
 \begin{itemdescr}
 \pnum
 \effects
-Let \tcode{is-const} be
+Let \exposid{is-const} be
 \tcode{true} for the const-qualified overload, and
 \tcode{false} otherwise.
 Equivalent to:
 \begin{codeblock}
 constexpr auto N = sizeof...(Views);
-if constexpr (@\libconcept{common_range}@<@\exposid{maybe-const}@<is-const, Views...[N - 1]>>) {
-  return @\exposid{iterator}@<is-const>(this, in_place_index<N - 1>,
+if constexpr (@\libconcept{common_range}@<@\exposid{maybe-const}@<@\exposid{is-const}@, Views...[N - 1]>>) {
+  return @\exposid{iterator}@<@\exposid{is-const}@>(this, in_place_index<N - 1>,
                             ranges::end(std::get<N - 1>(@\exposid{views_}@)));
 } else {
   return default_sentinel;


### PR DESCRIPTION
..which is already used in [range.cartesian.view].