### PR TITLE
[format.context] Fix incorrect example

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -17713,12 +17713,13 @@ template<> struct std::formatter<S> {
   // Parses a width argument id in the format \tcode{\{} \fmtgrammarterm{digit} \tcode{\}}.
   constexpr auto parse(format_parse_context& ctx) {
     auto iter = ctx.begin();
+    auto is_digit = [](auto c) { return c >= '0' && c <= '9'; };
     auto get_char = [&]() { return iter != ctx.end() ? *iter : 0; };
     if (get_char() != '{')
       return iter;
     ++iter;
     char c = get_char();
-    if (!isdigit(c) || (++iter, get_char()) != '}')
+    if (!is_digit(c) || (++iter, get_char()) != '}')
       throw format_error("invalid format");
     width_arg_id = c - '0';
     ctx.check_arg_id(width_arg_id);
@@ -17735,7 +17736,7 @@ template<> struct std::formatter<S> {
       else
         return value;
       });
-    return format_to(ctx.out(), "{0:x<{1}}", s.value, width);
+    return format_to(ctx.out(), "{0:x>{1}}", s.value, width);
   }
 };
 


### PR DESCRIPTION
`isdigit()` is not a `contexpr` function so it cannot be used in `parse()`, and the alignment seems to be in the wrong direction.
Demo of the original example: https://godbolt.org/z/qbs6dvq9q
fixed: https://godbolt.org/z/sjWdxxzWc
