### PR TITLE
[fs.class.directory.entry.general] Remove unneeded "unneeded"

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -16121,7 +16121,7 @@ is shown above as a friend of class \tcode{directory_entry}.
 Friendship allows the \tcode{directory_iterator} implementation to cache
 already available attribute values
 directly into a \tcode{directory_entry} object
-without the cost of an unneeded call to \tcode{refresh()}.
+without the cost of a call to \tcode{refresh()}.
 \end{note}
 
 \pnum


### PR DESCRIPTION
It is a bit tautological to say "unneeded call" in a note, because implementations should always prevent unneeded calls.