### PR TITLE
[lex.comment] Move the subclause earlier, to where it better fits

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -467,6 +467,29 @@ the Unicode Character Database's \tcode{NameAliases.txt}.
 None of these names or aliases have leading or trailing spaces.
 \end{note}
 
+\rSec1[lex.comment]{Comments}
+
+\pnum
+\indextext{comment|(}%
+\indextext{comment!\tcode{/*} \tcode{*/}}%
+\indextext{comment!\tcode{//}}%
+The characters \tcode{/*} start a comment, which terminates with the
+characters \tcode{*/}. These comments do not nest.
+\indextext{comment!\tcode{//}}%
+The characters \tcode{//} start a comment, which terminates immediately before the
+next new-line character. If there is a form-feed or a vertical-tab
+character in such a comment, only whitespace characters shall appear
+between it and the new-line that terminates the comment; no diagnostic
+is required.
+\begin{note}
+The comment characters \tcode{//}, \tcode{/*},
+and \tcode{*/} have no special meaning within a \tcode{//} comment and
+are treated just like other characters. Similarly, the comment
+characters \tcode{//} and \tcode{/*} have no special meaning within a
+\tcode{/*} comment.
+\end{note}
+\indextext{comment|)}
+
 \rSec1[lex.pptoken]{Preprocessing tokens}
 
 \indextext{token!preprocessing|(}%
@@ -680,29 +703,6 @@ Whitespace can separate otherwise adjacent identifiers, keywords, numeric
 literals, and alternative tokens containing alphabetic characters.
 \end{note}
 \indextext{token|)}
-
-\rSec1[lex.comment]{Comments}
-
-\pnum
-\indextext{comment|(}%
-\indextext{comment!\tcode{/*} \tcode{*/}}%
-\indextext{comment!\tcode{//}}%
-The characters \tcode{/*} start a comment, which terminates with the
-characters \tcode{*/}. These comments do not nest.
-\indextext{comment!\tcode{//}}%
-The characters \tcode{//} start a comment, which terminates immediately before the
-next new-line character. If there is a form-feed or a vertical-tab
-character in such a comment, only whitespace characters shall appear
-between it and the new-line that terminates the comment; no diagnostic
-is required.
-\begin{note}
-The comment characters \tcode{//}, \tcode{/*},
-and \tcode{*/} have no special meaning within a \tcode{//} comment and
-are treated just like other characters. Similarly, the comment
-characters \tcode{//} and \tcode{/*} have no special meaning within a
-\tcode{/*} comment.
-\end{note}
-\indextext{comment|)}
 
 \rSec1[lex.header]{Header names}
 


### PR DESCRIPTION
Comments should fit betweem character sets (to define the basic source character set) and preprocessor tokens, that must already understand comments in order to treat them as whitespace.