### PR TITLE
[sf.cmath.assoc.laguerre,sf.cmath.assoc.legendre] Add reference to eq

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -9949,6 +9949,7 @@ of their respective arguments
 \returns
 $\mathsf{L}_n^m(x)$,
 where $\mathsf{L}_n^m$ is given by \eqref{sf.cmath.assoc.laguerre},
+$\mathsf{L}_{n+m}$ is given by \eqref{sf.cmath.laguerre},
 $n$ is \tcode{n},
 $m$ is \tcode{m}, and
 $x$ is \tcode{x}.
@@ -9990,7 +9991,8 @@ of their respective arguments
 \returns
 $\mathsf{P}_\ell^m(x)$,
 where $\mathsf{P}_\ell^m$ is given by \eqref{sf.cmath.assoc.legendre},
-$l$ is \tcode{l},
+$\mathsf{P}_\ell$ is given by \eqref{sf.cmath.legendre},
+$\ell$ is \tcode{l},
 $m$ is \tcode{m}, and
 $x$ is \tcode{x}.
 \begin{formula}{sf.cmath.assoc.legendre}


### PR DESCRIPTION
The associated Laguerre/Legendre functions build on the Laguerre/Legendre functions, which are defined in different equations. Point to them from the associated functions.

Also use the correct \ell as used in the formula.