### PR TITLE
[tab:headers.cpp.fs] Use a more appropriate subclause for inplace_vector

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1508,7 +1508,7 @@ include at least the headers shown in \tref{headers.cpp.fs}.
 \ref{support.limits}     & Implementation properties &
   \tcode{<cfloat>}, \tcode{<climits>}, \tcode{<limits>}, \\
                          &                           & \tcode{<version>}          \\ \rowsep
-\ref{cstdint.syn}        & Integer types             & \tcode{<cstdint>}   \\ \rowsep
+\ref{cstdint.syn}        & Integer types             & \tcode{<cstdint>}          \\ \rowsep
 \ref{support.dynamic}    & Dynamic memory management & \tcode{<new>}              \\ \rowsep
 \ref{support.rtti}       & Type identification       & \tcode{<typeinfo>}         \\ \rowsep
 \ref{support.srcloc}     & Source location           & \tcode{<source_location>}  \\ \rowsep
@@ -1535,8 +1535,8 @@ include at least the headers shown in \tref{headers.cpp.fs}.
 \ref{string.view}        & String view classes       & \tcode{<string_view>}      \\ \rowsep
 \ref{string.classes}     & String classes            & \tcode{<string>}           \\ \rowsep
 \ref{c.strings}          & Null-terminated sequence utilities & \tcode{<cstring>}, \tcode{<cwchar>} \\ \rowsep
-\ref{containers}         & Containers library        & \tcode{<inplace_vector>}   \\ \rowsep
 \ref{array}              & Class template \tcode{array} & \tcode{<array>}         \\ \rowsep
+\ref{inplace.vector}     & Class template \tcode{inplace_vector} & \tcode{<inplace_vector>} \\ \rowsep
 \ref{views.contiguous}   & Contiguous access         & \tcode{<span>}             \\ \rowsep
 \ref{views.multidim}     & Multidimensional access   & \tcode{<mdspan>}           \\ \rowsep
 \ref{iterators}          & Iterators library         & \tcode{<iterator>}         \\ \rowsep


### PR DESCRIPTION
Not all of [containers] is meant to be freestanding.

The original instructions came from https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p0843r14.html#libraryrequirementsorganizationheaders.