### PR TITLE
[input.output] Use `\exposid` for exposition-only names

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -844,9 +844,9 @@ namespace std {
     ios_base();
 
   private:
-    static int index;           // \expos
-    long*  iarray;              // \expos
-    void** parray;              // \expos
+    static int @\exposid{index}@;           // \expos
+    long*  @\exposid{iarray}@;              // \expos
+    void** @\exposid{parray}@;              // \expos
   };
 }
 \end{codeblock}
@@ -882,19 +882,19 @@ additional information that is stored by the program for its private use.
 For the sake of exposition, the maintained data is presented here as:
 \begin{itemize}
 \item
-\tcode{static int index},
+\tcode{static int \exposid{index}},
 specifies the next available
 unique index for the integer or pointer arrays maintained for the private use
 of the program, initialized to an unspecified value;
 \item
-\tcode{long* iarray},
+\tcode{long* \exposid{iarray}},
 points to the first element of an
 arbitrary-length
 \tcode{long}
 array maintained for the private use of the
 program;
 \item
-\tcode{void** parray},
+\tcode{void** \exposid{parray}},
 points to the first element of an
 arbitrary-length pointer array maintained for the private use of the program.
 \end{itemize}
@@ -1446,7 +1446,7 @@ static int xalloc();
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{index}
+\exposid{index}
 \tcode{++}.
 
 \pnum
@@ -1467,20 +1467,20 @@ long& iword(int idx);
 
 \pnum
 \effects
-If \tcode{iarray} is a null pointer, allocates an array of
+If \exposid{iarray} is a null pointer, allocates an array of
 \tcode{long}
 of unspecified size and stores a pointer to its first element in
-\tcode{iarray}.
+\exposid{iarray}.
 The function then extends the array pointed at by
-\tcode{iarray} as necessary to include the element
-\tcode{iarray[idx]}.
+\exposid{iarray} as necessary to include the element
+\tcode{\exposid{iarray}[idx]}.
 Each newly allocated element of the array is initialized to zero.
 The reference returned is invalid after any other operation on the
 object.
 \begin{footnote}
 An implementation is free to implement both the integer
-array pointed at by \tcode{iarray} and the pointer array pointed at by
-\tcode{parray} as sparse data structures, possibly with a one-element
+array pointed at by \exposid{iarray} and the pointer array pointed at by
+\exposid{parray} as sparse data structures, possibly with a one-element
 cache for each.
 \end{footnote}
 However, the value of the storage referred to is retained, so
@@ -1505,7 +1505,7 @@ on the derived object (which may throw
 \pnum
 \returns
 On success
-\tcode{iarray[idx]}.
+\tcode{\exposid{iarray}[idx]}.
 On failure, a valid
 \tcode{long\&}
 initialized to 0.
@@ -1523,13 +1523,13 @@ void*& pword(int idx);
 
 \pnum
 \effects
-If \tcode{parray} is a null pointer, allocates an array of
+If \exposid{parray} is a null pointer, allocates an array of
 pointers to \keyword{void} of unspecified size and stores a pointer to
 its
-first element in \tcode{parray}.
+first element in \exposid{parray}.
 The function then extends the array
-pointed at by \tcode{parray} as necessary to include the element
-\tcode{parray[idx]}.
+pointed at by \exposid{parray} as necessary to include the element
+\tcode{\exposid{parray}[idx]}.
 Each newly allocated element of the array is initialized to a null
 pointer.
 The reference returned is invalid after any other operation on the
@@ -1657,7 +1657,7 @@ namespace std {
     void state(stateT);
 
   private:
-    stateT st;                  // \expos
+    stateT @\exposid{st}@;                  // \expos
   };
 }
 \end{codeblock}
@@ -1672,7 +1672,7 @@ void state(stateT s);
 \begin{itemdescr}
 \pnum
 \effects
-Assigns \tcode{s} to \tcode{st}.
+Assigns \tcode{s} to \exposid{st}.
 \end{itemdescr}
 
 \indexlibrarymember{state}{fpos}%
@@ -1683,7 +1683,7 @@ stateT state() const;
 \begin{itemdescr}
 \pnum
 \returns
-Current value of \tcode{st}.
+Current value of \exposid{st}.
 \end{itemdescr}
 
 \rSec3[fpos.operations]{Requirements}
@@ -4521,12 +4521,12 @@ Exchanges the values returned by \tcode{gcount()} and
 namespace std {
   template<class charT, class traits>
   class basic_istream<charT, traits>::sentry {
-    bool ok_;                   // \expos
+    bool @\exposid{ok_}@;                   // \expos
 
   public:
     explicit sentry(basic_istream& is, bool noskipws = false);
     ~sentry();
-    explicit operator bool() const { return ok_; }
+    explicit operator bool() const { return @\exposid{ok_}@; }
     sentry(const sentry&) = delete;
     sentry& operator=(const sentry&) = delete;
   };
@@ -4623,9 +4623,9 @@ If, after any preparation is completed,
 \tcode{is.good()}
 is
 \tcode{true},
-\tcode{ok_ != false}
+\tcode{\exposid{ok_} != false}
 otherwise,
-\tcode{ok_ == false}.
+\tcode{\exposid{ok_} == false}.
 During preparation, the constructor may call
 \tcode{setstate(failbit)}
 (which may throw
@@ -4660,7 +4660,7 @@ explicit operator bool() const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{ok_}.
+\exposid{ok_}.
 \end{itemdescr}
 
 \rSec3[istream.formatted]{Formatted input functions}
@@ -6189,12 +6189,12 @@ Calls \tcode{basic_ios<charT, traits>::swap(rhs)}.
 namespace std {
   template<class charT, class traits>
   class basic_ostream<charT, traits>::sentry {
-    bool ok_;       // \expos
+    bool @\exposid{ok_}@;       // \expos
 
   public:
     explicit sentry(basic_ostream& os);
     ~sentry();
-    explicit operator bool() const { return ok_; }
+    explicit operator bool() const { return @\exposid{ok_}@; }
 
     sentry(const sentry&) = delete;
     sentry& operator=(const sentry&) = delete;
@@ -6235,9 +6235,9 @@ If, after any preparation is completed,
 \tcode{os.good()}
 is
 \tcode{true},
-\tcode{ok_ == true}
+\tcode{\exposid{ok_} == true}
 otherwise,
-\tcode{ok_ == false}.
+\tcode{\exposid{ok_} == false}.
 During preparation, the constructor may call
 \tcode{setstate(failbit)}
 (which may throw
@@ -6278,7 +6278,7 @@ explicit operator bool() const;
 \pnum
 \effects
 Returns
-\tcode{ok_}.
+\exposid{ok_}.
 \end{itemdescr}
 
 \rSec4[ostream.seeks]{Seek members}
@@ -7114,7 +7114,7 @@ Otherwise this manipulator has no effect.
 To work around the issue that the
 \tcode{Allocator} template argument cannot be deduced,
 implementations can introduce an intermediate base class
-to \tcode{basic_syncbuf} that manages its \tcode{emit_on_sync} flag.
+to \tcode{basic_syncbuf} that manages its \exposid{emit-on-sync} flag.
 \end{note}
 
 \pnum
@@ -8121,9 +8121,9 @@ namespace std {
                       = ios_base::in | ios_base::out) override;
 
   private:
-    ios_base::openmode mode;                        // \expos
-    basic_string<charT, traits, Allocator> buf;     // \expos
-    void init_buf_ptrs();                           // \expos
+    ios_base::openmode @\exposid{mode}@;                        // \expos
+    basic_string<charT, traits, Allocator> @\exposid{buf}@;     // \expos
+    void @\exposid{init-buf-ptrs}@();                           // \expos
   };
 }
 \end{codeblock}
@@ -8144,17 +8144,17 @@ For the sake of exposition,
 the maintained data and internal pointer initialization is presented here as:
 \begin{itemize}
 \item
-  \tcode{ios_base::openmode mode}, has
+  \tcode{ios_base::openmode \exposid{mode}}, has
   \tcode{in} set if the input sequence can be read, and
   \tcode{out} set if the output sequence can be written.
 \item
-  \tcode{basic_string<charT, traits, Allocator> buf}
+  \tcode{basic_string<charT, traits, Allocator> \exposid{buf}}
   contains the underlying character sequence.
 \item
-  \tcode{init_buf_ptrs()} sets the base class'
+  \tcode{\exposid{init-buf-ptrs}()} sets the base class'
   get area\iref{streambuf.get.area} and
   put area\iref{streambuf.put.area} pointers
-  after initializing, moving from, or assigning to \tcode{buf} accordingly.
+  after initializing, moving from, or assigning to \exposid{buf} accordingly.
 \end{itemize}
 
 \rSec3[stringbuf.cons]{Constructors}
@@ -8169,7 +8169,7 @@ explicit basic_stringbuf(ios_base::openmode which);
 \effects
 Initializes the base class with
 \tcode{basic_streambuf()}\iref{streambuf.cons}, and
-\tcode{mode}
+\exposid{mode}
 with \tcode{which}.
 It is
 \impldef{whether sequence pointers are initialized to null pointers}
@@ -8195,9 +8195,9 @@ explicit basic_stringbuf(
 \effects
 Initializes the base class with
 \tcode{basic_streambuf()}\iref{streambuf.cons},
-\tcode{mode} with \tcode{which}, and
-\tcode{buf} with \tcode{s},
-then calls \tcode{init_buf_ptrs()}.
+\exposid{mode} with \tcode{which}, and
+\exposid{buf} with \tcode{s},
+then calls \tcode{\exposid{init-buf-ptrs}()}.
 \end{itemdescr}
 
 \indexlibraryctor{basic_stringbuf}%
@@ -8210,9 +8210,9 @@ basic_stringbuf(ios_base::openmode which, const Allocator& a);
 \effects
 Initializes the base class with
 \tcode{basic_streambuf()}\iref{streambuf.cons},
-\tcode{mode} with \tcode{which}, and
-\tcode{buf} with \tcode{a},
-then calls \tcode{init_buf_ptrs()}.
+\exposid{mode} with \tcode{which}, and
+\exposid{buf} with \tcode{a},
+then calls \tcode{\exposid{init-buf-ptrs}()}.
 
 \pnum
 \ensures
@@ -8230,9 +8230,9 @@ explicit basic_stringbuf(
 \pnum
 \effects
 Initializes the base class with \tcode{basic_streambuf()}\iref{streambuf.cons},
-\tcode{mode} with \tcode{which}, and
-\tcode{buf} with \tcode{std::move(s)},
-then calls \tcode{init_buf_ptrs()}.
+\exposid{mode} with \tcode{which}, and
+\exposid{buf} with \tcode{std::move(s)},
+then calls \tcode{\exposid{init-buf-ptrs}()}.
 \end{itemdescr}
 
 \indexlibraryctor{basic_stringbuf}%
@@ -8247,9 +8247,9 @@ template<class SAlloc>
 \pnum
 \effects
 Initializes the base class with \tcode{basic_streambuf()}\iref{streambuf.cons},
-\tcode{mode} with \tcode{which}, and
-\tcode{buf} with \tcode{\{s,a\}},
-then calls \tcode{init_buf_ptrs()}.
+\exposid{mode} with \tcode{which}, and
+\exposid{buf} with \tcode{\{s,a\}},
+then calls \tcode{\exposid{init-buf-ptrs}()}.
 \end{itemdescr}
 
 \indexlibraryctor{basic_stringbuf}%
@@ -8268,9 +8268,9 @@ template<class SAlloc>
 \pnum
 \effects
 Initializes the base class with \tcode{basic_streambuf()}\iref{streambuf.cons},
-\tcode{mode} with \tcode{which}, and
-\tcode{buf} with \tcode{s},
-then calls \tcode{init_buf_ptrs()}.
+\exposid{mode} with \tcode{which}, and
+\exposid{buf} with \tcode{s},
+then calls \tcode{\exposid{init-buf-ptrs}()}.
 \end{itemdescr}
 
 \indexlibraryctor{basic_stringbuf}%
@@ -8299,9 +8299,9 @@ is \tcode{true}.
 Creates a variable \tcode{sv} as if by
 \tcode{basic_string_view<charT, traits> sv = t},
 then value-initializes the base class,
-initializes \tcode{mode} with \tcode{which}, and
-direct-non-list-initializes \tcode{buf} with \tcode{sv, a},
-then calls \tcode{init_buf_ptrs()}.
+initializes \exposid{mode} with \tcode{which}, and
+direct-non-list-initializes \exposid{buf} with \tcode{sv, a},
+then calls \tcode{\exposid{init-buf-ptrs}()}.
 \end{itemdescr}
 
 \indexlibraryctor{basic_stringbuf}%
@@ -8314,10 +8314,10 @@ basic_stringbuf(basic_stringbuf&& rhs, const Allocator& a);
 \pnum
 \effects
 Copy constructs the base class from \tcode{rhs} and
-initializes \tcode{mode} with \tcode{rhs.mode}.
+initializes \exposid{mode} with \tcode{rhs.mode}.
 In the first form \tcode{buf} is initialized
 from \tcode{std::move(rhs).str()}.
-In the second form \tcode{buf} is initialized
+In the second form \exposid{buf} is initialized
 from \tcode{\{std::move(rhs).str(), a\}}.
 It is
 \impldef{whether sequence pointers are copied by \tcode{basic_stringbuf} move
@@ -8422,39 +8422,39 @@ are now considered uninitialized
 (except for those characters re-initialized by the new \tcode{basic_string}).
 
 \begin{itemdecl}
-void init_buf_ptrs(); // \expos
+void @\exposid{init-buf-ptrs}@(); // \expos
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects
-Initializes the input and output sequences from \tcode{buf}
-according to \tcode{mode}.
+Initializes the input and output sequences from \exposid{buf}
+according to \exposid{mode}.
 
 \pnum
 \ensures
 \begin{itemize}
-\item If \tcode{ios_base::out} is set in \tcode{mode},
-  \tcode{pbase()} points to \tcode{buf.front()} and
-  \tcode{epptr() >= pbase() + buf.size()} is \tcode{true};
+\item If \tcode{ios_base::out} is set in \exposid{mode},
+  \tcode{pbase()} points to \tcode{\exposid{buf}.front()} and
+  \tcode{epptr() >= pbase() + \exposid{buf}.size()} is \tcode{true};
   \begin{itemize}
-  \item in addition, if \tcode{ios_base::ate} is set in \tcode{mode},
-    \tcode{pptr() == pbase() + buf.size()} is \tcode{true},
+  \item in addition, if \tcode{ios_base::ate} is set in \exposid{mode},
+    \tcode{pptr() == pbase() + \exposid{buf}.size()} is \tcode{true},
   \item otherwise \tcode{pptr() == pbase()} is \tcode{true}.
   \end{itemize}
-\item If \tcode{ios_base::in} is set in \tcode{mode},
-  \tcode{eback()} points to \tcode{buf.front()}, and
-  \tcode{(gptr() == eback() \&\& egptr() == eback() + buf.size())}
+\item If \tcode{ios_base::in} is set in \exposid{mode},
+  \tcode{eback()} points to \tcode{\exposid{buf}.front()}, and
+  \tcode{(gptr() == eback() \&\& egptr() == eback() + \exposid{buf}.size())}
   is \tcode{true}.
 \end{itemize}
 
 \pnum
 \begin{note}
 For efficiency reasons,
-stream buffer operations can violate invariants of \tcode{buf}
+stream buffer operations can violate invariants of \exposid{buf}
 while it is held encapsulated in the \tcode{basic_stringbuf},
 e.g., by writing to characters in the range
-\range{\tcode{buf.data() + buf.size()}}{\tcode{buf.data() + buf.capacity()}}.
+\range{\tcode{\exposid{buf}.data() + \exposid{buf}.size()}}{\tcode{\exposid{buf}.data() + \exposid{buf}.capacity()}}.
 All operations retrieving a \tcode{basic_string} from \tcode{buf}
 ensure that the \tcode{basic_string} invariants hold on the returned value.
 \end{note}
@@ -8468,7 +8468,7 @@ allocator_type get_allocator() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{buf.get_allocator()}.
+\tcode{\exposid{buf}.get_allocator()}.
 \end{itemdescr}
 
 \indexlibrarymember{str}{basic_stringbuf}%
@@ -8515,7 +8515,7 @@ basic_string<charT, traits, Allocator> str() &&;
 The underlying character sequence \tcode{buf} is empty and
 \tcode{pbase()}, \tcode{pptr()}, \tcode{epptr()}, \tcode{eback()},
 \tcode{gptr()}, and \tcode{egptr()}
-are initialized as if by calling \tcode{init_buf_ptrs()}
+are initialized as if by calling \tcode{\exposid{init-buf-ptrs}()}
 with an empty \tcode{buf}.
 
 \pnum
@@ -8541,9 +8541,9 @@ Let \tcode{sv} be \tcode{basic_string_view<charT, traits>}.
 A \tcode{sv} object referring to
 the \tcode{basic_stringbuf}'s underlying character sequence in \tcode{buf}:
 \begin{itemize}
-\item If \tcode{ios_base::out} is set in \tcode{mode},
+\item If \tcode{ios_base::out} is set in \exposid{mode},
   then \tcode{sv(pbase(), high_mark-pbase())} is returned.
-\item Otherwise, if \tcode{ios_base::in} is set in \tcode{mode},
+\item Otherwise, if \tcode{ios_base::in} is set in \exposid{mode},
   then \tcode{sv(eback(), egptr()-eback())} is returned.
 \item Otherwise, \tcode{sv()} is returned.
 \end{itemize}
@@ -8566,8 +8566,8 @@ void str(const basic_string<charT, traits, Allocator>& s);
 \effects
 Equivalent to:
 \begin{codeblock}
-buf = s;
-init_buf_ptrs();
+@\exposid{buf}@ = s;
+@\exposid{init-buf-ptrs}@();
 \end{codeblock}
 \end{itemdescr}
 
@@ -8586,8 +8586,8 @@ template<class SAlloc>
 \effects
 Equivalent to:
 \begin{codeblock}
-buf = s;
-init_buf_ptrs();
+@\exposid{buf}@ = s;
+@\exposid{init-buf-ptrs}@();
 \end{codeblock}
 \end{itemdescr}
 
@@ -8601,8 +8601,8 @@ void str(basic_string<charT, traits, Allocator>&& s);
 \effects
 Equivalent to:
 \begin{codeblock}
-buf = std::move(s);
-init_buf_ptrs();
+@\exposid{buf}@ = std::move(s);
+@\exposid{init-buf-ptrs}@();
 \end{codeblock}
 \end{itemdescr}
 
@@ -8623,8 +8623,8 @@ is \tcode{true}.
 Equivalent to:
 \begin{codeblock}
 basic_string_view<charT, traits> sv = t;
-buf = sv;
-init_buf_ptrs();
+@\exposid{buf}@ = sv;
+@\exposid{init-buf-ptrs}@();
 \end{codeblock}
 \end{itemdescr}
 
@@ -8683,7 +8683,7 @@ returns
 \tcode{false}
 and if the input sequence
 has a putback position available, and
-if \tcode{mode}
+if \exposid{mode}
 \tcode{\&}
 \tcode{ios_base::out} is
 nonzero,
@@ -8769,14 +8769,14 @@ result of any call.
 
 \pnum
 The function can make a write position available only if
-\tcode{ios_base::out} is set in \tcode{mode}.
+\tcode{ios_base::out} is set in \exposid{mode}.
 To make a write position available,
 the function reallocates (or initially allocates) an array object
 with a sufficient number of elements to hold
 the current array object (if any), plus
 at least
 one additional write position.
-If \tcode{ios_base::in} is set in \tcode{mode},
+If \tcode{ios_base::in} is set in \exposid{mode},
 the function alters the read end pointer
 \tcode{egptr()}
 to point just past the new write position.
@@ -8964,7 +8964,7 @@ namespace std {
       void str(const T& t);
 
   private:
-    basic_stringbuf<charT, traits, Allocator> sb;   // \expos
+    basic_stringbuf<charT, traits, Allocator> @\exposid{sb}@;   // \expos
   };
 }
 \end{codeblock}
@@ -8980,7 +8980,7 @@ object to control the associated storage.
 For the sake of exposition, the maintained data is presented here as:
 \begin{itemize}
 \item
-\tcode{sb}, the \tcode{stringbuf} object.
+\exposid{sb}, the \tcode{stringbuf} object.
 \end{itemize}
 
 \rSec3[istringstream.cons]{Constructors}
@@ -8994,8 +8994,8 @@ explicit basic_istringstream(ios_base::openmode which);
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_istream<charT, traits>(addressof(sb))}\iref{istream}
-and \tcode{sb} with
+\tcode{basic_istream<charT, traits>(addressof(\exposid{sb}))}\iref{istream}
+and \exposid{sb} with
 \tcode{basic_stringbuf<charT, traits, Allocator>(which | ios_base::in)}\iref{stringbuf.cons}.
 \end{itemdescr}
 
@@ -9010,8 +9010,8 @@ explicit basic_istringstream(
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_istream<charT, traits>(addressof(sb))}\iref{istream}
-and \tcode{sb} with
+\tcode{basic_istream<charT, traits>(addressof(\exposid{sb}))}\iref{istream}
+and \exposid{sb} with
 \tcode{basic_stringbuf<charT, traits, Allocator>(s, which | ios_base::in)}\linebreak\iref{stringbuf.cons}. % avoid Overfull
 \end{itemdescr}
 
@@ -9024,8 +9024,8 @@ basic_istringstream(ios_base::openmode which, const Allocator& a);
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_istream<charT, traits>(addressof(sb))}\iref{istream}
-and \tcode{sb} with
+\tcode{basic_istream<charT, traits>(addressof(\exposid{sb}))}\iref{istream}
+and \exposid{sb} with
 \tcode{basic_stringbuf<charT, traits, Allocator>(which | ios_base::in, a)}\iref{stringbuf.cons}.
 \end{itemdescr}
 
@@ -9040,8 +9040,8 @@ explicit basic_istringstream(
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_istream<charT, traits>(addressof(sb))}\iref{istream}
-and \tcode{sb} with
+\tcode{basic_istream<charT, traits>(addressof(\exposid{sb}))}\iref{istream}
+and \exposid{sb} with
 \tcode{basic_stringbuf<charT, traits, Allocator>(std::move(s), which | ios_base::\brk{}in)}\iref{stringbuf.cons}.
 \end{itemdescr}
 
@@ -9057,8 +9057,8 @@ template<class SAlloc>
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_istream<charT, traits>(addressof(sb))}\iref{istream}
-and \tcode{sb} with
+\tcode{basic_istream<charT, traits>(addressof(\exposid{sb}))}\iref{istream}
+and \exposid{sb} with
 \tcode{basic_stringbuf<charT, traits, Allocator>(s, which | ios_base::in, a)}\linebreak\iref{stringbuf.cons}. % avoid Overfull
 \end{itemdescr}
 
@@ -9078,8 +9078,8 @@ template<class SAlloc>
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_istream<charT, traits>(addressof(sb))}\iref{istream}
-and \tcode{sb} with
+\tcode{basic_istream<charT, traits>(addressof(\exposid{sb}))}\iref{istream}
+and \exposid{sb} with
 \tcode{basic_stringbuf<charT, traits, Allocator>(s, which | ios_base::in)}\iref{stringbuf.cons}.
 \end{itemdescr}
 
@@ -9106,8 +9106,8 @@ is \tcode{true}.
 
 \pnum
 \effects
-Initializes the base class with \tcode{addressof(sb)}, and
-direct-non-list-initializes \tcode{sb} with \tcode{t, which | ios_base::in, a}.
+Initializes the base class with \tcode{addressof(\exposid{sb})}, and
+direct-non-list-initializes \exposid{sb} with \tcode{t, which | ios_base::in, a}.
 \end{itemdescr}
 
 \indexlibraryctor{basic_istringstream}%
@@ -9121,7 +9121,7 @@ basic_istringstream(basic_istringstream&& rhs);
 Move constructs from the rvalue \tcode{rhs}. This
 is accomplished by move constructing the base class, and the contained
 \tcode{basic_stringbuf}.
-Then calls \tcode{basic_istream<charT, traits>::set_rdbuf(addressof(sb))}
+Then calls \tcode{basic_istream<charT, traits>::set_rdbuf(addressof(\exposid{sb}))}
 to install the contained \tcode{basic_stringbuf}.
 \end{itemdescr}
 
@@ -9138,7 +9138,7 @@ void swap(basic_istringstream& rhs);
 Equivalent to:
 \begin{codeblock}
 basic_istream<charT, traits>::swap(rhs);
-sb.swap(rhs.sb);
+@\exposid{sb}@.swap(rhs.@\exposid{sb}@);
 \end{codeblock}
 \end{itemdescr}
 
@@ -9166,7 +9166,7 @@ basic_stringbuf<charT, traits, Allocator>* rdbuf() const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{const_cast<basic_stringbuf<charT, traits, Allocator>*>(addressof(sb))}.
+\tcode{const_cast<basic_stringbuf<charT, traits, Allocator>*>(addressof(\exposid{sb}))}.
 \end{itemdescr}
 
 \indexlibrarymember{str}{basic_istringstream}%
@@ -9337,7 +9337,7 @@ namespace std {
       void str(const T& t);
 
    private:
-    basic_stringbuf<charT, traits, Allocator> sb;   // \expos
+    basic_stringbuf<charT, traits, Allocator> @\exposid{sb}@;   // \expos
   };
 }
 \end{codeblock}
@@ -9353,7 +9353,7 @@ object to control the associated storage.
 For the sake of exposition, the maintained data is presented here as:
 \begin{itemize}
 \item
-\tcode{sb}, the \tcode{stringbuf} object.
+\exposid{sb}, the \tcode{stringbuf} object.
 \end{itemize}
 
 \rSec3[ostringstream.cons]{Constructors}
@@ -9367,8 +9367,8 @@ explicit basic_ostringstream(ios_base::openmode which);
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_ostream<charT, traits>(addressof(sb))}\iref{ostream}
-and \tcode{sb} with
+\tcode{basic_ostream<charT, traits>(addressof(\exposid{sb}))}\iref{ostream}
+and \exposid{sb} with
 \tcode{basic_stringbuf<charT, traits, Allocator>(which | ios_base::out)}\iref{stringbuf.cons}.
 \end{itemdescr}
 
@@ -9383,8 +9383,8 @@ explicit basic_ostringstream(
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_ostream<charT, traits>(addressof(sb))}\iref{ostream}
-and \tcode{sb} with
+\tcode{basic_ostream<charT, traits>(addressof(\exposid{sb}))}\iref{ostream}
+and \exposid{sb} with
 \tcode{basic_stringbuf<charT, traits, Allocator>(s, which | ios_base::out)}\linebreak\iref{stringbuf.cons}. % avoid Overfull
 \end{itemdescr}
 
@@ -9397,8 +9397,8 @@ basic_ostringstream(ios_base::openmode which, const Allocator& a);
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_ostream<charT, traits>(addressof(sb))}\iref{ostream}
-and \tcode{sb} with
+\tcode{basic_ostream<charT, traits>(addressof(\exposid{sb}))}\iref{ostream}
+and \exposid{sb} with
 \tcode{basic_stringbuf<charT, traits, Allocator>(which | ios_base::out, a)}\linebreak\iref{stringbuf.cons}. % avoid Overfull
 \end{itemdescr}
 
@@ -9413,8 +9413,8 @@ explicit basic_ostringstream(
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_ostream<charT, traits>(addressof(sb))}\iref{ostream}
-and \tcode{sb} with
+\tcode{basic_ostream<charT, traits>(addressof(\exposid{sb}))}\iref{ostream}
+and \exposid{sb} with
 \tcode{basic_stringbuf<charT, traits, Allocator>(std::move(s), which | ios_base::\brk{}out)}\iref{stringbuf.cons}.
 \end{itemdescr}
 
@@ -9430,8 +9430,8 @@ template<class SAlloc>
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_ostream<charT, traits>(addressof(sb))}\iref{ostream}
-and \tcode{sb} with
+\tcode{basic_ostream<charT, traits>(addressof(\exposid{sb}))}\iref{ostream}
+and \exposid{sb} with
 \tcode{basic_stringbuf<charT, traits, Allocator>(s, which | ios_base::out, a)}\linebreak\iref{stringbuf.cons}. % avoid Overfull
 \end{itemdescr}
 
@@ -9451,8 +9451,8 @@ template<class SAlloc>
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_ostream<charT, traits>(addressof(sb))}\iref{ostream}
-and \tcode{sb} with
+\tcode{basic_ostream<charT, traits>(addressof(\exposid{sb}))}\iref{ostream}
+and \exposid{sb} with
 \tcode{basic_stringbuf<charT, traits, Allocator>(s, which | ios_base::out)}\linebreak\iref{stringbuf.cons}. % avoid Overfull
 \end{itemdescr}
 
@@ -9479,8 +9479,8 @@ is \tcode{true}.
 
 \pnum
 \effects
-Initializes the base class with \tcode{addressof(sb)}, and
-direct-non-list-initializes \tcode{sb} with \tcode{t, which | ios_base::out, a}.
+Initializes the base class with \tcode{addressof(\exposid{sb})}, and
+direct-non-list-initializes \exposid{sb} with \tcode{t, which | ios_base::out, a}.
 \end{itemdescr}
 
 \indexlibraryctor{basic_ostringstream}%
@@ -9494,7 +9494,7 @@ basic_ostringstream(basic_ostringstream&& rhs);
 Move constructs from the rvalue \tcode{rhs}. This
 is accomplished by move constructing the base class, and the contained
 \tcode{basic_stringbuf}.
-Then calls \tcode{basic_ostream<charT, traits>::set_rdbuf(addressof(sb))}
+Then calls \tcode{basic_ostream<charT, traits>::set_rdbuf(addressof(\exposid{sb}))}
 to install the contained \tcode{basic_stringbuf}.
 \end{itemdescr}
 
@@ -9511,7 +9511,7 @@ void swap(basic_ostringstream& rhs);
 Equivalent to:
 \begin{codeblock}
 basic_ostream<charT, traits>::swap(rhs);
-sb.swap(rhs.sb);
+@\exposid{sb}@.swap(rhs.@\exposid{sb}@);
 \end{codeblock}
 \end{itemdescr}
 
@@ -9538,7 +9538,7 @@ basic_stringbuf<charT, traits, Allocator>* rdbuf() const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{const_cast<basic_stringbuf<charT, traits, Allocator>*>(addressof(sb))}.
+\tcode{const_cast<basic_stringbuf<charT, traits, Allocator>*>(addressof(\exposid{sb}))}.
 \end{itemdescr}
 
 \indexlibrarymember{str}{basic_ostringstream}%
@@ -9710,7 +9710,7 @@ namespace std {
       void str(const T& t);
 
   private:
-    basic_stringbuf<charT, traits, Allocator> sb;   // \expos
+    basic_stringbuf<charT, traits, Allocator> @\exposid{sb}@;   // \expos
   };
 }
 \end{codeblock}
@@ -9727,7 +9727,7 @@ object to control the associated sequence.
 For the sake of exposition, the maintained data is presented here as
 \begin{itemize}
 \item
-\tcode{sb}, the \tcode{stringbuf} object.
+\exposid{sb}, the \tcode{stringbuf} object.
 \end{itemize}
 
 \rSec3[stringstream.cons]{Constructors}
@@ -9741,9 +9741,9 @@ explicit basic_stringstream(ios_base::openmode which);
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_iostream<charT, traits>(addressof(sb))}\iref{iostream.cons}
+\tcode{basic_iostream<charT, traits>(addressof(\exposid{sb}))}\iref{iostream.cons}
 and
-\tcode{sb}
+\exposid{sb}
 with
 \tcode{basic_string\-buf<charT, traits, Allocator>(which)}.
 \end{itemdescr}
@@ -9759,9 +9759,9 @@ explicit basic_stringstream(
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_iostream<charT, traits>(addressof(sb))}\iref{iostream.cons}
+\tcode{basic_iostream<charT, traits>(addressof(\exposid{sb}))}\iref{iostream.cons}
 and
-\tcode{sb}
+\exposid{sb}
 with
 \tcode{basic_string\-buf<charT, traits, Allocator>(s, which)}.
 \end{itemdescr}
@@ -9775,8 +9775,8 @@ basic_stringstream(ios_base::openmode which, const Allocator& a);
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_iostream<charT, traits>(addressof(sb))}\iref{iostream.cons}
-and \tcode{sb} with
+\tcode{basic_iostream<charT, traits>(addressof(\exposid{sb}))}\iref{iostream.cons}
+and \exposid{sb} with
 \tcode{basic_stringbuf<charT, traits, Allocator>(which, a)}\iref{stringbuf.cons}.
 \end{itemdescr}
 
@@ -9791,8 +9791,8 @@ explicit basic_stringstream(
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_iostream<charT, traits>(addressof(sb))}\iref{iostream.cons}
-and \tcode{sb} with
+\tcode{basic_iostream<charT, traits>(addressof(\exposid{sb}))}\iref{iostream.cons}
+and \exposid{sb} with
 \tcode{basic_stringbuf<charT, traits, Allocator>(std::move(s), which)}\iref{stringbuf.cons}.
 \end{itemdescr}
 
@@ -9808,8 +9808,8 @@ template<class SAlloc>
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_iostream<charT, traits>(addressof(sb))}\iref{iostream.cons}
-and \tcode{sb} with
+\tcode{basic_iostream<charT, traits>(addressof(\exposid{sb}))}\iref{iostream.cons}
+and \exposid{sb} with
 \tcode{basic_stringbuf<charT, traits, Allocator>(s, which, a)}\iref{stringbuf.cons}.
 \end{itemdescr}
 
@@ -9829,8 +9829,8 @@ template<class SAlloc>
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_iostream<charT, traits>(addressof(sb))}\iref{iostream.cons}
-and \tcode{sb} with
+\tcode{basic_iostream<charT, traits>(addressof(\exposid{sb}))}\iref{iostream.cons}
+and \exposid{sb} with
 \tcode{basic_stringbuf<charT, traits, Allocator>(s, which)}\iref{stringbuf.cons}.
 \end{itemdescr}
 
@@ -9857,8 +9857,8 @@ is \tcode{true}.
 
 \pnum
 \effects
-Initializes the base class with \tcode{addressof(sb)}, and
-direct-non-list-initializes \tcode{sb} with \tcode{t, which, a}.
+Initializes the base class with \tcode{addressof(\exposid{sb})}, and
+direct-non-list-initializes \exposid{sb} with \tcode{t, which, a}.
 \end{itemdescr}
 
 \indexlibraryctor{basic_stringstream}%
@@ -9872,7 +9872,7 @@ basic_stringstream(basic_stringstream&& rhs);
 Move constructs from the rvalue \tcode{rhs}. This
 is accomplished by move constructing the base class, and the contained
 \tcode{basic_stringbuf}.
-Then calls \tcode{basic_istream<charT, traits>::set_rdbuf(addressof(sb))}
+Then calls \tcode{basic_istream<charT, traits>::set_rdbuf(addressof(\exposid{sb}))}
 to install the contained \tcode{basic_stringbuf}.
 \end{itemdescr}
 
@@ -9889,7 +9889,7 @@ void swap(basic_stringstream& rhs);
 Equivalent to:
 \begin{codeblock}
 basic_iostream<charT,traits>::swap(rhs);
-sb.swap(rhs.sb);
+@\exposid{sb}@.swap(rhs.@\exposid{sb}@);
 \end{codeblock}
 \end{itemdescr}
 
@@ -9916,7 +9916,7 @@ basic_stringbuf<charT, traits, Allocator>* rdbuf() const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{const_cast<basic_stringbuf<charT, traits, Allocator>*>(addressof(sb))}.
+\tcode{const_cast<basic_stringbuf<charT, traits, Allocator>*>(addressof(\exposid{sb}))}.
 \end{itemdescr}
 
 \indexlibrarymember{str}{basic_stringstream}%
@@ -10365,7 +10365,7 @@ when \tcode{way} is \tcode{ios_base::end} :
 if \tcode{ios_base::out} is set in \exposid{mode} and
 \tcode{ios_base::in} is not set in \exposid{mode},
 \item
-\tcode{buf.size()} otherwise.
+\tcode{\exposid{buf}.size()} otherwise.
 \end{itemize}
 \end{itemize}
 
@@ -10453,7 +10453,7 @@ namespace std {
     template<class ROS> void span(ROS&& s) noexcept;
 
   private:
-    basic_spanbuf<charT, traits> sb;    // \expos
+    basic_spanbuf<charT, traits> @\exposid{sb}@;    // \expos
   };
 }
 \end{codeblock}
@@ -10476,8 +10476,8 @@ explicit basic_ispanstream(std::span<charT> s, ios_base::openmode which = ios_ba
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_istream<charT, traits>(addressof(sb))}
-and \tcode{sb} with
+\tcode{basic_istream<charT, traits>(addressof(\exposid{sb}))}
+and \exposid{sb} with
 \tcode{basic_spanbuf<charT, traits>(s, which | ios_base::in)}\iref{spanbuf.cons}.
 \end{itemdescr}
 
@@ -10490,9 +10490,9 @@ basic_ispanstream(basic_ispanstream&& rhs);
 \pnum
 \effects
 Initializes the base class with \tcode{std::move(rhs)}
-and \tcode{sb} with \tcode{std::move(rhs.sb)}.
-Next, \tcode{basic_istream<charT, traits>::set_rdbuf(addressof(sb))} is called
-to install the contained \tcode{basic_spanbuf}.
+and \exposid{sb} with \tcode{std::move(rhs.\exposid{sb})}.
+Next, \tcode{basic_istream<charT, traits>::set_rdbuf(addressof(\exposid{sb}))} is called
+to install the contained \tcode{ba\-sic_\-span\-buf}.
 \end{itemdescr}
 
 \indexlibraryctor{basic_ispanstream}%
@@ -10529,7 +10529,7 @@ void swap(basic_ispanstream& rhs);
 Equivalent to:
 \begin{codeblock}
 basic_istream<charT, traits>::swap(rhs);
-sb.swap(rhs.sb);
+@\exposid{sb}@.swap(rhs.@\exposid{sb}@);
 \end{codeblock}
 \end{itemdescr}
 
@@ -10557,7 +10557,7 @@ basic_spanbuf<charT, traits>* rdbuf() const noexcept;
 \effects
 Equivalent to:
 \begin{codeblock}
-return const_cast<basic_spanbuf<charT, traits>*>(addressof(sb));
+return const_cast<basic_spanbuf<charT, traits>*>(addressof(@\exposid{sb}@));
 \end{codeblock}
 \end{itemdescr}
 
@@ -10639,7 +10639,7 @@ namespace std {
     void span(std::span<charT> s) noexcept;
 
   private:
-    basic_spanbuf<charT, traits> sb;    // \expos
+    basic_spanbuf<charT, traits> @\exposid{sb}@;    // \expos
   };
 }
 \end{codeblock}
@@ -10656,8 +10656,8 @@ explicit basic_ospanstream(std::span<charT> s,
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_ostream<charT, traits>(addressof(sb))}
-and \tcode{sb} with
+\tcode{basic_ostream<charT, traits>(addressof(\exposid{sb}))}
+and \exposid{sb} with
 \tcode{basic_spanbuf<charT, traits>(s, which | ios_base::out)}\iref{spanbuf.cons}.
 \end{itemdescr}
 
@@ -10670,9 +10670,9 @@ basic_ospanstream(basic_ospanstream&& rhs) noexcept;
 \pnum
 \effects
 Initializes the base class with \tcode{std::move(rhs)}
-and \tcode{sb} with \tcode{std::move(rhs.sb)}.
-Next, \tcode{basic_ostream<charT, traits>::set_rdbuf(addressof(sb))}
-is called to install the contained \tcode{basic_spanbuf}.
+and \exposid{sb} with \tcode{std::move(rhs.\exposid{sb})}.
+Next, \tcode{basic_ostream<charT, traits>::set_rdbuf(addressof(\exposid{sb}))}
+is called to install the contained \tcode{ba\-sic_\-span\-buf}.
 \end{itemdescr}
 
 \rSec3[ospanstream.swap]{Swap}
@@ -10688,7 +10688,7 @@ void swap(basic_ospanstream& rhs);
 Equivalent to:
 \begin{codeblock}
 basic_ostream<charT, traits>::swap(rhs);
-sb.swap(rhs.sb);
+@\exposid{sb}@.swap(rhs.@\exposid{sb}@);
 \end{codeblock}
 \end{itemdescr}
 
@@ -10716,7 +10716,7 @@ basic_spanbuf<charT, traits>* rdbuf() const noexcept;
 \effects
 Equivalent to:
 \begin{codeblock}
-return const_cast<basic_spanbuf<charT, traits>*>(addressof(sb));
+return const_cast<basic_spanbuf<charT, traits>*>(addressof(@\exposid{sb}@));
 \end{codeblock}
 \end{itemdescr}
 
@@ -10778,7 +10778,7 @@ namespace std {
     void span(std::span<charT> s) noexcept;
 
   private:
-    basic_spanbuf<charT, traits> sb;    // \expos
+    basic_spanbuf<charT, traits> @\exposid{sb}@;    // \expos
   };
 }
 \end{codeblock}
@@ -10795,8 +10795,8 @@ explicit basic_spanstream(std::span<charT> s,
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_iostream<charT, traits>(addressof(sb))}
-and \tcode{sb} with
+\tcode{basic_iostream<charT, traits>(addressof(\exposid{sb}))}
+and \exposid{sb} with
 \tcode{basic_spanbuf<charT, traits>(s, which)}\iref{spanbuf.cons}.
 \end{itemdescr}
 
@@ -10809,8 +10809,8 @@ basic_spanstream(basic_spanstream&& rhs);
 \pnum
 \effects
 Initializes the base class with \tcode{std::move(rhs)}
-and \tcode{sb} with \tcode{std::move(rhs.sb)}.
-Next, \tcode{basic_iostream<charT, traits>::set_rdbuf(addressof(sb))}
+and \exposid{sb} with \tcode{std::move(rhs.\exposid{sb})}.
+Next, \tcode{basic_iostream<charT, traits>::set_rdbuf(addressof(\exposid{sb}))}
 is called to install the contained \tcode{basic_spanbuf}.
 \end{itemdescr}
 
@@ -10827,7 +10827,7 @@ void swap(basic_spanstream& rhs);
 Equivalent to:
 \begin{codeblock}
 basic_iostream<charT, traits>::swap(rhs);
-sb.swap(rhs.sb);
+@\exposid{sb}@.swap(rhs.@\exposid{sb}@);
 \end{codeblock}
 \end{itemdescr}
 
@@ -10855,7 +10855,7 @@ basic_spanbuf<charT, traits>* rdbuf() const noexcept;
 \effects
 Equivalent to:
 \begin{codeblock}
-return const_cast<basic_spanbuf<charT, traits>*>(addressof(sb));
+return const_cast<basic_spanbuf<charT, traits>*>(addressof(@\exposid{sb}@));
 \end{codeblock}
 \end{itemdescr}
 
@@ -11834,7 +11834,7 @@ namespace std {
     void close();
 
   private:
-    basic_filebuf<charT, traits> sb;    // \expos
+    basic_filebuf<charT, traits> @\exposid{sb}@;    // \expos
   };
 }
 \end{codeblock}
@@ -11850,7 +11850,7 @@ sequence.
 For the sake of exposition, the maintained data is presented here as:
 \begin{itemize}
 \item
-\tcode{sb}, the \tcode{filebuf} object.
+\exposid{sb}, the \tcode{filebuf} object.
 \end{itemize}
 
 \rSec3[ifstream.cons]{Constructors}
@@ -11864,8 +11864,8 @@ basic_ifstream();
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_istream<charT, traits>(addressof(sb))}\iref{istream.cons}
-and \tcode{sb} with
+\tcode{basic_istream<charT, traits>(addressof(\exposid{sb}))}\iref{istream.cons}
+and \exposid{sb} with
 \tcode{basic_filebuf<charT, traits>()}\iref{filebuf.cons}.
 \end{itemdescr}
 
@@ -11881,8 +11881,8 @@ explicit basic_ifstream(const filesystem::path::value_type* s,
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_istream<charT, traits>(addressof(sb))}\iref{istream.cons}
-and \tcode{sb} with
+\tcode{basic_istream<charT, traits>(addressof(\exposid{sb}))}\iref{istream.cons}
+and \exposid{sb} with
 \tcode{basic_filebuf<charT, traits>()}\iref{filebuf.cons},
 then calls
 \tcode{rdbuf()->open(s, mode | ios_base::in)}.
@@ -11927,7 +11927,7 @@ basic_ifstream(basic_ifstream&& rhs);
 \pnum
 \effects
 Move constructs the base class, and the contained \tcode{basic_filebuf}.
-Then calls \tcode{basic_istream<charT, traits>::set_rdbuf(\brk{}addressof(sb))}
+Then calls \tcode{basic_istream<charT, traits>::set_rdbuf(\brk{}addressof(\exposid{sb}))}
 to install the contained \tcode{basic_filebuf}.
 \end{itemdescr}
 
@@ -11944,7 +11944,7 @@ void swap(basic_ifstream& rhs);
 Exchanges the state of \tcode{*this}
 and \tcode{rhs} by calling
 \tcode{basic_istream<charT, traits>::swap(rhs)} and
-\tcode{sb.swap(rhs.sb)}.
+\tcode{\exposid{sb}.swap(rhs.\exposid{sb})}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{basic_ifstream}%
@@ -11969,7 +11969,7 @@ basic_filebuf<charT, traits>* rdbuf() const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{const_cast<basic_filebuf<charT, traits>*>(addressof(sb))}.
+\tcode{const_cast<basic_filebuf<charT, traits>*>(addressof(@\exposid{sb}@))}.
 \end{itemdescr}
 
 \indexlibrarymember{native_handle}{basic_ifstream}%
@@ -12093,7 +12093,7 @@ namespace std {
     void close();
 
   private:
-    basic_filebuf<charT, traits> sb;    // \expos
+    basic_filebuf<charT, traits> @\exposid{sb}@;    // \expos
   };
 }
 \end{codeblock}
@@ -12109,7 +12109,7 @@ sequence.
 For the sake of exposition, the maintained data is presented here as:
 \begin{itemize}
 \item
-\tcode{sb}, the \tcode{filebuf} object.
+\exposid{sb}, the \tcode{filebuf} object.
 \end{itemize}
 
 \rSec3[ofstream.cons]{Constructors}
@@ -12123,8 +12123,8 @@ basic_ofstream();
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_ostream<charT, traits>(addressof(sb))}\iref{ostream.cons}
-and \tcode{sb} with
+\tcode{basic_ostream<charT, traits>(addressof(\exposid{sb}))}\iref{ostream.cons}
+and \exposid{sb} with
 \tcode{basic_filebuf<charT, traits>()}\iref{filebuf.cons}.
 \end{itemdescr}
 
@@ -12140,8 +12140,8 @@ explicit basic_ofstream(const filesystem::path::value_type* s,
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_ostream<charT, traits>(addressof(sb))}\iref{ostream.cons}
-and \tcode{sb} with
+\tcode{basic_ostream<charT, traits>(addressof(\exposid{sb}))}\iref{ostream.cons}
+and \exposid{sb} with
 \tcode{basic_filebuf<charT, traits>()}\iref{filebuf.cons},
 then calls
 \tcode{rdbuf()->open(s, mode | ios_base::out)}.
@@ -12186,7 +12186,7 @@ basic_ofstream(basic_ofstream&& rhs);
 \pnum
 \effects
 Move constructs the base class, and the contained \tcode{basic_filebuf}.
-Then calls \tcode{basic_ostream<charT, traits>::set_rdbuf(\brk{}addressof(sb))}
+Then calls \tcode{basic_ostream<charT, traits>::set_rdbuf(\brk{}addressof(\exposid{sb}))}
 to install the contained \tcode{basic_filebuf}.
 \end{itemdescr}
 
@@ -12203,7 +12203,7 @@ void swap(basic_ofstream& rhs);
 Exchanges the state of \tcode{*this}
 and \tcode{rhs} by calling
 \tcode{basic_ostream<charT, traits>::swap(rhs)} and
-\tcode{sb.swap(rhs.sb)}.
+\tcode{\exposid{sb}.swap(rhs.\exposid{sb})}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{basic_ofstream}%
@@ -12228,7 +12228,7 @@ basic_filebuf<charT, traits>* rdbuf() const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{const_cast<basic_filebuf<charT, traits>*>(addressof(sb))}.
+\tcode{const_cast<basic_filebuf<charT, traits>*>(addressof(\exposid{sb}))}.
 \end{itemdescr}
 
 \indexlibrarymember{native_handle}{basic_ofstream}%
@@ -12360,7 +12360,7 @@ namespace std {
     void close();
 
   private:
-    basic_filebuf<charT, traits> sb;    // \expos
+    basic_filebuf<charT, traits> @\exposid{sb}@;    // \expos
   };
 }
 \end{codeblock}
@@ -12376,7 +12376,7 @@ object to control the associated sequences.
 For the sake of exposition, the maintained data is presented here as:
 \begin{itemize}
 \item
-\tcode{sb}, the \tcode{basic_filebuf} object.
+\exposid{sb}, the \tcode{basic_filebuf} object.
 \end{itemize}
 
 \rSec3[fstream.cons]{Constructors}
@@ -12390,9 +12390,9 @@ basic_fstream();
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_iostream<charT, traits>(addressof(sb))}\iref{iostream.cons}
+\tcode{basic_iostream<charT, traits>(addressof(\exposid{sb}))}\iref{iostream.cons}
 and
-\tcode{sb} with \tcode{basic_filebuf<charT, traits>()}.
+\exposid{sb} with \tcode{basic_filebuf<charT, traits>()}.
 \end{itemdescr}
 
 \indexlibraryctor{basic_fstream}%
@@ -12409,9 +12409,9 @@ explicit basic_fstream(
 \pnum
 \effects
 Initializes the base class with
-\tcode{basic_iostream<charT, traits>(addressof(sb))}\iref{iostream.cons}
+\tcode{basic_iostream<charT, traits>(addressof(\exposid{sb}))}\iref{iostream.cons}
 and
-\tcode{sb} with \tcode{basic_filebuf<charT, traits>()}.
+\exposid{sb} with \tcode{basic_filebuf<charT, traits>()}.
 Then calls
 \tcode{rdbuf()->open(s, mode)}.
 If that function returns a null pointer, calls
@@ -12456,7 +12456,7 @@ basic_fstream(basic_fstream&& rhs);
 \pnum
 \effects
 Move constructs the base class, and the contained \tcode{basic_filebuf}.
-Then calls \tcode{basic_istream<charT, traits>::set_rdbuf(\brk{}addressof(sb))}
+Then calls \tcode{basic_istream<charT, traits>::set_rdbuf(\brk{}addressof(\exposid{sb}))}
 to install the contained \tcode{basic_filebuf}.
 \end{itemdescr}
 
@@ -12473,7 +12473,7 @@ void swap(basic_fstream& rhs);
 Exchanges the state of \tcode{*this}
 and \tcode{rhs} by calling
 \tcode{basic_iostream<charT,traits>::swap(rhs)} and
-\tcode{sb.swap(rhs.sb)}.
+\tcode{\exposid{sb}.swap(rhs.\exposid{sb})}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{basic_fstream}%
@@ -12499,7 +12499,7 @@ basic_filebuf<charT, traits>* rdbuf() const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{const_cast<basic_filebuf<charT, traits>*>(addressof(sb))}.
+\tcode{const_cast<basic_filebuf<charT, traits>*>(addressof(\exposid{sb}))}.
 \end{itemdescr}
 
 \indexlibrarymember{native_handle}{basic_fstream}%
@@ -12661,8 +12661,8 @@ namespace std {
     int sync() override;
 
   private:
-    streambuf_type* wrapped;    // \expos
-    bool emit_on_sync{};        // \expos
+    streambuf_type* @\exposid{wrapped}@;    // \expos
+    bool @\exposid{emit-on-sync}@{};        // \expos
   };
 }
 \end{codeblock}
@@ -12672,7 +12672,7 @@ Class template \tcode{basic_syncbuf} stores character data
 written to it, known as the associated output, into internal
 buffers allocated using the object's allocator.
 The associated output is transferred to the
-wrapped stream buffer object \tcode{*wrapped}
+wrapped stream buffer object \tcode{*\exposid{wrapped}}
 when \tcode{emit()} is called
 or when the \tcode{basic_syncbuf} object is destroyed.
 Such transfers are atomic with respect to transfers
@@ -12689,7 +12689,7 @@ basic_syncbuf(streambuf_type* obuf, const Allocator& allocator);
 \begin{itemdescr}
 \pnum
 \effects
-Sets \tcode{wrapped} to \tcode{obuf}.
+Sets \exposid{wrapped} to \tcode{obuf}.
 
 \pnum
 \ensures
@@ -12823,10 +12823,10 @@ bool emit();
 \pnum
 \effects
 Atomically transfers the associated output of \tcode{*this}
-to the stream buffer \tcode{*wrapped},
+to the stream buffer \tcode{*\exposid{wrapped}},
 so that it appears in the output stream
 as a contiguous sequence of characters.
-\tcode{wrapped->pubsync()} is called
+\tcode{\exposid{wrapped}->pubsync()} is called
 if and only if a call was made to \tcode{sync()}
 since the most recent call to \tcode{emit()}, if any.
 
@@ -12849,15 +12849,15 @@ On success, the associated output is empty.
 \tcode{true} if all of the following conditions hold;
 otherwise \tcode{false}:
 \begin{itemize}
-\item \tcode{wrapped == nullptr} is \tcode{false}.
+\item \tcode{\exposid{wrapped} == nullptr} is \tcode{false}.
 \item All of the characters in the associated output were successfully transferred.
-\item The call to \tcode{wrapped->pubsync()} (if any) succeeded.
+\item The call to \tcode{\exposid{wrapped}->pubsync()} (if any) succeeded.
 \end{itemize}
 
 \pnum
 \remarks
-May call member functions of \tcode{wrapped}
-while holding a lock uniquely associated with \tcode{wrapped}.
+May call member functions of \exposid{wrapped}
+while holding a lock uniquely associated with \exposid{wrapped}.
 \end{itemdescr}
 
 \indexlibrarymember{get_wrapped}{basic_syncbuf}%
@@ -12868,7 +12868,7 @@ streambuf_type* get_wrapped() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{wrapped}.
+\exposid{wrapped}.
 \end{itemdescr}
 
 \indexlibrarymember{get_allocator}{basic_syncbuf}%
@@ -12890,7 +12890,7 @@ void set_emit_on_sync(bool b) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-\tcode{emit_on_sync = b}.
+\tcode{\exposid{emit-on-sync} = b}.
 \end{itemdescr}
 
 \rSec3[syncstream.syncbuf.virtuals]{Overridden virtual functions}
@@ -12904,9 +12904,9 @@ int sync() override;
 \pnum
 \effects
 Records that the wrapped stream buffer is to be flushed.
-Then, if \tcode{emit_on_sync} is \tcode{true}, calls \tcode{emit()}.
+Then, if \exposid{emit-on-sync} is \tcode{true}, calls \tcode{emit()}.
 \begin{note}
-If \tcode{emit_on_sync} is \tcode{false},
+If \exposid{emit-on-sync} is \tcode{false},
 the actual flush is delayed until a call to \tcode{emit()}.
 \end{note}
 
@@ -12968,10 +12968,10 @@ namespace std {
     // \ref{syncstream.osyncstream.members}, member functions
     void emit();
     streambuf_type* get_wrapped() const noexcept;
-    syncbuf_type* rdbuf() const noexcept { return const_cast<syncbuf_type*>(addressof(sb)); }
+    syncbuf_type* rdbuf() const noexcept { return const_cast<syncbuf_type*>(addressof(@\exposid{sb}@)); }
 
   private:
-    syncbuf_type sb;    // \expos
+    syncbuf_type @\exposid{sb}@;    // \expos
   };
 }
 \end{codeblock}
@@ -13013,8 +13013,8 @@ basic_osyncstream(streambuf_type* buf, const Allocator& allocator);
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{sb} from \tcode{buf} and \tcode{allocator}.
-Initializes the base class with \tcode{basic_ostream<charT, traits>(addressof(sb))}.
+Initializes \exposid{sb} from \tcode{buf} and \tcode{allocator}.
+Initializes the base class with \tcode{basic_ostream<charT, traits>(addressof(\exposid{sb}))}.
 
 \pnum
 \begin{note}
@@ -13037,8 +13037,8 @@ basic_osyncstream(basic_osyncstream&& other) noexcept;
 \pnum
 \effects
 Move constructs the base class
-and \tcode{sb} from the corresponding subobjects of \tcode{other},
-and calls \tcode{basic_ostream<charT, traits>::set_rdbuf(addressof(sb))}.
+and \exposid{sb} from the corresponding subobjects of \tcode{other},
+and calls \tcode{basic_ostream<charT, traits>::set_rdbuf(addressof(\exposid{sb}))}.
 
 \pnum
 \ensures
@@ -13059,7 +13059,7 @@ void emit();
 \pnum
 \effects
 Behaves as an unformatted output function\iref{ostream.unformatted}.
-After constructing a \tcode{sentry} object, calls \tcode{sb.emit()}.
+After constructing a \tcode{sentry} object, calls \tcode{\exposid{sb}.emit()}.
 If that call returns \tcode{false},
 calls \tcode{setstate(ios_base::badbit)}.
 
@@ -13104,7 +13104,7 @@ streambuf_type* get_wrapped() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{sb.get_wrapped()}.
+\tcode{\exposid{sb}.get_wrapped()}.
 
 \pnum
 \begin{example}
@@ -16095,7 +16095,7 @@ namespace std::filesystem {
         operator<<(basic_ostream<charT, traits>& os, const directory_entry& d);
 
   private:
-    filesystem::path pathobject;        // \expos
+    filesystem::path @\exposid{path-object}@;        // \expos
   };
 }
 \end{codeblock}
@@ -16186,7 +16186,7 @@ void assign(const filesystem::path& p, error_code& ec);
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to \tcode{pathobject = p},
+Equivalent to \tcode{\exposid{path-object} = p},
 then \tcode{refresh()} or \tcode{refresh(ec)}, respectively.
 If an error occurs, the values of any cached attributes are unspecified.
 
@@ -16204,7 +16204,7 @@ void replace_filename(const filesystem::path& p, error_code& ec);
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to \tcode{pathobject.replace_filename(p)},
+Equivalent to \tcode{\exposid{path-object}.replace_filename(p)},
 then \tcode{refresh()} or \tcode{refresh(ec)}, respectively.
 If an error occurs, the values of any cached attributes are unspecified.
 
@@ -16255,7 +16255,7 @@ operator const filesystem::path&() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{pathobject}.
+\exposid{path-object}.
 \end{itemdescr}
 
 \indexlibrarymember{exists}{directory_entry}%
@@ -16495,7 +16495,7 @@ bool operator==(const directory_entry& rhs) const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{pathobject == rhs.pathobject}.
+\tcode{\exposid{path-object} == rhs.\exposid{path-object}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{directory_entry}%
@@ -16506,7 +16506,7 @@ strong_ordering operator<=>(const directory_entry& rhs) const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{pathobject <=> rhs.pathobject}.
+\tcode{\exposid{path-object} <=> rhs.\exposid{path-object}}.
 \end{itemdescr}
 
 \rSec3[fs.dir.entry.io]{Inserter}


### PR DESCRIPTION
Towards #5940 and #4702.

Renaming:
- `init_buf_ptrs` to _`init-buf-ptrs`_,
- `emit_on_sync` to _`emit-on-sync`_,
- `pathobject` to _`path-object`_.

`init_cnt` is not changed because it should be removed.