### PR TITLE
[depr.lit] Fix grammar according to P2361R6

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -171,7 +171,7 @@ that these implicit definitions are deleted\iref{dcl.fct.def.delete}.
 \pnum
 A \grammarterm{literal-operator-id}\iref{over.literal} of the form
 \begin{codeblock}
-operator @\grammarterm{string-literal}@ @\grammarterm{identifier}@
+operator @\grammarterm{unevaluated-string}@ @\grammarterm{identifier}@
 \end{codeblock}
 is deprecated.
 


### PR DESCRIPTION
P2361R6 introduced the notion of unevaluated strings, and updated the grammar for literal operator function accodingly. Unfortunely, the corresponding grammar reference that was deprecated was not similarly updated.