### PR TITLE
[mdspan.mdspan.overview, mutex.syn] Mini fixes for synopses

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -23238,7 +23238,7 @@ namespace std {
     constexpr bool is_exhaustive() const
       { return @\exposid{map_}@.is_exhaustive(); }
     constexpr bool is_strided() const
-      { return @\exposid{map_.}@is_strided(); }
+      { return @\exposid{map_}@.is_strided(); }
     constexpr index_type stride(rank_type r) const
       { return @\exposid{map_}@.stride(r); }
 

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -6456,7 +6456,7 @@ namespace std {
   class mutex;
   // \ref{thread.mutex.recursive}, class \tcode{recursive_mutex}
   class recursive_mutex;
-  // \ref{thread.timedmutex.class} class \tcode{timed_mutex}
+  // \ref{thread.timedmutex.class}, class \tcode{timed_mutex}
   class timed_mutex;
   // \ref{thread.timedmutex.recursive}, class \tcode{recursive_timed_mutex}
   class recursive_timed_mutex;


### PR DESCRIPTION
In [mdspan.mdspan.overview], the `.`in `@\exposid{map_.}@is_strided()` was misplaced. It should be `@\exposid{map_}@.is_strided()`.

In [mutex.syn], add a comma after `\ref{thread.timedmutex.class}` for consistency.