### PR TITLE
[diff,bibliography] Move details of old C++ standards to the bibliography

### DIFF
--- a/source/back.tex
+++ b/source/back.tex
@@ -9,6 +9,24 @@
   ISO/IEC 10967-1:2012,
   \doccite{Information technology --- Language independent arithmetic ---
     Part 1: Integer and floating point arithmetic}
+\bibitem{iso14882:2023}
+  ISO/IEC 14882:2023,
+  \doccite{Programming Languages --- \Cpp{}}
+\bibitem{iso14882:2020}
+  ISO/IEC 14882:2020,
+  \doccite{Programming Languages --- \Cpp{}}
+\bibitem{iso14882:2017}
+  ISO/IEC 14882:2017,
+  \doccite{Programming Languages --- \Cpp{}}
+\bibitem{iso14882:2014}
+  ISO/IEC 14882:2014,
+  \doccite{Information technology --- Programming Languages --- \Cpp{}}
+\bibitem{iso14882:2011}
+  ISO/IEC 14882:2011,
+  \doccite{Information technology --- Programming Languages --- \Cpp{}}
+\bibitem{iso14882:2003}
+  ISO/IEC 14882:2003,
+  \doccite{Programming Languages --- \Cpp{}}
 \bibitem{iso18661-3}
   ISO/IEC TS 18661-3:2015,
   \doccite{Information Technology ---

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -241,6 +241,7 @@ A valid \CppXXIII{} program using these interfaces may become ill-formed.
 \indextext{summary!compatibility with ISO \CppXX{}}%
 Subclause \ref{diff.cpp20} lists the differences between \Cpp{} and
 ISO \CppXX{},
+in addition to those listed above,
 by the chapters of this document.
 
 \rSec2[diff.cpp20.lex]{\ref{lex}: lexical conventions}
@@ -598,6 +599,7 @@ b1.arrive();            // implementation-defined; previously well-defined
 \indextext{summary!compatibility with ISO \CppXVII{}}%
 Subclause \ref{diff.cpp17} lists the differences between \Cpp{} and
 ISO \CppXVII{},
+in addition to those listed above,
 by the chapters of this document.
 
 \rSec2[diff.cpp17.lex]{\ref{lex}: lexical conventions}

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -8,7 +8,7 @@
 \pnum
 \indextext{summary!compatibility with ISO \CppXXIII{}}%
 Subclause \ref{diff.cpp23} lists the differences between \Cpp{} and
-ISO \CppXXIII{} (ISO/IEC 14882:2023, \doccite{Programming Languages --- \Cpp{}}),
+ISO \CppXXIII{},
 by the chapters of this document.
 
 \rSec2[diff.cpp23.expr]{\ref{expr}: expressions}
@@ -240,7 +240,7 @@ A valid \CppXXIII{} program using these interfaces may become ill-formed.
 \pnum
 \indextext{summary!compatibility with ISO \CppXX{}}%
 Subclause \ref{diff.cpp20} lists the differences between \Cpp{} and
-ISO \CppXX{} (ISO/IEC 14882:2020, \doccite{Programming Languages --- \Cpp{}}),
+ISO \CppXX{},
 by the chapters of this document.
 
 \rSec2[diff.cpp20.lex]{\ref{lex}: lexical conventions}
@@ -597,7 +597,7 @@ b1.arrive();            // implementation-defined; previously well-defined
 \pnum
 \indextext{summary!compatibility with ISO \CppXVII{}}%
 Subclause \ref{diff.cpp17} lists the differences between \Cpp{} and
-ISO \CppXVII{} (ISO/IEC 14882:2017, \doccite{Programming Languages --- \Cpp{}}),
+ISO \CppXVII{},
 by the chapters of this document.
 
 \rSec2[diff.cpp17.lex]{\ref{lex}: lexical conventions}
@@ -1337,7 +1337,7 @@ or on the \tcode{result_of_t} alias template may fail to compile.
 \pnum
 \indextext{summary!compatibility with ISO \CppXIV{}}%
 Subclause \ref{diff.cpp14} lists the differences between \Cpp{} and
-ISO \CppXIV{} (ISO/IEC 14882:2014, \doccite{Programming Languages --- \Cpp{}}),
+ISO \CppXIV{},
 in addition to those listed above,
 by the chapters of this document.
 
@@ -1697,7 +1697,7 @@ may be ill-formed in this revision of \Cpp{}.
 \pnum
 \indextext{summary!compatibility with ISO \CppXI{}}%
 Subclause \ref{diff.cpp11} lists the differences between \Cpp{} and
-ISO \CppXI{} (ISO/IEC 14882:2011, \doccite{Programming Languages --- \Cpp{}}),
+ISO \CppXI{},
 in addition to those listed above,
 by the chapters of this document.
 
@@ -1850,7 +1850,7 @@ in this revision of \Cpp{}.
 \pnum
 \indextext{summary!compatibility with ISO \CppIII{}}%
 Subclause \ref{diff.cpp03} lists the differences between \Cpp{} and
-ISO \CppIII{} (ISO/IEC 14882:2003, \doccite{Programming Languages --- \Cpp{}}),
+ISO \CppIII{},
 in addition to those listed above,
 by the chapters of this document.
 


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

Fixes #7006 