### PR TITLE
[array.creation] Clarify Mandates for `to_array` overloads

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -6460,7 +6460,7 @@ template<class T, size_t N>
 \pnum
 \mandates
 \tcode{is_array_v<T>} is \tcode{false} and
-\tcode{is_constructible_v<T, T\&>} is \tcode{true}.
+\tcode{is_constructible_v<remove_cv_t<T>, T\&>} is \tcode{true}.
 
 \pnum
 \expects
@@ -6481,7 +6481,7 @@ template<class T, size_t N>
 \pnum
 \mandates
 \tcode{is_array_v<T>} is \tcode{false} and
-\tcode{is_move_constructible_v<T>} is \tcode{true}.
+\tcode{is_constructible_v<remove_cv_t<T>, T>} is \tcode{true}.
 
 \pnum
 \expects


### PR DESCRIPTION
It's confusing that these `to_array` overloads require `T` to be constructible from various types, when they actually construct `remove_cv_t<T>` objects. We experts know that initialization doesn't depend on the cv-qualification of the target type ([dcl.init.general]/16) but there's no need to make readers jump through hoops to understand the spec.