### PR TITLE
[intro.compliance.general] Refer to Annex B normatively

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -723,7 +723,7 @@ execution of programs. Such requirements have the following meaning:
 If a program contains no violations of the rules in
 \ref{lex} through \ref{\lastlibchapter} and \ref{depr},
 a conforming implementation shall,
-within its resource limits as described in \ref{implimits},
+in accordance with the resource limits specified in \ref{implimits},
 accept and correctly execute
 \begin{footnote}
 ``Correct execution'' can include undefined behavior


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

DO NOT MERGE INTO THE WORKING DRAFT

The numerical values of the limits are not normative (per the status quo); this change makes them appear more normative.  CWG2891 seeks to move the normative parts out of Annex B.