### PR TITLE
[expr.delete] Specify value category of a delete-expression

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5803,7 +5803,7 @@ type
 and the converted operand is used in place of the original operand
 for the remainder of this subclause.
 Otherwise, it shall be a prvalue of pointer to object type.
-The \grammarterm{delete-expression} has type
+The \grammarterm{delete-expression} is a prvalue of type
 \keyword{void}.
 
 \pnum


### PR DESCRIPTION
I found it surprising that we don't specify the value category here but say:
> has type `void`

http://eel.is/c++draft/basic.lval#1.2 generally makes any expression of type `void` a prvalue, so this change is editorial only.

I believe it is a slight improvement because it reduces the reader's dependency on that general rule and makes the wording more conventional. We have the tendency to say "prvalue of type `void`" almost anywhere else, such as in https://eel.is/c++draft/expr.type.conv#2. For better or for worse, that's why I didn't even know about the blanket rule for `void` up until recently.

Perhaps in the long run, since almost any place specifies that `void` expressions are pvalues explicitly, we could even turn it into a note:
> Note: Expressions of type *cv* `void` are always prvalues.