### PR TITLE
[meta.const.eval] Fix `is_within_lifetime` example

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -2504,7 +2504,7 @@ struct OptBool {
     }
   }
 
-  constexpr auto operator*() -> bool& {
+  constexpr auto operator*() const -> const bool& {
     return b;
   }
 };


### PR DESCRIPTION
`operator*` is invoked on a `const` object below (`static_assert(*engaged);`) but the member function is not `const`-qualified