### PR TITLE
[basic.fundamental,cstdarg.syn] Use full reference for ISO C sections

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5072,11 +5072,11 @@ in the object representation are
 alternative representations of the value specified by the value representation.
 \begin{note}
 Padding bits have unspecified value, but cannot cause traps.
-In contrast, see ISO C 6.2.6.2.
+In contrast, see \IsoC{} 6.2.6.2.
 \end{note}
 \begin{note}
 The signed and unsigned integer types satisfy
-the constraints given in ISO C 5.2.4.2.1.
+the constraints given in \IsoC{} 5.2.4.2.1.
 \end{note}
 Except as specified above,
 the width of a signed or unsigned integer type is

--- a/source/support.tex
+++ b/source/support.tex
@@ -5802,7 +5802,7 @@ The contents of the header \libheaderdef{cstdarg} are the same as the C
 standard library header \libheader{stdarg.h}, with the following changes:
 \begin{itemize}
 \item
-In lieu of the default argument promotions specified in ISO C 6.5.2.2,
+In lieu of the default argument promotions specified in \IsoC{} 6.5.2.2,
 the definition in~\ref{expr.call} applies.
 \item
 The restrictions that ISO C places on the second parameter to the


### PR DESCRIPTION
Fixes ISO/CS comment (C++23)

Partially addresses #7011 

@tkoeppe , this feels like an improvement to me also for the Working Draft (since we talk about specific section numbers, and "see also" already has the format we end up with here)