### PR TITLE
[range.concat.iterator] Remove redundant \expos

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -8871,7 +8871,7 @@ Otherwise, \tcode{iterator_category} denotes \tcode{input_iterator_tag}.
 \indexlibrarymember{\exposid{satisfy}}{concat_view::\exposid{iterator}}%
 \begin{itemdecl}
 template<size_t N>
-  constexpr void @\exposid{satisfy}@();                                 // \expos
+  constexpr void @\exposid{satisfy}@();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8891,7 +8891,7 @@ if constexpr (N < (sizeof...(Views) - 1)) {
 \indexlibrarymember{\exposid{prev}}{concat_view::\exposid{iterator}}%
 \begin{itemdecl}
 template<size_t N>
-  constexpr void @\exposid{prev}@();                                    // \expos
+  constexpr void @\exposid{prev}@();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8915,7 +8915,7 @@ if constexpr (N == 0) {
 \indexlibrarymember{\exposid{advance-fwd}}{concat_view::\exposid{iterator}}%
 \begin{itemdecl}
 template<size_t N>
-  constexpr void @\exposid{advance-fwd}@(difference_type offset, difference_type steps);        // \expos
+  constexpr void @\exposid{advance-fwd}@(difference_type offset, difference_type steps);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8941,7 +8941,7 @@ if constexpr (N == sizeof...(Views) - 1) {
 \indexlibrarymember{\exposid{advance-bwd}}{concat_view::\exposid{iterator}}%
 \begin{itemdecl}
 template<size_t N>
-  constexpr void @\exposid{advance-bwd}@(difference_type offset, difference_type steps);        // \expos
+  constexpr void @\exposid{advance-bwd}@(difference_type offset, difference_type steps);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8967,7 +8967,7 @@ if constexpr (N == 0) {
 \indexlibraryctor{concat_view::\exposid{iterator}}%
 \begin{itemdecl}
 template<class... Args>
-  constexpr explicit @\exposid{iterator}@(@\exposid{maybe-const}@<Const, concat_view>* parent,          // \expos
+  constexpr explicit @\exposid{iterator}@(@\exposid{maybe-const}@<Const, concat_view>* parent,
                               Args&&... args)
     requires @\libconcept{constructible_from}@<@\exposid{base-iter}@, Args&&...>;
 \end{itemdecl}


### PR DESCRIPTION
..which was already there when it was declared.