### PR TITLE
[config.tex] Create and apply macros denoting first and last core chapters

### DIFF
--- a/source/config.tex
+++ b/source/config.tex
@@ -8,6 +8,9 @@
 %% Release date
 \newcommand{\reldate}{\today}
 
+%% Core chapters
+\newcommand{\lastcorechapter}{cpp}
+
 %% Library chapters
 \newcommand{\firstlibchapter}{support}
 \newcommand{\lastlibchapter}{exec}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -7552,7 +7552,7 @@ limits (see \ref{implimits});
 
 \item
 an operation that would have undefined or erroneous behavior
-as specified in \ref{intro} through \ref{cpp},
+as specified in \ref{intro} through \ref{\lastcorechapter},
 excluding \ref{dcl.attr.assume} and \ref{dcl.attr.noreturn};
 \begin{footnote}
 This includes,

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -256,7 +256,7 @@ Erroneous behavior is always the consequence of incorrect program code.
 Implementations are allowed, but not required,
 to diagnose it\iref{intro.compliance.general}.
 Evaluation of a constant expression\iref{expr.const}
-never exhibits behavior specified as erroneous in \ref{intro} through \ref{cpp}.
+never exhibits behavior specified as erroneous in \ref{intro} through \ref{\lastcorechapter}.
 \end{defnote}
 
 \definition{expression-equivalent}{defns.expression.equivalent}
@@ -644,7 +644,7 @@ characteristic of the environment (with or without the issuance of a
 issuance of a diagnostic message). Many incorrect program constructs do
 not engender undefined behavior; they are required to be diagnosed.
 Evaluation of a constant expression\iref{expr.const} never exhibits behavior explicitly
-specified as undefined in \ref{intro} through \ref{cpp}.
+specified as undefined in \ref{intro} through \ref{\lastcorechapter}.
 \end{defnote}
 
 \indexdefn{behavior!unspecified}%
@@ -808,7 +808,7 @@ A hosted implementation
 supports all the facilities described in this document, while
 a freestanding implementation
 supports the entire \Cpp{} language
-described in \ref{lex} through \ref{cpp} and
+described in \ref{lex} through \ref{\lastcorechapter} and
 the subset of the library facilities described in \ref{compliance}.
 
 \pnum
@@ -958,7 +958,7 @@ semantics can be defined by each implementation.
 \pnum
 \indextext{standard!structure of|(}%
 \indextext{standard!structure of}%
-\ref{lex} through \ref{cpp} describe the \Cpp{} programming
+\ref{lex} through \ref{\lastcorechapter} describe the \Cpp{} programming
 language. That description includes detailed syntactic specifications in
 a form described in~\ref{syntax}. For convenience, \ref{gram}
 repeats all such syntactic specifications.


### PR DESCRIPTION
This PR should show no difference in the rendered document, but will make it much easier to refactor the Core clauses in the future --- just as we can refactor Library clauses today.