### PR TITLE
Clarify functions, member functions, and constructors

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1321,7 +1321,7 @@ object may fail to compile.
 Remove deprecated type traits.
 \rationale
 The traits had unreliable or awkward interfaces. The \tcode{is_literal_type}
-trait provided no way to detect which subset of constructors and member
+trait provided no way to detect which subset of member
 functions of a type were declared \keyword{constexpr}. The \tcode{result_of}
 trait had a surprising syntax that did not directly support function types.
 It has been superseded by the \tcode{invoke_result} trait.

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -598,8 +598,7 @@ If an invocation of a constructor uses the default value of an optional
 allocator argument, then the allocator type must support value-initialization.
 \end{note}
 A copy of this allocator is used for any memory allocation and element construction
-performed, by these constructors and by all member functions,
-during the lifetime of each container object
+performed, by all member functions, during the lifetime of each container object
 or until the allocator is replaced. The allocator may be replaced only via assignment or
 \tcode{swap()}. Allocator replacement is performed by
 copy assignment, move assignment, or swapping of the allocator only if
@@ -15160,7 +15159,7 @@ both \tcode{key_container_type} and \tcode{mapped_container_type} arguments with
 containers of different sizes is undefined.
 
 \pnum
-The effect of calling a constructor or member function
+The effect of calling a member function
 that takes a \tcode{sorted_unique_t} argument with
 a container, containers, or range
 that is not sorted with respect to \tcode{key_comp()}, or
@@ -16351,7 +16350,7 @@ that takes both \tcode{key_container_type} and
 with containers of different sizes is undefined.
 
 \pnum
-The effect of calling a constructor or member function
+The effect of calling a member function
 that takes a \tcode{sorted_equivalent_t} argument
 with a container, containers, or range
 that are not sorted with respect to \tcode{key_comp()} is undefined.
@@ -16939,7 +16938,7 @@ The program is ill-formed if \tcode{Key} is not the same type
 as \tcode{KeyContainer::value_type}.
 
 \pnum
-The effect of calling a constructor or member function
+The effect of calling a member function
 that takes a \tcode{sorted_unique_t} argument
 with a range that is not sorted with respect to \tcode{key_comp()}, or
 that contains equal elements, is undefined.
@@ -17603,7 +17602,7 @@ The program is ill-formed if \tcode{Key} is not the same type
 as \tcode{KeyContainer::value_type}.
 
 \pnum
-The effect of calling a constructor or member function
+The effect of calling a member function
 that takes a \tcode{sorted_equivalent_t} argument with a range
 that is not sorted with respect to \tcode{key_comp()} is undefined.
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4989,7 +4989,7 @@ no virtual functions\iref{class.virtual} or virtual base classes\iref{class.mi}.
 \end{itemize}
 \begin{note}
 Aggregate initialization does not allow accessing
-protected and private base class' members or constructors.
+protected and private base class' members, including constructors.
 \end{note}
 
 \pnum

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -879,7 +879,7 @@ used in the declaration of a function
 declares that function to be
 a \defnx{constexpr function}{specifier!\idxcode{constexpr}!function}.
 \begin{note}
-A function or constructor declared with the \keyword{consteval} specifier
+A function declared with the \keyword{consteval} specifier
 is an immediate function\iref{expr.const}.
 \end{note}
 A destructor, an allocation function, or a deallocation function

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -8067,7 +8067,7 @@ An immediate-escalating expression shall appear only
 in an immediate-escalating function.
 
 \pnum
-An \defnadj{immediate}{function} is a function or constructor that is
+An \defnadj{immediate}{function} is a function that is
 \begin{itemize}
 \item
 declared with the \keyword{consteval} specifier, or

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3252,7 +3252,7 @@ containing a possibly empty, comma-separated list of
 \grammarterm{initializer-clause}{s} which
 constitute the arguments to the function.
 \begin{note}
-If the postfix expression is a function or member function name,
+If the postfix expression is a function name,
 the appropriate function and the validity of the call
 are determined according to the rules in~\ref{over.match}.
 \end{note}
@@ -3281,7 +3281,7 @@ an object under construction or destruction.
 
 \pnum
 \begin{note}
-If a function or member function name is used, and name
+If a function name is used, and name
 lookup\iref{basic.lookup} does not find a declaration of that name,
 the program is ill-formed. No function is implicitly declared by such a
 call.

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -3673,7 +3673,7 @@ This document explicitly requires that certain standard library functions are
 any standard library function signature as \keyword{constexpr} except for those where
 it is explicitly required.
 Within any header that provides any non-defining declarations of constexpr
-functions or constructors an implementation shall provide corresponding definitions.
+functions an implementation shall provide corresponding definitions.
 
 \rSec3[algorithm.stable]{Requirements for stable algorithms}
 

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -5716,10 +5716,8 @@ a variable template, a class template,
 a member of a class template, or a class member template,
 the variable or class that is explicitly specialized
 shall be specified with a \grammarterm{simple-template-id}.
-In the explicit specialization declaration for a function template or
-a member function template,
-the function or member function explicitly specialized may be specified
-using a \grammarterm{template-id}.
+In the explicit specialization declaration for a function template,
+the function explicitly specialized may be specified using a \grammarterm{template-id}.
 \begin{example}
 \begin{codeblock}
 template<class T = int> struct A {
@@ -6087,7 +6085,7 @@ void g(S<int>& sr) {
 \end{example}
 
 \pnum
-If a function template or a member function template specialization is used in
+If a function template specialization is used in
 a way that involves overload resolution,
 a declaration of the specialization is implicitly instantiated\iref{temp.over}.
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -783,7 +783,7 @@ namespace std {
 \end{codeblock}
 
 \pnum
-Constructors and member functions of \tcode{pair} do not throw exceptions unless one of
+Member functions of \tcode{pair} do not throw exceptions unless one of
 the element-wise operations specified to be called for that operation
 throws an exception.
 


### PR DESCRIPTION
We shouldn't say "constructors and/or member functions", "functions name or member function name". or "function or constructor" etc., because
- a constructor is a member function, and
- a member function is a function, and
- a constructor is a function.

I'm not very sure of the last point. But as a constexpr constructor is considered to be a constexpr function, I think it's consistent to say a constructor is a function.