### PR TITLE
[lex.ccon,expr.prim.lambda.capture] Excise 'ISO' prefix

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2345,7 +2345,7 @@ be of the form
 or ``\tcode{* \keyword{this}}''.
 \begin{note}
 The form \tcode{[\&,\keyword{this}]} is redundant but accepted
-for compatibility with ISO \CppXIV{}.
+for compatibility with \CppXIV{}.
 \end{note}
 Ignoring appearances in
 \grammarterm{initializer}{s} of \grammarterm{init-capture}{s}, an identifier or

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1573,7 +1573,7 @@ The character specified by a \grammarterm{simple-escape-sequence}
 is specified in \tref{lex.ccon.esc}.
 \begin{note}
 Using an escape sequence for a question mark
-is supported for compatibility with ISO \CppXIV{} and C.
+is supported for compatibility with \CppXIV{} and C.
 \end{note}
 
 \begin{floattable}{Simple escape sequences}{lex.ccon.esc}


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

- [ ] What is ISO C++ 2014? Please use the ISO/IEC document identifier number
