### PR TITLE
[std] Rename 'In general' headings to 'General' for consistency

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -5952,7 +5952,7 @@ function or comparison function, the \tcode{rehash()} function has no effect.
 
 \rSec1[sequences]{Sequence containers}
 
-\rSec2[sequences.general]{In general}
+\rSec2[sequences.general]{General}
 
 \pnum
 The headers
@@ -9454,7 +9454,7 @@ Equivalent to: \tcode{return \exposid{underlying_}.format(ref, ctx);}
 
 \rSec1[associative]{Associative containers}
 
-\rSec2[associative.general]{In general}
+\rSec2[associative.general]{General}
 
 \pnum
 The header \libheader{map} defines the class templates \tcode{map} and
@@ -11383,7 +11383,7 @@ return original_size - c.size();
 
 \rSec1[unord]{Unordered associative containers}
 
-\rSec2[unord.general]{In general}
+\rSec2[unord.general]{General}
 
 \pnum
 The header \libheader{unordered_map} defines the class templates
@@ -13560,7 +13560,7 @@ return original_size - c.size();
 
 \rSec1[container.adaptors]{Container adaptors}
 
-\rSec2[container.adaptors.general]{In general}
+\rSec2[container.adaptors.general]{General}
 
 \pnum
 The headers

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6323,7 +6323,7 @@ int a[] = { 2, f(2), f(2.0) };  // OK, the \tcode{double}-to-\tcode{int} convers
 \rSec1[dcl.fct.def]{Function definitions}%
 \indextext{definition!function|(}
 
-\rSec2[dcl.fct.def.general]{In general}
+\rSec2[dcl.fct.def.general]{General}
 
 \pnum
 \indextext{body!function}%

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -519,7 +519,7 @@ namespace std {
 
 \rSec1[iterator.requirements]{Iterator requirements}
 
-\rSec2[iterator.requirements.general]{In general}
+\rSec2[iterator.requirements.general]{General}
 
 \pnum
 \indextext{requirements!iterator}%

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -20,7 +20,7 @@ as summarized in \tref{mem.summary}.
 
 \rSec1[memory]{Memory}
 
-\rSec2[memory.general]{In general}
+\rSec2[memory.general]{General}
 
 \pnum
 Subclause~\ref{memory} describes the contents of the header
@@ -1935,7 +1935,7 @@ function.
 
 \rSec3[unique.ptr.dltr]{Default deleters}
 
-\rSec4[unique.ptr.dltr.general]{In general}
+\rSec4[unique.ptr.dltr.general]{General}
 
 \pnum
 The class template \tcode{default_delete} serves as the default deleter (destruction policy)

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -15,7 +15,7 @@ These facilities are summarized in \tref{meta.summary}.
 
 \rSec1[intseq]{Compile-time integer sequences}
 
-\rSec2[intseq.general]{In general}
+\rSec2[intseq.general]{General}
 
 \pnum
 The library provides a class template that can represent an integer sequence.
@@ -2520,7 +2520,7 @@ static_assert(*engaged);
 
 \rSec1[ratio]{Compile-time rational arithmetic}
 
-\rSec2[ratio.general]{In general}
+\rSec2[ratio.general]{General}
 
 \pnum
 \indexlibraryglobal{ratio}%

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -3073,7 +3073,7 @@ template<class Sseq> explicit subtract_with_carry_engine(Sseq& q);
 
 \rSec2[rand.adapt]{Random number engine adaptor class templates}
 
-\rSec3[rand.adapt.general]{In general}
+\rSec3[rand.adapt.general]{General}
 
 \pnum
 Each type instantiated
@@ -4138,7 +4138,7 @@ than the output when computing $S$.
 \rSec2[rand.dist]{Random number distribution class templates}%
 \indextext{random number generation!distributions|(}
 
-\rSec3[rand.dist.general]{In general}
+\rSec3[rand.dist.general]{General}
 
 \pnum
 Each type instantiated

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -169,7 +169,7 @@ the implementation as specified in~\ref{time.clock} do not throw exceptions.
 
 \rSec2[thread.req.lockable]{Requirements for \oldconcept{Lockable} types}
 
-\rSec3[thread.req.lockable.general]{In general}
+\rSec3[thread.req.lockable.general]{General}
 
 \pnum
 An \defn{execution agent} is an entity such as a thread that may perform work in parallel with
@@ -6208,7 +6208,7 @@ namespace std {
 
 \rSec2[thread.mutex.requirements]{Mutex requirements}
 
-\rSec3[thread.mutex.requirements.general]{In general}
+\rSec3[thread.mutex.requirements.general]{General}
 
 \pnum
 A mutex object facilitates protection against data races and allows safe synchronization of

--- a/source/time.tex
+++ b/source/time.tex
@@ -3921,7 +3921,7 @@ The best well-formed clock time conversion expression in the above list.
 
 \rSec1[time.cal]{The civil calendar}
 
-\rSec2[time.cal.general]{In general}
+\rSec2[time.cal.general]{General}
 
 \pnum
 The types in \ref{time.cal} describe the civil (Gregorian) calendar
@@ -8732,7 +8732,7 @@ the value returned is unspecified.
 
 \rSec1[time.zone]{Time zones}
 
-\rSec2[time.zone.general]{In general}
+\rSec2[time.zone.general]{General}
 
 \pnum
 \ref{time.zone} describes an interface for accessing

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -711,7 +711,7 @@ int b = f(3);           // undefined behavior
 
 \rSec1[pairs]{Pairs}
 
-\rSec2[pairs.general]{In general}
+\rSec2[pairs.general]{General}
 
 \pnum
 The library provides a template for heterogeneous pairs of values.
@@ -1482,7 +1482,7 @@ for piecewise construction of the elements of the \tcode{pair} object.
 
 \rSec1[tuple]{Tuples}
 
-\rSec2[tuple.general]{In general}
+\rSec2[tuple.general]{General}
 
 \pnum
 \indexlibraryglobal{tuple}%
@@ -3144,7 +3144,7 @@ noexcept(x.swap(y))
 
 \rSec1[optional]{Optional objects}
 
-\rSec2[optional.general]{In general}
+\rSec2[optional.general]{General}
 
 \pnum
 Subclause~\ref{optional} describes class template \tcode{optional} that represents
@@ -4864,7 +4864,7 @@ The member functions are not guaranteed to be \keyword{noexcept}.
 
 \rSec1[variant]{Variants}
 
-\rSec2[variant.general]{In general}
+\rSec2[variant.general]{General}
 
 \pnum
 A variant object holds and manages the lifetime of a value.
@@ -6985,7 +6985,7 @@ bool is_string(const any& operand) {
 \rSec1[expected]{Expected objects}
 \indexlibraryglobal{expected}%
 
-\rSec2[expected.general]{In general}
+\rSec2[expected.general]{General}
 
 \pnum
 Subclause \ref{expected} describes the class template \tcode{expected}
@@ -15114,7 +15114,7 @@ For an object \tcode{index} of type \tcode{type_index},
 \end{itemdescr}
 
 \rSec1[execpol]{Execution policies}
-\rSec2[execpol.general]{In general}
+\rSec2[execpol.general]{General}
 
 \pnum
 Subclause~\ref{execpol} describes classes that are \defn{execution policy} types. An
@@ -15847,7 +15847,7 @@ has the template parameters, data members, and special members specified above. 
 
 \rSec2[format.string]{Format string}
 
-\rSec3[format.string.general]{In general}
+\rSec3[format.string.general]{General}
 
 \pnum
 A \defn{format string} for arguments \tcode{args} is


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

- [ ] Why is this clause named "In general"? Please change to "General".