### PR TITLE
[macros] Avoid small caps for cross-references to C.

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -371,8 +371,8 @@
 \newcommand{\templalias}{\Fundesc{Alias template}}
 
 %% Cross-reference
-\newcommand{\xref}{\textsc{See also:}\space}
-\newcommand{\xrefc}[1]{\xref{} \IsoC{}, #1}
+\newcommand{\xref}[1]{\textsc{See also:}\space #1}
+\newcommand{\xrefc}[1]{\xref{\IsoC{}, #1}}
 \newcommand{\termref}[3]{\textit{#2}{#3}\iref{#1}} % in Clause 3
 
 %% Inline comma-separated parenthesized references

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -371,7 +371,7 @@
 \newcommand{\templalias}{\Fundesc{Alias template}}
 
 %% Cross-reference
-\newcommand{\xref}[1]{\textsc{See also:}\space #1}
+\newcommand{\xref}[1]{See also #1.}
 \newcommand{\xrefc}[1]{\xref{\IsoC{}, #1}}
 \newcommand{\termref}[3]{\textit{#2}{#3}\iref{#1}} % in Clause 3
 

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -686,7 +686,7 @@ sensitive.%
 \tcode{ECMAScript} &
 Specifies that the grammar recognized by the regular expression engine
 shall be that used by ECMAScript in ECMA-262, as modified in~\ref{re.grammar}.
-\newline \xref ECMA-262 15.10
+\newline \xref{ECMA-262 15.10}
 \indextext{ECMAScript}%
 \indexlibrarymember{syntax_option_type}{ECMAScript}%
 \\ \rowsep
@@ -694,7 +694,7 @@ shall be that used by ECMAScript in ECMA-262, as modified in~\ref{re.grammar}.
 \tcode{basic} &
 Specifies that the grammar recognized by the regular expression engine
 shall be that used by basic regular expressions in POSIX.
-\newline \xref POSIX, Base Definitions and Headers, Section 9.3
+\newline \xref{POSIX, Base Definitions and Headers, Section 9.3}
 \indextext{POSIX!regular expressions}%
 \indexlibrarymember{syntax_option_type}{basic}%
 \\ \rowsep
@@ -702,7 +702,7 @@ shall be that used by basic regular expressions in POSIX.
 \tcode{extended} &
 Specifies that the grammar recognized by the regular expression engine
 shall be that used by extended regular expressions in POSIX.
-\newline \xref POSIX, Base Definitions and Headers, Section 9.4
+\newline \xref{POSIX, Base Definitions and Headers, Section 9.4}
 \indextext{POSIX!extended regular expressions}%
 \indexlibrarymember{syntax_option_type}{extended}%
 \\ \rowsep
@@ -3997,5 +3997,5 @@ of characters, a character \tcode{c} is a member of a character class designated
 iterator range \range{first}{last} if
 \tcode{traits_inst.isctype(c, traits_inst.lookup_classname(first, last, flags() \& icase))} is \tcode{true}.
 \end{itemize}
-\xref ECMA-262 15.10
+\xref{ECMA-262 15.10}
 \indextext{regular expression|)}


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

- [ ] Please remove all caps. Change to "See also..." or make this NOTE 2, if it is necessary to use capital letters for this information.
- [ ] Remove all caps and make this a full sentence i.e."See ISO/IEC 9899...."
- [ ] Please remove all caps and change to a full sentence i.e. "See also ISO/IEC 9899...."
- [ ] remove all caps and change to a full sentence "See ISO/IEC ..."
- [ ] idem: change to "See also ISO/IEC 9899:2018, 7.8."
- [ ] Please modify to a full sentence with no all caps text i.e. "See also ECMA-262, 15.10."