### PR TITLE
[locale.codecvt.virtuals] Improve wording

### DIFF
--- a/source/text.tex
+++ b/source/text.tex
@@ -2161,10 +2161,8 @@ Stops if it encounters a character it cannot convert.
 It always leaves the \tcode{from_next} and \tcode{to_next} pointers
 pointing one beyond the last element successfully converted.
 If it returns \tcode{noconv},
-\tcode{internT} and \tcode{externT} are the same type, and
-the converted sequence is identical to
-the input sequence \range{from}{from\textunderscore\nobreak next},
 \tcode{to_next} is set equal to \tcode{to},
+\tcode{from_next} is set equal to \tcode{from},
 the value of \tcode{state} is unchanged, and
 there are no changes to the values in \range{to}{to_end}.
 


### PR DESCRIPTION
Pre-C++98 draft N1146 [[lib.locale.codecvt.virtuals]/2](https://www.open-std.org/jtc1/sc22/wg21/docs/wp/html/nov97-2/lib-locales.html#lib.locale.codecvt.virtuals) mentions:

> [Note: If no translation is needed (returns `noconv`), sets `to_next` equal to argument `to`, and `from_next` equal to argument `from`.  --end note]

[LWG 19](http://cplusplus.github.io/LWG/issue19) proposes to "change the Note in paragraph 2 to normative text", but in doing so, it introduces a few problems:

- grammar error (fixed in #7338);
- the meaning of `noconv` is specified twice (once in this paragraph, once in the table [[tab:locale.codecvt.inout]](https://eel.is/c++draft/locale.codecvt.virtuals#tab:locale.codecvt.inout-row-5));
- the effect on `from_next` is lost.

This PR fixes the last two problems.
