### PR TITLE
[rand.req] Replace 'that Table' with a precise reference

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -1660,7 +1660,7 @@ in \tref{rand.req.seedseq}
 are valid and have the indicated semantics,
 and if \tcode{S} also meets all other requirements
 of this subclause \ref{rand.req.seedseq}.
-In that Table and throughout this subclause:
+In \tref{rand.req.seedseq} and throughout this subclause:
 \begin{itemize}
   \item
     \tcode{T} is the type named by
@@ -1876,7 +1876,7 @@ in \tref{rand.req.eng}
 are valid and have the indicated semantics,
 and if \tcode{E} also meets all other requirements
 of this subclause \ref{rand.req.eng}.
-In that Table and throughout this subclause:
+In \tref{rand.req.eng} and throughout this subclause:
 \begin{itemize}
   \item
     \tcode{T} is the type named by
@@ -2255,7 +2255,7 @@ are valid and have the indicated semantics,
 and if \tcode{D} and its associated types
 also meet all other requirements
 of this subclause \ref{rand.req.dist}.
-In that Table and throughout this subclause,
+In \tref{rand.req.dist} and throughout this subclause,
 \begin{itemize}
   \item
     \tcode{T} is the type named by


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)