### PR TITLE
[exec.split], [exec.when.all] Fix typo stop_callback_of_t -> stop_callback_for_t

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -3690,7 +3690,7 @@ namespace std::execution {
   template<class Sndr, class Rcvr>
   struct @\exposid{local-state}@ : @\exposid{local-state-base}@ {                       // \expos
     using @\exposid{on-stop-callback}@ =                                    // \expos
-      stop_callback_of_t<stop_token_of_t<env_of_t<Rcvr>>, @\exposid{on-stop-request}@>;
+      stop_callback_for_t<stop_token_of_t<env_of_t<Rcvr>>, @\exposid{on-stop-request}@>;
 
     @\exposid{local-state}@(Sndr&& sndr, Rcvr& rcvr) noexcept;
     ~@\exposid{local-state}@();
@@ -4126,7 +4126,7 @@ struct @\exposid{make-state}@ {
   auto operator()(auto, auto, Sndrs&&... sndrs) const {
     using values_tuple = @\seebelow@;
     using errors_variant = @\seebelow@;
-    using stop_callback = stop_callback_of_t<stop_token_of_t<env_of_t<Rcvr>>, @\exposid{on-stop-request}@>;
+    using stop_callback = stop_callback_for_t<stop_token_of_t<env_of_t<Rcvr>>, @\exposid{on-stop-request}@>;
 
     struct @\exposid{state-type}@ {
       void @\exposid{arrive}@(Rcvr& rcvr) noexcept {                        // \expos


### PR DESCRIPTION
The wording for [exec.split] and [exec.when.all] refers to an alias template `stop_callback_of_t` which is not defined anywhere.

There is, however, a `stop_callback_for_t` alias template defined in [thread.stoptoken.syn] which has the desired shape and semantics.