### PR TITLE
[meta.unary.prop] [class.default.ctor] [class.dtor] Indexing and xrefs for the word "trivial"

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1208,7 +1208,6 @@ A constructor shall not have an explicit object parameter\iref{dcl.fct}.
 
 \pnum
 \indextext{constructor!inheritance of}%
-\indextext{constructor!non-trivial}%
 A \defnadj{default}{constructor} for a class \tcode{X}
 is a constructor of class \tcode{X}
 for which each parameter
@@ -2043,7 +2042,9 @@ A defaulted destructor for a class
 \end{itemize}
 
 \pnum
-A destructor is trivial if it is not user-provided and if:
+A destructor is
+\defnx{trivial}{destructor!trivial}
+if it is not user-provided and if:
 \begin{itemize}
 \item the destructor is not virtual,
 

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -787,7 +787,7 @@ the argument is a complete type.
 \pnum
 For the purpose of defining the templates in this subclause,
 a function call expression \tcode{declval<T>()} for any type \tcode{T}
-is considered to be a trivial\iref{term.trivial.type,special} function call
+is considered to be a trivial\iref{special} function call
 that is not an odr-use\iref{term.odr.use} of \tcode{declval}
 in the context of the corresponding definition
 notwithstanding the restrictions of~\ref{declval}.
@@ -1047,7 +1047,7 @@ The compilation of the
   \tcode{is_constructible_v<T,}\br
   \tcode{Args...>} is \tcode{true} and the variable
   definition for \tcode{is_constructible}, as defined below, is known to call
-  no operation that is not trivial\iref{term.trivial.type,special}. &
+  no operation that is not trivial\iref{special}. &
   \tcode{T} and all types in the template parameter pack \tcode{Args} shall be complete types,
   \cv{}~\keyword{void}, or arrays of unknown bound. \\ \rowsep
 
@@ -1082,7 +1082,7 @@ The compilation of the
   \tcode{struct is_trivially_assignable;} &
   \tcode{is_assignable_v<T, U>} is \tcode{true} and the assignment, as defined by
   \tcode{is_assignable}, is known to call no operation that is not
-  trivial\iref{term.trivial.type,special}. &
+  trivial\iref{special}. &
   \tcode{T} and \tcode{U} shall be complete types, \cv{}~\keyword{void},
   or arrays of unknown bound. \\ \rowsep
 
@@ -1553,7 +1553,7 @@ Base classes that are private, protected, or ambiguous
 \pnum
 For the purpose of defining the templates in this subclause,
 a function call expression \tcode{declval<T>()} for any type \tcode{T}
-is considered to be a trivial\iref{term.trivial.type,special} function call
+is considered to be a trivial\iref{special} function call
 that is not an odr-use\iref{term.odr.use} of \tcode{declval}
 in the context of the corresponding definition
 notwithstanding the restrictions of~\ref{declval}.


### PR DESCRIPTION
The definition of "trivial type" isn't relevant to the notion of "non-trivial function" (which isn't really defined anywhere, I'm finding).
We have a bogus index entry for "non-trivial constructor" (should have been "non-trivial default constructor," which already exists), and lack an entry (and `\defnx` italicization) for "trivial destructor".

FWIW I checked that [P3247 "Deprecate the notion of trivial types"](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3247r0.html) didn't already touch either of these; I think this cleanup is pretty orthogonal to P3247.