### PR TITLE
Harmonize the phrasing of "X models foo_of<Y>"

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -4292,9 +4292,8 @@ If
   and \tcode{last1 - first1 != last2 - first2}
   for the overloads in namespace \tcode{std};
 \item
- the types of \tcode{first1}, \tcode{last1}, \tcode{first2}, and \tcode{last2}
- pairwise model \libconcept{sized_sentinel_for}\iref{iterator.concept.sizedsentinel}
-  and \tcode{last1 - first1 != last2 - first2}
+ \tcode{S1} models \tcode{\libconcept{sized_sentinel_for}<I1>}, \tcode{S2} models \tcode{\libconcept{sized_sentinel_for}<I2>},
+   and \tcode{last1 - first1 != last2 - first2}
   for the first overload in namespace \tcode{ranges},
 \item
    \tcode{R1} and \tcode{R2} each model \libconcept{sized_range} and
@@ -4408,8 +4407,8 @@ No applications of the corresponding predicate and projections if:
 \item
 for the first overload,
 \begin{itemize}
-\item \tcode{S1} and \tcode{I1} model \tcode{\libconcept{sized_sentinel_for}<S1, I1>},
-\item \tcode{S2} and \tcode{I2} model \tcode{\libconcept{sized_sentinel_for}<S2, I2>}, and
+\item \tcode{S1} models \tcode{\libconcept{sized_sentinel_for}<I1>},
+\item \tcode{S2} models \tcode{\libconcept{sized_sentinel_for}<I2>}, and
 \item \tcode{last1 - first1 != last2 - first2};
 \end{itemize}
 \item

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1418,13 +1418,13 @@ that of every integral type of the same signedness.
 
 \pnum
 A type \tcode{I} other than \cv{}~\tcode{bool} is \defn{integer-like}
-if it models \tcode{\libconcept{integral}<I>} or
+if it models \libconcept{integral} or
 if it is an integer-class type.
 An integer-like type \tcode{I} is \defn{signed-integer-like}
-if it models \tcode{\libconcept{signed_integral}<I>} or
+if it models \libconcept{signed_integral} or
 if it is a signed-integer-class type.
 An integer-like type \tcode{I} is \defn{unsigned-integer-like}
-if it models \tcode{\libconcept{unsigned_integral}<I>} or
+if it models \libconcept{unsigned_integral} or
 if it is an unsigned-integer-class type.
 
 \pnum
@@ -1544,7 +1544,7 @@ if and only if \tcode{I} is a signed-integer-like type.
 \pnum
 Let \tcode{i} be an object of type \tcode{I}. When \tcode{i} is in the domain of
 both pre- and post-increment, \tcode{i} is said to be \defn{incrementable}.
-\tcode{I} models \tcode{\libconcept{weakly_incrementable}<I>} only if
+\tcode{I} models \libconcept{weakly_incrementable} only if
 \begin{itemize}
 \item The expressions \tcode{++i} and \tcode{i++} have the same domain.
 \item If \tcode{i} is incrementable, then both \tcode{++i}
@@ -1654,7 +1654,7 @@ template<class S, class I>
 \pnum
 Let \tcode{s} and \tcode{i} be values of type \tcode{S} and
 \tcode{I} such that \range{i}{s} denotes a range. Types
-\tcode{S} and \tcode{I} model \tcode{\libconcept{sentinel_for}<S, I>} only if
+\tcode{S} models \tcode{\libconcept{sentinel_for}<I>} only if
 \begin{itemize}
 \item \tcode{i == s} is well-defined.
 
@@ -1699,7 +1699,7 @@ Let \tcode{i} be an iterator of type \tcode{I}, and \tcode{s}
 a sentinel of type \tcode{S} such that \range{i}{s} denotes a range.
 Let $N$ be the smallest number of applications of \tcode{++i}
 necessary to make \tcode{bool(i == s)} be \tcode{true}.
-\tcode{S} and \tcode{I} model \tcode{\libconcept{sized_sentinel_for}<S, I>} only if
+\tcode{S} models \tcode{\libconcept{sized_sentinel_for}<I>} only if
 \begin{itemize}
 \item If $N$ is representable by \tcode{iter_difference_t<I>},
       then \tcode{s - i} is well-defined and equals $N$.
@@ -3004,9 +3004,9 @@ Either \tcode{\libconcept{assignable_from}<I\&, S> || \libconcept{sized_sentinel
 \pnum
 \effects
 \begin{itemize}
-\item If \tcode{I} and \tcode{S} model \tcode{\libconcept{assignable_from}<I\&, S>},
+\item If \tcode{I&} models \tcode{\libconcept{assignable_from}<S>},
   equivalent to \tcode{i = std::move(bound)}.
-\item Otherwise, if \tcode{S} and \tcode{I} model \tcode{\libconcept{sized_sentinel_for}<S, I>},
+\item Otherwise, if \tcode{S} models \tcode{\libconcept{sized_sentinel_for}<I>},
   equivalent to \tcode{ranges::advance(i, bound - i)}.
 \item Otherwise, while \tcode{bool(i != bound)} is \tcode{true},
   increments \tcode{i}.
@@ -3026,12 +3026,12 @@ If \tcode{n > 0}, \range{i}{bound} denotes a range.
 If \tcode{n == 0}, \range{i}{bound} or \range{bound}{i} denotes a range.
 If \tcode{n < 0}, \range{bound}{i} denotes a range,
 \tcode{I} models \libconcept{bidirectional_iterator}, and
-\tcode{I} and \tcode{S} model \tcode{\libconcept{same_as}<I, S>}.
+\tcode{S} models \tcode{\libconcept{same_as}<I>}.
 
 \pnum
 \effects
 \begin{itemize}
-\item If \tcode{S} and \tcode{I} model \tcode{\libconcept{sized_sentinel_for}<S, I>}:
+\item If \tcode{S} models \tcode{\libconcept{sized_sentinel_for}<I>}:
   \begin{itemize}
   \item If \brk{}$|\tcode{n}| \ge |\tcode{bound - i}|$,
     equivalent to \tcode{ranges::advance(i, bound)}.
@@ -5316,8 +5316,7 @@ constexpr move_iterator<Iterator> make_move_iterator(Iterator i);
 Class template \tcode{move_sentinel} is a sentinel adaptor useful for denoting
 ranges together with \tcode{move_iterator}. When an input iterator type
 \tcode{I} and sentinel type \tcode{S} model \tcode{\libconcept{sentinel_for}<S, I>},
-\tcode{move_sentinel<S>} and \tcode{move_iterator<I>} model
-\tcode{\libconcept{sentinel_for}<move_sentinel<S>, move_iterator<I>>} as well.
+\tcode{\libconcept{sentinel_for}<move_sentinel<S>, move_iterator<I>>} is modeled as well.
 
 \pnum
 \begin{example}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -743,10 +743,8 @@ appears in the immediate context of a template instantiation.
 
 \pnum
 \begin{note}
-Whenever \tcode{ranges::end(E)} is a valid expression,
-the types \tcode{S} and \tcode{I} of
-\tcode{ranges::end(E)} and \tcode{ranges::begin(E)}
-model \tcode{\libconcept{sentinel_for}<S, I>}.
+Whenever \tcode{ranges::end(E)} is a valid expression, its type models
+\tcode{\libconcept{sentinel_for}<decltype(ranges::begin(E))>}.
 \end{note}
 
 \rSec2[range.access.cbegin]{\tcode{ranges::cbegin}}
@@ -799,12 +797,10 @@ let \tcode{U} be \tcode{ranges::end(\exposid{possibly-const-range}(t))}.
 
 \pnum
 \begin{note}
-Whenever \tcode{ranges::cend(E)} is a valid expression,
-the types \tcode{S} and \tcode{I} of the expressions
-\tcode{ranges::cend(E)} and \tcode{ranges::cbegin(E)}
-model \tcode{\libconcept{sentinel_for}<S, I>}.
-If \tcode{S} models \libconcept{input_iterator},
-then \tcode{S} also models \exposconceptx{constant-itera\-tor}{constant-iterator}.
+Whenever \tcode{ranges::cend(E)} is a valid expression, its type models
+\tcode{\libconcept{sentinel_for}<decltype(ranges::cbegin(E))>}.
+If the type of \tcode{ranges::cend(E)} models \libconcept{input_iterator},
+then it also models \exposconcept{constant-iterator}.
 \end{note}
 
 \rSec2[range.access.rbegin]{\tcode{ranges::rbegin}}
@@ -897,7 +893,7 @@ Then:
 \item
   Otherwise, if \tcode{auto(t.rend())}
   is a valid expression whose type models
-  \tcode{\libconcept{sentinel_for}<decltype(\brk{}ranges::rbegin(E))>}
+  \tcode{\libconcept{sentinel_for}<decltype(\brk{}ranges::rbegin(E))>},
   then \tcode{ranges::rend(E)} is expression-equivalent to
   \tcode{auto(t.rend())}.
 
@@ -931,10 +927,8 @@ appears in the immediate context of a template instantiation.
 
 \pnum
 \begin{note}
-Whenever \tcode{ranges::rend(E)} is a valid expression,
-the types \tcode{S} and \tcode{I} of the expressions
-\tcode{ranges::rend(E)} and \tcode{ranges::rbegin(E)}
-model \tcode{\libconcept{sentinel_for}<S, I>}.
+Whenever \tcode{ranges::rend(E)} is a valid expression, its type models
+\tcode{\libconcept{sentinel_for}<decltype(ranges::rbegin(E))>}.
 \end{note}
 
 \rSec2[range.access.crbegin]{\tcode{ranges::crbegin}}
@@ -988,12 +982,10 @@ let \tcode{U} be \tcode{ranges::rend(\exposid{possibly-const-range}(t))}.
 
 \pnum
 \begin{note}
-Whenever \tcode{ranges::crend(E)} is a valid expression,
-the types \tcode{S} and \tcode{I} of the expressions
-\tcode{ranges::crend(E)} and \tcode{ranges::crbegin(E)}
-model \tcode{\libconcept{sentinel_for}<S, I>}.
-If \tcode{S} models \libconcept{input_iterator},
-then \tcode{S} also models \exposconceptx{constant-itera\-tor}{constant-iterator}.
+Whenever \tcode{ranges::crend(E)} is a valid expression, its type models
+\tcode{\libconcept{sentinel_for}<decltype(ranges::crbegin(E))>}.
+If the type of \tcode{ranges::crend(E)} models \libconcept{input_iterator},
+then it also models \exposconcept{constant-iterator}.
 \end{note}
 
 \rSec2[range.prim.size]{\tcode{ranges::size}}


### PR DESCRIPTION
This leaves at least two places that I don't know quite how to reword without major surgery; but it makes everything else consistent. The two places are

- sentence https://eel.is/c++draft/ranges#range.req.general-1.sentence-3
- the first half of sentence https://eel.is/c++draft/iterators#move.sentinel-1.sentence-2

I started down this rabbit hole with <a href="https://eel.is/c++draft/alg.nonmodifying#alg.equal-3.2">[alg.equal]</a>, which currently says

> the types of `first1`, `last1`, `first2`, and `last2` pairwise model [sized_sentinel_for](https://eel.is/c++draft/iterator.concept.sizedsentinel#concept:sized_sentinel_for) ([iterator.concept.sizedsentinel])

which is obviously awkward since what it actually wants to say is that `last1, first1` and `last2, first2` model `sized_sentinel_for` — that's a weirdly reversed way of interpreting "pairwise". It now says simply "`S1` models `sized_sentinel_for<I1>`"... but then I noticed all the random places where we said things like "`S1` models `sized_sentinel_for<S1, I1>`" or "`I1` and `S1` model `sized_sentinel_for<S1, I1>`", and cleaned them up too.

The style being selected-for here is:

- "`I` models `input_iterator`" (not "`I` models `input_iterator<I>`")
- "`S` models `sentinel_for<I>`" (not "`S` models `sentinel_for<S, I>`"; not "`S` and `I` model `sentinel_for`")
- "`sentinel_for<S, I>` is modeled" (only if absolutely necessary)
