### PR TITLE
[temp.pre] Fix note about uniqueness of a template name in a scope

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -143,12 +143,26 @@ instantiation\iref{temp.decls} and must obey the one-definition rule\iref{basic.
 \begin{note}
 A template cannot have the same name as any other
 name bound in the same scope\iref{basic.scope.scope}, except
-that a function template can share a name with non-template
-functions\iref{dcl.fct} and/or function templates\iref{temp.over}.
+that a function template can share a name with \grammarterm{using-declarator}s,
+a type, non-template functions\iref{dcl.fct} and/or function templates\iref{temp.over}.
 Specializations, including partial specializations\iref{temp.spec.partial},
 do not reintroduce or bind names.
 Their target scope is the target scope of the primary template,
 so all specializations of a template belong to the same scope as it does.
+\begin{example}
+\begin{codeblock}
+void f() {}
+class f {};                                     // OK
+namespace N {
+  void f(int) {}
+}
+using N::f;                                     // OK
+template<typename> void f(long) {}              // \#1, OK
+template<typename> void f(long) {}              // error: redefinition of \#1
+template<typename> void f(long long) {}         // OK
+template<>         void f<int>(long long) {}    // OK, doesn't bind a name
+\end{codeblock}
+\end{example}
 \end{note}
 
 \pnum


### PR DESCRIPTION
https://eel.is/c++draft/temp.pre#7 was normative wording that was converted into a note by [P1787R6](https://wg21.link/p1787r6). The first half of it reads:
> A template cannot have the same name as any other name bound in the same scope ([[basic.scope.scope]](https://eel.is/c++draft/basic.scope.scope)), except that a function template can share a name with non-template functions ([[dcl.fct]](https://eel.is/c++draft/dcl.fct)) and/or function templates ([[temp.over]](https://eel.is/c++draft/temp.over))[.](https://eel.is/c++draft/temp.pre#7.sentence-1)

I think it refers to wording about which declarations correspond (and consequently might conflict, rendering the program ill-formed), but it only reflects [[basic.scope.scope]/4.3](https://eel.is/c++draft/basic.scope#scope-4.3). The problem is that it's worded in a way that claims completeness, despite omitting [4.1](https://eel.is/c++draft/basic.scope#scope-4.1) (using-declarators) and [4.2](https://eel.is/c++draft/basic.scope#scope-4.2) (types not conflicting with non-types, including function templates).

This PR makes the note complete, and adds an example that focuses on function templates.