### PR TITLE
[cpp.subst] proprocessing file -> translation unit

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1215,7 +1215,7 @@ naming the parameter are replaced by a token sequence determined as follows:
   macros contained therein have been expanded. The argument's
   preprocessing tokens are completely macro replaced before
   being substituted as if they formed the rest of the preprocessing
-  file with no other preprocessing tokens being available.
+  tranlation unit with no other preprocessing tokens being available.
 \end{itemize}
 \begin{example}
 \begin{codeblock}


### PR DESCRIPTION
The term 'preprocessing translation unit' is defined in [lex.separate] while the term 'preprocessing file' is never defined, and is not used anywhere else in the standard.  Prefer to use the specified term, as it reasonably covers this case.