### PR TITLE
[classes] Turn ad-hoc examples into proper examples

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -950,7 +950,7 @@ definition, if they are defined at all.
 A member function can be declared (but not defined) using a typedef for
 a function type. The resulting member function has exactly the same type
 as it would have if the function declarator were provided explicitly,
-see~\ref{dcl.fct}. Also see~\ref{temp.arg}.
+see~\ref{dcl.fct} and \ref{temp.arg}.
 \begin{example}
 \begin{codeblock}
 typedef void fv();

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -431,7 +431,8 @@ void g(int s) {
 \begin{note}
 The declaration of a class name takes effect immediately after the
 \grammarterm{identifier} is seen in the class definition or
-\grammarterm{elaborated-type-specifier}. For example,
+\grammarterm{elaborated-type-specifier}.
+\begin{example}
 \begin{codeblock}
 class A * A;
 \end{codeblock}
@@ -439,6 +440,7 @@ first specifies \tcode{A} to be the name of a class and then redefines
 it as the name of a pointer to an object of that class. This means that
 the elaborated form \keyword{class} \tcode{A} must be used to refer to the
 class. Such artistry with names can be confusing and is best avoided.
+\end{example}
 \end{note}
 
 \pnum
@@ -948,8 +950,8 @@ definition, if they are defined at all.
 A member function can be declared (but not defined) using a typedef for
 a function type. The resulting member function has exactly the same type
 as it would have if the function declarator were provided explicitly,
-see~\ref{dcl.fct}. For example,
-
+see~\ref{dcl.fct}. Also see~\ref{temp.arg}.
+\begin{example}
 \begin{codeblock}
 typedef void fv();
 typedef void fvc() const;
@@ -962,8 +964,7 @@ fv  S::* pmfv1 = &S::memfunc1;
 fv  S::* pmfv2 = &S::memfunc2;
 fvc S::* pmfv3 = &S::memfunc3;
 \end{codeblock}
-
-Also see~\ref{temp.arg}.
+\end{example}
 \end{note}
 
 \rSec2[class.mfct.non.static]{Non-static member functions}%
@@ -2221,7 +2222,7 @@ addresses using a placement
 Such use of explicit placement and destruction of objects can be necessary
 to cope with dedicated hardware resources and for writing memory management
 facilities.
-For example,
+\begin{example}
 \begin{codeblock}
 void* operator new(std::size_t, void* p) { return p; }
 struct X {
@@ -2237,6 +2238,7 @@ void g() {                      // rare, specialized use:
   p->X::~X();                   // cleanup
 }
 \end{codeblock}
+\end{example}
 \end{note}
 
 \pnum
@@ -2866,7 +2868,7 @@ of a
 refers to an object of class type with a virtual destructor,
 because the deallocation function is chosen by the destructor
 of the dynamic type of the object, the effect is the same in that case.
-For example,
+\begin{example}
 \begin{codeblock}
 struct B {
   virtual ~B();
@@ -2902,6 +2904,7 @@ the object of class \tcode{E} is destroyed
 and its storage is deallocated
 by \tcode{E::operator delete()},
 due to the virtual destructor.
+\end{example}
 \end{note}
 \begin{note}
 Virtual destructors have no effect on the deallocation function actually
@@ -2910,7 +2913,7 @@ called when the
 of a
 \grammarterm{delete-expression}
 refers to an array of objects of class type.
-For example,
+\begin{example}
 \begin{codeblock}
 struct B {
   virtual ~B();
@@ -2928,6 +2931,7 @@ void f(int i) {
   delete[] bp;      // undefined behavior
 }
 \end{codeblock}
+\end{example}
 \end{note}
 
 \pnum
@@ -4242,8 +4246,7 @@ void g(S* sp) {
 Because access control applies to the declarations named, if access control is applied to a
 \grammarterm{typedef-name}, only the accessibility of the typedef or alias declaration itself is considered.
 The accessibility of the entity referred to by the \grammarterm{typedef-name} is not considered.
-For example,
-
+\begin{example}
 \begin{codeblock}
 class A {
   class B { };
@@ -4256,6 +4259,7 @@ void f() {
   A::B y;           // access error, \tcode{A::B} is private
 }
 \end{codeblock}
+\end{example}
 \end{note}
 
 \pnum
@@ -4520,8 +4524,7 @@ explicit casts\iref{expr.type.conv,expr.static.cast,expr.cast},
 a conversion from a pointer to a derived class to a pointer
 to an inaccessible base class can be ill-formed if an implicit conversion
 is used, but well-formed if an explicit cast is used.
-For example,
-
+\begin{example}
 \begin{codeblock}
 class B {
 public:
@@ -4546,6 +4549,7 @@ void DD::f() {
   bp2->mi = 3;                  // OK, access through a pointer to \tcode{B}.
 }
 \end{codeblock}
+\end{example}
 \end{note}
 
 \pnum


### PR DESCRIPTION
Also addresses an ISO comment about not having "For example," as the last part of the normal sentence.