### PR TITLE
[complex.numbers.general] Clarify that the template is primary

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -191,7 +191,7 @@ The header \libheader{complex} defines a class template,
 and numerous functions for representing and manipulating complex numbers.
 
 \pnum
-The effect of instantiating the template \tcode{complex} for any type
+The effect of instantiating the primary template of \tcode{complex} for any type
 that is not a cv-unqualified floating-point type\iref{basic.fundamental}
 is unspecified.
 Specializations of \tcode{complex} for cv-unqualified floating-point types


### PR DESCRIPTION
The difference between between "the `complex` template" and "the template named `complex`" (which including program-defined specializations) is obscure. It seems better to cleary say that [complex.numbers.general] only covers the primary template.

Fixes #7270.