### PR TITLE
[variant.visit] Add `constexpr` to `as-variant`

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6141,13 +6141,13 @@ template<class R, class Visitor, class... Variants>
 Let \exposid{as-variant} denote the following exposition-only function templates:
 \begin{codeblock}
 template<class... Ts>
-  auto&& @\exposid{as-variant}@(variant<Ts...>& var) { return var; }
+  constexpr auto&& @\exposid{as-variant}@(variant<Ts...>& var) { return var; }
 template<class... Ts>
-  auto&& @\exposid{as-variant}@(const variant<Ts...>& var) { return var; }
+  constexpr auto&& @\exposid{as-variant}@(const variant<Ts...>& var) { return var; }
 template<class... Ts>
-  auto&& @\exposid{as-variant}@(variant<Ts...>&& var) { return std::move(var); }
+  constexpr auto&& @\exposid{as-variant}@(variant<Ts...>&& var) { return std::move(var); }
 template<class... Ts>
-  auto&& @\exposid{as-variant}@(const variant<Ts...>&& var) { return std::move(var); }
+  constexpr auto&& @\exposid{as-variant}@(const variant<Ts...>&& var) { return std::move(var); }
 \end{codeblock}
 Let $n$ be \tcode{sizeof...(Variants)}.
 For each $0 \leq i < n$, let


### PR DESCRIPTION
Fixes #7038.