### PR TITLE
[inplace.vector.cons] "Constructs an object" is redundant

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9768,7 +9768,7 @@ template<@\exposconcept{container-compatible-range}@<T> R>
 \begin{itemdescr}
 \pnum
 \effects
-Constructs an \tcode{inplace_vector} object with
+Constructs an \tcode{inplace_vector} with
 the elements of the range \tcode{rg}.
 
 \pnum


### PR DESCRIPTION
So we don't need this `from_range_t` constructor (and only this constructor) to tell us that the `inplace_vector` it constructs happens to be an object. I should also point out that this is inconsistent with the other constructors which simply say "constructs an `inplace_vector` with [properties]".