### PR TITLE
[expr.static.cast], [over.call.object] Replace 'greater cv-qualification' with 'more cv-qualified'

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4049,9 +4049,8 @@ away constness\iref{expr.const.cast}.
 An lvalue of type ``\cvqual{cv1} \tcode{B}'', where \tcode{B} is a class
 type, can be cast to type ``reference to \cvqual{cv2} \tcode{D}'', where
 \tcode{D} is a complete class derived\iref{class.derived} from \tcode{B},
-if \cvqual{cv2} is the
-same cv-qualification as, or greater cv-qualification than,
-\cvqual{cv1}. If \tcode{B} is a virtual base class of \tcode{D}
+if \cvqual{cv2}~\tcode{D} is equally as or more cv-qualified than \cvqual{cv1}~\tcode{B}.
+If \tcode{B} is a virtual base class of \tcode{D}
 or a base class of a virtual base class of \tcode{D},
 or if no valid standard conversion from ``pointer to \tcode{D}''
 to ``pointer to \tcode{B}'' exists\iref{conv.ptr}, the program is ill-formed.
@@ -4214,10 +4213,8 @@ Otherwise, the behavior is undefined.
 A prvalue of type ``pointer to \cvqual{cv1} \tcode{B}'', where \tcode{B}
 is a class type, can be converted to a prvalue of type ``pointer to
 \cvqual{cv2} \tcode{D}'',
-where \tcode{D} is a complete class derived\iref{class.derived}
-from \tcode{B},
-if \cvqual{cv2} is the same cv-qualification as,
-or greater cv-qualification than, \cvqual{cv1}.
+where \tcode{D} is a complete class derived\iref{class.derived} from \tcode{B},
+if \cvqual{cv2}~\tcode{D} is equally as or more cv-qualified than \cvqual{cv1}~\tcode{B}.
 If \tcode{B} is a virtual base class of \tcode{D} or
 a base class of a virtual base class of \tcode{D}, or
 if no valid standard conversion from ``pointer to \tcode{D}''
@@ -4236,8 +4233,7 @@ A prvalue of type ``pointer to member of \tcode{D} of type \cvqual{cv1}
 \tcode{B} of type \cvqual{cv2} \tcode{T}'', where
 \tcode{D} is a complete class type and
 \tcode{B} is a base class\iref{class.derived} of \tcode{D},
-if \cvqual{cv2} is the same cv-qualification
-as, or greater cv-qualification than, \cvqual{cv1}.
+if \cvqual{cv2}~\tcode{T} is equally as or more cv-qualified than \cvqual{cv1}~\tcode{T}.
 \begin{note}
 Function types (including those used in pointer-to-member-function types)
 are never cv-qualified\iref{dcl.fct}.
@@ -4261,8 +4257,8 @@ see~\ref{expr.mptr.oper}.
 \pnum
 A prvalue of type ``pointer to \cvqual{cv1} \keyword{void}'' can be
 converted to a prvalue of type ``pointer to \cvqual{cv2} \tcode{T}'',
-where \tcode{T} is an object type and \cvqual{cv2} is the same
-cv-qualification as, or greater cv-qualification than, \cvqual{cv1}.
+where \tcode{T} is an object type,
+and \cvqual{cv2}~\tcode{T} is equally as or more cv-qualified than \cvqual{cv1}~\tcode{void}.
 If the original pointer value represents the address
 \tcode{A} of a byte in memory and
 \tcode{A} does not satisfy the alignment requirement of \tcode{T},
@@ -7038,7 +7034,7 @@ formed and at least one of the operands has (possibly cv-qualified) class type:
 \begin{itemize}
 \item if \tcode{T1} and \tcode{T2} are the same class type
 (ignoring cv-qualification) and
-\tcode{T2} is at least as cv-qualified as \tcode{T1},
+\tcode{T2} is equally as or more cv-qualified than \tcode{T1},
 the target type is \tcode{T2},
 
 \item otherwise, if \tcode{T2} is a base class of \tcode{T1},

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -546,10 +546,9 @@ form
 \begin{ncsimplebnf}
 \keyword{operator} conversion-type-id \terminal{(\,)} \opt{cv-qualifier-seq} \opt{ref-qualifier} \opt{noexcept-specifier} \opt{attribute-specifier-seq} \terminal{;}
 \end{ncsimplebnf}
-where the optional
-\grammarterm{cv-qualifier-seq}
-is the same cv-qualification as, or a greater cv-qualification than,
-\cv{},
+where if \grammarterm{cv-qualifier-seq} is provided,
+\grammarterm{cv-qualifier-seq}~\grammarterm{conversion-type-id}
+is equally as or more cv-qualified than \cv{}~\tcode{T},
 and where
 \grammarterm{conversion-type-id}
 denotes the type ``pointer to function


### PR DESCRIPTION
Fixes https://github.com/cplusplus/draft/issues/7048.

Generally, the strategy is to replace "same cv-qualification, or greater cv-qualification" with "at least as cv-qualified", which is much shorter and more natural. "At least as" is arguably not a defined term (unlike "more cv-qualified"), but I believe it naturally stems from the defined term. If we really wanted to, we could defined "at least as cv-qualified" and "more cv-qualified" more strictly, but I don't believe it's entirely necessary to do so.

Note that there is precedent for "at least as cv-qualified" in https://eel.is/c++draft/expr.cond#4.3.1