### PR TITLE
[time.format,time.parse] Fix references to ISO week calendar

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -10652,11 +10652,13 @@ the locale's alternative representation.
 Equivalent to \tcode{\%Y-\%m-\%d}.
 \\ \rowsep
 \tcode{\%g} &
-The last two decimal digits of the ISO week-based year.
+The last two decimal digits of the calendar year
+as specified in ISO 8601-1:2019 for the week calendar.
 If the result is a single digit it is prefixed by \tcode{0}.
 \\ \rowsep
 \tcode{\%G} &
-The ISO week-based year as a decimal number.
+The calendar year as a decimal number,
+as specified in ISO 8601-1:2019 for the week calendar.
 If the result is less than four digits
 it is left-padded with \tcode{0} to four digits.
 \\ \rowsep
@@ -10682,7 +10684,7 @@ If the type being formatted is a specialization of \tcode{duration},
 the decimal number of \tcode{days} without padding.
 Otherwise,
 the day of the year as a decimal number.
-Jan 1 is \tcode{001}.
+January 1 is \tcode{001}.
 If the result is less than three digits,
 it is left-padded with \tcode{0} to three digits.
 \\ \rowsep
@@ -10736,7 +10738,8 @@ A horizontal-tab character.
 Equivalent to \tcode{\%H:\%M:\%S}.
 \\ \rowsep
 \tcode{\%u} &
-The ISO weekday as a decimal number (\tcode{1}-\tcode{7}),
+The calendar day of week as a decimal number (\tcode{1}-\tcode{7}),
+as specified in ISO 8601-1:2019,
 where Monday is \tcode{1}.
 The modified command \tcode{\%Ou} produces
 the locale's alternative representation.
@@ -10750,7 +10753,8 @@ The modified command \tcode{\%OU} produces
 the locale's alternative representation.
 \\ \rowsep
 \tcode{\%V} &
-The ISO week-based week number as a decimal number.
+The calendar week of year as a decimal number,
+as specified in ISO 8601-1:2019 for the week calendar.
 If the result is a single digit, it is prefixed with \tcode{0}.
 The modified command \tcode{\%OV} produces
 the locale's alternative representation.
@@ -11268,14 +11272,16 @@ If modified with a width \tcode{\placeholder{N}},
 the width is applied to only \tcode{\%Y}.
 \\ \rowsep
 \tcode{\%g} &
-The last two decimal digits of the ISO week-based year.
+The last two decimal digits of the calendar year,
+as specified in ISO 8601-1:2019 for the week calendar.
 The modified command \tcode{\%\placeholder{N}g} specifies
 the maximum number of characters to read.
 If \tcode{\placeholder{N}} is not specified, the default is 2.
 Leading zeroes are permitted but not required.
 \\ \rowsep
 \tcode{\%G} &
-The ISO week-based year as a decimal number.
+The calendar year as a decimal number,
+as specified in ISO 8601-1:2019 for the week calendar.
 The modified command \tcode{\%\placeholder{N}G} specifies
 the maximum number of characters to read.
 If \tcode{\placeholder{N}} is not specified, the default is 4.
@@ -11307,7 +11313,7 @@ If the type being parsed is a specialization of \tcode{duration},
 a decimal number of \tcode{days}.
 Otherwise,
 the day of the year as a decimal number.
-Jan 1 is \tcode{1}.
+January 1 is \tcode{1}.
 In either case,
 the modified command \tcode{\%\placeholder{N}j} specifies
 the maximum number of characters to read.
@@ -11316,7 +11322,7 @@ Leading zeroes are permitted but not required.
 \\ \rowsep
 \tcode{\%m} &
 The month as a decimal number.
-Jan is \tcode{1}.
+January is \tcode{1}.
 The modified command \tcode{\%\placeholder{N}m} specifies
 the maximum number of characters to read.
 If \tcode{\placeholder{N}} is not specified, the default is 2.
@@ -11373,7 +11379,9 @@ Matches zero or one whitespace characters.
 Equivalent to \tcode{\%H:\%M:\%S}.
 \\ \rowsep
 \tcode{\%u} &
-The ISO weekday as a decimal number (\tcode{1}-\tcode{7}), where Monday is \tcode{1}.
+The calendar day of week as a decimal number (\tcode{1}-\tcode{7}),
+as specified in ISO 8601-1:2019,
+where Monday is \tcode{1}.
 The modified command \tcode{\%\placeholder{N}u} specifies
 the maximum number of characters to read.
 If \tcode{\placeholder{N}} is not specified, the default is \tcode{1}.
@@ -11391,7 +11399,8 @@ The modified command \tcode{\%OU} interprets
 the locale's alternative representation.
 \\ \rowsep
 \tcode{\%V} &
-The ISO week-based week number as a decimal number.
+The calendar week of year as a decimal number,
+as specified in ISO 8601-1:2019 for the week calendar.
 The modified command \tcode{\%\placeholder{N}V} specifies
 the maximum number of characters to read.
 If \tcode{\placeholder{N}} is not specified, the default is 2.


### PR DESCRIPTION
Fixes #6984 