### PR TITLE
[exec.split] Add \libconcept for copyable

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -3942,7 +3942,7 @@ return @\exposid{make-sender}@(@\exposid{split-impl-tag}@(), @\exposid{shared-wr
 where \exposid{shared-wrapper} is an exposition-only class
 that manages the reference count of the \exposid{shared-state} object
 pointed to by sh_state.
-\exposid{shared-wrapper} models copyable
+\exposid{shared-wrapper} models \libconcept{copyable}
 with move operations nulling out the moved-from object,
 copy operations incrementing the reference count
 by calling \tcode{sh_state->\exposid{inc-ref}()}, and


### PR DESCRIPTION
The word _copyable_ here should be a concept. The [original paper](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html) also confirms this.