### PR TITLE
[basic.stc.inherit] Dissolve paragraph into [basic.stc.general]

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3912,6 +3912,12 @@ with implicitly created objects\iref{intro.object}.
 \pnum
 The storage duration categories apply to references as well.
 
+\pnum
+\indextext{storage duration!class member}%
+The storage duration of subobjects and reference members
+is that of their complete object\iref{intro.object}.
+\indextext{storage duration|)}%
+
 \rSec3[basic.stc.static]{Static storage duration}
 
 \pnum
@@ -4243,14 +4249,6 @@ If the argument given to a deallocation function in the standard library
 is a pointer that is not the null pointer value\iref{basic.compound}, the
 deallocation function shall deallocate the storage referenced by the
 pointer, ending the duration of the region of storage.
-
-\rSec3[basic.stc.inherit]{Duration of subobjects}
-
-\pnum
-\indextext{storage duration!class member}%
-The storage duration of subobjects and reference members
-is that of their complete object\iref{intro.object}.
-\indextext{storage duration|)}%
 
 \rSec2[basic.align]{Alignment}
 

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -95,6 +95,9 @@
 \movedxref{stoptoken.cons}{stopsource}
 \movedxref{stoptoken.nonmembers}{stopsource}
 
+% https://github.com/cplusplus/draft/pull/7345
+\movedxref{basic.stc.inherit}{basic.stc.general}
+
 %%% Deprecated features.
 %%% Example:
 %


### PR DESCRIPTION
The whole subclause [basic.stc.inherit] is a single sentence that belongs adjacent to the material in [basic.std.general] that specifies how entities acquire a storage duration, wheras all the remaining subclauses below [basic.stc] describe specific storage durations.  Folding that sentence directly into the general clause is even clearer.