### PR TITLE
[meta.const.eval] make the example compilable

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -2522,7 +2522,7 @@ struct OptBool {
     }
   }
 
-  constexpr auto operator*() -> bool& {
+  constexpr auto operator*() const -> const bool& {
     return b;
   }
 };


### PR DESCRIPTION
As I was implementing `std::is_within_lifetime` I tried to compile the example and fixed its problem.