### PR TITLE
[inplace.vector] Use `T*`, not `pointer`, for some return types

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9672,9 +9672,9 @@ namespace std {
     constexpr void pop_back();
 
     template<class... Args>
-      constexpr pointer try_emplace_back(Args&&... args);
-    constexpr pointer try_push_back(const T& x);
-    constexpr pointer try_push_back(T&& x);
+      constexpr T* try_emplace_back(Args&&... args);
+    constexpr T* try_push_back(const T& x);
+    constexpr T* try_push_back(T&& x);
     template<@\exposconcept{container-compatible-range}@<T> R>
       constexpr ranges::borrowed_iterator_t<R> try_append_range(R&& rg);
 
@@ -9950,9 +9950,9 @@ If an exception is thrown, there are no effects on \tcode{*this}.
 \indexlibrarymember{try_push_back}{inplace_vector}%
 \begin{itemdecl}
 template<class... Args>
-  constexpr pointer try_emplace_back(Args&&... args);
-constexpr pointer try_push_back(const T& x);
-constexpr pointer try_push_back(T&& x);
+  constexpr T* try_emplace_back(Args&&... args);
+constexpr T* try_push_back(const T& x);
+constexpr T* try_push_back(T&& x);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
This is editorial for now. But P3160 "allocator-aware `inplace_vector`" *might* change the definition of `pointer` (that's still up in the air), and if so, we definitely want `try_emplace_back` to continue returning a raw pointer, not some kind of fancy pointer. Make that change now, so that we don't have to worry about it during the discussion of P3160.

Marking as "draft" until @phalpern confirms that this is desirable (or at least not harmful) from his POV too.