### PR TITLE
[charconv.syn] Use higher-level indexing macros

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15067,28 +15067,18 @@ in lieu of \tcode{\placeholder{floating-point-type}}.
 \indexheader{charconv}%
 \begin{codeblock}
 namespace std {
-@%
-\indexlibraryglobal{chars_format}%
-\indexlibrarymember{scientific}{chars_format}%
-\indexlibrarymember{fixed}{chars_format}%
-\indexlibrarymember{hex}{chars_format}%
-\indexlibrarymember{general}{chars_format}%
-@  // floating-point format for primitive numerical conversion
-  enum class chars_format {
-    scientific = @\unspec@,
-    fixed = @\unspec@,
-    hex = @\unspec@,
-    general = fixed | scientific
+  // floating-point format for primitive numerical conversion
+  enum class @\libglobal{chars_format}@ {
+    @\libmember{scientific}{chars_format}@ = @\unspec@,
+    @\libmember{fixed}{chars_format}@ = @\unspec@,
+    @\libmember{hex}{chars_format}@ = @\unspec@,
+    @\libmember{general}{chars_format}@ = fixed | scientific
   };
-@%
-\indexlibraryglobal{to_chars_result}%
-\indexlibrarymember{ptr}{to_chars_result}%
-\indexlibrarymember{ec}{to_chars_result}
-@
+
   // \ref{charconv.to.chars}, primitive numerical output conversion
-  struct to_chars_result {                                              // freestanding
-    char* ptr;
-    errc ec;
+  struct @\libglobal{to_chars_result}@ {                                              // freestanding
+    char* @\libmember{ptr}{to_chars_result}@;
+    errc @\libmember{ec}{to_chars_result}@;
     friend bool operator==(const to_chars_result&, const to_chars_result&) = default;
     constexpr explicit operator bool() const noexcept { return ec == errc{}; }
   };
@@ -15104,15 +15094,11 @@ namespace std {
                            @\placeholder{floating-point-type}@ value, chars_format fmt);
   to_chars_result to_chars(char* first, char* last,                     // freestanding-deleted
                            @\placeholder{floating-point-type}@ value, chars_format fmt, int precision);
-@%
-\indexlibraryglobal{from_chars_result}%
-\indexlibrarymember{ptr}{from_chars_result}%
-\indexlibrarymember{ec}{from_chars_result}
-@
+
   // \ref{charconv.from.chars}, primitive numerical input conversion
-  struct from_chars_result {                                            // freestanding
-    const char* ptr;
-    errc ec;
+  struct @\libglobal{from_chars_result}@ {                                            // freestanding
+    const char* @\libmember{ptr}{from_chars_result}@;
+    errc @\libmember{ec}{from_chars_result}@;
     friend bool operator==(const from_chars_result&, const from_chars_result&) = default;
     constexpr explicit operator bool() const noexcept { return ec == errc{}; }
   };


### PR DESCRIPTION
This avoids false positives with the automated checks.