### PR TITLE
[dcl.array] No longer explain array subscript in terms of array-to-pointer conversion

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3452,25 +3452,17 @@ can reasonably appear in an expression.
 The expression
 \tcode{x3d[i]}
 is equivalent to
-\tcode{*(x3d + i)};
-in that expression,
-\tcode{x3d}
-is subject to the array-to-pointer conversion\iref{conv.array}
-and is first converted to
-a pointer to a 2-dimensional
-array with rank
-$5 \times 7$
-that points to the first element of \tcode{x3d}.
-Then \tcode{i} is added,
-which on typical implementations involves multiplying
-\tcode{i} by the
-length of the object to which the pointer points,
-which is \tcode{sizeof(int)}$ \times 5 \times 7$.
-The result of the addition and indirection is
-an lvalue denoting
+\tcode{*(x3d + i)},
+and is an lvalue denoting
 the $\tcode{i}^\text{th}$ array element of
-\tcode{x3d}
-(an array of five arrays of seven integers).
+\tcode{x3d},
+which is an array with rank $5 \times 7$.
+On typical implementations,
+computing the address of this two-dimensional array
+involves multiplying
+\tcode{i} by the
+length of the array in bytes,
+which is \tcode{sizeof(int)}$ \times 5 \times 7$.
 If there is another subscript,
 the same argument applies again, so
 \tcode{x3d[i][j]} is


### PR DESCRIPTION
Fixes https://github.com/cplusplus/draft/issues/7052.

![image](https://github.com/cplusplus/draft/assets/22040976/3b8c41d5-0647-4adf-a19a-7a885f8fe859)
