### PR TITLE
[inplace.vector] Move reserve+shrink_to_fit from #modifiers to #capacity

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9638,7 +9638,7 @@ namespace std {
     constexpr const_reverse_iterator crbegin() const noexcept;
     constexpr const_reverse_iterator crend()   const noexcept;
 
-    // \ref{inplace.vector.capacity}, size/capacity
+    // \ref{inplace.vector.capacity}, capacity
     constexpr bool empty() const noexcept;
     constexpr size_type size() const noexcept;
     static constexpr size_type max_size() noexcept;
@@ -9788,7 +9788,7 @@ the elements of the range \tcode{rg}.
 Linear in \tcode{ranges::distance(rg)}.
 \end{itemdescr}
 
-\rSec3[inplace.vector.capacity]{Size and capacity}
+\rSec3[inplace.vector.capacity]{Capacity}
 
 \indexlibrarymember{capacity}{inplace_vector}%
 \indexlibrarymember{max_size}{inplace_vector}%
@@ -9847,6 +9847,32 @@ appends \tcode{sz - size()} copies of \tcode{c} to the sequence.
 \pnum
 \remarks
 If an exception is thrown, there are no effects on \tcode{*this}.
+\end{itemdescr}
+
+\indexlibrarymember{reserve}{inplace_vector}%
+\begin{itemdecl}
+static constexpr void reserve(size_type n);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+None.
+
+\pnum
+\throws
+\tcode{bad_alloc} if \tcode{n > capacity()} is \tcode{true}.
+\end{itemdescr}
+
+\indexlibrarymember{shrink_to_fit}{inplace_vector}%
+\begin{itemdecl}
+static constexpr void shrink_to_fit() noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+None.
 \end{itemdescr}
 
 \rSec3[inplace.vector.data]{Data}
@@ -10064,32 +10090,6 @@ constexpr reference unchecked_push_back(T&& x);
 \effects
 Equivalent to:
 \tcode{return *try_push_back(std::forward<decltype(x)>(x));}
-\end{itemdescr}
-
-\indexlibrarymember{reserve}{inplace_vector}%
-\begin{itemdecl}
-static constexpr void reserve(size_type n);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-None.
-
-\pnum
-\throws
-\tcode{bad_alloc} if \tcode{n > capacity()} is \tcode{true}.
-\end{itemdescr}
-
-\indexlibrarymember{shrink_to_fit}{inplace_vector}%
-\begin{itemdecl}
-static constexpr void shrink_to_fit() noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-None.
 \end{itemdescr}
 
 \indexlibrarymember{erase}{inplace_vector}%


### PR DESCRIPTION
> In the synopsis [inplace.vector.overview], reserve() and shrink_to_fit() are under size/capacity, but their actual descriptions are in [inplace.vector.modifiers], not [inplace.vector.capacity].

And the English title of [inplace.vector.capacity] doesn't quite match [vector.capacity], either. I think this is editorial and easy to patch.