### PR TITLE
[out.ptr.t] Fix bullet placement for item that starts with codeblock.

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -5176,6 +5176,8 @@ value-initializes \tcode{p}.
 Then, equivalent to:
 \begin{itemize}
 \item
+% pretend to \item that there is real text here, but undo the vertical spacing
+\mbox{}\vspace{-\baselineskip}\vspace{-\parskip}
 \begin{codeblock}
 s.reset();
 \end{codeblock}


### PR DESCRIPTION
Using the trick from https://github.com/cplusplus/draft/blob/decb06cd28ca5187444092ddebbb6845cae878c6/source/memory.tex#L5221-L5224