### PR TITLE
[alg.rand.generate] Remove redundant `}`

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -11776,7 +11776,7 @@ ranges::generate(std::forward<R>(r), [&d, &g] { return invoke(d, g); });
 \remarks
 The effects of \tcode{generate_random(r, g, d)} shall be equivalent to
 \begin{codeblock}
-ranges::generate(std::forward<R>(r), [&d, &g] { return invoke(d, g); })}
+ranges::generate(std::forward<R>(r), [&d, &g] { return invoke(d, g); })
 \end{codeblock}
 \begin{note}
 This implies that \tcode{d.generate_random(a, g)}


### PR DESCRIPTION
..which is a typo.