### PR TITLE
[intro.execution] Add comma after conditional clause

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5955,7 +5955,7 @@ subexpression) in general includes both value computations (including
 determining the identity of an object for glvalue evaluation and fetching
 a value previously assigned to an object for prvalue evaluation) and
 initiation of side effects. When a call to a library I/O function
-returns or an access through a volatile glvalue is evaluated the side
+returns or an access through a volatile glvalue is evaluated, the side
 effect is considered complete, even though some external actions implied
 by the call (such as the I/O itself) or by the \keyword{volatile} access
 may not have completed yet.


### PR DESCRIPTION
For readability, there should be a comma after the conditional clause

> When a call to a library I/O function returns or an access through a volatile glvalue is evaluated

(https://eel.is/c++draft/intro.execution#7.sentence-3)