### PR TITLE
[execpol.general] Use 'this document', not 'this standard'

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15141,7 +15141,7 @@ sort(execution::par_unseq, v.begin(), v.end());
 \end{example}
 \begin{note}
 Implementations can provide additional execution policies
-to those described in this standard as extensions
+to those described in this document as extensions
 to address parallel architectures that require idiosyncratic
 parameters for efficient execution.
 \end{note}


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

- [ ] replace "standard" with "document"