### PR TITLE
[intro.memory] Move footnote about Unicode trademark to [lex.phases]

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3086,11 +3086,6 @@ the ordinary literal encoding of any element of the basic
 \indextext{character set!basic literal}%
 literal character set\iref{lex.charset}
 and the eight-bit code units of the Unicode
-\begin{footnote}
-Unicode\textregistered\ is a registered trademark of Unicode, Inc.
-This information is given for the convenience of users of this document and
-does not constitute an endorsement by ISO or IEC of this product.
-\end{footnote}
 \indextext{UTF-8}%
 UTF-8 encoding form
 and is composed of a contiguous sequence of

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -83,7 +83,13 @@ recognizing the \unicode{feff}{byte order mark} is not sufficient.
 \end{note}
 If an input file is determined to be a UTF-8 file,
 then it shall be a well-formed UTF-8 code unit sequence and
-it is decoded to produce a sequence of Unicode scalar values.
+it is decoded to produce a sequence of Unicode
+\begin{footnote}
+Unicode\textregistered\ is a registered trademark of Unicode, Inc.
+This information is given for the convenience of users of this document and
+does not constitute an endorsement by ISO or IEC of this product.
+\end{footnote}
+scalar values.
 A sequence of translation character set elements is then formed
 by mapping each Unicode scalar value
 to the corresponding translation character set element.


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

Fixes #7003 