### PR TITLE
[over.oper.general]: Avoid use of the term "basic type"

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3380,14 +3380,14 @@ operator function.
 \pnum
 \indextext{operator}%
 \begin{note}
-The identities among certain predefined operators applied to basic types
+The identities among certain predefined operators applied to fundamental types
 (for example,
 \tcode{++a} $\equiv$
 \tcode{a+=1})
 need not hold for operator functions.
 Some predefined operators, such as
 \tcode{+=},
-require an operand to be an lvalue when applied to basic types;
+require an operand to be an lvalue when applied to fundamental types;
 this is not required by operator functions.
 \end{note}
 


### PR DESCRIPTION
The term "basic type" is used twice in this note but it's never defined anywhere. It's not used anywhere else either.

---

A similar fix was done in https://github.com/cplusplus/draft/pull/6012, so I was thinking we could do the same here. Alternatively, we could use "arithmetic types" instead of "fundamental types".