### PR TITLE
[iterator.synopsis] Add \ref for `indirect-value-t`

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -84,6 +84,7 @@ namespace std {
   template<class In>
     concept indirectly_readable = @\seebelow@;                                        // freestanding
 
+  // \ref{indirectcallable.traits}, indirect callable traits
   template<@\libconcept{indirectly_readable}@ T>
     using @\exposidnc{indirect-value-t}@ = @\seebelow@;         // \expos
 


### PR DESCRIPTION
..as it is not under [[iterator.concepts]](https://eel.is/c++draft/iterator.concepts), which is difficult to find where it is defined.