### PR TITLE
[fs.op.copy] Replace non-`codeblock`s with `outputblock`s

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -17372,16 +17372,16 @@ library functions called by the implementation shall have an \tcode{error_code} 
 \pnum
 \begin{example}
 Given this directory structure:
-\begin{codeblock}
+\begin{outputblock}
 /dir1
   file1
   file2
   dir2
     file3
-\end{codeblock}
+\end{outputblock}
 
 Calling \tcode{copy("/dir1", "/dir3")} would result in:
-\begin{codeblock}
+\begin{outputblock}
 /dir1
   file1
   file2
@@ -17390,10 +17390,10 @@ Calling \tcode{copy("/dir1", "/dir3")} would result in:
 /dir3
   file1
   file2
-\end{codeblock}
+\end{outputblock}
 
 Alternatively, calling \tcode{copy("/dir1", "/dir3", copy_options::recursive)} would result in:
-\begin{codeblock}
+\begin{outputblock}
 /dir1
   file1
   file2
@@ -17404,7 +17404,7 @@ Alternatively, calling \tcode{copy("/dir1", "/dir3", copy_options::recursive)} w
   file2
   dir2
     file3
-\end{codeblock}
+\end{outputblock}
 \end{example}
 \end{itemdescr}
 


### PR DESCRIPTION
These blocks are used for showing of directory hierarchy but not code, so we should use `outputblock`.
