### PR TITLE
[except.handle] Remove confusing comparison to variadic functions

### DIFF
--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -604,10 +604,7 @@ A
 \tcode{...}
 in a handler's
 \grammarterm{exception-declaration}
-functions similarly to
-\tcode{...}
-in a function parameter declaration;
-it specifies a match for any exception.
+specifies a match for any exception.
 If present, a
 \tcode{...}
 handler shall be the last handler for its try block.


### PR DESCRIPTION
The analogy that the ellipsis in an exception handler was similar to an ellipsis in a function declaration may have made sense at one time, but the comparison with a syntax using a macro based API calling 'va_arg' to access its contents --- something that is not possible for an exception handler --- seems more confusing than helpful today.