### PR TITLE
[futures.state] Turn note into example

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -10259,9 +10259,9 @@ An \defn{asynchronous provider} is an object that provides a result to a shared
 state.
 The result of a shared state is set by
 respective functions on the asynchronous provider.
-\begin{note}
-Such as promises or tasks.
-\end{note}
+\begin{example}
+Examples for asynchronous providers include promises or tasks.
+\end{example}
 The means of setting the result of a shared state is specified
 in the description of those classes and functions that create such a state object.
 

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -10260,7 +10260,7 @@ state.
 The result of a shared state is set by
 respective functions on the asynchronous provider.
 \begin{example}
-Examples for asynchronous providers include promises or tasks.
+Promises and tasks are examples of asynchronous providers.
 \end{example}
 The means of setting the result of a shared state is specified
 in the description of those classes and functions that create such a state object.


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

- [ ] Please make this a full sentence, or incorporate this text into the sentence above. It does not make sense on its own. If it is giving an example, consider changing is to "EXAMPLE Promises and tasks"