### PR TITLE
[range.utility.conv.general] Fix typo

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2268,10 +2268,10 @@ constexpr bool @\exposid{container-appendable}@ =          // \expos
 \end{codeblock}
 
 \pnum
-Let \exposid{container-appendable} be defined as follows:
+Let \exposid{container-append} be defined as follows:
 \begin{codeblock}
 template<class Ref, class Container>
-constexpr auto @\exposid{container-appendable}@(Container& c) {                // \expos
+constexpr auto @\exposid{container-append}@(Container& c) {                // \expos
   return [&c]<class Ref>(Ref&& ref) {
     if constexpr (requires { c.emplace_back(declval<Ref>()); })
       c.emplace_back(std::forward<Ref>(ref));

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2270,7 +2270,7 @@ constexpr bool @\exposid{container-appendable}@ =          // \expos
 \pnum
 Let \exposid{container-append} be defined as follows:
 \begin{codeblock}
-template<class Ref, class Container>
+template<class Container>
 constexpr auto @\exposid{container-append}@(Container& c) {                    // \expos
   return [&c]<class Ref>(Ref&& ref) {
     if constexpr (requires { c.emplace_back(declval<Ref>()); })

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -2271,7 +2271,7 @@ constexpr bool @\exposid{container-appendable}@ =          // \expos
 Let \exposid{container-append} be defined as follows:
 \begin{codeblock}
 template<class Ref, class Container>
-constexpr auto @\exposid{container-append}@(Container& c) {                // \expos
+constexpr auto @\exposid{container-append}@(Container& c) {                    // \expos
   return [&c]<class Ref>(Ref&& ref) {
     if constexpr (requires { c.emplace_back(declval<Ref>()); })
       c.emplace_back(std::forward<Ref>(ref));


### PR DESCRIPTION
This appears to be a mistake when applying [LWG 4016](https://cplusplus.github.io/LWG/issue4016).