### PR TITLE
[text.encoding.aliases] Add note about what isn't required

### DIFF
--- a/source/locales.tex
+++ b/source/locales.tex
@@ -5063,6 +5063,11 @@ struct text_encoding::aliases_view : ranges::view_interface<text_encoding::alias
 \tcode{ranges::\libconcept{view}},
 \tcode{ranges::\libconcept{random_access_range}}, and
 \tcode{ranges::\libconcept{borrowed_range}}.
+\begin{note}
+\tcode{text_encoding::aliases_view} is not required to satisfy
+\tcode{ranges::}\libconcept{common_range},
+nor \libconcept{default_initializable}.
+\end{note}
 
 \pnum
 Both
@@ -5071,7 +5076,6 @@ Both
 denote \tcode{const char*}.
 
 \pnum
-%FIXME: Is this supposed to be a remark or a requirement? Same above?
 \tcode{ranges::iterator_t<text_encoding::aliases_view>}
 is a constexpr iterator\iref{iterator.requirements.general}.
 \end{itemdescr}


### PR DESCRIPTION
Make it explicit that `copyable` is intended, rather than `semiregular`, and that the return types of `begin()` and `end()` can differ.

Also remove a FIXME comment for something that doesn't need fixing. These requirements on a type are specified in our usual form, it would be wrong to use _Remarks_: or _Requires_: here.