### PR TITLE
[macros,diff] Rework header indexing to avoid hyphenation hints

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2264,7 +2264,7 @@ The following \Cpp{} headers are new:
 \libheaderrefx{condition_variable}{condition.variable.syn},
 \libheaderrefx{forward_list}{forward.list.syn},
 \libheaderref{future},
-\libheaderrefx{initiali\-zer_list}{initializer.list.syn},
+\libheaderrefxx{initializer_list}{initiali\-zer_list}{initializer.list.syn},
 \libheaderref{mutex},
 \libheaderrefx{random}{rand.synopsis},
 \libheaderref{ratio},
@@ -2273,7 +2273,7 @@ The following \Cpp{} headers are new:
 \libheaderrefx{system_error}{system.error.syn},
 \libheaderref{thread},
 \libheaderref{tuple},
-\libheaderrefx{type\-index}{type.index.synopsis},
+\libheaderrefxx{typeindex}{type\-index}{type.index.synopsis},
 \libheaderrefx{type_traits}{meta.type.synop},
 \libheaderrefx{unordered_map}{unord.map.syn},
 and

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -215,11 +215,13 @@
 \newcommand{\libspec}[2]{\indexlibrarymemberx{#1}{#2}#1}
 
 % index for library headers
-\newcommand{\libheader}[1]{\indexhdr{#1}\tcode{<#1>}}
+\newcommand{\libheaderx}[2]{\indexhdr{#1}\tcode{<#2>}}
+\newcommand{\libheader}[1]{\libheaderx{#1}{#1}}
 \newcommand{\indexheader}[1]{\index[headerindex]{\idxhdr{#1}|idxbfpage}}
 \newcommand{\libheaderdef}[1]{\indexheader{#1}\tcode{<#1>}}
 \newcommand{\libnoheader}[1]{\indextext{\idxhdr{#1}!absence thereof}\tcode{<#1>}}
-\newcommand{\libheaderrefx}[2]{\libheader{#1}\iref{#2}}
+\newcommand{\libheaderrefxx}[3]{\libheaderx{#1}{#2}\iref{#3}}
+\newcommand{\libheaderrefx}[2]{\libheaderrefxx{#1}{#1}{#2}}
 \newcommand{\libheaderref}[1]{\libheaderrefx{#1}{#1.syn}}
 \newcommand{\libdeprheaderref}[1]{\libheaderrefx{#1}{depr.#1.syn}}
 


### PR DESCRIPTION
Fixes #6649.