### PR TITLE
[namespace.future] Replace 'this International Standard' with 'this document'

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2993,7 +2993,7 @@ The behavior of a \Cpp{} program is undefined if
 it adds declarations or definitions to such a namespace.
 \begin{example}
 The top-level namespace \tcode{std2} is reserved
-for use by future revisions of this International Standard.
+for use by future revisions of this document.
 \end{example}
 
 \rSec3[reserved.names]{Reserved names}%


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)