### PR TITLE
[uaxid] Replace 'this requirement' with a specific reference

### DIFF
--- a/source/uax31.tex
+++ b/source/uax31.tex
@@ -91,7 +91,7 @@ their use of whitespace and syntactically significant characters
 during the processes of lexing and parsing.
 
 \pnum
-\Cpp{} does not claim conformance with this requirement.
+\Cpp{} does not claim conformance with requirement R3 of \UAX{31}.
 
 \rSec1[uaxid.eqn]{R4 Equivalent normalized identifiers}
 
@@ -109,7 +109,7 @@ This is described in \ref{lex.name}.
 \pnum
 \Cpp{} considers case to be significant in identifier comparison, and
 does not do any case folding.
-This requirement does not apply to \Cpp{}.
+Requirement R5 of \UAX{31} does not apply to \Cpp{}.
 
 \rSec1[uaxid.filter]{R6 Filtered normalized identifiers}
 
@@ -124,9 +124,9 @@ If any characters are excluded from normalization,
 
 \pnum
 \Cpp{} identifiers are case sensitive, and
-therefore this requirement does not apply.
+therefore requirement R7 of \UAX{31} does not apply.
 
 \rSec1[uaxid.hashtag]{R8 Hashtag identifiers}
 
 \pnum
-There are no hashtags in \Cpp{}, so this requirement does not apply.
+There are no hashtags in \Cpp{}, so requirement R8 of \UAX{31} does not apply.


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

This seems ok for the WD, in the interest of avoiding further bifurcation.