### PR TITLE
[range.reverse.overview] Replace 'equivalent to' with 'then'

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -9660,26 +9660,21 @@ Given a subexpression \tcode{E}, the expression
 \item
   If the type of \tcode{E} is
   a (possibly cv-qualified) specialization of \tcode{reverse_view},
-  equivalent to \tcode{E.base()}.
+  then \tcode{E.base()}.
 \item
   Otherwise, if the type of \tcode{E} is \cv{} \tcode{subrange<reverse_iterator<I>, reverse_iterator<I>, K>}
   for some iterator type \tcode{I} and
   value \tcode{K} of type \tcode{subrange_kind},
   \begin{itemize}
   \item
-    if \tcode{K} is \tcode{subrange_kind::sized}, equivalent to:
-\begin{codeblock}
-subrange<I, I, K>(E.end().base(), E.begin().base(), E.size())
-\end{codeblock}
+    if \tcode{K} is \tcode{subrange_kind::sized}, then
+\tcode{subrange<I, I, K>(E.end().base(), E.begin().base(), E.size())};
   \item
-    otherwise, equivalent to:
-\begin{codeblock}
-subrange<I, I, K>(E.end().base(), E.begin().base())
-\end{codeblock}
+    otherwise, \tcode{subrange<I, I, K>(E.end().base(), E.begin().base())}.
   \end{itemize}
   However, in either case \tcode{E} is evaluated only once.
 \item
-  Otherwise, equivalent to \tcode{reverse_view\{E\}}.
+  Otherwise, \tcode{reverse_view\{E\}}.
 \end{itemize}
 
 \pnum


### PR DESCRIPTION
since those 'equivalent to' s seems superfluous.