### PR TITLE
[specialized.algorithms.general] Restore the note for potentially-overlapping objects and undefined behavior

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -11163,7 +11163,6 @@ the algorithms specified in \ref{specialized.algorithms},
 the lifetime ends for any existing objects
 (including potentially-overlapping subobjects \ref{intro.object})
 in storage that is reused \ref{basic.life}.
-Subsequent operations on these objects can result in undefined behavior.
 \end{note}
 
 \pnum

--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -11157,6 +11157,16 @@ are destroyed in an unspecified order
 before allowing the exception to propagate.
 
 \pnum
+\begin{note}
+When new objects are created by
+the algorithms specified in \ref{specialized.algorithms},
+the lifetime ends for any existing objects
+(including potentially-overlapping subobjects \ref{intro.object})
+in storage that is reused \ref{basic.life}.
+Subsequent operations on these objects can result in undefined behavior.
+\end{note}
+
+\pnum
 Some algorithms specified in \ref{specialized.algorithms}
 make use of the exposition-only function template
 \tcode{\placeholdernc{voidify}}:


### PR DESCRIPTION
The original note was incorrect and removed by #6157. But it turns out that _some_ note would still be helpful. This PR tries to find the right way to describe storage reusing and potential subsequent undefined behavior.

Fixes #6143.