### PR TITLE
[func.require] Add missing formatting of variable index

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -10825,7 +10825,7 @@ Define \tcode{\placeholdernc{INVOKE}(f, t$_1$, t$_2$, $\dotsc$, t$_N$)} as follo
 \item \tcode{(t$_1$.*f)(t$_2$, $\dotsc$, t$_N$)} when \tcode{f} is a pointer to a
 member function of a class \tcode{T}
 and
-\tcode{is_same_v<T, remove_cvref_t<decltype(t1)>> ||}
+\tcode{is_same_v<T, remove_cvref_t<decltype(t$_1$)>> ||}
 \tcode{is_base_of_v<T, remove_cvref_t<decltype(t$_1$)>>} is \tcode{true};
 
 \item \tcode{(t$_1$.get().*f)(t$_2$, $\dotsc$, t$_N$)} when \tcode{f} is a pointer to a
@@ -10839,7 +10839,7 @@ and \tcode{t$_1$} does not satisfy the previous two items;
 \item \tcode{t$_1$.*f} when $N = 1$ and \tcode{f} is a pointer to
 data member of a class \tcode{T}
 and
-\tcode{is_same_v<T, remove_cvref_t<decltype(t1)>> ||}
+\tcode{is_same_v<T, remove_cvref_t<decltype(t$_1$)>> ||}
 \tcode{is_base_of_v<T, remove_cvref_t<decltype(t$_1$)>>} is \tcode{true};
 
 \item \tcode{t$_1$.get().*f} when $N = 1$ and \tcode{f} is a pointer to


### PR DESCRIPTION
In paragraph [func.require#1](https://eel.is/c++draft/func.require#1), all variables use subscripted indices in text that is formatted as code, except in two cases. These look like an unintended omission. Adjust them to subscripts.