### PR TITLE
[numeric.limits.members,bibliography] Remove LIA-1 abbreviation for ISO 10967

### DIFF
--- a/source/back.tex
+++ b/source/back.tex
@@ -68,9 +68,6 @@
   ACM Trans.\ Math.\ Soft., Vol.\ 28, Issue 2, 2002.
 \end{thebibliography}
 
-The arithmetic specification described in ISO/IEC 10967-1:2012 is
-called \defn{LIA-1} in this document.
-
 % FIXME: For unknown reasons, hanging paragraphs are not indented within our
 % glossaries by default.
 \let\realglossitem\glossitem

--- a/source/support.tex
+++ b/source/support.tex
@@ -1012,6 +1012,11 @@ Non-arithmetic standard types, such as
 \pnum
 \indextext{signal-safe!\idxcode{numeric_limits} members}%
 Each member function defined in this subclause is signal-safe\iref{support.signal}.
+\begin{note}
+\indextext{LIA-1}%
+The arithmetic specification described in ISO/IEC 10967-1:2012 is
+commonly termed LIA-1.
+\end{note}
 
 \indexlibrarymember{min}{numeric_limits}%
 \begin{itemdecl}
@@ -1222,9 +1227,7 @@ static constexpr T round_error() noexcept;
 \pnum
 Measure of the maximum rounding error.
 \begin{footnote}
-Rounding error is described in
-LIA-1
-Section 5.2.4 and
+Rounding error is described in ISO/IEC 10967-1:2012 Section 5.2.4 and
 Annex C Rationale Section C.5.2.4 --- Rounding and rounding constants.
 \end{footnote}
 \end{itemdescr}
@@ -1334,7 +1337,7 @@ static constexpr bool has_quiet_NaN;
 \tcode{true} if the type has a representation for a quiet (non-signaling) ``Not a
 Number''.
 \begin{footnote}
-Required by LIA-1.
+Required by ISO/IEC 10967-1:2012.
 \end{footnote}
 
 \pnum
@@ -1356,7 +1359,7 @@ static constexpr bool has_signaling_NaN;
 \pnum
 \tcode{true} if the type has a representation for a signaling ``Not a Number''.
 \begin{footnote}
-Required by LIA-1.
+Required by ISO/IEC 10967-1:2012.
 \end{footnote}
 
 \pnum
@@ -1378,7 +1381,7 @@ static constexpr T infinity() noexcept;
 \pnum
 Representation of positive infinity, if available.
 \begin{footnote}
-Required by LIA-1.
+Required by ISO/IEC 10967-1:2012.
 \end{footnote}
 
 \pnum
@@ -1397,7 +1400,7 @@ static constexpr T quiet_NaN() noexcept;
 \pnum
 Representation of a quiet ``Not a Number'', if available.
 \begin{footnote}
-Required by LIA-1.
+Required by ISO/IEC 10967-1:2012.
 \end{footnote}
 
 \pnum
@@ -1416,7 +1419,7 @@ static constexpr T signaling_NaN() noexcept;
 \pnum
 Representation of a signaling ``Not a Number'', if available.
 \begin{footnote}
-Required by LIA-1.
+Required by ISO/IEC 10967-1:2012.
 \end{footnote}
 
 \pnum
@@ -1436,7 +1439,7 @@ static constexpr T denorm_min() noexcept;
 \pnum
 Minimum positive subnormal value, if available.
 \begin{footnote}
-Required by LIA-1.
+Required by ISO/IEC 10967-1:2012.
 \end{footnote}
 Otherwise, minimum positive normalized value.
 
@@ -1474,7 +1477,7 @@ static constexpr bool is_bounded;
 \pnum
 \tcode{true} if the set of values representable by the type is finite.
 \begin{footnote}
-Required by LIA-1.
+Required by ISO/IEC 10967-1:2012.
 \end{footnote}
 \begin{note}
 All fundamental types\iref{basic.fundamental} are bounded. This member would be \tcode{false} for arbitrary
@@ -1494,7 +1497,7 @@ static constexpr bool is_modulo;
 \pnum
 \tcode{true} if the type is modulo.
 \begin{footnote}
-Required by LIA-1.
+Required by ISO/IEC 10967-1:2012.
 \end{footnote}
 A type is modulo if, for any operation involving \tcode{+}, \tcode{-}, or
 \tcode{*} on values of that type whose result would fall outside the range
@@ -1523,7 +1526,7 @@ static constexpr bool traps;
 if, at the start of the program, there exists a value of the type that would cause
 an arithmetic operation using that value to trap.
 \begin{footnote}
-Required by LIA-1.
+Required by ISO/IEC 10967-1:2012.
 \end{footnote}
 
 \pnum
@@ -1542,7 +1545,7 @@ if tinyness is detected before rounding.
 \begin{footnote}
 Refer to
 ISO/IEC/IEEE 60559.
-Required by LIA-1.
+Required by ISO/IEC 10967-1:2012.
 \end{footnote}
 
 \pnum
@@ -1559,7 +1562,7 @@ static constexpr float_round_style round_style;
 The rounding style for the type.
 \begin{footnote}
 Equivalent to \tcode{FLT_ROUNDS}.
-Required by LIA-1.
+Required by ISO/IEC 10967-1:2012.
 \end{footnote}
 
 \pnum


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

Fixes #6993 