### PR TITLE
[lex.pptoken] Do not use terms before they are defined

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -510,11 +510,6 @@ characters \tcode{//} and \tcode{/*} have no special meaning within a
 \end{bnf}
 
 \pnum
-Each preprocessing token that is converted to a token\iref{lex.token}
-shall have the lexical form of a keyword, an identifier, a literal,
-or an operator or punctuator.
-
-\pnum
 A preprocessing token is the minimal lexical element of the language in translation
 phases 3 through 6.
 In this document,
@@ -547,6 +542,22 @@ thereof) serves as more than preprocessing token separation. Whitespace
 can appear within a preprocessing token only as part of a header name or
 between the quotation characters in a character literal or
 string literal.
+
+\pnum
+Each preprocessing token that is converted to a token\iref{lex.token}
+shall have the lexical form of a keyword, an identifier, a literal,
+or an operator or punctuator.
+
+\pnum
+The \grammarterm{import-keyword} is produced
+by processing an \keyword{import} directive\iref{cpp.import},
+the \grammarterm{module-keyword} is produced
+by preprocessing a \keyword{module} directive\iref{cpp.module}, and
+the \grammarterm{export-keyword} is produced
+by preprocessing either of the previous two directives.
+\begin{note}
+None has any observable spelling.
+\end{note}
 
 \pnum
 If the input stream has been parsed into preprocessing tokens up to a
@@ -587,23 +598,13 @@ within a \grammarterm{has-include-expression}.
 \end{itemize}
 \end{itemize}
 
+\pnum
 \begin{example}
 \begin{codeblock}
 #define R "x"
 const char* s = R"y";           // ill-formed raw string, not \tcode{"x" "y"}
 \end{codeblock}
 \end{example}
-
-\pnum
-The \grammarterm{import-keyword} is produced
-by preprocessing an \keyword{import} directive\iref{cpp.import},
-the \grammarterm{module-keyword} is produced
-by preprocessing a \keyword{module} directive\iref{cpp.module}, and
-the \grammarterm{export-keyword} is produced
-by preprocessing either of the previous two directives.
-\begin{note}
-None has any observable spelling.
-\end{note}
 
 \pnum
 \begin{example}


### PR DESCRIPTION
This PR purely moves existing words around, and does not create any new content.  First move p1 below p2, so that we do not refer to preprocessing tokens before they are defined.  Then move p4 up, as it is splitting some unrelated examples, neither of which use its contents.