### PR TITLE
[print.syn] Show `locking` functions in the synopsis of `<print>`

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4270,9 +4270,11 @@ namespace std {
 
   void vprint_unicode(string_view fmt, format_args args);
   void vprint_unicode(FILE* stream, string_view fmt, format_args args);
+  void vprint_unicode_locking(FILE* stream, string_view fmt, format_args args);
 
   void vprint_nonunicode(string_view fmt, format_args args);
   void vprint_nonunicode(FILE* stream, string_view fmt, format_args args);
+  void vprint_nonunicode_locking(FILE* stream, string_view fmt, format_args args);
 }
 \end{codeblock}
 


### PR DESCRIPTION
The changes seem missed in #6908.