### PR TITLE
[except.uncaught] Tidy the specification for uncaught exceptions

### DIFF
--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -1023,8 +1023,10 @@ needed.
 The function \tcode{std::terminate}\iref{except.terminate}
 is used by the exception
 handling mechanism for coping with errors related to the exception handling
-mechanism itself. The function
-\tcode{std::current_exception()}\iref{propagation} and the class
+mechanism itself.
+The function \tcode{std::uncaught_exceptions}\iref{uncaught.exceptions}
+reports how many exceptions are uncaught in the current thread.
+The function \tcode{std::current_exception}\iref{propagation} and the class
 \tcode{std::nested_exception}\iref{except.nested} can be used by a program to
 capture the currently handled exception.
 

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -318,6 +318,26 @@ the selected constructor is odr-used\iref{basic.def.odr} and
 the destructor of \tcode{T} is potentially invoked\iref{class.dtor}.
 
 \pnum
+\indextext{exception handling!uncaught}%
+An exception is considered \defnx{uncaught}{uncaught exception}
+after completing the initialization of the exception object
+until completing the activation of a handler for the exception\iref{except.handle}.
+\begin{note}
+As a consequence, an exception is considered uncaught
+during any stack unwinding resulting from it being thrown.
+\end{note}
+
+\pnum
+\indexlibraryglobal{uncaught_exceptions}%
+If an exception is rethrown\iref{expr.throw,propagation},
+it is considered uncaught from the point of rethrow
+until the rethrown exception is caught.
+\begin{note}
+The function \tcode{std::uncaught_exceptions}\iref{uncaught.exceptions}
+returns the number of uncaught exceptions in the current thread.
+\end{note}
+
+\pnum
 \indextext{exception handling!rethrow}%
 \indextext{rethrow|see{exception handling, rethrow}}%
 An exception is considered caught when a handler for that exception
@@ -331,7 +351,7 @@ it is rethrown.
 \indextext{exception handling!terminate called@\tcode{terminate} called}%
 \indextext{\idxcode{terminate}!called}%
 If the exception handling mechanism
-handling an uncaught exception\iref{except.uncaught}
+handling an uncaught exception
 directly invokes a function that exits via an
 exception, the function \tcode{std::terminate} is invoked\iref{except.terminate}.
 \begin{example}
@@ -1127,21 +1147,4 @@ An implementation is not permitted to finish stack unwinding
 prematurely based on a determination that the unwind process
 will eventually cause an invocation of the function
 \tcode{std::terminate}.
-
-\rSec2[except.uncaught]{The \tcode{std::uncaught_exceptions} function}%
-\indexlibraryglobal{uncaught_exceptions}
-
-\pnum
-An exception is considered uncaught
-after completing the initialization of the exception object\iref{except.throw}
-until completing the activation of a handler for the exception\iref{except.handle}.
-\begin{note}
-As a consequence, an exception is considered uncaught
-during any stack unwinding resulting from it being thrown.
-\end{note}
-If an exception is rethrown\iref{expr.throw,propagation},
-it is considered uncaught from the point of rethrow
-until the rethrown exception is caught.
-The function \tcode{std::uncaught_exceptions}\iref{uncaught.exceptions}
-returns the number of uncaught exceptions in the current thread.%
 \indextext{exception handling|)}

--- a/source/support.tex
+++ b/source/support.tex
@@ -4013,7 +4013,7 @@ int uncaught_exceptions() noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-The number of uncaught exceptions\iref{except.uncaught}.
+The number of uncaught exceptions\iref{except.throw} in the current thread.
 
 \pnum
 \remarks

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -95,6 +95,9 @@
 \movedxref{stoptoken.cons}{stopsource}
 \movedxref{stoptoken.nonmembers}{stopsource}
 
+% https://github.com/cplusplus/draft/pull/7276
+\movedxref{except.uncaught}{except.throw}
+
 % https://github.com/cplusplus/draft/pull/7345
 \movedxref{basic.stc.inherit}{basic.stc.general}
 


### PR DESCRIPTION
Several concurrent fixes.  First include the normative wording that 'uncaught_exceptions' returns the number of uncaught exceptions *on the current thread*.  This wording is present in the core language.

Then move the core wording for when an exception is uncaught directly into the text that talks about caught and uncaught exceptions.  In the process, turn the reference to into a note, so that there is only one normative specification.

Finally, remove [except.uncaught] as it is now empty, and add the missing descriptive sentence to the intro paragraph of [except.special.general].  This happens to produce quite a pleasing page-break, but that is just luck, not design.