### PR TITLE
[lex.pptoken] Consistent use of preprocessing vs processing

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -571,7 +571,7 @@ const char* s = R"y";           // ill-formed raw string, not \tcode{"x" "y"}
 
 \pnum
 The \grammarterm{import-keyword} is produced
-by processing an \keyword{import} directive\iref{cpp.import},
+by preprocessing an \keyword{import} directive\iref{cpp.import},
 the \grammarterm{module-keyword} is produced
 by preprocessing a \keyword{module} directive\iref{cpp.module}, and
 the \grammarterm{export-keyword} is produced


### PR DESCRIPTION
There are three cases here all doing the same thing.  Two refer to preprocessing a directive, while the first refers to processing without the pre.