### PR TITLE
Fix forbidden words in notes and examples

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -5020,7 +5020,7 @@ The ranges \range{first}{last} and \range{result}{result + (last - first)}
 do not overlap.
 \begin{note}
 For the overload with an \tcode{ExecutionPolicy},
-there might be a performance cost
+there can be a performance cost
 if \tcode{iterator_traits<For\-ward\-It\-er\-ator1>::value_type}
 is not \oldconcept{\-Move\-Constructible} (\tref{cpp17.moveconstructible}).
 \end{note}
@@ -5943,7 +5943,7 @@ The ranges \range{first}{last} and \range{result}{result + (last - first)}
 do not overlap.
 \begin{note}
 For the overloads with an \tcode{ExecutionPolicy},
-there might be a performance cost
+there can be a performance cost
 if \tcode{iterator_traits<ForwardIterator1>::value_type} does not meet
 the \oldconcept{\-Move\-Constructible} (\tref{cpp17.moveconstructible}) requirements.
 \end{note}
@@ -6130,7 +6130,7 @@ let $E$ be
     \oldconcept{CopyAssignable} requirements.
     \begin{note}
     For the overloads with an \tcode{ExecutionPolicy},
-    there might be a performance cost
+    there can be a performance cost
     if the value type of \tcode{ForwardIterator1} does not meet both the
     \oldconcept{CopyConstructible} and \oldconcept{CopyAssignable} requirements.
     \end{note}
@@ -7717,7 +7717,7 @@ The input range and output ranges do not overlap.
 
 \begin{note}
 For the overload with an \tcode{ExecutionPolicy},
-there might be a performance cost if \tcode{first}'s value type
+there can be a performance cost if \tcode{first}'s value type
 does not meet the \oldconcept{CopyConstructible} requirements.
 \end{note}
 

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -790,7 +790,7 @@ still applies to these declarations. In particular,
 appearing in the type of \tcode{D} can result
 in the different declarations having distinct types, and
 \grammarterm{lambda-expression}{s} appearing in a default argument of \tcode{D}
-might still denote different types in different translation units.
+can still denote different types in different translation units.
 \end{note}
 
 \pnum
@@ -1512,7 +1512,7 @@ A program point $P$ is said to follow
 any declaration in the same translation unit
 whose locus\iref{basic.scope.pdecl} is before $P$.
 \begin{note}
-The declaration might appear in a scope that does not contain $P$.
+The declaration can appear in a scope that does not contain $P$.
 \end{note}
 \indextext{precede|see{declaration, precede}}%
 A declaration $X$ \defnx{precedes}{declaration!precede}
@@ -1795,7 +1795,7 @@ void g() {
 \pnum
 \begin{note}
 Even if the result of name lookup is unambiguous, use of a name found in
-multiple subobjects might still be
+multiple subobjects can still be
 ambiguous\iref{conv.mem,expr.ref,class.access.base}.
 \end{note}
 \begin{example}
@@ -3111,7 +3111,7 @@ A \defn{memory location} is either an object of scalar type that is not a bit-fi
 or a maximal sequence of adjacent bit-fields all having nonzero width.
 \begin{note}
 Various
-features of the language, such as references and virtual functions, might
+features of the language, such as references and virtual functions, can
 involve additional memory locations that are not accessible to programs but are
 managed by the implementation.
 \end{note}
@@ -4270,7 +4270,7 @@ struct D : virtual B { char c; };
 When \tcode{D} is the type of a complete object, it will have a subobject of
 type \tcode{B}, so it must be aligned appropriately for a \tcode{\keyword{long} \keyword{double}}.
 If \tcode{D} appears as a subobject of another object that also has \tcode{B}
-as a virtual base class, the \tcode{B} subobject might be part of a different
+as a virtual base class, the \tcode{B} subobject can be part of a different
 subobject, reducing the alignment requirements on the \tcode{D} subobject.
 \end{example}
 The result of the \keyword{alignof} operator reflects the alignment
@@ -4583,7 +4583,7 @@ containing the \grammarterm{expression-list}.
 
 \item A temporary bound to a reference in a \grammarterm{new-initializer}\iref{expr.new} persists until the completion of the full-expression containing the \grammarterm{new-initializer}.
 \begin{note}
-This might introduce a dangling reference.
+This can introduce a dangling reference.
 \end{note}
 \begin{example}
 \begin{codeblock}
@@ -4752,7 +4752,7 @@ subsequently hold its original value.
 constexpr std::size_t N = sizeof(T);
 char buf[N];
 T obj;                          // \tcode{obj} initialized to its original value
-std::memcpy(buf, &obj, N);      // between these two calls to \tcode{std::memcpy}, \tcode{obj} might be modified
+std::memcpy(buf, &obj, N);      // between these two calls to \tcode{std::memcpy}, \tcode{obj} can be modified
 std::memcpy(&obj, buf, N);      // at this point, each subobject of \tcode{obj} of scalar type holds its original value
 \end{codeblock}
 \end{example}
@@ -4953,7 +4953,7 @@ that is not a copy or move constructor.
 \end{itemize}
 \begin{note}
 A literal type is one for which
-it might be possible to create an object
+it is possible to create an object
 within a constant expression.
 It is not a guarantee that it is possible to create such an object,
 nor is it a guarantee that any object of that type
@@ -5508,7 +5508,7 @@ an indirection\iref{expr.unary.op} or
 an invocation of a deallocation function\iref{basic.stc.dynamic.deallocation},
 and \impldef{invalid pointer value in the context of an evaluation} otherwise.
 \begin{footnote}
-Some implementations might define that
+Some implementations can define that
 copying such a pointer value causes a system-generated runtime fault.
 \end{footnote}
 \begin{note}
@@ -6133,7 +6133,7 @@ The value of an object visible to a thread $T$ at a particular point is the
 initial value of the object, a value assigned to the object by $T$, or a
 value assigned to the object by another thread, according to the rules below.
 \begin{note}
-In some cases, there might instead be undefined behavior. Much of this
+In some cases, there can instead be undefined behavior. Much of this
 subclause is motivated by the desire to support atomic operations with explicit
 and detailed visibility constraints. However, it also implicitly supports a
 simpler view for more restricted programs.
@@ -6500,19 +6500,19 @@ in $B$.
 \begin{note}
 Compiler transformations that introduce assignments to a potentially
 shared memory location that would not be modified by the abstract machine are
-generally precluded by this document, since such an assignment might overwrite
+generally precluded by this document, since such an assignment can overwrite
 another assignment by a different thread in cases in which an abstract machine
 execution would not have encountered a data race. This includes implementations
 of data member assignment that overwrite adjacent members in separate memory
 locations. Reordering of atomic loads in cases in which the atomics in question
-might alias is also generally precluded, since this could violate the coherence
+can alias is also generally precluded, since this could violate the coherence
 rules.
 \end{note}
 
 \pnum
 \begin{note}
 Transformations that introduce a speculative read of a potentially
-shared memory location might not preserve the semantics of the \Cpp{} program as
+shared memory location can not preserve the semantics of the \Cpp{} program as
 defined in this document, since they potentially introduce a data race. However,
 they are typically valid in the context of an optimizing compiler that targets a
 specific machine with well-defined semantics for data races. They would be
@@ -6553,7 +6553,7 @@ are \defnx{lock-free executions}{lock-free execution}.
   a lock-free execution in that thread shall complete.
   \begin{note}
     Concurrently executing threads
-    might prevent progress of a lock-free execution.
+    can prevent progress of a lock-free execution.
     For example,
     this situation can occur
     with load-locked store-conditional implementations.
@@ -6673,7 +6673,7 @@ Concurrent forward progress guarantees are stronger than parallel forward progre
 guarantees, which in turn are stronger than weakly parallel forward progress
 guarantees.
 \begin{note}
-For example, some kinds of synchronization between threads of execution might only
+For example, some kinds of synchronization between threads of execution can only
 make progress if the respective threads of execution provide parallel forward progress
 guarantees, but will fail to make progress under weakly parallel guarantees.
 \end{note}

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1299,7 +1299,7 @@ its non-static data members are implicitly defined.
 \begin{note}
 An implicitly-declared default constructor has an
 exception specification\iref{except.spec}.
-An explicitly-defaulted definition might have an
+An explicitly-defaulted definition can have an
 implicit exception specification, see~\ref{dcl.fct.def}.
 \end{note}
 
@@ -1502,7 +1502,7 @@ implicitly declared as defaulted if and only if
 
 \begin{note}
 When the move constructor is not implicitly declared or explicitly supplied,
-expressions that otherwise would have invoked the move constructor might instead invoke
+expressions that otherwise would have invoked the move constructor can instead invoke
 a copy constructor.
 \end{note}
 
@@ -2111,7 +2111,7 @@ their constructor (see~\ref{class.base.init}).
 \begin{note}
 A
 \tcode{return}
-statement\iref{stmt.return} in a destructor might not directly return to the
+statement\iref{stmt.return} in a destructor can not directly return to the
 caller; before transferring control to the caller, the destructors for the
 members and bases are called.
 \end{note}
@@ -4053,7 +4053,7 @@ a \defnx{pure virtual function}{function!virtual!pure} by using a
 \grammarterm{pure-specifier}\iref{class.mem} in the function declaration
 in the class definition.
 \begin{note}
-Such a function might be inherited: see below.
+Such a function can be inherited: see below.
 \end{note}
 A class is an \defnadj{abstract}{class}
 if it has at least one pure virtual function.
@@ -4423,7 +4423,7 @@ private:
 \begin{note}
 In a derived class, the lookup of a base class name will find the
 injected-class-name instead of the name of the base class in the scope
-in which it was declared. The injected-class-name might be less accessible
+in which it was declared. The injected-class-name can be less accessible
 than the name of the base class in the scope in which it was declared.
 \end{note}
 
@@ -6033,7 +6033,7 @@ struct D : virtual A { D(A*); };
 struct X { X(A*); };
 
 struct E : C, D, X {
-  E() : D(this),    // undefined behavior: upcast from \tcode{E*} to \tcode{A*} might use path \tcode{E*} $\rightarrow$ \tcode{D*} $\rightarrow$ \tcode{A*}
+  E() : D(this),    // undefined behavior: upcast from \tcode{E*} to \tcode{A*} can use path \tcode{E*} $\rightarrow$ \tcode{D*} $\rightarrow$ \tcode{A*}
                     // but \tcode{D} is not constructed
 
                     // ``\tcode{D((C*)this)}\!'' would be defined: \tcode{E*} $\rightarrow$ \tcode{C*} is defined because \tcode{E()} has started,
@@ -6705,7 +6705,7 @@ a second overload resolution for
 the expression resulting from the interpretation of \tcode{x @ y}
 using the selected rewritten candidate\iref{over.match.oper}
 does not result in a usable candidate
-(for example, that expression might be \tcode{(x <=> y) @ 0}), or
+(for example, that expression can be \tcode{(x <=> y) @ 0}), or
 
 \item
 \tcode{x @ y} cannot be implicitly converted to \tcode{bool}.

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -65,7 +65,7 @@ A \grammarterm{class-specifier} whose
 \grammarterm{class-head} omits the
 \grammarterm{class-head-name} defines an \defnadj{unnamed}{class}.
 \begin{note}
-An unnamed class thus can't
+An unnamed class thus cannot
 be \tcode{final}.
 \end{note}
 Otherwise, the \grammarterm{class-name} is an \grammarterm{identifier};
@@ -1026,7 +1026,7 @@ An implicitly-declared special member function is declared at the closing
 Programs shall not define implicitly-declared special member functions.
 
 \pnum
-Programs may explicitly refer to implicitly-declared special member functions.
+Programs can explicitly refer to implicitly-declared special member functions.
 \begin{example}
 A program may explicitly call or form a pointer to member
 to an implicitly-declared special member function.

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -591,7 +591,7 @@ during the phase.
 Correct contradictory wording and
 improve implementation flexibility for performance.
 \effect
-Valid \CppXX{} code using a barrier might have
+Valid \CppXX{} code using a barrier can have
 different semantics in this revision of \Cpp{}
 if it depends on a completion function's side effects occurring exactly once,
 on a specific thread running the phase completion step, or
@@ -1175,7 +1175,7 @@ changed from \keyword{void} to \tcode{container::size_type}.
 \rationale
 Improve efficiency and convenience of finding number of removed elements.
 \effect
-Code that depends on the return types might have different semantics in this revision of \Cpp{}.
+Code that depends on the return types can have different semantics in this revision of \Cpp{}.
 Translation units compiled against this version of \Cpp{} may be incompatible with
 translation units compiled against \CppXVII{}, either failing to link or having undefined behavior.
 
@@ -1615,7 +1615,7 @@ invalid in this revision of \Cpp{}.
 New reserved namespaces.
 \rationale
 Reserve namespaces for future revisions of the standard library
-that might otherwise be incompatible with existing programs.
+that can otherwise be incompatible with existing programs.
 \effect
 The global namespaces \tcode{std}
 followed by an arbitrary sequence of \grammarterm{digit}{s}\iref{lex.name}
@@ -1788,7 +1788,7 @@ void* operator new(std::size_t, std::size_t);
 void operator delete(void*, std::size_t) noexcept;
 \end{codeblock}
 In this revision of \Cpp{}, however, the declaration of \tcode{operator delete}
-might match a predefined usual (non-placement)
+can match a predefined usual (non-placement)
 \tcode{operator delete}\iref{basic.stc.dynamic}. If so, the
 program is ill-formed, as it was for class member allocation functions and
 deallocation functions\iref{expr.new}.
@@ -2567,7 +2567,7 @@ from ``array of \keyword{wchar_t}''
 to ``array of \tcode{const wchar_t}''.
 \rationale
 This avoids calling an inappropriate overloaded function,
-which might expect to be able to modify its argument.
+such as one that expects to be able to modify its argument.
 \effect
 Change to semantics of well-defined feature.
 \difficulty

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1391,7 +1391,7 @@ Removal of trigraph support as a required feature.
 \rationale
 Prevents accidental uses of trigraphs in non-raw string literals and comments.
 \effect
-Valid \CppXIV{} code that uses trigraphs may not be valid or may have different
+Valid \CppXIV{} code that uses trigraphs can be invalid or have different
 semantics in this revision of \Cpp{}. Implementations may choose to
 translate trigraphs as specified in \CppXIV{} if they appear outside of a raw
 string literal, as part of the \impldef{mapping input source file characters
@@ -1521,8 +1521,8 @@ Inheriting a constructor no longer injects a constructor into the derived class.
 \rationale
 Better interaction with other language features.
 \effect
-Valid \CppXIV{} code that uses inheriting constructors may not be valid
-or may have different semantics. A \grammarterm{using-declaration}
+Valid \CppXIV{} code that uses inheriting constructors can be invalid
+or have different semantics. A \grammarterm{using-declaration}
 that names a constructor now makes the corresponding base class constructors
 visible to initializations of the derived class
 rather than declaring additional derived class constructors.
@@ -2218,7 +2218,7 @@ Additional restrictions on macro names.
 \rationale
 Avoid hard to diagnose or non-portable constructs.
 \effect
-Names of attribute identifiers may not be used as macro names. Valid \CppIII{}
+It is not allowed to use names of attribute identifiers as macro names. Valid \CppIII{}
 code that defines \tcode{override}, \tcode{final},
 \tcode{carries_dependency}, or \tcode{noreturn} as macros is invalid in this
 revision of \Cpp{}.
@@ -2297,7 +2297,7 @@ Complexity of \tcode{size()} member functions now constant.
 Lack of specification of complexity of \tcode{size()} resulted in
 divergent implementations with inconsistent performance characteristics.
 \effect
-Some container implementations that conform to \CppIII{} may not conform to the
+It is possible that some container implementations that conform to \CppIII{} do not conform to the
 specified \tcode{size()} requirements in this revision of \Cpp{}. Adjusting
 containers such as \tcode{std::list} to the stricter requirements may require
 incompatible changes.
@@ -2404,7 +2404,7 @@ Compatibility with C99.
 \effect
 Valid \CppIII{} code that uses implementation-specific knowledge about the
 binary representation of the required template specializations of
-\tcode{std::complex} may not be compatible with this revision of \Cpp{}.
+\tcode{std::complex} can be incompatible with this revision of \Cpp{}.
 
 \rSec2[diff.cpp03.locale]{\ref{localization}: localization library}
 
@@ -2414,7 +2414,7 @@ The \tcode{num_get} facet recognizes hexadecimal floating point values.
 \rationale
 Required by new feature.
 \effect
-Valid \CppIII{} code may have different behavior in this revision of \Cpp{}.
+Valid \CppIII{} code can have different behavior in this revision of \Cpp{}.
 
 \rSec2[diff.cpp03.input.output]{\ref{input.output}: input/output library}
 
@@ -3020,7 +3020,7 @@ Common.
 
 \diffref{dcl.fct} [see \ref{expr.sizeof}]
 \change
-In \Cpp{}, types may not be defined in return or parameter types.
+In \Cpp{}, defining types in return or parameter types is not allowed.
 In C, these type definitions are allowed.
 
 \begin{example}
@@ -3347,7 +3347,7 @@ Seldom.
 
 \diffref{class.member.lookup}
 \change
-In \Cpp{}, a \grammarterm{typedef-name} may not be redeclared in a class definition after being used in that definition.
+In \Cpp{}, it is not allowed to redeclare a \grammarterm{typedef-name} in a class definition after being used in that definition.
 
 \begin{example}
 \begin{codeblock}

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -623,7 +623,7 @@ template<class T>
   \begin{note}
   This precludes calling unconstrained program-defined overloads of
   \tcode{swap}. When the deleted overload is viable, program-defined overloads
-  need to be more specialized\iref{temp.func.order} to be selected.
+  are only selected if they are more specialized\iref{temp.func.order}.
   \end{note}
 
 \item

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -22314,7 +22314,7 @@ The expression is equality preserving.
 \pnum
 \begin{note}
 Concrete accessor policies can impose preconditions for their \tcode{access} function.
-However, they can not.
+However, it is possible that they do not.
 For example, an accessor where
 \tcode{p} is \tcode{span<A::element_type, dynamic_extent>} and
 \tcode{access(p, i)} returns \tcode{p[i \% p.size()]}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -22314,7 +22314,7 @@ The expression is equality preserving.
 \pnum
 \begin{note}
 Concrete accessor policies can impose preconditions for their \tcode{access} function.
-However, they might not.
+However, they can not.
 For example, an accessor where
 \tcode{p} is \tcode{span<A::element_type, dynamic_extent>} and
 \tcode{access(p, i)} returns \tcode{p[i \% p.size()]}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -6291,7 +6291,7 @@ expression whose value after integral promotions will fit into the target type, 
 \end{itemize}
 
 \begin{note}
-As indicated above, such conversions are not allowed at the top level in
+As indicated above, such conversions are not possible at the top level in
 list-initializations.
 \end{note}
 \begin{example}
@@ -9377,7 +9377,7 @@ if the attribute does not cause suppression of such warnings.
   [[maybe_unused]] x:
 }
 \end{codeblock}
-Implementations should not warn that \tcode{b} or \tcode{x} is unused,
+Implementations are discouraged from warning that \tcode{b} or \tcode{x} is unused,
 whether or not \tcode{NDEBUG} is defined.
 \end{example}
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4370,7 +4370,7 @@ that inhabits a scope $S$,
 any default argument associated with any reachable declaration that inhabits $S$
 is available to the call.
 \begin{note}
-The candidate might have been found through a \grammarterm{using-declarator}
+The candidate can be found through a \grammarterm{using-declarator}
 from which the declaration that provides the default argument is not reachable.
 \end{note}
 
@@ -4944,7 +4944,7 @@ even if the object is of non-class type or
 no constructor of the object's class
 is invoked for the initialization.
 \begin{note}
-Such an object might have been value-initialized
+Such an object can be value-initialized
 or initialized by aggregate initialization\iref{dcl.init.aggr}
 or by an inherited constructor\iref{class.inhctor.init}.
 \end{note}
@@ -8454,7 +8454,7 @@ have a \defn{language linkage}.
 \begin{note}
 Some of the properties associated with an entity with language linkage
 are specific to each implementation and are not described here. For
-example, a particular language linkage might be associated with a
+example, a particular language linkage can be associated with a
 particular form of representing names of objects and functions with
 external linkage, or with a particular calling convention, etc.
 \end{note}
@@ -9039,7 +9039,7 @@ program is ill-formed, no diagnostic required.
 \pnum
 \begin{note}
 The \tcode{carries_dependency} attribute does not change the meaning of the
-program, but might result in generation of more efficient code.
+program, but can result in generation of more efficient code.
 \end{note}
 
 \pnum
@@ -9082,8 +9082,9 @@ need not constrain ordering upon return from \tcode{f}. Implementations of
 hardware memory ordering instructions (a.k.a.\ fences).
 Function \tcode{g}'s second parameter has a \tcode{carries_dependency} attribute,
 but its first parameter does not. Therefore, function \tcode{h}'s first call to
-\tcode{g} carries a dependency into \tcode{g}, but its second call does not. The
-implementation might need to insert a fence prior to the second call to
+\tcode{g} carries a dependency into \tcode{g}, but its second call does not.
+It is possible that the
+implementation needs to insert a fence prior to the second call to
 \tcode{g}.
 \end{example}
 \indextext{attribute|)}%
@@ -9169,7 +9170,7 @@ The program is ill-formed if there is no such statement.
 \pnum
 \recommended
 The use of a fallthrough statement should suppress
-a warning that an implementation might otherwise issue
+a warning that an implementation can otherwise issue
 for a case or default label that is reachable
 from another case or default label along some path of execution.
 The value of
@@ -9498,7 +9499,7 @@ terminate by throwing an exception.
 \pnum
 \recommended
 Implementations should issue a
-warning if a function marked \tcode{[[noreturn]]} might return.
+warning if a function marked \tcode{[[noreturn]]} can return.
 The value of
 a \grammarterm{has-attribute-expression} for the \tcode{noreturn} attribute
 should be \tcode{0} unless the implementation can issue such warnings.

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -1077,7 +1077,7 @@ Otherwise, the function returns \tcode{error_condition(ev, system_category())}.
 What constitutes correspondence for any given operating system is unspecified.
 \begin{note}
 The number of potential system error codes is large
-and unbounded, and some might not correspond to any POSIX \tcode{errno} value. Thus
+and unbounded, and some can not correspond to any POSIX \tcode{errno} value. Thus
 implementations are given latitude in determining correspondence.
 \end{note}
 \end{itemdescr}
@@ -1719,7 +1719,7 @@ const char* what() const noexcept override;
 An \ntbs{} incorporating the arguments supplied in the constructor.
 
 \begin{note}
-The returned \ntbs{} might be the contents of \tcode{what_arg + ": " +
+The returned \ntbs{} can be the contents of \tcode{what_arg + ": " +
 code.message()}.
 \end{note}
 \end{itemdescr}

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -817,7 +817,7 @@ non-throwing exception specification,
 the function \tcode{std::terminate} is invoked\iref{except.terminate}.
 \begin{note}
 An implementation is not permitted to reject an expression merely because, when
-executed, it throws or might
+executed, it throws or can
 throw an exception from a function with a non-throwing exception specification.
 \end{note}
 \begin{example}

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -987,8 +987,9 @@ function that calls the function.
 A defaulted declaration does not require the
 exception specification of a base member function to be evaluated
 until the implicit exception specification of the derived
-function is needed, but an explicit \grammarterm{noexcept-specifier} needs
-the implicit exception specification to compare against.
+function is needed, but an explicit \grammarterm{noexcept-specifier}
+compares against
+the implicit exception specification.
 \end{note}
 \end{itemize}
 The exception specification of a defaulted

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1445,7 +1445,7 @@ void g() {
 \end{codeblock}
 In each case, the constraints of \tcode{f} are not satisfied.
 In the declaration of \tcode{p2},
-those constraints need to be satisfied
+those constraints are expected to be satisfied
 even though
 \tcode{f} is an unevaluated operand\iref{term.unevaluated.operand}.
 \end{example}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -114,7 +114,7 @@ or
 \begin{codeblock}
 a = (a + (b + 32765));
 \end{codeblock}
-since the values for \tcode{a} and \tcode{b} might have been,
+since the values for \tcode{a} and \tcode{b} can be,
 respectively, 4 and $-8$ or $-17$ and 12. However on a machine in which
 overflows do not produce an exception and in which the results of
 overflows are reversible, the above expression statement can be
@@ -262,7 +262,7 @@ a prvalue of type \keyword{int} is required.
 \begin{note}
 There are no prvalue bit-fields; if a bit-field is converted to a
 prvalue\iref{conv.lval}, a prvalue of the type of the bit-field is
-created, which might then be promoted\iref{conv.prom}.
+created, which can then be promoted\iref{conv.prom}.
 \end{note}
 
 \pnum
@@ -4308,7 +4308,7 @@ its operand.
 
 \pnum
 \begin{note}
-The mapping performed by \keyword{reinterpret_cast} might, or might not, produce a
+The mapping performed by \keyword{reinterpret_cast} can, or can not, produce a
 representation different from the original value.
 \end{note}
 
@@ -7068,7 +7068,7 @@ that conversion is applied to the chosen operand
 and the converted operand is used in place of the original operand for
 the remainder of this subclause.
 \begin{note}
-The conversion might be ill-formed even if an implicit conversion
+The conversion can be ill-formed even if an implicit conversion
 sequence could be formed.
 \end{note}
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -13018,7 +13018,7 @@ Initializes the base class with \tcode{basic_ostream<charT, traits>(addressof(sb
 \begin{note}
 The member functions of the provided stream buffer
 can be called from \tcode{emit()} while a lock is held,
-which might result in a deadlock if used incautiously.
+which can result in a deadlock if used incautiously.
 \end{note}
 
 \pnum
@@ -14386,7 +14386,7 @@ Otherwise, modifies \tcode{*this} as if by these steps:
 \begin{example}
 Even if \tcode{//host} is interpreted as a \grammarterm{root-name},
 both of the paths \tcode{path("//host")/"foo"} and \tcode{path("//host/")/"foo"}
-equal \tcode{"//host/foo"} (although the former might use backslash as the
+equal \tcode{"//host/foo"} (although the former can use backslash as the
 preferred separator).
 
 Expression examples:
@@ -16624,11 +16624,12 @@ as a friend of class \tcode{directory_entry}.
 
 \pnum
 \begin{note}
-A path obtained by dereferencing a directory iterator might not actually exist;
-it could be a symbolic link to a non-existent file.
+In some cases,
+a path obtained by dereferencing a directory iterator does not actually exist,
+for example when a directory entry is a symbolic link to a non-existent file.
 Recursively walking directory trees
 for purposes of removing and renaming entries
-might invalidate symbolic links that are being followed.
+can invalidate symbolic links that are being followed.
 \end{note}
 
 \pnum
@@ -17205,7 +17206,7 @@ and not consider \tcode{!exists(p)} an error.
 For POSIX-based operating systems,
 \tcode{absolute(p)} is simply \tcode{current_path()/p}.
 For Windows-based operating systems,
-\tcode{absolute} might have the same semantics as \tcode{GetFullPathNameW}.
+\tcode{absolute} can have the same semantics as \tcode{GetFullPathNameW}.
 \end{example}
 \end{itemdescr}
 
@@ -18522,7 +18523,7 @@ Renames \tcode{old_p} to \tcode{new_p}, as if by
     \tcode{new_p} is removed; otherwise,
 \item if \tcode{new_p} resolves to an existing directory,
     \tcode{new_p} is removed if empty on POSIX compliant operating systems
-    but might be an error on other operating systems.
+    but can be an error on other operating systems.
 \end{itemize}
 \end{itemize}
 A symbolic link is itself renamed, rather than the file it resolves to.
@@ -18585,7 +18586,7 @@ As specified in~\ref{fs.err.report}.
 The value of member \tcode{space_info::available}
       is operating system dependent.
 \begin{note}
-\tcode{available} might be
+\tcode{available} can be
       less than \tcode{free}.
 \end{note}
 \end{itemdescr}
@@ -18791,12 +18792,12 @@ As specified in~\ref{fs.err.report}.
 
 \pnum
 \begin{example}
-For POSIX-based operating systems, an implementation might
+For POSIX-based operating systems, a possible implementation is to
   return the path
   supplied by the first environment variable found in the list TMPDIR, TMP, TEMP, TEMPDIR,
   or if none of these are found, \tcode{"/tmp"}.
 
-For Windows-based operating systems, an implementation might return the path
+For Windows-based operating systems, an implementation can return the path
   reported by the Windows \tcode{GetTempPath} API function.
 \end{example}
 \end{itemdescr}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1213,8 +1213,8 @@ denoted by \tcode{E1} and \tcode{E2},
 the program is ill-formed, no diagnostic required.
 \begin{note}
 This precludes calling unconstrained \tcode{std::iter_swap}. When the deleted
-overload is viable, program-defined overloads need to be more
-specialized\iref{temp.func.order} to be selected.
+overload is viable, program-defined overloads are only selected
+if they are more specialized\iref{temp.func.order}.
 \end{note}
 
 \item Otherwise, if the types of \tcode{E1} and \tcode{E2} each model

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1086,9 +1086,9 @@ conformance to the iterator concepts\iref{iterator.concepts}.
 To indicate conformance to the \libconcept{input_iterator} concept
 but a lack of conformance to
 the \oldconcept{InputIter\-ator} requirements\iref{input.iterators},
-an \tcode{iterator_traits} specialization might have
+an \tcode{iterator_traits} specialization can have
 \tcode{iterator_concept} denote \tcode{input_iterator_tag}
-but not define \tcode{iterator_category}.
+and not define \tcode{iterator_category}.
 \end{example}
 
 \pnum

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -855,12 +855,12 @@ Nothing.
 \begin{note}
 The alignment assumption on an object \tcode{X}
 expressed by a call to \tcode{assume_aligned}
-might result in generation of more efficient code.
+can result in generation of more efficient code.
 It is up to the program to ensure that the assumption actually holds.
 The call does not cause the implementation to verify or enforce this.
-An implementation might only make the assumption
-for those operations on \tcode{X} that access \tcode{X}
-through the pointer returned by \tcode{assume_aligned}.
+For operations on \tcode{X} that do not access \tcode{X}
+through the pointer returned by \tcode{assume_aligned},
+an implementation can ignore the alignment assumption.
 \end{note}
 \end{itemdescr}
 
@@ -2531,7 +2531,7 @@ with the old value of the stored pointer, \tcode{old_p},
 evaluates \tcode{if (old_p) get_deleter()(old_p);}
 \begin{note}
 The order of these operations is significant
-because the call to \tcode{get_deleter()} might destroy \tcode{*this}.
+because the call to \tcode{get_deleter()} can destroy \tcode{*this}.
 \end{note}
 
 \pnum
@@ -3813,7 +3813,7 @@ can affect the return value of \tcode{use_count()}.
 \pnum
 \begin{note}
 When multiple threads
-might affect the return value of \tcode{use_count()},
+can affect the return value of \tcode{use_count()},
 the result is approximate.
 In particular, \tcode{use_count() == 1} does not imply that accesses through
 a previously destroyed \tcode{shared_ptr} have in any sense completed.

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -2115,7 +2115,7 @@ meet the \oldconcept{NullablePointer} requirements (\tref{cpp17.nullablepointer}
 Given an allocator type \tcode{X}\iref{allocator.requirements.general} and
 letting \tcode{A} be a synonym for \tcode{allocator_traits<X>}, the types \tcode{A::pointer},
 \tcode{A::const_pointer}, \tcode{A::void_pointer}, and \tcode{A::const_void_pointer}
-may be used as \tcode{unique_ptr<T, D>::pointer}.
+can be used as \tcode{unique_ptr<T, D>::pointer}.
 \end{example}
 
 \rSec4[unique.ptr.single.ctor]{Constructors}
@@ -4852,14 +4852,9 @@ namespace std {
 \pnum
 \tcode{operator()(x, y)} returns \tcode{x.owner_before(y)}.
 \begin{note}
-Note that
-\begin{itemize}
-\item \tcode{operator()} defines a strict weak ordering as defined in~\ref{alg.sorting};
-
-\item
+\tcode{operator()} defines a strict weak ordering as defined in~\ref{alg.sorting}.
 \tcode{!operator()(a, b) \&\& !operator()(b, a)} is \tcode{true}
 if and only if \tcode{a.owner_equal(b)} is \tcode{true}.
-\end{itemize}
 \end{note}
 
 \rSec3[util.smartptr.owner.hash]{Struct \tcode{owner_hash}}
@@ -6231,10 +6226,9 @@ to tune the largest block size and the maximum chunk size.
 A \tcode{synchronized_pool_resource} may be accessed from multiple threads
 without external synchronization
 and may have thread-specific pools to reduce synchronization costs.
-An \tcode{unsynchronized_pool_resource} class may not be accessed
-from multiple threads simultaneously
-and thus avoids the cost of synchronization entirely
-in single-threaded applications.
+Using an \tcode{unsynchronized_pool_resource} from multiple threads
+results in potentially concurrent conflicting accesses\iref{intro.races},
+but use within a single thread avoids the need for any synchronization.
 
 \indexlibraryglobal{pool_options}%
 \indexlibraryglobal{synchronized_pool_resource}%

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -11570,8 +11570,7 @@ perform additional arithmetic operations
 (other than those specified by the function's wording and \ref{linalg.reqs.alg})
 in order to improve performance or accuracy; and
 \item
-use approximations
-(that might not be exact even if computing with real numbers),
+use inexact approximations
 instead of computations that would be exact
 if it were possible to compute without rounding error;
 \end{itemize}

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2043,7 +2043,7 @@ alignment, accessibility of the argument, whether the argument is a bit-field,
 and whether a function is deleted\iref{dcl.fct.def.delete}, are ignored.
 So, although an implicit
 conversion sequence can be defined for a given argument-parameter
-pair, the conversion from the argument to the parameter might still
+pair, the conversion from the argument to the parameter can still
 be ill-formed in the final analysis.
 \end{note}
 

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1712,7 +1712,7 @@ replace the value of this macro with a greater value.
 The macros defined in \tref{cpp.predefined.ft} shall be defined to
 the corresponding integer literal.
 \begin{note}
-Future revisions of this document might replace
+Future revisions of this document can replace
 the values of these macros with greater values.
 \end{note}
 

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -1099,7 +1099,7 @@ of the initialization.
 \begin{note}
 A conforming implementation cannot introduce
 any deadlock around execution of the initializer.
-Deadlocks might still be caused by the program logic;
+Deadlocks can still be caused by the program logic;
 the implementation need only avoid deadlocks
 due to its own synchronization operations.
 \end{note}

--- a/source/support.tex
+++ b/source/support.tex
@@ -546,7 +546,7 @@ Each of the macros defined in \libheader{version} is also defined
 after inclusion of any member of the set of library headers
 indicated in the corresponding comment in this synopsis.
 \begin{note}
-Future revisions of this document might replace
+Future revisions of this document can replace
 the values of these macros with greater values.
 \end{note}
 
@@ -2185,7 +2185,7 @@ than one thread.
 \begin{note}
 The
 \tcode{at_quick_exit} registrations are distinct from the \tcode{atexit} registrations,
-and applications might need to call both registration functions with the same argument.
+and it is possible that applications need to call both registration functions with the same argument.
 \end{note}
 
 \pnum
@@ -2508,7 +2508,7 @@ If a function with a \tcode{size} parameter is defined,
 the program shall also define
 the corresponding version without the \tcode{size} parameter.
 \begin{note}
-The default behavior below might change in the future, which will require
+The default behavior below can change in the future, which will require
 replacing both deallocation functions when replacing the allocation function.
 \end{note}
 
@@ -2751,7 +2751,7 @@ If a function with a \tcode{size} parameter is defined,
 the program shall also define
 the corresponding version without the \tcode{size} parameter.
 \begin{note}
-The default behavior below might change in the future, which will require
+The default behavior below can change in the future, which will require
 replacing both deallocation functions when replacing the allocation function.
 \end{note}
 
@@ -4351,7 +4351,7 @@ all of the six two-way comparison operators\iref{expr.rel,expr.eq},
 for which equality need not imply substitutability,
 and that permits two values to be incomparable.%
 \begin{footnote}
-That is, \tcode{a < b}, \tcode{a == b}, and \tcode{a > b} might all be \tcode{false}.
+That is, \tcode{a < b}, \tcode{a == b}, and \tcode{a > b} can all be \tcode{false}.
 \end{footnote}
 
 \indexlibraryglobal{partial_ordering}%

--- a/source/support.tex
+++ b/source/support.tex
@@ -6187,7 +6187,7 @@ explicit \grammarterm{using-declaration}{s}\iref{namespace.udecl}.
 \begin{example}
 The header \libheader{cstdlib} assuredly
 provides its declarations and definitions within the namespace
-\tcode{std}. It may also provide these names within the
+\tcode{std}. It can also provide these names within the
 global namespace.
 The header \libheader{stdlib.h}
 assuredly provides the same declarations and definitions within

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -690,7 +690,7 @@ If the name is an \grammarterm{identifier},
 it is then interpreted as a \grammarterm{template-name}.
 The keyword \keyword{template} is used to indicate
 that a dependent qualified name\iref{temp.dep.type} denotes a template
-where an expression might appear.
+where an expression can appear.
 \end{note}
 \begin{example}
 \begin{codeblock}
@@ -2161,7 +2161,7 @@ denotes a unique dependent type. Two such \grammarterm{decltype-specifier}{s}
 refer to the same type only if their \grammarterm{expression}{s} are
 equivalent\iref{temp.over.link}.
 \begin{note}
-However, such a type might be aliased,
+However, such a type can be aliased,
 e.g., by a \grammarterm{typedef-name}.
 \end{note}
 
@@ -4289,7 +4289,7 @@ because the lookup depends on a template parameter.
 \begin{note}
 Some dependent names are also looked up during parsing to determine
 that they are dependent or to interpret following \tcode{<} tokens.
-Uses of other names might be type-dependent or
+Uses of other names can be type-dependent or
 value-dependent\iref{temp.dep.expr,temp.dep.constexpr}.
 A \grammarterm{using-declarator} is never dependent in a specialization and
 is therefore replaced during lookup for that specialization\iref{basic.lookup}.

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6358,7 +6358,7 @@ translation unit in which it is explicitly instantiated.
 
 \pnum
 \begin{note}
-An explicit instantiation of a constrained template needs
+An explicit instantiation of a constrained template is expected
 to satisfy that template's associated constraints\iref{temp.constr.decl}.
 The satisfaction of constraints is determined
 % FIXME: What is a "template name"? Does this mean "simple-template-id"?
@@ -6681,7 +6681,7 @@ X<int> x;                                       // error: object of incomplete c
 
 \pnum
 \begin{note}
-An explicit specialization of a constrained template needs
+An explicit specialization of a constrained template is expected
 to satisfy that template's associated constraints\iref{temp.constr.decl}.
 The satisfaction of constraints is determined
 when forming the template name of an explicit specialization

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -4166,7 +4166,7 @@ bool zap() {
 \end{note}
 \begin{note}
 For a union with bits that participate in the value representation
-of some members but not others, compare-and-exchange might always fail.
+of some members but not others, compare-and-exchange can always fail.
 This is because such padding bits have an indeterminate value when they
 do not participate in the value representation of the active member.
 As a consequence, the following code is not guaranteed to ever succeed:
@@ -6430,7 +6430,7 @@ It is a standard-layout class\iref{class.prop}.
 \begin{note}
 A program can deadlock if the thread that owns a \tcode{mutex} object calls
 \tcode{lock()} on that object. If the implementation can detect the deadlock,
-a \tcode{resource_deadlock_would_occur} error condition might be observed.
+a \tcode{resource_deadlock_would_occur} error condition can be observed.
 \end{note}
 
 \pnum
@@ -8480,7 +8480,7 @@ all objects with thread storage duration associated with the current thread.
 \pnum
 \begin{note}
 The supplied lock is held until the thread exits,
-which might cause deadlock due to lock ordering issues.
+which can cause deadlock due to lock ordering issues.
 \end{note}
 
 \pnum
@@ -11185,7 +11185,7 @@ the return type and return value of the member function \tcode{get}.
 \pnum
 \begin{note}
 Access to a value object stored in the shared state is
-unsynchronized, so operations on \tcode{R} might
+unsynchronized, so operations on \tcode{R} can
 introduce a data race\iref{intro.multithread}.
 \end{note}
 
@@ -11475,9 +11475,9 @@ int work(int value) {
 \end{codeblock}
 
 \begin{note}
-Line \#1 might not result in concurrency because
-the \tcode{async} call uses the default policy, which might use
-\tcode{launch::deferred}, in which case the lambda might not be invoked until the
+Line \#1 can result in no concurrency, because
+the \tcode{async} call uses the default policy, which can use
+\tcode{launch::deferred}, in which case the lambda can not be invoked until the
 \tcode{get()} call; in that case, \tcode{work1} and \tcode{work2} are called on the
 same thread and there is no concurrency.
 \end{note}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -57,11 +57,11 @@ meeting its specifications. Failure to allocate storage is reported as described
 in~\ref{res.on.exception.handling}.
 
 \begin{example}
-Consider a function in this Clause that is specified to throw exceptions of type
+If a function in this Clause is specified to throw exceptions of type
 \tcode{system_error} and specifies error conditions that include
 \tcode{operation_not_permitted} for a thread that does not have the privilege to
-perform the operation. Assume that, during the execution of this function, an \tcode{errno}
-of \tcode{EPERM} is reported by a POSIX API call used by the implementation. Since POSIX
+perform the operation, and if during the execution of this function, an \tcode{errno}
+of \tcode{EPERM} is reported by a POSIX API call used by the implementation, since POSIX
 specifies an \tcode{errno} of \tcode{EPERM} when ``the caller does not have the privilege
 to perform the operation'', the implementation maps \tcode{EPERM} to an
 \tcode{error_condition} of \tcode{operation_not_permitted}\iref{syserr} and an exception
@@ -2516,8 +2516,9 @@ affected memory location.
 \item \tcode{memory_order::consume}: a load operation performs a consume operation on the
 affected memory location.
 \begin{note}
-Prefer \tcode{memory_order::acquire}, which provides stronger guarantees
-than \tcode{memory_order::consume}. Implementations have found it infeasible
+\tcode{memory_order::acquire}, which provides stronger guarantees
+than \tcode{memory_order::consume}, is preferred.
+Implementations have found it infeasible
 to provide performance better than that of \tcode{memory_order::acquire}.
 Specification revisions are under consideration.
 \end{note}
@@ -2606,7 +2607,7 @@ that precedes $A$ in $S$.
 
 \pnum
 \begin{note}
-We do not require that $S$ be consistent with
+It is not necessary for $S$ to be consistent with
 ``happens before''\iref{intro.races}.
 This allows more efficient implementation
 of \tcode{memory_order::acquire} and \tcode{memory_order::release}
@@ -2908,14 +2909,14 @@ which is at least \tcode{alignof(T)}.
 
 \pnum
 \begin{note}
-Hardware could require an object
+Hardware can require an object
 referenced by an \tcode{atomic_ref}
 to have stricter alignment\iref{basic.align}
 than other objects of type \tcode{T}.
 Further, whether operations on an \tcode{atomic_ref}
-are lock-free could depend on the alignment of the referenced object.
+are lock-free can depend on the alignment of the referenced object.
 For example, lock-free operations on \tcode{std::complex<double>}
-could be supported only if aligned to \tcode{2*alignof(double)}.
+can be restricted to alignment to \tcode{2*alignof(double)}.
 \end{note}
 \end{itemdescr}
 

--- a/source/time.tex
+++ b/source/time.tex
@@ -6983,7 +6983,7 @@ Otherwise, the returned value is unspecified.
 
 \pnum
 \begin{note}
-This value might be computed on demand.
+This value can be computed on demand.
 \end{note}
 \end{itemdescr}
 
@@ -9293,13 +9293,13 @@ offset = local_time - sys_time
 The \tcode{save} data member is extra information not normally needed
 for conversion between \tcode{local_time} and \tcode{sys_time}.
 If \tcode{save != 0min}, this \tcode{sys_info} is said to be on ``daylight saving'' time,
-and \tcode{offset - save} suggests what offset this \tcode{time_zone} might use
-if it were off daylight saving time.
+and \tcode{offset - save} suggests what offset this \tcode{time_zone} uses
+when not on daylight saving time.
 However, this information should not be taken as authoritative.
 The only sure way to get such information
 is to query the \tcode{time_zone} with a \tcode{time_point}
 that returns a \tcode{sys_info} where \tcode{save == 0min}.
-There is no guarantee what \tcode{time_point} might return such a \tcode{sys_info}
+There is no guarantee what \tcode{time_point} can return such a \tcode{sys_info}
 except that it is guaranteed not to be in the range \range{begin}{end}
 (if \tcode{save != 0min} for this \tcode{sys_info}).
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -3004,8 +3004,8 @@ The second overload is to be found via argument-dependent lookup\iref{basic.look
 \pnum
 \begin{note}
 The above definition does not require \tcode{t$_{\mathrm{tail}}$}
-(or \tcode{u$_{\mathrm{tail}}$}) to be constructed. It might not
-even be possible, as \tcode{t} and \tcode{u} are not required to be copy
+(or \tcode{u$_{\mathrm{tail}}$}) to be constructed. It can
+even be impossible, as \tcode{t} and \tcode{u} are not required to be copy
 constructible. Also, all comparison operator functions are short circuited;
 they do not perform element accesses beyond what is needed to determine the
 result of the comparison.
@@ -13035,7 +13035,7 @@ is \tcode{R(ArgTypes...)}.
 \pnum
 \begin{note}
 The types deduced by the deduction guides for \tcode{function}
-might change in future revisions of \Cpp{}.
+are not guaranteed to remain unchanged in future revisions of \Cpp{}.
 \end{note}
 
 \rSec4[func.wrap.func.con]{Constructors and destructor}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1359,7 +1359,7 @@ In place of:
 \begin{codeblock}
 return pair<int, double>(5, 3.1415926);     // explicit types
 \end{codeblock}
-a \Cpp{} program may contain:
+a \Cpp{} program can contain:
 \begin{codeblock}
 return make_pair(5, 3.1415926);             // types are deduced
 \end{codeblock}


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)

Carefully select each hunk when / if applying to the Working Draft.
