### PR TITLE
[dcl.fct] Fix obsolete phrasing when defining 'function type'

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3588,16 +3588,14 @@ the \grammarterm{parameter-declaration-clause} as described below and
 the optional \keyword{noexcept} is present if and only if
 the exception specification\iref{except.spec} is non-throwing.
 \end{itemize}
+Such a type is a \defnadj{function}{type}.
+\begin{footnote}
+As indicated by syntax, cv-qualifiers are a significant component in function return types.
+\end{footnote}
 The optional \grammarterm{attribute-specifier-seq}
 appertains to the function type.
 
 \pnum
-\indextext{type!function}%
-A type of either form is a \term{function type}.%
-\begin{footnote}
-As indicated by syntax, cv-qualifiers are a significant component in function return types.
-\end{footnote}
-
 \indextext{declaration!function}%
 \begin{bnf}
 \nontermdef{parameter-declaration-clause}\br


### PR DESCRIPTION
Fixes cplusplus/CWG#588