### PR TITLE
[ios.syn] Fix typo'd xref to [fpos] introduced in 4b3f32ae

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -686,7 +686,7 @@ namespace std {
   // \ref{stream.types}, types
   using streamoff  = @\impdef@;
   using streamsize = @\impdef@;
-  // \ref{ios}, class template \tcode{fpos}
+  // \ref{fpos}, class template \tcode{fpos}
   template<class stateT> class fpos;
 
   // \ref{ios.base}, class \tcode{ios_base}


### PR DESCRIPTION
@jwakely LGTY, right? https://eel.is/c++draft/fpos exists.