### PR TITLE
[fs.class.path.general] Defuse cross-reference to POSIX

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -13627,7 +13627,8 @@ is the operating system dependent mechanism for resolving
 a pathname to a particular file in a file hierarchy. There may be multiple
 pathnames that resolve to the same file.
 \begin{example}
-POSIX specifies the mechanism in section 4.12, Pathname resolution.
+For POSIX-based operating systems,
+this mechanism is specified in POSIX, section 4.12, Pathname resolution.
 \end{example}
 
 \begin{codeblock}


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

- [ ] where is section 4.12? Is this in the POSIX document? If so, please be more specific i.e. "The pathname resolution mechanism is described in POSIX, section 4.12."