### PR TITLE
[format.string.std] Add (R) symbol after Windows

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16260,14 +16260,13 @@ a locale-independent,
 Implementations should use either UTF-8, UTF-16, or UTF-32,
 on platforms capable of displaying Unicode text in a terminal.
 \begin{note}
-This is the case for Windows
+This is the case for Windows\textregistered{}-based
 \begin{footnote}
 Windows\textregistered\ is a registered trademark of Microsoft Corporation.
 This information is given for the convenience of users of this document and
 does not constitute an endorsement by ISO or IEC of this product.
-\end{footnote}%
--based and
-many POSIX-based operating systems.
+\end{footnote}
+and many POSIX-based operating systems.
 \end{note}
 
 \pnum


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

Fixes
- [ ] the registered trademark symbol (R) should be added here in Note 6