### PR TITLE
[class.derived.general] Restore accidental reversal of P2662R3 change

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3381,7 +3381,7 @@ the notation:
 \nontermdef{class-or-decltype}\br
     \opt{nested-name-specifier} type-name\br
     nested-name-specifier \keyword{template} simple-template-id\br
-    decltype-specifier
+    computed-type-specifier
 \end{bnf}
 
 \indextext{specifier access|see{access specifier}}%


### PR DESCRIPTION
P2662R3 contained a rename of the grammar production "class-or-decltype" to "class-or-computed-type-specifier".  That was editorially reverted with commit c831ec0b8aac369aa61ce392783865ff04b84b19, but that commit also accidentally reverted the change from "decltype-specifier" to "computed-type-specifier" as one of the options for "class-or-decltype".

This commit restores the latter change, as intended by P2662R3.