### PR TITLE
[basic.align] Move the Alignment clause adjacent to the Object model

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3453,6 +3453,100 @@ Some functions in the \Cpp{} standard library implicitly create objects%
 \end{note}
 \indextext{object model|)}
 
+\rSec2[basic.align]{Alignment}
+
+\pnum
+Object types have \defnx{alignment requirements}{alignment requirement!implementation-defined}\iref{basic.fundamental,basic.compound}
+which place restrictions on the addresses at which an object of that type
+may be allocated. An \defn{alignment} is an \impldef{alignment}
+integer value representing the number of bytes between successive addresses
+at which a given object can be allocated. An object type imposes an alignment
+requirement on every object of that type; stricter alignment can be requested
+using the alignment specifier\iref{dcl.align}.
+Attempting to create an object\iref{intro.object} in storage that
+does not meet the alignment requirements of the object's type
+is undefined behavior.
+
+\pnum
+A \defnadj{fundamental}{alignment} is represented by an alignment
+less than or equal to the greatest alignment supported by the implementation in
+all contexts, which is equal to
+\tcode{\keyword{alignof}(std::max_align_t)}\iref{support.types}.
+The alignment required for a type may be different when it is used as the type
+of a complete object and when it is used as the type of a subobject.
+\begin{example}
+\begin{codeblock}
+struct B { long double d; };
+struct D : virtual B { char c; };
+\end{codeblock}
+
+When \tcode{D} is the type of a complete object, it will have a subobject of
+type \tcode{B}, so it must be aligned appropriately for a \tcode{\keyword{long} \keyword{double}}.
+If \tcode{D} appears as a subobject of another object that also has \tcode{B}
+as a virtual base class, the \tcode{B} subobject might be part of a different
+subobject, reducing the alignment requirements on the \tcode{D} subobject.
+\end{example}
+The result of the \keyword{alignof} operator reflects the alignment
+requirement of the type in the complete-object case.
+
+\pnum
+An \defnadj{extended}{alignment} is represented by an alignment
+greater than \tcode{\keyword{alignof}(std::max_align_t)}. It is \impldef{support for extended alignments}
+whether any extended alignments are supported and the contexts in which they are
+supported\iref{dcl.align}. A type having an extended alignment
+requirement is an \defnadj{over-aligned}{type}.
+\begin{note}
+Every over-aligned type is or contains a class type
+to which extended alignment applies (possibly through a non-static data member).
+\end{note}
+A \defnadj{new-extended}{alignment} is represented by
+an alignment greater than \mname{STDCPP_DEFAULT_NEW_ALIGNMENT}\iref{cpp.predefined}.
+
+\pnum
+Alignments are represented as values of the type \tcode{std::size_t}.
+Valid alignments include only those values returned by an \keyword{alignof}
+expression for the fundamental types plus an additional \impldef{alignment additional
+values}
+set of values, which may be empty.
+Every alignment value shall be a non-negative integral power of two.
+
+\pnum
+Alignments have an order from \defnx{weaker}{alignment!weaker} to
+\defnx{stronger}{alignment!stronger} or \defnx{stricter}{alignment!stricter} alignments. Stricter
+alignments have larger alignment values. An address that satisfies an alignment
+requirement also satisfies any weaker valid alignment requirement.
+
+\pnum
+The alignment requirement of a complete type can be queried using an
+\keyword{alignof} expression\iref{expr.alignof}. Furthermore,
+the narrow character types\iref{basic.fundamental} shall have the weakest
+alignment requirement.
+\begin{note}
+This enables the ordinary character types to be used as the
+underlying type for an aligned memory area\iref{dcl.align}.
+\end{note}
+
+\pnum
+Comparing alignments is meaningful and provides the obvious results:
+
+\begin{itemize}
+\item Two alignments are equal when their numeric values are equal.
+\item Two alignments are different when their numeric values are not equal.
+\item When an alignment is larger than another it represents a stricter alignment.
+\end{itemize}
+
+\pnum
+\begin{note}
+The runtime pointer alignment function\iref{ptr.align}
+can be used to obtain an aligned pointer within a buffer;
+an \grammarterm{alignment-specifier}\iref{dcl.align}
+can be used to align storage explicitly.
+\end{note}
+
+\pnum
+If a request for a specific extended alignment in a specific context is not
+supported by an implementation, the program is ill-formed.
+
 \rSec2[basic.life]{Lifetime}
 
 \pnum
@@ -4248,100 +4342,6 @@ If the argument given to a deallocation function in the standard library
 is a pointer that is not the null pointer value\iref{basic.compound}, the
 deallocation function shall deallocate the storage referenced by the
 pointer, ending the duration of the region of storage.
-
-\rSec2[basic.align]{Alignment}
-
-\pnum
-Object types have \defnx{alignment requirements}{alignment requirement!implementation-defined}\iref{basic.fundamental,basic.compound}
-which place restrictions on the addresses at which an object of that type
-may be allocated. An \defn{alignment} is an \impldef{alignment}
-integer value representing the number of bytes between successive addresses
-at which a given object can be allocated. An object type imposes an alignment
-requirement on every object of that type; stricter alignment can be requested
-using the alignment specifier\iref{dcl.align}.
-Attempting to create an object\iref{intro.object} in storage that
-does not meet the alignment requirements of the object's type
-is undefined behavior.
-
-\pnum
-A \defnadj{fundamental}{alignment} is represented by an alignment
-less than or equal to the greatest alignment supported by the implementation in
-all contexts, which is equal to
-\tcode{\keyword{alignof}(std::max_align_t)}\iref{support.types}.
-The alignment required for a type may be different when it is used as the type
-of a complete object and when it is used as the type of a subobject.
-\begin{example}
-\begin{codeblock}
-struct B { long double d; };
-struct D : virtual B { char c; };
-\end{codeblock}
-
-When \tcode{D} is the type of a complete object, it will have a subobject of
-type \tcode{B}, so it must be aligned appropriately for a \tcode{\keyword{long} \keyword{double}}.
-If \tcode{D} appears as a subobject of another object that also has \tcode{B}
-as a virtual base class, the \tcode{B} subobject might be part of a different
-subobject, reducing the alignment requirements on the \tcode{D} subobject.
-\end{example}
-The result of the \keyword{alignof} operator reflects the alignment
-requirement of the type in the complete-object case.
-
-\pnum
-An \defnadj{extended}{alignment} is represented by an alignment
-greater than \tcode{\keyword{alignof}(std::max_align_t)}. It is \impldef{support for extended alignments}
-whether any extended alignments are supported and the contexts in which they are
-supported\iref{dcl.align}. A type having an extended alignment
-requirement is an \defnadj{over-aligned}{type}.
-\begin{note}
-Every over-aligned type is or contains a class type
-to which extended alignment applies (possibly through a non-static data member).
-\end{note}
-A \defnadj{new-extended}{alignment} is represented by
-an alignment greater than \mname{STDCPP_DEFAULT_NEW_ALIGNMENT}\iref{cpp.predefined}.
-
-\pnum
-Alignments are represented as values of the type \tcode{std::size_t}.
-Valid alignments include only those values returned by an \keyword{alignof}
-expression for the fundamental types plus an additional \impldef{alignment additional
-values}
-set of values, which may be empty.
-Every alignment value shall be a non-negative integral power of two.
-
-\pnum
-Alignments have an order from \defnx{weaker}{alignment!weaker} to
-\defnx{stronger}{alignment!stronger} or \defnx{stricter}{alignment!stricter} alignments. Stricter
-alignments have larger alignment values. An address that satisfies an alignment
-requirement also satisfies any weaker valid alignment requirement.
-
-\pnum
-The alignment requirement of a complete type can be queried using an
-\keyword{alignof} expression\iref{expr.alignof}. Furthermore,
-the narrow character types\iref{basic.fundamental} shall have the weakest
-alignment requirement.
-\begin{note}
-This enables the ordinary character types to be used as the
-underlying type for an aligned memory area\iref{dcl.align}.
-\end{note}
-
-\pnum
-Comparing alignments is meaningful and provides the obvious results:
-
-\begin{itemize}
-\item Two alignments are equal when their numeric values are equal.
-\item Two alignments are different when their numeric values are not equal.
-\item When an alignment is larger than another it represents a stricter alignment.
-\end{itemize}
-
-\pnum
-\begin{note}
-The runtime pointer alignment function\iref{ptr.align}
-can be used to obtain an aligned pointer within a buffer;
-an \grammarterm{alignment-specifier}\iref{dcl.align}
-can be used to align storage explicitly.
-\end{note}
-
-\pnum
-If a request for a specific extended alignment in a specific context is not
-supported by an implementation, the program is ill-formed.
 
 \rSec2[class.temporary]{Temporary objects}
 


### PR DESCRIPTION
[Edit]
Simplified to move just the Alignment subclause.

[Original, for reference]
Reorder the subclauses of [basic.memobj], Memory and objects, into a logical progression where each clause augments the one before.

* Memory model specifies the notion of memory for C++
* Object model specifies objects, and how they occupy memory
* Alignment restricts where objects can reside in memory
* Storage duration describes how objects acquire well-aligned memory
* Intermediate and erroneous values specifies the initial contents of acquired memory
* Lifetime describes the validity of objects within their acquired storage
* Temporary objects have a lifetime of their own.