### PR TITLE
[ios.init] Remove unused Init::init_cnt static member

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -1132,9 +1132,6 @@ namespace std {
     Init(const Init&) = default;
     ~Init();
     Init& operator=(const Init&) = default;
-
-  private:
-    static int init_cnt;        // \expos
   };
 }
 \end{codeblock}
@@ -1147,17 +1144,6 @@ ensures the construction of the eight objects declared in
 stream buffers with the standard C streams
 provided for by the functions declared in
 \libheaderref{cstdio}.
-
-\pnum
-For the sake of exposition, the maintained data is presented here as:
-\begin{itemize}
-\item
-\tcode{static int init_cnt},
-counts the number of
-constructor and destructor calls for class
-\tcode{Init},
-initialized to zero.
-\end{itemize}
 
 \indexlibraryctor{ios_base::Init}%
 \begin{itemdecl}


### PR DESCRIPTION
The text that made use of this variable was removed by LWG1123 and has not been present in the WP since N3090. The effects of `Init` construction and destruction are specified entirely without the use of this variable, so it serves no purpose now.

LWG1123 even noted that this variable could be dropped, stating "Some editorial changes are expected (in addition to the proposed wording) to remove `init_cnt` from `Init`." Let's do that. Better late than never.