### PR TITLE
[basic.types.general] Refactor confusing phrase "object and value representation"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4808,10 +4808,14 @@ The \defnx{value representation}{representation!value}
 of a type \tcode{T} is the set of bits
 in the object representation of \tcode{T}
 that participate in representing a value of type \tcode{T}.
-The object and value representation of
-a non-bit-field complete object of type \tcode{T} are
-the bytes and bits, respectively, of
-the object corresponding to the object and value representation of its type.
+The object representation of
+a non-bit-field complete object of type \tcode{T} is
+the bytes of
+the object corresponding to the object representation of its type.
+The value representation of
+a non-bit-field complete object of type \tcode{T} is
+the bits of
+the object corresponding to the value representation of its type.
 The object representation of a bit-field object is
 the sequence of \placeholder{N} bits taken up by the object,
 where \placeholder{N} is the width of the bit-field\iref{class.bit}.


### PR DESCRIPTION
This came up in mailing-list review of D1839R6; @t3nsor rightly suggested I open an editorial issue for this.

There is no such thing as the "object and value representation" of a type; there is only the "object representation" and the "value representation." Refactor the confusing sentence accordingly. This seems to make one of the two new sentences potentially nonsensical, but no worse than it was when it was both grammatically confusing *and* potentially nonsensical.

I suggested that the first new sentence should be more like:

>  The object representation of a non-bit-field complete object of type _cv_ `T` is the <ins>sequence of</ins> bytes of the object corresponding to the object representation of its type.

Still, AFAIK, until P1839 actually lands, there is no "object corresponding to the object representation..." at all. Right now, an object representation is a sequence of unsigned char objects, which (sequence) is not an object. P1839 is what will replace that sequence with a singular array object so that we can meaningfully talk about "the (array) object corresponding to the object representation [of an object]."

Worse, the second new sentence remains nonsensical to me: "The value representation of its type" is not an object at all, it's a set of bits. And if we mean "The value representation of a non-bit-field complete object of type `T` consists of the bits in the value representation of its type," well, that's just tautological, isn't it?