### PR TITLE
[dcl.type.elab] Remove redundant full stop

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1604,7 +1604,7 @@ This implies that, within a class template with a template
 \begin{codeblock}
 friend class T;
 \end{codeblock}
-is ill-formed. However, the similar declaration \tcode{friend T;} is well-formed.\iref{class.friend}.
+is ill-formed. However, the similar declaration \tcode{friend T;} is well-formed\iref{class.friend}.
 \end{note}
 
 \pnum


### PR DESCRIPTION
There is full stop after the reference.