### PR TITLE
[locale.ctype.general] Better cross-ref standard headers

### DIFF
--- a/source/locales.tex
+++ b/source/locales.tex
@@ -1043,7 +1043,7 @@ namespace std {
 \end{codeblock}
 
 \pnum
-Class \tcode{ctype} encapsulates the C library \libheader{cctype} features.
+Class \tcode{ctype} encapsulates the C library \libheaderref{cctype} features.
 \tcode{istream} members are required to use \tcode{ctype<>}
 for character classing during input parsing.
 
@@ -2335,7 +2335,7 @@ In all cases, the remainder is left in the input.
 \stage{3}
 The sequence of \tcode{char}{s} accumulated in stage 2 (the field)
 is converted to a numeric value by the rules of one of the functions
-declared in the header \libheader{cstdlib}:
+declared in the header \libheaderref{cstdlib}:
 
 \begin{itemize}
 \item


### PR DESCRIPTION
Use the macro libheaderref to add a direct cross reference to a couple of referenced headers.