### PR TITLE
[alg.replace] Fix misapplication of P2248R8 to `std::replace_copy`

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -5559,14 +5559,12 @@ of the corresponding predicate and any projection.
 \indexlibraryglobal{replace_copy}%
 \indexlibraryglobal{replace_copy_if}%
 \begin{itemdecl}
-template<class InputIterator, class OutputIterator,
-         class T = iterator_traits<OutputIterator>::value_type>
+template<class InputIterator, class OutputIterator, class T>
   constexpr OutputIterator
     replace_copy(InputIterator first, InputIterator last,
                  OutputIterator result,
                  const T& old_value, const T& new_value);
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2,
-         class T = iterator_traits<ForwardIterator2>::value_type>
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T>
   ForwardIterator2
     replace_copy(ExecutionPolicy&& exec,
                  ForwardIterator1 first, ForwardIterator1 last,


### PR DESCRIPTION
Removes wrongly added default template arguments that are not present in that paper. Fixes #6949.