### PR TITLE
[lex.separate][module.unit] move definitions of program and translation unit

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2649,23 +2649,10 @@ during the lookup for a \grammarterm{namespace-name} or for a name in a
 only namespace names are considered.%
 \indextext{lookup!name|)}%
 
-\rSec1[basic.link]{Program and linkage}%
+\rSec1[basic.link]{Linkage}%
 \indextext{linkage|(}
 
 \pnum
-\indextext{program}%
-A \defn{program} consists of one or more translation units\iref{lex.separate}
-linked together. A translation unit consists
-of a sequence of declarations.
-
-\begin{bnf}
-\nontermdef{translation-unit}\br
-    \opt{declaration-seq}\br
-    \opt{global-module-fragment} module-declaration \opt{declaration-seq} \opt{private-module-fragment}
-\end{bnf}
-
-\pnum
-\indextext{translation unit}%
 A name can have
 \defnadj{external}{linkage},
 \defnadj{module}{linkage},

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -476,7 +476,7 @@ whose definition is provided by a \Cpp{} program
 \begin{defnote}
 Only one definition for such a function is in effect for the duration of the program's
 execution, as the result of creating the program\iref{lex.phases} and resolving the
-definitions of all translation units\iref{basic.link}.
+definitions of all translation units\iref{module.unit}.
 \end{defnote}
 
 \definition{required behavior}{defns.required.behavior}

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -25,6 +25,11 @@
 \rSec1[lex.separate]{Separate translation}
 
 \pnum
+\indextext{program}%
+A \defn{program} consists of one or more translation units\iref{lex.phases,module.unit}
+linked together.
+
+\pnum
 \indextext{conventions!lexical|(}%
 \indextext{compilation!separate|(}%
 The text of the program is kept in units called

--- a/source/modules.tex
+++ b/source/modules.tex
@@ -6,6 +6,10 @@
 \rSec1[module.unit]{Module units and purviews}
 
 \begin{bnf}
+\nontermdef{translation-unit}\br
+    \opt{declaration-seq}\br
+    \opt{global-module-fragment} module-declaration \opt{declaration-seq} \opt{private-module-fragment}
+
 \nontermdef{module-declaration}\br
     \opt{export-keyword} module-keyword module-name \opt{module-partition} \opt{attribute-specifier-seq} \terminal{;}
 \end{bnf}
@@ -25,6 +29,10 @@
     identifier \terminal{.}\br
     module-name-qualifier identifier \terminal{.}
 \end{bnf}
+
+\pnum
+\indextext{translation unit}%
+A translation unit consists of a sequence of declarations.
 
 \pnum
 A \defn{module unit} is a translation unit that contains


### PR DESCRIPTION
The definition of program at the top of [basic.link] should move to the front of [lex.separate] so that it is defined before its first usage, and also clarifies what the phases of translation produce.

Similarly, move the definition of the grammar production translation-unit to the top of the first clause to actually use it, [module.unit].

Finally, retitle [basic.link] as just Linkage, rather than prgrams and linkage.