### PR TITLE
[util.smartptr.weak.general] Clarify when a `weak_ptr` is empty

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -4508,6 +4508,8 @@ The \tcode{weak_ptr} class template stores a weak reference to an object
 that is already managed by a \tcode{shared_ptr}. To access the object, a
 \tcode{weak_ptr} can be converted to a \tcode{shared_ptr} using the member
 function \tcode{lock}.
+A \tcode{weak_ptr} may become empty by expiring,
+without a call to one if its member functions.
 
 \begin{codeblock}
 namespace std {


### PR DESCRIPTION
It is not entirely clear whether an expired (but not null) `weak_ptr` is said to be "empty".

@t3nsor had to ask about this two years ago (https://stackoverflow.com/q/73253624/5740428) and I found it difficult answering another Q&A (https://stackoverflow.com/q/78475345/5740428) because it isn't obvious when a `weak_ptr` is empty. I could only be confident in my answer once I've looked into the libstdc++ implementation of `compare_exchange_weak` for `weak_ptr`.

There are ways to obtain an answer indirectly by digging through various wording or implementations, but it should be more obvious. [[util.smartptr.shared.general] paragraph 1](http://eel.is/c++draft/util.smartptr.shared.general#1) already states what it means for `shared_ptr` to be empty, so why don't we add corresponding wording for `weak_ptr`?