### PR TITLE
[time.duration.nonmember] Fix operator index entries.

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -1601,7 +1601,7 @@ static constexpr duration max() noexcept;
 In the function descriptions that follow, unless stated otherwise,
 let \tcode{CD} represent the return type of the function.
 
-\indexlibraryglobal{common_type}%
+\indexlibrarymember{operator+}{duration}%
 \begin{itemdecl}
 template<class Rep1, class Period1, class Rep2, class Period2>
   constexpr common_type_t<duration<Rep1, Period1>, duration<Rep2, Period2>>
@@ -1614,11 +1614,11 @@ template<class Rep1, class Period1, class Rep2, class Period2>
 \tcode{CD(CD(lhs).count() + CD(rhs).count())}.
 \end{itemdescr}
 
-\indexlibraryglobal{common_type}%
+\indexlibrarymember{operator-}{duration}%
 \begin{itemdecl}
 template<class Rep1, class Period1, class Rep2, class Period2>
   constexpr common_type_t<duration<Rep1, Period1>, duration<Rep2, Period2>>
-  operator-(const duration<Rep1, Period1>& lhs, const duration<Rep2, Period2>& rhs);
+    operator-(const duration<Rep1, Period1>& lhs, const duration<Rep2, Period2>& rhs);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
(I threw in a little drive-by indentation fix.)