### PR TITLE
[lex.phases] Add crossreferences from phases 3 and 4

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -140,7 +140,7 @@ or \tcode{>}. A partial comment
 would arise from a source file ending with an unclosed \tcode{/*}
 comment.
 \end{footnote}
-Each comment is replaced by one space character. New-line characters are
+Each comment\iref{lex.comment} is replaced by one space character. New-line characters are
 retained. Whether each nonempty sequence of whitespace characters other
 than new-line is retained or replaced by one space character is
 unspecified.
@@ -153,8 +153,8 @@ except when matching a
 \grammarterm{r-char-sequence},
 \grammarterm{h-char-sequence}, or
 \grammarterm{q-char-sequence},
-\grammarterm{universal-character-name}s are recognized and
-replaced by the designated element of the translation character set.
+\grammarterm{universal-character-name}s are recognized\iref{lex.universal.char} and
+replaced by the designated element of the translation character set\iref{lex.charset}.
 The process of dividing a source file's
 characters into preprocessing tokens is context-dependent.
 \begin{example}
@@ -162,9 +162,9 @@ See the handling of \tcode{<} within a \tcode{\#include} preprocessing
 directive\iref{cpp.include}.
 \end{example}
 
-\item Preprocessing directives are executed, macro invocations are
-expanded, and \tcode{_Pragma} unary operator expressions are executed.
-A \tcode{\#include} preprocessing directive causes the named header or
+\item Preprocessing directives\iref{cpp} are executed, macro invocations are
+expanded\iref{cpp.replace}, and \tcode{_Pragma} unary operator expressions are executed\iref{cpp.pragma.op}.
+A \tcode{\#include} preprocessing directive\iref{cpp.include} causes the named header or
 source file to be processed from phase 1 through phase 4, recursively.
 All preprocessing directives are then deleted.
 


### PR DESCRIPTION
The phases of translation use forward references to the rest of the standard well, but phases 3 and 4 almost entirely lack such crossreferences, despite doing significant work in the process of translating a file.