### PR TITLE
[expr.new] Extend example for new-expressions with zero size arrays

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5285,6 +5285,15 @@ Given the definition \tcode{int n = 42},
 \grammarterm{expression} of a \grammarterm{noptr-new-declarator}), but
 \tcode{new float[5][n]} is ill-formed (because \tcode{n} is not a
 constant expression).
+Furthermore,
+\tcode{new float[0]} is well-formed
+(because \tcode{0} is the \grammarterm{expression}
+of a \grammarterm{noptr-new-declarator},
+where a value of zero results in the allocation of an array with no elements),
+but \tcode{new float[n][0]} is ill-formed
+(because \tcode{0} is the \grammarterm{constant-expression}
+of a \grammarterm{noptr-new-declarator},
+where only values greater than zero are allowed).
 \end{example}
 
 \pnum


### PR DESCRIPTION
Someone has told me that they've been reading [[expr.new] p6](http://eel.is/c++draft/expr.new#6) wrong; namely in a way that implies `new int[0]` is ill-formed.

It's not immediately obvious that it is okay even though the wording says that something shall not be zero.

![image](https://github.com/cplusplus/draft/assets/22040976/fae39f54-4042-468c-9d78-fa93d75d5ac1)
