### PR TITLE
(library-wide) Remove `inline` from variable templates

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -464,7 +464,7 @@ namespace std::execution {
   enum class forward_progress_guarantee;
   inline constexpr get_forward_progress_guarantee_t get_forward_progress_guarantee{};
   template<class CPO>
-    inline constexpr get_completion_scheduler_t<CPO> get_completion_scheduler{};
+    constexpr get_completion_scheduler_t<CPO> get_completion_scheduler{};
 
   struct empty_env {};
   struct get_env_t { @\unspec@ };
@@ -550,7 +550,7 @@ namespace std::execution {
 
   template<class Sndr, class Env = empty_env>
       requires @\libconcept{sender_in}@<Sndr, Env>
-    inline constexpr bool sends_stopped = @\seebelow@;
+    constexpr bool sends_stopped = @\seebelow@;
 
   template<class Sndr, class Env>
     using @\exposidnc{single-sender-value-type}@ = @\seebelownc@;                 // \expos
@@ -4827,7 +4827,7 @@ namespace std::execution {
 
   template<class Sndr, class Env = empty_env>
       requires @\libconcept{sender_in}@<Sndr, Env>
-    inline constexpr bool sends_stopped =
+    constexpr bool sends_stopped =
       !@\libconcept{same_as}@<@\exposid{type-list}@<>,
                @\exposid{gather-signatures}@<set_stopped_t, completion_signatures_of_t<Sndr, Env>,
                                  @\exposid{type-list}@, @\exposid{type-list}@>>;

--- a/source/time.tex
+++ b/source/time.tex
@@ -10834,7 +10834,7 @@ the library only provides the following specialization
 of \tcode{enable_nonlocking_formatter_optimization}:
 \begin{codeblock}
 template<class Rep, class Period>
-  inline constexpr bool enable_nonlocking_formatter_optimization<
+  constexpr bool enable_nonlocking_formatter_optimization<
     chrono::duration<Rep, Period>> =
       enable_nonlocking_formatter_optimization<Rep>;
 \end{codeblock}
@@ -10845,7 +10845,7 @@ the library only provides the following specialization of
 \tcode{enable_nonlocking_formatter_optimization}:
 \begin{codeblock}
 template<class Duration>
-  inline constexpr bool enable_nonlocking_formatter_optimization<
+  constexpr bool enable_nonlocking_formatter_optimization<
     chrono::zoned_time<Duration, const std::chrono::time_zone*>> = true;
 \end{codeblock}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15896,7 +15896,7 @@ namespace std {
 
   template<ranges::input_range R>
       requires (format_kind<R> != range_format::disabled)
-    inline constexpr bool enable_nonlocking_formatter_optimization<R> = false;
+    constexpr bool enable_nonlocking_formatter_optimization<R> = false;
 
   // \ref{format.arguments}, arguments
   // \ref{format.arg}, class template \tcode{basic_format_arg}
@@ -18799,7 +18799,7 @@ namespace std {
   };
 
   template<class... Ts>
-    inline constexpr bool enable_nonlocking_formatter_optimization<@\placeholder{pair-or-tuple}@<Ts...>> =
+    constexpr bool enable_nonlocking_formatter_optimization<@\placeholder{pair-or-tuple}@<Ts...>> =
       (enable_nonlocking_formatter_optimization<Ts> && ...);
 }
 \end{codeblock}


### PR DESCRIPTION
Removes extraneous `inline` from the definitions of variable templates in [format.syn], [format.tuple], [time.format], [execution.syn], and [exec.util.cmplsig].