### PR TITLE
[basic.scope.scope] Fix a note about declarations that do not bind names

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -889,8 +889,7 @@ The declaration in a \grammarterm{template-declaration}
 inhabits the same scope as the \grammarterm{template-declaration}.
 \item
 Friend declarations and
-declarations of qualified names and
-template specializations do not bind names\iref{dcl.meaning};
+declarations of template specializations do not bind names\iref{dcl.meaning};
 those with qualified names target a specified scope, and
 other friend declarations and
 certain \grammarterm{elaborated-type-specifier}s\iref{dcl.type.elab}


### PR DESCRIPTION
The note is saying that declarations of qualified names do not bind names, but this is not supported by normative wording in [dcl.meaning]. @opensdh suggested that this is a leftover from P1787R4 (R6 is what was voted in).

This was discussed in Mattermost (https://chat.isocpp.org/general/pl/1rjh7gn95ifg9kx11kgibcg1fw) and on the Core reflector (https://lists.isocpp.org/core/2024/08/16249.php).

CC @jensmaurer 