### PR TITLE
[class.mi] Define ambiguous/unambiguous base class

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3654,6 +3654,27 @@ by \tcode{X} and \tcode{Y}, as shown in \fref{class.virtnonvirt}.
 \end{importgraphic}
 \end{note}
 
+\pnum
+\indextext{base class!ambiguous}%
+\indextext{base class!unambiguous}%
+If an object of class \tcode{D} has a single base class subobject of type \tcode{B},
+\tcode{B} is an \defnadj{unambiguous}{base class} of \tcode{D}.
+If an object of class \tcode{D} has more than one base class subobject of type \tcode{B},
+\tcode{B} is an \defnadj{ambiguous}{base class} of \tcode{D}.
+\begin{example}
+\begin{codeblock}
+class B { @\commentellip@ };
+class MX : public B { @\commentellip@ };
+class MY : public B { @\commentellip@ };
+class D1 : public MX, public MY { @\commentellip@ };      // \tcode{B} is an ambiguous base class of \tcode{D1}
+class D2 : public MX, public B { @\commentellip@ };       // \tcode{B} is an ambiguous base class of \tcode{D2}
+
+class VMX : virtual public B { @\commentellip@ };
+class VMY : virtual public B { @\commentellip@ };
+class D3 : public VMX, public VMY { @\commentellip@ };    // \tcode{B} is an unambiguous base class of \tcode{D3}
+\end{codeblock}
+\end{example}
+
 \rSec2[class.virtual]{Virtual functions}%
 \indextext{function!virtual|(}%
 \indextext{type!polymorphic}%


### PR DESCRIPTION
Currently, terms _ambiguous base class_ and _unambiguous base class_ are used without clear definition. The intent seems already clear to me, but perhaps it would be better to properly define them.

Fixes #5173.