### PR TITLE
[range.join.with.iterator] Fix typo

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -7264,7 +7264,7 @@ is \tcode{false},
 \item
 Otherwise,
 if \placeholder{OUTERC}, \placeholder{INNERC}, and \placeholder{PATTERNC}
-each model \tcode{\libconcept{derived_from}<bidirectional_iterator_category>}
+each model \tcode{\libconcept{derived_from}<bidirectional_iterator_tag>}
 and \exposid{InnerBase} and \exposid{PatternBase}
 each model \libconcept{common_range},
 \tcode{iterator_cate\-gory} denotes \tcode{bidirectional_iterator_tag}.


### PR DESCRIPTION
There is no such thing as a `bidirectional_iterator_category`.