### PR TITLE
[input.output] Add cross-references to header synopses

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -683,11 +683,15 @@ declared in \libheaderref{cstdio}.
 #include <iosfwd>   // see \ref{iosfwd.syn}
 
 namespace std {
+  // \ref{stream.types}, types
   using streamoff  = @\impdef@;
   using streamsize = @\impdef@;
+  // \ref{ios}, class template \tcode{fpos}
   template<class stateT> class fpos;
 
+  // \ref{ios.base}, class \tcode{ios_base}
   class ios_base;
+  // \ref{ios}, class template \tcode{basic_ios}
   template<class charT, class traits = char_traits<charT>>
     class basic_ios;
 
@@ -2883,6 +2887,7 @@ The object's \tcode{default_error_condition} and \tcode{equivalent} virtual func
 \indexlibraryglobal{basic_streambuf<wchar_t>}%
 \begin{codeblock}
 namespace std {
+  // \ref{streambuf}, class template \tcode{basic_streambuf}
   template<class charT, class traits = char_traits<charT>>
     class basic_streambuf;
   using streambuf  = basic_streambuf<char>;
@@ -4147,21 +4152,25 @@ argument character sequence.
 \indexheader{istream}%
 \begin{codeblock}
 namespace std {
+  // \ref{istream}, class template \tcode{basic_istream}
   template<class charT, class traits = char_traits<charT>>
     class basic_istream;
 
   using istream  = basic_istream<char>;
   using wistream = basic_istream<wchar_t>;
 
+  // \ref{iostreamclass}, class template \tcode{basic_iostream}
   template<class charT, class traits = char_traits<charT>>
     class basic_iostream;
 
   using iostream  = basic_iostream<char>;
   using wiostream = basic_iostream<wchar_t>;
 
+  // \ref{istream.manip}, standard \tcode{basic_istream} manipulators
   template<class charT, class traits>
     basic_istream<charT, traits>& ws(basic_istream<charT, traits>& is);
 
+  // \ref{istream.rvalue}, rvalue stream extraction
   template<class Istream, class T>
     Istream&& operator>>(Istream&& is, T&& x);
 }
@@ -4177,12 +4186,14 @@ namespace std {
 \indexheader{ostream}%
 \begin{codeblock}
 namespace std {
+  // \ref{ostream}, class template \tcode{basic_ostream}
   template<class charT, class traits = char_traits<charT>>
     class basic_ostream;
 
   using ostream  = basic_ostream<char>;
   using wostream = basic_ostream<wchar_t>;
 
+  // \ref{ostream.manip}, standard \tcode{basic_ostream} manipulators
   template<class charT, class traits>
     basic_ostream<charT, traits>& endl(basic_ostream<charT, traits>& os);
   template<class charT, class traits>
@@ -4197,6 +4208,7 @@ namespace std {
   template<class charT, class traits>
     basic_ostream<charT, traits>& flush_emit(basic_ostream<charT, traits>& os);
 
+  // \ref{ostream.rvalue}, rvalue stream insertion
   template<class Ostream, class T>
     Ostream&& operator<<(Ostream&& os, const T& x);
 
@@ -4222,17 +4234,21 @@ namespace std {
 \indexheader{iomanip}%
 \begin{codeblock}
 namespace std {
+  // \ref{std.manip}, standard manipulators
   @\unspec@ resetiosflags(ios_base::fmtflags mask);
   @\unspec@ setiosflags  (ios_base::fmtflags mask);
   @\unspec@ setbase(int base);
   template<class charT> @\unspec@ setfill(charT c);
   @\unspec@ setprecision(int n);
   @\unspec@ setw(int n);
+
+  // \ref{ext.manip}, extended manipulators
   template<class moneyT> @\unspec@ get_money(moneyT& mon, bool intl = false);
   template<class moneyT> @\unspec@ put_money(const moneyT& mon, bool intl = false);
   template<class charT> @\unspec@ get_time(tm* tmb, const charT* fmt);
   template<class charT> @\unspec@ put_time(const tm* tmb, const charT* fmt);
 
+  // \ref{quoted.manip}, quoted manipulators
   template<class charT>
     @\unspec@ quoted(const charT* s, charT delim = charT('"'), charT escape = charT('\\'));
 
@@ -7015,7 +7031,7 @@ Otherwise, if the \tcode{sentry} object returns \tcode{false}, does nothing.
 \tcode{*this}.
 \end{itemdescr}
 
-\rSec3[ostream.manip]{Standard manipulators}
+\rSec3[ostream.manip]{Standard \tcode{basic_ostream} manipulators}
 
 \pnum
 Each instantiation of any of the function templates
@@ -7956,6 +7972,7 @@ May throw \tcode{bad_alloc}.
 \indexlibraryglobal{basic_stringstream<wchar_t>}%
 \begin{codeblock}
 namespace std {
+  // \ref{stringbuf}, class template \tcode{basic_stringbuf}
   template<class charT, class traits = char_traits<charT>,
            class Allocator = allocator<charT>>
     class basic_stringbuf;
@@ -7967,6 +7984,7 @@ namespace std {
   using stringbuf  = basic_stringbuf<char>;
   using wstringbuf = basic_stringbuf<wchar_t>;
 
+  // \ref{istringstream}, class template \tcode{basic_istringstream}
   template<class charT, class traits = char_traits<charT>,
            class Allocator = allocator<charT>>
     class basic_istringstream;
@@ -7978,6 +7996,7 @@ namespace std {
   using istringstream  = basic_istringstream<char>;
   using wistringstream = basic_istringstream<wchar_t>;
 
+  // \ref{ostringstream}, class template \tcode{basic_ostringstream}
   template<class charT, class traits = char_traits<charT>,
            class Allocator = allocator<charT>>
     class basic_ostringstream;
@@ -7989,6 +8008,7 @@ namespace std {
   using ostringstream  = basic_ostringstream<char>;
   using wostringstream = basic_ostringstream<wchar_t>;
 
+  // \ref{stringstream}, class template \tcode{basic_stringstream}
   template<class charT, class traits = char_traits<charT>,
            class Allocator = allocator<charT>>
     class basic_stringstream;
@@ -10022,6 +10042,7 @@ results in a data race.
 \indexlibraryglobal{wspanstream}%
 \begin{codeblock}
 namespace std {
+  // \ref{spanbuf}, class template \tcode{basic_spanbuf}
   template<class charT, class traits = char_traits<charT>>
     class basic_spanbuf;
 
@@ -10031,6 +10052,7 @@ namespace std {
   using spanbuf = basic_spanbuf<char>;
   using wspanbuf = basic_spanbuf<wchar_t>;
 
+  // \ref{ispanstream}, class template \tcode{basic_ispanstream}
   template<class charT, class traits = char_traits<charT>>
     class basic_ispanstream;
 
@@ -10040,6 +10062,7 @@ namespace std {
   using ispanstream = basic_ispanstream<char>;
   using wispanstream = basic_ispanstream<wchar_t>;
 
+  // \ref{ospanstream}, class template \tcode{basic_ospanstream}
   template<class charT, class traits = char_traits<charT>>
     class basic_ospanstream;
 
@@ -10049,6 +10072,7 @@ namespace std {
   using ospanstream = basic_ospanstream<char>;
   using wospanstream = basic_ospanstream<wchar_t>;
 
+  // \ref{spanstream}, class template \tcode{basic_spanstream}
   template<class charT, class traits = char_traits<charT>>
     class basic_spanstream;
 
@@ -10876,6 +10900,7 @@ Equivalent to \tcode{rdbuf()->span(s)}.
 \indexlibraryglobal{basic_fstream<wchar_t>}%
 \begin{codeblock}
 namespace std {
+  // \ref{filebuf}, class template \tcode{basic_filebuf}
   template<class charT, class traits = char_traits<charT>>
     class basic_filebuf;
 
@@ -10885,6 +10910,7 @@ namespace std {
   using filebuf  = basic_filebuf<char>;
   using wfilebuf = basic_filebuf<wchar_t>;
 
+  // \ref{ifstream}, class template \tcode{basic_ifstream}
   template<class charT, class traits = char_traits<charT>>
     class basic_ifstream;
 
@@ -10894,6 +10920,7 @@ namespace std {
   using ifstream  = basic_ifstream<char>;
   using wifstream = basic_ifstream<wchar_t>;
 
+  // \ref{ofstream}, class template \tcode{basic_ofstream}
   template<class charT, class traits = char_traits<charT>>
     class basic_ofstream;
 
@@ -10903,6 +10930,7 @@ namespace std {
   using ofstream  = basic_ofstream<char>;
   using wofstream = basic_ofstream<wchar_t>;
 
+  // \ref{fstream}, class template \tcode{basic_fstream}
   template<class charT, class traits = char_traits<charT>>
     class basic_fstream;
 
@@ -12561,6 +12589,7 @@ calls
 #include <ostream>  // see \ref{ostream.syn}
 
 namespace std {
+  // \ref{syncstream.syncbuf}, class template \tcode{basic_syncbuf}
   template<class charT, class traits = char_traits<charT>, class Allocator = allocator<charT>>
     class basic_syncbuf;
 
@@ -12572,6 +12601,7 @@ namespace std {
   using syncbuf = basic_syncbuf<char>;
   using wsyncbuf = basic_syncbuf<wchar_t>;
 
+  // \ref{syncstream.osyncstream}, class template \tcode{basic_osyncstream}
   template<class charT, class traits = char_traits<charT>, class Allocator = allocator<charT>>
     class basic_osyncstream;
 


### PR DESCRIPTION
Several of the synopses are not adjacent to the types they declare. Adding cross-references makes it easier to find the relevant definitions of classes and class templates.

Also make the title of [ostream.manip] more specific to its content.