### PR TITLE
[std] Remove ISO from any mention of 'C'

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -12,7 +12,7 @@ The following subclauses describe components for
 non-modifying sequence operations,
 mutating sequence operations,
 sorting and related operations,
-and algorithms from the ISO C library,
+and algorithms from the C library,
 as summarized in \tref{algorithms.summary}.
 
 \begin{libsumtab}{Algorithms library summary}{algorithms.summary}

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2469,13 +2469,13 @@ int main() {
 \end{codeblock}
 \end{example}
 
-\rSec1[diff.iso]{\Cpp{} and ISO C}
+\rSec1[diff.iso]{\Cpp{} and C}
 
 \rSec2[diff.iso.general]{General}
 
 \pnum
-\indextext{summary!compatibility with ISO C}%
-Subclause \ref{diff.iso} lists the differences between \Cpp{} and ISO C,
+\indextext{summary!compatibility with C}%
+Subclause \ref{diff.iso} lists the differences between \Cpp{} and C,
 in addition to those listed above,
 by the chapters of this document.
 
@@ -2491,7 +2491,7 @@ These keywords were added in order to implement the new
 semantics of \Cpp{}.
 \effect
 Change to semantics of well-defined feature.
-Any ISO C programs that used any of these keywords as identifiers
+Any C programs that used any of these keywords as identifiers
 are not valid \Cpp{} programs.
 \difficulty
 Syntactic transformation.
@@ -2519,7 +2519,7 @@ function rather than the first.
 \end{example}
 \effect
 Change to semantics of well-defined feature.
-ISO C programs which depend on
+C programs which depend on
 \begin{codeblock}
 sizeof('x') == sizeof(int)
 \end{codeblock}
@@ -2713,7 +2713,7 @@ void foo() {
 }
 \end{codeblock}
 
-ISO C accepts this usage of pointer to \keyword{void} being assigned
+C accepts this usage of pointer to \keyword{void} being assigned
 to a pointer to object type.
 \Cpp{} does not.
 \end{example}
@@ -2734,7 +2734,7 @@ char* c = (char*) b;
 \howwide
 This is fairly widely used but it is good
 programming practice to add the cast when assigning pointer-to-void to pointer-to-object.
-Some ISO C translators will give a warning
+Some C translators will give a warning
 if the cast is not used.
 
 \diffref{expr.arith.conv}
@@ -2774,7 +2774,7 @@ Decrement operator is not allowed with \keyword{bool} operand.
 \rationale
 Feature with surprising semantics.
 \effect
-A valid ISO C expression utilizing the decrement operator on
+A valid C expression utilizing the decrement operator on
 a \keyword{bool} lvalue
 (for instance, via the C typedef in \libheaderref{stdbool.h})
 is ill-formed in \Cpp{}.
@@ -3242,7 +3242,7 @@ The implicitly-declared copy constructor and
 implicitly-declared copy assignment operator
 cannot make a copy of a volatile lvalue.
 \begin{example}
-The following is valid in ISO C:
+The following is valid in C:
 \begin{codeblock}
 struct X { int i; };
 volatile struct X x1 = {0};
@@ -3377,7 +3377,7 @@ Seldom.
 Whether \mname{STDC} is defined and if so, what its value is, are
 \impldef{definition and meaning of \mname{STDC}}.
 \rationale
-\Cpp{} is not identical to ISO C\@.
+\Cpp{} is not identical to C\@.
 Mandating that \mname{STDC}
 be defined would require that translators make an incorrect claim.
 \effect

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -622,7 +622,7 @@ the cv-unqualified version of \tcode{T}. Otherwise, the type of the
 prvalue is \tcode{T}.
 \begin{footnote}
 In \Cpp{} class and array prvalues can have cv-qualified types.
-This differs from ISO C, in which non-lvalues never have
+This differs from C, in which non-lvalues never have
 cv-qualified types.
 \end{footnote}
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -86,7 +86,7 @@ integral types.
 It is used to represent the number of characters transferred in an I/O
 operation, or the size of I/O buffers.
 \begin{footnote}
-Most places where \tcode{streamsize} is used would use \tcode{size_t} in ISO C,
+Most places where \tcode{streamsize} is used would use \tcode{size_t} in C,
 or \tcode{ssize_t} in POSIX.
 \end{footnote}
 \end{itemdescr}

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1086,8 +1086,7 @@ in translation phase 7\iref{lex.phases}.%
 There are several kinds of literals.
 \begin{footnote}
 The term ``literal'' generally designates, in this
-document, those tokens that are called ``constants'' in
-ISO C.
+document, those tokens that are called ``constants'' in C.
 \end{footnote}
 
 \begin{bnf}
@@ -1574,7 +1573,7 @@ The character specified by a \grammarterm{simple-escape-sequence}
 is specified in \tref{lex.ccon.esc}.
 \begin{note}
 Using an escape sequence for a question mark
-is supported for compatibility with ISO \CppXIV{} and ISO C.
+is supported for compatibility with ISO \CppXIV{} and C.
 \end{note}
 
 \begin{floattable}{Simple escape sequences}{lex.ccon.esc}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -144,8 +144,8 @@ the signatures specified in this document
 may be different from the signatures in the C standard library,
 and additional overloads may be declared in this document,
 but the behavior and the preconditions
-(including any preconditions implied by the use of an
-ISO C \tcode{restrict} qualifier)
+(including any preconditions implied by the use of
+a C \tcode{restrict} qualifier)
 are the same unless otherwise stated.
 
 \pnum

--- a/source/locales.tex
+++ b/source/locales.tex
@@ -16,7 +16,7 @@ message retrieval.
 The following subclauses describe components for
 locales themselves,
 the standard facets, and
-facilities from the ISO C library,
+facilities from the C library,
 as summarized in \tref{localization.summary}.
 
 \begin{libsumtab}{Localization library summary}{localization.summary}

--- a/source/support.tex
+++ b/source/support.tex
@@ -5808,7 +5808,7 @@ standard library header \libheader{stdarg.h}, with the following changes:
 In lieu of the default argument promotions specified in \IsoC{} 6.5.2.2,
 the definition in~\ref{expr.call} applies.
 \item
-The restrictions that ISO C places on the second parameter to the
+The restrictions that C places on the second parameter to the
 \indexlibraryglobal{va_start}%
 \tcode{va_start} macro in header \libheader{stdarg.h}
 are different in this document.
@@ -6002,8 +6002,8 @@ C standard library, the \Cpp{} standard library provides
 the \defnx{C headers}{headers!C library} shown in \tref{c.headers}.
 The intended use of these headers is for interoperability only.
 It is possible that \Cpp{} source files need to include
-one of these headers in order to be valid ISO C.
-Source files that are not intended to also be valid ISO C
+one of these headers in order to be valid C.
+Source files that are not intended to also be valid C
 should not use any of the C headers.
 
 \begin{note}
@@ -6014,7 +6014,7 @@ provides the same facilities and
 assuredly defines them in namespace \tcode{std}.
 \end{note}
 \begin{example}
-The following source file is both valid \Cpp{} and valid ISO C.
+The following source file is both valid \Cpp{} and valid C.
 Viewed as \Cpp{}, it declares a function with C language linkage;
 viewed as C it simply declares a function (and provides a prototype).
 \begin{codeblock}


### PR DESCRIPTION

(Based on pull request #7012.)

Fixes #7011 

ISO/CS wants to have a full "ISO/IEC 9899:2018" where we mention "ISO C".  That seems a bit over-the-top, and [intro.scope] p2 already explains what we mean with "C", so let's just use "C" (and drop the ISO prefix in front of it).