### PR TITLE
Correctly mark state.error as an exposition-only identifier in [exec.sync.wait] p9

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -4604,7 +4604,7 @@ start(op);
 
 state.@\exposid{loop}@.run();
 if (state.@\exposid{error}@) {
-  rethrow_exception(std::move(state.error));
+  rethrow_exception(std::move(state.@\exposid{error}@));
 }
 return std::move(state.@\exposid{result}@);
 \end{codeblock}


### PR DESCRIPTION
Fixes one use of the exposition-only member _sync-wait-state::error_ in the wording of [exec.sync.wait] p9 where the identifier was not marked as exposition-only.