### PR TITLE
[basic.pre] Defragment specification of names and entities

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -32,17 +32,21 @@ Clauses.
 \indextext{storage class}%
 \indextext{scope}%
 \indextext{linkage}%
-An \defn{entity} is a value, object, reference,
-structured binding,
-function, enumerator, type,
-class member, bit-field, template, template specialization, namespace, or
-pack.
-
-\pnum
 A \defn{name} is an \grammarterm{identifier}\iref{lex.name},
 \grammarterm{operator-function-id}\iref{over.oper},
 \grammarterm{literal-operator-id}\iref{over.literal}, or
 \grammarterm{conversion-function-id}\iref{class.conv.fct}.
+
+\pnum
+Two names are \defnx{the same}{name!same} if
+\begin{itemize}
+\item they are \grammarterm{identifier}{s} composed of the same character sequence, or
+\item they are \grammarterm{operator-function-id}{s} formed with the same operator, or
+\item they are \grammarterm{literal-operator-id}{s} formed with the same
+literal suffix identifier, or
+\item they are \grammarterm{conversion-function-id}{s} formed with
+equivalent\iref{temp.over.link} types.
+\end{itemize}
 
 \pnum
 Every name is introduced by a \defn{declaration}, which is a
@@ -85,9 +89,13 @@ implicit declaration of an injected-class-name\iref{class.pre}.
 The interpretation of a \grammarterm{for-range-declaration} produces
 one or more of the above\iref{stmt.ranged}.
 \end{note}
-An entity $E$ is denoted by the name (if any)
-that is introduced by a declaration of $E$ or
-by a \grammarterm{typedef-name} introduced by a declaration specifying $E$.
+
+\pnum
+Some names denote types or templates. In general, whenever a name is
+encountered it is necessary to determine whether that name denotes one of these
+entities before continuing to parse the program that contains it. The process
+that determines this is called
+\defnx{name lookup}{lookup!name}\iref{basic.lookup}.
 
 \pnum
 A \defn{variable} is introduced by the
@@ -96,30 +104,18 @@ a reference other than a non-static data member or of
 an object. The variable's name, if any, denotes the reference or object.
 
 \pnum
+An \defn{entity} is a value, object, reference, structured binding, function,
+enumerator, type, class member, bit-field, template, template specialization,
+namespace, or pack. An entity $E$ is denoted by the name (if any) that is
+introduced by a declaration of $E$ or by a \grammarterm{typedef-name}
+introduced by a declaration specifying $E$.
+
+\pnum
 A \defnadj{local}{entity} is a variable with
 automatic storage duration\iref{basic.stc.auto},
 a structured binding\iref{dcl.struct.bind}
 whose corresponding variable is such an entity,
 or the \tcode{*\keyword{this}} object\iref{expr.prim.this}.
-
-\pnum
-Some names denote types or templates. In general,
-whenever a name is encountered it is necessary to determine whether that name denotes
-one of these entities before continuing to parse the program that contains it. The
-process that determines this is called
-\defnx{name lookup}{lookup!name}\iref{basic.lookup}.
-
-\pnum
-Two names are \defnx{the same}{name!same} if
-\begin{itemize}
-\item they are \grammarterm{identifier}{s} composed of the same character sequence, or
-\item they are \grammarterm{operator-function-id}{s} formed with
-the same operator, or
-\item they are \grammarterm{conversion-function-id}{s} formed
-with equivalent\iref{temp.over.link} types, or
-\item they are \grammarterm{literal-operator-id}{s}\iref{over.literal} formed with
-the same literal suffix identifier.
-\end{itemize}
 
 \pnum
 \indextext{translation unit!name and}%


### PR DESCRIPTION
The current contents of [basic.pre] jump between specifying different things.  This PR moves all the specification of names to the front, followed by the specification of entities.

There are two main benefits: (1) the specification for when two names are the same is a list of 4 rules that correspond to the 4 things than can form a name --- the connection is much clearer when the paragraphs are adjacent and the list is sorted to the same order; (2) in this form, even though all the words are the same, the reordering and merging of paragraphs a fit on a single page.  The very last paragraph was forced over a page-break in the original layout.