### PR TITLE
[lex.pptoken] Fix indefinitive article for consistency

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -577,7 +577,7 @@ would cause further lexical analysis to fail,
 except that a \grammarterm{header-name}\iref{lex.header} is only formed
 \begin{itemize}
 \item
-after the \tcode{include} or \tcode{import} preprocessing token in an
+after the \tcode{include} or \tcode{import} preprocessing token in a
 \tcode{\#include}\iref{cpp.include} or
 \tcode{import}\iref{cpp.import} directive, or
 


### PR DESCRIPTION
There exist 16 "a #include" in the draft, but only this one "an #include".