### PR TITLE
[snd.expos] Fix typo in definition of SCHED-ENV exposition-only helper

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -1312,7 +1312,7 @@ such that \tcode{o1.query(get_domain)} is expression-equivalent to
 \tcode{sch.query(get_domain)}.
 \tcode{\exposid{SCHED-ENV}(sch)} is an expression \tcode{o2}
 whose type satisfies \exposconcept{queryable}
-such that \tcode{o1.query(get_scheduler)} is a prvalue
+such that \tcode{o2.query(get_scheduler)} is a prvalue
 with the same type and value as \tcode{sch}, and
 such that \tcode{o2.query(get_domain)} is expression-equivalent to
 \tcode{sch.query(get_domain)}.


### PR DESCRIPTION
Change `o1` -> `o2` to reference the expression declared as part of the definition of `SCHED-ENV`.