### PR TITLE
[class.copy.ctor] Remove reference to non-existing example

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1594,7 +1594,7 @@ The implicitly-defined copy/move constructor for a non-union class
 \tcode{X}
 performs a memberwise copy/move of its bases and members.
 \begin{note}
-Default member initializers of non-static data members are ignored. See also the example in~\ref{class.base.init}.
+Default member initializers of non-static data members are ignored.
 \end{note}
 The order of initialization is the same as the order of initialization of bases
 and members in a user-defined constructor (see~\ref{class.base.init}).


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

- [ ] Which example in 11.9.3? Please be specific as there are several examples i.e. "See Example 1..."