### PR TITLE
[dcl.fct.default][stmt.jump.general][stmt.return][except.ctor][facet.num.get.virtuals][facet.num.put.virtuals][re.regiter.incr][re.tokiter.incr] Replace the uses of "local variable" with "[block] variable with automatic storage duration"

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4442,7 +4442,7 @@ void C::g(int i = 88, int j) {} // in this translation unit, \tcode{C::g} can be
 
 \pnum
 \begin{note}
-A local variable cannot be odr-used\iref{term.odr.use}
+A variable with automatic storage duration cannot be odr-used\iref{term.odr.use}
 in a default argument.
 \end{note}
 \begin{example}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4509,7 +4509,7 @@ void C::g(int i = 88, int j) {} // in this translation unit, \tcode{C::g} can be
 
 \pnum
 \begin{note}
-A local variable cannot be odr-used\iref{term.odr.use}
+A variable with automatic storage duration cannot be odr-used\iref{term.odr.use}
 in a default argument.
 \end{note}
 \begin{example}

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -396,7 +396,7 @@ Each object with automatic storage duration is destroyed if it has been
 constructed, but not yet destroyed,
 since the try block was entered.
 If an exception is thrown during the destruction of temporaries or
-local variables for a \keyword{return} statement\iref{stmt.return},
+variables for a \keyword{return} statement\iref{stmt.return},
 the destructor for the returned object (if any) is also invoked.
 The objects are destroyed in the reverse order of the completion
 of their construction.
@@ -418,11 +418,11 @@ A f() {
 }
 \end{codeblock}
 At \#1, the returned object of type \tcode{A} is constructed.
-Then, the local variable \tcode{b} is destroyed\iref{stmt.jump}.
-Next, the local variable \tcode{y} is destroyed,
+Then, the variable \tcode{b} is destroyed\iref{stmt.jump}.
+Next, the variable \tcode{y} is destroyed,
 causing stack unwinding,
 resulting in the destruction of the returned object,
-followed by the destruction of the local variable \tcode{a}.
+followed by the destruction of the variable \tcode{a}.
 Finally, the returned object is constructed again at \#2.
 \end{example}
 

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -1016,7 +1016,7 @@ Jump statements unconditionally transfer control.
 \end{bnf}
 
 \pnum
-\indextext{local variable!destruction of}%
+\indextext{block variable with automatic storage duration!destruction of}%
 \indextext{scope!destructor and exit from}%
 \begin{note}
 On exit from a scope (however accomplished), objects with automatic storage

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -1127,11 +1127,11 @@ results in undefined behavior.
 The copy-initialization of the result of the call is sequenced before the
 destruction of temporaries at the end of the full-expression established
 by the operand of the \tcode{return} statement, which, in turn, is sequenced
-before the destruction of local variables\iref{stmt.jump} of the block
+before the destruction of block variables with automatic storage duration\iref{stmt.jump} of the block
 enclosing the \tcode{return} statement.
 \begin{note}
 These operations
-are sequenced before the destruction of local variables
+are sequenced before the destruction of block variables with automatic storage duration
 in each remaining enclosing block of the function\iref{stmt.dcl},
 which, in turn,
 is sequenced before the evaluation of

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -1136,11 +1136,11 @@ results in undefined behavior\ubdef{stmt.return.flow.off}.
 The copy-initialization of the result of the call is sequenced before the
 destruction of temporaries at the end of the full-expression established
 by the operand of the \tcode{return} statement, which, in turn, is sequenced
-before the destruction of local variables\iref{stmt.jump} of the block
+before the destruction of block variables with automatic storage duration\iref{stmt.jump} of the block
 enclosing the \tcode{return} statement.
 \begin{note}
 These operations
-are sequenced before the destruction of local variables
+are sequenced before the destruction of block variables with automatic storage duration
 in each remaining enclosing block of the function\iref{stmt.dcl},
 which, in turn,
 is sequenced before the evaluation of

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -1025,7 +1025,7 @@ Jump statements unconditionally transfer control.
 \end{bnf}
 
 \pnum
-\indextext{local variable!destruction of}%
+\indextext{block variable with automatic storage duration!destruction of}%
 \indextext{scope!destructor and exit from}%
 \begin{note}
 On exit from a scope (however accomplished), objects with automatic storage

--- a/source/text.tex
+++ b/source/text.tex
@@ -12766,9 +12766,8 @@ regex_token_iterator& operator++();
 \begin{itemdescr}
 \pnum
 \effects
-Constructs a local variable \tcode{prev} of
-type \tcode{position_iterator}, initialized with the value
-of \tcode{position}.
+Constructs a variable \tcode{prev} of type \tcode{position_iterator}
+with automatic storage duration, initialized with the value of \tcode{position}.
 
 \pnum
 If \tcode{*this} is a suffix iterator, sets \tcode{*this} to an

--- a/source/text.tex
+++ b/source/text.tex
@@ -2885,7 +2885,8 @@ iter_type do_put(iter_type out, ios_base& str, char_type fill, const void* val) 
 \effects
 Writes characters to the sequence \tcode{out},
 formatting \tcode{val} as desired.
-In the following description, \tcode{loc} names a local variable initialized as
+In the following description, \tcode{loc} names a variable with
+automatic storage duration initialized as
 \begin{codeblock}
 locale loc = str.getloc();
 \end{codeblock}
@@ -2929,7 +2930,8 @@ Detailed descriptions of each stage follow.
 \begin{description}
 \stage{1}
 The first action of stage 1 is to determine a conversion specifier.
-The tables that describe this determination use the following local variables
+The tables that describe this determination use the following variables with
+automatic storage duration.
 
 \begin{codeblock}
 fmtflags flags = str.flags();
@@ -3027,7 +3029,7 @@ a \tcode{charT} via
 use_facet<ctype<charT>>(loc).widen(c)
 \end{codeblock}
 
-A local variable \tcode{punct} is initialized via
+A variable \tcode{punct} with automatic storage duration is initialized via
 \begin{codeblock}
 const numpunct<charT>& punct = use_facet<numpunct<charT>>(loc);
 \end{codeblock}
@@ -3040,7 +3042,7 @@ using the method described in~\ref{facet.numpunct.virtuals}.
 Decimal point characters(.) are replaced by \tcode{punct.decimal_point()}.
 
 \stage{3}
-A local variable is initialized as
+A variable with automatic storage is initialized as
 \begin{codeblock}
 fmtflags adjustfield = (flags & (ios_base::adjustfield));
 \end{codeblock}

--- a/source/text.tex
+++ b/source/text.tex
@@ -2587,7 +2587,7 @@ The details of the stages are presented below.
 
 \begin{description}
 \stage{1}
-The function initializes local variables via
+The function initializes variables with automatic storage duration via
 \begin{codeblock}
 fmtflags flags = str.flags();
 fmtflags basefield = (flags & ios_base::basefield);
@@ -2636,7 +2636,7 @@ as indicated in \tref{facet.num.get.length}.
 \stage{2}
 If \tcode{in == end} then stage 2 terminates.
 Otherwise a \tcode{charT} is taken from \tcode{in} and
-local variables are initialized as if by
+variables with automatic storage duration are initialized as if by
 \begin{codeblock}
 char_type ct = *in;
 char c = src[find(atoms, atoms + sizeof(src) - 1, ct) - atoms];

--- a/source/text.tex
+++ b/source/text.tex
@@ -12420,7 +12420,8 @@ regex_iterator& operator++();
 \begin{itemdescr}
 \pnum
 \effects
-Constructs a local variable \tcode{start} of type \tcode{BidirectionalIterator} and
+Constructs a variable \tcode{start} of type \tcode{BidirectionalIterator}
+with automatic storage duration and
 initializes it with the value of \tcode{match[0].second}.
 
 \pnum

--- a/source/text.tex
+++ b/source/text.tex
@@ -2890,7 +2890,8 @@ iter_type do_put(iter_type out, ios_base& str, char_type fill, const void* val) 
 \effects
 Writes characters to the sequence \tcode{out},
 formatting \tcode{val} as desired.
-In the following description, \tcode{loc} names a local variable initialized as
+In the following description, \tcode{loc} names a variable with
+automatic storage duration initialized as
 \begin{codeblock}
 locale loc = str.getloc();
 \end{codeblock}
@@ -2934,7 +2935,8 @@ Detailed descriptions of each stage follow.
 \begin{description}
 \stage{1}
 The first action of stage 1 is to determine a conversion specifier.
-The tables that describe this determination use the following local variables
+The tables that describe this determination use the following variables with
+automatic storage duration.
 
 \begin{codeblock}
 fmtflags flags = str.flags();
@@ -3032,7 +3034,7 @@ a \tcode{charT} via
 use_facet<ctype<charT>>(loc).widen(c)
 \end{codeblock}
 
-A local variable \tcode{punct} is initialized via
+A variable \tcode{punct} with automatic storage duration is initialized via
 \begin{codeblock}
 const numpunct<charT>& punct = use_facet<numpunct<charT>>(loc);
 \end{codeblock}
@@ -3045,7 +3047,7 @@ using the method described in~\ref{facet.numpunct.virtuals}.
 Decimal point characters(.) are replaced by \tcode{punct.decimal_point()}.
 
 \stage{3}
-A local variable is initialized as
+A variable with automatic storage is initialized as
 \begin{codeblock}
 fmtflags adjustfield = (flags & (ios_base::adjustfield));
 \end{codeblock}

--- a/source/text.tex
+++ b/source/text.tex
@@ -12771,9 +12771,8 @@ regex_token_iterator& operator++();
 \begin{itemdescr}
 \pnum
 \effects
-Constructs a local variable \tcode{prev} of
-type \tcode{position_iterator}, initialized with the value
-of \tcode{position}.
+Constructs a variable \tcode{prev} of type \tcode{position_iterator}
+with automatic storage duration, initialized with the value of \tcode{position}.
 
 \pnum
 If \tcode{*this} is a suffix iterator, sets \tcode{*this} to an

--- a/source/text.tex
+++ b/source/text.tex
@@ -2592,7 +2592,7 @@ The details of the stages are presented below.
 
 \begin{description}
 \stage{1}
-The function initializes local variables via
+The function initializes variables with automatic storage duration via
 \begin{codeblock}
 fmtflags flags = str.flags();
 fmtflags basefield = (flags & ios_base::basefield);
@@ -2641,7 +2641,7 @@ as indicated in \tref{facet.num.get.length}.
 \stage{2}
 If \tcode{in == end} then stage 2 terminates.
 Otherwise a \tcode{charT} is taken from \tcode{in} and
-local variables are initialized as if by
+variables with automatic storage duration are initialized as if by
 \begin{codeblock}
 char_type ct = *in;
 char c = src[find(atoms, atoms + sizeof(src) - 1, ct) - atoms];

--- a/source/text.tex
+++ b/source/text.tex
@@ -12441,7 +12441,8 @@ regex_iterator& operator++();
 \begin{itemdescr}
 \pnum
 \effects
-Constructs a local variable \tcode{start} of type \tcode{BidirectionalIterator} and
+Constructs a variable \tcode{start} of type \tcode{BidirectionalIterator}
+with automatic storage duration and
 initializes it with the value of \tcode{match[0].second}.
 
 \pnum


### PR DESCRIPTION
P1787R6 dropped the previous buggy uses and definition of term _local variable_. But there're many remaining use of local variable.

This PR removes the remaining occurrences except for one "conceptual local variable" in a comment (which seems OK to me as we're not talking about real local variable).
- In [dcl.fct.default] and [stmt.return], "local variable" is replaced with "block variable with automatic storage duration".
- In [stmt.jump.general], the index for "destruction of local variable" is replaced with "destruction of block variable with automatic storage duration".
- In [except.ctor], [facet.num.get.virtuals], [facet.num.put.virtuals], [re.regiter.incr], and [re.tokiter.incr], "local variable" is replaced with "variable with automatic storage duration".

Fixes #6617.