### PR TITLE
[expr.delete] Remove stray "the" between words

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5948,7 +5948,7 @@ the program is ill-formed because the lookup set is empty\iref{basic.lookup}.
 \end{note}
 
 \pnum
-The deallocation the function to be called is selected as follows:
+The deallocation function to be called is selected as follows:
 \begin{itemize}
 \item
 If any of the deallocation functions is a destroying operator delete,


### PR DESCRIPTION
Not sure how this got there ...