### PR TITLE
[res.on.exception.handling] Add cross-reference to [except.spec]

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -3844,7 +3844,7 @@ and
 Destructor operations defined in the \Cpp{} standard library
 shall not throw exceptions.
 Every destructor in the \Cpp{} standard library shall behave as if it had a
-non-throwing exception specification.
+non-throwing exception specification\iref{except.spec}.
 
 \pnum
 Functions defined in the


### PR DESCRIPTION
Not much to say here ... I personally find it helpful to have a link that takes you straight to the definition of "non-throwing exception specification" here so you can double check what it means.