### PR TITLE
[except.handle] group all paragraphs on searching for a handler

### DIFF
--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -619,6 +619,40 @@ handler continues in a dynamically surrounding try block
 of the same thread.
 
 \pnum
+\indextext{exception handling!terminate called@\tcode{terminate} called}%
+\indextext{\idxcode{terminate}!called}%
+If the search for a handler
+encounters the outermost block of a function with a
+non-throwing exception specification,
+the function \tcode{std::terminate}\iref{except.terminate} is invoked.
+\begin{note}
+An implementation is not permitted to reject an expression merely because, when
+executed, it throws or might
+throw an exception from a function with a non-throwing exception specification.
+\end{note}
+\begin{example}
+\begin{codeblock}
+extern void f();                // potentially-throwing
+
+void g() noexcept {
+  f();                          // valid, even if \tcode{f} throws
+  throw 42;                     // valid, effectively a call to \tcode{std::terminate}
+}
+\end{codeblock}
+The call to
+\tcode{f}
+is well-formed despite the possibility for it to throw an exception.
+\end{example}
+
+\pnum
+If no matching handler is found,
+the function \tcode{std::terminate} is invoked;
+whether or not the stack is unwound before this invocation of
+\tcode{std::terminate}
+is \impldef{stack unwinding before invocation of
+\tcode{std::terminate}}\iref{except.terminate}.
+
+\pnum
 A handler is considered \defnx{active}{exception handling!handler!active} when
 initialization is complete for the parameter (if any) of the catch clause.
 \begin{note}
@@ -634,14 +668,6 @@ catch clause exits.
 The exception with the most recently activated handler that is
 still active is called the
 \defnx{currently handled exception}{exception handling!currently handled exception}.
-
-\pnum
-If no matching handler is found,
-the function \tcode{std::terminate} is invoked;
-whether or not the stack is unwound before this invocation of
-\tcode{std::terminate}
-is \impldef{stack unwinding before invocation of
-\tcode{std::terminate}}\iref{except.terminate}.
 
 \pnum
 Referring to any non-static member or base class of an object
@@ -805,33 +831,6 @@ has a potentially-throwing exception specification,
 whereas
 \tcode{B::f}
 has a non-throwing exception specification.
-\end{example}
-
-\pnum
-\indextext{exception handling!terminate called@\tcode{terminate} called}%
-\indextext{\idxcode{terminate}!called}%
-Whenever an exception is thrown
-and the search for a handler\iref{except.handle}
-encounters the outermost block of a function with a
-non-throwing exception specification,
-the function \tcode{std::terminate} is invoked\iref{except.terminate}.
-\begin{note}
-An implementation is not permitted to reject an expression merely because, when
-executed, it throws or might
-throw an exception from a function with a non-throwing exception specification.
-\end{note}
-\begin{example}
-\begin{codeblock}
-extern void f();                // potentially-throwing
-
-void g() noexcept {
-  f();                          // valid, even if \tcode{f} throws
-  throw 42;                     // valid, effectively a call to \tcode{std::terminate}
-}
-\end{codeblock}
-The call to
-\tcode{f}
-is well-formed despite the possibility for it to throw an exception.
 \end{example}
 
 \pnum


### PR DESCRIPTION
This commit moves all of the paragraphs involved in the search for a handler for an exception into a single logical sequence.

After this change, [except.spec] deals only with specifying the `noexcept` function decorator and its interaction with the `noexcept` operator, and contains no text regarding exceptions themselves.  It might be appropriate to move that subclause into the [dcl] structure at a future date.