### PR TITLE
[optional.syn] Use `decay_t<T>` directly instead of "see below"

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -3238,7 +3238,7 @@ namespace std {
     constexpr void swap(optional<T>&, optional<T>&) noexcept(@\seebelow@);
 
   template<class T>
-    constexpr optional<@\seebelow@> make_optional(T&&);
+    constexpr optional<decay_t<T>> make_optional(T&&);
   template<class T, class... Args>
     constexpr optional<T> make_optional(Args&&... args);
   template<class T, class U, class... Args>


### PR DESCRIPTION
The `@\seebelow@` has been present since a307ec1e76cbe1c4f76f25fab3371177154f64be, but it's unclear to me why it was preferred. Perhaps it would be an improvement to make the return type clearer in the synopsis.