### PR TITLE
[cpp.import] Active macro directive -> definition

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -912,8 +912,8 @@ macro definition, whichever (if any) occurs first.
 \end{itemize}
 
 \pnum
-\indextext{active macro directive|see{macro, active}}%
-A macro directive is \defnx{active}{macro!active} at a source location
+\indextext{active macro definition|see{macro, active}}%
+A macro definition is \defnx{active}{macro!active} at a source location
 if it has a point of definition in that translation unit preceding the location,
 and does not have a point of undefinition in that translation unit preceding
 the location.


### PR DESCRIPTION
The term 'active macro directive' is defined in p6, but never used. Meanwhile, there are multiple uses of 'active macro definition' but that term is never defined, including in the very sentence following the definition of the unused term, and in other clauses that cross-reference to this clause for their definition.

This seems clear enough to be an editorial fix, rather than a Core issue, but I defer to the CWG chair to make that call.