### PR TITLE
[std] Format URLs in blue regular font

### DIFF
--- a/source/std.tex
+++ b/source/std.tex
@@ -43,6 +43,7 @@
             colorlinks=true,
             linkcolor=blue,
             citecolor=blue,
+            urlcolor=blue,    % ISO/IEC Directives, Part 2, section 6.5
             plainpages=false}
 \usepackage{memhfixc}     % fix interactions between hyperref and memoir
 \usepackage[active,header=false,handles=false,copydocumentclass=false,generate=std-gram.ext,extract-cmdline={gramSec},extract-env={bnf,simplebnf}]{extract} % Grammar extraction
@@ -86,6 +87,10 @@
 %%--------------------------------------------------
 %% turn off all ligatures inside \texttt
 \DisableLigatures{encoding = T1, family = tt*}
+
+%%--------------------------------------------------
+%% select regular text font for \url
+\urlstyle{same}
 
 \begin{document}
 \chapterstyle{cppstd}


### PR DESCRIPTION
See ISO/IEC Directives, Part 2, section 6.5 Supplementary content

Fixes ISO/CS comment (C++23 proof)