### PR TITLE
[over.oper.general] Clarify operator functions being inherited from base classes

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3342,8 +3342,8 @@ defining operator functions that implement these operators.
 Likewise, the meaning of the operators (unary) \tcode{\&} and \tcode{,} (comma)
 can be changed for specific enumeration types.
 \indextext{overloaded operator!inheritance of}%
-Operator functions are inherited in the same manner as other base class
-functions.
+Operator functions are inherited in the same manner as other
+member functions of a base class\iref{class.member.lookup}.
 
 \pnum
 An operator function shall be a


### PR DESCRIPTION
It is not entirely clear what "inheriting" base class functions means here. It could refer to:
- Inheriting member functions through a using-declaration.
- Operator overloads of base classes being looked up.

Judging from the context, I think it refers to the latter. This edit clarifies that by adding a reference to [class.member.lookup].

I also find "base class functions" a little bit unconventional. We probably want to say "member functions" here.