### PR TITLE
[func.wrap.func.con] Fix ill-formed postcondition

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -13170,7 +13170,7 @@ function(const function& f);
 \pnum
 \ensures
 \tcode{!*this} if \tcode{!f}; otherwise,
-the target object of \tcode{*this} is a copy of \tcode{f.target()}.
+the target object of \tcode{*this} is a copy of the target object of \tcode{f}.
 
 \pnum
 \throws


### PR DESCRIPTION
[[func.wrap.func.con] p3](https://eel.is/c++draft/func.wrap.func.con#3) contains the ill-formed call
> `f.target()`

To make a call to `target()`, it is necessary to provide the target type explicitly. Furthermore, this wording implies that the pointer returned by `target()` is copied, not the object itself, which is obviously not intended.

To fix this, we can copy the more recent wording from [[func.wrap.copy.ctor] p3](https://eel.is/c++draft/func.wrap.copy.ctor#3).