### PR TITLE
[depr.c.macros] Cross-reference the C headers for deprecated macros

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -227,7 +227,7 @@ static constexpr bool has_denorm_loss = false;
 \rSec1[depr.c.macros]{Deprecated C macros}
 
 \pnum
-The header \libheader{stdalign.h} has the following macros:
+The header \libheaderref{stdalign.h} has the following macros:
 \indexheader{stdalign.h}%
 \indexlibraryglobal{__alignas_is_defined}%
 \begin{codeblock}
@@ -236,7 +236,7 @@ The header \libheader{stdalign.h} has the following macros:
 \end{codeblock}
 
 \pnum
-The header \libheader{stdbool.h} has the following macro:
+The header \libheaderref{stdbool.h} has the following macro:
 \indexheader{stdbool.h}%
 \indexhdr{stdbool.h}%
 \indexlibraryglobal{__bool_true_false_are_defined}%
@@ -327,8 +327,7 @@ template<class T> bool operator>=(const T& x, const T& y);
 \rSec1[depr.cerrno]{Deprecated error numbers}
 
 \pnum
-The following macros are defined in addition to those
-specified in \ref{cerrno.syn}:
+The header \libheaderref{cerrno} has the following additional macros:
 
 \indexlibraryglobal{ENODATA}%
 \indexlibraryglobal{ENOSR}%


### PR DESCRIPTION
Add cross-references to the corresponding C headers now that they are an adopted part of the standard library.