### PR TITLE
[basic.life] Reference [intro.object] in transparent replacement note and improve example

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3660,6 +3660,13 @@ of the original object will automatically refer to the new object and, once the
 lifetime of the new object has started, can be used to manipulate the new
 object.
 
+\begin{note}
+Additionally, if the requirements in \ref{intro.object}
+for the creation of subobjects are met,
+once the lifetime of the new object has started,
+the containing object of the original object
+can be used to manipulate the new object.
+\end{note}
 \begin{example}
 \begin{codeblock}
 struct C {
@@ -3677,10 +3684,14 @@ const C& C::operator=( const C& other) {
   return *this;
 }
 
-C c1;
-C c2;
-c1 = c2;                        // well-defined
-c1.f();                         // well-defined; \tcode{c1} refers to a new object of type \tcode{C}
+void g() {
+  C c1;
+  C c2;
+  c1 = c2;                      // well-defined
+  c1.f();                       // well-defined; \tcode{c1} refers to a new object of type \tcode{C}
+  new (&c1.i) int(42);          // well-defined
+  int j = c1.i;                 // well-defined
+}
 \end{codeblock}
 \end{example}
 \begin{note}


### PR DESCRIPTION
Recently, it was really difficult for me to find out what happens when you transparently replace a subobject. [[basic.life] p9](https://eel.is/c++draft/basic.life#9) does not elaborate on this; the relevant parts are in [[intro.object] p2](https://eel.is/c++draft/intro.object#2.sentence-4).

Namely, the containing object is kept alive if the conditions are met and can be used to access the new subobject. A new note highlights this behavior and links back to [intro.object].

Furthermore, [[basic.life] Example 3](https://eel.is/c++draft/basic.life#example-3) is currently ill-formed (fixed by this PR) because it contains `c1 = c2;` at a top level, which should be taking place in a function body. The example is further expanded by two lines that demonstrate how a containing object survives when transparent replacement of one of its subobjects takes place.