### PR TITLE
[dcl.type.elab] Remove normative duplication about name binding

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1572,7 +1572,10 @@ class-key nested-name-specifier \opt{\keyword{template}} simple-template-id
 \end{ncsimplebnf}
 Any unqualified lookup for the \grammarterm{identifier} (in the first case)
 does not consider scopes that contain
-the nearest enclosing namespace or block scope; no name is bound.
+the nearest enclosing namespace or block scope.
+\begin{note}
+Friend declarations do not bind names\iref{dcl.meaning}.
+\end{note}
 \begin{note}
 A \grammarterm{using-directive} in the target scope is ignored
 if it refers to a namespace not contained by that scope.


### PR DESCRIPTION
[[dcl.type.elab]/4](https://eel.is/c++draft/dcl.type.elab#4.sentence-1) goes out of its way to normatively specify that elaborated type specifiers in friend declarations do not bind names, despite a blanket statement in [[dcl.meaning.general]/2.1](https://eel.is/c++draft/dcl.meaning.general#2.1) that (all) friend declarations do not bind names.

I suggest to turn this into a note referencing [dcl.meaning], or remove it altogether.