### PR TITLE
[version.syn] Remove redundant <version> in __cpp_lib_ranges_enumerate

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -739,7 +739,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_ranges_chunk_by}@                   202202L // freestanding, also in \libheader{ranges}
 #define @\defnlibxname{cpp_lib_ranges_concat}@                     202403L // also in \libheader{ranges}
 #define @\defnlibxname{cpp_lib_ranges_contains}@                   202207L // also in \libheader{algorithm}
-#define @\defnlibxname{cpp_lib_ranges_enumerate}@                  202302L // also in \libheader{ranges}, \libheader{version}
+#define @\defnlibxname{cpp_lib_ranges_enumerate}@                  202302L // also in \libheader{ranges}
 #define @\defnlibxname{cpp_lib_ranges_find_last}@                  202207L // also in \libheader{algorithm}
 #define @\defnlibxname{cpp_lib_ranges_fold}@                       202207L // also in \libheader{algorithm}
 #define @\defnlibxname{cpp_lib_ranges_generate_random}@            202403L // also in \libheader{random}


### PR DESCRIPTION
This clause is already "Header \<version\> synopsis", no need to say "also in \<version\>" for any feature-test macro.