### PR TITLE
[diff] Replace 'this revision of C++' with 'this document'

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -91,7 +91,7 @@ The following \Cpp{} headers are new:
 \libheaderref{rcu}, and
 \libheaderrefx{text_encoding}{text.encoding.syn}.
 Valid \CppXXIII{} code that \tcode{\#include}{s} headers with these names may be
-invalid in this revision of \Cpp{}.
+invalid in this document.
 
 \rSec2[diff.cpp23.strings]{\ref{strings}: strings library}
 
@@ -121,7 +121,7 @@ auto s = std::to_string(1e-7);  // \tcode{"1e-07"}
 Permit passing a braced initializer list to a function taking \tcode{span}.
 \effect
 Valid \CppXXIII{} code that relies on the lack of this constructor
-may refuse to compile, or change behavior in this revision of \Cpp{}.
+may refuse to compile, or change behavior in this document.
 \begin{example}
 \begin{codeblock}
 void one(pair<int, int>);       // \#1
@@ -375,7 +375,7 @@ Deducing template arguments from exception specifications.
 \rationale
 Facilitate generic handling of throwing and non-throwing functions.
 \effect
-Valid ISO \CppXX{} code may be ill-formed in this revision of \Cpp{}.
+Valid ISO \CppXX{} code may be ill-formed in this document.
 \begin{example}
 \begin{codeblock}
 template<bool> struct A { };
@@ -407,7 +407,7 @@ The following \Cpp{} headers are new:
 \libheaderref{stdatomic.h}, and
 \libheaderref{stdfloat}.
 Valid \CppXX{} code that \tcode{\#include}{s} headers with these names may be
-invalid in this revision of \Cpp{}.
+invalid in this document.
 
 \rSec2[diff.cpp20.concepts]{\ref{concepts}: concepts library}
 
@@ -421,7 +421,7 @@ Allow uncopyable, but movable, types to model these concepts.
 \effect
 Valid \CppXX{} code relying on subsumption
 with \tcode{common_reference_with}
-may fail to compile in this revision of \Cpp{}.
+may fail to compile in this document.
 \begin{example}
 \begin{codeblock}
 template<class T, class U>
@@ -450,7 +450,7 @@ and potentially other members in the future.
 \effect
 Valid \CppXX{} code
 that partially or explicitly specializes \tcode{allocator_traits}
-is ill-formed with no diagnostic required in this revision of \Cpp{}.
+is ill-formed with no diagnostic required in this document.
 
 \rSec2[diff.cpp20.utilities]{\ref{utilities}: general utilities library}
 
@@ -541,7 +541,7 @@ Valid \CppXX{} code that created a substring
 by calling \tcode{substr} (or the corresponding constructor)
 on an xvalue expression with type \tcode{S}
 that is a specialization of \tcode{basic_string}
-may change meaning in this revision of \Cpp{}.
+may change meaning in this document.
 \begin{example}
 \begin{codeblock}
 std::string s1 = "some long string that forces allocation", s2 = s1;
@@ -561,7 +561,7 @@ for associative containers.
 \rationale
 Improve efficiency of erasing elements from associative containers.
 \effect
-Valid \CppXX{} code may fail to compile in this revision of \Cpp{}.
+Valid \CppXX{} code may fail to compile in this document.
 \begin{example}
 \begin{codeblock}
 struct B {
@@ -580,11 +580,11 @@ struct D : private B {
 
 \diffref{thread.barrier}
 \change
-In this revision of \Cpp{},
+In this document,
 it is implementation-defined whether a barrier's phase completion step runs
 if no thread calls \tcode{wait}.
 Previously the phase completion step was guaranteed to run on the last thread that calls \tcode{arrive} or \tcode{arrive_and_drop} during the phase.
-In this revision of \Cpp{},
+In this document,
 it can run on any of the threads that arrived or waited at the barrier
 during the phase.
 \rationale
@@ -592,7 +592,7 @@ Correct contradictory wording and
 improve implementation flexibility for performance.
 \effect
 Valid \CppXX{} code using a barrier might have
-different semantics in this revision of \Cpp{}
+different semantics in this document
 if it depends on a completion function's side effects occurring exactly once,
 on a specific thread running the phase completion step, or
 on a completion function's side effects occurring
@@ -633,7 +633,7 @@ Required for new features.
 Logical lines beginning with
 \tcode{module} or \tcode{import} may
 be interpreted differently
-in this revision of \Cpp{}.
+in this document.
 \begin{example}
 \begin{codeblock}
 class module {};
@@ -698,7 +698,7 @@ Valid \CppXVII{} code using
 \keyword{constinit},
 \keyword{co_await}, \keyword{co_yield}, \keyword{co_return},
 or \tcode{requires}
-as an identifier is not valid in this revision of \Cpp{}.
+as an identifier is not valid in this document.
 
 \diffref{lex.operators}
 \change
@@ -708,7 +708,7 @@ Necessary for new functionality.
 \effect
 Valid \CppXVII{} code that contains a \tcode{<=} token
 immediately followed by a \tcode{>} token
-may be ill-formed or have different semantics in this revision of \Cpp{}.
+may be ill-formed or have different semantics in this document.
 \begin{example}
 \begin{codeblock}
 namespace N {
@@ -732,7 +732,7 @@ type deduction to distinguish ordinary and UTF-8 string and character literals.
 Valid \CppXVII{} code that depends on
 UTF-8 string literals having type ``array of \tcode{const char}'' and
 UTF-8 character literals having type ``\tcode{char}''
-is not valid in this revision of \Cpp{}.
+is not valid in this document.
 \begin{example}
 \begin{codeblock}
 const auto *u8s = u8"text";     // \tcode{u8s} previously deduced as \tcode{const char*}; now deduced as \tcode{const char8_t*}
@@ -764,7 +764,7 @@ the object to which it is applied.
 Increase consistency of the language model.
 \effect
 Valid ISO \CppXVII{} code may be ill-formed or
-have undefined behavior in this revision of \Cpp{}.
+have undefined behavior in this document.
 \begin{example}
 \begin{codeblock}
 int f() {
@@ -812,7 +812,7 @@ can contain only C-compatible constructs.
 \rationale
 Necessary for implementability.
 \effect
-Valid \CppXVII{} code may be ill-formed in this revision of \Cpp{}.
+Valid \CppXVII{} code may be ill-formed in this document.
 \begin{example}
 \begin{codeblock}
 typedef struct {
@@ -828,7 +828,7 @@ in different translation units.
 \rationale
 Required for modules support.
 \effect
-Valid \CppXVII{} code may be ill-formed in this revision of \Cpp{},
+Valid \CppXVII{} code may be ill-formed in this document,
 with no diagnostic required.
 \begin{example}
 \begin{codeblock}
@@ -853,7 +853,7 @@ which may apply notwithstanding the declared constructors of a class.
 Valid \CppXVII{} code that aggregate-initializes
 a type with a user-declared constructor
 may be ill-formed or have different semantics
-in this revision of \Cpp{}.
+in this document.
 \begin{example}
 \begin{codeblock}
 struct A {              // not an aggregate; previously an aggregate
@@ -897,7 +897,7 @@ is now a narrowing conversion.
 Catches bugs.
 \effect
 Valid \CppXVII{} code may fail to compile
-in this revision of \Cpp{}.
+in this document.
 \begin{example}
 \begin{codeblock}
 bool y[] = { "bc" };    // ill-formed; previously well-formed
@@ -918,7 +918,7 @@ in a conversion function declaration.
 Necessary for new functionality.
 \effect
 Valid \CppXVII{} code may fail to compile
-in this revision of \Cpp{}.
+in this document.
 \begin{example}
 \begin{codeblock}
 struct S {
@@ -937,7 +937,7 @@ is no longer valid as the \grammarterm{declarator-id} of a constructor or destru
 Remove potentially error-prone option for redundancy.
 \effect
 Valid \CppXVII{} code may fail to compile
-in this revision of \Cpp{}.
+in this document.
 \begin{example}
 \begin{codeblock}
 template<class T>
@@ -960,7 +960,7 @@ Side effect of making it easier to write
 more efficient code that takes advantage of moves.
 \effect
 Valid \CppXVII{} code may fail to compile or have different semantics
-in this revision of \Cpp{}.
+in this document.
 \begin{example}
 \begin{codeblock}
 struct base {
@@ -1035,7 +1035,7 @@ Overload resolution may change for equality operators\iref{expr.eq}.
 Support calling \tcode{operator==} with reversed order of arguments.
 \effect
 Valid \CppXVII{} code that uses equality operators with conversion functions
-may be ill-formed or have different semantics in this revision of \Cpp{}.
+may be ill-formed or have different semantics in this document.
 \begin{example}
 \begin{codeblock}
 struct A {
@@ -1102,7 +1102,7 @@ revision of \Cpp{}. It should simply be replaced with \keyword{noexcept} for no
 change of meaning since \CppXVII{}.
 \begin{note}
 There is no way to write a function declaration
-that is non-throwing in this revision of \Cpp{}
+that is non-throwing in this document
 and is also non-throwing in \CppIII{}
 except by using the preprocessor to generate
 a different token sequence in each case.
@@ -1134,7 +1134,7 @@ The following \Cpp{} headers are new:
 \libheaderref{syncstream}, and
 \libheaderrefx{version}{support.limits.general}.
 Valid \CppXVII{} code that \tcode{\#include}{s} headers with these names may be
-invalid in this revision of \Cpp{}.
+invalid in this document.
 
 \diffref{headers}
 \change
@@ -1175,7 +1175,7 @@ changed from \keyword{void} to \tcode{container::size_type}.
 \rationale
 Improve efficiency and convenience of finding number of removed elements.
 \effect
-Code that depends on the return types might have different semantics in this revision of \Cpp{}.
+Code that depends on the return types might have different semantics in this document.
 Translation units compiled against this version of \Cpp{} may be incompatible with
 translation units compiled against \CppXVII{}, either failing to link or having undefined behavior.
 
@@ -1214,7 +1214,7 @@ Character array extraction only takes array types.
 \rationale
 Increase safety via preventing buffer overflow at compile time.
 \effect
-Valid \CppXVII{} code may fail to compile in this revision of \Cpp{}.
+Valid \CppXVII{} code may fail to compile in this document.
 \begin{example}
 \begin{codeblock}
 auto p = new char[100];
@@ -1272,7 +1272,7 @@ Required for new features.
 \effect
 Valid \CppXVII{} code that depends on the \tcode{u8string()} and
 \tcode{generic_u8string()} member functions of \tcode{std::filesystem::path}
-returning \tcode{std::string} is not valid in this revision of \Cpp{}.
+returning \tcode{std::string} is not valid in this document.
 \begin{example}
 \begin{codeblock}
 std::filesystem::path p;
@@ -1392,7 +1392,7 @@ Removal of trigraph support as a required feature.
 Prevents accidental uses of trigraphs in non-raw string literals and comments.
 \effect
 Valid \CppXIV{} code that uses trigraphs may not be valid or may have different
-semantics in this revision of \Cpp{}. Implementations may choose to
+semantics in this document. Implementations may choose to
 translate trigraphs as specified in \CppXIV{} if they appear outside of a raw
 string literal, as part of the \impldef{mapping input source file characters
 to translation character set} mapping from input source file characters to
@@ -1406,9 +1406,9 @@ the translation character set.
 Necessary to enable \grammarterm{hexadecimal-floating-point-literal}s.
 \effect
 Valid \CppXIV{} code may fail to compile or produce different results in
-this revision of \Cpp{}. Specifically, character sequences like \tcode{0p+0}
+this document. Specifically, character sequences like \tcode{0p+0}
 and \tcode{0e1_p+0} are three separate tokens each in \CppXIV{}, but one single token
-in this revision of \Cpp{}.
+in this document.
 \begin{example}
 \begin{codeblock}
 #define F(a) b ## a
@@ -1425,7 +1425,7 @@ Remove increment operator with \tcode{bool} operand.
 Obsolete feature with occasionally surprising semantics.
 \effect
 A valid \CppXIV{} expression utilizing the increment operator on
-a \tcode{bool} lvalue is ill-formed in this revision of \Cpp{}.
+a \tcode{bool} lvalue is ill-formed in this document.
 
 \diffref{expr.new,expr.delete}
 \change
@@ -1438,7 +1438,7 @@ to allocate an object with an over-aligned class type,
 where that class has no allocation functions of its own,
 \tcode{::operator new(std::size_t)}
 is used to allocate the memory.
-In this revision of \Cpp{},
+In this document,
 \tcode{::operator new(std::size_t, std::align_val_t)}
 is used instead.
 
@@ -1452,7 +1452,7 @@ Removal of \keyword{register} \grammarterm{storage-class-specifier}.
 Enable repurposing of deprecated keyword in future revisions of \Cpp{}.
 \effect
 A valid \CppXIV{} declaration utilizing the \keyword{register}
-\grammarterm{storage-class-specifier} is ill-formed in this revision of \Cpp{}.
+\grammarterm{storage-class-specifier} is ill-formed in this document.
 The specifier can simply be removed to retain the original meaning.
 
 \diffref{dcl.spec.auto}
@@ -1462,7 +1462,7 @@ The specifier can simply be removed to retain the original meaning.
 More intuitive deduction behavior.
 \effect
 Valid \CppXIV{} code may fail to compile or may change meaning
-in this revision of \Cpp{}.
+in this document.
 \begin{example}
 \begin{codeblock}
 auto x1{1};         // was \tcode{std::initializer_list<int>}, now \tcode{int}
@@ -1554,7 +1554,7 @@ allows partial specializations to decompose
 from the type deduced for the non-type template argument.
 \effect
 Valid \CppXIV{} code may fail to compile
-or produce different results in this revision of \Cpp{}.
+or produce different results in this document.
 \begin{example}
 \begin{codeblock}
 template <int N> struct A;
@@ -1575,7 +1575,7 @@ Remove dynamic exception specifications.
 Dynamic exception specifications were a deprecated feature
 that was complex and brittle in use.
 They interacted badly with the type system,
-which became a more significant issue in this revision of \Cpp{}
+which became a more significant issue in this document
 where (non-dynamic) exception specifications are part of the function type.
 \effect
 A valid \CppXIV{} function declaration,
@@ -1583,7 +1583,7 @@ member function declaration,
 function pointer declaration,
 or function reference declaration,
 if it has a potentially throwing dynamic exception specification,
-is rejected as ill-formed in this revision of \Cpp{}.
+is rejected as ill-formed in this document.
 Violating a non-throwing dynamic exception specification
 calls \tcode{terminate} rather than \tcode{unexpected},
 and it is unspecified whether stack unwinding is performed
@@ -1608,7 +1608,7 @@ The following \Cpp{} headers are new:
 and
 \libheaderref{variant}.
 Valid \CppXIV{} code that \tcode{\#include}{s} headers with these names may be
-invalid in this revision of \Cpp{}.
+invalid in this document.
 
 \diffref{namespace.future}
 \change
@@ -1621,7 +1621,7 @@ The global namespaces \tcode{std}
 followed by an arbitrary sequence of \grammarterm{digit}{s}\iref{lex.name}
 are reserved for future standardization.
 Valid \CppXIV{} code that uses such a top-level namespace,
-e.g., \tcode{std2}, may be invalid in this revision of \Cpp{}.
+e.g., \tcode{std2}, may be invalid in this document.
 
 \rSec2[diff.cpp14.utilities]{\ref{utilities}: general utilities library}
 
@@ -1634,7 +1634,7 @@ No implementation consensus.
 Valid \CppXIV{} code may fail to compile or may change meaning in this
 revision of \Cpp{}. Specifically, constructing a \tcode{std::function} with
 an allocator is ill-formed and uses-allocator construction will not pass an
-allocator to \tcode{std::function} constructors in this revision of \Cpp{}.
+allocator to \tcode{std::function} constructors in this document.
 
 \diffref{util.smartptr.shared}
 \change
@@ -1667,7 +1667,7 @@ Overloaded functions which have differing code paths
 for \tcode{char*} and \tcode{const char*} arguments
 will execute differently
 when called with a non-const string's \tcode{.data()} member
-in this revision of \Cpp{}.
+in this document.
 \begin{example}
 \begin{codeblock}
 int f(char *) = delete;
@@ -1687,7 +1687,7 @@ Increase portability, clarification of associative container requirements.
 \effect
 Valid \CppXIV{} code that attempts to use associative containers
 having a comparison object with non-const function call operator
-may fail to compile in this revision of \Cpp{}.
+may fail to compile in this document.
 \begin{example}
 \begin{codeblock}
 #include <set>
@@ -1728,7 +1728,7 @@ are not defined.
 Superseded by new features.
 \effect
 Valid \CppXIV{} code that uses these class templates
-and function templates may fail to compile in this revision of \Cpp{}.
+and function templates may fail to compile in this document.
 
 \nodiffref
 \change
@@ -1738,7 +1738,7 @@ Redundant feature for compatibility with pre-standard code
 has served its time.
 \effect
 A valid \CppXIV{} program using these identifiers
-may be ill-formed in this revision of \Cpp{}.
+may be ill-formed in this document.
 
 \rSec1[diff.cpp11]{\Cpp{} and ISO \CppXI{}}
 
@@ -1761,15 +1761,15 @@ Necessary to enable single quotes as digit separators.
 \effect
 Valid \CppXI{} code may fail to compile or may change meaning in this
 revision of \Cpp{}. For example, the following code is valid both in \CppXI{} and in
-this revision of \Cpp{}, but the macro invocation produces different outcomes
+this document, but the macro invocation produces different outcomes
 because the single quotes delimit a \grammarterm{character-literal} in \CppXI{}, whereas they are digit
-separators in this revision of \Cpp{}.
+separators in this document.
 \begin{example}
 \begin{codeblock}
 #define M(x, ...) __VA_ARGS__
 int x[2] = { M(1'2,3'4, 5) };
 // \tcode{int x[2] = \{ 5 \};\ \ \ \ \ } --- \CppXI{}
-// \tcode{int x[2] = \{ 3'4, 5 \};} --- this revision of \Cpp{}
+// \tcode{int x[2] = \{ 3'4, 5 \};} --- this document
 \end{codeblock}
 \end{example}
 
@@ -1787,7 +1787,7 @@ deallocation function as follows:
 void* operator new(std::size_t, std::size_t);
 void operator delete(void*, std::size_t) noexcept;
 \end{codeblock}
-In this revision of \Cpp{}, however, the declaration of \tcode{operator delete}
+In this document, however, the declaration of \tcode{operator delete}
 might match a predefined usual (non-placement)
 \tcode{operator delete}\iref{basic.stc.dynamic}. If so, the
 program is ill-formed, as it was for class member allocation functions and
@@ -1806,7 +1806,7 @@ standard conversions), especially the creation of the temporary due to
 lvalue-to-rvalue conversion, were considered gratuitous and surprising.
 \effect
 Valid \CppXI{} code that relies on the conversions may behave differently
-in this revision of \Cpp{}.
+in this document.
 \begin{example}
 \begin{codeblock}
 struct S {
@@ -1819,7 +1819,7 @@ int f(bool cond) {
   return s.x;
 }
 \end{codeblock}
-In \CppXI{}, \tcode{f(true)} returns \tcode{1}. In this revision of \Cpp{},
+In \CppXI{}, \tcode{f(true)} returns \tcode{1}. In this document,
 it returns \tcode{2}.
 \begin{codeblock}
 sizeof(true ? "" : throw 0)
@@ -1838,7 +1838,7 @@ revision of \Cpp{}, it yields \tcode{sizeof(const char[1])}.
 Necessary to allow \keyword{constexpr} member functions to mutate
 the object.
 \effect
-Valid \CppXI{} code may fail to compile in this revision of \Cpp{}.
+Valid \CppXI{} code may fail to compile in this document.
 \begin{example}
 \begin{codeblock}
 struct S {
@@ -1847,7 +1847,7 @@ struct S {
 };
 \end{codeblock}
 This code is valid in \CppXI{}
-but invalid in this revision of \Cpp{} because it declares the same member
+but invalid in this document because it declares the same member
 function twice with different return types.
 \end{example}
 
@@ -1858,7 +1858,7 @@ Classes with default member initializers can be aggregates.
 Necessary to allow default member initializers to be used
 by aggregate initialization.
 \effect
-Valid \CppXI{} code may fail to compile or may change meaning in this revision of \Cpp{}.
+Valid \CppXI{} code may fail to compile or may change meaning in this document.
 \begin{example}
 \begin{codeblock}
 struct S {          // Aggregate in \CppXIV{} onwards.
@@ -1870,7 +1870,7 @@ struct X {
 };
 X a{};
 S b{a};             // uses copy constructor in \CppXI{},
-                    // performs aggregate initialization in this revision of \Cpp{}
+                    // performs aggregate initialization in this document
 \end{codeblock}
 \end{example}
 
@@ -1884,7 +1884,7 @@ New functionality.
 \effect
 The \Cpp{} header \libheaderrefx{shared_mutex}{shared.mutex.syn} is new.
 Valid \CppXI{} code that \tcode{\#include}{s} a header with that name may be
-invalid in this revision of \Cpp{}.
+invalid in this document.
 
 \rSec2[diff.cpp11.input.output]{\ref{input.output}: input/output library}
 
@@ -1895,7 +1895,7 @@ invalid in this revision of \Cpp{}.
 Use of \tcode{gets} is considered dangerous.
 \effect
 Valid \CppXI{} code that uses the \tcode{gets} function may fail to compile
-in this revision of \Cpp{}.
+in this document.
 
 \rSec1[diff.cpp03]{\Cpp{} and ISO \CppIII{}}
 
@@ -1917,7 +1917,7 @@ New kinds of \grammarterm{string-literal}s.
 Required for new features.
 \effect
 Valid \CppIII{} code may fail to compile or produce different results in
-this revision of \Cpp{}. Specifically, macros named \tcode{R}, \tcode{u8},
+this document. Specifically, macros named \tcode{R}, \tcode{u8},
 \tcode{u8R}, \tcode{u}, \tcode{uR}, \tcode{U}, \tcode{UR}, or \tcode{LR} will
 not be expanded when adjacent to a \grammarterm{string-literal} but will be interpreted as
 part of the \grammarterm{string-literal}.
@@ -1935,7 +1935,7 @@ User-defined literal string support.
 Required for new features.
 \effect
 Valid \CppIII{} code may fail to compile or produce different results in
-this revision of \Cpp{}.
+this document.
 \begin{example}
 \begin{codeblock}
 #define _x "there"
@@ -1943,7 +1943,7 @@ this revision of \Cpp{}.
 \end{codeblock}
 
 Previously, \#1 would have consisted of two separate preprocessing tokens and
-the macro \tcode{_x} would have been expanded. In this revision of \Cpp{},
+the macro \tcode{_x} would have been expanded. In this document,
 \#1 consists of a single preprocessing token, so the macro is not expanded.
 \end{example}
 
@@ -1965,7 +1965,7 @@ Added to \tref{lex.key}, the following identifiers are new keywords:
 \keyword{static_assert},
 and
 \keyword{thread_local}.
-Valid \CppIII{} code using these identifiers is invalid in this revision of \Cpp{}.
+Valid \CppIII{} code using these identifiers is invalid in this document.
 
 \diffref{lex.icon}
 \change
@@ -1986,7 +1986,7 @@ Removing surprising interactions with templates and constant
 expressions.
 \effect
 Valid \CppIII{} code may fail to compile or produce different results in
-this revision of \Cpp{}.
+this document.
 \begin{example}
 \begin{codeblock}
 void f(void *);     // \#1
@@ -2004,7 +2004,7 @@ Specify rounding for results of integer \tcode{/} and \tcode{\%}.
 Increase portability, C99 compatibility.
 \effect
 Valid \CppIII{} code that uses integer division rounds the result toward 0 or
-toward negative infinity, whereas this revision of \Cpp{} always rounds
+toward negative infinity, whereas this document always rounds
 the result toward 0.
 
 \diffref{expr.log.and}
@@ -2014,7 +2014,7 @@ the result toward 0.
 Required for new features.
 \effect
 Valid \CppIII{} code may fail to compile or produce different results in
-this revision of \Cpp{}.
+this document.
 \begin{example}
 \begin{codeblock}
 bool b1 = new int && false;             // previously \tcode{false}, now ill-formed
@@ -2033,8 +2033,8 @@ New feature.
 \effect
 Valid \CppIII{} code that uses the keyword \keyword{auto} as a storage class
 specifier
-may be invalid in this revision of \Cpp{}.
-In this revision of \Cpp{},
+may be invalid in this document.
+In this document,
 \keyword{auto} indicates that the type of a variable is to be deduced
 from its initializer expression.
 
@@ -2044,7 +2044,7 @@ Narrowing restrictions in aggregate initializers.
 \rationale
 Catches bugs.
 \effect
-Valid \CppIII{} code may fail to compile in this revision of \Cpp{}.
+Valid \CppIII{} code may fail to compile in this document.
 \begin{example}
 \begin{codeblock}
 int x[] = { 2.0 };
@@ -2063,7 +2063,7 @@ language linkage applies to names with external linkage only.
 Alignment with user expectations.
 \effect
 Valid \CppIII{} code may violate the one-definition rule\iref{basic.def.odr}
-in this revision of \Cpp{}.
+in this document.
 \begin{example}
 \begin{codeblock}
 namespace { extern "C" { extern int x; } }  // \#1, previously external linkage and C language linkage,
@@ -2073,7 +2073,7 @@ int main(void) { return x; }
 \end{codeblock}
 This code is valid in \CppIII{},
 but \tcode{\#2} is not a definition for \tcode{\#1}
-in this revision of \Cpp{}, violating the one-definition rule.
+in this document, violating the one-definition rule.
 \end{example}
 
 \rSec2[diff.cpp03.class]{\ref{class}: classes}
@@ -2095,7 +2095,7 @@ User-declared destructors have an implicit exception specification.
 \rationale
 Clarification of destructor requirements.
 \effect
-Valid \CppIII{} code may execute differently in this revision of \Cpp{}. In
+Valid \CppIII{} code may execute differently in this document. In
 particular, destructors that throw exceptions will call \tcode{std::terminate}
 (without calling \tcode{std::unexpected}) if their exception specification is
 non-throwing.
@@ -2129,7 +2129,7 @@ template <int N> struct Y { };
 X< Y< 1 >> 2 > > x;
 \end{codeblock}
 This code is valid in \CppIII{} because ``\tcode{>>}''
-is a right-shift operator, but invalid in this revision of \Cpp{} because
+is a right-shift operator, but invalid in this document because
 ``\tcode{>>}'' closes two templates.
 \end{example}
 
@@ -2153,7 +2153,7 @@ Required by new features.
 \effect
 Valid \CppIII{} code that uses any identifiers added to the \Cpp{} standard
 library by later revisions of \Cpp{} may fail to compile or produce different
-results in this revision of \Cpp{}. A comprehensive list of identifiers used
+results in this document. A comprehensive list of identifiers used
 by the \Cpp{} standard library can be found in the Index of Library Names in this
 document.
 
@@ -2191,7 +2191,7 @@ In addition the following C compatibility headers are new:
 and
 \libheaderref{cuchar}.
 Valid \CppIII{} code that \tcode{\#include}{s} headers with these names may be
-invalid in this revision of \Cpp{}.
+invalid in this document.
 
 \diffref{swappable.requirements}
 \effect
@@ -2210,7 +2210,7 @@ New functionality.
 \effect
 The global namespace \tcode{posix} is now reserved for standardization. Valid
 \CppIII{} code that uses a top-level namespace \tcode{posix} may be invalid in
-this revision of \Cpp{}.
+this document.
 
 \diffref{res.on.macro.definitions}
 \change
@@ -2234,10 +2234,10 @@ language support library}
 Consistent application of \keyword{noexcept}.
 \effect
 Valid \CppIII{} code that assumes that global \tcode{operator new} only
-throws \tcode{std::bad_alloc} may execute differently in this revision of \Cpp{}.
+throws \tcode{std::bad_alloc} may execute differently in this document.
 Valid \CppIII{} code that replaces the global replaceable \tcode{operator new}
-is ill-formed in this revision of \Cpp{},
-because the exception specification of \tcode{throw(std::bad_alloc)}
+is ill-formed in this document,
+because the exception specification of \tcode{throw(std::\newline bad_alloc)}
 was removed.
 
 \rSec2[diff.cpp03.diagnostics]{\ref{diagnostics}: diagnostics library}
@@ -2264,7 +2264,7 @@ Superseded by new feature; \tcode{unary_function} and
 \effect
 Valid \CppIII{} code that depends on function object types being derived from
 \tcode{unary_function} or \tcode{binary_function} may fail to compile
-in this revision of \Cpp{}.
+in this document.
 
 \rSec2[diff.cpp03.strings]{\ref{strings}: strings library}
 
@@ -2276,7 +2276,7 @@ strings.
 Invalidation is subtly different with reference-counted strings.
 This change regularizes behavior.
 \effect
-Valid \CppIII{} code may execute differently in this revision of \Cpp{}.
+Valid \CppIII{} code may execute differently in this document.
 
 \diffref{string.require}
 \change
@@ -2284,7 +2284,7 @@ Loosen \tcode{basic_string} invalidation rules.
 \rationale
 Allow small-string optimization.
 \effect
-Valid \CppIII{} code may execute differently in this revision of \Cpp{}.
+Valid \CppIII{} code may execute differently in this document.
 Some \keyword{const} member functions, such as \tcode{data} and \tcode{c_str},
 no longer invalidate iterators.
 
@@ -2298,7 +2298,7 @@ Lack of specification of complexity of \tcode{size()} resulted in
 divergent implementations with inconsistent performance characteristics.
 \effect
 Some container implementations that conform to \CppIII{} may not conform to the
-specified \tcode{size()} requirements in this revision of \Cpp{}. Adjusting
+specified \tcode{size()} requirements in this document. Adjusting
 containers such as \tcode{std::list} to the stricter requirements may require
 incompatible changes.
 
@@ -2344,7 +2344,7 @@ The following member functions have changed:
 
 Valid \CppIII{} code that relies on these functions returning \keyword{void}
 (e.g., code that creates a pointer to member function that points to one
-of these functions) will fail to compile with this revision of \Cpp{}.
+of these functions) will fail to compile with this document.
 
 \diffref{sequence.reqmts,associative.reqmts}
 \change
@@ -2378,7 +2378,7 @@ Performance, compatibility with move semantics.
 For \tcode{vector}, \tcode{deque}, and \tcode{list}
 the fill value passed to \tcode{resize} is now passed by reference instead of
 by value, and an additional overload of \tcode{resize} has been added. Valid
-\CppIII{} code that uses this function may fail to compile with this revision of \Cpp{}.
+\CppIII{} code that uses this function may fail to compile with this document.
 
 \rSec2[diff.cpp03.algorithms]{\ref{algorithms}: algorithms library}
 
@@ -2404,7 +2404,7 @@ Compatibility with C99.
 \effect
 Valid \CppIII{} code that uses implementation-specific knowledge about the
 binary representation of the required template specializations of
-\tcode{std::complex} may not be compatible with this revision of \Cpp{}.
+\tcode{std::complex} may not be compatible with this document.
 
 \rSec2[diff.cpp03.locale]{\ref{localization}: localization library}
 
@@ -2414,7 +2414,7 @@ The \tcode{num_get} facet recognizes hexadecimal floating point values.
 \rationale
 Required by new feature.
 \effect
-Valid \CppIII{} code may have different behavior in this revision of \Cpp{}.
+Valid \CppIII{} code may have different behavior in this document.
 
 \rSec2[diff.cpp03.input.output]{\ref{input.output}: input/output library}
 
@@ -2425,7 +2425,7 @@ Specify use of \keyword{explicit} in existing boolean conversion functions.
 Clarify intentions, avoid workarounds.
 \effect
 Valid \CppIII{} code that relies on implicit boolean conversions will fail to
-compile with this revision of \Cpp{}. Such conversions occur in the
+compile with this document. Such conversions occur in the
 following conditions:
 
 \begin{itemize}
@@ -2446,7 +2446,7 @@ More detailed error messages.
 \tcode{std::exception}, but is now derived from \tcode{std::system_error},
 which in turn is derived from \tcode{std::runtime_error}. Valid \CppIII{} code
 that assumes that \tcode{std::ios_base::failure} is derived directly from
-\tcode{std::exception} may execute differently in this revision of \Cpp{}.
+\tcode{std::exception} may execute differently in this document.
 
 \diffref{ios.base}
 \change
@@ -2457,7 +2457,7 @@ Required for new features.
 \effect
 Valid \CppIII{} code that relies on \tcode{std::ios_base} flag types being
 represented as \tcode{std::bitset} or as an integer type may fail to compile
-with this revision of \Cpp{}.
+with this document.
 \begin{example}
 \begin{codeblock}
 #include <iostream>


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

DO NOT MERGE TO THE WORKING DRAFT; this makes some sentences awkward.

- [ ] Please change to "in this document". As per HYPERLINK "https://www.iso.org/sites/directives/current/part2/index.xhtml#_idTextAnchor138"ISO/IEC Directives, Part 2, 2021, 10.6 : "This document" is used as a generic term to refer to "this International Standard", "this Technical Report",