### PR TITLE
[macros,numerics] Add and use numbered 'formula' environment

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -615,6 +615,17 @@
 \makeatother
 
 %%--------------------------------------------------
+%% Formulae
+%%--------------------------------------------------
+
+% usage: \begin{formula}{XREF}
+\newenvironment{formula}[1]
+{\begin{equation}\label{eq:#1}}
+{\end{equation}}
+
+\renewcommand{\eqref}[1]{Formula \nolinebreak[3] \hyperref[eq:#1]{\ref*{eq:#1}}}
+
+%%--------------------------------------------------
 %% Indented text
 %%--------------------------------------------------
 \newenvironment{indented}[1][]

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -4074,11 +4074,10 @@ Let
 \end{itemize}
 An \defn{attempt} is $k$ invocations of \tcode{g()}
 to obtain values $g_0, \dotsc, g_{k-1}$, respectively,
-and the calculation of a quantity
- \[
-   S = \sum_{i=0}^{k-1} (g_i - \tcode{g.min()})
-                        \cdot R^i
- \]
+and the calculation of a quantity $S$ given by \eqref{rand.gencanonical}:
+\begin{formula}{rand.gencanonical}
+S = \sum_{i=0}^{k-1} (g_i - \tcode{g.min()}) \cdot R^i
+\end{formula}
 
 \pnum
 \effects
@@ -4191,8 +4190,11 @@ A \tcode{uniform_int_distribution} random number distribution
 produces random integers $i$,
 $a \leq i \leq b$,
 distributed according to
-the constant discrete probability function%
-\[  P(i\,|\,a,b) = 1 / (b - a + 1) \text{ .} \]
+the constant discrete probability function in \eqref{rand.dist.uni.int}.
+
+\begin{formula}{rand.dist.uni.int}
+P(i\,|\,a,b) = 1 / (b - a + 1)
+\end{formula}
 
 \indexlibraryglobal{uniform_int_distribution}%
 \indexlibrarymember{result_type}{uniform_int_distribution}%
@@ -4291,8 +4293,10 @@ A \tcode{uniform_real_distribution} random number distribution
 produces random numbers $x$,
 $a \leq x < b$,
 distributed according to
-the constant probability density function%
-\[ p(x\,|\,a,b) = 1 / (b - a) \text{ .} \]
+the constant probability density function in \eqref{rand.dist.uni.real}.
+\begin{formula}{rand.dist.uni.real}
+p(x\,|\,a,b) = 1 / (b - a)
+\end{formula}
 \begin{note}
 This implies that $p(x\,|\,a,b)$ is undefined when \tcode{a == b}.
 \end{note}
@@ -4409,12 +4413,13 @@ The value of the \tcode{b} parameter
 A \tcode{bernoulli_distribution} random number distribution
 produces \tcode{bool} values $b$
 distributed according to
-the discrete probability function
-\[  P(b\,|\,p) = \left\{ \begin{array}{ll}
+the discrete probability function in \eqref{rand.dist.bern.bernoulli}.
+\begin{formula}{rand.dist.bern.bernoulli}
+P(b\,|\,p) = \left\{ \begin{array}{ll}
                           p     & \text{ if $b = \tcode{true}$, or} \\
                           1 - p & \text{ if $b = \tcode{false}$.}
                           \end{array}\right.
-\]
+\end{formula}
 
 \indexlibraryglobal{bernoulli_distribution}%
 \indexlibrarymember{result_type}{bernoulli_distribution}%
@@ -4498,8 +4503,11 @@ The value of the \tcode{p} parameter
 A \tcode{binomial_distribution} random number distribution
 produces integer values $i \geq 0$
 distributed according to
-the discrete probability function%
-\[ P(i\,|\,t,p) = \binom{t}{i} \cdot p^i \cdot (1-p)^{t-i} \text{ .} \]
+the discrete probability function in \eqref{rand.dist.bern.bin}.
+
+\begin{formula}{rand.dist.bern.bin}
+P(i\,|\,t,p) = \binom{t}{i} \cdot p^i \cdot (1-p)^{t-i}
+\end{formula}
 
 \indexlibraryglobal{binomial_distribution}%
 \indexlibrarymember{result_type}{binomial_distribution}%
@@ -4596,8 +4604,10 @@ The value of the \tcode{p} parameter
 A \tcode{geometric_distribution} random number distribution
 produces integer values $i \geq 0$
 distributed according to
-the discrete probability function
-\[ P(i\,|\,p) = p \cdot (1-p)^{i} \text{ .} \]
+the discrete probability function in \eqref{rand.dist.bern.geo}.
+\begin{formula}{rand.dist.bern.geo}
+P(i\,|\,p) = p \cdot (1-p)^{i}
+\end{formula}
 
 \indexlibraryglobal{geometric_distribution}%
 \indexlibrarymember{result_type}{geometric_distribution}%
@@ -4683,8 +4693,10 @@ The value of the \tcode{p} parameter
 A \tcode{negative_binomial_distribution} random number distribution
 produces random integers $i \geq 0$
 distributed according to
-the discrete probability function
-\[ P(i\,|\,k,p) = \binom{k+i-1}{i} \cdot p^k \cdot (1-p)^i \text{ .} \]
+the discrete probability function in \eqref{rand.dist.bern.negbin}.
+\begin{formula}{rand.dist.bern.negbin}
+P(i\,|\,k,p) = \binom{k+i-1}{i} \cdot p^k \cdot (1-p)^i
+\end{formula}
 \begin{note}
 This implies that $P(i\,|\,k,p)$ is undefined when \tcode{p == 1}.
 \end{note}
@@ -4800,11 +4812,12 @@ The value of the \tcode{p} parameter
 A \tcode{poisson_distribution} random number distribution
 produces integer values $i \geq 0$
 distributed according to
-the discrete probability function
-\[ P(i\,|\,\mu) = \frac{e^{-\mu} \mu^{i}}{i\,!} \text{ .} \]
+the discrete probability function in \eqref{rand.dist.pois.poisson}.
+\begin{formula}{rand.dist.pois.poisson}
+P(i\,|\,\mu) = \frac{e^{-\mu} \mu^{i}}{i\,!}
+\end{formula}
 The distribution parameter $\mu$
-is also known as this distribution's \term{mean}%
-.
+is also known as this distribution's \term{mean}.
 
 \indexlibraryglobal{poisson_distribution}%
 \indexlibrarymember{result_type}{poisson_distribution}%
@@ -4887,8 +4900,10 @@ The value of the \tcode{mean} parameter
 An \tcode{exponential_distribution} random number distribution
 produces random numbers $x > 0$
 distributed according to
-the probability density function%
-\[ p(x\,|\,\lambda) = \lambda e^{-\lambda x} \text{ .} \]
+the probability density function in \eqref{rand.dist.pois.exp}.
+\begin{formula}{rand.dist.pois.exp}
+p(x\,|\,\lambda) = \lambda e^{-\lambda x}
+\end{formula}
 
 \indexlibraryglobal{exponential_distribution}%
 \indexlibrarymember{result_type}{exponential_distribution}%
@@ -4972,10 +4987,11 @@ The value of the \tcode{lambda} parameter
 A \tcode{gamma_distribution} random number distribution
 produces random numbers $x > 0$
 distributed according to
-the probability density function%
-\[ p(x\,|\,\alpha,\beta) =
+the probability density function in \eqref{rand.dist.pois.gamma}.
+\begin{formula}{rand.dist.pois.gamma}
+p(x\,|\,\alpha,\beta) =
      \frac{e^{-x/\beta}}{\beta^{\alpha} \cdot \Gamma(\alpha)} \, \cdot \, x^{\, \alpha-1}
-     \text{ .} \]
+\end{formula}
 
 \indexlibraryglobal{gamma_distribution}%
 \indexlibrarymember{result_type}{gamma_distribution}%
@@ -5074,11 +5090,12 @@ The value of the \tcode{beta} parameter
 A \tcode{weibull_distribution} random number distribution
 produces random numbers $x \geq 0$
 distributed according to
-the probability density function%
-\[ p(x\,|\,a,b) = \frac{a}{b}
+the probability density function in \eqref{rand.dist.pois.weibull}.
+\begin{formula}{rand.dist.pois.weibull}
+p(x\,|\,a,b) = \frac{a}{b}
      \cdot \left(\frac{x}{b}\right)^{a-1}
      \cdot \, \exp\left( -\left(\frac{x}{b}\right)^a\right)
-     \text{ .} \]
+\end{formula}
 
 \indexlibraryglobal{weibull_distribution}%
 \indexlibrarymember{result_type}{weibull_distribution}%
@@ -5176,7 +5193,7 @@ The value of the \tcode{b} parameter
 An \tcode{extreme_value_distribution} random number distribution
 produces random numbers $x$
 distributed according to
-the probability density function
+the probability density function in \eqref{rand.dist.pois.extreme}.
 \begin{footnote}
 The distribution corresponding to
  this probability density function
@@ -5187,9 +5204,10 @@ The distribution corresponding to
  or the Fisher-Tippett Type I
  distribution.
 \end{footnote}
-\[ p(x\,|\,a,b) = \frac{1}{b}
+\begin{formula}{rand.dist.pois.extreme}
+p(x\,|\,a,b) = \frac{1}{b}
      \cdot \exp\left(\frac{a-x}{b} - \exp\left(\frac{a-x}{b}\right)\right)
-     \text{ .} \]
+\end{formula}
 
 \indexlibraryglobal{extreme_value_distribution}%
 \indexlibrarymember{result_type}{extreme_value_distribution}%
@@ -5301,8 +5319,8 @@ The value of the \tcode{b} parameter
 A \tcode{normal_distribution} random number distribution
 produces random numbers $x$
 distributed according to
-the probability density function%
-\[%
+the probability density function in \eqref{rand.dist.norm.normal}.
+\begin{formula}{rand.dist.norm.normal}
  p(x\,|\,\mu,\sigma)
       = \frac{1}{\sigma \sqrt{2\pi}}
         \cdot
@@ -5311,8 +5329,7 @@ the probability density function%
                              {2 \sigma^2}
              \right)
             }
- \text{ .}
-\]
+\end{formula}
 The distribution parameters $\mu$ and $\sigma$
 are also known as this distribution's \term{mean}
 and \term{standard deviation}.
@@ -5414,10 +5431,11 @@ The value of the \tcode{stddev} parameter
 A \tcode{lognormal_distribution} random number distribution
 produces random numbers $x > 0$
 distributed according to
-the probability density function%
-\[ p(x\,|\,m,s) = \frac{1}{s x \sqrt{2 \pi}}
+the probability density function in \eqref{rand.dist.norm.lognormal}.
+\begin{formula}{rand.dist.norm.lognormal}
+p(x\,|\,m,s) = \frac{1}{s x \sqrt{2 \pi}}
      \cdot \exp{\left(-\frac{(\ln{x} - m)^2}{2 s^2}\right)}
-     \text{ .} \]
+\end{formula}
 
 \indexlibraryglobal{lognormal_distribution}%
 \indexlibrarymember{result_type}{lognormal_distribution}%
@@ -5516,8 +5534,10 @@ The value of the \tcode{s} parameter
 A \tcode{chi_squared_distribution} random number distribution
 produces random numbers $x > 0$
 distributed according to
-the probability density function%
-\[ p(x\,|\,n) = \frac{x^{(n/2)-1} \cdot e^{-x/2}}{\Gamma(n/2) \cdot 2^{n/2}} \text{ .} \]
+the probability density function in \eqref{rand.dist.norm.chisq}.
+\begin{formula}{rand.dist.norm.chisq}
+p(x\,|\,n) = \frac{x^{(n/2)-1} \cdot e^{-x/2}}{\Gamma(n/2) \cdot 2^{n/2}}
+\end{formula}
 
 \indexlibraryglobal{chi_squared_distribution}%
 \indexlibrarymember{result_type}{chi_squared_distribution}%
@@ -5602,8 +5622,10 @@ The value of the \tcode{n} parameter
 A \tcode{cauchy_distribution} random number distribution
 produces random numbers $x$
 distributed according to
-the probability density function%
-\[  p(x\,|\,a,b) = \left(\pi b \left(1 + \left(\frac{x-a}{b} \right)^2 \, \right)\right)^{-1} \text{ .} \]
+the probability density function in \eqref{rand.dist.norm.cauchy}.
+\begin{formula}{rand.dist.norm.cauchy}
+p(x\,|\,a,b) = \left(\pi b \left(1 + \left(\frac{x-a}{b} \right)^2 \, \right)\right)^{-1}
+\end{formula}
 
 \indexlibraryglobal{cauchy_distribution}%
 \indexlibrarymember{result_type}{cauchy_distribution}%
@@ -5702,12 +5724,13 @@ The value of the \tcode{b} parameter
 A \tcode{fisher_f_distribution} random number distribution
 produces random numbers $x \ge 0$
 distributed according to
-the probability density function%
-\[ p(x\,|\,m,n) = \frac{\Gamma\big((m+n)/2\big)}{\Gamma(m/2) \; \Gamma(n/2)}
+the probability density function in \eqref{rand.dist.norm.f}.
+\begin{formula}{rand.dist.norm.f}
+p(x\,|\,m,n) = \frac{\Gamma\big((m+n)/2\big)}{\Gamma(m/2) \; \Gamma(n/2)}
      \cdot \left(\frac{m}{n}\right)^{m/2}
      \cdot x^{(m/2)-1}
      \cdot \left(1 + \frac{m x}{n}\right)^{-(m + n)/2}
-     \text{ .} \]
+\end{formula}
 
 \indexlibraryglobal{fisher_f_distribution}%
 \indexlibrarymember{result_type}{fisher_distribution}%
@@ -5806,11 +5829,12 @@ The value of the \tcode{n} parameter
 A \tcode{student_t_distribution} random number distribution
 produces random numbers $x$
 distributed according to
-the probability density function%
-\[ p(x\,|\,n) = \frac{1}{\sqrt{n \pi}}
+the probability density function in \eqref{rand.dist.norm.t}.
+\begin{formula}{rand.dist.norm.t}
+p(x\,|\,n) = \frac{1}{\sqrt{n \pi}}
      \cdot \frac{\Gamma\big((n+1)/2\big)}{\Gamma(n/2)}
      \cdot \left(1 + \frac{x^2}{n} \right)^{-(n+1)/2}
-     \text{ .} \]
+\end{formula}
 
 \indexlibraryglobal{student_t_distribution}%
 \indexlibrarymember{result_type}{student_t_distribution}%
@@ -5909,8 +5933,10 @@ The value of the \tcode{n} parameter
 A \tcode{discrete_distribution} random number distribution
 produces random integers $i$, $0 \leq i < n$,
 distributed according to
-the discrete probability function%
-\[  P(i \,|\, p_0, \dotsc, p_{n-1}) = p_i \text{ .} \]
+the discrete probability function in \eqref{rand.dist.samp.discrete}.
+\begin{formula}{rand.dist.samp.discrete}
+P(i \,|\, p_0, \dotsc, p_{n-1}) = p_i
+\end{formula}
 
 \pnum
 Unless specified otherwise,
@@ -6011,7 +6037,7 @@ double>} is \tcode{true}.
 \pnum
 \effects
 Constructs a \tcode{discrete_distribution} object
-with probabilities given by the formula above.
+with probabilities given by the \eqref{rand.dist.samp.discrete}.
 \end{itemdescr}
 
 
@@ -6088,9 +6114,11 @@ produces random numbers $x$,
 $b_0 \leq x < b_n$,
 uniformly distributed over each subinterval
 $[ b_i, b_{i+1} )$
-according to the probability density function
-\[ p(x \,|\, b_0, \dotsc, b_n, \; \rho_0, \dotsc, \rho_{n-1}) = \rho_i
-   \text{ , for $b_i \le x < b_{i+1}$.} \]
+according to the probability density function in \eqref{rand.dist.samp.pconst}.
+\begin{formula}{rand.dist.samp.pconst}
+p(x \,|\, b_0, \dotsc, b_n, \; \rho_0, \dotsc, \rho_{n-1}) = \rho_i
+   \text{ , for $b_i \le x < b_{i+1}$.}
+\end{formula}
 
 \pnum
 The $n + 1$ distribution parameters $b_i$,
@@ -6324,11 +6352,13 @@ produces random numbers $x$,
 $b_0 \leq x < b_n$,
 distributed over each subinterval
 $[b_i, b_{i+1})$
-according to the probability density function
-\[ p(x \,|\, b_0, \dotsc, b_n, \; \rho_0, \dotsc, \rho_n)
+according to the probability density function in \eqref{rand.dist.samp.plinear}.
+\begin{formula}{rand.dist.samp.plinear}
+p(x \,|\, b_0, \dotsc, b_n, \; \rho_0, \dotsc, \rho_n)
      = \rho_{i}   \cdot {\frac{b_{i+1} - x}{b_{i+1} - b_i}}
      + \rho_{i+1} \cdot {\frac{x - b_i}{b_{i+1} - b_i}}
-     \text{ , for $b_i \le x < b_{i+1}$.} \]
+     \text{ , for $b_i \le x < b_{i+1}$.}
+\end{formula}
 
 \pnum
 The $n + 1$ distribution parameters $b_i$,
@@ -9648,13 +9678,16 @@ of their respective arguments
 
 \pnum
 \returns
-\[ \mathsf{L}_n^m(x) =
-   (-1)^m \frac{\mathsf{d} ^ m}{\mathsf{d}x ^ m} \, \mathsf{L}_{n+m}(x)
-   \text{ ,\quad for $x \ge 0$,} \]
-where
+$\mathsf{L}_n^m(x)$,
+where $\mathsf{L}_n^m$ is given by \eqref{sf.cmath.assoc.laguerre},
 $n$ is \tcode{n},
 $m$ is \tcode{m}, and
 $x$ is \tcode{x}.
+\begin{formula}{sf.cmath.assoc.laguerre}
+\mathsf{L}_n^m(x) =
+   (-1)^m \frac{\mathsf{d} ^ m}{\mathsf{d}x ^ m} \, \mathsf{L}_{n+m}(x)
+   \text{ ,\quad for $x \ge 0$}
+\end{formula}
 
 \pnum
 \remarks
@@ -9686,13 +9719,16 @@ of their respective arguments
 
 \pnum
 \returns
-\[ \mathsf{P}_\ell^m(x) = (1 - x^2) ^ {m/2} \:
-   \frac{\mathsf{d} ^ m}{\mathsf{d}x ^ m} \, \mathsf{P}_\ell(x)
-   \text{ ,\quad for $|x| \le 1$,} \]
-where
+$\mathsf{P}_\ell^m(x)$,
+where $\mathsf{P}_\ell^m$ is given by \eqref{sf.cmath.assoc.legendre},
 $l$ is \tcode{l},
 $m$ is \tcode{m}, and
 $x$ is \tcode{x}.
+\begin{formula}{sf.cmath.assoc.legendre}
+\mathsf{P}_\ell^m(x) = (1 - x^2) ^ {m/2} \:
+   \frac{\mathsf{d} ^ m}{\mathsf{d}x ^ m} \, \mathsf{P}_\ell(x)
+   \text{ ,\quad for $|x| \le 1$}
+\end{formula}
 
 \pnum
 \remarks
@@ -9723,11 +9759,14 @@ of their respective arguments
 
 \pnum
 \returns
-\[ \mathsf{B}(x, y) = \frac{\Gamma(x) \, \Gamma(y)}{\Gamma(x + y)}
-   \text{ ,\quad for $x > 0$,\, $y > 0$,} \]
-where
+$\mathsf{B}(x, y)$,
+where $\mathsf{B}$ is given by \eqref{sf.cmath.beta},
 $x$ is \tcode{x} and
 $y$ is \tcode{y}.
+\begin{formula}{sf.cmath.beta}
+\mathsf{B}(x, y) = \frac{\Gamma(x) \, \Gamma(y)}{\Gamma(x + y)}
+   \text{ ,\quad for $x > 0$,\, $y > 0$}
+\end{formula}
 \end{itemdescr}
 
 \rSec3[sf.cmath.comp.ellint.1]{Complete elliptic integral of the first kind}%
@@ -9752,9 +9791,12 @@ of their respective arguments
 
 \pnum
 \returns
-\[ \mathsf{K}(k) = \mathsf{F}(k, \pi / 2) \text{ ,\quad for $|k| \le 1$,} \]
-where
+$\mathsf{K}(k)$,
+where $\mathsf{K}$ is given by \eqref{sf.cmath.comp.ellint.1} and
 $k$ is \tcode{k}.
+\begin{formula}{sf.cmath.comp.ellint.1}
+\mathsf{K}(k) = \mathsf{F}(k, \pi / 2) \text{ ,\quad for $|k| \le 1$}
+\end{formula}
 
 \pnum
 See also \ref{sf.cmath.ellint.1}.
@@ -9782,9 +9824,12 @@ of their respective arguments
 
 \pnum
 \returns
-\[ \mathsf{E}(k) = \mathsf{E}(k, \pi / 2) \text{ ,\quad for $|k| \le 1$,} \]
-where
+$\mathsf{E}(k)$,
+where $\mathsf{E}$ is given by \eqref{sf.cmath.comp.ellint.2} and
 $k$ is \tcode{k}.
+\begin{formula}{sf.cmath.comp.ellint.2}
+\mathsf{E}(k) = \mathsf{E}(k, \pi / 2) \text{ ,\quad for $|k| \le 1$}
+\end{formula}
 
 \pnum
 See also \ref{sf.cmath.ellint.2}.
@@ -9812,10 +9857,13 @@ of their respective arguments
 
 \pnum
 \returns
-\[ \mathsf{\Pi}(\nu, k) = \mathsf{\Pi}(\nu, k, \pi / 2) \text{ ,\quad for $|k| \le 1$,} \]
-where
-$k$ is \tcode{k} and
+$\mathsf{\Pi}(\nu, k)$,
+where $\mathsf{\Pi}$ is given by \eqref{sf.cmath.comp.ellint.3},
+$k$ is \tcode{k}, and
 $\nu$ is \tcode{nu}.
+\begin{formula}{sf.cmath.comp.ellint.3}
+\mathsf{\Pi}(\nu, k) = \mathsf{\Pi}(\nu, k, \pi / 2) \text{ ,\quad for $|k| \le 1$}
+\end{formula}
 
 \pnum
 See also \ref{sf.cmath.ellint.3}.
@@ -9843,13 +9891,16 @@ of their respective arguments
 
 \pnum
 \returns
-\[ \mathsf{I}_\nu(x) =
+$\mathsf{I}_\nu(x)$,
+where $\mathsf{I}_\nu$ is given by \eqref{sf.cmath.cyl.bessel.i},
+$\nu$ is \tcode{nu}, and
+$x$ is \tcode{x}.
+\begin{formula}{sf.cmath.cyl.bessel.i}
+\mathsf{I}_\nu(x) =
      \mathrm{i}^{-\nu} \mathsf{J}_\nu(\mathrm{i}x) =
      \sum_{k=0}^\infty \frac{(x/2)^{\nu+2k}}{k! \: \Gamma(\nu+k+1)}
-     \text{ ,\quad for $x \ge 0$,} \]
-where
-$\nu$ is \tcode{nu} and
-$x$ is \tcode{x}.
+     \text{ ,\quad for $x \ge 0$}
+\end{formula}
 
 \pnum
 \remarks
@@ -9884,12 +9935,15 @@ of their respective arguments
 
 \pnum
 \returns
-\[ \mathsf{J}_\nu(x) =
-   \sum_{k=0}^\infty \frac{(-1)^k (x/2)^{\nu+2k}}{k! \: \Gamma(\nu+k+1)}
-   \text{ ,\quad for $x \ge 0$,} \]
-where
-$\nu$ is \tcode{nu} and
+$\mathsf{J}_\nu(x)$,
+where $\mathsf{J}_\nu$ is given by \eqref{sf.cmath.cyl.bessel.j},
+$\nu$ is \tcode{nu}, and
 $x$ is \tcode{x}.
+\begin{formula}{sf.cmath.cyl.bessel.j}
+\mathsf{J}_\nu(x) =
+   \sum_{k=0}^\infty \frac{(-1)^k (x/2)^{\nu+2k}}{k! \: \Gamma(\nu+k+1)}
+   \text{ ,\quad for $x \ge 0$}
+\end{formula}
 
 \pnum
 \remarks
@@ -9921,7 +9975,11 @@ of their respective arguments
 
 \pnum
 \returns
-\[%
+$\mathsf{K}_\nu(x)$,
+where $\mathsf{K}_\nu$ is given by \eqref{sf.cmath.cyl.bessel.k},
+$\nu$ is \tcode{nu}, and
+$x$ is \tcode{x}.
+\begin{formula}{sf.cmath.cyl.bessel.k}
   \mathsf{K}_\nu(x) =
   (\pi/2)\mathrm{i}^{\nu+1} (            \mathsf{J}_\nu(\mathrm{i}x)
 			    + \mathrm{i} \mathsf{N}_\nu(\mathrm{i}x)
@@ -9943,10 +10001,7 @@ of their respective arguments
   & \mbox{for $x \ge 0$ and integral $\nu$}
   \end{array}
   \right.
-\]
-where
-$\nu$ is \tcode{nu} and
-$x$ is \tcode{x}.
+\end{formula}
 
 \pnum
 \remarks
@@ -9982,7 +10037,11 @@ of their respective arguments
 
 \pnum
 \returns
-\[%
+$\mathsf{N}_\nu(x)$,
+where $\mathsf{N}_\nu$ is given by \eqref{sf.cmath.cyl.neumann},
+$\nu$ is \tcode{nu}, and
+$x$ is \tcode{x}.
+\begin{formula}{sf.cmath.cyl.neumann}
   \mathsf{N}_\nu(x) =
   \left\{
   \begin{array}{cl}
@@ -9998,10 +10057,7 @@ of their respective arguments
   & \mbox{for $x \ge 0$ and integral $\nu$}
   \end{array}
   \right.
-\]
-where
-$\nu$ is \tcode{nu} and
-$x$ is \tcode{x}.
+\end{formula}
 
 \pnum
 \remarks
@@ -10035,12 +10091,15 @@ of their respective arguments
 
 \pnum
 \returns
-\[ \mathsf{F}(k, \phi) =
-     \int_0^\phi \! \frac{\mathsf{d}\theta}{\sqrt{1 - k^2 \sin^2 \theta}}
-     \text{ ,\quad for $|k| \le 1$,} \]
-where
-$k$ is \tcode{k} and
+$\mathsf{F}(k, \phi)$,
+where $\mathsf{F}$ is given by \eqref{sf.cmath.ellint.1},
+$k$ is \tcode{k}, and
 $\phi$ is \tcode{phi}.
+\begin{formula}{sf.cmath.ellint.1}
+\mathsf{F}(k, \phi) =
+     \int_0^\phi \! \frac{\mathsf{d}\theta}{\sqrt{1 - k^2 \sin^2 \theta}}
+     \text{ ,\quad for $|k| \le 1$}
+\end{formula}
 \end{itemdescr}
 
 \rSec3[sf.cmath.ellint.2]{Incomplete elliptic integral of the second kind}%
@@ -10065,11 +10124,14 @@ of their respective arguments
 
 \pnum
 \returns
-\[ \mathsf{E}(k, \phi) = \int_0^\phi \! \sqrt{1 - k^2 \sin^2 \theta} \, \mathsf{d}\theta
-   \text{ ,\quad for $|k| \le 1$,} \]
-where
-$k$ is \tcode{k} and
+$\mathsf{E}(k, \phi)$,
+where $\mathsf{E}$ is given by \eqref{sf.cmath.ellint.2},
+$k$ is \tcode{k}, and
 $\phi$ is \tcode{phi}.
+\begin{formula}{sf.cmath.ellint.2}
+\mathsf{E}(k, \phi) = \int_0^\phi \! \sqrt{1 - k^2 \sin^2 \theta} \, \mathsf{d}\theta
+   \text{ ,\quad for $|k| \le 1$}
+\end{formula}
 \end{itemdescr}
 
 \rSec3[sf.cmath.ellint.3]{Incomplete elliptic integral of the third kind}%
@@ -10096,12 +10158,15 @@ of their respective arguments
 
 \pnum
 \returns
-\[ \mathsf{\Pi}(\nu, k, \phi) = \int_0^\phi \!
-   \frac{ \mathsf{d}\theta }{ (1 - \nu \, \sin^2 \theta) \sqrt{1 - k^2 \sin^2 \theta} } \text{ ,\quad for $|k| \le 1$,} \]
-where
+$\mathsf{\Pi}(\nu, k, \phi)$,
+where $\mathsf{\Pi}$ is given by \eqref{sf.cmath.ellint.3},
 $\nu$ is \tcode{nu},
 $k$ is \tcode{k}, and
 $\phi$ is \tcode{phi}.
+\begin{formula}{sf.cmath.ellint.3}
+\mathsf{\Pi}(\nu, k, \phi) = \int_0^\phi \!
+   \frac{ \mathsf{d}\theta }{ (1 - \nu \, \sin^2 \theta) \sqrt{1 - k^2 \sin^2 \theta} } \text{ ,\quad for $|k| \le 1$}
+\end{formula}
 \end{itemdescr}
 
 \rSec3[sf.cmath.expint]{Exponential integral}%
@@ -10126,15 +10191,14 @@ of their respective arguments
 
 \pnum
 \returns
-\[%
+$\mathsf{Ei}(x)$,
+where $\mathsf{Ei}$  is given by \eqref{sf.cmath.expint} and
+$x$ is \tcode{x}.
+\begin{formula}{sf.cmath.expint}
   \mathsf{Ei}(x) =
   - \int_{-x}^\infty \frac{e^{-t}}
                           {t     } \, \mathsf{d}t
-\;
-\]
-where
-$x$ is \tcode{x}.
-
+\end{formula}
 \end{itemdescr}
 
 \rSec3[sf.cmath.hermite]{Hermite polynomials}%
@@ -10158,15 +10222,15 @@ of their respective arguments
 
 \pnum
 \returns
-\[%
+$\mathsf{H}_n(x)$,
+where $\mathsf{H}_n$ is given by \eqref{sf.cmath.hermite},
+$n$ is \tcode{n}, and
+$x$ is \tcode{x}.
+\begin{formula}{sf.cmath.hermite}
   \mathsf{H}_n(x) =
   (-1)^n e^{x^2} \frac{ \mathsf{d} ^n}
 		      { \mathsf{d}x^n} \, e^{-x^2}
-\;
-\]
-where
-$n$ is \tcode{n} and
-$x$ is \tcode{x}.
+\end{formula}
 
 \pnum
 \remarks
@@ -10196,12 +10260,15 @@ of their respective arguments
 
 \pnum
 \returns
-\[ \mathsf{L}_n(x) =
-     \frac{e^x}{n!} \frac{\mathsf{d}^n}{\mathsf{d}x^n} \, (x^n e^{-x})
-     \text{ ,\quad for $x \ge 0$,} \]
-where
-$n$ is \tcode{n} and
+$\mathsf{L}_n(x)$,
+where $\mathsf{L}_n$ is given by \eqref{sf.cmath.laguerre},
+$n$ is \tcode{n}, and
 $x$ is \tcode{x}.
+\begin{formula}{sf.cmath.laguerre}
+\mathsf{L}_n(x) =
+     \frac{e^x}{n!} \frac{\mathsf{d}^n}{\mathsf{d}x^n} \, (x^n e^{-x})
+     \text{ ,\quad for $x \ge 0$}
+\end{formula}
 
 \pnum
 \remarks
@@ -10231,13 +10298,16 @@ respective arguments
 
 \pnum
 \returns
-\[ \mathsf{P}_\ell(x) =
+$\mathsf{P}_\ell(x)$,
+where $\mathsf{P}_\ell$ is given by \eqref{sf.cmath.legendre},
+$l$ is \tcode{l}, and
+$x$ is \tcode{x}.
+\begin{formula}{sf.cmath.legendre}
+\mathsf{P}_\ell(x) =
      \frac{1}{2^\ell \, \ell!}
      \frac{\mathsf{d}^\ell}{\mathsf{d}x^\ell} \, (x^2 - 1) ^ \ell
-     \text{ ,\quad for $|x| \le 1$,} \]
-where
-$l$ is \tcode{l} and
-$x$ is \tcode{x}.
+     \text{ ,\quad for $|x| \le 1$}
+\end{formula}
 
 \pnum
 \remarks
@@ -10267,7 +10337,10 @@ of their respective arguments
 
 \pnum
 \returns
-\[%
+$\mathsf{\zeta}(x)$,
+where $\mathsf{\zeta}$ is given by \eqref{sf.cmath.riemann.zeta} and
+$x$ is \tcode{x}.
+\begin{formula}{sf.cmath.riemann.zeta}
   \mathsf{\zeta}(x) =
   \left\{
   \begin{array}{cl}
@@ -10288,10 +10361,7 @@ of their respective arguments
   & \mbox{for $x < 0$}
   \end{array}
   \right.
-\;
-\]
-where
-$x$ is \tcode{x}.
+\end{formula}
 \end{itemdescr}
 
 \rSec3[sf.cmath.sph.bessel]{Spherical Bessel functions of the first kind}%
@@ -10316,10 +10386,13 @@ of their respective arguments
 
 \pnum
 \returns
-\[ \mathsf{j}_n(x) = (\pi/2x)^{1\!/\!2} \mathsf{J}_{n + 1\!/\!2}(x) \text{ ,\quad for $x \ge 0$,} \]
-where
-$n$ is \tcode{n} and
+$\mathsf{j}_n(x)$,
+where $\mathsf{j}_n$ is given by \eqref{sf.cmath.sph.bessel},
+$n$ is \tcode{n}, and
 $x$ is \tcode{x}.
+\begin{formula}{sf.cmath.sph.bessel}
+\mathsf{j}_n(x) = (\pi/2x)^{1\!/\!2} \mathsf{J}_{n + 1\!/\!2}(x) \text{ ,\quad for $x \ge 0$}
+\end{formula}
 
 \pnum
 \remarks
@@ -10353,17 +10426,17 @@ of their respective arguments
 
 \pnum
 \returns
-\[ \mathsf{Y}_\ell^m(\theta, 0) \]
-where
-\[ \mathsf{Y}_\ell^m(\theta, \phi) =
-     (-1)^m \left[\frac{(2 \ell + 1)}{4 \pi} \frac{(\ell - m)!}{(\ell + m)!}\right]^{1/2}
-     \mathsf{P}_\ell^m (\cos\theta) e^{i m \phi}
-     \text{ ,\quad for $|m| \le \ell$,}
-\]
-and
+$\mathsf{Y}_\ell^m(\theta, 0)$,
+where $\mathsf{Y}_\ell^m$ is given by \eqref{sf.cmath.sph.legendre},
 $l$ is \tcode{l},
 $m$ is \tcode{m}, and
 $\theta$ is \tcode{theta}.
+\begin{formula}{sf.cmath.sph.legendre}
+\mathsf{Y}_\ell^m(\theta, \phi) =
+     (-1)^m \left[\frac{(2 \ell + 1)}{4 \pi} \frac{(\ell - m)!}{(\ell + m)!}\right]^{1/2}
+     \mathsf{P}_\ell^m (\cos\theta) e^{i m \phi}
+     \text{ ,\quad for $|m| \le \ell$}
+\end{formula}
 
 \pnum
 \remarks
@@ -10398,11 +10471,14 @@ of their respective arguments
 
 \pnum
 \returns
-\[ \mathsf{n}_n(x) = (\pi/2x)^{1\!/\!2} \mathsf{N}_{n + 1\!/\!2}(x)
-   \text{ ,\quad for $x \ge 0$,} \]
-where
-$n$ is \tcode{n} and
+$\mathsf{n}_n(x)$,
+where $\mathsf{n}_n$ is given by \eqref{sf.cmath.sph.neumann},
+$n$ is \tcode{n}, and
 $x$ is \tcode{x}.
+\begin{formula}{sf.cmath.sph.neumann}
+\mathsf{n}_n(x) = (\pi/2x)^{1\!/\!2} \mathsf{N}_{n + 1\!/\!2}(x)
+   \text{ ,\quad for $x \ge 0$}
+\end{formula}
 
 \pnum
 \remarks

--- a/tools/check-output.sh
+++ b/tools/check-output.sh
@@ -36,7 +36,7 @@ rm -f tmp.txt
 
 # Find bad labels
 grep newlabel `ls *.aux | grep -v std.aux` | awk -F '{' '{ print  $2 }' |
-    sed 's/}//g' | sed 's/^tab://;s/fig://;s/idx.*\..//' |
+    sed 's/}//g' | sed 's/^tab://;s/fig://;s/eq://;s/idx.*\..//' |
     grep -v '^[a-z.0-9]*$' |
     sed 's/^\(.*\)$/bad label \1/' |
     fail || failed=1


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

- [ ] This is a formula which should be labelled Formula (1).  See  HYPERLINK "https://www.iso.org/sites/directives/current/part2/index.xhtml#_idTextAnchor410"ISO/IEC Directives Part 2, 2021, 27.4  "Please number mathematical formulae in the document, for cross-referencing purposes. Arabic numbers in parentheses shall be used, starting with 1. If a mathematical formula is numbered, it should also be referred to in the text and its purpose should be made clear by its context, for example, with an introductory proposition, e.g.  "see 10.1, Formula (3)".
- [ ] see comment above regarding Formulae
- [ ] this appears to be a formulae - please follow the ISO/IEC Directives Part 2, Clause 27