### PR TITLE
[lex.phases] replace term 'input file' with 'source file' in phase 1

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -69,19 +69,19 @@ occur, although in practice different phases can be folded together.
 \begin{enumerate}
 \item
 \indextext{character!source file}%
-An implementation shall support input files
+An implementation shall support source files
 that are a sequence of UTF-8 code units (UTF-8 files).
 It may also support
-an \impldef{supported input files} set of other kinds of input files, and,
-if so, the kind of an input file is determined in
-an \impldef{determination of kind of input file} manner
-that includes a means of designating input files as UTF-8 files,
+an \impldef{supported source files} set of other kinds of source files, and,
+if so, the kind of a source file is determined in
+an \impldef{determination of kind of source file} manner
+that includes a means of designating source files as UTF-8 files,
 independent of their content.
 \begin{note}
 In other words,
 recognizing the \unicode{feff}{byte order mark} is not sufficient.
 \end{note}
-If an input file is determined to be a UTF-8 file,
+If a source file is determined to be a UTF-8 file,
 then it shall be a well-formed UTF-8 code unit sequence and
 it is decoded to produce a sequence of Unicode
 \begin{footnote}
@@ -100,7 +100,7 @@ as well as each
 \unicode{000d}{carriage return} not immediately followed by a \unicode{000a}{line feed},
 is replaced by a single new-line character.
 
-For any other kind of input file supported by the implementation,
+For any other kind of source file supported by the implementation,
 characters are mapped, in an
 \impldef{mapping physical source file characters to translation character set} manner,
 to a sequence of translation character set elements\iref{lex.charset},


### PR DESCRIPTION
The only part of the standard that refers to input files is phase 1 of the phases of translation.  Everywhere else, we use the term source file, that has a clear definition in the preceding [lex.separate] clarifying that we do not necessarily mean text files in a hosted filing system.