### PR TITLE
[diff] Prefer ill-formed to not compile

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -168,7 +168,7 @@ auto s = std::to_string(1e-7);  // \tcode{"1e-07"}
 Permit passing a braced initializer list to a function taking \tcode{span}.
 \effect
 Valid \CppXXIII{} code that relies on the lack of this constructor
-may refuse to compile, or change behavior in this revision of \Cpp{}.
+may become ill-formed, or change behavior in this revision of \Cpp{}.
 \begin{example}
 \begin{codeblock}
 void one(pair<int, int>);       // \#1
@@ -219,7 +219,7 @@ this API would, in some cases, silently produce undefined behavior. A complete
 type-safe replacement is provided in the form of \tcode{atomic<shared_ptr<T>>}.
 \effect
 A valid \CppXXIII{} program that relies on the presence of the removed functions
-may fail to compile.
+may become ill-formed.
 
 \nodiffref
 \change
@@ -229,7 +229,7 @@ The overload of \tcode{reserve} with no parameters is redundant.
 The \tcode{shrink_to_fit} member function can be used instead.
 \effect
 A valid \CppXXIII{} program that calls \tcode{reserve()}
-on a \tcode{basic_string} object may fail to compile.
+on a \tcode{basic_string} object may become ill-formed.
 The old functionality can be achieved by calling \tcode{shrink_to_fit()} instead,
 or the function call can be safely eliminated with no side effects.
 
@@ -244,8 +244,8 @@ Ongoing support is at implementer's discretion,
 exercising freedoms granted by \ref{zombie.names}.
 \effect
 A valid \CppXXIII{} program \tcode{\#include}-ing the header or importing the
-header unit may fail to compile. Code that uses any of the following names by
-importing the standard library modules may fail to compile:
+header unit may become ill-formed. Code that uses any of the following names by
+importing the standard library modules may become ill-formed:
 \begin{itemize}
 \item \tcode{codecvt_mode},
 \item \tcode{codecvt_utf16},
@@ -336,7 +336,7 @@ Change move-eligible \grammarterm{id-expression}s from lvalues to xvalues.
 Simplify the rules for implicit move.
 \effect
 Valid \CppXX{} code that relies on a returned \grammarterm{id-expression}'s
-being an lvalue may change behavior or fail to compile.
+being an lvalue may change behavior or become ill-formed.
 \begin{example}
 \begin{codeblock}
 decltype(auto) f(int&& x) { return (x); }       // returns \tcode{int\&\&}; previously returned \tcode{int\&}
@@ -351,7 +351,7 @@ Change the meaning of comma in subscript expressions.
 Enable repurposing a deprecated syntax to support multidimensional indexing.
 \effect
 Valid \CppXX{} code that uses a comma expression within a
-subscript expression may fail to compile.
+subscript expression may become ill-formed.
 \begin{example}
 \begin{codeblock}
 arr[1, 2]               // was equivalent to \tcode{arr[(1, 2)]},
@@ -468,7 +468,7 @@ Allow uncopyable, but movable, types to model these concepts.
 \effect
 Valid \CppXX{} code relying on subsumption
 with \tcode{common_reference_with}
-may fail to compile in this revision of \Cpp{}.
+may become ill-formed in this revision of \Cpp{}.
 \begin{example}
 \begin{codeblock}
 template<class T, class U>
@@ -608,7 +608,7 @@ for associative containers.
 \rationale
 Improve efficiency of erasing elements from associative containers.
 \effect
-Valid \CppXX{} code may fail to compile in this revision of \Cpp{}.
+Valid \CppXX{} code may become ill-formed in this revision of \Cpp{}.
 \begin{example}
 \begin{codeblock}
 struct B {
@@ -943,7 +943,7 @@ is now a narrowing conversion.
 \rationale
 Catches bugs.
 \effect
-Valid \CppXVII{} code may fail to compile
+Valid \CppXVII{} code may become ill-formed
 in this revision of \Cpp{}.
 \begin{example}
 \begin{codeblock}
@@ -964,7 +964,7 @@ in a conversion function declaration.
 \rationale
 Necessary for new functionality.
 \effect
-Valid \CppXVII{} code may fail to compile
+Valid \CppXVII{} code may become ill-formed
 in this revision of \Cpp{}.
 \begin{example}
 \begin{codeblock}
@@ -983,7 +983,7 @@ is no longer valid as the \grammarterm{declarator-id} of a constructor or destru
 \rationale
 Remove potentially error-prone option for redundancy.
 \effect
-Valid \CppXVII{} code may fail to compile
+Valid \CppXVII{} code may become ill-formed
 in this revision of \Cpp{}.
 \begin{example}
 \begin{codeblock}
@@ -1006,7 +1006,7 @@ Function and catch-clause parameters can be thrown using move constructors.
 Side effect of making it easier to write
 more efficient code that takes advantage of moves.
 \effect
-Valid \CppXVII{} code may fail to compile or have different semantics
+Valid \CppXVII{} code may become ill-formed or have different semantics
 in this revision of \Cpp{}.
 \begin{example}
 \begin{codeblock}
@@ -1189,7 +1189,7 @@ Remove vacuous \Cpp{} header files.
 \rationale
 The empty headers implied a false requirement to achieve C compatibility with the \Cpp{} headers.
 \effect
-A valid \CppXVII{} program that \tcode{\#include}{s} any of the following headers may fail to compile:
+A valid \CppXVII{} program that \tcode{\#include}{s} any of the following headers may become ill-formed:
 \libnoheader{ccomplex},
 \libnoheader{ciso646},
 \libnoheader{cstdalign},
@@ -1237,7 +1237,7 @@ Corrects an issue misidentifying pointer types that are not incrementable
 as iterator types.
 \effect
 A valid \CppXVII{} program that relies on the presence of the typedefs
-may fail to compile, or have different behavior.
+may become ill-formed, or have different behavior.
 
 \rSec2[diff.cpp17.alg.reqs]{\ref{algorithms}: algorithms library}
 
@@ -1251,7 +1251,7 @@ to be implemented as function objects with templated call operators.
 \effect
 A valid \CppXVII{} program that passes explicit template arguments to
 algorithms not explicitly specified to allow such in this version of \Cpp{}
-may fail to compile or have undefined behavior.
+may become ill-formed or have undefined behavior.
 
 \rSec2[diff.cpp17.input.output]{\ref{input.output}: input/output library}
 
@@ -1261,7 +1261,7 @@ Character array extraction only takes array types.
 \rationale
 Increase safety via preventing buffer overflow at compile time.
 \effect
-Valid \CppXVII{} code may fail to compile in this revision of \Cpp{}.
+Valid \CppXVII{} code may become ill-formed in this revision of \Cpp{}.
 \begin{example}
 \begin{codeblock}
 auto p = new char[100];
@@ -1337,8 +1337,8 @@ Remove \tcode{uncaught_exception}.
 The function did not have a clear specification when multiple exceptions were
 active, and has been superseded by \tcode{uncaught_exceptions}.
 \effect
-A valid \CppXVII{} program that calls \tcode{std::uncaught_exception} may fail
-to compile. It can be revised to use \tcode{std::uncaught_exceptions} instead,
+A valid \CppXVII{} program that calls \tcode{std::uncaught_exception} may become
+ill-formed. It can be revised to use \tcode{std::uncaught_exceptions} instead,
 for clear and portable semantics.
 
 \nodiffref
@@ -1352,10 +1352,10 @@ superseded by direct language support with \keyword{decltype}, and by the
 \effect
 A valid \CppXVII{} program that relies on the presence of \tcode{result_type},
 \tcode{argument_type}, \tcode{first_argument_type}, or
-\tcode{second_argument_type} in a standard library class may fail to compile. A
+\tcode{second_argument_type} in a standard library class may become ill-formed. A
 valid \CppXVII{} program that calls \tcode{not1} or \tcode{not2}, or uses the
-class templates \tcode{unary_negate} or \tcode{binary_negate}, may fail to
-compile.
+class templates \tcode{unary_negate} or \tcode{binary_negate}, may become
+ill-formed.
 
 \nodiffref
 \change
@@ -1368,7 +1368,7 @@ A valid \CppXVII{} program that directly makes use of the \tcode{pointer},
 \tcode{const_pointer}, \tcode{reference}, \tcode{const_reference},
 \tcode{rebind}, \tcode{address}, \tcode{construct}, \tcode{destroy}, or
 \tcode{max_size} members of \tcode{std::allocator}, or that directly calls
-\tcode{allocate} with an additional hint argument, may fail to compile.
+\tcode{allocate} with an additional hint argument, may become ill-formed.
 
 \nodiffref
 \change
@@ -1378,7 +1378,7 @@ The iterator encouraged use of potentially-throwing algorithms, but did
 not return the number of elements successfully constructed,
 as would be necessary to destroy them.
 \effect
-A valid \CppXVII{} program that uses this iterator class may fail to compile.
+A valid \CppXVII{} program that uses this iterator class may become ill-formed.
 
 \nodiffref
 \change
@@ -1390,7 +1390,7 @@ practice, while requiring the user to provide their own exception-safe wrappers
 to guard use of the facility in many cases.
 \effect
 A valid \CppXVII{} program that calls \tcode{get_temporary_buffer} or
-\tcode{return_temporary_buffer} may fail to compile.
+\tcode{return_temporary_buffer} may become ill-formed.
 
 \nodiffref
 \change
@@ -1402,7 +1402,7 @@ similarly unreliable, but has a clearer contract in such cases, and remains
 available for well-defined use in single-threaded cases.
 \effect
 A valid \CppXVII{} program that calls \tcode{unique} on a \tcode{shared_ptr}
-object may fail to compile.
+object may become ill-formed.
 
 \diffref{depr.meta.types}
 \change
@@ -1416,7 +1416,7 @@ It has been superseded by the \tcode{invoke_result} trait.
 \effect
 A valid \CppXVII{} program that relies on the \tcode{is_literal_type} or
 \tcode{result_of} type traits, on the \tcode{is_literal_type_v} variable template,
-or on the \tcode{result_of_t} alias template may fail to compile.
+or on the \tcode{result_of_t} alias template may become ill-formed.
 
 \rSec1[diff.cpp14]{\Cpp{} and ISO \CppXIV{}}
 
@@ -1452,7 +1452,7 @@ the translation character set.
 \rationale
 Necessary to enable \grammarterm{hexadecimal-floating-point-literal}s.
 \effect
-Valid \CppXIV{} code may fail to compile or produce different results in
+Valid \CppXIV{} code may become ill-formed or produce different results in
 this revision of \Cpp{}. Specifically, character sequences like \tcode{0p+0}
 and \tcode{0e1_p+0} are three separate tokens each in \CppXIV{}, but one single token
 in this revision of \Cpp{}.
@@ -1508,7 +1508,7 @@ The specifier can simply be removed to retain the original meaning.
 \rationale
 More intuitive deduction behavior.
 \effect
-Valid \CppXIV{} code may fail to compile or may change meaning
+Valid \CppXIV{} code may become ill-formed or may change meaning
 in this revision of \Cpp{}.
 \begin{example}
 \begin{codeblock}
@@ -1523,7 +1523,7 @@ Make exception specifications be part of the type system.
 \rationale
 Improve type-safety.
 \effect
-Valid \CppXIV{} code may fail to compile or change meaning in this
+Valid \CppXIV{} code may become ill-formed or change meaning in this
 revision of \Cpp{}.
 \begin{example}
 \begin{codeblock}
@@ -1541,7 +1541,7 @@ to apply to user-defined types with base classes.
 \rationale
 To increase convenience of aggregate initialization.
 \effect
-Valid \CppXIV{} code may fail to compile or produce different results in this
+Valid \CppXIV{} code may become ill-formed or produce different results in this
 revision of \Cpp{}; initialization from an empty initializer list will
 perform aggregate initialization instead of invoking a default constructor
 for the affected types.
@@ -1600,7 +1600,7 @@ non-type template arguments with placeholder types,
 allows partial specializations to decompose
 from the type deduced for the non-type template argument.
 \effect
-Valid \CppXIV{} code may fail to compile
+Valid \CppXIV{} code may become ill-formed
 or produce different results in this revision of \Cpp{}.
 \begin{example}
 \begin{codeblock}
@@ -1678,7 +1678,7 @@ Constructors taking allocators removed.
 \rationale
 No implementation consensus.
 \effect
-Valid \CppXIV{} code may fail to compile or may change meaning in this
+Valid \CppXIV{} code may become ill-formed or may change meaning in this
 revision of \Cpp{}. Specifically, constructing a \tcode{std::function} with
 an allocator is ill-formed and uses-allocator construction will not pass an
 allocator to \tcode{std::function} constructors in this revision of \Cpp{}.
@@ -1690,7 +1690,7 @@ Different constraint on conversions from \tcode{unique_ptr}.
 Adding array support to \tcode{shared_ptr},
 via the syntax \tcode{shared_ptr<T[]>} and \tcode{shared_ptr<T[N]>}.
 \effect
-Valid \CppXIV{} code may fail to compile or may change meaning in this
+Valid \CppXIV{} code may become ill-formed or may change meaning in this
 revision of \Cpp{}.
 \begin{example}
 \begin{codeblock}
@@ -1734,7 +1734,7 @@ Increase portability, clarification of associative container requirements.
 \effect
 Valid \CppXIV{} code that attempts to use associative containers
 having a comparison object with non-const function call operator
-may fail to compile in this revision of \Cpp{}.
+may become ill-formed in this revision of \Cpp{}.
 \begin{example}
 \begin{codeblock}
 #include <set>
@@ -1775,7 +1775,7 @@ are not defined.
 Superseded by new features.
 \effect
 Valid \CppXIV{} code that uses these class templates
-and function templates may fail to compile in this revision of \Cpp{}.
+and function templates may become ill-formed in this revision of \Cpp{}.
 
 \nodiffref
 \change
@@ -1806,7 +1806,7 @@ by the chapters of this document.
 \rationale
 Necessary to enable single quotes as digit separators.
 \effect
-Valid \CppXI{} code may fail to compile or may change meaning in this
+Valid \CppXI{} code may become ill-formed or may change meaning in this
 revision of \Cpp{}. For example, the following code is valid both in \CppXI{} and in
 this revision of \Cpp{}, but the macro invocation produces different outcomes
 because the single quotes delimit a \grammarterm{character-literal} in \CppXI{}, whereas they are digit
@@ -1885,7 +1885,7 @@ revision of \Cpp{}, it yields \tcode{sizeof(const char[1])}.
 Necessary to allow \keyword{constexpr} member functions to mutate
 the object.
 \effect
-Valid \CppXI{} code may fail to compile in this revision of \Cpp{}.
+Valid \CppXI{} code may become ill-formed in this revision of \Cpp{}.
 \begin{example}
 \begin{codeblock}
 struct S {
@@ -1905,7 +1905,7 @@ Classes with default member initializers can be aggregates.
 Necessary to allow default member initializers to be used
 by aggregate initialization.
 \effect
-Valid \CppXI{} code may fail to compile or may change meaning in this revision of \Cpp{}.
+Valid \CppXI{} code may become ill-formed or may change meaning in this revision of \Cpp{}.
 \begin{example}
 \begin{codeblock}
 struct S {          // Aggregate in \CppXIV{} onwards.
@@ -1941,7 +1941,7 @@ invalid in this revision of \Cpp{}.
 \rationale
 Use of \tcode{gets} is considered dangerous.
 \effect
-Valid \CppXI{} code that uses the \tcode{gets} function may fail to compile
+Valid \CppXI{} code that uses the \tcode{gets} function may become ill-formed
 in this revision of \Cpp{}.
 
 \rSec1[diff.cpp03]{\Cpp{} and ISO \CppIII{}}
@@ -1963,7 +1963,7 @@ New kinds of \grammarterm{string-literal}s.
 \rationale
 Required for new features.
 \effect
-Valid \CppIII{} code may fail to compile or produce different results in
+Valid \CppIII{} code may become ill-formed or produce different results in
 this revision of \Cpp{}. Specifically, macros named \tcode{R}, \tcode{u8},
 \tcode{u8R}, \tcode{u}, \tcode{uR}, \tcode{U}, \tcode{UR}, or \tcode{LR} will
 not be expanded when adjacent to a \grammarterm{string-literal} but will be interpreted as
@@ -1981,7 +1981,7 @@ User-defined literal string support.
 \rationale
 Required for new features.
 \effect
-Valid \CppIII{} code may fail to compile or produce different results in
+Valid \CppIII{} code may become ill-formed or produce different results in
 this revision of \Cpp{}.
 \begin{example}
 \begin{codeblock}
@@ -2032,7 +2032,7 @@ Only literals are integer null pointer constants.
 Removing surprising interactions with templates and constant
 expressions.
 \effect
-Valid \CppIII{} code may fail to compile or produce different results in
+Valid \CppIII{} code may become ill-formed or produce different results in
 this revision of \Cpp{}.
 \begin{example}
 \begin{codeblock}
@@ -2082,7 +2082,7 @@ the result toward 0.
 \rationale
 Required for new features.
 \effect
-Valid \CppIII{} code may fail to compile or produce different results in
+Valid \CppIII{} code may become ill-formed or produce different results in
 this revision of \Cpp{}.
 \begin{example}
 \begin{codeblock}
@@ -2138,7 +2138,7 @@ Narrowing restrictions in aggregate initializers.
 \rationale
 Catches bugs.
 \effect
-Valid \CppIII{} code may fail to compile in this revision of \Cpp{}.
+Valid \CppIII{} code may become ill-formed in this revision of \Cpp{}.
 \begin{example}
 \begin{codeblock}
 int x[] = { 2.0 };
@@ -2246,7 +2246,7 @@ New reserved identifiers.
 Required by new features.
 \effect
 Valid \CppIII{} code that uses any identifiers added to the \Cpp{} standard
-library by later revisions of \Cpp{} may fail to compile or produce different
+library by later revisions of \Cpp{} may become ill-formed or produce different
 results in this revision of \Cpp{}. A comprehensive list of identifiers used
 by the \Cpp{} standard library can be found in the Index of Library Names in this
 document.
@@ -2357,7 +2357,7 @@ Superseded by new feature; \tcode{unary_function} and
 \tcode{binary_function} are no longer defined.
 \effect
 Valid \CppIII{} code that depends on function object types being derived from
-\tcode{unary_function} or \tcode{binary_function} may fail to compile
+\tcode{unary_function} or \tcode{binary_function} may become ill-formed
 in this revision of \Cpp{}.
 
 \rSec2[diff.cpp03.strings]{\ref{strings}: strings library}
@@ -2419,7 +2419,7 @@ Requirements change: default constructible.
 Clarification of container requirements.
 \effect
 Valid \CppIII{} code that attempts to explicitly instantiate a container using
-a user-defined type with no default constructor may fail to compile.
+a user-defined type with no default constructor may become ill-formed.
 
 \diffref{sequence.reqmts,associative.reqmts}
 \change
@@ -2438,7 +2438,7 @@ The following member functions have changed:
 
 Valid \CppIII{} code that relies on these functions returning \keyword{void}
 (e.g., code that creates a pointer to member function that points to one
-of these functions) will fail to compile with this revision of \Cpp{}.
+of these functions) will become ill-formed with this revision of \Cpp{}.
 
 \diffref{sequence.reqmts,associative.reqmts}
 \change
@@ -2460,7 +2460,7 @@ The signatures of the following member functions changed from taking an
 \item all forms of \tcode{list::merge}
 \end{itemize}
 
-Valid \CppIII{} code that uses these functions may fail to compile with this
+Valid \CppIII{} code that uses these functions may become ill-formed with this
 revision of \Cpp{}.
 
 \diffref{sequence.reqmts,associative.reqmts}
@@ -2472,7 +2472,7 @@ Performance, compatibility with move semantics.
 For \tcode{vector}, \tcode{deque}, and \tcode{list}
 the fill value passed to \tcode{resize} is now passed by reference instead of
 by value, and an additional overload of \tcode{resize} has been added. Valid
-\CppIII{} code that uses this function may fail to compile with this revision of \Cpp{}.
+\CppIII{} code that uses this function may become ill-formed with this revision of \Cpp{}.
 
 \rSec2[diff.cpp03.algorithms]{\ref{algorithms}: algorithms library}
 
@@ -2518,8 +2518,8 @@ Specify use of \keyword{explicit} in existing boolean conversion functions.
 \rationale
 Clarify intentions, avoid workarounds.
 \effect
-Valid \CppIII{} code that relies on implicit boolean conversions will fail to
-compile with this revision of \Cpp{}. Such conversions occur in the
+Valid \CppIII{} code that relies on implicit boolean conversions will become
+ill-formed with this revision of \Cpp{}. Such conversions occur in the
 following conditions:
 
 \begin{itemize}
@@ -2550,7 +2550,7 @@ defined as constexpr static members.
 Required for new features.
 \effect
 Valid \CppIII{} code that relies on \tcode{std::ios_base} flag types being
-represented as \tcode{std::bitset} or as an integer type may fail to compile
+represented as \tcode{std::bitset} or as an integer type may become ill-formed
 with this revision of \Cpp{}.
 \begin{example}
 \begin{codeblock}
@@ -2847,7 +2847,7 @@ int x = 1 ? e : f;      // valid in C; ill-formed in \Cpp{}
 \rationale
 Reinforcing type safety in \Cpp{}.
 \effect
-Well-formed C code will not compile with this International Standard.
+Well-formed C code will be ill-formed with this International Standard.
 \difficulty
 Violations will be diagnosed by the \Cpp{} translator.
 The original behavior can be restored with a cast or integral promotion.


### PR DESCRIPTION
Fixes #6901 that was opened following LWG wording review at the Tokyo 2024 meeting.  Rather than say code may not compiled, prefer to say that code may become ill-formed.

Applied the recommended change throughout the whole of Annex C.