### PR TITLE
[priqueue.cons.alloc] Add missing initialization for comp

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -15285,8 +15285,9 @@ template<@\exposconcept{container-compatible-range}@<T> R, class Alloc>
 \pnum
 \effects
 Initializes
-\tcode{c} with \tcode{ranges::to<Container>(std::forward<R>(rg), a)};
-calls \tcode{make_heap(c.\linebreak begin(), c.end(), comp)}.
+\tcode{c} with \tcode{ranges::to<Container>(std::forward<R>(rg), a)}
+and value-initializes \tcode{comp};
+calls \tcode{make_heap(c.begin(), c.end(), comp)}.
 \end{itemdescr}
 
 \rSec3[priqueue.members]{Members}


### PR DESCRIPTION
This is consistent with p2 and p8 which also value-initialize it.