### PR TITLE
[LWG 7 2024-06] P0843R14 inplace_vector

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -133,6 +133,7 @@ New functionality.
 The following \Cpp{} headers are new:
 \libheaderref{debugging},
 \libheaderrefx{hazard_pointer}{hazard.pointer.syn},
+\libheaderrefx{inplace_vector}{inplace.vector.syn},
 \libheaderref{linalg},
 \libheaderref{rcu}, and
 \libheaderrefx{text_encoding}{text.encoding.syn}.

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -20,6 +20,7 @@ as summarized in
 \ref{container.requirements} & Requirements                     &                           \\ \rowsep
 \ref{sequences}              & Sequence containers              &
   \tcode{<array>}, \tcode{<deque>}, \tcode{<forward_list>},
+  \tcode{<inplace_vector>}, \\ & &
   \tcode{<list>}, \tcode{<vector>} \\ \rowsep
 \ref{associative}            & Associative containers           &
   \tcode{<map>}, \tcode{<set>}     \\ \rowsep
@@ -262,7 +263,7 @@ X u = rv;
 
 \pnum
 \complexity
-Linear for \tcode{array} and constant for all other standard containers.
+Linear for \tcode{array} and \tcode{inplace_vector} and constant for all other standard containers.
 \end{itemdescr}
 
 \indexcont{operator=}%
@@ -479,7 +480,8 @@ Exchanges the contents of \tcode{t} and \tcode{s}.
 
 \pnum
 \complexity
-Linear for \tcode{array} and constant for all other standard containers.
+Linear for \tcode{array} and \tcode{inplace_vector}, and
+constant for all other standard containers.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -617,7 +619,8 @@ has been replaced, a copy of the most recent replacement.
 
 \pnum
 The expression \tcode{a.swap(b)}, for containers \tcode{a} and \tcode{b} of a standard
-container type other than \tcode{array}, shall exchange the values of \tcode{a} and
+container type other than \tcode{array} and \tcode{inplace_vector},
+shall exchange the values of \tcode{a} and
 \tcode{b} without invoking any move, copy, or swap operations on the individual
 container elements.
 Any \tcode{Compare}, \tcode{Pred}, or \tcode{Hash} types
@@ -637,7 +640,7 @@ with value \tcode{a.end()} before the swap will have value \tcode{b.end()} after
 swap.
 
 \pnum
-Unless otherwise specified (see~\ref{associative.reqmts.except}, \ref{unord.req.except}, \ref{deque.modifiers}, and
+Unless otherwise specified (see~\ref{associative.reqmts.except}, \ref{unord.req.except}, \ref{deque.modifiers}, \ref{inplace.vector.modifiers}, and
 \ref{vector.modifiers})
 all container types defined in this Clause meet
 the following additional requirements:
@@ -908,7 +911,8 @@ Linear.
 \rSec3[container.alloc.reqmts]{Allocator-aware containers}
 
 \pnum
-Except for \tcode{array}, all of the containers defined in \ref{containers},
+Except for \tcode{array} and \tcode{inplace_vector},
+all of the containers defined in \ref{containers},
 \ref{stacktrace.basic}, \ref{basic.string}, and \ref{re.results}
 meet the additional requirements of an \defnadj{allocator-aware}{container},
 as described below.
@@ -1263,8 +1267,10 @@ can race with \tcode{y[1] = true}.
 
 \pnum
 A sequence container organizes a finite set of objects, all of the same type, into a strictly
-linear arrangement. The library provides four basic kinds of sequence containers:
-\tcode{vector}, \tcode{forward_list}, \tcode{list}, and \tcode{deque}. In addition,
+linear arrangement. The library provides the following basic kinds of sequence containers:
+\tcode{vector}, \tcode{inplace_vector},
+\tcode{forward_list}, \tcode{list}, and \tcode{deque}.
+In addition,
 \tcode{array} is provided as a sequence container which provides limited sequence operations
 because it has a fixed number of elements. The library also provides container adaptors that
 make it easy to construct abstract data types,
@@ -1481,7 +1487,7 @@ a.insert(p, t)
 \pnum
 \expects
 \tcode{T} is \oldconcept{CopyInsertable} into \tcode{X}.
-For \tcode{vector} and \tcode{deque},
+For \tcode{vector}, \tcode{inplace_vector}, and \tcode{deque},
 \tcode{T} is also \oldconcept{CopyAssignable}.
 
 \pnum
@@ -1505,7 +1511,7 @@ a.insert(p, rv)
 \pnum
 \expects
 \tcode{T} is \oldconcept{MoveInsertable} into \tcode{X}.
-For \tcode{vector} and \tcode{deque},
+For \tcode{vector}, \tcode{inplace_vector}, and \tcode{deque},
 \tcode{T} is also \oldconcept{MoveAssignable}.
 
 \pnum
@@ -1554,12 +1560,12 @@ a.insert(p, i, j)
 \pnum
 \expects
 \tcode{T} is \oldconcept{EmplaceConstructible} into \tcode{X} from \tcode{*i}.
-For \tcode{vector} and \tcode{deque},
+For \tcode{vector}, \tcode{inplace_vector}, and \tcode{deque},
 \tcode{T} is also
 \oldconcept{MoveInsertable} into \tcode{X},
 and \tcode{T} meets the
 \oldconcept{MoveConstructible},
-\oldconcept{MoveAssignable}, and
+\oldconcept{MoveAs\-signable}, and
 \oldconcept{Swappable}\iref{swappable.requirements} requirements.
 Neither \tcode{i} nor \tcode{j} are iterators into \tcode{a}.
 
@@ -1589,12 +1595,12 @@ a.insert_range(p, rg)
 \expects
 \tcode{T} is \oldconcept{EmplaceConstructible} into \tcode{X}
 from \tcode{*ranges::begin(rg)}.
-For \tcode{vector} and \tcode{deque},
+For \tcode{vector}, \tcode{inplace_vector}, and \tcode{deque},
 \tcode{T} is also
 \oldconcept{MoveInsertable} into \tcode{X},
 and \tcode{T} meets the
-\oldconcept{MoveConstructible},
-\oldconcept{Move\-Assignable}, and
+\oldconcept{Move\-Constructible},
+\oldconcept{MoveAssignable}, and
 \oldconcept{Swappable}\iref{swappable.requirements} requirements.
 \tcode{rg} and \tcode{a} do not overlap.
 
@@ -1632,7 +1638,7 @@ a.erase(q)
 
 \pnum
 \expects
-For \tcode{vector} and \tcode{deque},
+For \tcode{vector}, \tcode{inplace_vector}, and \tcode{deque},
 \tcode{T} is \oldconcept{MoveAssignable}.
 
 \pnum
@@ -1657,7 +1663,8 @@ a.erase(q1, q2)
 
 \pnum
 \expects
-For \tcode{vector} and \tcode{deque}, \tcode{T} is \oldconcept{MoveAssignable}.
+For \tcode{vector}, \tcode{inplace_vector}, and \tcode{deque},
+\tcode{T} is \oldconcept{MoveAssignable}.
 
 \pnum
 \effects
@@ -1858,6 +1865,7 @@ Required for
 \tcode{array},
 \tcode{deque},
 \tcode{forward_list},
+\tcode{inplace_vector},
 \tcode{list}, and
 \tcode{vector}.
 \end{itemdescr}
@@ -1886,6 +1894,7 @@ Required for
 \tcode{basic_string},
 \tcode{array},
 \tcode{deque},
+\tcode{inplace_vector},
 \tcode{list}, and
 \tcode{vector}.
 \end{itemdescr}
@@ -1948,6 +1957,7 @@ constructed with \tcode{std::forward<Args>(args)...}.
 \remarks
 Required for
 \tcode{deque},
+\tcode{inplace_vector},
 \tcode{list}, and
 \tcode{vector}.
 \end{itemdescr}
@@ -2060,6 +2070,7 @@ Appends a copy of \tcode{t}.
 Required for
 \tcode{basic_string},
 \tcode{deque},
+\tcode{inplace_vector},
 \tcode{list}, and
 \tcode{vector}.
 \end{itemdescr}
@@ -2086,6 +2097,7 @@ Appends a copy of \tcode{rv}.
 Required for
 \tcode{basic_string},
 \tcode{deque},
+\tcode{inplace_vector},
 \tcode{list}, and
 \tcode{vector}.
 \end{itemdescr}
@@ -2116,6 +2128,7 @@ Each iterator in the range \tcode{rg} is dereferenced exactly once.
 \remarks
 Required for
 \tcode{deque},
+\tcode{inplace_vector},
 \tcode{list}, and
 \tcode{vector}.
 \end{itemdescr}
@@ -2167,6 +2180,7 @@ Destroys the last element.
 Required for
 \tcode{basic_string},
 \tcode{deque},
+\tcode{inplace_vector},
 \tcode{list}, and
 \tcode{vector}.
 \end{itemdescr}
@@ -2189,7 +2203,8 @@ Equivalent to: \tcode{return *(a.begin() + n);}
 Required for
 \tcode{basic_string},
 \tcode{array},
-\tcode{deque}, and
+\tcode{deque},
+\tcode{inplace_vector}, and
 \tcode{vector}.
 \end{itemdescr}
 
@@ -2215,7 +2230,8 @@ a.at(n)
 Required for
 \tcode{basic_string},
 \tcode{array},
-\tcode{deque}, and
+\tcode{deque},
+\tcode{inplace_vector}, and
 \tcode{vector}.
 \end{itemdescr}
 
@@ -5959,6 +5975,7 @@ The headers
 \libheaderref{array},
 \libheaderref{deque},
 \libheaderrefx{forward_list}{forward.list.syn},
+\libheaderrefx{inplace_vector}{inplace.vector.syn},
 \libheaderref{list}, and
 \libheaderref{vector}
 define class templates that meet the requirements for sequence containers.
@@ -6174,6 +6191,28 @@ namespace std {
   // \ref{vector.bool.fmt}, formatter specialization for \tcode{vector<bool>}
   template<class T, class charT> requires @\exposid{is-vector-bool-reference}@<T>
     struct formatter<T, charT>;
+}
+\end{codeblock}
+
+\rSec2[inplace.vector.syn]{Header \tcode{<inplace_vector>} synopsis}
+
+\indexheader{inplace_vector}%
+\begin{codeblock}
+// mostly freestanding
+#include <compare>              // see \ref{compare.syn}
+#include <initializer_list>     // see \ref{initializer.list.syn}
+
+namespace std {
+  // \ref{inplace.vector}, class template \tcode{inplace_vector}
+  template<class T, size_t N> class inplace_vector;             // partially freestanding
+
+  // \ref{inplace.vector.erasure}, erasure
+  template<class T, size_t N, class U>
+    constexpr typename inplace_vector<T, N>::size_type
+      erase(inplace_vector<T, N>& c, const U& value);
+  template<class T, size_t N, class Predicate>
+    constexpr typename inplace_vector<T, N>::size_type
+      erase_if(inplace_vector<T, N>& c, Predicate pred);
 }
 \end{codeblock}
 
@@ -9450,6 +9489,659 @@ template<class FormatContext>
 \begin{itemdescr}
 \pnum
 Equivalent to: \tcode{return \exposid{underlying_}.format(ref, ctx);}
+\end{itemdescr}
+
+\rSec2[inplace.vector]{Class template \tcode{inplace_vector}}
+
+\rSec3[inplace.vector.overview]{Overview}
+
+\pnum
+\indexlibraryglobal{inplace_vector}%
+An \tcode{inplace_vector} is a contiguous container.
+Its capacity is fixed and
+its elements are stored within the \tcode{inplace_vector} object itself.
+
+\pnum
+An \tcode{inplace_vector} meets all of the requirements
+of a container\iref{container.reqmts},
+of a reversible container\iref{container.rev.reqmts},
+of a contiguous container, and
+of a sequence container,
+including most of the optional sequence container requirements\iref{sequence.reqmts}.
+The exceptions are the
+\tcode{push_front},
+\tcode{prepend_range},
+\tcode{pop_front}, and
+\tcode{emplace_front}
+member functions, which are not provided.
+Descriptions are provided here only
+for operations on \tcode{inplace_vector} that
+are not described in one of these tables or
+for operations where there is additional semantic information.
+
+\pnum
+For any \tcode{N},
+\tcode{inplace_vector<T, N>::iterator} and
+\tcode{inplace_vector<T, N>::const_iterator}
+meet the constexpr iterator requirements.
+
+\pnum
+For any $\tcode{N} > 0$,
+if \tcode{is_trivial_v<T>} is \tcode{false}, then
+no \tcode{inplace_vector<T, N>} member functions
+are usable in constant expressions.
+
+\pnum
+Any member function of \tcode{inplace_vector<T, N>} that
+would cause the size to exceed \tcode{N}
+throws an exception of type \tcode{bad_alloc}.
+
+\pnum
+Let \tcode{IV} denote a specialization of \tcode{inplace_vector<T, N>}.
+If \tcode{N} is zero, then
+\tcode{IV} is both trivial and empty.
+Otherwise:
+\begin{itemize}
+\item
+If \tcode{is_trivially_copy_constructible_v<T>} is \tcode{true}, then
+\tcode{IV} has a trivial copy constructor.
+\item
+If \tcode{is_trivially_move_constructible_v<T>} is \tcode{true}, then
+\tcode{IV} has a trivial move constructor.
+\item
+If \tcode{is_trivially_destructible_v<T>} is \tcode{true}, then:
+  \begin{itemize}
+  \item
+  \tcode{IV} has a trivial destructor.
+  \item
+  If
+\begin{codeblock}
+  is_trivially_copy_constructible_v<T> && is_trivially_copy_assignable_v<T>
+\end{codeblock}
+  is \tcode{true}, then
+  \tcode{IV} has a trivial copy assignment operator.
+  \item
+  If
+\begin{codeblock}
+  is_trivially_move_constructible_v<T> && is_trivially_move_assignable_v<T>
+\end{codeblock}
+  is \tcode{true}, then
+  \tcode{IV} has a trivial move assignment operator.
+  \end{itemize}
+\end{itemize}
+
+\begin{codeblock}
+namespace std {
+  template<class T, size_t N>
+  class inplace_vector {
+  public:
+    // types:
+    using value_type             = T;
+    using pointer                = T*;
+    using const_pointer          = const T*;
+    using reference              = value_type&;
+    using const_reference        = const value_type&;
+    using size_type              = size_t;
+    using difference_type        = ptrdiff_t;
+    using iterator               = @\impdefx{type of \tcode{inplace_vector::iterator}}@; // see \ref{container.requirements}
+    using const_iterator         = @\impdefx{type of \tcode{inplace_vector::const_iterator}}@; // see \ref{container.requirements}
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    // \ref{inplace.vector.cons}, construct/copy/destroy
+    constexpr inplace_vector() noexcept;
+    constexpr explicit inplace_vector(size_type n);                         // freestanding-deleted
+    constexpr inplace_vector(size_type n, const T& value);                  // freestanding-deleted
+    template<class InputIterator>
+      constexpr inplace_vector(InputIterator first, InputIterator last);    // freestanding-deleted
+    template<@\exposconcept{container-compatible-range}@<T> R>
+      constexpr inplace_vector(from_range_t, R&& rg);                       // freestanding-deleted
+    constexpr inplace_vector(const inplace_vector&);
+    constexpr inplace_vector(inplace_vector&&)
+      noexcept(N == 0 || is_nothrow_move_constructible_v<T>);
+    constexpr inplace_vector(initializer_list<T> il);                       // freestanding-deleted
+    constexpr ~inplace_vector();
+    constexpr inplace_vector& operator=(const inplace_vector& other);
+    constexpr inplace_vector& operator=(inplace_vector&& other)
+      noexcept(N == 0 || (is_nothrow_move_assignable_v<T> &&
+                          is_nothrow_move_constructible_v<T>));
+    constexpr inplace_vector& operator=(initializer_list<T>);               // freestanding-deleted
+    template<class InputIterator>
+      constexpr void assign(InputIterator first, InputIterator last);       // freestanding-deleted
+    template<@\exposconcept{container-compatible-range}@<T> R>
+      constexpr void assign_range(R&& rg);                                  // freestanding-deleted
+    constexpr void assign(size_type n, const T& u);                         // freestanding-deleted
+    constexpr void assign(initializer_list<T> il);                          // freestanding-deleted
+
+    // iterators
+    constexpr iterator               begin()         noexcept;
+    constexpr const_iterator         begin()   const noexcept;
+    constexpr iterator               end()           noexcept;
+    constexpr const_iterator         end()     const noexcept;
+    constexpr reverse_iterator       rbegin()        noexcept;
+    constexpr const_reverse_iterator rbegin()  const noexcept;
+    constexpr reverse_iterator       rend()          noexcept;
+    constexpr const_reverse_iterator rend()    const noexcept;
+
+    constexpr const_iterator         cbegin()  const noexcept;
+    constexpr const_iterator         cend()    const noexcept;
+    constexpr const_reverse_iterator crbegin() const noexcept;
+    constexpr const_reverse_iterator crend()   const noexcept;
+
+    // \ref{inplace.vector.capacity} size/capacity
+    constexpr bool empty() const noexcept;
+    constexpr size_type size() const noexcept;
+    static constexpr size_type max_size() noexcept;
+    static constexpr size_type capacity() noexcept;
+    constexpr void resize(size_type sz);                                    // freestanding-deleted
+    constexpr void resize(size_type sz, const T& c);                        // freestanding-deleted
+    static constexpr void reserve(size_type n);                             // freestanding-deleted
+    static constexpr void shrink_to_fit() noexcept;
+
+    // element access
+    constexpr reference       operator[](size_type n);
+    constexpr const_reference operator[](size_type n) const;
+    constexpr reference       at(size_type n);                              // freestanding-deleted
+    constexpr const_reference at(size_type n) const;                        // freestanding-deleted
+    constexpr reference       front();
+    constexpr const_reference front() const;
+    constexpr reference       back();
+    constexpr const_reference back() const;
+
+    // \ref{inplace.vector.data}, data access
+    constexpr       T* data()       noexcept;
+    constexpr const T* data() const noexcept;
+
+    // \ref{inplace.vector.modifiers}, modifiers
+    template<class... Args>
+      constexpr reference emplace_back(Args&&... args);                     // freestanding-deleted
+    constexpr reference push_back(const T& x);                              // freestanding-deleted
+    constexpr reference push_back(T&& x);                                   // freestanding-deleted
+    template<@\exposconcept{container-compatible-range}@<T> R>
+      constexpr void append_range(R&& rg);                                  // freestanding-deleted
+    constexpr void pop_back();
+
+    template<class... Args>
+      constexpr pointer try_emplace_back(Args&&... args);
+    constexpr pointer try_push_back(const T& x);
+    constexpr pointer try_push_back(T&& x);
+    template<@\exposconcept{container-compatible-range}@<T> R>
+      constexpr ranges::borrowed_iterator_t<R> try_append_range(R&& rg);
+
+    template<class... Args>
+      constexpr reference unchecked_emplace_back(Args&&... args);
+    constexpr reference unchecked_push_back(const T& x);
+    constexpr reference unchecked_push_back(T&& x);
+
+    template<class... Args>
+      constexpr iterator emplace(const_iterator position, Args&&... args);  // freestanding-deleted
+    constexpr iterator insert(const_iterator position, const T& x);         // freestanding-deleted
+    constexpr iterator insert(const_iterator position, T&& x);              // freestanding-deleted
+    constexpr iterator insert(const_iterator position, size_type n,         // freestanding-deleted
+                              const T& x);
+    template<class InputIterator>
+      constexpr iterator insert(const_iterator position,                    // freestanding-deleted
+                                InputIterator first, InputIterator last);
+    template<@\exposconcept{container-compatible-range}@<T> R>
+      constexpr iterator insert_range(const_iterator position, R&& rg);     // freestanding-deleted
+    constexpr iterator insert(const_iterator position,                      // freestanding-deleted
+                              initializer_list<T> il);
+    constexpr iterator erase(const_iterator position);
+    constexpr iterator erase(const_iterator first, const_iterator last);
+    constexpr void swap(inplace_vector& x)
+      noexcept(N == 0 || (is_nothrow_swappable_v<T> &&
+                          is_nothrow_move_constructible_v<T>));
+    constexpr void clear() noexcept;
+
+    constexpr friend bool operator==(const inplace_vector& x,
+                                     const inplace_vector& y);
+    constexpr friend @\exposid{synth-three-way-result}@<T>
+      operator<=>(const inplace_vector& x, const inplace_vector& y);
+    constexpr friend void swap(inplace_vector& x, inplace_vector& y)
+      noexcept(N == 0 || (is_nothrow_swappable_v<T> &&
+                          is_nothrow_move_constructible_v<T>))
+      { x.swap(y); }
+  };
+};
+\end{codeblock}
+
+\rSec3[inplace.vector.cons]{Constructors}
+
+\indexlibraryctor{inplace_vector}
+\begin{itemdecl}
+constexpr explicit inplace_vector(size_type n);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{T} is \oldconcept{DefaultInsertable} into \tcode{*this}.
+
+\pnum
+\effects
+Constructs an \tcode{inplace_vector} with \tcode{n} default-inserted elements.
+
+\pnum
+\complexity
+Linear in \tcode{n}.
+\end{itemdescr}
+
+\indexlibraryctor{inplace_vector}
+\begin{itemdecl}
+constexpr inplace_vector(size_type n, const T& value);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{T} is \oldconcept{CopyInsertable} into \tcode{*this}.
+
+\pnum
+\effects
+Constructs an \tcode{inplace_vector} with \tcode{n} copies of \tcode{value}.
+
+\pnum
+\complexity
+Linear in \tcode{n}.
+\end{itemdescr}
+
+\indexlibraryctor{inplace_vector}
+\begin{itemdecl}
+template<class InputIterator>
+  constexpr inplace_vector(InputIterator first, InputIterator last);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Constructs an \tcode{inplace_vector} equal to the range \range{first}{last}.
+
+\pnum
+\complexity
+Linear in \tcode{distance(first, last)}.
+\end{itemdescr}
+
+\indexlibraryctor{inplace_vector}
+\begin{itemdecl}
+template<@\exposconcept{container-compatible-range}@<T> R>
+  constexpr inplace_vector(from_range_t, R&& rg);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Constructs an \tcode{inplace_vector} object with
+the elements of the range \tcode{rg}.
+
+\pnum
+\complexity
+Linear in \tcode{ranges::distance(rg)}.
+\end{itemdescr}
+
+\rSec3[inplace.vector.capacity]{Size and capacity}
+
+\indexlibrarymember{capacity}{inplace_vector}%
+\indexlibrarymember{max_size}{inplace_vector}%
+\begin{itemdecl}
+static constexpr size_type capacity() noexcept;
+static constexpr size_type max_size() noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{N}.
+\end{itemdescr}
+
+\indexlibrarymember{resize}{inplace_vector}%
+\begin{itemdecl}
+constexpr void resize(size_type sz);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{T} is \oldconcept{DefaultInsertable} into \tcode{*this}.
+
+\pnum
+\effects
+%FIXME: Should "is \tcode{true}" be appended here?
+If \tcode{sz < size()},
+erases the last \tcode{size() - sz} elements from the sequence.
+Otherwise,
+appends \tcode{sz - size()} default-inserted elements to the sequence.
+
+\pnum
+\remarks
+If an exception is thrown, there are no effects on \tcode{*this}.
+\end{itemdescr}
+
+\indexlibrarymember{resize}{inplace_vector}%
+\begin{itemdecl}
+constexpr void resize(size_type sz, const T& c);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{T} is \oldconcept{CopyInsertable} into \tcode{*this}.
+
+\pnum
+\effects
+%FIXME: Should "is \tcode{true}" be appended here?
+If \tcode{sz < size()},
+erases the last \tcode{size() - sz} elements from the sequence.
+Otherwise,
+appends \tcode{sz - size()} copies of \tcode{c} to the sequence.
+
+\pnum
+\remarks
+If an exception is thrown, there are no effects on \tcode{*this}.
+\end{itemdescr}
+
+\rSec3[inplace.vector.data]{Data}
+
+\indexlibrarymember{data}{inplace_vector}%
+\begin{itemdecl}
+constexpr       T* data()       noexcept;
+constexpr const T* data() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+A pointer such that \range{data()}{data() + size()} is a valid range.
+For a non-empty \tcode{inplace_vector},
+\tcode{data() == addressof(front())} is \tcode{true}.
+
+\pnum
+\complexity
+Constant time.
+\end{itemdescr}
+
+\rSec3[inplace.vector.modifiers]{Modifiers}
+
+\indexlibrarymember{insert}{inplace_vector}%
+\indexlibrarymember{insert_range}{inplace_vector}%
+\indexlibrarymember{emplace}{inplace_vector}%
+\indexlibrarymember{append_range}{inplace_vector}%
+\begin{itemdecl}
+constexpr iterator insert(const_iterator position, const T& x);
+constexpr iterator insert(const_iterator position, T&& x);
+constexpr iterator insert(const_iterator position, size_type n, const T& x);
+template<class InputIterator>
+  constexpr iterator insert(const_iterator position, InputIterator first, InputIterator last);
+template<@\exposconcept{container-compatible-range}@<T> R>
+  constexpr iterator insert_range(const_iterator position, R&& rg);
+constexpr iterator insert(const_iterator position, initializer_list<T> il);
+
+template<class... Args>
+  constexpr iterator emplace(const_iterator position, Args&&... args);
+template<@\exposconcept{container-compatible-range}@<T> R>
+  constexpr void append_range(R&& rg);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let $n$ be value of \tcode{size()} before this call for
+the \tcode{append_range} overload, and
+\tcode{distance(begin, position)} otherwise.
+
+\pnum
+\complexity
+Linear in the number of elements inserted plus
+the distance to the end of the vector.
+
+\pnum
+\remarks
+If an exception is thrown other than by the
+copy constructor,
+move constructor,
+assignment operator, or
+move assignment operator
+of \tcode{T} or by
+any \tcode{InputIterator} operation,
+there are no effects.
+Otherwise,
+if an exception is thrown, then
+$\tcode{size()} \ge n$ and
+elements in the range \tcode{begin() + \range{0}{$n$}} are not modified.
+\end{itemdescr}
+
+\indexlibrarymember{push_back}{inplace_vector}%
+\indexlibrarymember{emplace_back}{inplace_vector}%
+\begin{itemdecl}
+constexpr reference push_back(const T& x);
+constexpr reference push_back(T&& x);
+template<class... Args>
+  constexpr reference emplace_back(Args&&... args);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{back()}.
+
+\pnum
+\throws
+\tcode{bad_alloc} or
+any exception thrown by initialization of inserted element.
+
+\pnum
+\complexity
+Constant.
+
+\pnum
+\remarks
+If an exception is thrown there are no effects on \tcode{*this}.
+\end{itemdescr}
+
+\indexlibrarymember{try_emplace_back}{inplace_vector}%
+\indexlibrarymember{try_push_back}{inplace_vector}%
+\begin{itemdecl}
+template<class... Args>
+  constexpr pointer try_emplace_back(Args&&... args);
+constexpr pointer try_push_back(const T& x);
+constexpr pointer try_push_back(T&& x);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{vals} denote a pack:
+\begin{itemize}
+\item \tcode{std::forward<Args>(args)...} for the first overload,
+\item \tcode{x} for the second overload,
+\item \tcode{set::move(x)} for the third overload.
+\end{itemize}
+
+\pnum
+\expects
+\tcode{value_type} is \oldconcept{EmplaceConstructible}
+into \tcode{inplace_vector} from \tcode{vals...}.
+
+\pnum
+\effects
+If \tcode{size() < capacity()} is \tcode{true},
+appends an object of type \tcode{T}
+direct-non-list-initialized with \tcode{vals...}.
+Otherwise, there are no effects.
+
+\pnum
+\returns
+\keyword{nullptr} if \tcode{size() == capacity()} is \tcode{true},
+otherwise \tcode{addressof(back())}.
+
+\pnum
+\throws
+Nothing unless an exception is thrown by initialization of inserted element.
+
+\pnum
+\complexity
+Constant.
+
+\pnum
+\remarks
+If an exception is thrown there are no effects on \tcode{*this}.
+\end{itemdescr}
+
+\indexlibrarymember{try_append_range}{inplace_vector}%
+\begin{itemdecl}
+template<@\exposconcept{container-compatible-range}@<T> R>
+  constexpr ranges::borrowed_iterator_t<R> try_append_range(R&& rg);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{value_type} is \oldconcept{EmplaceConstructible}
+into \tcode{inplace_vector} from\\\tcode{*ranges::begin(rg)}.
+
+\pnum
+\effects
+Appends copies of initial elements in \tcode{rg} before \tcode{end()},
+until all elements are inserted or \tcode{size() == capacity()} is \tcode{true}.
+Each iterator in the range \tcode{rg} is dereferenced at most once.
+
+\pnum
+\returns
+%FIXME: Should this be "An iterator past the last inserted element of rg."?
+Iterator past last inserted element of \tcode{rg}.
+
+\pnum
+\complexity
+Linear in the number of elements inserted.
+
+\pnum
+\remarks
+Let $n$ be the value of \tcode{size()} prior to this call.
+If an exception is thrown after the insertion of $k$ elements, then
+\tcode{size()} equals $n + k$,
+elements in the range \tcode{begin() + \range{0}{$n$}} are not modified, and
+elements in the range \tcode{begin() + \range{$n$}{$n + k$}} correspond to
+the inserted elements.
+\end{itemdescr}
+
+\indexlibrarymember{unchecked_emplace_back}{inplace_vector}%
+\begin{itemdecl}
+template<class... Args>
+  constexpr reference unchecked_emplace_back(Args&&... args);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{size() < capacity()} is \tcode{true}.
+
+\pnum
+\effects
+Equivalent to:
+\tcode{return *try_emplace_back(std::forward<Args>(args)...);}
+\end{itemdescr}
+
+\indexlibrarymember{unchecked_push_back}{inplace_vector}%
+\begin{itemdecl}
+constexpr reference unchecked_push_back(const T& x);
+constexpr reference unchecked_push_back(T&& x);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{size() < capacity()} is \tcode{true}.
+
+\pnum
+\effects
+Equivalent to:
+\tcode{return *try_push_back(std::forward<decltype(x)>(x));}
+\end{itemdescr}
+
+\indexlibrarymember{reserve}{inplace_vector}%
+\begin{itemdecl}
+static constexpr void reserve(size_type n);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+None.
+
+\pnum
+\throws
+\tcode{bad_alloc} if \tcode{n > capacity()} is \tcode{true}.
+\end{itemdescr}
+
+\indexlibrarymember{shrink_to_fit}{inplace_vector}%
+\begin{itemdecl}
+static constexpr void shrink_to_fit() noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+None.
+\end{itemdescr}
+
+\indexlibrarymember{erase}{inplace_vector}%
+\indexlibrarymember{pop_back}{inplace_vector}%
+\begin{itemdecl}
+constexpr iterator erase(const_iterator position);
+constexpr iterator erase(const_iterator first, const_iterator last);
+constexpr void pop_back();
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Invalidates iterators and references at or after the point of the erase.
+
+\pnum
+\throws
+Nothing unless an exception is thrown by
+the assignment operator or move assignment operator of \tcode{T}.
+
+\pnum
+\complexity
+The destructor of \tcode{T} is called the number of times
+equal to the number of the elements erased, but
+the assignment operator of \tcode{T} is called the number of times
+equal to the number of elements after the erased elements.
+\end{itemdescr}
+
+\rSec3[inplace.vector.erasure]{Erasure}
+
+\indexlibrarymember{erase}{inplace_vector}%
+\begin{itemdecl}
+template<class T, size_t N, class U = T>
+  constexpr size_t erase(inplace_vector<T, N>& c, const U& value);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+auto it = remove(c.begin(), c.end(), value);
+auto r = distance(it, c.end());
+c.erase(it, c.end());
+return r;
+\end{codeblock}
+\end{itemdescr}
+
+\indexlibrarymember{erase_if}{inplace_vector}%
+\begin{itemdecl}
+template<class T, size_t N, class Predicate>
+  constexpr size_t erase_if(inplace_vector<T, N>& c, Predicate pred);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+auto it = remove_if(c.begin(), c.end(), pred);
+auto r = distance(it, c.end());
+c.erase(it, c.end());
+\end{codeblock}
 \end{itemdescr}
 
 \rSec1[associative]{Associative containers}
@@ -18378,6 +19070,7 @@ constexpr span() noexcept;
 
 \pnum
 \ensures
+%FIXME: Should "is \tcode{true}" be appended here?
 \tcode{size() == 0 \&\& data() == nullptr}.
 \end{itemdescr}
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10004,8 +10004,9 @@ Each iterator in the range \tcode{rg} is dereferenced at most once.
 
 \pnum
 \returns
-%FIXME: Should this be "An iterator past the last inserted element of rg."?
-Iterator past last inserted element of \tcode{rg}.
+An iterator pointing to the first element of \tcode{rg}
+that was not inserted into \tcode{*this},
+or \tcode{ranged::end(rg)} if no such element exists.
 
 \pnum
 \complexity

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -7254,6 +7254,7 @@ headers are included:
 \libheaderrefx{flat_map}{flat.map.syn},
 \libheaderrefx{flat_set}{flat.set.syn},
 \libheaderrefx{forward_list}{forward.list.syn},
+\libheaderrefx{inplace_vector}{inplace.vector.syn},
 \libheaderref{list},
 \libheaderrefx{map}{associative.map.syn},
 \libheaderrefx{regex}{re.syn},

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1149,6 +1149,7 @@ shown in \tref{headers.cpp}.
 \tcode{<generator>} \\
 \tcode{<hazard_pointer>} \\
 \tcode{<initializer_list>} \\
+\tcode{<inplace_vector>} \\
 \tcode{<iomanip>} \\
 \tcode{<ios>} \\
 \tcode{<iosfwd>} \\
@@ -1534,6 +1535,7 @@ include at least the headers shown in \tref{headers.cpp.fs}.
 \ref{string.view}        & String view classes       & \tcode{<string_view>}      \\ \rowsep
 \ref{string.classes}     & String classes            & \tcode{<string>}           \\ \rowsep
 \ref{c.strings}          & Null-terminated sequence utilities & \tcode{<cstring>}, \tcode{<cwchar>} \\ \rowsep
+\ref{containers}         & Containers library        & \tcode{<inplace_vector>}   \\ \rowsep
 \ref{array}              & Class template \tcode{array} & \tcode{<array>}         \\ \rowsep
 \ref{views.contiguous}   & Contiguous access         & \tcode{<span>}             \\ \rowsep
 \ref{views.multidim}     & Multidimensional access   & \tcode{<mdspan>}           \\ \rowsep
@@ -2048,7 +2050,7 @@ This information includes the knowledge of pointer types, the type of their
 difference, the type of the size of objects in this allocation model, as well
 as the memory allocation and deallocation primitives for it. All of the
 string types\iref{strings},
-containers\iref{containers} (except \tcode{array}),
+containers\iref{containers} (except \tcode{array} and \tcode{inplace_vector}),
 string buffers and string streams\iref{input.output}, and
 \tcode{match_results}\iref{re} are parameterized in terms of
 allocators.

--- a/source/support.tex
+++ b/source/support.tex
@@ -681,6 +681,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_hypot}@                             201603L // also in \libheader{cmath}
 #define @\defnlibxname{cpp_lib_incomplete_container_elements}@     201505L
   // also in \libheader{forward_list}, \libheader{list}, \libheader{vector}
+#define @\defnlibxname{cpp_lib_inplace_vector}@                    202406L // also in \libheader{inplace_vector}
 #define @\defnlibxname{cpp_lib_int_pow2}@                          202002L // freestanding, also in \libheader{bit}
 #define @\defnlibxname{cpp_lib_integer_comparison_functions}@      202002L // also in \libheader{utility}
 #define @\defnlibxname{cpp_lib_integer_sequence}@                  201304L // freestanding, also in \libheader{utility}


### PR DESCRIPTION
Editor notes:
* Unable to apply change to Complexity for "a.swap(b)" in section [container.reqmts]; only such \itemdecl is in [container.alloc.reqmts] with different wording. UPDATE: found and fixed
* Unable to apply change to note in "sequence.reqmts.2" - wording does not appear to exist. UPDATE: wording was removed
* Sections named [containers.sequences.inplace.vector.\*] renamed to [inplace.vector.\*].
* [inplace.vector.modifiers] Add commas for clarity.
* [inplace.vector] Minor editorial fixes (e.g. add missing "the").

Fixes #7090
Fixes cplusplus/papers#114

Notes/questions on paper:
* Paper wants [inplace_vector] after [vector], but wouldn't it make more sense to put it after [vector.bool]? UPDATE: We probably do want [inplace_vector] after [vector.bool] - should add as a separate commit before merging (for me to do this now would complicate the review)
* Sections have been renamed from what's in the paper, e.g. 
[containers.sequences.general] is now [sequences.general],[container.requirements.sequence.reqmts] is now [sequence.reqmts], etc..
* See added FIXMEs.
