### PR TITLE
2024-06 CWG-5 P3144 Deleting a pointer to incomplete type is illformed

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -33,6 +33,26 @@ auto x = true ? e : f;  // ill-formed; previously well-formed
 \end{codeblock}
 \end{example}
 
+\diffref{expr.delete}
+\change
+Calling \tcode{delete} on a pointer to an incomplete class is ill-formed.
+\rationale
+Reduce undefined behavior.
+\effect
+A valid \CppXXIII{} program that that calls \tcode{delete} on an incomplete
+class type is ill-formed.
+\begin{example}
+\begin{codeblock}
+struct S;
+
+void f(S *p) {
+  delete p;             // ill-formed; previously well-formed
+}
+
+struct S {};
+\end{codeblock}
+\end{example}
+
 \rSec2[diff.cpp23.dcl.dcl]{\ref{dcl.dcl}: Declarations}
 
 \diffref{dcl.init.list}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5853,9 +5853,8 @@ its static type, the behavior is undefined.
 
 \pnum
 \indextext{type!incomplete}%
-If the object being deleted has incomplete class type at the point of
-deletion and the complete class has a non-trivial destructor or a
-deallocation function, the behavior is undefined.
+If the object being deleted has incomplete class type at the point of deletion,
+the program is ill-formed.
 
 \pnum
 \indextext{\idxcode{delete}!destructor and}%


### PR DESCRIPTION
Applies P3144, adopted at the St Louis meeting.

Fixes #7081
Fixes https://github.com/cplusplus/papers/issues/1796