### PR TITLE
[expr.new], [class.free] Remove "free store" from the index

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -2805,7 +2805,6 @@ void f() {
 \end{example}
 
 \rSec2[class.free]{Allocation and deallocation functions}%
-\indextext{free store}%
 
 \pnum
 \indextext{\idxcode{new}!type of}%

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5141,8 +5141,6 @@ is an integral constant expression\iref{expr.const}.
 
 \pnum
 \indextext{expression!\idxcode{new}}%
-\indextext{free store|seealso{\tcode{new}}}%
-\indextext{free store|seealso{\tcode{delete}}}%
 \indextext{memory management|see{\tcode{new}}}%
 \indextext{memory management|see{\tcode{delete}}}%
 \indextext{storage management|see{\tcode{new}}}%

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -17,7 +17,7 @@ programming language as described in \IsoC{}.
 beyond those provided by C, including additional data types,
 classes, templates, exceptions, namespaces, operator
 overloading, function name overloading, references, allocation and
-deallocation functions, and additional library facilities.%
+deallocation operator functions, and additional library facilities.%
 \indextext{scope|)}
 
 \rSec0[intro.refs]{Normative references}%

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -16,8 +16,8 @@ programming language as described in \IsoC{}.
 \Cpp{} provides many facilities
 beyond those provided by C, including additional data types,
 classes, templates, exceptions, namespaces, operator
-overloading, function name overloading, references, free store
-management operators, and additional library facilities.%
+overloading, function name overloading, references, allocation and
+deallocation functions, and additional library facilities.%
 \indextext{scope|)}
 
 \rSec0[intro.refs]{Normative references}%

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -16,8 +16,8 @@ programming language as described in \IsoC{}.
 \Cpp{} provides many facilities
 beyond those provided by C, including additional data types,
 classes, templates, exceptions, namespaces, operator
-overloading, function name overloading, references, allocation and
-deallocation operator functions, and additional library facilities.%
+overloading, function name overloading, references, free store
+management operators, and additional library facilities.%
 \indextext{scope|)}
 
 \rSec0[intro.refs]{Normative references}%


### PR DESCRIPTION
As we have already indexed class-specific allocation and deallocation functions, it is perhaps fine to remove "free store".