### PR TITLE
[func.wrap.func] Drop Lvalue-Callable

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -13120,17 +13120,6 @@ and call arbitrary callable objects\iref{func.def}, given a call
 signature\iref{func.def}.
 
 \pnum
-\indextext{callable type}%
-A callable type\iref{func.def} \tcode{F}
-is \defn{Lvalue-Callable} for argument
-types \tcode{ArgTypes}
-and return type \tcode{R}
-if the expression
-\tcode{\placeholdernc{INVOKE}<R>(declval<F\&>(), declval<ArgTypes>()...)},
-considered as an unevaluated operand\iref{term.unevaluated.operand}, is
-well-formed\iref{func.require}.
-
-\pnum
 The \tcode{function} class template is a call
 wrapper\iref{func.def} whose call signature\iref{func.def}
 is \tcode{R(ArgTypes...)}.
@@ -13227,8 +13216,7 @@ Let \tcode{FD} be \tcode{decay_t<F>}.
 \item
 \tcode{is_same_v<remove_cvref_t<F>, function>} is \tcode{false}, and
 \item
-\tcode{FD} is Lvalue-Callable\iref{func.wrap.func} for argument types
-\tcode{ArgTypes...} and return type \tcode{R}.
+\tcode{is_invocable_r_v<R, FD\&, ArgTypes...>} is \tcode{true}.
 \end{itemize}
 
 \pnum
@@ -13371,8 +13359,7 @@ template<class F> function& operator=(F&& f);
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{decay_t<F>} is Lvalue-Callable\iref{func.wrap.func}
-for argument types \tcode{ArgTypes...} and return type \tcode{R}.
+\tcode{is_invocable_r_v<R, decay_t<F>\&, ArgTypes...>} is \tcode{true}.
 
 \pnum
 \effects


### PR DESCRIPTION
Replace its usages with `is_invocable_r_v` and remove an unnecessary index. Fixes #6582.