### PR TITLE
[dcl.dcl][stmt.stmt] Remove tautonyms from top level stable labels

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -135,7 +135,7 @@ translation unit.
 \indextext{declaration!definition versus}%
 \indextext{declaration}%
 \indextext{declaration!name}%
-A declaration\iref{dcl.dcl} may (re)introduce
+A declaration\iref{dcl} may (re)introduce
 one or more names and/or entities into a translation
 unit.
 If so, the

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -53,7 +53,7 @@ struct S {};
 \end{codeblock}
 \end{example}
 
-\rSec2[diff.cpp23.dcl.dcl]{\ref{dcl.dcl}: declarations}
+\rSec2[diff.cpp23.dcl]{\ref{dcl}: declarations}
 
 \diffref{dcl.init.list}
 \change
@@ -359,7 +359,7 @@ arr[1, 2]               // was equivalent to \tcode{arr[(1, 2)]},
 \end{codeblock}
 \end{example}
 
-\rSec2[diff.cpp20.stmt]{\ref{stmt.stmt}: statements}
+\rSec2[diff.cpp20.stmt]{\ref{stmt}: statements}
 
 \diffref{stmt.ranged}
 \change
@@ -383,7 +383,7 @@ void f() {
 \end{codeblock}
 \end{example}
 
-\rSec2[diff.cpp20.dcl]{\ref{dcl.dcl}: declarations}
+\rSec2[diff.cpp20.dcl]{\ref{dcl}: declarations}
 
 \diffref{dcl.init.string}
 \change
@@ -850,7 +850,7 @@ that were not captured in \CppXVII{}
 if those entities are only referenced in contexts
 that do not result in an odr-use.
 
-\rSec2[diff.cpp17.dcl.dcl]{\ref{dcl.dcl}: declarations}
+\rSec2[diff.cpp17.dcl]{\ref{dcl}: declarations}
 
 \diffref{dcl.typedef}
 \change
@@ -1489,7 +1489,7 @@ In this revision of \Cpp{},
 \tcode{::operator new(std::size_t, std::align_val_t)}
 is used instead.
 
-\rSec2[diff.cpp14.dcl.dcl]{\ref{dcl.dcl}: declarations}
+\rSec2[diff.cpp14.dcl]{\ref{dcl}: declarations}
 
 \diffref{dcl.stc}
 \indextext{\idxcode{register} storage class}%
@@ -1875,7 +1875,7 @@ In \CppXI{}, the expression yields \tcode{sizeof(const char*)}. In this
 revision of \Cpp{}, it yields \tcode{sizeof(const char[1])}.
 \end{example}
 
-\rSec2[diff.cpp11.dcl.dcl]{\ref{dcl.dcl}: declarations}
+\rSec2[diff.cpp11.dcl]{\ref{dcl}: declarations}
 
 \diffref{dcl.constexpr}
 \change
@@ -2117,7 +2117,7 @@ void f() {
 \end{codeblock}
 \end{example}
 
-\rSec2[diff.cpp03.dcl.dcl]{\ref{dcl.dcl}: declarations}
+\rSec2[diff.cpp03.dcl]{\ref{dcl}: declarations}
 
 \diffref{dcl.spec}
 \change
@@ -2923,7 +2923,7 @@ Programs must add explicit casts to the appropriate rvalue.
 \howwide
 Rare.
 
-\rSec2[diff.stat]{\ref{stmt.stmt}: statements}
+\rSec2[diff.stmt]{\ref{stmt}: statements}
 
 \diffref{stmt.switch,stmt.goto}
 \change
@@ -2971,7 +2971,7 @@ Seldom.
 For several years, many existing C implementations have produced warnings in
 this case.
 
-\rSec2[diff.dcl]{\ref{dcl.dcl}: declarations}
+\rSec2[diff.dcl]{\ref{dcl}: declarations}
 
 \diffref{dcl.stc}
 \change

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1,5 +1,5 @@
 %!TEX root = std.tex
-\rSec0[dcl.dcl]{Declarations}%
+\rSec0[dcl]{Declarations}%
 \indextext{declaration|(}
 
 \gramSec[gram.dcl]{Declarations}
@@ -129,7 +129,7 @@ the form
 \indextext{scope}%
 Certain declarations contain one or more scopes\iref{basic.scope.scope}.
 Unless otherwise stated, utterances in
-\ref{dcl.dcl} about components in, of, or contained by a
+\ref{dcl} about components in, of, or contained by a
 declaration or subcomponent thereof refer only to those components of
 the declaration that are \emph{not} nested within scopes nested within
 the declaration.
@@ -8838,7 +8838,7 @@ requirements on the \grammarterm{attribute-argument-clause} (if any).
 \pnum
 Each \grammarterm{attribute-specifier-seq} is said to \defn{appertain} to some entity or
 statement, identified by the syntactic context
-where it appears\iref{stmt.stmt,dcl.dcl,dcl.decl}.
+where it appears\iref{stmt,dcl,dcl.decl}.
 If an \grammarterm{attribute-specifier-seq} that appertains to some
 entity or statement contains an \grammarterm{attribute} or \grammarterm{alignment-specifier} that
 is not allowed to apply to that

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1478,7 +1478,7 @@ even though
 \indextext{identifier}%
 An \grammarterm{identifier} is only
 an \grammarterm{id-expression} if it has
-been suitably declared\iref{dcl.dcl}
+been suitably declared\iref{dcl}
 or if it appears as part of a \grammarterm{declarator-id}\iref{dcl.decl}.
 An \grammarterm{identifier} that names a coroutine parameter
 refers to the copy of the parameter\iref{dcl.fct.def.coroutine}.
@@ -7724,7 +7724,7 @@ or
 \item
 a \keyword{goto} statement\iref{stmt.goto}.
 \begin{note}
-A \keyword{goto} statement introduced by equivalence\iref{stmt.stmt}
+A \keyword{goto} statement introduced by equivalence\iref{stmt}
 is not in scope.
 For example, a \keyword{while} statement\iref{stmt.while}
 can be executed during constant evaluation.

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -1,5 +1,5 @@
 %!TEX root = std.tex
-\rSec0[stmt.stmt]{Statements}%
+\rSec0[stmt]{Statements}%
 \indextext{statement|(}
 
 \gramSec[gram.stmt]{Statements}
@@ -92,7 +92,7 @@ appears in a \grammarterm{condition},
 the \grammarterm{condition} is a structured binding declaration\iref{dcl.pre}.
 A \grammarterm{condition} that is
 neither an \grammarterm{expression} nor a structured binding declaration
-is a declaration\iref{dcl.dcl}.
+is a declaration\iref{dcl}.
 The \grammarterm{declarator} shall not
 specify a function or an array. The \grammarterm{decl-specifier-seq} shall not
 define a class or enumeration. If the \keyword{auto} \grammarterm{type-specifier} appears in

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -95,8 +95,18 @@
 \movedxref{stoptoken.cons}{stopsource}
 \movedxref{stoptoken.nonmembers}{stopsource}
 
+% https://github.com/cplusplus/draft/pull/7179
+\movedxref{dcl.dcl}{dcl}
+\movedxref{diff.cpp03.dcl.dcl}{diff.cpp03.dcl}
+\movedxref{diff.cpp11.dcl.dcl}{diff.cpp11.dcl}
+\movedxref{diff.cpp14.dcl.dcl}{diff.cpp14.dcl}
+\movedxref{diff.cpp17.dcl.dcl}{diff.cpp17.dcl}
+\movedxref{diff.stat}{diff.stmt}
+\movedxref{stmt.stmt}{stmt}
+
 % https://github.com/cplusplus/draft/pull/7345
 \movedxref{basic.stc.inherit}{basic.stc.general}
+
 
 %%% Deprecated features.
 %%% Example:


### PR DESCRIPTION
Per comment on issue #5315.
Thanks to Jonathan Wakely for the notion of tautonyms.

Quickly force-pushed a correction to the comment identifying the PR number.