### PR TITLE
[macros] Prefer page break above 'note' or 'example' introducers

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -318,7 +318,7 @@
 \newcommand{\newnoteenvironment}[3]{
 \newsubclausecounter{#1}
 \newenvironment{tail#1}
-{\par\small\stepcounter{#1}\noteintro{#2}}
+{\par\small\penalty -200\stepcounter{#1}\noteintro{#2}}
 {\noteoutro{#3}}
 \newenvironment{#1}
 {\begin{tail#1}}
@@ -570,7 +570,7 @@
 % surrounded by @ signs.
 \newcommand{\CodeBlockSetup}{%
 \lstset{escapechar=@, aboveskip=\parskip, belowskip=0pt,
-        midpenalty=500, endpenalty=-50,
+        beginpenalty=200, midpenalty=500, endpenalty=-50,
         emptylinepenalty=-250, semicolonpenalty=0,upquote=true}%
 \renewcommand{\tcode}[1]{\textup{\CodeStylex{##1}}}
 \renewcommand{\term}[1]{\textit{##1}}%


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

Fixes #6978