### PR TITLE
[func.wrap.func.con], [func.wrap.move.class], [func.wrap.copy.class], [any.class.general] Reword avoidance of 'dynamically allocated memory' as 'nesting an object within'

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -6550,7 +6550,8 @@ Two states are equivalent if either they both have no value, or they both have a
 The non-member \tcode{any_cast} functions provide type-safe access to the contained value.
 
 \pnum
-Implementations should avoid the use of dynamically allocated memory for a small contained value.
+Implementations should nest an object within\iref{intro.object}
+an object of type \tcode{any} for a small contained value.
 However, any such small-object optimization shall only be applied to types \tcode{T} for which
 \tcode{is_nothrow_move_constructible_v<T>} is \tcode{true}.
 \begin{example}
@@ -13181,8 +13182,9 @@ or any exception thrown by the copy constructor of the stored callable object.
 
 \pnum
 \recommended
-Implementations should avoid the use of
-dynamically allocated memory for small callable objects, for example, where
+Implementations should nest an object within\iref{intro.object}
+a \tcode{function} for small callable objects,
+for example, where
 \tcode{f}'s target is an object holding only a pointer or reference
 to an object and a member function pointer.
 \end{itemdescr}
@@ -13202,8 +13204,9 @@ the target of \tcode{f} before the construction, and
 
 \pnum
 \recommended
-Implementations should avoid the use of
-dynamically allocated memory for small callable objects, for example,
+Implementations should nest an object within\iref{intro.object}
+a \tcode{function} for small callable objects,
+for example,
 where \tcode{f}'s target is an object holding only a pointer or reference
 to an object and a member function pointer.
 \end{itemdescr}
@@ -13265,8 +13268,9 @@ any exception thrown by the initialization of the target object.
 
 \pnum
 \recommended
-Implementations should avoid the use of
-dynamically allocated memory for small callable objects, for example,
+Implementations should nest an object within\iref{intro.object}
+a \tcode{function} for small callable objects,
+for example,
 where \tcode{f} refers to an object holding only a pointer or
 reference to an object and a member function pointer.
 \end{itemdescr}
@@ -13583,8 +13587,8 @@ given a call signature.
 
 \pnum
 \recommended
-Implementations should avoid the use of dynamically allocated memory
-for a small contained value.
+Implementations should nest an object within\iref{intro.object}
+a \tcode{move_only_function} for a small contained value.
 \begin{note}
 Such small-object optimization can only be applied to a type \tcode{T}
 for which \tcode{is_nothrow_move_constructible_v<T>} is \tcode{true}.
@@ -13978,8 +13982,8 @@ given a call signature.
 
 \pnum
 \recommended
-Implementations should avoid the use of dynamically allocated memory
-for a small contained value.
+Implementations should nest an object within\iref{intro.object}
+a \tcode{copyable_function} for a small contained value.
 \begin{note}
 Such small-object optimization can only be applied to a type \tcode{T}
 for which \tcode{is_nothrow_move_constructible_v<T>} is \tcode{true}.


### PR DESCRIPTION
Partially addresses #7261.

This PR replaces the informal *"avoid the use of dynamically allocated memory"* terminology with the more formal *"should nest an object within"* terminology, which similar to *"is nested within"*, seen in [LWG4141](https://cplusplus.github.io/LWG/issue4141).

This does not yet fix all such issues pointed out in #7261 for the sake of keeping this PR minimal.