### PR TITLE
[range.access] Clarify notes on SFINAE for CPOs

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -670,7 +670,7 @@ Then:
 
 \pnum
 \begin{note}
-Diagnosable ill-formed cases above
+Diagnosable ill-formed cases for customization point objects, as above,
 result in substitution failure when \tcode{ranges::begin(E)}
 appears in the immediate context of a template instantiation.
 \end{note}
@@ -860,8 +860,8 @@ Then:
 
 \pnum
 \begin{note}
-Diagnosable ill-formed cases above result in substitution failure
-when \tcode{ranges::rbegin(E)}
+Diagnosable ill-formed cases for customization point objects, as above,
+result in substitution failure when \tcode{ranges::rbegin(E)}
 appears in the immediate context of a template instantiation.
 \end{note}
 
@@ -1053,7 +1053,7 @@ Then:
 
 \pnum
 \begin{note}
-Diagnosable ill-formed cases above
+Diagnosable ill-formed cases for customization point objects, as above,
 result in substitution failure when \tcode{ranges::size(E)}
 appears in the immediate context of a template instantiation.
 \end{note}
@@ -1122,7 +1122,7 @@ Then:
 
 \pnum
 \begin{note}
-Diagnosable ill-formed cases above
+Diagnosable ill-formed cases for customization point objects, as above,
 result in substitution failure when \tcode{ranges::empty(E)}
 appears in the immediate context of a template instantiation.
 \end{note}
@@ -1175,7 +1175,7 @@ Then:
 
 \pnum
 \begin{note}
-Diagnosable ill-formed cases above
+Diagnosable ill-formed cases for customization point objects, as above,
 result in substitution failure when \tcode{ranges::data(E)}
 appears in the immediate context of a template instantiation.
 \end{note}
@@ -9500,8 +9500,8 @@ If \tcode{decltype((F))} does not model
 \tcode{\libconcept{convertible_to}<D>},
 \tcode{views::counted(E, F)} is ill-formed.
 \begin{note}
-This case can result in substitution failure
-when \tcode{views::counted(E, F)}
+Diagnosable ill-formed cases for customization point objects, such as this,
+result in substitution failure when \tcode{views::counted(E, F)}
 appears in the immediate context of a template instantiation.
 \end{note}
 Otherwise, \tcode{views::counted(E, F)}


### PR DESCRIPTION
Readers need a deep knowledge of the standard to understand why the notes on diagnosable ill-formed code are already specified, rather than serving as a normative Remark.

Here we call out that the SFINAE constraints are specified for the function call operator of all customization point objects.