### PR TITLE
[implimits] Reorder Annex B by clause number

### DIFF
--- a/source/limits.tex
+++ b/source/limits.tex
@@ -10,23 +10,19 @@ a potential minimum value for that quantity.
 \item%
 Characters in one logical source line\iref{lex.phases} [65\,536].
 \item%
-Number of
-characters in an internal identifier\iref{lex.name}
-or macro name\iref{cpp.replace} [1\,024].
+Number of characters in an internal identifier\iref{lex.name} [1\,024].
 \item%
 Number of
 characters in an external identifier\iref{lex.name,basic.link} [1\,024].
 \item%
 Characters in a \grammarterm{string-literal}\iref{lex.string}
 (after concatenation\iref{lex.phases}) [65\,536].
-
 \item%
 Identifiers with block scope declared in one block\iref{basic.scope.block} [1\,024].
 \item%
 External identifiers\iref{basic.link} in one translation unit [65\,536].
 \item%
 Size of an object\iref{intro.object} [262\,144].
-
 \item%
 Nesting levels of parenthesized expressions\iref{expr.prim.paren} within a full-expression [256].
 \item%
@@ -37,11 +33,10 @@ Lambda-captures in one \grammarterm{lambda-expression}\iref{expr.prim.lambda.cap
 Arguments in one function call\iref{expr.call} [256].
 \item%
 Full-expressions evaluated within a core constant expression\iref{expr.const} [1\,048\,576].
-
 \item%
-Nesting levels of compound statements\iref{stmt.block},
-iteration control structures\iref{stmt.iter},
-and selection control structures\iref{stmt.select} [256].
+Nesting levels of compound statements\iref{stmt.block} [256].
+\item%
+Nesting levels of selection control structures\iref{stmt.select} [256].
 \item%
 Case labels for a
 \keyword{switch}
@@ -49,7 +44,8 @@ statement\iref{stmt.switch} (excluding those for any nested
 \keyword{switch}
 statements)
 [16\,384].
-
+\item%
+Nesting levels of iteration control structures\iref{stmt.iter} [256].
 \item%
 Recursive constexpr function invocations\iref{dcl.constexpr} [512].
 \item%
@@ -69,7 +65,6 @@ Structured bindings\iref{dcl.struct.bind} introduced in one declaration [256].
 Enumeration constants in a single enumeration\iref{dcl.enum} [4\,096].
 \item%
 Nested \grammarterm{linkage-specification}s\iref{dcl.link} [1\,024].
-
 \item%
 Class members declared in a single \grammarterm{member-specification}
 (including member functions)\iref{class.mem} [4\,096].
@@ -97,16 +92,13 @@ Access control declarations in a class\iref{class.access.spec} [4\,096].
 Friend declarations in a class\iref{class.friend} [4\,096].
 \item%
 Member initializers in a constructor definition\iref{class.base.init} [6\,144].
-
 \item%
 Template parameters in a template declaration\iref{temp.param} [1\,024].
 \item%
 Recursively nested template instantiations\iref{temp.inst}, including substitution
 during template argument deduction\iref{temp.deduct} [1\,024].
-
 \item%
 Handlers per try block\iref{except.handle} [256].
-
 \item%
 Nesting levels of conditional inclusion\iref{cpp.cond} [256].
 \item%
@@ -114,14 +106,14 @@ Nesting levels for
 \tcode{\#include}
 files\iref{cpp.include} [256].
 \item%
+Number of characters in a macro name\iref{cpp.replace} [1\,024].
+\item%
+Macro identifiers\iref{cpp.replace} simultaneously defined in one
+translation unit [65\,536].
+\item%
 Parameters in one macro definition\iref{cpp.replace} [256].
 \item%
 Arguments in one macro invocation\iref{cpp.replace} [256].
-\item%
-Macro identifiers\iref{cpp.replace} simultaneously defined in one
-translation
-unit [65\,536].
-
 \item%
 Functions registered by
 \tcode{atexit()}\iref{support.start.term} [32].

--- a/source/limits.tex
+++ b/source/limits.tex
@@ -8,20 +8,7 @@ The bracketed number following each quantity is
 a potential minimum value for that quantity.
 \begin{itemize}
 \item%
-Nesting levels of compound statements\iref{stmt.block},
-iteration control structures\iref{stmt.iter},
-and selection control structures\iref{stmt.select} [256].
-\item%
-Nesting levels of conditional inclusion\iref{cpp.cond} [256].
-\item%
-Pointer\iref{dcl.ptr},
-pointer-to-member\iref{dcl.mptr},
-array\iref{dcl.array}, and
-function\iref{dcl.fct}
-declarators (in any combination)
-modifying a type in a declaration [256].
-\item%
-Nesting levels of parenthesized expressions\iref{expr.prim.paren} within a full-expression [256].
+Characters in one logical source line\iref{lex.phases} [65\,536].
 \item%
 Number of
 characters in an internal identifier\iref{lex.name}
@@ -30,34 +17,31 @@ or macro name\iref{cpp.replace} [1\,024].
 Number of
 characters in an external identifier\iref{lex.name,basic.link} [1\,024].
 \item%
-External identifiers\iref{basic.link} in one translation unit [65\,536].
+Characters in a \grammarterm{string-literal}\iref{lex.string}
+(after concatenation\iref{lex.phases}) [65\,536].
+
 \item%
 Identifiers with block scope declared in one block\iref{basic.scope.block} [1\,024].
 \item%
-Structured bindings\iref{dcl.struct.bind} introduced in one declaration [256].
+External identifiers\iref{basic.link} in one translation unit [65\,536].
 \item%
-Macro identifiers\iref{cpp.replace} simultaneously defined in one
-translation
-unit [65\,536].
+Size of an object\iref{intro.object} [262\,144].
+
 \item%
-Parameters in one function definition\iref{dcl.fct.def.general} [256].
+Nesting levels of parenthesized expressions\iref{expr.prim.paren} within a full-expression [256].
+\item%
+Scope qualifications of one identifier\iref{expr.prim.id.qual} [256].
+\item%
+Lambda-captures in one \grammarterm{lambda-expression}\iref{expr.prim.lambda.capture} [256].
 \item%
 Arguments in one function call\iref{expr.call} [256].
 \item%
-Parameters in one macro definition\iref{cpp.replace} [256].
+Full-expressions evaluated within a core constant expression\iref{expr.const} [1\,048\,576].
+
 \item%
-Arguments in one macro invocation\iref{cpp.replace} [256].
-\item%
-Characters in one logical source line\iref{lex.phases} [65\,536].
-\item%
-Characters in a \grammarterm{string-literal}\iref{lex.string}
-(after concatenation\iref{lex.phases}) [65\,536].
-\item%
-Size of an object\iref{intro.object} [262\,144].
-\item%
-Nesting levels for
-\tcode{\#include}
-files\iref{cpp.include} [256].
+Nesting levels of compound statements\iref{stmt.block},
+iteration control structures\iref{stmt.iter},
+and selection control structures\iref{stmt.select} [256].
 \item%
 Case labels for a
 \keyword{switch}
@@ -65,60 +49,85 @@ statement\iref{stmt.switch} (excluding those for any nested
 \keyword{switch}
 statements)
 [16\,384].
+
+\item%
+Recursive constexpr function invocations\iref{dcl.constexpr} [512].
+\item%
+Pointer\iref{dcl.ptr},
+pointer-to-member\iref{dcl.mptr},
+array\iref{dcl.array}, and
+function\iref{dcl.fct}
+declarators (in any combination)
+modifying a type in a declaration [256].
+\item%
+\grammarterm{initializer-clause}{s} in one \grammarterm{braced-init-list}\iref{dcl.init} [16\,384].
+\item%
+Parameters in one function definition\iref{dcl.fct.def.general} [256].
+\item%
+Structured bindings\iref{dcl.struct.bind} introduced in one declaration [256].
+\item%
+Enumeration constants in a single enumeration\iref{dcl.enum} [4\,096].
+\item%
+Nested \grammarterm{linkage-specification}s\iref{dcl.link} [1\,024].
+
+\item%
+Class members declared in a single \grammarterm{member-specification}
+(including member functions)\iref{class.mem} [4\,096].
 \item%
 Non-static data members (including inherited ones) in a single class\iref{class.mem} [16\,384].
 \item%
-Lambda-captures in one \grammarterm{lambda-expression}\iref{expr.prim.lambda.capture} [256].
-\item%
-Enumeration constants in a single enumeration\iref{dcl.enum} [4\,096].
+Static data members of a class\iref{class.static.data} [1\,024].
 \item%
 Levels of nested class definitions\iref{class.nest}
 in a single
 \grammarterm{member-specification}
 [256].
 \item%
-Functions registered by
-\tcode{atexit()}\iref{support.start.term} [32].
-\item%
-Functions registered by
-\tcode{at_quick_exit()}\iref{support.start.term} [32].
+Direct base classes for a single class\iref{class.derived} [1\,024].
 \item%
 Direct and indirect base classes\iref{class.derived} [16\,384].
 \item%
-Direct base classes for a single class\iref{class.derived} [1\,024].
-\item%
-Class members declared in a single \grammarterm{member-specification}
-(including member functions)\iref{class.mem} [4\,096].
+Direct and indirect virtual bases of a class\iref{class.mi} [1\,024].
 \item%
 Final overriding virtual functions in a class,
 accessible or not\iref{class.virtual} [16\,384].
 \item%
-Direct and indirect virtual bases of a class\iref{class.mi} [1\,024].
-\item%
-Static data members of a class\iref{class.static.data} [1\,024].
+Access control declarations in a class\iref{class.access.spec} [4\,096].
 \item%
 Friend declarations in a class\iref{class.friend} [4\,096].
 \item%
-Access control declarations in a class\iref{class.access.spec} [4\,096].
-\item%
 Member initializers in a constructor definition\iref{class.base.init} [6\,144].
-\item%
-\grammarterm{initializer-clause}{s} in one \grammarterm{braced-init-list}\iref{dcl.init} [16\,384].
-\item%
-Scope qualifications of one identifier\iref{expr.prim.id.qual} [256].
-\item%
-Nested \grammarterm{linkage-specification}s\iref{dcl.link} [1\,024].
-\item%
-Recursive constexpr function invocations\iref{dcl.constexpr} [512].
-\item%
-Full-expressions evaluated within a core constant expression\iref{expr.const} [1\,048\,576].
+
 \item%
 Template parameters in a template declaration\iref{temp.param} [1\,024].
 \item%
 Recursively nested template instantiations\iref{temp.inst}, including substitution
 during template argument deduction\iref{temp.deduct} [1\,024].
+
 \item%
 Handlers per try block\iref{except.handle} [256].
+
+\item%
+Nesting levels of conditional inclusion\iref{cpp.cond} [256].
+\item%
+Nesting levels for
+\tcode{\#include}
+files\iref{cpp.include} [256].
+\item%
+Parameters in one macro definition\iref{cpp.replace} [256].
+\item%
+Arguments in one macro invocation\iref{cpp.replace} [256].
+\item%
+Macro identifiers\iref{cpp.replace} simultaneously defined in one
+translation
+unit [65\,536].
+
+\item%
+Functions registered by
+\tcode{atexit()}\iref{support.start.term} [32].
+\item%
+Functions registered by
+\tcode{at_quick_exit()}\iref{support.start.term} [32].
 \item%
 Number of placeholders\iref{func.bind.place} [10].
 \item%


### PR DESCRIPTION
Reorder the entries in the list of implementation limits according to their clause number.  This ordering neatly groups related items such as all the preprocessor limits, and segregates library from core language limits.  It loses some of the local organisation of the original ordering, such as all parameter and argument list lengths being colocated.

A second commit splits lines that defined several quantities into separate lines that can then be correctly ordered.  The secondary benefit is that these quantities may now be updated independently.  The new risk is that these quantities that were previously guaranteed to be the same can now vary in a future standard.