### PR TITLE
[unique.ptr.general] Delete note listing unique_ptr use cases

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -1922,15 +1922,6 @@ is \oldconcept{MoveConstructible} and \oldconcept{MoveAssignable}, but is not
 \oldconcept{CopyConstructible} nor \oldconcept{CopyAssignable}.
 The template parameter \tcode{T} of \tcode{unique_ptr} may be an incomplete type.
 
-\pnum
-\begin{note}
-The uses
-of \tcode{unique_ptr} include providing exception safety for
-dynamically allocated memory, passing ownership of dynamically allocated
-memory to a function, and returning dynamically allocated memory from a
-function.
-\end{note}
-
 \rSec3[unique.ptr.dltr]{Default deleters}
 
 \rSec4[unique.ptr.dltr.general]{General}


### PR DESCRIPTION
As part of #7261.

[[unique.ptr.general] p5](https://eel.is/c++draft/unique.ptr.general#5) states:
> [*Note*: The uses of `unique_ptr` include providing exception safety for dynamically allocated memory, passing ownership of dynamically allocated memory to a function, and returning dynamically allocated memory from a function. - *end note*]

This note should be deleted. It is not incorrect or misleading, but it is worded improperly for the standard and would require too much effort to fix. Specifically, the problems are:

1. The note provides very little value because everyone and their dog knows what `std::unique_ptr` is used for at this point.

2. The standard does not define "dynamically allocated memory", so the note is informal.

3. The note is needlessly exhaustive. `std::unique_ptr` with custom deleters can be used to own all sorts of resources. At the very least, the note should state *"include, but are not limited to"*.

4. The note is not providing guidance to implementers and language lawyers, who are the actual target audience of the document. It seems to be listing possible uses for developers, so it reads like a tutorial note.

5. [[unique.ptr.general] p1](https://eel.is/c++draft/unique.ptr.general#1) already provides a more general introduction to `std::unique_ptr` with much less problematic wording.

One could try to tackle all of these issues and turn this into a fantastic note perhaps, but I'm inclined to simply deleting it. It's not worth putting in the time, and it arguably reduces the quality of the standard.