### PR TITLE
[styles] Format title of \codeblocktu using 'caption' package

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -587,22 +587,6 @@
 
 \lstnewenvironment{codeblock}{\CodeBlockSetup}{}
 
-% Left-align listings titles
-\makeatletter
-\def\lst@maketitle{\@makeleftcaption\lst@title@dropdelim}
-\long\def\@makeleftcaption#1#2{%
-  \vskip\abovecaptionskip
-  \sbox\@tempboxa{#1: #2}%
-  \ifdim \wd\@tempboxa >\hsize
-    #1: #2\par
-  \else
-    \global \@minipagefalse
-    \hb@xt@\hsize{%\hfil -- REMOVED
-    \box\@tempboxa\hfil}%
-  \fi
-  \vskip\belowcaptionskip}%
-\makeatother
-
 \lstnewenvironment{codeblocktu}[1]{%
 \lstset{title={%\parabullnum{Bullets1}{0pt}
 #1:}}\CodeBlockSetup}{}

--- a/source/styles.tex
+++ b/source/styles.tex
@@ -121,10 +121,10 @@
                   leftmargin=\bnfindentrest, listparindent=-\bnfindentinc, itemindent=\listparindent}
 
 %%--------------------------------------------------
-%%  set caption style
-\captionstyle{\centering}
+%%  set caption styles
 \DeclareCaptionLabelSeparator{emdash}{ --- }
-\captionsetup{labelsep=emdash,font+=bf}
+\captionsetup{justification=centering,labelsep=emdash,font+=bf}
+\captionsetup[lstlisting]{justification=raggedright,singlelinecheck=false,font=normal}
 
 %%--------------------------------------------------
 %% set global styles that get reset by \mainmatter


### PR DESCRIPTION
This restores the C++20 status of the formatting.