### PR TITLE
[conv.lval] Add example of erroneous 'trap representation' being read

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -678,6 +678,20 @@ and the value contained in the object is the prvalue result.
 If the result is an erroneous value\iref{basic.indet} and
 the bits in the value representation are not valid for the object's type,
 the behavior is undefined.
+\begin{example}
+\begin{codeblock}
+int main() {
+  bool a;
+  bool b = a;
+}
+\end{codeblock}
+If the values of the bytes of the object representation of \tcode{a}
+are determined by the implementation so that the
+bits of the value representation of \tcode{a}
+correspond to \tcode{true} or \tcode{false},
+the lvalue-to-rvalue conversion during the initialization of \tcode{b}
+has erroneous behavior, and undefined behavior otherwise.
+\end{example}
 \end{itemize}
 
 \pnum


### PR DESCRIPTION
Fixes #7047.

![image](https://github.com/cplusplus/draft/assets/22040976/4e4f9f96-a4d4-434d-958e-d75154b8d2f9)
