### PR TITLE
LWG3031 Fix missing code-formatting of const

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -159,7 +159,7 @@ the type \tcode{decltype(pred(*first))} shall model
 \exposconcept{boolean-testable}\iref{concept.booleantestable}.
 The function object \tcode{pred} shall not apply any non-constant function
 through its argument.
-Given a glvalue \tcode{u} of type (possibly const) \tcode{T}
+Given a glvalue \tcode{u} of type (possibly \tcode{const}) \tcode{T}
 that designates the same object as \tcode{*first},
 \tcode{pred(u)} shall be a valid expression
 that is equal to \tcode{pred(*first)}.
@@ -186,9 +186,9 @@ the type \tcode{decltype(binary_pred(*first1, value))} shall model
 \exposconcept{boolean-testable}.
 \tcode{binary_pred} shall not apply any non-constant function
 through any of its arguments.
-Given a glvalue \tcode{u} of type (possibly const) \tcode{T1}
+Given a glvalue \tcode{u} of type (possibly \tcode{const}) \tcode{T1}
 that designates the same object as \tcode{*first1}, and
-a glvalue \tcode{v} of type (possibly const) \tcode{T2}
+a glvalue \tcode{v} of type (possibly \tcode{const}) \tcode{T2}
 that designates the same object as \tcode{*first2},
 \tcode{binary_pred(u, *first2)},
 \tcode{binary_pred(*first1, v)}, and


### PR DESCRIPTION
https://cplusplus.github.io/LWG/issue3031 proposed approved wording that includes:
> (possibly `const`)

However, all of these occurrences were formatted as plain "(possibly const)".

On top of being an editorial mistake, it's also somewhat misleading, as this shifts the intuition of the reader towards "const objects", and away from "`const` on `T`". It's clear from the surrounding wording that this `const` refers to types, but it's still easier to understand the wording with intended formatting in my opinion.