### PR TITLE
[exec.snd.expos] Fix markup of exposition-only identifiers in `basic-state` constructor

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -1618,8 +1618,8 @@ namespace std::execution {
   template<class Sndr, class Rcvr>
   struct @\exposid{basic-state}@ {                                          // \expos
     @\exposid{basic-state}@(Sndr&& sndr, Rcvr&& rcvr) noexcept(@\seebelow@)
-      : rcvr(std::move(rcvr))
-      , state(@\exposid{impls-for}@<tag_of_t<Sndr>>::@\exposid{get-state}@(std::forward<Sndr>(sndr), rcvr)) { }
+      : @\exposid{rcvr}@(std::move(rcvr))
+      , @\exposid{state}@(@\exposid{impls-for}@<tag_of_t<Sndr>>::@\exposid{get-state}@(std::forward<Sndr>(sndr), @\exposid{rcvr}@)) { }
 
     Rcvr @\exposid{rcvr}@;                                                  // \expos
     @\exposid{state-type}@<Sndr, Rcvr> @\exposid{state}@;                               // \expos


### PR DESCRIPTION
The initialization of the exposition-only `recv` and `state`
data-members in the `basic-state` constructor should have marked-up
the member identifiers using \exposid.

Also, the `recv` argument passed to `get-state` was supposed to be
referring to the exposition-only data-member rather than the parameter
of the same name as otherwise it would be referring to a moved-from
object.
So markup the `recv` argument to `get-state` using \exposid as well
to make this (slightly) clearer.