### PR TITLE
[stmt.pre] Cross-reference [intro.execution]

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -9,7 +9,7 @@
 \rSec1[stmt.pre]{Preamble}
 
 \pnum
-Except as indicated, statements are executed in sequence.
+Except as indicated, statements are executed in sequence\iref{intro.execution}.
 
 \begin{bnf}
 \nontermdef{statement}\br


### PR DESCRIPTION
I think it's helpful to refer to [intro.execution] here for two reasons.

Firstly, [intro.execution] contains the definition of [sequenced before](https://eel.is/c++draft/intro.execution#def:sequenced_before), and while "in sequence" isn't a defined term, it at least is vaguely related to that.

Secondly, this semi-normative sentence is basically a reference to its normative counterpart ([[intro.execution] p9](https://eel.is/c++draft/intro.execution#9)):

> Every value computation and side effect associated with a full-expression is sequenced before every value computation and side effect associated with the next full-expression to be evaluated[.](https://eel.is/c++draft/intro.execution#9.sentence-1)[36](https://eel.is/c++draft/intro.execution#footnote-36)
