### PR TITLE
[inplace.vector.overview] Constexpr iterator requirements

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9520,10 +9520,8 @@ are not described in one of these tables or
 for operations where there is additional semantic information.
 
 \pnum
-For any \tcode{N},
-\tcode{inplace_vector<T, N>::iterator} and
-\tcode{inplace_vector<T, N>::const_iterator}
-meet the constexpr iterator requirements.
+The types \tcode{iterator} and \tcode{const_iterator} meet
+the constexpr iterator requirements\iref{iterator.requirements.general}.
 
 \pnum
 For any $\tcode{N} > 0$,


### PR DESCRIPTION
Use the same wording in `inplace_vector` that we already use in `array` and `vector`. (Note that `array<T,N>` is exactly isomorphic to `inplace_vector<T,N>` in this respect.)

[Here](https://github.com/cplusplus/draft/pull/7115#discussion_r1673545130) @jwakely writes "LWG spent a lot of time on that sentence, please don't change it editorially" — but I think he must be thinking of some other sentence, surely? I can't see any reason for this sentence to differ in formulation from the existing sentences in [array] and [vector]. So I'm adding jwakely as a reviewer on this PR... er, I guess I hope someone will add him, since I guess I can't.