### PR TITLE
[basic.link] Add oxford comma

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2714,8 +2714,8 @@ can have external or module linkage, even if not declared \keyword{extern}.
 \pnum
 An unnamed namespace or a namespace declared directly or indirectly within an
 unnamed namespace has internal linkage. All other namespaces have external linkage.
-The name of an entity that belongs to a namespace scope
-that has not been given internal linkage above
+The name of an entity that belongs to a namespace scope,
+that has not been given internal linkage above,
 and that is the name of
 \begin{itemize}
 \item a variable; or


### PR DESCRIPTION
The lack of commas in [[basic.link] p4](https://eel.is/c++draft/basic.link#4) really had me stumped for a few minutes because I thought it should be read as:
```
The name of an entity that belongs to a
    namespace scope that has not been given internal linkage above
and that is the name of ...
```
... when the intended reading is
```
The name of an entity
- that belongs to a namespace scope,
- that has not been given internal linkage above, and
- that is the name of ...
```
This PR adds an Oxford comma to make it immediately obvious which reading is intended.