### PR TITLE
[numerics] correct typo Bessell -> Bessel

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -10143,7 +10143,7 @@ See also \ref{sf.cmath.ellint.3}.
 \indexlibraryglobal{cyl_bessel_if}%
 \indexlibraryglobal{cyl_bessel_il}%
 \indextext{Bessel functions!$\mathsf{I}_\nu$}%
-\indextext{I nu@$\mathsf{I}_\nu$ (Bessell functions)}%
+\indextext{I nu@$\mathsf{I}_\nu$ (Bessel functions)}%
 \begin{itemdecl}
 @\placeholder{floating-point-type}@ cyl_bessel_i(@\placeholder{floating-point-type}@ nu, @\placeholder{floating-point-type}@ x);
 float        cyl_bessel_if(float nu, float x);
@@ -10186,7 +10186,7 @@ See also \ref{sf.cmath.cyl.bessel.j}.
 \indexlibraryglobal{cyl_bessel_jf}%
 \indexlibraryglobal{cyl_bessel_jl}%
 \indextext{Bessel functions!$\mathsf{J}_\nu$}%
-\indextext{J nu@$\mathsf{J}_\nu$ (Bessell functions)}%
+\indextext{J nu@$\mathsf{J}_\nu$ (Bessel functions)}%
 \begin{itemdecl}
 @\placeholder{floating-point-type}@ cyl_bessel_j(@\placeholder{floating-point-type}@ nu, @\placeholder{floating-point-type}@ x);
 float        cyl_bessel_jf(float nu, float x);
@@ -10226,7 +10226,7 @@ if \tcode{nu >= 128}.
 \indexlibraryglobal{cyl_bessel_kf}%
 \indexlibraryglobal{cyl_bessel_kl}%
 \indextext{Bessel functions!$\mathsf{K}_\nu$}%
-\indextext{K nu@$\mathsf{K}_\nu$ (Bessell functions)}%
+\indextext{K nu@$\mathsf{K}_\nu$ (Bessel functions)}%
 \begin{itemdecl}
 @\placeholder{floating-point-type}@ cyl_bessel_k(@\placeholder{floating-point-type}@ nu, @\placeholder{floating-point-type}@ x);
 float        cyl_bessel_kf(float nu, float x);


### PR DESCRIPTION
In three places, correct typo Bessell -> Bessel