### PR TITLE
[LWG motion 9 2024-06] P2968R2 Make std::ignore a first-class object

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1494,6 +1494,11 @@ heterogeneous, fixed-size collections of values. An instantiation of \tcode{tupl
 two arguments is similar to an instantiation of \tcode{pair} with the same two arguments.
 See~\ref{pairs}.
 
+\pnum
+In addition to being available via inclusion of the \libheader{tuple} header,
+\tcode{ignore}\iref{tuple.syn} is available when
+\libheader{utility}\iref{utility} is included.
+
 \rSec2[tuple.syn]{Header \tcode{<tuple>} synopsis}
 
 \indexheader{tuple}%
@@ -1520,9 +1525,14 @@ namespace std {
   template<@\exposconceptnc{tuple-like}@ TTuple, @\exposconceptnc{tuple-like}@ UTuple>
     struct common_type<TTuple, UTuple>;
 
-  // \ref{tuple.creation}, tuple creation functions
-  inline constexpr @\unspec@ ignore;
+  // \tcode{ignore}
+  struct @\exposidnc{ignore-type}@ {                      // \expos
+    constexpr const @\exposid{ignore-type}@
+      operator=(const auto &) const noexcept { return *this; }
+  };
+  inline constexpr @\exposid{ignore-type}@ ignore;
 
+  // \ref{tuple.creation}, tuple creation functions
   template<class... TTypes>
     constexpr tuple<unwrap_ref_decay_t<TTypes>...> make_tuple(TTypes&&...);
 
@@ -2591,9 +2601,7 @@ template<class... TTypes>
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{tuple<TTypes\&...>(t...)}.  When an
-argument in \tcode{t} is \tcode{ignore}, assigning
-any value to the corresponding tuple element has no effect.
+\tcode{tuple<TTypes\&...>(t...)}.
 
 \pnum
 \begin{example}


### PR DESCRIPTION
Fixes #7092
Fixes cplusplus/papers#1640