### PR TITLE
[print.syn] Update `locking` to `buffered`

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4288,11 +4288,11 @@ namespace std {
 
   void vprint_unicode(string_view fmt, format_args args);
   void vprint_unicode(FILE* stream, string_view fmt, format_args args);
-  void vprint_unicode_locking(FILE* stream, string_view fmt, format_args args);
+  void vprint_unicode_buffered(FILE* stream, string_view fmt, format_args args);
 
   void vprint_nonunicode(string_view fmt, format_args args);
   void vprint_nonunicode(FILE* stream, string_view fmt, format_args args);
-  void vprint_nonunicode_locking(FILE* stream, string_view fmt, format_args args);
+  void vprint_nonunicode_buffered(FILE* stream, string_view fmt, format_args args);
 }
 \end{codeblock}
 


### PR DESCRIPTION
#6971 added missing function declarations to the synopsis, but the function names were changed later by P3235R3.