### PR TITLE
[basic.stc.dynamic.general] Strike "during program execution"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3992,8 +3992,7 @@ specified in~\ref{class.copy.elision}.
 \indextext{storage duration!dynamic|(}
 
 \pnum
-Objects can be created dynamically during program
-execution\iref{intro.execution}, using
+Objects can be created dynamically using
 \indextext{\idxcode{new}}%
 \grammarterm{new-expression}{s}\iref{expr.new}, and destroyed using
 \indextext{\idxcode{delete}}%


### PR DESCRIPTION
Since C++20, it is possible to use `new` during program translation, not just during execution, so it is misleading to specify "during program execution" here.

Note that this text has not been changed since C++98.