### PR TITLE
[array.cons] Fix various wording issues

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -6295,12 +6295,11 @@ namespace std {
 \pnum
 \indextext{\idxcode{array}!initialization}%
 \indextext{requirements!container}%
-The conditions for an aggregate\iref{dcl.init.aggr} shall be
-met. Class \tcode{array} relies on the implicitly-declared special
+An \tcode{array} relies on the implicitly-declared special
 member functions\iref{class.default.ctor,class.dtor,class.copy.ctor} to
 conform to the container requirements table in~\ref{container.requirements}.
 In addition to the requirements specified in the container requirements table,
-the implicit move constructor and move assignment operator for \tcode{array}
+the implicitly-declared move constructor and move assignment operator for \tcode{array}
 require that \tcode{T} be \oldconcept{MoveConstructible} or \oldconcept{MoveAssignable},
 respectively.
 


### PR DESCRIPTION
This PR fixes the following issues:

- *"The conditions for an aggregate shall be met."* does not specify that `array` meets those requirements, and usually we say this explicitly instead of letting the reader figure it out based on the subclause the wording is in. If we reworded this sentence to say *"An `array` is an aggregate"* (or something similar), this would just be repeating [[array.overview] p2](https://eel.is/c++draft/array.overview#2), and we don't need the same normative wording copied and pasted multiple times. **Therefore, the first sentence is deleted.**

- "Class `array`" is wrong. `array` is a class template, not a class. In the rest of [array], we say "an `array`" which is not wrong at least; it can be seen as a shorthand for "a specialization of the `array` class template".

- "implicit move constructor" is wrong. It's not a defined term, and could reasonably be interpreted to mean "the non-`explicit` move constructor", i.e. converting constructor. That's not what we are trying to say here; we are talking about the implicitly-declared move constructor.

I believe the LWG intent is clear enough for all of these issues to be editorial.