### PR TITLE
[diff.cpp03.library] Use a new macro to avoid `\-` in index reference

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2264,7 +2264,7 @@ The following \Cpp{} headers are new:
 \libheaderrefx{condition_variable}{condition.variable.syn},
 \libheaderrefx{forward_list}{forward.list.syn},
 \libheaderref{future},
-\libheaderrefx{initiali\-zer_list}{initializer.list.syn},
+\libheaderreftxtx{initializer_list}{initiali\-zer_list}{initializer.list.syn},
 \libheaderref{mutex},
 \libheaderrefx{random}{rand.synopsis},
 \libheaderref{ratio},
@@ -2273,7 +2273,7 @@ The following \Cpp{} headers are new:
 \libheaderrefx{system_error}{system.error.syn},
 \libheaderref{thread},
 \libheaderref{tuple},
-\libheaderrefx{type\-index}{type.index.synopsis},
+\libheaderreftxtx{typeindex}{type\-index}{type.index.synopsis},
 \libheaderrefx{type_traits}{meta.type.synop},
 \libheaderrefx{unordered_map}{unord.map.syn},
 and

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -222,6 +222,7 @@
 \newcommand{\libheaderrefx}[2]{\libheader{#1}\iref{#2}}
 \newcommand{\libheaderref}[1]{\libheaderrefx{#1}{#1.syn}}
 \newcommand{\libdeprheaderref}[1]{\libheaderrefx{#1}{depr.#1.syn}}
+\newcommand{\libheaderreftxtx}[3]{\indexhdr{#1}\tcode{<#2>}\iref{#3}}
 
 %%--------------------------------------------------
 % General code style


### PR DESCRIPTION
Fixes #6649.