### PR TITLE
[util.smartptr.shared.cast] Properly describe a bad outcome in notes

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -4356,7 +4356,7 @@ where \tcode{\placeholder{R}} is \tcode{r} for the first overload, and
 \begin{note}
 The seemingly equivalent expression
 \tcode{shared_ptr<T>(static_cast<T*>(r.get()))}
-will eventually result in undefined behavior, attempting to delete the
+can result in undefined behavior, attempting to delete the
 same object twice.
 \end{note}
 \end{itemdescr}
@@ -4393,7 +4393,7 @@ The expression \tcode{dynamic_cast<typename shared_ptr<T>::element_type*>(r.get(
 \pnum
 \begin{note}
 The seemingly equivalent expression
-\tcode{shared_ptr<T>(dynamic_cast<T*>(r.get()))} will eventually result in
+\tcode{shared_ptr<T>(dynamic_cast<T*>(r.get()))} can result in
 undefined behavior, attempting to delete the same object twice.
 \end{note}
 \end{itemdescr}
@@ -4422,7 +4422,7 @@ where \tcode{\placeholder{R}} is \tcode{r} for the first overload, and
 \pnum
 \begin{note}
 The seemingly equivalent expression
-\tcode{shared_ptr<T>(const_cast<T*>(r.get()))} will eventually result in
+\tcode{shared_ptr<T>(const_cast<T*>(r.get()))} can result in
 undefined behavior, attempting to delete the same object twice.
 \end{note}
 \end{itemdescr}
@@ -4451,7 +4451,7 @@ where \tcode{\placeholder{R}} is \tcode{r} for the first overload, and
 \pnum
 \begin{note}
 The seemingly equivalent expression
-\tcode{shared_ptr<T>(reinterpret_cast<T*>(r.get()))} will eventually result in
+\tcode{shared_ptr<T>(reinterpret_cast<T*>(r.get()))} can result in
 undefined behavior, attempting to delete the same object twice.
 \end{note}
 \end{itemdescr}


### PR DESCRIPTION
The notes may want to warn the users with the phrase" will eventually result in undefined behavior," but the saying is inaccurate.

Closes: cplusplus/draft#7035