### PR TITLE
Added three more examples in basic.tex

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1018,7 +1018,7 @@ struct X {
   void k(this X&);              // error: redeclaration
   void m(this const X);
   void m() const ;              //error: redeclaration
-  void n(this X );   
+  void n(this X);   
   void n(X);                    // OK
   void o(this const X&);
   void o() const ;              //error: redeclaration

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1017,8 +1017,8 @@ struct X {
   void k();
   void k(this X&);              // error: redeclaration
   void m(this const X);
-  void m() const ;              //error: redeclaration
-  void n(this X);   
+  void m() const;               //error: redeclaration
+  void n(this X);
   void n(X);                    // OK
   void o(this const X&);
   void o() const ;              //error: redeclaration

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1016,6 +1016,12 @@ struct X {
   void j() const &;             // error: redeclaration
   void k();
   void k(this X&);              // error: redeclaration
+  void m(this const X);
+  void m() const ;              //error: redeclaration
+  void n(this X );   
+  void n(X);                    // OK
+  void o(this const X&);
+  void o() const ;              //error: redeclaration
 };
 \end{codeblock}
 \end{example}

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1017,7 +1017,7 @@ struct X {
   void k();
   void k(this X&);              // error: redeclaration
   void m(this const X);
-  void m() const;               //error: redeclaration
+  void m() const;               // OK
   void n(this X);
   void n(X);                    // OK
   void o(this const X&);

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -917,7 +917,7 @@ Two non-static member functions have
 exactly one is an implicit object member function
 with no \grammarterm{ref-qualifier} and
 the types of their object parameters\iref{dcl.fct},
-after removing top-level references,
+after removing references,
 are the same, or
 \item
 their object parameters have the same type.


### PR DESCRIPTION
Added some more examples in [basic.scope.scope] to make it more clear as currently we see many compilers diverge from expected behavior. This examples and explanation for them are given in [this thread](https://stackoverflow.com/questions/78758215/explicit-object-member-function-discrepancies-between-different-compilers).