### PR TITLE
[basic.scope.scope] Replaced the term top-level reference with just reference

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -917,7 +917,7 @@ Two non-static member functions have
 exactly one is an implicit object member function
 with no \grammarterm{ref-qualifier} and
 the types of their object parameters\iref{dcl.fct},
-after removing top-level references,
+after removing references,
 are the same, or
 \item
 their object parameters have the same type.


### PR DESCRIPTION
…eference

[basic.scope.scope] Replaced the term top-level reference with just reference in light of [this issue](https://github.com/cplusplus/CWG/issues/569)

Fixes cplusplus/CWG#569