### PR TITLE
[coro.generator] Rename the `generator`'s template parameter `V` to `Val`

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -16773,12 +16773,12 @@ void f() {
 \begin{codeblock}
 namespace std {
   // \ref{coro.generator.class}, class template \tcode{generator}
-  template<class Ref, class V = void, class Allocator = void>
+  template<class Ref, class Val = void, class Allocator = void>
     class generator;
 
   namespace pmr {
-    template<class R, class V = void>
-      using generator = std::generator<R, V, polymorphic_allocator<>>;
+    template<class Ref, class Val = void>
+      using generator = std::generator<Ref, Val, polymorphic_allocator<>>;
   }
 }
 \end{codeblock}
@@ -16787,11 +16787,11 @@ namespace std {
 
 \begin{codeblock}
 namespace std {
-  template<class Ref, class V = void, class Allocator = void>
-  class @\libglobal{generator}@ : public ranges::view_interface<generator<Ref, V, Allocator>> {
+  template<class Ref, class Val = void, class Allocator = void>
+  class @\libglobal{generator}@ : public ranges::view_interface<generator<Ref, Val, Allocator>> {
   private:
-    using @\exposid{value}@ = conditional_t<is_void_v<V>, remove_cvref_t<Ref>, V>;  // \expos
-    using @\exposid{reference}@ = conditional_t<is_void_v<V>, Ref&&, Ref>;          // \expos
+    using @\exposid{value}@ = conditional_t<is_void_v<Val>, remove_cvref_t<Ref>, Val>;  // \expos
+    using @\exposid{reference}@ = conditional_t<is_void_v<Val>, Ref&&, Ref>;          // \expos
 
     // \ref{coro.generator.iterator}, class \tcode{generator::\exposid{iterator}}
     class @\exposidnc{iterator}@;                                                     // \expos
@@ -16977,8 +16977,8 @@ default_sentinel_t end() const noexcept;
 
 \begin{codeblock}
 namespace std {
-  template<class Ref, class V, class Allocator>
-  class generator<Ref, V, Allocator>::promise_type {
+  template<class Ref, class Val, class Allocator>
+  class generator<Ref, Val, Allocator>::promise_type {
   public:
     generator get_return_object() noexcept;
 
@@ -17280,8 +17280,8 @@ using an allocator equivalent to that used to allocate it.
 
 \begin{codeblock}
 namespace std {
-  template<class Ref, class V, class Allocator>
-  class generator<Ref, V, Allocator>::@\exposid{iterator}@ {
+  template<class Ref, class Val, class Allocator>
+  class generator<Ref, Val, Allocator>::@\exposid{iterator}@ {
   public:
     using value_type = @\exposid{value}@;
     using difference_type = ptrdiff_t;


### PR DESCRIPTION
Fixes #6451.