### PR TITLE
Use itemize list for optional<T>& operator=(U&& v) constraints

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -3767,10 +3767,12 @@ template<class U = T> constexpr optional<T>& operator=(U&& v);
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{is_same_v<remove_cvref_t<U>, optional>} is \tcode{false},
-\tcode{conjunction_v<is_scalar<T>, is_same<T, decay_t<U>>>} is \tcode{false},
-\tcode{is_constructible_v<T, U>} is \tcode{true}, and
-\tcode{is_assignable_v<T\&, U>} is \tcode{true}.
+\begin{itemize}
+\item \tcode{is_same_v<remove_cvref_t<U>, optional>} is \tcode{false},
+\item \tcode{conjunction_v<is_scalar<T>, is_same<T, decay_t<U>>>} is \tcode{false},
+\item \tcode{is_constructible_v<T, U>} is \tcode{true}, and
+\item \tcode{is_assignable_v<T\&, U>} is \tcode{true}.
+\end{itemize}
 
 \pnum
 \effects


### PR DESCRIPTION
Use an itemize list for the constraints on template<class U = T> constexpr optional<T>& operator=(U&& v);
No change to the constraints, just editorial parallelism.