### PR TITLE
[expr.prim.lambda.capture] Incorporate ellipsis into "captured by copy" definition

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2625,8 +2625,8 @@ the captured entity is not \tcode{*\keyword{this}}, or
 \item
 it is explicitly captured with a capture that is not of the form
 \keyword{this},
-\tcode{\&} \grammarterm{identifier}, or
-\tcode{\&} \grammarterm{identifier} \grammarterm{initializer}.
+\tcode{\&} \grammarterm{identifier} \opt{\tcode{...}}, or
+\tcode{\&} \opt{\tcode{...}} \grammarterm{identifier} \grammarterm{initializer}.
 \end{itemize}
 For each entity captured by copy, an
 unnamed non-static data member is declared in the closure type. The declaration order of


### PR DESCRIPTION
It would be quite strange if captures starting with `&` would suddenly be captured by copy because of presence of ellipsis.