### PR TITLE
[diff] Mark examples as such

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -23,7 +23,7 @@ Reinforcing type safety.
 A valid \CppXXIII{} program that performs operations mixing a value of an
 enumeration type and a value of a different enumeration type or of a
 floating-point type is ill-formed.
-For example:
+\begin{example}
 \begin{codeblock}
 enum E1 { e };
 enum E2 { f };
@@ -31,6 +31,7 @@ bool b = e <= 3.7;      // ill-formed; previously well-formed
 int  k = f - e;         // ill-formed; previously well-formed
 auto x = true ? e : f;  // ill-formed; previously well-formed
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp23.dcl.dcl]{\ref{dcl.dcl}: Declarations}
 
@@ -44,13 +45,14 @@ Permit the implementation to store backing arrays in static read-only memory.
 Valid \CppXXIII{} code
 that relies on the result of pointer comparison between backing arrays
 may change behavior.
-For example:
+\begin{example}
 \begin{codeblock}
 bool ne(std::initializer_list<int> a, std::initializer_list<int> b) {
   return a.begin() != b.begin() + 1;
 }
 bool b = ne({2,3}, {1,2,3});    // unspecified result; previously \tcode{false}
 \end{codeblock}
+\end{example}
 
 \diffref{dcl.array}
 \change
@@ -61,7 +63,7 @@ Improve the handling of packs.
 \effect
 Valid \CppXXIII{} code that declares a pack of parameters
 without specifying a \grammarterm{declarator-id} becomes ill-formed.
-For example:
+\begin{example}
 \begin{codeblock}
 template <typename... T>
 void f(T... [1]);
@@ -72,6 +74,7 @@ int main() {
   g<int, double>(nullptr, nullptr);     // ok
 }
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp23.library]{\ref{library}: library introduction}
 
@@ -101,12 +104,13 @@ facilities.
 \effect
 \tcode{to_string} and \tcode{to_wstring} function calls that take
 floating-point arguments may produce a different output.
-For example:
+\begin{example}
 \begin{codeblock}
 auto s = std::to_string(1e-7);  // \tcode{"1e-07"}
                                 // previously \tcode{"0.000000"} with \tcode{'.'} possibly
                                 // changed according to the global C locale
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp23.containers]{\ref{containers}: containers library}
 
@@ -118,7 +122,7 @@ Permit passing a braced initializer list to a function taking \tcode{span}.
 \effect
 Valid \CppXXIII{} code that relies on the lack of this constructor
 may refuse to compile, or change behavior in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 void one(pair<int, int>);       // \#1
 void one(span<const int>);      // \#2
@@ -132,6 +136,7 @@ int x = span<void* const>{a, 0}.size();     // \tcode{x} is \tcode{2}; previousl
 any b[10];
 int y = span<const any>{b, b + 10}.size();  // \tcode{y} is \tcode{2}; previously \tcode{10}
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp23.depr]{\ref{depr}: compatibility features}
 
@@ -144,7 +149,8 @@ define an \tcode{is_always_equal} member type so that \tcode{allocator_traits}
 would not use the one from the allocator base class.
 \effect
 It is simpler to correctly define an allocator class with an allocator base
-class. For example:
+class.
+\begin{example}
 \begin{codeblock}
 template <class T>
 struct MyAlloc : allocator<T> {
@@ -154,6 +160,7 @@ struct MyAlloc : allocator<T> {
 static_assert(!allocator_traits<MyAlloc<int>>::is_always_equal);        // Error in \CppXXIII{},
                                                                         // OK in \CppXXVI{}
 \end{codeblock}
+\end{example}
 
 \nodiffref
 \change
@@ -266,10 +273,11 @@ Removal of unimplemented conditionally-supported feature.
 Concatenation of \grammarterm{string-literal}s
 with different \grammarterm{encoding-prefix}es
 is now ill-formed.
-For example:
+\begin{example}
 \begin{codeblock}
 auto c = L"a" U"b";             // was conditionally-supported; now ill-formed
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp20.expr]{\ref{expr}: expressions}
 
@@ -281,11 +289,12 @@ Simplify the rules for implicit move.
 \effect
 Valid \CppXX{} code that relies on a returned \grammarterm{id-expression}'s
 being an lvalue may change behavior or fail to compile.
-For example:
+\begin{example}
 \begin{codeblock}
 decltype(auto) f(int&& x) { return (x); }       // returns \tcode{int\&\&}; previously returned \tcode{int\&}
 int& g(int&& x) { return x; }                   // ill-formed; previously well-formed
 \end{codeblock}
+\end{example}
 
 \diffref{expr.sub}
 \change
@@ -295,11 +304,12 @@ Enable repurposing a deprecated syntax to support multidimensional indexing.
 \effect
 Valid \CppXX{} code that uses a comma expression within a
 subscript expression may fail to compile.
-For example:
+\begin{example}
 \begin{codeblock}
 arr[1, 2]               // was equivalent to \tcode{arr[(1, 2)]},
                         // now equivalent to \tcode{arr.operator[](1, 2)} or ill-formed
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp20.stmt]{\ref{stmt.stmt}: statements}
 
@@ -311,7 +321,7 @@ is extended until the end of the loop\iref{class.temporary}.
 Improve usability of the range-based \keyword{for} statement.
 \effect
 Destructors of some temporary objects are invoked later.
-For example:
+\begin{example}
 \begin{codeblock}
 void f() {
   std::vector<int> v = { 42, 17, 13 };
@@ -323,6 +333,7 @@ void f() {
   }
 }
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp20.dcl]{\ref{dcl.dcl}: declarations}
 
@@ -337,7 +348,7 @@ Arrays of \keyword{char} or \tcode{\keyword{unsigned} \keyword{char}}
 may now be initialized with a UTF-8 string literal.
 This can affect initialization that includes arrays
 that are directly initialized within class types, typically aggregates.
-For example:
+\begin{example}
 \begin{codeblock}
 struct A {
   char8_t s[10];
@@ -353,6 +364,7 @@ int main() {
   f({u8""});            // ambiguous
 }
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp20.temp]{\ref{temp}: templates}
 
@@ -363,7 +375,7 @@ Deducing template arguments from exception specifications.
 Facilitate generic handling of throwing and non-throwing functions.
 \effect
 Valid ISO \CppXX{} code may be ill-formed in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 template<bool> struct A { };
 template<bool B> void f(void (*)(A<B>) noexcept(B));
@@ -372,6 +384,7 @@ void h() {
   f(g);                         // ill-formed; previously well-formed
 }
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp20.library]{\ref{library}: library introduction}
 
@@ -408,7 +421,7 @@ Allow uncopyable, but movable, types to model these concepts.
 Valid \CppXX{} code relying on subsumption
 with \tcode{common_reference_with}
 may fail to compile in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 template<class T, class U>
   requires @\libconcept{equality_comparable_with}@<T, U>
@@ -422,6 +435,7 @@ bool test(shared_ptr<int> p) {
   return attempted_equals(p, nullptr);          // ill-formed; previously well-formed
 }
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp20.memory]{\ref{mem}: memory management library}
 
@@ -452,11 +466,12 @@ Valid \CppXX{} code that
 contained errors in format strings or
 relied on previous format string signatures or
 \tcode{format_args_t} may become ill-formed.
-For example:
+\begin{example}
 \begin{codeblock}
 auto s = std::format("{:d}", "I am not a number");      // ill-formed,
                                                         // previously threw \tcode{format_error}
 \end{codeblock}
+\end{example}
 
 \diffref{format}
 \change
@@ -469,7 +484,7 @@ that are not copyable.
 \effect
 Valid \CppXX{} code that passes bit-fields to formatting functions
 may become ill-formed.
-For example:
+\begin{example}
 \begin{codeblock}
 struct tiny {
   int bit: 1;
@@ -478,6 +493,7 @@ struct tiny {
 auto t = tiny();
 std::format("{}", t.bit);       // ill-formed, previously returned \tcode{"0"}
 \end{codeblock}
+\end{example}
 
 \diffref{format.string.std}
 \change
@@ -490,12 +506,13 @@ a formatting width or precision.
 \effect
 Valid \CppXX{} code that passes a boolean or character type as
 \fmtgrammarterm{arg-id} becomes invalid.
-For example:
+\begin{example}
 \begin{codeblock}
 std::format("{:*^{}}", "", true);   // ill-formed, previously returned \tcode{"*"}
 std::format("{:*^{}}", "", '1');    // ill-formed, previously returned an
                                     // implementation-defined number of \tcode{'*'} characters
 \end{codeblock}
+\end{example}
 
 \diffref{format.formatter.spec}
 \change
@@ -524,7 +541,7 @@ by calling \tcode{substr} (or the corresponding constructor)
 on an xvalue expression with type \tcode{S}
 that is a specialization of \tcode{basic_string}
 may change meaning in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 std::string s1 = "some long string that forces allocation", s2 = s1;
 std::move(s1).substr(10, 5);
@@ -532,6 +549,7 @@ assert(s1 == s2);       // unspecified, previously guaranteed to be \tcode{true}
 std::string s3(std::move(s2), 10, 5);
 assert(s1 == s2);       // unspecified, previously guaranteed to be \tcode{true}
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp20.containers]{\ref{containers}: containers library}
 
@@ -543,7 +561,7 @@ for associative containers.
 Improve efficiency of erasing elements from associative containers.
 \effect
 Valid \CppXX{} code may fail to compile in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 struct B {
   auto operator<=>(const B&) const = default;
@@ -555,6 +573,7 @@ struct D : private B {
   }
 };
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp20.thread]{\ref{thread}: concurrency support library}
 
@@ -577,7 +596,7 @@ if it depends on a completion function's side effects occurring exactly once,
 on a specific thread running the phase completion step, or
 on a completion function's side effects occurring
 without \tcode{wait} having been called.
-For example:
+\begin{example}
 \begin{codeblock}
 auto b0 = std::barrier(1);
 b0.arrive();
@@ -589,6 +608,7 @@ b1.arrive();
 assert(data == 1);      // implementation-defined; previously well-defined
 b1.arrive();            // implementation-defined; previously well-defined
 \end{codeblock}
+\end{example}
 
 \rSec1[diff.cpp17]{\Cpp{} and ISO \CppXVII{}}
 
@@ -612,7 +632,7 @@ Logical lines beginning with
 \tcode{module} or \tcode{import} may
 be interpreted differently
 in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 class module {};
 module m1;          // was variable declaration; now \grammarterm{module-declaration}
@@ -622,6 +642,7 @@ class import {};
 import j1;          // was variable declaration; now \grammarterm{module-import-declaration}
 ::import j2;        // variable declaration
 \end{codeblock}
+\end{example}
 
 \diffref{lex.header}
 \change
@@ -632,12 +653,13 @@ Required for new features.
 When the identifier \tcode{import}
 is followed by a \tcode{<} character,
 a \grammarterm{header-name} token may be formed.
-For example:
+\begin{example}
 \begin{codeblock}
 template<typename> class import {};
 import<int> f();                // ill-formed; previously well-formed
 ::import<int> g();              // OK
 \end{codeblock}
+\end{example}
 
 \diffref{lex.key}
 \change
@@ -685,7 +707,7 @@ Necessary for new functionality.
 Valid \CppXVII{} code that contains a \tcode{<=} token
 immediately followed by a \tcode{>} token
 may be ill-formed or have different semantics in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 namespace N {
   struct X {};
@@ -694,6 +716,7 @@ namespace N {
   Y<operator<=> y;              // ill-formed; previously well-formed
 }
 \end{codeblock}
+\end{example}
 
 \diffref{lex.literal}
 \indextext{UTF-8}%
@@ -708,7 +731,7 @@ Valid \CppXVII{} code that depends on
 UTF-8 string literals having type ``array of \tcode{const char}'' and
 UTF-8 character literals having type ``\tcode{char}''
 is not valid in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 const auto *u8s = u8"text";     // \tcode{u8s} previously deduced as \tcode{const char*}; now deduced as \tcode{const char8_t*}
 const char *ps = u8s;           // ill-formed; previously well-formed
@@ -727,6 +750,7 @@ template<> struct ct<char> {
 };
 ct<decltype(u8'c')>::type x;    // ill-formed; previously well-formed.
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp17.basic]{\ref{basic}: basics}
 
@@ -739,7 +763,7 @@ Increase consistency of the language model.
 \effect
 Valid ISO \CppXVII{} code may be ill-formed or
 have undefined behavior in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 int f() {
   int a = 123;
@@ -748,6 +772,7 @@ int f() {
   return a;         // undefined behavior; previously returned 123
 }
 \end{codeblock}
+\end{example}
 
 \diffref{intro.races}
 \change
@@ -786,12 +811,13 @@ can contain only C-compatible constructs.
 Necessary for implementability.
 \effect
 Valid \CppXVII{} code may be ill-formed in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 typedef struct {
   void f() {}           // ill-formed; previously well-formed
 } S;
 \end{codeblock}
+\end{example}
 
 \diffref{dcl.fct.default}
 \change
@@ -802,7 +828,7 @@ Required for modules support.
 \effect
 Valid \CppXVII{} code may be ill-formed in this revision of \Cpp{},
 with no diagnostic required.
-For example:
+\begin{example}
 \begin{codeblock}
 // Translation unit 1
 int f(int a = 42);
@@ -813,6 +839,7 @@ int f(int a = 76) { return a; }         // ill-formed, no diagnostic required; p
 int g();
 int main() { return g(); }              // used to return 42
 \end{codeblock}
+\end{example}
 
 \diffref{dcl.init.aggr}
 \change
@@ -825,7 +852,7 @@ Valid \CppXVII{} code that aggregate-initializes
 a type with a user-declared constructor
 may be ill-formed or have different semantics
 in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 struct A {              // not an aggregate; previously an aggregate
   A() = delete;
@@ -858,6 +885,7 @@ struct Y {              // not an aggregate; previously an aggregate
 
 Y y{X{}};               // copy constructor call; previously aggregate-initialization
 \end{codeblock}
+\end{example}
 
 \diffref{dcl.init.list}
 \change
@@ -868,10 +896,11 @@ Catches bugs.
 \effect
 Valid \CppXVII{} code may fail to compile
 in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 bool y[] = { "bc" };    // ill-formed; previously well-formed
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp17.class]{\ref{class}: classes}
 
@@ -888,7 +917,7 @@ Necessary for new functionality.
 \effect
 Valid \CppXVII{} code may fail to compile
 in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 struct S {
   explicit (S)(const S&);       // ill-formed; previously well-formed
@@ -896,6 +925,7 @@ struct S {
   explicit(true) (S)(int);      // OK
 };
 \end{codeblock}
+\end{example}
 
 \diffref{class.ctor,class.dtor}
 \change
@@ -906,7 +936,7 @@ Remove potentially error-prone option for redundancy.
 \effect
 Valid \CppXVII{} code may fail to compile
 in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 template<class T>
 struct A {
@@ -915,6 +945,7 @@ struct A {
   ~A<T>();          // error: \grammarterm{simple-template-id} not allowed for destructor
 };
 \end{codeblock}
+\end{example}
 
 \diffref{class.copy.elision}
 \change
@@ -928,7 +959,7 @@ more efficient code that takes advantage of moves.
 \effect
 Valid \CppXVII{} code may fail to compile or have different semantics
 in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 struct base {
   base();
@@ -960,6 +991,7 @@ void g() {
   char c = *s.m;                // undefined behavior; previously ok
 }
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp17.over]{\ref{over}: overloading}
 
@@ -976,7 +1008,7 @@ equality or inequality expressions between an object of one type
 and an object of the other type invoke a different operator.
 Also, for certain types, equality or inequality expressions
 between two objects of that type become ambiguous.
-For example:
+\begin{example}
 \begin{codeblock}
 struct A {
   operator int() const;
@@ -992,6 +1024,7 @@ int check(A x, A y) {
     (10 != x);                  // calls \#1, previously selected \#3
 }
 \end{codeblock}
+\end{example}
 
 \diffref{over.match.oper}
 \change
@@ -1001,7 +1034,7 @@ Support calling \tcode{operator==} with reversed order of arguments.
 \effect
 Valid \CppXVII{} code that uses equality operators with conversion functions
 may be ill-formed or have different semantics in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 struct A {
   operator int() const { return 10; }
@@ -1017,6 +1050,7 @@ struct B {
 B b1;
 bool eq = (b1 == b1);           // ambiguous; previously well-formed
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp17.temp]{\ref{temp}: templates}
 
@@ -1038,7 +1072,7 @@ visible via normal lookup.
 Previously valid code that uses a function name
 as the left operand of a \tcode{<} operator
 would become ill-formed.
-For example:
+\begin{example}
 \begin{codeblock}
 struct A {};
 bool operator<(void (*fp)(), A);
@@ -1049,6 +1083,7 @@ int main() {
   (f) < a;  // still well-formed
 }
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp17.except]{\ref{except}: exception handling}
 
@@ -1178,13 +1213,14 @@ Character array extraction only takes array types.
 Increase safety via preventing buffer overflow at compile time.
 \effect
 Valid \CppXVII{} code may fail to compile in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 auto p = new char[100];
 char q[100];
 std::cin >> std::setw(20) >> p;         // ill-formed; previously well-formed
 std::cin >> std::setw(20) >> q;         // OK
 \end{codeblock}
+\end{example}
 
 \diffref{ostream.inserters.character}
 \indextext{UTF-8}%
@@ -1196,13 +1232,14 @@ Required for new features.
 Valid \CppXVII{} code that passes UTF-8 literals to
 \tcode{basic_ostream<char, ...>::operator<<} or
 \tcode{basic_ostream<wchar_t, ...>::operator<<} is now ill-formed.
-For example:
+\begin{example}
 \begin{codeblock}
 std::cout << u8"text";          // previously called \tcode{operator<<(const char*)} and printed a string;
                                 // now ill-formed
 std::cout << u8'X';             // previously called \tcode{operator<<(char)} and printed a character;
                                 // now ill-formed
 \end{codeblock}
+\end{example}
 
 \diffref{ostream.inserters.character}
 \change
@@ -1216,13 +1253,14 @@ Valid \CppXVII{} code that passes
 to \tcode{basic_ostream<char, ...>::operator<<} or
 that passes \keyword{char16_t} or \keyword{char32_t} characters or strings
 to \tcode{basic_ostream<wchar_t, ...>::operator<<} is now ill-formed.
-For example:
+\begin{example}
 \begin{codeblock}
 std::cout << u"text";           // previously formatted the string as a pointer value;
                                 // now ill-formed
 std::cout << u'X';              // previously formatted the character as an integer value;
                                 // now ill-formed
 \end{codeblock}
+\end{example}
 
 \diffref{fs.class.path}
 \change
@@ -1233,12 +1271,13 @@ Required for new features.
 Valid \CppXVII{} code that depends on the \tcode{u8string()} and
 \tcode{generic_u8string()} member functions of \tcode{std::filesystem::path}
 returning \tcode{std::string} is not valid in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 std::filesystem::path p;
 std::string s1 = p.u8string();          // ill-formed; previously well-formed
 std::string s2 = p.generic_u8string();  // ill-formed; previously well-formed
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp17.depr]{\ref{depr}: compatibility features}
 
@@ -1368,11 +1407,12 @@ Valid \CppXIV{} code may fail to compile or produce different results in
 this revision of \Cpp{}. Specifically, character sequences like \tcode{0p+0}
 and \tcode{0e1_p+0} are three separate tokens each in \CppXIV{}, but one single token
 in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 #define F(a) b ## a
 int b0p = F(0p+0);  // ill-formed; equivalent to ``\tcode{int b0p = b0p + 0;}\!'' in \CppXIV{}
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp14.expr]{\ref{expr}: expressions}
 
@@ -1421,11 +1461,12 @@ More intuitive deduction behavior.
 \effect
 Valid \CppXIV{} code may fail to compile or may change meaning
 in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 auto x1{1};         // was \tcode{std::initializer_list<int>}, now \tcode{int}
 auto x2{1, 2};      // was \tcode{std::initializer_list<int>}, now ill-formed
 \end{codeblock}
+\end{example}
 
 \diffref{dcl.fct}
 \change
@@ -1435,13 +1476,14 @@ Improve type-safety.
 \effect
 Valid \CppXIV{} code may fail to compile or change meaning in this
 revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 void g1() noexcept;
 void g2();
 template<class T> int f(T *, T *);
 int x = f(g1, g2);              // ill-formed; previously well-formed
 \end{codeblock}
+\end{example}
 
 \diffref{dcl.init.aggr}
 \change
@@ -1454,7 +1496,7 @@ Valid \CppXIV{} code may fail to compile or produce different results in this
 revision of \Cpp{}; initialization from an empty initializer list will
 perform aggregate initialization instead of invoking a default constructor
 for the affected types.
-For example:
+\begin{example}
 \begin{codeblock}
 struct derived;
 struct base {
@@ -1467,6 +1509,7 @@ struct derived : base {};
 derived d1{};       // error; the code was well-formed in \CppXIV{}
 derived d2;         // still OK
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp14.class]{\ref{class}: classes}
 
@@ -1481,7 +1524,7 @@ or may have different semantics. A \grammarterm{using-declaration}
 that names a constructor now makes the corresponding base class constructors
 visible to initializations of the derived class
 rather than declaring additional derived class constructors.
-For example:
+\begin{example}
 \begin{codeblock}
 struct A {
   template<typename T> A(T, typename T::type = 0);
@@ -1495,6 +1538,7 @@ B b(42L);           // now calls \tcode{B(int)}, used to call \tcode{B<long>(lon
                     // which called \tcode{A(int)} due to substitution failure
                     // in \tcode{A<long>(long)}.
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp14.temp]{\ref{temp}: templates}
 
@@ -1509,7 +1553,7 @@ from the type deduced for the non-type template argument.
 \effect
 Valid \CppXIV{} code may fail to compile
 or produce different results in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 template <int N> struct A;
 template <typename T, T N> int foo(A<N> *) = delete;
@@ -1518,6 +1562,7 @@ void bar(A<0> *p) {
   foo(p);           // ill-formed; previously well-formed
 }
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp14.except]{\ref{except}: exception handling}
 
@@ -1598,12 +1643,13 @@ via the syntax \tcode{shared_ptr<T[]>} and \tcode{shared_ptr<T[N]>}.
 \effect
 Valid \CppXIV{} code may fail to compile or may change meaning in this
 revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 #include <memory>
 std::unique_ptr<int[]> arr(new int[1]);
 std::shared_ptr<int> ptr(std::move(arr));   // error: \tcode{int(*)[]} is not compatible with \tcode{int*}
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp14.string]{\ref{strings}: strings library}
 
@@ -1620,13 +1666,14 @@ for \tcode{char*} and \tcode{const char*} arguments
 will execute differently
 when called with a non-const string's \tcode{.data()} member
 in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 int f(char *) = delete;
 int f(const char *);
 string s;
 int x = f(s.data());            // ill-formed; previously well-formed
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp14.containers]{\ref{containers}: containers library}
 
@@ -1639,7 +1686,7 @@ Increase portability, clarification of associative container requirements.
 Valid \CppXIV{} code that attempts to use associative containers
 having a comparison object with non-const function call operator
 may fail to compile in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 #include <set>
 
@@ -1656,6 +1703,7 @@ int main() {
   s.find(0);
 }
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp14.depr]{\ref{depr}: compatibility features}
 
@@ -1714,13 +1762,14 @@ revision of \Cpp{}. For example, the following code is valid both in \CppXI{} an
 this revision of \Cpp{}, but the macro invocation produces different outcomes
 because the single quotes delimit a \grammarterm{character-literal} in \CppXI{}, whereas they are digit
 separators in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 #define M(x, ...) __VA_ARGS__
 int x[2] = { M(1'2,3'4, 5) };
 // \tcode{int x[2] = \{ 5 \};\ \ \ \ \ } --- \CppXI{}
 // \tcode{int x[2] = \{ 3'4, 5 \};} --- this revision of \Cpp{}
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp11.basic]{\ref{basic}: basics}
 
@@ -1756,7 +1805,7 @@ lvalue-to-rvalue conversion, were considered gratuitous and surprising.
 \effect
 Valid \CppXI{} code that relies on the conversions may behave differently
 in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 struct S {
   int x = 1;
@@ -1775,6 +1824,7 @@ sizeof(true ? "" : throw 0)
 \end{codeblock}
 In \CppXI{}, the expression yields \tcode{sizeof(const char*)}. In this
 revision of \Cpp{}, it yields \tcode{sizeof(const char[1])}.
+\end{example}
 
 \rSec2[diff.cpp11.dcl.dcl]{\ref{dcl.dcl}: declarations}
 
@@ -1787,7 +1837,7 @@ Necessary to allow \keyword{constexpr} member functions to mutate
 the object.
 \effect
 Valid \CppXI{} code may fail to compile in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 struct S {
   constexpr const int &f();
@@ -1797,6 +1847,7 @@ struct S {
 This code is valid in \CppXI{}
 but invalid in this revision of \Cpp{} because it declares the same member
 function twice with different return types.
+\end{example}
 
 \diffref{dcl.init.aggr}
 \change
@@ -1806,7 +1857,7 @@ Necessary to allow default member initializers to be used
 by aggregate initialization.
 \effect
 Valid \CppXI{} code may fail to compile or may change meaning in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 struct S {          // Aggregate in \CppXIV{} onwards.
   int m = 1;
@@ -1819,6 +1870,7 @@ X a{};
 S b{a};             // uses copy constructor in \CppXI{},
                     // performs aggregate initialization in this revision of \Cpp{}
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp11.library]{\ref{library}: library introduction}
 
@@ -1867,11 +1919,12 @@ this revision of \Cpp{}. Specifically, macros named \tcode{R}, \tcode{u8},
 \tcode{u8R}, \tcode{u}, \tcode{uR}, \tcode{U}, \tcode{UR}, or \tcode{LR} will
 not be expanded when adjacent to a \grammarterm{string-literal} but will be interpreted as
 part of the \grammarterm{string-literal}.
-For example:
+\begin{example}
 \begin{codeblock}
 #define u8 "abc"
 const char* s = u8"def";        // Previously \tcode{"abcdef"}, now \tcode{"def"}
 \end{codeblock}
+\end{example}
 
 \diffref{lex.pptoken}
 \change
@@ -1881,7 +1934,7 @@ Required for new features.
 \effect
 Valid \CppIII{} code may fail to compile or produce different results in
 this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 #define _x "there"
 "hello"_x           // \#1
@@ -1890,6 +1943,7 @@ For example:
 Previously, \#1 would have consisted of two separate preprocessing tokens and
 the macro \tcode{_x} would have been expanded. In this revision of \Cpp{},
 \#1 consists of a single preprocessing token, so the macro is not expanded.
+\end{example}
 
 \diffref{lex.key}
 \change
@@ -1931,7 +1985,7 @@ expressions.
 \effect
 Valid \CppIII{} code may fail to compile or produce different results in
 this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 void f(void *);     // \#1
 void f(...);        // \#2
@@ -1939,6 +1993,7 @@ template<int N> void g() {
   f(0*N);           // calls \#2; used to call \#1
 }
 \end{codeblock}
+\end{example}
 
 \diffref{expr.mul}
 \change
@@ -1958,12 +2013,13 @@ Required for new features.
 \effect
 Valid \CppIII{} code may fail to compile or produce different results in
 this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 bool b1 = new int && false;             // previously \tcode{false}, now ill-formed
 struct S { operator int(); };
 bool b2 = &S::operator int && false;    // previously \tcode{false}, now ill-formed
 \end{codeblock}
+\end{example}
 
 \rSec2[diff.cpp03.dcl.dcl]{\ref{dcl.dcl}: declarations}
 
@@ -1987,13 +2043,14 @@ Narrowing restrictions in aggregate initializers.
 Catches bugs.
 \effect
 Valid \CppIII{} code may fail to compile in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 int x[] = { 2.0 };
 \end{codeblock}
 This code is valid in \CppIII{} but invalid in this
 revision of \Cpp{} because \tcode{double} to \tcode{int} is a narrowing
 conversion.
+\end{example}
 
 \diffref{dcl.link}
 \change
@@ -2005,7 +2062,7 @@ Alignment with user expectations.
 \effect
 Valid \CppIII{} code may violate the one-definition rule\iref{basic.def.odr}
 in this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 namespace { extern "C" { extern int x; } }  // \#1, previously external linkage and C language linkage,
                                             // now internal linkage and \Cpp{} language linkage
@@ -2015,6 +2072,7 @@ int main(void) { return x; }
 This code is valid in \CppIII{},
 but \tcode{\#2} is not a definition for \tcode{\#1}
 in this revision of \Cpp{}, violating the one-definition rule.
+\end{example}
 
 \rSec2[diff.cpp03.class]{\ref{class}: classes}
 
@@ -2062,7 +2120,7 @@ representing non-class types would exacerbate whitespace issues.
 Change to semantics of well-defined expression. A valid \CppIII{} expression
 containing a right angle bracket (``\tcode{>}'') followed immediately by
 another right angle bracket may now be treated as closing two templates.
-For example:
+\begin{example}
 \begin{codeblock}
 template <class T> struct X { };
 template <int N> struct Y { };
@@ -2071,6 +2129,7 @@ X< Y< 1 >> 2 > > x;
 This code is valid in \CppIII{} because ``\tcode{>>}''
 is a right-shift operator, but invalid in this revision of \Cpp{} because
 ``\tcode{>>}'' closes two templates.
+\end{example}
 
 \diffref{temp.dep.candidate}
 \change
@@ -2397,7 +2456,7 @@ Required for new features.
 Valid \CppIII{} code that relies on \tcode{std::ios_base} flag types being
 represented as \tcode{std::bitset} or as an integer type may fail to compile
 with this revision of \Cpp{}.
-For example:
+\begin{example}
 \begin{codeblock}
 #include <iostream>
 
@@ -2406,6 +2465,7 @@ int main() {
   std::cout.setf(flag);         // error: \tcode{setf} does not take argument of type \tcode{int}
 }
 \end{codeblock}
+\end{example}
 
 \rSec1[diff.iso]{\Cpp{} and ISO C}
 
@@ -2444,7 +2504,8 @@ Common.
 Type of \grammarterm{character-literal} is changed from \tcode{int} to \tcode{char}.
 \rationale
 This is needed for improved overloaded function argument type
-matching. For example:
+matching.
+\begin{example}
 \begin{codeblock}
 int function( int i );
 int function( char c );
@@ -2453,6 +2514,7 @@ function( 'x' );
 \end{codeblock}
 It is preferable that this call match the second version of
 function rather than the first.
+\end{example}
 \effect
 Change to semantics of well-defined feature.
 ISO C programs which depend on
@@ -2525,16 +2587,18 @@ as potentially modifiable memory are probably rare.
 \diffref{basic.def}
 \change
 \Cpp{} does not have ``tentative definitions'' as in C.\\
-E.g., at file scope,
+\begin{example}
+At file scope,
 \begin{codeblock}
 int i;
 int i;
 \end{codeblock}
 is valid in C, invalid in \Cpp{}.
+\end{example}
 This makes it impossible to define
 mutually referential file-local objects with static storage duration,
 if initializers are restricted to the syntactic forms of C\@.
-For example,
+\begin{example}
 \begin{codeblock}
 struct X { int i; struct X* next; };
 
@@ -2542,6 +2606,7 @@ static struct X a;
 static struct X b = { 0, &a };
 static struct X a = { 1, &b };
 \end{codeblock}
+\end{example}
 \rationale
 This avoids having different initialization rules for
 fundamental types and user-defined types.
@@ -2559,7 +2624,7 @@ Seldom.
 \diffref{basic.scope}
 \change
 A \keyword{struct} is a scope in \Cpp{}, not in C.
-For example,
+\begin{example}
 \begin{codeblock}
 struct X {
   struct Y { int a; } b;
@@ -2567,6 +2632,7 @@ struct X {
 struct Y c;
 \end{codeblock}
 is valid in C but not in \Cpp{}, which would require \tcode{X::Y c;}.
+\end{example}
 \rationale
 Class scope is crucial to \Cpp{}, and a struct is a class.
 \effect
@@ -2636,6 +2702,7 @@ Common.
 \diffref{conv.ptr}
 \change
 Converting \tcode{\keyword{void}*} to a pointer-to-object type requires casting.
+\begin{example}
 \begin{codeblock}
 char a[10];
 void* b=a;
@@ -2647,6 +2714,7 @@ void foo() {
 ISO C accepts this usage of pointer to \keyword{void} being assigned
 to a pointer to object type.
 \Cpp{} does not.
+\end{example}
 \rationale
 \Cpp{} tries harder than C to enforce compile-time type safety.
 \effect
@@ -2654,12 +2722,12 @@ Deletion of semantically well-defined feature.
 \difficulty
 Can be automated.
 Violations will be diagnosed by the \Cpp{} translator.
-The
-fix is to add a  cast.
-For example:
+The fix is to add a  cast.
+\begin{example}
 \begin{codeblock}
 char* c = (char*) b;
 \end{codeblock}
+\end{example}
 
 \howwide
 This is fairly widely used but it is good
@@ -2671,7 +2739,7 @@ if the cast is not used.
 \change
 Operations mixing a value of an enumeration type and a value of a different
 enumeration type or of a floating-point type are not valid.
-For example:
+\begin{example}
 \begin{codeblock}
 enum E1 { e };
 enum E2 { f };
@@ -2679,6 +2747,7 @@ int b = e <= 3.7;       // valid in C; ill-formed in \Cpp{}
 int k = f - e;          // valid in C; ill-formed in \Cpp{}
 int x = 1 ? e : f;      // valid in C; ill-formed in \Cpp{}
 \end{codeblock}
+\end{example}
 \rationale
 Reinforcing type safety in \Cpp{}.
 \effect
@@ -2686,13 +2755,14 @@ Well-formed C code will not compile with this International Standard.
 \difficulty
 Violations will be diagnosed by the \Cpp{} translator.
 The original behavior can be restored with a cast or integral promotion.
-For example:
+\begin{example}
 \begin{codeblock}
 enum E1 { e };
 enum E2 { f };
 int b = (int)e <= 3.7;
 int k = +f - e;
 \end{codeblock}
+\end{example}
 \howwide
 Uncommon.
 
@@ -2711,11 +2781,12 @@ is ill-formed in \Cpp{}.
 \change
 In \Cpp{}, types can only be defined in declarations, not in expressions.\\
 In C, a \keyword{sizeof} expression or cast expression may define a new type.
-For example,
+\begin{example}
 \begin{codeblock}
 p = (void*)(struct x {int i;} *)0;
 \end{codeblock}
 defines a new type, struct \tcode{x}.
+\end{example}
 \rationale
 This prohibition helps to clarify the location of
 definitions in the source code.
@@ -2740,7 +2811,7 @@ yield lvalues.
 Change to semantics of well-defined feature.  Some C
 expressions that implicitly rely on lvalue-to-rvalue
 conversions will yield different results.
-For example,
+\begin{example}
 \begin{codeblock}
 char arr[100];
 sizeof(0, arr)
@@ -2750,6 +2821,7 @@ yields
 in \Cpp{} and
 \tcode{sizeof(char*)}
 in C.
+\end{example}
 \difficulty
 Programs must add explicit casts to the appropriate rvalue.
 \howwide
@@ -2811,12 +2883,13 @@ In \Cpp{}, the \keyword{static} or \keyword{extern} specifiers can only be appli
 Using these specifiers with type declarations is illegal in \Cpp{}.
 In C, these specifiers are ignored when used on type declarations.
 
-Example:
+\begin{example}
 \begin{codeblock}
 static struct S {               // valid C, invalid in \Cpp{}
   int i;
 };
 \end{codeblock}
+\end{example}
 
 \rationale
 Storage class specifiers don't have any meaning when associated
@@ -2851,23 +2924,25 @@ in the same scope (except if the typedef is a synonym of the class name with the
 same name). In C, a \grammarterm{typedef-name} and a struct tag name declared in the same scope
 can have the same name (because they have different name spaces).
 
-Example:
+\begin{example}
 \begin{codeblock}
 typedef struct name1 { @\commentellip@ } name1;         // valid C and \Cpp{}
 struct name { @\commentellip@ };
 typedef int name;               // valid C, invalid \Cpp{}
 \end{codeblock}
+\end{example}
 
 \rationale
 For ease of use, \Cpp{} doesn't require that a type name be prefixed
 with the keywords \keyword{class}, \keyword{struct} or \keyword{union} when used in object
 declarations or type casts.
 
-Example:
+\begin{example}
 \begin{codeblock}
 class name { @\commentellip@ };
 name i;                         // \tcode{i} has type \tcode{class name}
 \end{codeblock}
+\end{example}
 
 \effect
 Deletion of semantically well-defined feature.
@@ -2894,12 +2969,13 @@ Seldom.
 \change
 The keyword \keyword{auto} cannot be used as a storage class specifier.
 
-Example:
+\begin{example}
 \begin{codeblock}
 void f() {
   auto int x;       // valid C, invalid \Cpp{}
 }
 \end{codeblock}
+\end{example}
 
 \rationale
 Allowing the use of \keyword{auto} to deduce the type
@@ -2917,11 +2993,12 @@ Rare.
 In \Cpp{}, a function declared with an empty parameter list takes no arguments.
 In C, an empty parameter list means that the number and type of the function arguments are unknown.
 
-Example:
+\begin{example}
 \begin{codeblock}
 int f();            // means   \tcode{int f(void)} in \Cpp{}
                     // \tcode{int f(} unknown \tcode{)} in C
 \end{codeblock}
+\end{example}
 
 \rationale
 This is to avoid function calls
@@ -2944,11 +3021,12 @@ Common.
 In \Cpp{}, types may not be defined in return or parameter types.
 In C, these type definitions are allowed.
 
-Example:
+\begin{example}
 \begin{codeblock}
 void f( struct S { int a; } arg ) {}    // valid C, invalid \Cpp{}
 enum E { A, B, C } f() {}               // valid C, invalid \Cpp{}
 \end{codeblock}
+\end{example}
 
 \rationale
 When comparing types in different translation units, \Cpp{} relies
@@ -2991,7 +3069,7 @@ and
 designated and non-designated initializers
 cannot be mixed in the same initializer list.
 
-Example:
+\begin{example}
 \begin{codeblock}
 struct A { int x, y; };
 struct B { struct A a; };
@@ -3000,6 +3078,7 @@ int arr[3] = {[1] = 5};         // valid C, invalid \Cpp{}
 struct B b = {.a.x = 0};        // valid C, invalid \Cpp{}
 struct A c = {.x = 1, 2};       // valid C, invalid \Cpp{}
 \end{codeblock}
+\end{example}
 \rationale
 In \Cpp{}, members are destroyed in reverse construction order
 and the elements of an initializer list are evaluated in lexical order,
@@ -3021,10 +3100,11 @@ characters in the string (including the terminating \tcode{'\textbackslash 0'}) 
 number of elements in the array. In C, an array can be initialized with a string even if
 the array is not large enough to contain the string-terminating \tcode{'\textbackslash 0'}.
 
-Example:
+\begin{example}
 \begin{codeblock}
 char array[4] = "abcd";         // valid C, invalid \Cpp{}
 \end{codeblock}
+\end{example}
 \rationale
 When these non-terminated arrays are manipulated by standard
 string functions, there is potential for major catastrophe.
@@ -3043,11 +3123,12 @@ This style of array initialization is seen as poor coding style.
 \Cpp{} objects of enumeration type can only be assigned values of the same enumeration type.
 In C, objects of enumeration type can be assigned values of any integral type.
 
-Example:
+\begin{example}
 \begin{codeblock}
 enum color { red, blue, green };
 enum color c = 1;               // valid C, invalid \Cpp{}
 \end{codeblock}
+\end{example}
 
 \rationale
 The type-safe nature of \Cpp{}.
@@ -3064,13 +3145,14 @@ Common.
 \change
 In \Cpp{}, the type of an enumerator is its enumeration. In C, the type of an enumerator is \keyword{int}.
 
-Example:
+\begin{example}
 \begin{codeblock}
 enum e { A };
 sizeof(A) == sizeof(int)        // in C
 sizeof(A) == sizeof(e)          // in \Cpp{}
 /* and @sizeof(int)@ is not necessarily equal to @sizeof(e)@ */
 \end{codeblock}
+\end{example}
 
 \rationale
 In \Cpp{}, an enumeration is a distinct type.
@@ -3091,12 +3173,14 @@ In \Cpp{},
 an \grammarterm{alignment-specifier} is an \grammarterm{attribute-specifier}.
 In C, an \grammarterm{alignment-specifier} is a \gterm{declaration-specifier}.
 
-Example:
+\begin{example}
 \begin{codeblock}
 #include <stdalign.h>
 unsigned alignas(8) int x;      // valid C, invalid \Cpp{}
 unsigned int y alignas(8);      // valid \Cpp{}, invalid C
 \end{codeblock}
+\end{example}
+
 \rationale
 \Cpp{} requires unambiguous placement of the \grammarterm{alignment-specifier}.
 \effect
@@ -3115,7 +3199,7 @@ declared and hides any object, function or other declaration of that name in an 
 scope. In C, an inner scope declaration of a struct tag name never hides the name of an
 object or function in an outer scope.
 
-Example:
+\begin{example}
 \begin{codeblock}
 int x[99];
 void f() {
@@ -3124,6 +3208,7 @@ void f() {
   /* size of the struct in @\textit{\textrm{\Cpp{}}}@ */
 }
 \end{codeblock}
+\end{example}
 \rationale
 This is one of the few incompatibilities between C and \Cpp{} that
 can be attributed to the new \Cpp{} name space definition where a
@@ -3154,7 +3239,8 @@ Copying volatile objects.
 The implicitly-declared copy constructor and
 implicitly-declared copy assignment operator
 cannot make a copy of a volatile lvalue.
-For example, the following is valid in ISO C:
+\begin{example}
+The following is valid in ISO C:
 \begin{codeblock}
 struct X { int i; };
 volatile struct X x1 = {0};
@@ -3162,6 +3248,7 @@ struct X x2 = x1;               // invalid \Cpp{}
 struct X x3;
 x3 = x1;                        // also invalid \Cpp{}
 \end{codeblock}
+\end{example}
 
 \rationale
 Several alternatives were debated at length.
@@ -3214,13 +3301,14 @@ Seldom.
 In \Cpp{}, the name of a nested class is local to its enclosing class. In C
 the name of the nested class belongs to the same scope as the name of the outermost enclosing class.
 
-Example:
+\begin{example}
 \begin{codeblock}
 struct X {
   struct Y { @\commentellip@ } y;
 };
 struct Y yy;                    // valid C, invalid \Cpp{}
 \end{codeblock}
+\end{example}
 \rationale
 \Cpp{} classes have member functions which require that classes
 establish scopes.
@@ -3238,13 +3326,14 @@ Semantic transformation.
 To make the struct type name visible in the scope of the enclosing
 struct, the struct tag can be declared in the scope of the
 enclosing struct, before the enclosing struct is defined.
-Example:
+\begin{example}
 \begin{codeblock}
 struct Y;                       // \tcode{struct Y} and \tcode{struct X} are at the same scope
 struct X {
   struct Y { @\commentellip@ } y;
 };
 \end{codeblock}
+\end{example}
 
 All the definitions of C struct types enclosed in other struct
 definitions and accessed outside the scope of the enclosing
@@ -3258,7 +3347,7 @@ Seldom.
 \change
 In \Cpp{}, a \grammarterm{typedef-name} may not be redeclared in a class definition after being used in that definition.
 
-Example:
+\begin{example}
 \begin{codeblock}
 typedef int I;
 struct S {
@@ -3266,6 +3355,7 @@ struct S {
   int I;            // valid C, invalid \Cpp{}
 };
 \end{codeblock}
+\end{example}
 \rationale
 When classes become complicated, allowing such a redefinition
 after the type has been used can create confusion for \Cpp{}


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

Fixes #6990