### PR TITLE
[utility.syn, flat.map.defn] Remove all [[nodiscard]] from library wording

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -15999,7 +15999,7 @@ namespace std {
     const_reverse_iterator crend() const noexcept;
 
     // \ref{flat.map.capacity}, capacity
-    [[nodiscard]] bool empty() const noexcept;
+    bool empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
 
@@ -17187,7 +17187,7 @@ namespace std {
     const_reverse_iterator crend() const noexcept;
 
     // capacity
-    [[nodiscard]] bool empty() const noexcept;
+    bool empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
 
@@ -17743,7 +17743,7 @@ namespace std {
     const_reverse_iterator crend() const noexcept;
 
     // capacity
-    [[nodiscard]] bool empty() const noexcept;
+    bool empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
 
@@ -18406,7 +18406,7 @@ namespace std {
     const_reverse_iterator crend() const noexcept;
 
     // capacity
-    [[nodiscard]] bool empty() const noexcept;
+    bool empty() const noexcept;
     size_type size() const noexcept;
     size_type max_size() const noexcept;
 
@@ -23204,7 +23204,7 @@ namespace std {
       constexpr reference operator[](const array<OtherIndexType, rank()>& indices) const;
 
     constexpr size_type size() const noexcept;
-    [[nodiscard]] constexpr bool empty() const noexcept;
+    constexpr bool empty() const noexcept;
 
     friend constexpr void swap(mdspan& x, mdspan& y) noexcept;
 
@@ -23670,7 +23670,7 @@ is representable as a value of type \tcode{size_type}\iref{basic.fundamental}.
 
 \indexlibrarymember{empty}{mdspan}%
 \begin{itemdecl}
-[[nodiscard]] constexpr bool empty() const noexcept;
+constexpr bool empty() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -58,7 +58,7 @@ namespace std {
   template<class T>
     constexpr T&& forward(remove_reference_t<T>&& t) noexcept;
   template<class T, class U>
-    [[nodiscard]] constexpr auto forward_like(U&& x) noexcept -> @\seebelow@;
+    constexpr auto forward_like(U&& x) noexcept -> @\seebelow@;
   template<class T>
     constexpr remove_reference_t<T>&& move(T&&) noexcept;
   template<class T>


### PR DESCRIPTION
After extensive discussion about [[nodiscard]] policy in LEWG, it was agreed that [[nodiscard]] should not appear in the library wording (see [SD-9](https://isocpp.org/std/standing-documents/sd-9-library-evolution-policies)). However, the wording removal paper, P2422R1 (approved in St. Louis, #7110), does not seem to remove all occurrences of [[nodiscard]] in the library clauses due to some recently added [[nodiscard]] annotation (such as those on flat containers’ `empty()`) being missed.

Therefore, this PR removes all occurrences of [[nodiscard]] in N4988. Those are:
- 22.2.1 [utility.syn]
- 24.6.9.2 [flat.map.defn]
- 24.6.10.2 [flat.multimap.defn]
- 24.6.11.2 [flat.set.defn]
- 24.6.12.2 [flat.multiset.defn]
- 24.7.3.6.1 [mdspan.mdspan.overview] and 24.7.3.6.3 [mdspan.mdspan.members]

After the change, the only mention of [[nodiscard]] in the standard is in examples and Core wording.

(I assumed that this is editorial since it seems likely that these are just missed by P2422's wording...)