### PR TITLE
[container.requirements] Index missing members of flat containers

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -122,6 +122,10 @@ concept @\defexposconcept{container-compatible-range}@ =    // \expos
 \indexlibrarymemberx{unordered_set}{#1}%
 \indexlibrarymemberx{unordered_multiset}{#1}%
 \indexlibrarymemberx{unordered_multimap}{#1}%
+\indexlibrarymemberx{flat_map}{#1}%
+\indexlibrarymemberx{flat_set}{#1}%
+\indexlibrarymemberx{flat_multiset}{#1}%
+\indexlibrarymemberx{flat_multimap}{#1}%
 }
 
 \pnum
@@ -733,6 +737,10 @@ is well-formed when treated as an unevaluated operand.
 \indexlibrarymemberx{unordered_set}{#1}%
 \indexlibrarymemberx{unordered_multiset}{#1}%
 \indexlibrarymemberx{unordered_multimap}{#1}%
+\indexlibrarymemberx{flat_map}{#1}%
+\indexlibrarymemberx{flat_set}{#1}%
+\indexlibrarymemberx{flat_multiset}{#1}%
+\indexlibrarymemberx{flat_multimap}{#1}%
 }
 
 \pnum
@@ -2747,6 +2755,10 @@ need to be \oldconcept{CopyAssignable} even though the associated
 \indexlibrary{\idxcode{map}!\idxcode{#1}}%
 \indexlibrary{\idxcode{multiset}!\idxcode{#1}}%
 \indexlibrary{\idxcode{multimap}!\idxcode{#1}}%
+\indexlibrary{\idxcode{flat_set}!\idxcode{#1}}%
+\indexlibrary{\idxcode{flat_map}!\idxcode{#1}}%
+\indexlibrary{\idxcode{flat_multiset}!\idxcode{#1}}%
+\indexlibrary{\idxcode{flat_multimap}!\idxcode{#1}}%
 }
 
 \indexordmem{key_type}%
@@ -18039,7 +18051,7 @@ The returned iterator points to the element
 whose key is equivalent to \tcode{x}.
 \end{itemdescr}
 
-\indexlibrarymember{insert}{flatset}%
+\indexlibrarymember{insert}{flat_set}%
 \begin{itemdecl}
 template<class InputIterator>
   void insert(InputIterator first, InputIterator last);
@@ -18132,7 +18144,7 @@ ranges::swap(@\exposid{c}@, y.@\exposid{c}@);
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{extract}{flatset}%
+\indexlibrarymember{extract}{flat_set}%
 \begin{itemdecl}
 container_type extract() &&;
 \end{itemdecl}


### PR DESCRIPTION
Add the missing containers to index the operations defined by the container requirements clauses.