### PR TITLE
[range.common.overview] Removing redundant requirement of `views​::​all(E)` to be well-formed

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -9544,9 +9544,8 @@ range adaptor object\iref{range.adaptor.object}.
 Given a subexpression \tcode{E},
 the expression \tcode{views::common(E)} is expression-equivalent to:
 \begin{itemize}
-\item \tcode{views::all(E)},
-  if \tcode{decltype((E))} models \libconcept{common_range}
-  and \tcode{views::all(E)} is a well-formed expression.
+\item \tcode{views::all(E)}
+  if \tcode{decltype((E))} models \libconcept{common_range}.
 
 \item Otherwise, \tcode{common_view\{E\}}.
 \end{itemize}


### PR DESCRIPTION
This is consistent with [[range.as.rvalue.overview]](https://eel.is/c++draft/range.as.rvalue.overview#2.1). Is this editorial?