### PR TITLE
[ostream.inserters.arithmetic] Put use_facet use on fewer lines

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -6432,9 +6432,8 @@ or
 \tcode{const void*},
 the formatting conversion occurs as if it performed the following code fragment:
 \begin{codeblock}
-bool failed = use_facet<
-  num_put<charT, ostreambuf_iterator<charT, traits>>
-    >(getloc()).put(*this, *this, fill(), val).failed();
+bool failed = use_facet<num_put<charT, ostreambuf_iterator<charT, traits>>>(
+    getloc()).put(*this, *this, fill(), val).failed();
 \end{codeblock}
 
 When \tcode{val} is of type
@@ -6442,9 +6441,8 @@ When \tcode{val} is of type
 the formatting conversion occurs as if it performed the following code fragment:
 \begin{codeblock}
 ios_base::fmtflags baseflags = ios_base::flags() & ios_base::basefield;
-bool failed = use_facet<
-  num_put<charT, ostreambuf_iterator<charT, traits>>
-    >(getloc()).put(*this, *this, fill(),
+bool failed = use_facet<num_put<charT, ostreambuf_iterator<charT, traits>>>(
+  getloc()).put(*this, *this, fill(),
     baseflags == ios_base::oct || baseflags == ios_base::hex
       ? static_cast<long>(static_cast<unsigned short>(val))
       : static_cast<long>(val)).failed();
@@ -6455,9 +6453,8 @@ When \tcode{val} is of type
 the formatting conversion occurs as if it performed the following code fragment:
 \begin{codeblock}
 ios_base::fmtflags baseflags = ios_base::flags() & ios_base::basefield;
-bool failed = use_facet<
-  num_put<charT, ostreambuf_iterator<charT, traits>>
-    >(getloc()).put(*this, *this, fill(),
+bool failed = use_facet<num_put<charT, ostreambuf_iterator<charT, traits>>>(
+  getloc()).put(*this, *this, fill(),
     baseflags == ios_base::oct || baseflags == ios_base::hex
       ? static_cast<long>(static_cast<unsigned int>(val))
       : static_cast<long>(val)).failed();
@@ -6469,20 +6466,16 @@ or
 \tcode{unsigned int}
 the formatting conversion occurs as if it performed the following code fragment:
 \begin{codeblock}
-bool failed = use_facet<
-  num_put<charT, ostreambuf_iterator<charT, traits>>
-    >(getloc()).put(*this, *this, fill(),
-      static_cast<unsigned long>(val)).failed();
+bool failed = use_facet<num_put<charT, ostreambuf_iterator<charT, traits>>>(
+  getloc()).put(*this, *this, fill(), static_cast<unsigned long>(val)).failed();
 \end{codeblock}
 
 When \tcode{val} is of type
 \tcode{float}
 the formatting conversion occurs as if it performed the following code fragment:
 \begin{codeblock}
-bool failed = use_facet<
-  num_put<charT, ostreambuf_iterator<charT, traits>>
-    >(getloc()).put(*this, *this, fill(),
-      static_cast<double>(val)).failed();
+bool failed = use_facet<num_put<charT, ostreambuf_iterator<charT, traits>>>(
+  getloc()).put(*this, *this, fill(), static_cast<double>(val)).failed();
 \end{codeblock}
 
 \pnum
@@ -6539,20 +6532,16 @@ If the floating-point conversion rank of \tcode{\placeholder{extended-floating-p
 is less than or equal to that of \tcode{double},
 the formatting conversion occurs as if it performed the following code fragment:
 \begin{codeblock}
-bool failed = use_facet<
-  num_put<charT, ostreambuf_iterator<charT, traits>>
-    >(getloc()).put(*this, *this, fill(),
-      static_cast<double>(val)).failed();
+bool failed = use_facet<num_put<charT, ostreambuf_iterator<charT, traits>>>(
+  getloc()).put(*this, *this, fill(), static_cast<double>(val)).failed();
 \end{codeblock}
 Otherwise,
 if the floating-point conversion rank of \tcode{\placeholder{extended-floating-point-type}}
 is less than or equal to that of \tcode{long double},
 the formatting conversion occurs as if it performed the following code fragment:
 \begin{codeblock}
-bool failed = use_facet<
-  num_put<charT, ostreambuf_iterator<charT, traits>>
-    >(getloc()).put(*this, *this, fill(),
-      static_cast<long double>(val)).failed();
+bool failed = use_facet<num_put<charT, ostreambuf_iterator<charT, traits>>>(
+  getloc()).put(*this, *this, fill(), static_cast<long double>(val)).failed();
 \end{codeblock}
 Otherwise, an invocation of the operator function is conditionally supported
 with \impldef{\tcode{operator<<} for large extended floating-point types}


### PR DESCRIPTION
This is more compact, keeps the whole template-id on a single line, and avoids some awkward page breaks.