### PR TITLE
[memory.syn] Move specification macros to appropriate subclause

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -41,30 +41,6 @@ The header also defines the templates
 \tcode{out_ptr_t}, \tcode{inout_ptr_t}, and various function
 templates that operate on objects of these types\iref{smartptr}.
 
-\pnum
-Let \tcode{\exposid{POINTER_OF}(T)} denote a type that is
-\begin{itemize}
-\item
-\tcode{T::pointer} if the \grammarterm{qualified-id} \tcode{T::pointer}
-is valid and denotes a type,
-\item
-otherwise, \tcode{T::element_type*}
-if the \grammarterm{qualified-id} \tcode{T::element_type}
-is valid and denotes a type,
-\item
-otherwise, \tcode{pointer_traits<T>::element_type*}.
-\end{itemize}
-
-\pnum
-Let \tcode{\exposid{POINTER_OF_OR}(T, U)} denote a type that is:
-\begin{itemize}
-\item
-\tcode{\exposid{POINTER_OF}(T)}
-if \tcode{\exposid{POINTER_OF}(T)} is valid and denotes a type,
-\item
-otherwise, \tcode{U}.
-\end{itemize}
-
 \begin{codeblock}
 #include <compare>              // see \ref{compare.syn}
 
@@ -5081,6 +5057,36 @@ the same value as \tcode{hash<typename shared_ptr<T>::element_type*>()(p.get())}
 \indextext{smart pointers|)}
 
 \rSec2[smartptr.adapt]{Smart pointer adaptors}
+
+\rSec3[smartptr.adapt.defns]{Definitions}
+
+\pnum
+\indextext{pointer_of@\tcode{\placeholder{POINTER_OF}}}%
+\indexlibrary{pointer_of@\tcode{\placeholder{POINTER_OF}}}%
+Let \tcode{\exposid{POINTER_OF}(T)} denote a type that is
+\begin{itemize}
+\item
+\tcode{T::pointer} if the \grammarterm{qualified-id} \tcode{T::pointer}
+is valid and denotes a type,
+\item
+otherwise, \tcode{T::element_type*}
+if the \grammarterm{qualified-id} \tcode{T::element_type}
+is valid and denotes a type,
+\item
+otherwise, \tcode{pointer_traits<T>::element_type*}.
+\end{itemize}
+
+\pnum
+\indextext{pointer_of_or@\tcode{\placeholder{POINTER_OF_OR}}}%
+\indexlibrary{pointer_of_or@\tcode{\placeholder{POINTER_OF_OR}}}%
+Let \tcode{\exposid{POINTER_OF_OR}(T, U)} denote a type that is:
+\begin{itemize}
+\item
+\tcode{\exposid{POINTER_OF}(T)}
+if \tcode{\exposid{POINTER_OF}(T)} is valid and denotes a type,
+\item
+otherwise, \tcode{U}.
+\end{itemize}
 
 \rSec3[out.ptr.t]{Class template \tcode{out_ptr_t}}
 


### PR DESCRIPTION
The specification macros _POINTER_OF_ and _POINTER_OF_OR_ do not appear in the synopsis of the `<memory>` header, but are in fact used only to specify behavior of the smart pointer adapters.  Created a new Definitions heading in that subclause, and moved the text there.

In addition, add the two specification macros to the main index, and also the index of library names, following the example set by _INVOKE_. Given the choice, I would rather all of these entries were in just the main index, but following precedent.