### PR TITLE
[inplace.vector.syn] Add missing default template argument for `erase`

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -6207,7 +6207,7 @@ namespace std {
   template<class T, size_t N> class inplace_vector;             // partially freestanding
 
   // \ref{inplace.vector.erasure}, erasure
-  template<class T, size_t N, class U>
+  template<class T, size_t N, class U = T>
     constexpr typename inplace_vector<T, N>::size_type
       erase(inplace_vector<T, N>& c, const U& value);
   template<class T, size_t N, class Predicate>


### PR DESCRIPTION
The default template argument is already in [inplace.vector.erasure]. Fixes #7149.