### PR TITLE
[char.traits] Better cross-reference several headers

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -201,7 +201,7 @@ The class template
 \begin{codeblock}
 template<class charT> struct char_traits;
 \end{codeblock}
-is provided in the header \libheader{string}
+is provided in the header \libheaderref{string}
 as a basis for explicit specializations.
 
 \rSec2[char.traits.typedefs]{Traits typedefs}
@@ -307,7 +307,7 @@ namespace std {
 \end{codeblock}
 
 \pnum
-The type \tcode{mbstate_t} is defined in \libheader{cwchar}
+The type \tcode{mbstate_t} is defined in \libheaderref{cwchar}
 and can represent any of the conversion states that can occur in an
 \impldef{supported multibyte character encoding rules} set of supported multibyte
 character encoding rules.


### PR DESCRIPTION
Add a few cross-references for headers used in the char_traits clauses.