### PR TITLE
Fix markup of product-type constructor call in [exec.just]

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -2583,7 +2583,7 @@ The expression \tcode{\exposid{just-cpo}(ts...)} is ill-formed if
 \end{itemize}
 
 Otherwise, it is expression-equivalent to
-\tcode{\exposid{make-sender}(\exposid{just-cpo}, @\exposid{product-type}@{ts...})}.
+\tcode{\exposid{make-sender}(\exposid{just-cpo}, \exposid{product-type}\{ts...\})}.
 
 For \tcode{just}, \tcode{just_error}, and \tcode{just_stopped},
 let \exposid{set-cpo} be

--- a/source/exec.tex
+++ b/source/exec.tex
@@ -2583,7 +2583,7 @@ The expression \tcode{\exposid{just-cpo}(ts...)} is ill-formed if
 \end{itemize}
 
 Otherwise, it is expression-equivalent to
-\tcode{\exposid{make-sender}(\exposid{just-cpo}, \exposid{product-type}{ts...})}.
+\tcode{\exposid{make-sender}(\exposid{just-cpo}, @\exposid{product-type}@{ts...})}.
 
 For \tcode{just}, \tcode{just_error}, and \tcode{just_stopped},
 let \exposid{set-cpo} be


### PR DESCRIPTION
The `\exposid{product-type}` needed some extra `@` symbols surrounding so that the subsequent curly-braces for the constructor call are treated as literal text.