### PR TITLE
[LWG motion 11 2024-06] P2422R1 Remove nodiscard annotations from the standard library specification

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4025,16 +4025,16 @@ are implicitly declared in global scope in each translation unit of a
 program.
 
 \begin{codeblock}
-[[nodiscard]] void* operator new(std::size_t);
-[[nodiscard]] void* operator new(std::size_t, std::align_val_t);
+void* operator new(std::size_t);
+void* operator new(std::size_t, std::align_val_t);
 
 void operator delete(void*) noexcept;
 void operator delete(void*, std::size_t) noexcept;
 void operator delete(void*, std::align_val_t) noexcept;
 void operator delete(void*, std::size_t, std::align_val_t) noexcept;
 
-[[nodiscard]] void* operator new[](std::size_t);
-[[nodiscard]] void* operator new[](std::size_t, std::align_val_t);
+void* operator new[](std::size_t);
+void* operator new[](std::size_t, std::align_val_t);
 
 void operator delete[](void*) noexcept;
 void operator delete[](void*, std::size_t) noexcept;

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2317,7 +2317,7 @@ public:
 
   allocator_type get_allocator() const;
   explicit operator bool() const noexcept;
-  [[nodiscard]] bool empty() const noexcept;
+  bool empty() const noexcept;
 
   // \ref{container.node.modifiers}, modifiers
   void swap(@\placeholdernc{node-handle}@&)
@@ -2495,7 +2495,7 @@ explicit operator bool() const noexcept;
 \end{itemdescr}
 
 \begin{itemdecl}
-[[nodiscard]] bool empty() const noexcept;
+bool empty() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6306,7 +6306,7 @@ namespace std {
     constexpr const_reverse_iterator crend() const noexcept;
 
     // capacity
-    [[nodiscard]] constexpr bool empty() const noexcept;
+    constexpr bool empty() const noexcept;
     constexpr size_type size() const noexcept;
     constexpr size_type max_size() const noexcept;
 
@@ -6629,7 +6629,7 @@ namespace std {
     const_reverse_iterator crend() const noexcept;
 
     // \ref{deque.capacity}, capacity
-    [[nodiscard]] bool empty() const noexcept;
+    bool empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
     void      resize(size_type sz);
@@ -7088,7 +7088,7 @@ namespace std {
     const_iterator cend() const noexcept;
 
     // capacity
-    [[nodiscard]] bool empty() const noexcept;
+    bool empty() const noexcept;
     size_type max_size() const noexcept;
 
     // \ref{forward.list.access}, element access
@@ -7995,7 +7995,7 @@ namespace std {
     const_reverse_iterator crend() const noexcept;
 
     // \ref{list.capacity}, capacity
-    [[nodiscard]] bool empty() const noexcept;
+    bool empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
     void      resize(size_type sz);
@@ -8740,7 +8740,7 @@ namespace std {
     constexpr const_reverse_iterator crend() const noexcept;
 
     // \ref{vector.capacity}, capacity
-    [[nodiscard]] constexpr bool empty() const noexcept;
+    constexpr bool empty() const noexcept;
     constexpr size_type size() const noexcept;
     constexpr size_type max_size() const noexcept;
     constexpr size_type capacity() const noexcept;
@@ -9324,7 +9324,7 @@ namespace std {
     constexpr const_reverse_iterator crend() const noexcept;
 
     // capacity
-    [[nodiscard]] constexpr bool empty() const noexcept;
+    constexpr bool empty() const noexcept;
     constexpr size_type size() const noexcept;
     constexpr size_type max_size() const noexcept;
     constexpr size_type capacity() const noexcept;
@@ -10439,7 +10439,7 @@ namespace std {
     const_reverse_iterator crend() const noexcept;
 
     // capacity
-    [[nodiscard]] bool empty() const noexcept;
+    bool empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
 
@@ -11178,7 +11178,7 @@ namespace std {
     const_reverse_iterator crend() const noexcept;
 
     // capacity
-    [[nodiscard]] bool empty() const noexcept;
+    bool empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
 
@@ -11518,7 +11518,7 @@ namespace std {
     const_reverse_iterator crend() const noexcept;
 
     // capacity
-    [[nodiscard]] bool empty() const noexcept;
+    bool empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
 
@@ -11877,7 +11877,7 @@ namespace std {
     const_reverse_iterator crend() const noexcept;
 
     // capacity
-    [[nodiscard]] bool empty() const noexcept;
+    bool empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
 
@@ -12364,7 +12364,7 @@ namespace std {
     const_iterator cend() const noexcept;
 
     // capacity
-    [[nodiscard]] bool empty() const noexcept;
+    bool empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
 
@@ -13161,7 +13161,7 @@ namespace std {
     const_iterator cend() const noexcept;
 
     // capacity
-    [[nodiscard]] bool empty() const noexcept;
+    bool empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
 
@@ -13583,7 +13583,7 @@ namespace std {
     const_iterator cend() const noexcept;
 
     // capacity
-    [[nodiscard]] bool empty() const noexcept;
+    bool empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
 
@@ -14006,7 +14006,7 @@ namespace std {
     const_iterator cend() const noexcept;
 
     // capacity
-    [[nodiscard]] bool empty() const noexcept;
+    bool empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
 
@@ -14578,7 +14578,7 @@ namespace std {
     template<@\exposconcept{container-compatible-range}@<T> R, class Alloc>
       queue(from_range_t, R&& rg, const Alloc&);
 
-    [[nodiscard]] bool empty() const    { return c.empty(); }
+    bool              empty() const     { return c.empty(); }
     size_type         size()  const     { return c.size(); }
     reference         front()           { return c.front(); }
     const_reference   front() const     { return c.front(); }
@@ -14962,9 +14962,9 @@ namespace std {
     template<@\exposconcept{container-compatible-range}@<T> R, class Alloc>
       priority_queue(from_range_t, R&& rg, const Alloc&);
 
-    [[nodiscard]] bool empty() const { return c.empty(); }
-    size_type size()  const          { return c.size(); }
-    const_reference   top() const    { return c.front(); }
+    bool            empty() const { return c.empty(); }
+    size_type       size()  const { return c.size(); }
+    const_reference top()   const { return c.front(); }
     void push(const value_type& x);
     void push(value_type&& x);
     template<@\exposconcept{container-compatible-range}@<T> R>
@@ -15446,10 +15446,10 @@ namespace std {
     template<@\exposconcept{container-compatible-range}@<T> R, class Alloc>
       stack(from_range_t, R&& rg, const Alloc&);
 
-    [[nodiscard]] bool empty() const    { return c.empty(); }
-    size_type size()  const             { return c.size(); }
+    bool              empty() const     { return c.empty(); }
+    size_type         size()  const     { return c.size(); }
     reference         top()             { return c.back(); }
-    const_reference   top() const       { return c.back(); }
+    const_reference   top()   const     { return c.back(); }
     void push(const value_type& x)      { c.push_back(x); }
     void push(value_type&& x)           { c.push_back(std::move(x)); }
     template<@\exposconcept{container-compatible-range}@<T> R>
@@ -19005,7 +19005,7 @@ namespace std {
     // \ref{span.obs}, observers
     constexpr size_type size() const noexcept;
     constexpr size_type size_bytes() const noexcept;
-    [[nodiscard]] constexpr bool empty() const noexcept;
+    constexpr bool empty() const noexcept;
 
     // \ref{span.elem}, element access
     constexpr reference operator[](size_type idx) const;
@@ -19505,7 +19505,7 @@ Equivalent to: \tcode{return size() * sizeof(element_type);}
 
 \indexlibrarymember{span}{empty}%
 \begin{itemdecl}
-[[nodiscard]] constexpr bool empty() const noexcept;
+constexpr bool empty() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -2009,7 +2009,7 @@ namespace std {
     const_reverse_iterator crbegin() const noexcept;
     const_reverse_iterator crend() const noexcept;
 
-    [[nodiscard]] bool empty() const noexcept;
+    bool empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
 
@@ -2253,7 +2253,7 @@ const_reverse_iterator crend() const noexcept;
 
 \indexlibrarymember{empty}{basic_stacktrace}%
 \begin{itemdecl}
-[[nodiscard]] bool empty() const noexcept;
+bool empty() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -13750,7 +13750,7 @@ namespace std::filesystem {
     path extension() const;
 
     // \ref{fs.path.query}, query
-    [[nodiscard]] bool empty() const noexcept;
+    bool empty() const noexcept;
     bool has_root_name() const;
     bool has_root_directory() const;
     bool has_root_path() const;
@@ -14996,7 +14996,7 @@ even though the generic format pathnames are the same.
 
 \indexlibrarymember{empty}{path}%
 \begin{itemdecl}
-[[nodiscard]] bool empty() const noexcept;
+bool empty() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -503,11 +503,11 @@ namespace std {
   template<class T, ptrdiff_t N> constexpr ptrdiff_t
     ssize(const T (&array)[N]) noexcept;                                            // freestanding
 
-  template<class C> [[nodiscard]] constexpr auto
+  template<class C> constexpr auto
     empty(const C& c) -> decltype(c.empty());                                       // freestanding
-  template<class T, size_t N> [[nodiscard]] constexpr bool
+  template<class T, size_t N> constexpr bool
     empty(const T (&array)[N]) noexcept;                                            // freestanding
-  template<class E> [[nodiscard]] constexpr bool
+  template<class E> constexpr bool
     empty(initializer_list<E> il) noexcept;                                         // freestanding
 
   template<class C> constexpr auto data(C& c) -> decltype(c.data());                // freestanding
@@ -7462,7 +7462,7 @@ template<class T, ptrdiff_t N> constexpr ptrdiff_t ssize(const T (&array)[N]) no
 
 \indexlibrary{\idxcode{empty(C\& c)}}%
 \begin{itemdecl}
-template<class C> [[nodiscard]] constexpr auto empty(const C& c) -> decltype(c.empty());
+template<class C> constexpr auto empty(const C& c) -> decltype(c.empty());
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
@@ -7472,7 +7472,7 @@ template<class C> [[nodiscard]] constexpr auto empty(const C& c) -> decltype(c.e
 
 \indexlibrary{\idxcode{empty(T (\&array)[N])}}%
 \begin{itemdecl}
-template<class T, size_t N> [[nodiscard]] constexpr bool empty(const T (&array)[N]) noexcept;
+template<class T, size_t N> constexpr bool empty(const T (&array)[N]) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
@@ -7482,7 +7482,7 @@ template<class T, size_t N> [[nodiscard]] constexpr bool empty(const T (&array)[
 
 \indexlibrary{\idxcode{empty(initializer_list<E>)}}%
 \begin{itemdecl}
-template<class E> [[nodiscard]] constexpr bool empty(initializer_list<E> il) noexcept;
+template<class E> constexpr bool empty(initializer_list<E> il) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
 \pnum

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -82,7 +82,7 @@ namespace std {
   // \ref{ptr.align}, pointer alignment
   void* align(size_t alignment, size_t size, void*& ptr, size_t& space);            // freestanding
   template<size_t N, class T>
-    [[nodiscard]] constexpr T* assume_aligned(T* ptr);                              // freestanding
+    constexpr T* assume_aligned(T* ptr);                                            // freestanding
 
   // \ref{obj.lifetime}, explicit lifetime management
   template<class T>
@@ -829,7 +829,7 @@ arguments for the same buffer.
 \indexlibraryglobal{assume_aligned}%
 \begin{itemdecl}
 template<size_t N, class T>
-  [[nodiscard]] constexpr T* assume_aligned(T* ptr);
+  constexpr T* assume_aligned(T* ptr);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1379,10 +1379,9 @@ namespace std {
     template<class T> using rebind_alloc = @\seebelow@;
     template<class T> using rebind_traits = allocator_traits<rebind_alloc<T>>;
 
-    [[nodiscard]] static constexpr pointer allocate(Alloc& a, size_type n);
-    [[nodiscard]] static constexpr pointer allocate(Alloc& a, size_type n,
-                                                    const_void_pointer hint);
-    [[nodiscard]] static constexpr allocation_result<pointer, size_type>
+    static constexpr pointer allocate(Alloc& a, size_type n);
+    static constexpr pointer allocate(Alloc& a, size_type n, const_void_pointer hint);
+    static constexpr allocation_result<pointer, size_type>
       allocate_at_least(Alloc& a, size_type n);
 
     static constexpr void deallocate(Alloc& a, pointer p, size_type n);
@@ -1550,7 +1549,7 @@ otherwise, the instantiation of \tcode{rebind_alloc} is ill-formed.
 
 \indexlibrarymember{allocate}{allocator_traits}%
 \begin{itemdecl}
-[[nodiscard]] static constexpr pointer allocate(Alloc& a, size_type n);
+static constexpr pointer allocate(Alloc& a, size_type n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1561,7 +1560,7 @@ otherwise, the instantiation of \tcode{rebind_alloc} is ill-formed.
 
 \indexlibrarymember{allocate}{allocator_traits}%
 \begin{itemdecl}
-[[nodiscard]] static constexpr pointer allocate(Alloc& a, size_type n, const_void_pointer hint);
+static constexpr pointer allocate(Alloc& a, size_type n, const_void_pointer hint);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1572,8 +1571,7 @@ otherwise, the instantiation of \tcode{rebind_alloc} is ill-formed.
 
 \indexlibrarymember{allocate_at_least}{allocator_traits}%
 \begin{itemdecl}
-[[nodiscard]] static constexpr allocation_result<pointer, size_type>
-  allocate_at_least(Alloc& a, size_type n);
+static constexpr allocation_result<pointer, size_type> allocate_at_least(Alloc& a, size_type n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1685,8 +1683,8 @@ namespace std {
     constexpr ~allocator();
     constexpr allocator& operator=(const allocator&) = default;
 
-    [[nodiscard]] constexpr T* allocate(size_t n);
-    [[nodiscard]] constexpr allocation_result<T*> allocate_at_least(size_t n);
+    constexpr T* allocate(size_t n);
+    constexpr allocation_result<T*> allocate_at_least(size_t n);
     constexpr void deallocate(T* p, size_t n);
   };
 }
@@ -1707,7 +1705,7 @@ deallocation call shall happen before the next allocation (if any) in this order
 
 \indexlibrarymember{allocate}{allocator}%
 \begin{itemdecl}
-[[nodiscard]] constexpr T* allocate(size_t n);
+constexpr T* allocate(size_t n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1737,7 +1735,7 @@ but not that of any of the array elements.
 
 \indexlibrarymember{allocate_at_least}{allocator}%
 \begin{itemdecl}
-[[nodiscard]] constexpr allocation_result<T*> allocate_at_least(size_t n);
+constexpr allocation_result<T*> allocate_at_least(size_t n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5610,7 +5608,7 @@ namespace std::pmr {
 
     memory_resource& operator=(const memory_resource&) = default;
 
-    [[nodiscard]] void* allocate(size_t bytes, size_t alignment = max_align);
+    void* allocate(size_t bytes, size_t alignment = max_align);
     void deallocate(void* p, size_t bytes, size_t alignment = max_align);
 
     bool is_equal(const memory_resource& other) const noexcept;
@@ -5640,7 +5638,7 @@ Destroys this \tcode{memory_resource}.
 
 \indexlibrarymember{allocate}{memory_resource}%
 \begin{itemdecl}
-[[nodiscard]] void* allocate(size_t bytes, size_t alignment = max_align);
+void* allocate(size_t bytes, size_t alignment = max_align);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5800,14 +5798,14 @@ namespace std::pmr {
     polymorphic_allocator& operator=(const polymorphic_allocator&) = delete;
 
     // \ref{mem.poly.allocator.mem}, member functions
-    [[nodiscard]] Tp* allocate(size_t n);
+    Tp* allocate(size_t n);
     void deallocate(Tp* p, size_t n);
 
-    [[nodiscard]] void* allocate_bytes(size_t nbytes, size_t alignment = alignof(max_align_t));
+    void* allocate_bytes(size_t nbytes, size_t alignment = alignof(max_align_t));
     void deallocate_bytes(void* p, size_t nbytes, size_t alignment = alignof(max_align_t));
-    template<class T> [[nodiscard]] T* allocate_object(size_t n = 1);
+    template<class T> T* allocate_object(size_t n = 1);
     template<class T> void deallocate_object(T* p, size_t n = 1);
-    template<class T, class... CtorArgs> [[nodiscard]] T* new_object(CtorArgs&&... ctor_args);
+    template<class T, class... CtorArgs> T* new_object(CtorArgs&&... ctor_args);
     template<class T> void delete_object(T* p);
 
     template<class T, class... Args>
@@ -5882,7 +5880,7 @@ Sets \tcode{memory_rsrc} to \tcode{other.resource()}.
 
 \indexlibrarymember{allocate}{polymorphic_allocator}%
 \begin{itemdecl}
-[[nodiscard]] Tp* allocate(size_t n);
+Tp* allocate(size_t n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5919,7 +5917,7 @@ Nothing.
 
 \indexlibrarymember{allocate_bytes}{polymorphic_allocator}%
 \begin{itemdecl}
-[[nodiscard]] void* allocate_bytes(size_t nbytes, size_t alignment = alignof(max_align_t));
+void* allocate_bytes(size_t nbytes, size_t alignment = alignof(max_align_t));
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5950,7 +5948,7 @@ Equivalent to \tcode{memory_rsrc->deallocate(p, nbytes, alignment)}.
 \indexlibrarymember{allocate_object}{polymorphic_allocator}%
 \begin{itemdecl}
 template<class T>
-  [[nodiscard]] T* allocate_object(size_t n = 1);
+  T* allocate_object(size_t n = 1);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5990,7 +5988,7 @@ Equivalent to \tcode{deallocate_bytes(p, n*sizeof(T), alignof(T))}.
 \indexlibrarymember{new_object}{polymorphic_allocator}%
 \begin{itemdecl}
 template<class T, class... CtorArgs>
-  [[nodiscard]] T* new_object(CtorArgs&&... ctor_args);
+  T* new_object(CtorArgs&&... ctor_args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6803,8 +6801,8 @@ namespace std {
     outer_allocator_type& outer_allocator() noexcept;
     const outer_allocator_type& outer_allocator() const noexcept;
 
-    [[nodiscard]] pointer allocate(size_type n);
-    [[nodiscard]] pointer allocate(size_type n, const_void_pointer hint);
+    pointer allocate(size_type n);
+    pointer allocate(size_type n, const_void_pointer hint);
     void deallocate(pointer p, size_type n);
     size_type max_size() const;
 
@@ -7036,7 +7034,7 @@ const outer_allocator_type& outer_allocator() const noexcept;
 
 \indexlibrarymember{allocate}{scoped_allocator_adaptor}%
 \begin{itemdecl}
-[[nodiscard]] pointer allocate(size_type n);
+pointer allocate(size_type n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7047,7 +7045,7 @@ const outer_allocator_type& outer_allocator() const noexcept;
 
 \indexlibrarymember{allocate}{scoped_allocator_adaptor}%
 \begin{itemdecl}
-[[nodiscard]] pointer allocate(size_type n, const_void_pointer hint);
+pointer allocate(size_type n, const_void_pointer hint);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1852,17 +1852,17 @@ namespace std::ranges {
     constexpr operator PairLike() const;
 
     constexpr I begin() const requires @\libconcept{copyable}@<I>;
-    [[nodiscard]] constexpr I begin() requires (!@\libconcept{copyable}@<I>);
+    constexpr I begin() requires (!@\libconcept{copyable}@<I>);
     constexpr S end() const;
 
     constexpr bool empty() const;
     constexpr @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>> size() const
       requires (K == subrange_kind::sized);
 
-    [[nodiscard]] constexpr subrange next(iter_difference_t<I> n = 1) const &
+    constexpr subrange next(iter_difference_t<I> n = 1) const &
       requires @\libconcept{forward_iterator}@<I>;
-    [[nodiscard]] constexpr subrange next(iter_difference_t<I> n = 1) &&;
-    [[nodiscard]] constexpr subrange prev(iter_difference_t<I> n = 1) const
+    constexpr subrange next(iter_difference_t<I> n = 1) &&;
+    constexpr subrange prev(iter_difference_t<I> n = 1) const
       requires @\libconcept{bidirectional_iterator}@<I>;
     constexpr subrange& advance(iter_difference_t<I> n);
   };
@@ -1981,7 +1981,7 @@ Equivalent to: \tcode{return \exposid{begin_};}
 
 \indexlibrarymember{begin}{subrange}%
 \begin{itemdecl}
-[[nodiscard]] constexpr I begin() requires (!@\libconcept{copyable}@<I>);
+constexpr I begin() requires (!@\libconcept{copyable}@<I>);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2029,7 +2029,7 @@ constexpr @\placeholdernc{make-unsigned-like-t}@<iter_difference_t<I>> size() co
 
 \indexlibrarymember{next}{subrange}%
 \begin{itemdecl}
-[[nodiscard]] constexpr subrange next(iter_difference_t<I> n = 1) const &
+constexpr subrange next(iter_difference_t<I> n = 1) const &
   requires @\libconcept{forward_iterator}@<I>;
 \end{itemdecl}
 
@@ -2046,7 +2046,7 @@ return tmp;
 
 \indexlibrarymember{next}{subrange}%
 \begin{itemdecl}
-[[nodiscard]] constexpr subrange next(iter_difference_t<I> n = 1) &&;
+constexpr subrange next(iter_difference_t<I> n = 1) &&;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2061,7 +2061,7 @@ return std::move(*this);
 
 \indexlibrarymember{prev}{subrange}%
 \begin{itemdecl}
-[[nodiscard]] constexpr subrange prev(iter_difference_t<I> n = 1) const
+constexpr subrange prev(iter_difference_t<I> n = 1) const
   requires @\libconcept{bidirectional_iterator}@<I>;
 \end{itemdecl}
 

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -2207,7 +2207,7 @@ namespace std {
       // \ref{re.results.size}, size
       size_type size() const;
       size_type max_size() const;
-      [[nodiscard]] bool empty() const;
+      bool empty() const;
 
       // \ref{re.results.acc}, element access
       difference_type length(size_type sub = 0) const;
@@ -2403,7 +2403,7 @@ stored in \tcode{*this}.
 
 \indexlibrarymember{match_results}{empty}%
 \begin{itemdecl}
-[[nodiscard]] bool empty() const;
+bool empty() const;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -659,7 +659,7 @@ Because \tcode{basic_string_view} refers to a constant sequence, \tcode{iterator
     constexpr size_type size() const noexcept;
     constexpr size_type length() const noexcept;
     constexpr size_type max_size() const noexcept;
-    [[nodiscard]] constexpr bool empty() const noexcept;
+    constexpr bool empty() const noexcept;
 
     // \ref{string.view.access}, element access
     constexpr const_reference operator[](size_type pos) const;
@@ -1021,7 +1021,7 @@ The largest possible number of char-like objects that can be referred to by a \t
 
 \indexlibrarymember{empty}{basic_string_view}%
 \begin{itemdecl}
-[[nodiscard]] constexpr bool empty() const noexcept;
+constexpr bool empty() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2123,7 +2123,7 @@ namespace std {
     constexpr void reserve(size_type res_arg);
     constexpr void shrink_to_fit();
     constexpr void clear() noexcept;
-    [[nodiscard]] constexpr bool empty() const noexcept;
+    constexpr bool empty() const noexcept;
 
     // \ref{string.access}, element access
     constexpr const_reference operator[](size_type pos) const;
@@ -3074,7 +3074,7 @@ Equivalent to: \tcode{erase(begin(), end());}
 
 \indexlibrarymember{empty}{basic_string}%
 \begin{itemdecl}
-[[nodiscard]] constexpr bool empty() const noexcept;
+constexpr bool empty() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/support.tex
+++ b/source/support.tex
@@ -2273,7 +2273,7 @@ namespace std {
   new_handler set_new_handler(new_handler new_p) noexcept;
 
   // \ref{ptr.launder}, pointer optimization barrier
-  template<class T> [[nodiscard]] constexpr T* launder(T* p) noexcept;
+  template<class T> constexpr T* launder(T* p) noexcept;
 
   // \ref{hardware.interference}, hardware interference size
   inline constexpr size_t hardware_destructive_interference_size = @\impdef{}@;
@@ -2281,11 +2281,10 @@ namespace std {
 }
 
 // \ref{new.delete}, storage allocation and deallocation
-[[nodiscard]] void* operator new(std::size_t size);
-[[nodiscard]] void* operator new(std::size_t size, std::align_val_t alignment);
-[[nodiscard]] void* operator new(std::size_t size, const std::nothrow_t&) noexcept;
-[[nodiscard]] void* operator new(std::size_t size, std::align_val_t alignment,
-                                 const std::nothrow_t&) noexcept;
+void* operator new(std::size_t size);
+void* operator new(std::size_t size, std::align_val_t alignment);
+void* operator new(std::size_t size, const std::nothrow_t&) noexcept;
+void* operator new(std::size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept;
 
 void operator delete(void* ptr) noexcept;
 void operator delete(void* ptr, std::size_t size) noexcept;
@@ -2294,11 +2293,11 @@ void operator delete(void* ptr, std::size_t size, std::align_val_t alignment) no
 void operator delete(void* ptr, const std::nothrow_t&) noexcept;
 void operator delete(void* ptr, std::align_val_t alignment, const std::nothrow_t&) noexcept;
 
-[[nodiscard]] void* operator new[](std::size_t size);
-[[nodiscard]] void* operator new[](std::size_t size, std::align_val_t alignment);
-[[nodiscard]] void* operator new[](std::size_t size, const std::nothrow_t&) noexcept;
-[[nodiscard]] void* operator new[](std::size_t size, std::align_val_t alignment,
-                                   const std::nothrow_t&) noexcept;
+void* operator new[](std::size_t size);
+void* operator new[](std::size_t size, std::align_val_t alignment);
+void* operator new[](std::size_t size, const std::nothrow_t&) noexcept;
+void* operator new[](std::size_t size, std::align_val_t alignment,
+                     const std::nothrow_t&) noexcept;
 
 void operator delete[](void* ptr) noexcept;
 void operator delete[](void* ptr, std::size_t size) noexcept;
@@ -2307,8 +2306,8 @@ void operator delete[](void* ptr, std::size_t size, std::align_val_t alignment) 
 void operator delete[](void* ptr, const std::nothrow_t&) noexcept;
 void operator delete[](void* ptr, std::align_val_t alignment, const std::nothrow_t&) noexcept;
 
-[[nodiscard]] constexpr void* operator new  (std::size_t size, void* ptr) noexcept;
-[[nodiscard]] constexpr void* operator new[](std::size_t size, void* ptr) noexcept;
+constexpr void* operator new  (std::size_t size, void* ptr) noexcept;
+constexpr void* operator new[](std::size_t size, void* ptr) noexcept;
 void operator delete  (void* ptr, void*) noexcept;
 void operator delete[](void* ptr, void*) noexcept;
 \end{codeblock}
@@ -2355,8 +2354,8 @@ and thereby displace the default versions defined by the
 
 \indexlibrarymember{new}{operator}%
 \begin{itemdecl}
-[[nodiscard]] void* operator new(std::size_t size);
-[[nodiscard]] void* operator new(std::size_t size, std::align_val_t alignment);
+void* operator new(std::size_t size);
+void* operator new(std::size_t size, std::align_val_t alignment);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2415,9 +2414,8 @@ function does not return.
 
 \indexlibrarymember{new}{operator}%
 \begin{itemdecl}
-[[nodiscard]] void* operator new(std::size_t size, const std::nothrow_t&) noexcept;
-[[nodiscard]] void* operator new(std::size_t size, std::align_val_t alignment,
-                                 const std::nothrow_t&) noexcept;
+void* operator new(std::size_t size, const std::nothrow_t&) noexcept;
+void* operator new(std::size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2612,8 +2610,8 @@ respectively.
 
 \indexlibrarymember{new}{operator}%
 \begin{itemdecl}
-[[nodiscard]] void* operator new[](std::size_t size);
-[[nodiscard]] void* operator new[](std::size_t size, std::align_val_t alignment);
+void* operator new[](std::size_t size);
+void* operator new[](std::size_t size, std::align_val_t alignment);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2666,9 +2664,8 @@ respectively.
 
 \indexlibrarymember{new}{operator}%
 \begin{itemdecl}
-[[nodiscard]] void* operator new[](std::size_t size, const std::nothrow_t&) noexcept;
-[[nodiscard]] void* operator new[](std::size_t size, std::align_val_t alignment,
-                                   const std::nothrow_t&) noexcept;
+void* operator new[](std::size_t size, const std::nothrow_t&) noexcept;
+void* operator new[](std::size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2841,7 +2838,7 @@ placement forms of \tcode{operator new} and \tcode{operator delete}.
 
 \indexlibrarymember{new}{operator}%
 \begin{itemdecl}
-[[nodiscard]] constexpr void* operator new(std::size_t size, void* ptr) noexcept;
+constexpr void* operator new(std::size_t size, void* ptr) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2866,7 +2863,7 @@ Something* p = new (place) Something();
 
 \indexlibrarymember{new}{operator}%
 \begin{itemdecl}
-[[nodiscard]] constexpr void* operator new[](std::size_t size, void* ptr) noexcept;
+constexpr void* operator new[](std::size_t size, void* ptr) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3073,7 +3070,7 @@ This can be a null pointer value.
 
 \indexlibraryglobal{launder}%
 \begin{itemdecl}
-template<class T> [[nodiscard]] constexpr T* launder(T* p) noexcept;
+template<class T> constexpr T* launder(T* p) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -543,10 +543,10 @@ namespace std {
     void swap(stop_token&) noexcept;
 
     // \ref{stoptoken.mem}, stop handling
-    [[nodiscard]] bool stop_requested() const noexcept;
-    [[nodiscard]] bool stop_possible() const noexcept;
+    bool stop_requested() const noexcept;
+    bool stop_possible() const noexcept;
 
-    [[nodiscard]] friend bool operator==(const stop_token& lhs, const stop_token& rhs) noexcept;
+    friend bool operator==(const stop_token& lhs, const stop_token& rhs) noexcept;
     friend void swap(stop_token& lhs, stop_token& rhs) noexcept;
   };
 }
@@ -654,7 +654,7 @@ Exchanges the values of \tcode{*this} and \tcode{rhs}.
 
 \indexlibrarymember{stop_requested}{stop_token}%
 \begin{itemdecl}
-[[nodiscard]] bool stop_requested() const noexcept;
+bool stop_requested() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -667,7 +667,7 @@ otherwise, \tcode{false}.
 
 \indexlibrarymember{stop_possible}{stop_token}%
 \begin{itemdecl}
-[[nodiscard]] bool stop_possible() const noexcept;
+bool stop_possible() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -686,7 +686,7 @@ otherwise, \tcode{true}.
 
 \indexlibrarymember{operator==}{stop_token}%
 \begin{itemdecl}
-[[nodiscard]] bool operator==(const stop_token& lhs, const stop_token& rhs) noexcept;
+bool operator==(const stop_token& lhs, const stop_token& rhs) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -746,13 +746,12 @@ namespace std {
     void swap(stop_source&) noexcept;
 
     // \ref{stopsource.mem}, stop handling
-    [[nodiscard]] stop_token get_token() const noexcept;
-    [[nodiscard]] bool stop_possible() const noexcept;
-    [[nodiscard]] bool stop_requested() const noexcept;
+    stop_token get_token() const noexcept;
+    bool stop_possible() const noexcept;
+    bool stop_requested() const noexcept;
     bool request_stop() noexcept;
 
-    [[nodiscard]] friend bool
-      operator==(const stop_source& lhs, const stop_source& rhs) noexcept;
+    friend bool operator==(const stop_source& lhs, const stop_source& rhs) noexcept;
     friend void swap(stop_source& lhs, stop_source& rhs) noexcept;
   };
 }
@@ -879,7 +878,7 @@ Exchanges the values of \tcode{*this} and \tcode{rhs}.
 
 \indexlibrarymember{get_token}{stop_source sc}%
 \begin{itemdecl}
-[[nodiscard]] stop_token get_token() const noexcept;
+stop_token get_token() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -891,7 +890,7 @@ otherwise a new associated \tcode{stop_token} object.
 
 \indexlibrarymember{stop_possible}{stop_source}%
 \begin{itemdecl}
-[[nodiscard]] bool stop_possible() const noexcept;
+bool stop_possible() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -903,7 +902,7 @@ otherwise, \tcode{false}.
 
 \indexlibrarymember{stop_requested}{stop_source}%
 \begin{itemdecl}
-[[nodiscard]] bool stop_requested() const noexcept;
+bool stop_requested() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -955,8 +954,7 @@ otherwise \tcode{false}.
 
 \indexlibrarymember{operator==}{stop_source}%
 \begin{itemdecl}
-[[nodiscard]] friend bool
-  operator==(const stop_source& lhs, const stop_source& rhs) noexcept;
+friend bool operator==(const stop_source& lhs, const stop_source& rhs) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1650,22 +1648,22 @@ namespace std {
 
     // \ref{thread.jthread.mem}, members
     void swap(jthread&) noexcept;
-    [[nodiscard]] bool joinable() const noexcept;
+    bool joinable() const noexcept;
     void join();
     void detach();
-    [[nodiscard]] id get_id() const noexcept;
-    [[nodiscard]] native_handle_type native_handle();   // see~\ref{thread.req.native}
+    id get_id() const noexcept;
+    native_handle_type native_handle();                 // see~\ref{thread.req.native}
 
     // \ref{thread.jthread.stop}, stop token handling
-    [[nodiscard]] stop_source get_stop_source() noexcept;
-    [[nodiscard]] stop_token get_stop_token() const noexcept;
+    stop_source get_stop_source() noexcept;
+    stop_token get_stop_token() const noexcept;
     bool request_stop() noexcept;
 
     // \ref{thread.jthread.special}, specialized algorithms
     friend void swap(jthread& lhs, jthread& rhs) noexcept;
 
     // \ref{thread.jthread.static}, static members
-    [[nodiscard]] static unsigned int hardware_concurrency() noexcept;
+    static unsigned int hardware_concurrency() noexcept;
 
   private:
     stop_source ssource;        // \expos
@@ -1835,7 +1833,7 @@ Exchanges the values of \tcode{*this} and \tcode{x}.
 
 \indexlibrarymember{joinable}{jthread}%
 \begin{itemdecl}
-[[nodiscard]] bool joinable() const noexcept;
+bool joinable() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1934,7 +1932,7 @@ for the thread of execution represented by \tcode{*this}.
 
 \indexlibrarymember{get_stop_source}{jthread}%
 \begin{itemdecl}
-[[nodiscard]] stop_source get_stop_source() noexcept;
+stop_source get_stop_source() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1945,7 +1943,7 @@ Equivalent to: \tcode{return ssource;}
 
 \indexlibrarymember{get_stop_token}{jthread}%
 \begin{itemdecl}
-[[nodiscard]] stop_token get_stop_token() const noexcept;
+stop_token get_stop_token() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1983,7 +1981,7 @@ Equivalent to: \tcode{x.swap(y)}.
 
 \indexlibrarymember{hardware_concurrency}{jthread}%
 \begin{itemdecl}
-[[nodiscard]] static unsigned int hardware_concurrency() noexcept;
+static unsigned int hardware_concurrency() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9798,7 +9796,7 @@ namespace std {
     barrier(const barrier&) = delete;
     barrier& operator=(const barrier&) = delete;
 
-    [[nodiscard]] arrival_token arrive(ptrdiff_t update = 1);
+    arrival_token arrive(ptrdiff_t update = 1);
     void wait(arrival_token&& arrival) const;
 
     void arrive_and_wait();
@@ -9919,7 +9917,7 @@ Any exception thrown by \tcode{CompletionFunction}'s move constructor.
 
 \indexlibrarymember{arrive}{barrier}%
 \begin{itemdecl}
-[[nodiscard]] arrival_token arrive(ptrdiff_t update = 1);
+arrival_token arrive(ptrdiff_t update = 1);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10115,10 +10113,10 @@ namespace std {
 
   // \ref{futures.async}, function template \tcode{async}
   template<class F, class... Args>
-    [[nodiscard]] future<invoke_result_t<decay_t<F>, decay_t<Args>...>>
+    future<invoke_result_t<decay_t<F>, decay_t<Args>...>>
       async(F&& f, Args&&... args);
   template<class F, class... Args>
-    [[nodiscard]] future<invoke_result_t<decay_t<F>, decay_t<Args>...>>
+    future<invoke_result_t<decay_t<F>, decay_t<Args>...>>
       async(launch policy, F&& f, Args&&... args);
 }
 \end{codeblock}
@@ -11323,10 +11321,10 @@ it shares a shared state.
 \indexlibraryglobal{async}%
 \begin{itemdecl}
 template<class F, class... Args>
-  [[nodiscard]] future<invoke_result_t<decay_t<F>, decay_t<Args>...>>
+  future<invoke_result_t<decay_t<F>, decay_t<Args>...>>
     async(F&& f, Args&&... args);
 template<class F, class... Args>
-  [[nodiscard]] future<invoke_result_t<decay_t<F>, decay_t<Args>...>>
+  future<invoke_result_t<decay_t<F>, decay_t<Args>...>>
     async(launch policy, F&& f, Args&&... args);
 \end{itemdecl}
 
@@ -12394,7 +12392,7 @@ namespace std {
     hazard_pointer& operator=(hazard_pointer&&) noexcept;
     ~hazard_pointer();
 
-    [[nodiscard]] bool empty() const noexcept;
+    bool empty() const noexcept;
     template<class T> T* protect(const atomic<T*>& src) noexcept;
     template<class T> bool try_protect(T*& ptr, const atomic<T*>& src) noexcept;
     template<class T> void reset_protection(const T* ptr) noexcept;
@@ -12485,7 +12483,7 @@ If \tcode{this != \&other} is \tcode{true}, \tcode{other} is empty.
 
 \indexlibrarymember{empty}{hazard_pointer}%
 \begin{itemdecl}
-[[nodiscard]] bool empty() const noexcept;
+bool empty() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -372,7 +372,7 @@ both cases, \tcode{A2} is deduced as \tcode{double}, so
 \indexlibraryglobal{forward_like}%
 \begin{itemdecl}
 template<class T, class U>
-  [[nodiscard]] constexpr auto forward_like(U&& x) noexcept -> @\seebelow@;
+  constexpr auto forward_like(U&& x) noexcept -> @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -19050,9 +19050,9 @@ namespace std {
 
   // \ref{bit.rotate}, rotating
   template<class T>
-    [[nodiscard]] constexpr T rotl(T x, int s) noexcept;
+    constexpr T rotl(T x, int s) noexcept;
   template<class T>
-    [[nodiscard]] constexpr T rotr(T x, int s) noexcept;
+    constexpr T rotr(T x, int s) noexcept;
 
   // \ref{bit.count}, counting
   template<class T>
@@ -19268,7 +19268,7 @@ let \tcode{N} denote \tcode{numeric_limits<T>::digits}.
 
 \begin{itemdecl}
 template<class T>
-  [[nodiscard]] constexpr T rotl(T x, int s) noexcept;
+  constexpr T rotl(T x, int s) noexcept;
 \end{itemdecl}
 
 \indexlibraryglobal{rotl}%
@@ -19289,7 +19289,7 @@ if \tcode{r} is negative, \tcode{rotr(x, -r)}.
 
 \begin{itemdecl}
 template<class T>
-  [[nodiscard]] constexpr T rotr(T x, int s) noexcept;
+  constexpr T rotr(T x, int s) noexcept;
 \end{itemdecl}
 
 \indexlibraryglobal{rotr}%


### PR DESCRIPTION
Fixes #7094
Fixes cplusplus/papers#1744

Notes:
* [allocator.traits.other] No such declaration for allocation_result - change not applied. 
* Second edit for [set.overview] assumed to be intended for [multiset.overview].

