### PR TITLE
[associative.reqmts.general],[unord.req.general] Fix cross-references to [container.alloc.reqmts] and [container.reqmts]

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2726,12 +2726,12 @@ and \tcode{nh} denotes a non-const rvalue of type \tcode{X::node_type}.
 \pnum
 A type \tcode{X} meets the \defnadj{associative}{container} requirements
 if \tcode{X} meets all the requirements of an allocator-aware
-container\iref{container.reqmts} and
+container\iref{container.alloc.reqmts} and
 the following types, statements, and expressions are well-formed and
 have the specified semantics,
 except that for
 \tcode{map} and \tcode{multimap}, the requirements placed on \tcode{value_type}
-in \ref{container.alloc.reqmts} apply instead to \tcode{key_type}
+in \ref{container.reqmts} apply instead to \tcode{key_type}
 and \tcode{mapped_type}.
 \begin{note}
 For example, in some cases \tcode{key_type} and \tcode{mapped_type}
@@ -4225,11 +4225,11 @@ that models \tcode{\exposconcept{container-compatible-range}<value_type>},
 A type \tcode{X} meets
 the \defnadj{unordered associative}{container} requirements
 if \tcode{X} meets all the requirements of
-an allocator-aware container\iref{container.reqmts} and
+an allocator-aware container\iref{container.alloc.reqmts} and
 the following types, statements, and expressions are well-formed and
 have the specified semantics,
 except that for \tcode{unordered_map} and \tcode{unordered_multimap},
-the requirements placed on \tcode{value_type} in \ref{container.alloc.reqmts}
+the requirements placed on \tcode{value_type} in \ref{container.reqmts}
 apply instead to \tcode{key_type} and \tcode{mapped_type}.
 \begin{note}
 For example, \tcode{key_type} and \tcode{mapped_type}


### PR DESCRIPTION
Both paragraphs incorrectly point to [container.reqmts] instead of [container.alloc.reqmts] for "the requirements of an allocator-aware container".

Both paragraphs state "the requirements placed on `value_type` in [container.alloc.reqmts] apply instead to `key_type` and `mapped_type`" for `map`, `multimap`, `set`, and `multiset`. This would be nonsense, since those containers never allocate or (or allocator-construct) `key_type` or `map_type` objects: _do_ allocator-construct `value_type` objects. The examples in each paragraph also make the error obvious: there are no `CopyAssignable` requirements in [container.alloc.reqmts].

I suspect these pairs of xrefs in each paragraph were transposed sometime in the past and we just haven't noticed.