### PR TITLE
[depr.c.macros] Fix "macro" singular when referring to two macros

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -227,7 +227,7 @@ static constexpr bool has_denorm_loss = false;
 \rSec1[depr.c.macros]{Deprecated C macros}
 
 \pnum
-The header \libheader{stdalign.h} has the following macro:
+The header \libheader{stdalign.h} has the following macros:
 \indexheader{stdalign.h}%
 \indexlibraryglobal{__alignas_is_defined}%
 \begin{codeblock}


### PR DESCRIPTION
This should have been applied as part of LWG4036.