### PR TITLE
[basic.stc.dynamic.general] Fix definition/explanation of dynamic storage duration

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3992,12 +3992,16 @@ specified in~\ref{class.copy.elision}.
 \indextext{storage duration!dynamic|(}
 
 \pnum
-Objects can be created dynamically during program
-execution\iref{intro.execution}, using
+Objects created using
 \indextext{\idxcode{new}}%
-\grammarterm{new-expression}{s}\iref{expr.new}, and destroyed using
+\grammarterm{new-expression}{s}\iref{expr.new}
+and implicitly created objects\iref{intro.object}
+have \defnadj{dynamic}{storage duration}.
+Objects created using \grammarterm{new-expression}{s}
+may be destroyed using
 \indextext{\idxcode{delete}}%
-\grammarterm{delete-expression}{s}\iref{expr.delete}. A \Cpp{} implementation
+\grammarterm{delete-expression}{s}.
+A \Cpp{} implementation
 provides access to, and management of, dynamic storage via
 the global \defnx{allocation functions}{allocation function}
 \tcode{\keyword{operator} \keyword{new}} and


### PR DESCRIPTION
As part of https://github.com/cplusplus/draft/issues/7261.

This PR fixes numerous issues with [[basic.stc.dynamic.general] p1](https://eel.is/c++draft/basic.stc.dynamic.general#1):

1. "dynamically" is not defined in the standard, and the paragraph does not define it (judging by formatting), so this term is meaningless.

2. The paragraph specifically states "during program execution", but C++20 allows the user to create dynamic storage duration objects during *program translation*, i.e. within constant evaluation.

3. The explanation given here is not exhaustive. Normative wording in [[basic.stc.general] p2](https://eel.is/c++draft/basic.stc.general#2.sentence-2) already states "The dynamic storage duration is associated with objects created by a *new-expression* ([expr.new]) or with implicitly created objects ([intro.object]).". Notably, implicitly created objects are not mentioned in [basic.stc.dynamic.general].

It is worth noting that the new definition explicitly gives dynamic storage duration to *objects*, which is inconsistent with the other definitions. For example, [[basic.stc.static]](https://eel.is/c++draft/basic.stc.static) says:

> All variables which [...] have *static storage duration*.

@jensmaurer has stated in https://github.com/cplusplus/draft/issues/6523#issuecomment-1694706321 that we have long-standing problems with the term "variable". At first sight, this may be a blocker for this edit.

However, this editorial issue does not introduce a novel problem because [[expr.new] p10](https://eel.is/c++draft/expr.new#10) already states:

> Objects created by a *new-expression* have dynamic storage duration ([basic.stc.dynamic]).

In other words, this PR makes no normative changes. It aggregates existing wording from [expr.new] and [basic.stc.general] and replaces old incorrect or incomplete wording.