### PR TITLE
[containers] Consistently xref header synopses from General clauses

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10150,8 +10150,9 @@ c.erase(it, c.end());
 \rSec2[associative.general]{General}
 
 \pnum
-The header \libheader{map} defines the class templates \tcode{map} and
-\tcode{multimap}; the header \libheader{set} defines the class templates
+The header \libheaderrefx{map}{associative.map.syn} defines the class templates
+\tcode{map} and \tcode{multimap};
+the header \libheaderrefx{set}{associative.set.syn} defines the class templates
 \tcode{set} and \tcode{multiset}.
 
 \pnum
@@ -12079,10 +12080,10 @@ return original_size - c.size();
 \rSec2[unord.general]{General}
 
 \pnum
-The header \libheader{unordered_map} defines the class templates
-\tcode{unordered_map} and
-\tcode{unordered_multimap}; the header \libheader{unordered_set} defines the class templates
-\tcode{unordered_set} and \tcode{unordered_multiset}.
+The header \libheaderrefx{unordered_map}{unord.map.syn} defines the class
+templates \tcode{unordered_map} and \tcode{unordered_multimap};
+the header \libheaderrefx{unordered_set}{unord.set.syn} defines the class
+templates \tcode{unordered_set} and \tcode{unordered_multiset}.
 
 \pnum
 The exposition-only alias templates
@@ -14257,10 +14258,10 @@ return original_size - c.size();
 
 \pnum
 The headers
-\libheader{queue},
-\libheader{stack},
-\libheader{flat_map},
-and \libheader{flat_set}
+\libheaderref{queue},
+\libheaderref{stack},
+\libheaderrefx{flat_map}{flat.map.syn},
+and \libheaderrefx{flat_set}{flat.set.syn}
 define the container adaptors
 \tcode{queue} and \tcode{priority_queue},
 \tcode{stack},
@@ -18884,8 +18885,8 @@ Equivalent to: \tcode{return \exposid{underlying_}.format(r.c, ctx);}
 \rSec2[views.general]{General}
 
 \pnum
-The header \libheader{span} defines the view \tcode{span}.
-The header \libheader{mdspan} defines the class template \tcode{mdspan} and
+The header \libheaderref{span} defines the view \tcode{span}.
+The header \libheaderref{mdspan} defines the class template \tcode{mdspan} and
 other facilities for interacting with these multidimensional views.
 
 \rSec2[views.contiguous]{Contiguous access}


### PR DESCRIPTION
Introduce each header in its appropriate [*.general] clause with the appropriate libheaderref macro for that header.

Note that libheaderrefx must be used for header with underscores, as they would not match their computed stable label.  Similarly, plain `<map>` and `<set>` get an extra "associative." prepended to their stable label.