### PR TITLE
[std] Remove mid-sentence 'subclause' introducer

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -1222,7 +1222,7 @@ fundamental types like \tcode{int} and that are comparable with
 \rSec2[concepts.callable.general]{General}
 
 \pnum
-The concepts in subclause \ref{concepts.callable} describe the requirements on function
+The concepts in \ref{concepts.callable} describe the requirements on function
 objects\iref{function.objects} and their arguments.
 
 \rSec2[concept.invocable]{Concept \cname{invocable}}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -74,7 +74,7 @@ aligned buffers and call \tcode{construct} to place the element into the buffer.
 \rSec3[container.intro.reqmts]{Introduction}
 
 \pnum
-In subclause \ref{container.requirements.general},
+In \ref{container.requirements.general},
 \begin{itemize}
 \item
 \tcode{X} denotes a container class containing objects of type \tcode{T},
@@ -19108,7 +19108,7 @@ namespace std {
 
 The class template \tcode{extents} represents
 a multidimensional index space of rank equal to \tcode{sizeof...(Extents)}.
-In subclause \iref{views},
+In \iref{views},
 \tcode{extents} is used synonymously with multidimensional index space.
 
 \begin{codeblock}
@@ -19519,7 +19519,7 @@ such that \tcode{E::rank() == Rank \&\& E::rank() == E::rank_dynamic()} is \tcod
 \rSec4[mdspan.layout.general]{General}
 
 \pnum
-In subclauses \ref{mdspan.layout.reqmts} and \ref{mdspan.layout.policy.reqmts}:
+In \ref{mdspan.layout.reqmts} and \ref{mdspan.layout.policy.reqmts}:
 
 \begin{itemize}
 \item
@@ -19546,7 +19546,7 @@ all other elements are equal to 0.
 \end{itemize}
 
 \pnum
-In subclauses \ref{mdspan.layout.reqmts} through \ref{mdspan.layout.stride}:
+In \ref{mdspan.layout.reqmts} through \ref{mdspan.layout.stride}:
 \begin{itemize}
 \item
 Let \exposid{is-mapping-of} be the exposition-only variable template defined as follows:
@@ -22205,7 +22205,7 @@ if, for each $i$ in the range,
 the accessor policy's \tcode{access} function produces a valid reference to an object.
 
 \pnum
-In subclause \ref{mdspan.accessor.reqmts},
+In \ref{mdspan.accessor.reqmts},
 
 \begin{itemize}
 \item
@@ -22996,7 +22996,7 @@ The subset viewed by the created \tcode{mdspan} is determined by
 the \tcode{SliceSpecifier} arguments.
 
 \pnum
-For each function defined in subclause \ref{mdspan.sub} that
+For each function defined in \ref{mdspan.sub} that
 takes a parameter pack named \tcode{slices} as an argument:
 
 \begin{itemize}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -53,7 +53,7 @@ resolution, and as part of that process user-defined conversions will be
 considered where necessary to convert the operands to types appropriate
 for the built-in operator. If a built-in operator is selected, such
 conversions will be applied to the operands before the operation is
-considered further according to the rules in subclause \ref{expr.compound};
+considered further according to the rules in \ref{expr.compound};
 see~\ref{over.match.oper}, \ref{over.built}.
 
 \pnum

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -10024,7 +10024,7 @@ specializations of \tcode{span} as described in \ref{views.span}.
 \begin{note}
 A user of these classes is responsible for ensuring
 that the character sequence represented by the given \tcode{span}
-outlives the use of the sequence by objects of the classes in subclause \ref{span.streams}.
+outlives the use of the sequence by objects of the classes in \ref{span.streams}.
 Using multiple \tcode{basic_spanbuf} objects
 referring to overlapping underlying sequences from different threads,
 where at least one \tcode{basic_spanbuf} object is used

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2054,7 +2054,7 @@ string buffers and string streams\iref{input.output}, and
 allocators.
 
 \pnum
-In subclause \ref{allocator.requirements},
+In \ref{allocator.requirements},
 \begin{itemize}
 \item
 \tcode{T}, \tcode{U}, \tcode{C} denote

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -959,7 +959,7 @@ whose value they ignore,
 but set to \tcode{ios_base::failbit} in case of a parse error.
 
 \pnum
-Within subclause \ref{locale.categories} it is unspecified whether
+Within \ref{locale.categories} it is unspecified whether
 one virtual function calls another virtual function.
 
 \rSec2[category.ctype]{The \tcode{ctype} category}

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -3275,7 +3275,7 @@ themselves and not objects they refer to. Changes in \tcode{use_count()} do not
 reflect modifications that can introduce data races.
 
 \pnum
-For the purposes of subclause \ref{smartptr},
+For the purposes of \ref{smartptr},
 a pointer type \tcode{Y*} is said to be
 \defnx{compatible with}{compatible with!\idxcode{shared_ptr}}
 a pointer type \tcode{T*} when either

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -1556,7 +1556,7 @@ namespace std {
 \rSec3[rand.req.genl]{General requirements}%
 
 \pnum
-Throughout this subclause \ref{rand},
+Throughout \ref{rand},
 the effect of instantiating a template:
 \begin{itemize}
   \item
@@ -1616,7 +1616,7 @@ the effect of instantiating a template:
 \end{itemize}
 
 \pnum
-Throughout this subclause \ref{rand},
+Throughout \ref{rand},
 phrases of the form ``\tcode{x} is an iterator of a specific kind''
 shall be interpreted as equivalent to the more formal requirement that
 ``\tcode{x} is a value
@@ -1624,7 +1624,7 @@ of a type meeting the requirements
 of the specified iterator type''.
 
 \pnum
-Throughout this subclause \ref{rand},
+Throughout \ref{rand},
 any constructor that can be called with a single argument
 and that meets a requirement specified in this subclause
 shall be declared \keyword{explicit}.
@@ -1659,7 +1659,7 @@ if the expressions shown
 in \tref{rand.req.seedseq}
 are valid and have the indicated semantics,
 and if \tcode{S} also meets all other requirements
-of this subclause \ref{rand.req.seedseq}.
+of \ref{rand.req.seedseq}.
 In \tref{rand.req.seedseq} and throughout this subclause:
 \begin{itemize}
   \item
@@ -1875,7 +1875,7 @@ if the expressions shown
 in \tref{rand.req.eng}
 are valid and have the indicated semantics,
 and if \tcode{E} also meets all other requirements
-of this subclause \ref{rand.req.eng}.
+of \ref{rand.req.eng}.
 In \tref{rand.req.eng} and throughout this subclause:
 \begin{itemize}
   \item
@@ -2254,7 +2254,7 @@ in \tref{rand.req.dist}
 are valid and have the indicated semantics,
 and if \tcode{D} and its associated types
 also meet all other requirements
-of this subclause \ref{rand.req.dist}.
+of \ref{rand.req.dist}.
 In \tref{rand.req.dist} and throughout this subclause,
 \begin{itemize}
   \item
@@ -2465,7 +2465,7 @@ as would repeated invocations of \tcode{x(g)}.
 It is unspecified whether \tcode{D::param_type}
 is declared as a (nested) \keyword{class}
 or via a \keyword{typedef}.
-In this subclause \ref{rand},
+In \ref{rand},
 declarations of \tcode{D::param_type}
 are in the form of \keyword{typedef}s
 for convenience of exposition only.
@@ -2650,7 +2650,7 @@ namespace std {
 If the template parameter
 \tcode{m} is $0$,
 the modulus $m$
-used throughout this subclause~\ref{rand.eng.lcong}
+used throughout \ref{rand.eng.lcong}
 is \tcode{numeric_limits<result_type>::max()} plus $1$.
 \begin{note}
  $m$ need not be representable
@@ -3077,30 +3077,30 @@ template<class Sseq> explicit subtract_with_carry_engine(Sseq& q);
 
 \pnum
 Each type instantiated
-from a class template specified in this subclause~\ref{rand.adapt}
+from a class template specified in \ref{rand.adapt}
 meets the requirements
 of a random number engine adaptor\iref{rand.req.adapt} type.
 
 \pnum
 Except where specified otherwise,
 the complexity of each function
-specified in this subclause~\ref{rand.adapt}
+specified in \ref{rand.adapt}
 is constant.
 
 \pnum
 Except where specified otherwise,
-no function described in this subclause~\ref{rand.adapt}
+no function described in \ref{rand.adapt}
 throws an exception.
 
 \pnum
-Every function described in this subclause~\ref{rand.adapt}
+Every function described in \ref{rand.adapt}
 that has a function parameter \tcode{q} of type \tcode{Sseq\&}
 for a template type parameter named \tcode{Sseq}
 that is different from type \tcode{seed_seq}
 throws what and when the invocation of \tcode{q.generate} throws.
 
 \pnum
-Descriptions are provided in this subclause~\ref{rand.adapt}
+Descriptions are provided in \ref{rand.adapt}
 only for adaptor operations
 that are not described in subclause~\ref{rand.req.adapt}
 or for operations where there is additional semantic information.
@@ -3112,7 +3112,7 @@ and for equality and inequality operators
 are not shown in the synopses.
 
 \pnum
-Each template specified in this subclause~\ref{rand.adapt}
+Each template specified in \ref{rand.adapt}
 requires one or more relationships,
 involving the value(s) of its non-type template parameter(s), to hold.
 A program instantiating any of these templates
@@ -4142,12 +4142,12 @@ than the output when computing $S$.
 
 \pnum
 Each type instantiated
-from a class template specified in this subclause~\ref{rand.dist}
+from a class template specified in \ref{rand.dist}
 meets the requirements
 of a random number distribution\iref{rand.req.dist} type.
 
 \pnum
-Descriptions are provided in this subclause~\ref{rand.dist}
+Descriptions are provided in \ref{rand.dist}
 only for distribution operations
 that are not described in \ref{rand.req.dist}
 or for operations where there is additional semantic information.

--- a/source/preface.tex
+++ b/source/preface.tex
@@ -9,7 +9,7 @@
 Clauses and subclauses in this document are annotated
 with a so-called stable name,
 presented in square brackets next to the (sub)clause heading
-(such as ``[lex.token]'' for subclause \ref{lex.token}, ``Tokens'').
+(such as ``[lex.token]'' for \ref{lex.token}, ``Tokens'').
 Stable names aid in the discussion and evolution of this document
 by serving as stable references to subclauses across editions
 that are unaffected by changes of subclause numbering.

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1627,7 +1627,7 @@ manipulating ranges.
 \rSec2[range.utility.helpers]{Helper concepts}
 
 \pnum
-Many of the types in subclause~\ref{range.utility} are specified in terms of
+Many of the types in \ref{range.utility} are specified in terms of
 the following exposition-only concepts:
 
 \begin{codeblock}
@@ -4233,7 +4233,7 @@ if either \tcode{T} models \libconcept{movable} or
 \rSec2[range.nonprop.cache]{Non-propagating cache}
 
 \pnum
-Some types in subclause \ref{range.adaptors} are specified in terms of
+Some types in \ref{range.adaptors} are specified in terms of
 an exposition-only class template \exposid{non-propagating-\brk{}cache}.
 \tcode{\exposid{non-propagating-cache}<T>} behaves exactly like \tcode{optional<T>}
 with the following differences:

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -108,7 +108,7 @@ and
 denotes an lvalue of type
 \tcode{C}.
 No expression which is part of the character traits requirements
-specified in this subclause \ref{char.traits.require}
+specified in \ref{char.traits.require}
 shall exit via an exception.
 
 \begin{libreqtab4d}

--- a/source/support.tex
+++ b/source/support.tex
@@ -4335,7 +4335,7 @@ In this context, the behavior of a program that supplies
 an argument other than a literal \tcode{0} is undefined.
 
 \pnum
-For the purposes of subclause \ref{cmp.categories},
+For the purposes of \ref{cmp.categories},
 \defn{substitutability} is the property that \tcode{f(a) == f(b)} is \tcode{true}
 whenever \tcode{a == b} is \tcode{true},
 where \tcode{f} denotes a function that reads only comparison-salient state

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -8919,7 +8919,7 @@ This can happen if the re-locking of the mutex throws an exception.
 \rSec3[thread.condition.condvarany.general]{General}
 
 \pnum
-In this subclause \ref{thread.condition.condvarany},
+In \ref{thread.condition.condvarany},
 template arguments for template parameters named \tcode{Lock}
 shall meet the \oldconcept{Basic\-Lockable}
 requirements\iref{thread.req.lockable.basic}.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -4873,7 +4873,7 @@ of the template argument types given to \tcode{variant}.
 These template arguments are called alternatives.
 
 \pnum
-In subclause \ref{variant},
+In \ref{variant},
 \exposid{GET} denotes
 a set of exposition-only function templates\iref{variant.get}.
 
@@ -11026,7 +11026,7 @@ a trivially copyable type\iref{term.trivially.copyable.type}.
 The template parameter \tcode{T} of \tcode{reference_wrapper}
 may be an incomplete type.
 \begin{note}
-Using the comparison operators described in subclause \ref{refwrap.comparisons}
+Using the comparison operators described in \ref{refwrap.comparisons}
 with \tcode{T} being an incomplete type
 can lead to an ill-formed program
 with no diagnostic required\iref{temp.point,temp.constr.atomic}.
@@ -14312,7 +14312,7 @@ a trivially copyable type\iref{term.trivially.copyable.type}
 that models \libconcept{copyable}.
 
 \pnum
-Within subclause \ref{func.wrap.ref},
+Within \ref{func.wrap.ref},
 \tcode{\placeholder{call-args}} is an argument pack with elements such that
 \tcode{decltype((\placeholder{call-args}\linebreak{}))...} denote
 \tcode{Args\&\&...} respectively.


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

Partially addresses #6976