### PR TITLE
[lex.header] Modernize text around header names

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -661,16 +661,16 @@ violates a constraint on increment operators, even though the parse
 \end{bnf}
 
 \pnum
+The sequences in both forms of \grammarterm{header-name}{s} are mapped in an
+\impldef{mapping header name to header or external source file} manner to headers or to
+external source file names as specified in~\ref{cpp.include}.
 \begin{note}
-Header name preprocessing tokens only appear within
+Header name preprocessing tokens appear only within
 a \tcode{\#include} preprocessing directive,
 a \tcode{__has_include} preprocessing expression, or
 after certain occurrences of an \tcode{import} token
 (see~\ref{lex.pptoken}).
 \end{note}
-The sequences in both forms of \grammarterm{header-name}{s} are mapped in an
-\impldef{mapping header name to header or external source file} manner to headers or to
-external source file names as specified in~\ref{cpp.include}.
 
 \pnum
 The appearance of either of the characters \tcode{'} or \tcode{\textbackslash} or of
@@ -680,12 +680,12 @@ is conditionally-supported with \impldef{meaning of \tcode{'}, \tcode{\textbacks
 \tcode{/*}, or \tcode{//} in a \grammarterm{q-char-sequence} or an
 \grammarterm{h-char-sequence}} semantics, as is the appearance of the character
 \tcode{"} in an \grammarterm{h-char-sequence}.
-\begin{footnote}
+\begin{note}
 Thus, a sequence of characters
 that resembles an escape sequence can result in an error, be interpreted as the
 character corresponding to the escape sequence, or have a completely different meaning,
 depending on the implementation.
-\end{footnote}
+\end{note}
 \indextext{header!name|)}
 
 \rSec1[lex.ppnumber]{Preprocessing numbers}


### PR DESCRIPTION
The footnote better belongs in the main text as a regular note.                 
To make the notes flow consistently, switch the order of the                    
note and normative text in the first paragraph to lead with the                  
normative text.