### PR TITLE
[class.conv.general] Remove vague reference to unhelpful examples

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -2292,8 +2292,7 @@ Access control is applied after ambiguity resolution\iref{basic.lookup}.
 
 \pnum
 \begin{note}
-See~\ref{over.match} for a discussion of the use of conversions in function calls
-as well as examples below.
+See~\ref{over.match} for a discussion of the use of conversions in function calls.
 \end{note}
 
 \pnum


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

- [ ] which examples below? If outside of this subclause, please be specify which subclause applies.