### PR TITLE
[utility.arg.requirements] Break down requirement tables

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -3458,10 +3458,10 @@ template<class InputIterator, class Function>
 \pnum
 \expects
 \tcode{Function} meets
-the \oldconcept{MoveConstructible} requirements (\tref{cpp17.moveconstructible}).
+the \oldconcept{MoveConstructible} requirements\iref{cpp17.moveconstructible}.
 \begin{note}
 \tcode{Function} need not meet the requirements of
-\oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible}).
+\oldconcept{CopyConstructible}\iref{cpp17.copyconstructible}.
 \end{note}
 
 \pnum
@@ -5022,7 +5022,7 @@ do not overlap.
 For the overload with an \tcode{ExecutionPolicy},
 there might be a performance cost
 if \tcode{iterator_traits<For\-ward\-It\-er\-ator1>::value_type}
-is not \oldconcept{\-Move\-Constructible} (\tref{cpp17.moveconstructible}).
+is not \oldconcept{\-Move\-Constructible}\iref{cpp17.moveconstructible}.
 \end{note}
 
 \pnum
@@ -5835,7 +5835,7 @@ Let $E$ be
 \expects
 For the algorithms in namespace \tcode{std},
 the type of \tcode{*first}
-meets the \oldconcept{MoveAssignable} requirements (\tref{cpp17.moveassignable}).
+meets the \oldconcept{MoveAssignable} requirements\iref{cpp17.moveassignable}.
 
 \pnum
 \effects
@@ -5945,7 +5945,7 @@ do not overlap.
 For the overloads with an \tcode{ExecutionPolicy},
 there might be a performance cost
 if \tcode{iterator_traits<ForwardIterator1>::value_type} does not meet
-the \oldconcept{\-Move\-Constructible} (\tref{cpp17.moveconstructible}) requirements.
+the \oldconcept{\-Move\-Constructible}\iref{cpp17.moveconstructible} requirements.
 \end{note}
 
 \pnum
@@ -6018,7 +6018,7 @@ let $E$ be
 For the overloads in namespace \tcode{std},
 \tcode{pred} is an equivalence relation and
 the type of \tcode{*first} meets
-the \oldconcept{MoveAssignable} requirements (\tref{cpp17.moveassignable}).
+the \oldconcept{MoveAssignable} requirements\iref{cpp17.moveassignable}.
 
 \pnum
 \effects
@@ -6124,9 +6124,9 @@ let $E$ be
     the \oldconcept{ForwardIterator} requirements and
     its value type is the same as \tcode{T},
     then \tcode{T} meets
-    the \oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}) requirements.
+    the \oldconcept{CopyAssignable}\iref{cpp17.copyassignable} requirements.
     Otherwise, \tcode{T} meets both
-    the \oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible}) and
+    the \oldconcept{CopyConstructible}\iref{cpp17.copyconstructible} and
     \oldconcept{CopyAssignable} requirements.
     \begin{note}
     For the overloads with an \tcode{ExecutionPolicy},
@@ -6274,8 +6274,8 @@ For the overloads in namespace \tcode{std},
 \tcode{ForwardIterator} meets
 the \oldconcept{ValueSwappable} requirements\iref{swappable.requirements}, and
 the type of \tcode{*first} meets
-the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{MoveAssignable} (\tref{cpp17.moveassignable}) requirements.
+the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} and
+\oldconcept{MoveAssignable}\iref{cpp17.moveassignable} requirements.
 
 \pnum
 \effects
@@ -6666,6 +6666,7 @@ That is, \tcode{comp(*i, *j) != false} defaults to \tcode{*i < *j != false}.
 For algorithms other than those described in~\ref{alg.binary.search},
 \tcode{comp} shall induce a strict weak ordering on the values.
 
+\indextext{strict weak order}
 \pnum
 The term \term{strict} refers to the requirement
 of an irreflexive relation (\tcode{!comp(x, x)} for all \tcode{x}),
@@ -6772,8 +6773,8 @@ For the overloads in namespace \tcode{std},
 \tcode{RandomAccessIterator} meets
 the \oldconcept{Value\-Swappable} requirements\iref{swappable.requirements} and
 the type of \tcode{*first} meets
-the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{MoveAssignable} (\tref{cpp17.moveassignable}) requirements.
+the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} and
+\oldconcept{MoveAssignable}\iref{cpp17.moveassignable} requirements.
 
 \pnum
 \effects
@@ -6830,8 +6831,8 @@ For the overloads in namespace \tcode{std},
 \tcode{RandomAccessIterator} meets
 the \oldconcept{Value\-Swappable} requirements\iref{swappable.requirements} and
 the type of \tcode{*first} meets
-the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{MoveAssignable} (\tref{cpp17.moveassignable}) requirements.
+the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} and
+\oldconcept{MoveAssignable}\iref{cpp17.moveassignable} requirements.
 
 \pnum
 \effects
@@ -6900,8 +6901,8 @@ For the overloads in namespace \tcode{std},
 \tcode{RandomAccessIterator} meets
 the \oldconcept{ValueSwappable} requirements\iref{swappable.requirements} and
 the type of \tcode{*first} meets
-the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{MoveAssignable} (\tref{cpp17.moveassignable}) requirements.
+the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} and
+\oldconcept{MoveAssignable}\iref{cpp17.moveassignable} requirements.
 
 \pnum
 \effects
@@ -7008,8 +7009,8 @@ For the overloads in namespace \tcode{std},
 \tcode{RandomAccessIterator} meets
 the \oldconcept{Value\-Swappable} requirements\iref{swappable.requirements},
 the type of \tcode{*result_first} meets
-the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{\-Move\-Assignable} (\tref{cpp17.moveassignable}) requirements.
+the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} and
+\oldconcept{\-Move\-Assignable}\iref{cpp17.moveassignable} requirements.
 
 \pnum
 For iterators \tcode{a1} and \tcode{b1} in \range{first}{last}, and
@@ -7213,8 +7214,8 @@ For the overloads in namespace \tcode{std},
 \tcode{RandomAccessIterator} meets
 the \oldconcept{ValueSwappable} requirements\iref{swappable.requirements}, and
 the type of \tcode{*first} meets
-the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{MoveAssignable} (\tref{cpp17.moveassignable}) requirements.
+the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} and
+\oldconcept{MoveAssignable}\iref{cpp17.moveassignable} requirements.
 
 \pnum
 \effects
@@ -7634,8 +7635,8 @@ For the overloads in namespace \tcode{std},
 \tcode{BidirectionalIterator} meets
 the \oldconcept{Value\-Swappable} requirements\iref{swappable.requirements} and
 the type of \tcode{*first} meets
-the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{MoveAssignable} (\tref{cpp17.moveassignable}) requirements.
+the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} and
+\oldconcept{MoveAssignable}\iref{cpp17.moveassignable} requirements.
 
 \pnum
 \effects
@@ -7925,8 +7926,8 @@ For the overloads in namespace \tcode{std},
 \tcode{BidirectionalIterator} meets
 the \oldconcept{Value\-Swappable} requirements\iref{swappable.requirements} and
 the type of \tcode{*first} meets
-the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{MoveAssignable} (\tref{cpp17.moveassignable}) requirements.
+the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} and
+\oldconcept{MoveAssignable}\iref{cpp17.moveassignable} requirements.
 
 \pnum
 \effects
@@ -8495,8 +8496,8 @@ For the overloads in namespace \tcode{std},
 \tcode{RandomAccessIterator} meets
 the \oldconcept{ValueSwappable} requirements\iref{swappable.requirements} and
 the type of \tcode{*first} meets
-the \oldconcept{MoveConstructible} requirements (\tref{cpp17.moveconstructible}) and
-the \oldconcept{MoveAssignable} requirements (\tref{cpp17.moveassignable}).
+the \oldconcept{MoveConstructible} requirements\iref{cpp17.moveconstructible} and
+the \oldconcept{MoveAssignable} requirements\iref{cpp17.moveassignable}.
 
 \pnum
 \effects
@@ -8548,8 +8549,8 @@ For the overloads in namespace \tcode{std},
 \tcode{RandomAccessIterator} meets
 the \oldconcept{ValueSwappable} requirements\iref{swappable.requirements} and
 the type of \tcode{*first} meets
-the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{MoveAssignable} (\tref{cpp17.moveassignable}) requirements.
+the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} and
+\oldconcept{MoveAssignable}\iref{cpp17.moveassignable} requirements.
 
 \pnum
 \effects
@@ -8604,8 +8605,8 @@ For the overloads in namespace \tcode{std},
 \tcode{RandomAccessIterator} meets
 the \oldconcept{ValueSwap\-pable} requirements\iref{swappable.requirements} and
 the type of \tcode{*first} meets
-the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{MoveAssignable} (\tref{cpp17.moveassignable}) requirements.
+the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} and
+\oldconcept{MoveAssignable}\iref{cpp17.moveassignable} requirements.
 
 \pnum
 \effects
@@ -8657,8 +8658,8 @@ For the overloads in namespace \tcode{std},
 \tcode{RandomAccessIterator} meets
 the \oldconcept{ValueSwappable} requirements\iref{swappable.requirements} and
 the type of \tcode{*first} meets
-the \oldconcept{MoveConst\-ruct\-ible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{Move\-Assign\-able} (\tref{cpp17.moveassignable}) requirements.
+the \oldconcept{MoveConst\-ruct\-ible}\iref{cpp17.moveconstructible} and
+\oldconcept{Move\-Assign\-able}\iref{cpp17.moveassignable} requirements.
 
 \pnum
 \effects
@@ -8817,7 +8818,7 @@ template<class T, class Proj = identity,
 \pnum
 \expects
 For the first form, \tcode{T} meets the
-\oldconcept{LessThanComparable} requirements (\tref{cpp17.lessthancomparable}).
+\oldconcept{LessThanComparable} requirements\iref{cpp17.lessthancomparable}.
 
 \pnum
 \returns
@@ -8859,7 +8860,7 @@ template<@\libconcept{input_range}@ R, class Proj = identity,
 For the overloads in namespace \tcode{std},
 \tcode{T} meets the \oldconcept{\-Copy\-Constructible} requirements.
 For the first form, \tcode{T} meets the \oldconcept{LessThanComparable}
-requirements (\tref{cpp17.lessthancomparable}).
+requirements\iref{cpp17.lessthancomparable}.
 
 \pnum
 \returns
@@ -8895,7 +8896,7 @@ template<class T, class Proj = identity,
 \pnum
 \expects
 For the first form, \tcode{T} meets the
-\oldconcept{LessThanComparable} requirements (\tref{cpp17.lessthancomparable}).
+\oldconcept{LessThanComparable} requirements\iref{cpp17.lessthancomparable}.
 
 \pnum
 \returns
@@ -8937,7 +8938,7 @@ template<@\libconcept{input_range}@ R, class Proj = identity,
 For the overloads in namespace \tcode{std},
 \tcode{T} meets the \oldconcept{\-Copy\-Constructible} requirements.
 For the first form, \tcode{T} meets the \oldconcept{LessThanComparable}
-requirements (\tref{cpp17.lessthancomparable}).
+requirements\iref{cpp17.lessthancomparable}.
 
 \pnum
 \returns
@@ -8975,7 +8976,7 @@ template<class T, class Proj = identity,
 \pnum
 \expects
 For the first form, \tcode{T} meets the
-\oldconcept{LessThanComparable} requirements (\tref{cpp17.lessthancomparable}).
+\oldconcept{LessThanComparable} requirements\iref{cpp17.lessthancomparable}.
 
 \pnum
 \returns
@@ -9018,7 +9019,7 @@ template<@\libconcept{input_range}@ R, class Proj = identity,
 For the overloads in namespace \tcode{std},
 \tcode{T} meets the \oldconcept{\-Copy\-Constructible} requirements.
 For the first form, type \tcode{T} meets the \oldconcept{LessThanComparable}
-requirements (\tref{cpp17.lessthancomparable}).
+requirements\iref{cpp17.lessthancomparable}.
 
 \pnum
 \returns
@@ -9210,7 +9211,7 @@ for the overloads with no parameter \tcode{proj}.
 \tcode{bool(invoke(comp, invoke(proj, hi), invoke(proj, lo)))} is \tcode{false}.
 For the first form, type \tcode{T}
 meets the \oldconcept{LessThan\-Comparable}
-requirements (\tref{cpp17.lessthancomparable}).
+requirements\iref{cpp17.lessthancomparable}.
 
 \pnum
 \returns
@@ -9775,8 +9776,8 @@ template<class InputIterator, class T, class BinaryOperation>
 \pnum
 \expects
 \tcode{T} meets
-the \oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible})
-and \oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}) requirements.
+the \oldconcept{CopyConstructible}\iref{cpp17.copyconstructible}
+and \oldconcept{CopyAssignable}\iref{cpp17.copyassignable} requirements.
 In the range \crange{first}{last},
 \tcode{binary_op} neither modifies elements
 nor invalidates iterators or subranges.
@@ -9898,7 +9899,7 @@ are convertible to \tcode{T}.
 \expects
 \begin{itemize}
 \item
-  \tcode{T} meets the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) requirements.
+  \tcode{T} meets the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} requirements.
 \item
   \tcode{binary_op} neither invalidates iterators or subranges,
   nor modifies elements in the range \crange{first}{last}.
@@ -9942,8 +9943,8 @@ template<class InputIterator1, class InputIterator2, class T,
 \pnum
 \expects
 \tcode{T} meets
-the \oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible})
-and \oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}) requirements.
+the \oldconcept{CopyConstructible}\iref{cpp17.copyconstructible}
+and \oldconcept{CopyAssignable}\iref{cpp17.copyassignable} requirements.
 In the ranges \crange{first1}{last1} and
 \crange{first2}{first2 + (last1 - first1)}
 \tcode{binary_op1} and \tcode{binary_op2}
@@ -10038,7 +10039,7 @@ All of
 \expects
 \begin{itemize}
 \item
-  \tcode{T} meets the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) requirements.
+  \tcode{T} meets the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} requirements.
 \item
   Neither \tcode{binary_op1} nor \tcode{binary_op2}
   invalidates subranges, nor modifies elements in the ranges
@@ -10088,7 +10089,7 @@ template<class ExecutionPolicy,
 \expects
 \begin{itemize}
 \item
-  \tcode{T} meets the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) requirements.
+  \tcode{T} meets the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} requirements.
 \item
   Neither \tcode{unary_op} nor \tcode{binary_op} invalidates subranges,
   nor modifies elements in the range \crange{first}{last}.
@@ -10237,7 +10238,7 @@ template<class ExecutionPolicy,
 \expects
 \begin{itemize}
 \item
-  \tcode{T} meets the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) requirements.
+  \tcode{T} meets the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} requirements.
 \item
   \tcode{binary_op} neither invalidates iterators or subranges,
   nor modifies elements in
@@ -10358,7 +10359,7 @@ is convertible to \tcode{U}.
 \begin{itemize}
 \item
   If \tcode{init} is provided,
-  \tcode{T} meets the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) requirements;
+  \tcode{T} meets the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} requirements;
   otherwise, \tcode{U}
   meets the \oldconcept{MoveConstructible} requirements.
 \item
@@ -10437,7 +10438,7 @@ template<class ExecutionPolicy,
 \expects
 \begin{itemize}
 \item
-  \tcode{T} meets the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) requirements.
+  \tcode{T} meets the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} requirements.
 \item
   Neither \tcode{unary_op} nor \tcode{binary_op}
   invalidates iterators or subranges, nor modifies elements in
@@ -10536,7 +10537,7 @@ is convertible to \tcode{U}.
 \begin{itemize}
 \item
   If \tcode{init} is provided, \tcode{T} meets the
-  \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) requirements;
+  \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} requirements;
   otherwise, \tcode{U} meets the
   \oldconcept{MoveConstructible} requirements.
 \item
@@ -10637,7 +10638,7 @@ that denotes an object of type \tcode{minus<>}.
 \begin{itemize}
 \item
   For the overloads with no \tcode{ExecutionPolicy},
-  \tcode{T} meets the \oldconcept{MoveAssignable} (\tref{cpp17.moveassignable})
+  \tcode{T} meets the \oldconcept{MoveAssignable}\iref{cpp17.moveassignable}
   requirements.
 \item
   For all overloads, in the ranges \crange{first}{last}

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -754,7 +754,7 @@ template<class T>
 \begin{itemdescr}
 \pnum
 \begin{note}
-Unlike the \oldconcept{Destructible} requirements~(\tref{cpp17.destructible}), this
+Unlike the \oldconcept{Destructible} requirements\iref{cpp17.destructible}, this
 concept forbids destructors that are potentially throwing, even if a particular
 invocation of the destructor does not actually throw.
 \end{note}

--- a/source/future.tex
+++ b/source/future.tex
@@ -272,7 +272,7 @@ template<class T> bool operator!=(const T& x, const T& y);
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{T} meets the \oldconcept{EqualityComparable} requirements (\tref{cpp17.equalitycomparable}).
+\tcode{T} meets the \oldconcept{EqualityComparable} requirements\iref{cpp17.equalitycomparable}.
 
 \pnum
 \returns
@@ -287,7 +287,7 @@ template<class T> bool operator>(const T& x, const T& y);
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{T} meets the \oldconcept{LessThanComparable} requirements (\tref{cpp17.lessthancomparable}).
+\tcode{T} meets the \oldconcept{LessThanComparable} requirements\iref{cpp17.lessthancomparable}.
 
 \pnum
 \returns
@@ -302,7 +302,7 @@ template<class T> bool operator<=(const T& x, const T& y);
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{T} meets the \oldconcept{LessThanComparable} requirements (\tref{cpp17.lessthancomparable}).
+\tcode{T} meets the \oldconcept{LessThanComparable} requirements\iref{cpp17.lessthancomparable}.
 
 \pnum
 \returns
@@ -317,7 +317,7 @@ template<class T> bool operator>=(const T& x, const T& y);
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{T} meets the \oldconcept{LessThanComparable} requirements (\tref{cpp17.lessthancomparable}).
+\tcode{T} meets the \oldconcept{LessThanComparable} requirements\iref{cpp17.lessthancomparable}.
 
 \pnum
 \returns

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -1689,10 +1689,10 @@ An \tcode{fpos} type specifies file position information.
 It holds a state object
 whose type is equal to the template parameter \tcode{stateT}.
 Type \tcode{stateT} shall meet
-the \oldconcept{DefaultConstructible} (\tref{cpp17.defaultconstructible}),
-\oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible}),
-\oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}), and
-\oldconcept{Destructible} (\tref{cpp17.destructible}) requirements.
+the \oldconcept{DefaultConstructible}\iref{cpp17.defaultconstructible},
+\oldconcept{CopyConstructible}\iref{cpp17.copyconstructible},
+\oldconcept{CopyAssignable}\iref{cpp17.copyassignable}, and
+\oldconcept{Destructible}\iref{cpp17.destructible} requirements.
 If \tcode{is_trivially_copy_constructible_v<stateT>} is \tcode{true},
 then \tcode{fpos<stateT>} has a trivial copy constructor.
 If \tcode{is_trivially_copy_assignable_v<stateT>} is \tcode{true},
@@ -1704,7 +1704,7 @@ the \oldconcept{DefaultConstructible},
 \oldconcept{CopyConstructible},
 \oldconcept{CopyAssignable},
 \oldconcept{Destructible},
-and \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable}) requirements.
+and \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable} requirements.
 In addition, the expressions shown in \tref{fpos.operations}
 are valid and have the indicated semantics.
 In that table,

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2060,7 +2060,7 @@ meets the requirements of an input iterator for the value type
 \tcode{T}
 if
 \tcode{X} meets the \oldconcept{Iterator}\iref{iterator.iterators} and
-\oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable}) requirements and
+\oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable} requirements and
 the expressions in \tref{inputiterator} are valid and have
 the indicated semantics.
 
@@ -2152,7 +2152,7 @@ such an algorithm should be a single pass algorithm.
 \begin{note}
 For input iterators, \tcode{a == b} does not imply \tcode{++a == ++b}.
 (Equality does not guarantee the substitution property or referential transparency.)
-Value type \tcode{T} is not required to be a \oldconcept{CopyAssignable} type (\tref{cpp17.copyassignable}).
+Value type \tcode{T} is not required to be a \oldconcept{CopyAssignable} type\iref{cpp17.copyassignable}.
 Such an algorithm can be used with istreams as the source of the input data through the
 \tcode{istream_iterator}
 class template.

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -260,7 +260,7 @@ The library specification uses a typographical convention for naming
 requirements. Names in \textit{italic} type that begin with the prefix
 \oldconcept{} refer to sets of well-defined expression requirements typically
 presented in tabular form, possibly with additional prose semantic requirements.
-For example, \oldconcept{Destructible}~(\tref{cpp17.destructible}) is such a named
+For example, \oldconcept{Hash}~(\tref{cpp17.hash}) is such a named
 requirement. Names in \tcode{constant width} type refer to library concepts
 which are presented as a concept definition\iref{temp}, possibly with additional
 prose semantic requirements. For example,
@@ -1685,9 +1685,8 @@ allocators.
 
 \pnum
 The template definitions in the \Cpp{} standard library
-refer to various named requirements whose details are set out in
-Tables~\ref{tab:cpp17.equalitycomparable}--\ref{tab:cpp17.destructible}.
-In these tables,
+refer to various named requirements whose details are set out below. In
+subclause \ref{utility.arg.requirements},
 \begin{itemize}
 \item
 \tcode{T} denotes an object or reference type to be
@@ -1697,11 +1696,11 @@ supplied by a \Cpp{} program instantiating a template,
 \tcode{b}, and
 \tcode{c} denote values of type (possibly const) \tcode{T},
 \item
-\tcode{s} and \tcode{t} denote modifiable lvalues of type \tcode{T},
+\tcode{rv} denotes an rvalue of type \tcode{T}, and
+\item
+\tcode{t} denotes a modifiable lvalue of type \tcode{T},
 \item
 \tcode{u} denotes an identifier,
-\item
-\tcode{rv} denotes an rvalue of type \tcode{T}, and
 \item
 \tcode{v} denotes an lvalue of type (possibly const) \tcode{T} or an
 rvalue of type \tcode{const T}.
@@ -1713,14 +1712,23 @@ member function signatures specify \tcode{T()} as a default argument.
 \tcode{T()} shall be a well-defined expression\iref{dcl.init} if one of those
 signatures is called using the default argument\iref{dcl.fct.default}.
 
-\begin{oldconcepttable}{EqualityComparable}{}{cpp17.equalitycomparable}
-{x{1in}x{1in}p{3in}}
-\topline
-\hdstyle{Expression}  &   \hdstyle{Return type} &   \rhdr{Requirement} \\ \capsep
-\tcode{a == b}  &
-\tcode{decltype(a == b)} models \exposconceptx{boolean-testa\-ble}{boolean-testable} &
-\tcode{==} is an equivalence relation,
-that is, it has the following properties:
+\rSec4[cpp17.equalitycomparable]{\oldconcept{EqualityComparable} requirements}
+\pnum
+Type \tcode{T} meets the \defnoldconcept{EqualityComparable} requirements if
+the following types, statements, and expressions are well-formed and have the
+specified semantics.
+
+\begin{itemdecl}
+a == b
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result Models \exposconcept{boolean-testable}\iref{concept.booleantestable}.
+
+\pnum
+\remarks
+\tcode{==} is an equivalence relation, that is, it has the following properties:
 \begin{itemize}
 \item
 For all \tcode{a}, \tcode{a == a}.
@@ -1728,91 +1736,206 @@ For all \tcode{a}, \tcode{a == a}.
 If \tcode{a == b}, then \tcode{b == a}.
 \item
 If \tcode{a == b} and \tcode{b == c}, then \tcode{a == c}.
-\end{itemize} \\
-\end{oldconcepttable}
+\end{itemize}
+\end{itemdescr}
 
-\begin{oldconcepttable}{LessThanComparable}{}{cpp17.lessthancomparable}
-{x{1in}x{1in}p{3in}}
-\topline
-\hdstyle{Expression}  &   \hdstyle{Return type} &   \hdstyle{Requirement} \\ \capsep
-\tcode{a < b}   &
-\tcode{decltype(a < b)} models \exposconceptx{boolean-testa\-ble}{boolean-testable} &
-\tcode{<} is a strict weak ordering relation\iref{alg.sorting}    \\
-\end{oldconcepttable}
+\rSec4[cpp17.lessthancomparable]{\oldconcept{LessThanComparable} requirements}
+\pnum
+Type \tcode{T} meets the \defnoldconcept{LessThanComparable} requirements if
+the following types, statements, and expressions are well-formed and have the
+specified semantics.
 
-\enlargethispage{-3\baselineskip}
-\begin{oldconcepttable}{DefaultConstructible}{}{cpp17.defaultconstructible}
-{x{2.15in}p{3in}}
-\topline
-\hdstyle{Expression}        &     \hdstyle{Post-condition}  \\ \capsep
-\tcode{T t;}      &     object \tcode{t} is default-initialized   \\ \rowsep
-\tcode{T u\{\};}    &     object \tcode{u} is value-initialized or aggregate-initialized \\ \rowsep
-\tcode{T()}\br\tcode{T\{\}}  &  an object of type \tcode{T} is value-initialized
-                                or aggregate-initialized \\
-\end{oldconcepttable}
+\begin{itemdecl}
+a < b
+\end{itemdecl}
 
-\begin{oldconcepttable}{MoveConstructible}{}{cpp17.moveconstructible}
-{p{1in}p{4.15in}}
-\topline
-\hdstyle{Expression}          &   \hdstyle{Post-condition}  \\ \capsep
-\tcode{T u = rv;}    &   \tcode{u} is equivalent to the value of \tcode{rv} before the construction\\ \rowsep
-\tcode{T(rv)}       &
-  \tcode{T(rv)} is equivalent to the value of \tcode{rv} before the construction \\ \rowsep
-\multicolumn{2}{|p{5.3in}|}{
-  \tcode{rv}'s state is unspecified
-  \begin{tailnote}
-\tcode{rv} must still meet the requirements of the library
-  component that is using it. The operations listed in those requirements must
-  work as specified whether \tcode{rv} has been moved from or not.
-\end{tailnote}
-}\\
-\end{oldconcepttable}
+\begin{itemdescr}
+\pnum
+\result Models \exposconcept{boolean-testable}\iref{concept.booleantestable}.
 
-\begin{oldconcepttable}{CopyConstructible}{ (in addition to \oldconcept{MoveConstructible})}{cpp17.copyconstructible}
-{p{1in}p{4.15in}}
-\topline
-\hdstyle{Expression}          &   \hdstyle{Post-condition}  \\ \capsep
-\tcode{T u = v;}     &   the value of \tcode{v} is unchanged and is equivalent to \tcode{ u}\\ \rowsep
-\tcode{T(v)}        &
-  the value of \tcode{v} is unchanged and is equivalent to \tcode{T(v)} \\
-\end{oldconcepttable}
+\pnum
+\remarks \tcode{<} is a strict weak ordering relation\iref{alg.sorting}.
+\end{itemdescr}
 
-\begin{oldconcepttable}{MoveAssignable}{}{cpp17.moveassignable}
-{p{1in}p{1in}p{1in}p{1.9in}}
-\topline
-\hdstyle{Expression} & \hdstyle{Return type} & \hdstyle{Return value} & \hdstyle{Post-condition} \\ \capsep
-\tcode{t = rv}  &   \tcode{T\&} &   \tcode{t}       &
-  If \tcode{t} and \tcode{rv} do not refer to the same object,
-  \tcode{t} is equivalent to the value of \tcode{rv} before the assignment\\ \rowsep
-\multicolumn{4}{|p{5.3in}|}{
-  \tcode{rv}'s state is unspecified.
-  \begin{tailnote}
-  \tcode{rv} must still meet the requirements of the library
-  component that is using it, whether or not \tcode{t} and \tcode{rv} refer to the same object.
-  The operations listed in those requirements must
-  work as specified whether \tcode{rv} has been moved from or not.
-\end{tailnote}
-}\\
-\end{oldconcepttable}
+\rSec4[cpp17.defaultconstructible]{\oldconcept{DefaultConstructible} requirements}
+\pnum
+Type \tcode{T} meets the \defnoldconcept{DefaultConstructible} requirements if
+the following statements and expressions are well-formed and have the specified
+semantics.
 
-\begin{oldconcepttable}{CopyAssignable}{ (in addition to \oldconcept{MoveAssignable})}{cpp17.copyassignable}
-{p{1in}p{1in}p{1in}p{1.9in}}
-\topline
-\hdstyle{Expression} & \hdstyle{Return type} & \hdstyle{Return value} & \hdstyle{Post-condition} \\ \capsep
-\tcode{t = v}   &   \tcode{T\&} &   \tcode{t}   &   \tcode{t} is equivalent to \tcode{v}, the value of \tcode{v} is unchanged\\
-\end{oldconcepttable}
+\begin{itemdecl}
+T t;
+\end{itemdecl}
 
-\begin{oldconcepttable}{Destructible}{}{cpp17.destructible}
-{p{1in}p{4.15in}}
-\topline
-\hdstyle{Expression}      &   \hdstyle{Post-condition}  \\ \capsep
-\tcode{u.\~T()} &   All resources owned by \tcode{u} are reclaimed, no exception is propagated. \\ \rowsep
-\multicolumn{2}{|l|}{
-  \begin{tailnote}
-  Array types and non-object types are not \oldconcept{Destructible}.
-  \end{tailnote}
-} \\
-\end{oldconcepttable}
+\begin{itemdescr}
+\pnum
+\ensures
+Object \tcode{t} is default-initialized\iref{dcl.init}.
+\end{itemdescr}
+
+\begin{itemdecl}
+T u{};
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ensures
+Object \tcode{u} is value-initialized\iref{dcl.init} or
+aggregate-initialized\iref{dcl.init.aggr}.
+\end{itemdescr}
+
+\begin{itemdecl}
+T()
+T{};
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ensures
+An object of type \tcode{T} is value-initialized\iref{dcl.init} or
+aggregate-initialized\iref{dcl.init.aggr}.
+\end{itemdescr}
+
+\rSec4[cpp17.moveconstructible]{\oldconcept{MoveConstructible} requirements}
+\pnum
+Type \tcode{T} meets the \defnoldconcept{MoveConstructible} requirements if the
+following statements and expressions are well-formed and have the specified
+semantics.
+
+\begin{itemdecl}
+T u = rv;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ensures
+\tcode{u} is equivalent to the value of \tcode{rv} before the construction.
+\tcode{rv}'s state is unspecified.
+
+\pnum
+\begin{note}
+\tcode{rv} must still meet the requirements of the library component that is
+using it. The operations listed in those requirements must work as specified
+whether \tcode{rv} has been moved from or not.
+\end{note}
+\end{itemdescr}
+
+\begin{itemdecl}
+T(rv)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ensures
+\tcode{T(rv)} is equivalent to the value of \tcode{rv} before the construction.
+\tcode{rv}'s state is unspecified.
+
+\pnum
+\begin{note}
+\tcode{rv} must still meet the requirements of the library component that is
+using it. The operations listed in those requirements must work as specified
+whether \tcode{rv} has been moved from or not.
+\end{note}
+\end{itemdescr}
+
+\rSec4[cpp17.copyconstructible]{\oldconcept{CopyConstructible} requirements}
+\pnum
+Type \tcode{T} meets the \defnoldconcept{CopyConstructible} requirements if it
+meets the \oldconcept{MoveConstructible} requirements and the following
+statements and expressions are well-formed and have the specified semantics.
+
+\begin{itemdecl}
+T u = v;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ensures
+The value of \tcode{v} is unchanged and is equivalent to \tcode{u}.
+\end{itemdescr}
+
+\begin{itemdecl}
+T(v)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ensures
+The value of \tcode{v} is unchanged and is equivalent to \tcode{T(v)}.
+\end{itemdescr}
+
+\rSec4[cpp17.moveassignable]{\oldconcept{MoveAssignable} requirements}
+\pnum
+Type \tcode{T} meets the \defnoldconcept{MoveAssignable} requirements if the
+following types and expressions are well-formed and have the specified semantics.
+
+\begin{itemdecl}
+t = rv
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result \tcode{T\&}.
+
+\pnum
+\returns \tcode{t}.
+
+\pnum
+\ensures
+If \tcode{t} and \tcode{rv} do not refer to the same object, \tcode{t} is
+equivalent to the value of \tcode{rv} before the assignment.  \tcode{rv}'s
+state is unspecified.
+
+\pnum
+\begin{note}
+\tcode{rv} must still meet the requirements of the library component that is
+using it, whether or not \tcode{t} and \tcode{rv} refer to the same object.
+The operations listed in those requirements must work as specified whether
+\tcode{rv} has been moved from or not.
+\end{note}
+\end{itemdescr}
+
+\rSec4[cpp17.copyassignable]{\oldconcept{CopyAssignable} requirements}
+\pnum
+Type \tcode{T} meets the \defnoldconcept{CopyAssignable} requirements if it
+meets the \oldconcept{MoveAssignable} requirements and the following types and
+expressions are well-formed and have the specified semantics.
+
+\begin{itemdecl}
+t = v
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result \tcode{T\&}.
+
+\pnum
+\returns \tcode{t}.
+
+\pnum
+\ensures
+\tcode{t} is equivalent to \tcode{v}, the value of \tcode{v} is unchanged.
+\end{itemdescr}
+
+\rSec4[cpp17.destructible]{\oldconcept{Destructible} requirements}
+\pnum
+Type \tcode{T} meets the \oldconcept{Destructible} requirements if the following
+expression is well-formed and has the specified semantics.
+
+\begin{itemdecl}
+u.~T()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ensures
+All resources owned by \tcode{u} are reclaimed, no exception is propagated.
+
+\pnum
+\begin{note}
+Array types and non-object types are not \oldconcept{Destructible}.
+\end{note}
+\end{itemdescr}
 
 \rSec3[swappable.requirements]{Swappable requirements}
 
@@ -2003,8 +2126,8 @@ a value of type (possibly const) \tcode{std::nullptr_t}.
 A type \tcode{H} meets the \defnoldconcept{Hash} requirements if:
 \begin{itemize}
 \item it is a function object type\iref{function.objects},
-\item it meets the \oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible}) and
-  \oldconcept{Destructible} (\tref{cpp17.destructible}) requirements, and
+\item it meets the \oldconcept{CopyConstructible}\iref{cpp17.copyconstructible} and
+  \oldconcept{Destructible}\iref{cpp17.destructible} requirements, and
 \item the expressions shown in \tref{cpp17.hash}
 are valid and have the indicated semantics.
 \end{itemize}
@@ -2688,7 +2811,7 @@ Identical to or derived from \tcode{true_type} or \tcode{false_type}.
 \tcode{true_type} only if an allocator of type \tcode{X} should be copied
 when the client container is copy-assigned;
 if so, \tcode{X} shall meet
-the \oldconcept{CopyAssignable} requirements (\tref{cpp17.copyassignable}) and
+the \oldconcept{CopyAssignable} requirements\iref{cpp17.copyassignable} and
 the copy operation shall not throw exceptions.
 
 \pnum
@@ -2710,7 +2833,7 @@ Identical to or derived from \tcode{true_type} or \tcode{false_type}.
 \tcode{true_type} only if an allocator of type \tcode{X} should be moved
 when the client container is move-assigned;
 if so, \tcode{X} shall meet
-the \oldconcept{MoveAssignable} requirements (\tref{cpp17.moveassignable}) and
+the \oldconcept{MoveAssignable} requirements\iref{cpp17.moveassignable} and
 the move operation shall not throw exceptions.
 
 \pnum
@@ -2762,7 +2885,7 @@ Default: \tcode{is_empty<X>::type}
 
 \pnum
 An allocator type \tcode{X} shall meet the
-\oldconcept{CopyConstructible} requirements (\tref{cpp17.copyconstructible}).
+\oldconcept{CopyConstructible} requirements\iref{cpp17.copyconstructible}.
 The \tcode{XX::pointer}, \tcode{XX::const_pointer}, \tcode{XX::void_pointer}, and
 \tcode{XX::const_void_pointer} types shall meet the
 \oldconcept{Nullable\-Pointer} requirements (\tref{cpp17.nullablepointer}).

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -2100,7 +2100,7 @@ pointer as appropriate for that deleter.
 
 \pnum
 If the deleter's type \tcode{D} is not a reference type, \tcode{D} shall meet
-the \oldconcept{Destructible} requirements (\tref{cpp17.destructible}).
+the \oldconcept{Destructible} requirements\iref{cpp17.destructible}.
 
 \pnum
 If the \grammarterm{qualified-id} \tcode{remove_reference_t<D>::pointer} is valid and denotes a
@@ -2134,7 +2134,7 @@ constexpr unique_ptr(nullptr_t) noexcept;
 
 \pnum
 \expects
-\tcode{D} meets the \oldconcept{DefaultConstructible} requirements (\tref{cpp17.defaultconstructible}),
+\tcode{D} meets the \oldconcept{DefaultConstructible} requirements\iref{cpp17.defaultconstructible},
 and that construction does not throw an exception.
 
 \pnum
@@ -2161,7 +2161,7 @@ constexpr explicit unique_ptr(type_identity_t<pointer> p) noexcept;
 
 \pnum
 \expects
-\tcode{D} meets the \oldconcept{DefaultConstructible} requirements (\tref{cpp17.defaultconstructible}),
+\tcode{D} meets the \oldconcept{DefaultConstructible} requirements\iref{cpp17.defaultconstructible},
 and that construction does not throw an exception.
 
 \pnum
@@ -2241,7 +2241,7 @@ constexpr unique_ptr(unique_ptr&& u) noexcept;
 \expects
 If \tcode{D} is not a reference type,
 \tcode{D} meets the \oldconcept{MoveConstructible}
-requirements (\tref{cpp17.moveconstructible}).
+requirements\iref{cpp17.moveconstructible}.
 Construction
 of the deleter from an rvalue of type \tcode{D} does not
 throw an exception.
@@ -2349,7 +2349,7 @@ constexpr unique_ptr& operator=(unique_ptr&& u) noexcept;
 \pnum
 \expects
 If \tcode{D} is not a reference type, \tcode{D} meets the
-\oldconcept{MoveAssignable} requirements (\tref{cpp17.moveassignable}) and assignment
+\oldconcept{MoveAssignable} requirements\iref{cpp17.moveassignable} and assignment
 of the deleter from an rvalue of type \tcode{D} does not throw an exception.
 Otherwise, \tcode{D} is a reference type;
 \tcode{remove_reference_t<D>} meets the \oldconcept{CopyAssignable}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -2070,8 +2070,8 @@ according to \ref{strings} and \ref{input.output}.
 
 \pnum
 \tcode{E} shall meet the
-\oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible})
-and \oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}) requirements.
+\oldconcept{CopyConstructible}\iref{cpp17.copyconstructible}
+and \oldconcept{CopyAssignable}\iref{cpp17.copyassignable} requirements.
 These operations shall each be of complexity
 no worse than \bigoh{\text{size of state}}.
 
@@ -2440,8 +2440,8 @@ according to \ref{strings} and \ref{input.output}.
 
 \pnum
 \tcode{D} shall meet the
-\oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible})
-and \oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}) requirements.
+\oldconcept{CopyConstructible}\iref{cpp17.copyconstructible}
+and \oldconcept{CopyAssignable}\iref{cpp17.copyassignable} requirements.
 
 \pnum
 The sequence of numbers
@@ -2472,10 +2472,10 @@ for convenience of exposition only.
 
 \pnum
 \tcode{P} shall meet the
-\oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible}),
-\oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}),
+\oldconcept{CopyConstructible}\iref{cpp17.copyconstructible},
+\oldconcept{CopyAssignable}\iref{cpp17.copyassignable},
 and
-\oldconcept{Equality\-Comp\-arable} (\tref{cpp17.equalitycomparable}) requirements.
+\oldconcept{Equality\-Comp\-arable}\iref{cpp17.equalitycomparable} requirements.
 
 \pnum
 For each of the constructors of \tcode{D}

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -239,10 +239,10 @@ using state_type = @\seebelow@;
 \pnum
 \expects
 \tcode{state_type} meets the
-\oldconcept{Destructible} (\tref{cpp17.destructible}),
-\oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}),
-\oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible}), and
-\oldconcept{DefaultConstructible} (\tref{cpp17.defaultconstructible}) requirements.
+\oldconcept{Destructible}\iref{cpp17.destructible},
+\oldconcept{CopyAssignable}\iref{cpp17.copyassignable},
+\oldconcept{CopyConstructible}\iref{cpp17.copyconstructible}, and
+\oldconcept{DefaultConstructible}\iref{cpp17.defaultconstructible} requirements.
 \end{itemdescr}
 
 \rSec2[char.traits.specializations]{\tcode{char_traits} specializations}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -3626,8 +3626,8 @@ parameter as the arguments.
 
 \begin{note}
 If the pointers point to different complete objects (or subobjects thereof),
-the \tcode{<} operator does not establish a strict weak ordering
-(\tref{cpp17.lessthancomparable}, \ref{expr.rel}).
+the \tcode{<} operator does not establish a strict weak ordering\iref{cpp17.lessthancomparable},
+\ref{expr.rel}).
 \end{note}
 \end{itemdescr}
 
@@ -4861,8 +4861,8 @@ parameter as the arguments.
 
 \begin{note}
 If the pointers point to different complete objects (or subobjects thereof),
-the \tcode{<} operator does not establish a strict weak ordering
-(\tref{cpp17.lessthancomparable}, \ref{expr.rel}).
+the \tcode{<} operator does not establish a strict weak ordering\iref{cpp17.lessthancomparable},
+\ref{expr.rel}).
 \end{note}
 \end{itemdescr}
 
@@ -9860,8 +9860,8 @@ execute atomically.
 
 \pnum
 \tcode{CompletionFunction} shall meet the
-\oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{Destructible} (\tref{cpp17.destructible}) requirements.
+\oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} and
+\oldconcept{Destructible}\iref{cpp17.destructible} requirements.
 \tcode{is_nothrow_invocable_v<CompletionFunction\&>} shall be \tcode{true}.
 
 \pnum
@@ -9869,15 +9869,15 @@ The default value of the \tcode{CompletionFunction} template parameter is
 an unspecified type, such that,
 in addition to satisfying the requirements of \tcode{CompletionFunction},
 it meets the \oldconcept{DefaultConstructible}
-requirements (\tref{cpp17.defaultconstructible}) and
+requirements\iref{cpp17.defaultconstructible} and
 \tcode{completion()} has no effects.
 
 \pnum
 \tcode{barrier::arrival_token} is an unspecified type,
 such that it meets the
-\oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}),
-\oldconcept{MoveAssignable} (\tref{cpp17.moveassignable}), and
-\oldconcept{Destructible} (\tref{cpp17.destructible}) requirements.
+\oldconcept{MoveConstructible}\iref{cpp17.moveconstructible},
+\oldconcept{MoveAssignable}\iref{cpp17.moveassignable}, and
+\oldconcept{Destructible}\iref{cpp17.destructible} requirements.
 
 \indexlibrarymember{max}{barrier}%
 \begin{itemdecl}

--- a/source/time.tex
+++ b/source/time.tex
@@ -1043,8 +1043,8 @@ A type \tcode{TC} meets the \oldconcept{TrivialClock} requirements if:
 
 \item
 the types \tcode{TC::rep}, \tcode{TC::duration}, and \tcode{TC::time_point}
-meet the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable}) and
-\oldconcept{LessThanComparable} (\tref{cpp17.lessthancomparable})
+meet the \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable} and
+\oldconcept{LessThanComparable}\iref{cpp17.lessthancomparable}
 and \oldconcept{Swappable}\iref{swappable.requirements}
 requirements and the requirements of
 numeric types\iref{numeric.requirements},
@@ -3979,8 +3979,8 @@ It normally holds values in the range 1 to 31,
 but may hold non-negative values outside this range.
 It can be constructed with any \tcode{unsigned} value,
 which will be subsequently truncated to fit into \tcode{day}'s unspecified internal storage.
-\tcode{day} meets the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable})
-and \oldconcept{LessThanComparable} (\tref{cpp17.lessthancomparable}) requirements,
+\tcode{day} meets the \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable}
+and \oldconcept{LessThanComparable}\iref{cpp17.lessthancomparable} requirements,
 and participates in basic arithmetic with \tcode{days} objects,
 which represent a difference between two \tcode{day} objects.
 
@@ -4272,8 +4272,8 @@ It normally holds values in the range 1 to 12,
 but may hold non-negative values outside this range.
 It can be constructed with any \tcode{unsigned} value,
 which will be subsequently truncated to fit into \tcode{month}'s unspecified internal storage.
-\tcode{month} meets the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable})
-and \oldconcept{LessThanComparable} (\tref{cpp17.lessthancomparable}) requirements,
+\tcode{month} meets the \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable}
+and \oldconcept{LessThanComparable}\iref{cpp17.lessthancomparable} requirements,
 and participates in basic arithmetic with \tcode{months} objects,
 which represent a difference between two \tcode{month} objects.
 
@@ -4582,8 +4582,8 @@ namespace std::chrono {
 It can represent values in the range \crange{min()}{max()}.
 It can be constructed with any \tcode{int} value,
 which will be subsequently truncated to fit into \tcode{year}'s unspecified internal storage.
-\tcode{year} meets the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable})
-and \oldconcept{LessThanComparable} (\tref{cpp17.lessthancomparable}) requirements,
+\tcode{year} meets the \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable}
+and \oldconcept{LessThanComparable}\iref{cpp17.lessthancomparable} requirements,
 and participates in basic arithmetic with \tcode{years} objects,
 which represent a difference between two \tcode{year} objects.
 
@@ -4937,7 +4937,7 @@ corresponding to Sunday through Saturday, but
 it may hold non-negative values outside this range.
 It can be constructed with any \tcode{unsigned} value,
 which will be subsequently truncated to fit into \tcode{weekday}'s unspecified internal storage.
-\tcode{weekday} meets the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable}) requirements.
+\tcode{weekday} meets the \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable} requirements.
 \begin{note}
 \tcode{weekday} is not
 \oldconcept{LessThanComparable}
@@ -5520,8 +5520,8 @@ namespace std::chrono {
 \pnum
 \tcode{month_day} represents a specific day of a specific month,
 but with an unspecified year.
-\tcode{month_day} meets the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable})
-and \oldconcept{LessThanComparable} (\tref{cpp17.lessthancomparable}) requirements.
+\tcode{month_day} meets the \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable}
+and \oldconcept{LessThanComparable}\iref{cpp17.lessthancomparable} requirements.
 
 \pnum
 \tcode{month_day} is a trivially copyable and standard-layout class type.
@@ -6021,8 +6021,8 @@ namespace std::chrono {
 \tcode{year_month} represents a specific month of a specific year,
 but with an unspecified day.
 \tcode{year_month} is a field-based time point with a resolution of \tcode{months}.
-\tcode{year_month} meets the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable})
-and \oldconcept{LessThanComparable} (\tref{cpp17.lessthancomparable}) requirements.
+\tcode{year_month} meets the \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable}
+and \oldconcept{LessThanComparable}\iref{cpp17.lessthancomparable} requirements.
 
 \pnum
 \tcode{year_month} is a trivially copyable and standard-layout class type.
@@ -6377,8 +6377,8 @@ but not \tcode{days}-oriented arithmetic.
 For the latter, there is a conversion to \tcode{sys_days},
 which efficiently supports \tcode{days}-oriented arithmetic.
 \end{note}
-\tcode{year_month_day} meets the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable})
-and \oldconcept{LessThanComparable} (\tref{cpp17.lessthancomparable}) requirements.
+\tcode{year_month_day} meets the \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable}
+and \oldconcept{LessThanComparable}\iref{cpp17.lessthancomparable} requirements.
 
 \pnum
 \tcode{year_month_day} is a trivially copyable and standard-layout class type.
@@ -6838,8 +6838,8 @@ but not \tcode{days}-oriented arithmetic.
 For the latter, there is a conversion to \tcode{sys_days},
 which efficiently supports \tcode{days}-oriented arithmetic.
 \end{note}
-\tcode{year_month_day_last} meets the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable})
-and \oldconcept{LessThanComparable} (\tref{cpp17.lessthancomparable}) requirements.
+\tcode{year_month_day_last} meets the \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable}
+and \oldconcept{LessThanComparable}\iref{cpp17.lessthancomparable} requirements.
 
 \pnum
 \tcode{year_month_day_last} is a trivially copyable and standard-layout class type.
@@ -7209,7 +7209,7 @@ but not \tcode{days}-oriented arithmetic.
 For the latter, there is a conversion to \tcode{sys_days},
 which efficiently supports \tcode{days}-oriented arithmetic.
 \end{note}
-\tcode{year_month_weekday} meets the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable}) requirements.
+\tcode{year_month_weekday} meets the \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable} requirements.
 
 \pnum
 \tcode{year_month_weekday} is a trivially copyable and standard-layout class type.
@@ -7602,7 +7602,7 @@ but not \tcode{days}-oriented arithmetic.
 For the latter, there is a conversion to \tcode{sys_days},
 which efficiently supports \tcode{days}-oriented arithmetic.
 \end{note}
-\tcode{year_month_weekday_last} meets the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable}) requirements.
+\tcode{year_month_weekday_last} meets the \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable} requirements.
 
 \pnum
 \tcode{year_month_weekday_last} is a trivially copyable and standard-layout class type.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -247,9 +247,9 @@ template<class T>
 Type
 \tcode{T}
 meets the
-\oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible})
+\oldconcept{MoveConstructible}\iref{cpp17.moveconstructible}
 and
-\oldconcept{MoveAssignable} (\tref{cpp17.moveassignable})
+\oldconcept{MoveAssignable}\iref{cpp17.moveassignable}
 requirements.
 
 \pnum
@@ -3339,7 +3339,7 @@ member \tcode{val} points to the contained value.
 \pnum
 \tcode{T} shall be a type
 other than \cv{} \tcode{in_place_t} or \cv{} \tcode{nullopt_t}
-that meets the \oldconcept{Destructible} requirements (\tref{cpp17.destructible}).
+that meets the \oldconcept{Destructible} requirements\iref{cpp17.destructible}.
 
 \rSec3[optional.ctor]{Constructors}
 
@@ -5068,7 +5068,7 @@ memory, to allocate the contained value.
 
 \pnum
 All types in \tcode{Types} shall meet
-the \oldconcept{Destructible} requirements (\tref{cpp17.destructible}).
+the \oldconcept{Destructible} requirements\iref{cpp17.destructible}.
 
 \pnum
 A program that instantiates the definition of \tcode{variant} with
@@ -7479,7 +7479,7 @@ that is not a valid template argument for \tcode{unexpected} is ill-formed.
 
 \pnum
 When \tcode{T} is not \cv{} \tcode{void}, it shall meet
-the \oldconcept{Destructible} requirements (\tref{cpp17.destructible}).
+the \oldconcept{Destructible} requirements\iref{cpp17.destructible}.
 \tcode{E} shall meet
 the \oldconcept{Destructible} requirements.
 
@@ -8856,7 +8856,7 @@ is not a valid template argument for \tcode{unexpected} is ill-formed.
 
 \pnum
 \tcode{E} shall meet the requirements of
-\oldconcept{Destructible} (\tref{cpp17.destructible}).
+\oldconcept{Destructible}\iref{cpp17.destructible}.
 
 \rSec3[expected.void.cons]{Constructors}
 
@@ -14935,8 +14935,8 @@ An enabled specialization \tcode{hash<Key>} will:
 \begin{itemize}
 \item meet the \oldconcept{Hash} requirements (\tref{cpp17.hash}),
 with \tcode{Key} as the function
-call argument type, the \oldconcept{Default\-Constructible} requirements (\tref{cpp17.defaultconstructible}),
-the \oldconcept{CopyAssignable} requirements (\tref{cpp17.copyassignable}),
+call argument type, the \oldconcept{Default\-Constructible} requirements\iref{cpp17.defaultconstructible},
+the \oldconcept{CopyAssignable} requirements\iref{cpp17.copyassignable},
 the \oldconcept{Swappable} requirements\iref{swappable.requirements},
 \item meet the requirement that if \tcode{k1 == k2} is \tcode{true}, \tcode{h(k1) == h(k2)} is
 also \tcode{true}, where \tcode{h} is an object of type \tcode{hash<Key>} and \tcode{k1} and \tcode{k2}
@@ -16921,11 +16921,11 @@ As specified in~\ref{format.err.report}.
 A type \tcode{F} meets the \defnnewoldconcept{BasicFormatter} requirements if
 it meets the
 \begin{itemize}
-\item \oldconcept{DefaultConstructible} (\tref{cpp17.defaultconstructible}),
-\item \oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible}),
-\item \oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}),
+\item \oldconcept{DefaultConstructible}\iref{cpp17.defaultconstructible},
+\item \oldconcept{CopyConstructible}\iref{cpp17.copyconstructible},
+\item \oldconcept{CopyAssignable}\iref{cpp17.copyassignable},
 \item \oldconcept{Swappable}\iref{swappable.requirements}, and
-\item \oldconcept{Destructible} (\tref{cpp17.destructible})
+\item \oldconcept{Destructible}\iref{cpp17.destructible}
 \end{itemize}
 requirements, and
 the expressions shown in \tref{formatter.basic} are valid and


### PR DESCRIPTION
Fixes #6033, late, but as promised.

First draft that will probably need some consistent rewording.

Break down the requirements tables into regular specification text, following the lead of breaking down the container requirements.  This also solves the problem of floating tables floating into unrelated clauses, as there will be no more floating tables.

For simplicity, new subsections have the same stable label as the table they replace, which simplifies the diff but are probably not the best names.