### PR TITLE
[defns.undefined] Fix the note on undefined behavior in constant evaluation

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -644,7 +644,8 @@ characteristic of the environment (with or without the issuance of a
 issuance of a diagnostic message). Many incorrect program constructs do
 not engender undefined behavior; they are required to be diagnosed.
 Evaluation of a constant expression\iref{expr.const} never exhibits behavior explicitly
-specified as undefined in \ref{intro} through \ref{cpp}.
+specified as undefined in \ref{intro} through \ref{cpp}
+except for violation of semantic restrictions of standard attributes\iref{dcl.attr}.
 \end{defnote}
 
 \indexdefn{behavior!unspecified}%


### PR DESCRIPTION
Currently, the `assmue` and `noreturn` attributes are allowed to bring undefined behavior into constant evaluation. There might be more such standard attributes in the future.

Fixes #7042.