### PR TITLE
Fix typo in containers.tex

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2636,7 +2636,7 @@ In this subclause,
 \tcode{a2} denotes a value of a type with nodes compatible with type
 \tcode{X} (\tref{container.node.compat}),
 \item
-\tcode{b} denotes a value or type \tcode{X} or \tcode{const X},
+\tcode{b} denotes a value of type \tcode{X} or \tcode{const X},
 \item
 \tcode{u} denotes the name of a variable being declared,
 \item


### PR DESCRIPTION
In introduction in the same file there's a `\tcode{b} and \tcode{c} denote values of type (possibly const) \tcode{X},`, so this looks like a typo 