### PR TITLE
[lib] Excise Note A, Note B, etc. designations

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -1934,8 +1934,8 @@ argument passing.
 
  \tcode{template<class... T>} \tcode{struct common_type;}
  &
- Unless this trait is specialized (as specified in Note B, below),
- the member \tcode{type} is defined or omitted as specified in Note A, below.
+ Unless this trait is specialized,
+ the member \tcode{type} is defined or omitted as specified below.
  If it is omitted, there shall be no member \tcode{type}.
  Each type in the template parameter pack \tcode{T} shall be
  complete, \cv{}~\keyword{void}, or an array of unknown bound. \\ \rowsep
@@ -1947,14 +1947,14 @@ argument passing.
  \keyword{struct}
  \hspace*{2ex}\tcode{basic_common_reference;}
  &
- Unless this trait is specialized (as specified in Note D, below),
+ Unless this trait is specialized,
  there shall be no member \tcode{type}. \\ \rowsep
 
 \indexlibraryglobal{common_reference}%
 \tcode{template<class... T>} \tcode{struct common_reference;}
  &
  The member \grammarterm{typedef-name} \tcode{type} is defined or omitted
- as specified in Note C, below. Each type in the parameter pack \tcode{T} shall
+ as specified below. Each type in the parameter pack \tcode{T} shall
  be complete or \cv{} \keyword{void}. \\ \rowsep
 
 \indexlibraryglobal{underlying_type}%
@@ -2066,7 +2066,6 @@ If any of the types computed above is ill-formed, then
 \tcode{\placeholdernc{COMMON-REF}(A, B)} is ill-formed.
 
 \pnum
-Note A:
 For the \tcode{common_type} trait applied to a template parameter pack \tcode{T} of types,
 the member \tcode{type} shall be either defined or not present as follows:
 
@@ -2120,7 +2119,7 @@ Otherwise, there shall be no member \tcode{type}.
 \end{itemize}
 
 \pnum
-Note B: Notwithstanding the provisions of \ref{meta.type.synop}, and
+Notwithstanding the provisions of \ref{meta.type.synop}, and
 pursuant to \ref{namespace.std},
 a program may specialize \tcode{common_type<T1, T2>}
 for types \tcode{T1} and \tcode{T2} such that
@@ -2140,7 +2139,7 @@ the same type, if any, as does \tcode{common_type_t<T2, T1>}.
 No diagnostic is required for a violation of this Note's rules.
 
 \pnum
-Note C: For the \tcode{common_reference} trait applied to a parameter pack
+For the \tcode{common_reference} trait applied to a parameter pack
 \tcode{T} of types, the member \tcode{type} shall be either defined or not
 present as follows:
 \begin{itemize}
@@ -2186,7 +2185,7 @@ present as follows:
 \end{itemize}
 
 \pnum
-Note D: Notwithstanding the provisions of \ref{meta.type.synop}, and
+Notwithstanding the provisions of \ref{meta.type.synop}, and
 pursuant to \ref{namespace.std}, a program may partially specialize
 \tcode{basic_common_reference<T, U, TQual, UQual>}
 for types \tcode{T} and \tcode{U} such that

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2840,10 +2840,10 @@ template<size_t I, class... Types>
     get(tuple<Types...>& t) noexcept;
 template<size_t I, class... Types>
   constexpr tuple_element_t<I, tuple<Types...>>&&
-    get(tuple<Types...>&& t) noexcept;        // Note A
+    get(tuple<Types...>&& t) noexcept;        // \#1
 template<size_t I, class... Types>
   constexpr const tuple_element_t<I, tuple<Types...>>&
-    get(const tuple<Types...>& t) noexcept;   // Note B
+    get(const tuple<Types...>& t) noexcept;   // \#2
 template<size_t I, class... Types>
   constexpr const tuple_element_t<I, tuple<Types...>>&& get(const tuple<Types...>&& t) noexcept;
 \end{itemdecl}
@@ -2860,8 +2860,8 @@ indexing is zero-based.
 
 \pnum
 \begin{note}
-[Note A]
-If a type \tcode{T} in \tcode{Types} is some reference type \tcode{X\&},
+For the overload marked \#1,
+if a type \tcode{T} in \tcode{Types} is some reference type \tcode{X\&},
 the return type is \tcode{X\&}, not \tcode{X\&\&}.
 However, if the element type is a non-reference type \tcode{T},
 the return type is \tcode{T\&\&}.
@@ -2869,9 +2869,9 @@ the return type is \tcode{T\&\&}.
 
 \pnum
 \begin{note}
-[Note B]
 Constness is shallow.
-If a type \tcode{T} in \tcode{Types} is some reference type \tcode{X\&},
+For the overload marked \#2,
+if a type \tcode{T} in \tcode{Types} is some reference type \tcode{X\&},
 the return type is \tcode{X\&}, not \tcode{const X\&}.
 However, if the element type is a non-reference type \tcode{T},
 the return type is \tcode{const T\&}.


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

- [ ] What is "Note A"? And likewise for the text below, what is "Note B?" If these are meant to be "notes" according to the ISO/IEC Directives Part 2, then please change them to "NOTE x" as appropriate
- [ ] see earlier comment: what is Note A and Note B? 