### PR TITLE
[exec.snd.expos] Replace \exposconcept for nothrow-callable

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -1463,11 +1463,11 @@ struct @\exposid{emplace-from}@ {
   Fun @\exposid{fun}@;                                                      // \expos
   using type = @\exposid{call-result-t}@<Fun>;
 
-  constexpr operator type() && noexcept(@\exposid{nothrow-callable}@<Fun>) {
+  constexpr operator type() && noexcept(@\exposconcept{nothrow-callable}@<Fun>) {
     return std::move(fun)();
   }
 
-  constexpr type operator()() && noexcept(@\exposid{nothrow-callable}@<Fun>) {
+  constexpr type operator()() && noexcept(@\exposconcept{nothrow-callable}@<Fun>) {
     return std::move(fun)();
   }
 };
@@ -1730,7 +1730,7 @@ The expression in the \tcode{noexcept} clause of
 the constructor of \exposid{basic-state} is:
 \begin{codeblock}
 is_nothrow_move_constructible_v<Rcvr> &&
-@\exposid{nothrow-callable}@<decltype(@\exposid{impls-for}@<tag_of_t<Sndr>>::@\exposid{get-state}@), Sndr, Rcvr&>
+@\exposconcept{nothrow-callable}@<decltype(@\exposid{impls-for}@<tag_of_t<Sndr>>::@\exposid{get-state}@), Sndr, Rcvr&>
 \end{codeblock}
 
 \pnum


### PR DESCRIPTION
`nothrow-callable` defines in [[functional.syn]](https://eel.is/c++draft/functional.syn#concept:callable), which is a concept.