### PR TITLE
[tables] Avoid whitespace around float placement by disallowing float pages

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1850,7 +1850,6 @@ If \tcode{a == b} and \tcode{b == c}, then \tcode{a == c}.
 \tcode{<} is a strict weak ordering relation\iref{alg.sorting}    \\
 \end{oldconcepttable}
 
-\enlargethispage{-3\baselineskip}
 \begin{oldconcepttable}{DefaultConstructible}{}{cpp17.defaultconstructible}
 {x{2.15in}p{3in}}
 \topline

--- a/source/tables.tex
+++ b/source/tables.tex
@@ -85,7 +85,7 @@
 % by LaTeX.
 \newenvironment{floattable}[3]
 {
- \begin{floattablebase}{#1}{#2}{#3}{htbp}
+ \begin{floattablebase}{#1}{#2}{#3}{htb}
 }
 {
  \end{floattablebase}
@@ -124,7 +124,7 @@
 % by vertical lines. Used in the "Alternative tokens" table.
 \newenvironment{tokentable}[4]
 {
- \begin{floattablebase}{#1}{#2}{cc|cc|cc}{htbp}
+ \begin{floattablebase}{#1}{#2}{cc|cc|cc}{htb}
  \topline
  \hdstyle{#3}   &   \hdstyle{#4}    &
  \hdstyle{#3}   &   \hdstyle{#4}    &


### PR DESCRIPTION
This is particularly noticeable for Table 1 (basic character set).