### PR TITLE
[cpp.predefined,namespace.future,version.syn] Replace 'C++' with 'this document'

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1704,7 +1704,7 @@ The following macro names shall be defined by the implementation:
 \xname{cplusplus}\\
 The integer literal \tcode{\cppver}.
 \begin{note}
-Future revisions of \Cpp{} will
+Future revisions of this document will
 replace the value of this macro with a greater value.
 \end{note}
 
@@ -1712,7 +1712,7 @@ replace the value of this macro with a greater value.
 The macros defined in \tref{cpp.predefined.ft} shall be defined to
 the corresponding integer literal.
 \begin{note}
-Future revisions of \Cpp{} might replace
+Future revisions of this document might replace
 the values of these macros with greater values.
 \end{note}
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -546,7 +546,7 @@ Each of the macros defined in \libheader{version} is also defined
 after inclusion of any member of the set of library headers
 indicated in the corresponding comment in this synopsis.
 \begin{note}
-Future revisions of \Cpp{} might replace
+Future revisions of this document might replace
 the values of these macros with greater values.
 \end{note}
 


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

Fixes
- [ ] 15.11 do you mean "this document" when you use "C++"? Please be clearer and use "this document".
- [ ] 17.3.2 do you mean "this document" when you use "C++"? Please be clearer and use "this document".
- [ ] 16.4.5.2.3 replace with "document"