### PR TITLE
[rand.eng.philox] Make the round states explicit.

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -3186,27 +3186,24 @@ The state transition is performed as if by the following algorithm:
 \begin{codeblock}
 @$i$@ = @$i$@ + 1
 if (@$i$@ == @$n$@) {
-  @$Y$@ = Philox(@$K$@, @$X$@) // \seebelow
-  @$Z$@ = @$Z$@ + 1
+  @$Y$@ = Philox(@$K$@, @$X$@)        // \seebelow
+  @$Z$@ = @$Z$@ + 1                // this updates $X$
   @$i$@ = 0
 }
 \end{codeblock}
 
 \pnum
 The \tcode{Philox} function maps the length-$n/2$ sequence $K$ and
-the length-$n$ sequence $X$ into a length-$n$ output sequence $Y$.
+the length-$n$ sequence $X$ into a length-$n$ output sequence.
 Philox applies an $r$-round substitution-permutation network to the values in $X$.
-A single round of the generation algorithm performs the following steps:
+That is, there are intermediate values $X^{(0)}, X^{(1)}, \dotsc, X^{(r)}$,
+where $X^{(0)} \cedef X$, and for each round $q$ (with $q = 1, \dotsc, r$),
+$X^{(q)}$ is computed from $X^{(q - 1)}$ as follows. The output sequence is $X^{(r)}$.
 \begin{itemize}
 \item
-The output sequence $X'$ of the previous round
-($X$ in case of the first round)
-is permuted to obtain the intermediate state $V$:
-\begin{codeblock}
-@$V_j = X'_{f_n(j)}$@
-\end{codeblock}
-where $j = 0, \dotsc, n - 1$ and
-$f_n(j)$ is defined in \tref{rand.eng.philox.f}.
+An intermediate state $V^{(q)}$ is obtained by permuting the previous output,
+$V^{(q)}_j \cedef X^{(q - 1)}_{f_n(j)}$,
+where $j = 0, \dotsc, n - 1$, and $f_n(j)$ is defined in \tref{rand.eng.philox.f}.
 
 \begin{floattable}{Values for the word permutation $\bm{f}_{\bm{n}}\bm{(j)}$}{rand.eng.philox.f}
 {l|l|l|l|l|l}
@@ -3222,12 +3219,13 @@ For $n = 2$ the sequence is not permuted.
 \end{note}
 
 \item
-The following computations are applied to the elements of the $V$ sequence:
-\begin{codeblock}
-@$X_{2k + 0} = \mulhi(V_{2k}, M_{k}, w) \xor \mathit{key}^q_k \xor V_{2k + 1}$@
-@$X_{2k + 1} = \mullo(V_{2k}, M_{k}, w)$@
-\end{codeblock}
-where:
+The next output $X^{(q)}$ is computed from the elements of the $V^{(q)}$ as follows.
+For $k = 0, \dotsc, n/2 - 1$,
+\begin{itemize}
+\item $X^{(q)}_{2k + 0} = \mulhi(V^{(q)}_{2k}, M_{k}, w) \xor K^{(q)}_k \xor V^{(q)}_{2k + 1}$, and
+\item $X^{(q)}_{2k + 1} = \mullo(V^{(q)}_{2k}, M_{k}, w)$,
+\end{itemize}
+where
   \begin{itemize}
   \item
   $\mullo(\tcode{a}, \tcode{b}, \tcode{w})$ is
@@ -3240,17 +3238,11 @@ where:
   $(\left\lfloor (\tcode{a} \cdot \tcode{b}) / 2^w \right\rfloor)$,
 
   \item
-  $k = 0, \dotsc, n/2 - 1$ is the index in the sequences,
+  $K^{(q)}_k$ is the $k^\text{th}$ round key for round $q$,
+  $K^{(q)}_k \cedef (K_k + (q - 1) \cdot C_k) \mod 2^w$,
 
   \item
-  $q = 0, \dotsc, r - 1$ is the index of the round,
-
-  \item
-  $\mathit{key}^q_k$ is the $k^\text{th}$ round key for round $q$,
-  $\mathit{key}^q_k \cedef (K_k + q \cdot C_k) \mod 2^w$,
-
-  \item
-  $K_k$ are the elements of the key sequence $K$,
+  $K_k$ is the $k^\text{th}$ element of the key sequence $K$,
 
   \item
   $M_k$ is \tcode{multipliers[$k$]}, and
@@ -3259,10 +3251,6 @@ where:
   $C_k$ is \tcode{round_consts[$k$]}.
   \end{itemize}
 \end{itemize}
-
-\pnum
-After $r$ applications of the single-round function,
-\tcode{Philox} returns the sequence $Y = X'$.
 
 \indexlibraryglobal{philox_engine}%
 \indexlibrarymember{result_type}{philox_engine}%


### PR DESCRIPTION
This clarifies which state is the final result, and avoids the use of the vaguely defined variable $X'$. It changes the index variable $q$ to be 1-based. The single sequence $V$ is replaced with the sequence of sequences $V^{(q)}$.

Currently, the definition of the "r-round network", "rounds", and how they fit together, is somewhat informal and imprecise. In particular, the statement that `Philox` "returns the sequence $Y = X'$" is needlessly ambiguous.

It would be clearer if all involved mathematical entities and operations were clearly spelled out.

---

**Preview:**

![image](https://github.com/user-attachments/assets/ab29bc0a-93ce-4326-8c8c-48c809a48648)
