### PR TITLE
[stoptoken.general, stopsource.general] Remove DMI from stop-state member

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -849,7 +849,7 @@ namespace std {
     bool operator==(const stop_token& rhs) noexcept = default;
 
   private:
-    shared_ptr<@\unspec@> @\exposid{stop-state}@{};                         // \expos
+    shared_ptr<@\unspec@> @\exposid{stop-state}@;                           // \expos
   };
 }
 \end{codeblock}
@@ -925,7 +925,7 @@ namespace std {
     bool operator==(const stop_source& rhs) noexcept = default;
 
   private:
-    shared_ptr<@\unspec@> @\exposid{stop-state}@{};                       // \expos
+    shared_ptr<@\unspec@> @\exposid{stop-state}@;                         // \expos
   };
 }
 \end{codeblock}


### PR DESCRIPTION
For stoptoken::stop-state, the default-initialized value is already correct, and no further "{}" initializer is needed.

For stopsource::stop-state, the DMI "{}" is never used, since the constructor is explicitly specified and not defaulted.