### PR TITLE
[lex.charset] Extract universal-character-name grammar to new subclause

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -249,7 +249,9 @@ needed for execution in its execution environment.%
 \indextext{translation!phases|)}
 \end{enumerate}
 
-\rSec1[lex.charset]{Character sets}
+\rSec1[lex.char]{Characters}%
+
+\rSec2[lex.charset]{Character sets}
 
 \pnum
 \indextext{character set|(}%
@@ -326,91 +328,11 @@ the numerical value has no other meaning in this context.
 \end{floattable}
 
 \pnum
-The \grammarterm{universal-character-name} construct provides a way to name
-other characters.
-
-\begin{bnf}
-\nontermdef{n-char} \textnormal{one of}\br
-     \textnormal{any member of the translation character set except the \unicode{007d}{right curly bracket} or new-line character}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{n-char-sequence}\br
-    n-char\br
-    n-char-sequence n-char
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{named-universal-character}\br
-    \terminal{\textbackslash N\{} n-char-sequence \terminal{\}}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{hex-quad}\br
-    hexadecimal-digit hexadecimal-digit hexadecimal-digit hexadecimal-digit
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{simple-hexadecimal-digit-sequence}\br
-    hexadecimal-digit\br
-    simple-hexadecimal-digit-sequence hexadecimal-digit
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{universal-character-name}\br
-    \terminal{\textbackslash u} hex-quad\br
-    \terminal{\textbackslash U} hex-quad hex-quad\br
-    \terminal{\textbackslash u\{} simple-hexadecimal-digit-sequence \terminal{\}}\br
-    named-universal-character
-\end{bnf}
-
-\pnum
-A \grammarterm{universal-character-name}
-of the form \tcode{\textbackslash u} \grammarterm{hex-quad},
-\tcode{\textbackslash U} \grammarterm{hex-quad} \grammarterm{hex-quad}, or
-\tcode{\textbackslash u\{\grammarterm{simple-hexadecimal-digit-sequence}\}}
-designates the character in the translation character set
-whose Unicode scalar value is the hexadecimal number represented by
-the sequence of \grammarterm{hexadecimal-digit}s
-in the \grammarterm{universal-character-name}.
-The program is ill-formed if that number is not a Unicode scalar value.
-
-\pnum
-A \grammarterm{universal-character-name}
-that is a \grammarterm{named-universal-character}
-designates the corresponding character
-in the Unicode Standard (chapter 4.8 Name)
-if the \grammarterm{n-char-sequence} is equal
-to its character name or
-to one of its character name aliases of
-type ``control'', ``correction'', or ``alternate'';
-otherwise, the program is ill-formed.
-\begin{note}
-These aliases are listed in
-the Unicode Character Database's \tcode{NameAliases.txt}.
-None of these names or aliases have leading or trailing spaces.
-\end{note}
-
-\pnum
-If a \grammarterm{universal-character-name} outside
-the \grammarterm{c-char-sequence}, \grammarterm{s-char-sequence}, or
-\grammarterm{r-char-sequence} of
-a \grammarterm{character-literal} or \grammarterm{string-literal}
-(in either case, including within a \grammarterm{user-defined-literal})
-corresponds to a control character or
-to a character in the basic character set, the program is ill-formed.
-\begin{note}
-A sequence of characters resembling a \grammarterm{universal-character-name} in an
-\grammarterm{r-char-sequence}\iref{lex.string} does not form a
-\grammarterm{universal-character-name}.
-\end{note}
-
-\pnum
 The \defnadj{basic literal}{character set} consists of
 all characters of the basic character set,
 plus the control characters specified in \tref{lex.charset.literal}.
 
-\begin{floattable}{Additional control characters}{lex.charset.literal}{ll}
+\begin{floattable}{Additional control characters in the basic literal character set}{lex.charset.literal}{ll}
 \topline
 \ohdrx{2}{character} \\ \capsep
 \ucode{0000} & \uname{null} \\
@@ -464,6 +386,86 @@ corresponding to each character of the translation character set
 as specified in the Unicode Standard
 for the respective Unicode encoding form.
 \indextext{character set|)}
+
+\rSec2[lex.universal.char]{Universal character names}
+
+\begin{bnf}
+\nontermdef{n-char}\br
+     \textnormal{any member of the translation character set except the \unicode{007d}{right curly bracket} or new-line character}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{n-char-sequence}\br
+    n-char\br
+    n-char-sequence n-char
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{named-universal-character}\br
+    \terminal{\textbackslash N\{} n-char-sequence \terminal{\}}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{hex-quad}\br
+    hexadecimal-digit hexadecimal-digit hexadecimal-digit hexadecimal-digit
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{simple-hexadecimal-digit-sequence}\br
+    hexadecimal-digit\br
+    simple-hexadecimal-digit-sequence hexadecimal-digit
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{universal-character-name}\br
+    \terminal{\textbackslash u} hex-quad\br
+    \terminal{\textbackslash U} hex-quad hex-quad\br
+    \terminal{\textbackslash u\{} simple-hexadecimal-digit-sequence \terminal{\}}\br
+    named-universal-character
+\end{bnf}
+
+\pnum
+The \grammarterm{universal-character-name} construct provides a way to name any
+element in the translation character set using just the basic character set.
+If a \grammarterm{universal-character-name} outside
+the \grammarterm{c-char-sequence}, \grammarterm{s-char-sequence}, or
+\grammarterm{r-char-sequence} of a \grammarterm{character-literal} or
+\grammarterm{string-literal}
+(in either case, including within a \grammarterm{user-defined-literal})
+corresponds to a control character or to a character in the basic character set,
+the program is ill-formed.
+\begin{note}
+A sequence of characters resembling a \grammarterm{universal-character-name} in an
+\grammarterm{r-char-sequence}\iref{lex.string} does not form a
+\grammarterm{universal-character-name}.
+\end{note}
+
+\pnum
+A \grammarterm{universal-character-name}
+of the form \tcode{\textbackslash u} \grammarterm{hex-quad},
+\tcode{\textbackslash U} \grammarterm{hex-quad} \grammarterm{hex-quad}, or
+\tcode{\textbackslash u\{\grammarterm{simple-hexadecimal-digit-sequence}\}}
+designates the character in the translation character set
+whose Unicode scalar value is the hexadecimal number represented by
+the sequence of \grammarterm{hexadecimal-digit}s
+in the \grammarterm{universal-character-name}.
+The program is ill-formed if that number is not a Unicode scalar value.
+
+\pnum
+A \grammarterm{universal-character-name}
+that is a \grammarterm{named-universal-character}
+designates the corresponding character
+in the Unicode Standard (chapter 4.8 Name)
+if the \grammarterm{n-char-sequence} is equal
+to its character name or
+to one of its character name aliases of
+type ``control'', ``correction'', or ``alternate'';
+otherwise, the program is ill-formed.
+\begin{note}
+These aliases are listed in
+the Unicode Character Database's \tcode{NameAliases.txt}.
+None of these names or aliases have leading or trailing spaces.
+\end{note}
 
 \rSec1[lex.pptoken]{Preprocessing tokens}
 


### PR DESCRIPTION
The grammar for universal-character-name is oddly sandwiched into the middle of the subcluase talking about the different character sets used by the standard.  To improve the flow, extract that grammar into its own subclause.

In the extraction, I make two other clarifying changes.  First, describe this new subclause as 'a way to name any element of the of the tranlation character set using just the basic character set' rather than simply 'a way to name other characters'.  Secondly, remove the 'one of' in the grammar where there is only one option to choose.