### PR TITLE
[list] [vector] [inplace.vector] Consistent comma in "If X, there are no effects"

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -6912,7 +6912,7 @@ and causes a single call to a constructor of
 If an exception is thrown other than by the
 copy constructor, move constructor,
 assignment operator, or move assignment operator of
-\tcode{T}
+\tcode{T},
 there are no effects.
 If an exception is thrown while inserting a single element at either end,
 there are no effects.
@@ -8271,7 +8271,7 @@ to the number of elements inserted.
 \pnum
 \remarks
 Does not affect the validity of iterators and references.
-If an exception is thrown there are no effects.
+If an exception is thrown, there are no effects.
 \end{itemdescr}
 
 \indexlibrarymember{erase}{list}%
@@ -8571,7 +8571,7 @@ otherwise, no comparisons are performed.
 Stable\iref{algorithm.stable}.
 If \tcode{addressof(x) != this}, \tcode{x} is empty after the merge.
 No elements are copied by this operation.
-If an exception is thrown other than by a comparison there are no effects.
+If an exception is thrown other than by a comparison, there are no effects.
 \end{itemdescr}
 
 \indexlibrarymember{reverse}{list}%
@@ -9019,7 +9019,7 @@ implementation-specific optimizations.
 It does not increase \tcode{capacity()}, but may reduce \tcode{capacity()}
 by causing reallocation.
 If an exception is thrown other than by the move constructor
-of a non-\oldconcept{CopyInsertable} \tcode{T} there are no effects.
+of a non-\oldconcept{CopyInsertable} \tcode{T}, there are no effects.
 
 \pnum
 \complexity
@@ -9076,7 +9076,7 @@ appends \tcode{sz - size()} default-inserted elements to the sequence.
 \pnum
 \remarks
 If an exception is thrown other than by the move constructor of a non-\oldconcept{CopyInsertable}
-\tcode{T} there are no effects.
+\tcode{T}, there are no effects.
 \end{itemdescr}
 
 \indexlibrarymember{resize}{vector}%
@@ -9098,7 +9098,7 @@ appends \tcode{sz - size()} copies of \tcode{c} to the sequence.
 
 \pnum
 \remarks
-If an exception is thrown there are no effects.
+If an exception is thrown, there are no effects.
 \end{itemdescr}
 
 \rSec3[vector.data]{Data}
@@ -9164,7 +9164,7 @@ are invalidated.
 If an exception is thrown other than by
 the copy constructor, move constructor,
 assignment operator, or move assignment operator of
-\tcode{T} or by any \tcode{InputIterator} operation
+\tcode{T} or by any \tcode{InputIterator} operation,
 there are no effects.
 If an exception is thrown while inserting a single element at the end and
 \tcode{T} is \oldconcept{CopyInsertable} or \tcode{is_nothrow_move_constructible_v<T>}
@@ -9933,7 +9933,7 @@ Constant.
 
 \pnum
 \remarks
-If an exception is thrown there are no effects on \tcode{*this}.
+If an exception is thrown, there are no effects on \tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{try_emplace_back}{inplace_vector}%
@@ -9981,7 +9981,7 @@ Constant.
 
 \pnum
 \remarks
-If an exception is thrown there are no effects on \tcode{*this}.
+If an exception is thrown, there are no effects on \tcode{*this}.
 \end{itemdescr}
 
 \indexlibrarymember{try_append_range}{inplace_vector}%


### PR DESCRIPTION
There is exactly one place in containers.tex where we have "If X, *then* there are no effects." But the "X" in that case is very convoluted, so I think the "then" is kind of helpful.

Notice the several novel instances of "there are no effects *on `*this`*" in [inplace.vector]. I want to fix those too, for consistency with [vector] and [list]; but I think that probably requires a formal LWG issue.