### PR TITLE
[stoptoken.concepts] Remove redundant 'swappable<Token>' clause from 'stoppable_token' concept

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -692,8 +692,7 @@ template<class Token>
       { Token(tok) } noexcept;                  // see implicit expression variations\iref{concepts.equality}
     } &&
     @\libconcept{copyable}@<Token> &&
-    @\libconcept{equality_comparable}@<Token> &&
-    @\libconcept{swappable}@<Token>;
+    @\libconcept{equality_comparable}@<Token>;
 
 template<class Token>
   concept @\deflibconcept{unstoppable_token}@ =


### PR DESCRIPTION
The `stoppable_token<Token>` concept requires both `copyable<Token>` to be satisfied and `swappable<Token>` to be satisfied.

However, the `copyable<Token>` requirement already subsumes `movable<Token>`, which subsumes `swappable<Token>`.

Therefore the requirement for `swappable<Token>` can be removed from the `stoppable_token` concept definition with no semantic change.