### PR TITLE
[except.terminate] Better describe the  function `terminate`

### DIFF
--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -1012,9 +1012,10 @@ capture the currently handled exception.
 
 \pnum
 \indextext{\idxcode{terminate}}%
-% FIXME: What does it mean to abandon exception handling?
-In some situations, exception handling is abandoned
-for less subtle error handling techniques.
+Some errors in a program cannot be recovered from, such as when an exception
+is not handled or a \tcode{std::thread} object is destroyed while its thread
+function is still executing. In such cases,
+the function \tcode{std::terminate}\iref{exception.terminate} is invoked.
 \begin{note}
 These situations are:
 \indextext{\idxcode{terminate}!called}%
@@ -1108,8 +1109,6 @@ whose promise type has an \tcode{unhandled_stopped} member function.
 
 \pnum
 \indextext{\idxcode{terminate}}%
-In such cases,
-the function \tcode{std::terminate} is invoked\iref{exception.terminate}.
 In the situation where no matching handler is found, it is
 \impldef{stack unwinding before invocation of \tcode{std::terminate}}
 whether or not the stack is unwound


### PR DESCRIPTION
While `std:terminate` was originally conceived as the way to report failures in the exception handling machinery, it has evolved to become a more general tool for reporting unrecoverable failures in the C++ runtime.  This rewording attempts to address that evolving design, and in doing so addresses the outstanding %FIXME% that the current text is not adequately descriptive in the first place.