### PR TITLE
[tab:lex.charset.literal] Shorten table heading

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -410,7 +410,7 @@ The \defnadj{basic literal}{character set} consists of
 all characters of the basic character set,
 plus the control characters specified in \tref{lex.charset.literal}.
 
-\begin{floattable}{Additional control characters in the basic literal character set}{lex.charset.literal}{ll}
+\begin{floattable}{Additional control characters}{lex.charset.literal}{ll}
 \topline
 \ohdrx{2}{character} \\ \capsep
 \ucode{0000} & \uname{null} \\

--- a/source/regex.tex
+++ b/source/regex.tex
@@ -784,8 +784,7 @@ expression object, modified according to the effects listed in \tref{re.matchfla
 any bitmask elements set.
 
 \begin{longlibefftab}
-  {\tcode{regex_constants::match_flag_type} effects when obtaining a match against a
-     character container sequence \range{first}{last}.}
+  {\tcode{regex_constants::match_flag_type} effects}
   {re.matchflag}
 %
 \indexlibraryglobal{match_not_bol}%


### PR DESCRIPTION
Fixes ISO/CS comment (C++23 proof)