### PR TITLE
[except.ctor] Retitle subclause as 'stack unwinding'

### DIFF
--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -359,7 +359,7 @@ If a destructor directly invoked by stack unwinding exits via an exception,
 \end{note}
 
 
-\rSec1[except.ctor]{Constructors and destructors}%
+\rSec1[except.ctor]{Stack unwinding}%
 \indextext{exception handling!constructors and destructors}%
 \indextext{constructor!exception handling|see{exception handling, constructors and destructors}}%
 \indextext{destructor!exception handling|see{exception handling, constructors and destructors}}


### PR DESCRIPTION
The purpose of this subclause is to define stack unwinding, which in specified in terms of the lifetime of objects, not just class types.  Hence, while much of the text is addressing interactions with contructors and destructors (the original subclause title) it does more than just that.