### PR TITLE
[std] Replace 'this standard' with 'this document'

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -183,7 +183,7 @@ or the function call can be safely eliminated with no side effects.
 \change
 Remove header \libnoheader{codecvt} and all its contents.
 \rationale
-The header has been deprecated for the previous three editions of this standard
+The header has been deprecated for the previous three editions of this document
 and no longer implements the current Unicode standard, supporting only the
 obsolete UCS-2 encoding.
 Ongoing support is at implementer's discretion,
@@ -227,7 +227,7 @@ Remove convenience interfaces \tcode{wstring_convert} and
 \tcode{wbuffer_convert}.
 \rationale
 These features were underspecified with no clear error reporting mechanism and
-were deprecated for the last three editions of this standard.
+were deprecated for the last three editions of this document.
 Ongoing support is at implementer's discretion,
 exercising freedoms granted by \ref{zombie.names}.
 \effect

--- a/source/future.tex
+++ b/source/future.tex
@@ -4,8 +4,8 @@
 \rSec1[depr.general]{General}
 
 \pnum
-This Annex describes features of the \Cpp{} Standard that are specified for compatibility with
-existing implementations.
+This Annex describes features of this document
+that are specified for compatibility with existing implementations.
 
 \pnum
 These are deprecated features, where

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15141,7 +15141,7 @@ sort(execution::par_unseq, v.begin(), v.end());
 \end{example}
 \begin{note}
 Implementations can provide additional execution policies
-to those described in this standard as extensions
+to those described in this document as extensions
 to address parallel architectures that require idiosyncratic
 parameters for efficient execution.
 \end{note}


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

This seems good to apply to the WD as well.