### PR TITLE
[lex.separate] Redistribute second comment

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -39,17 +39,8 @@ if any, is
 called a \defnadj{preprocessing}{translation unit}.
 \begin{note}
 A \Cpp{} program need not all be translated at the same time.
-\end{note}
-
-\pnum
-\begin{note}
-Previously translated translation units can be preserved individually or in libraries.
-The separate translation units of a program communicate\iref{basic.link} by (for example)
-calls to functions whose identifiers have external or module linkage,
-manipulation of objects whose identifiers have external or module linkage, or
-manipulation of data files. Translation units can be separately
-translated and then later linked to produce an executable
-program\iref{basic.link}.
+Translation units can be separately translated and then later linked
+to produce an executable program\iref{basic.link}.
 \end{note}
 \indextext{compilation!separate|)}
 
@@ -206,6 +197,13 @@ units and translated translation units need not necessarily be stored as
 files, nor need there be any one-to-one correspondence between these
 entities and any external representation. The description is conceptual
 only, and does not specify any particular implementation.
+\end{note}
+\begin{note}
+Previously translated translation units can be preserved individually or in libraries.
+The separate translation units of a program communicate\iref{basic.link} by (for example)
+calls to functions whose identifiers have external or module linkage,
+manipulation of objects whose identifiers have external or module linkage, or
+manipulation of data files.
 \end{note}
 
 While the tokens constituting translation units


### PR DESCRIPTION
The second comment in [lex.separate] is both too specific, and not specific enough.  Move the last sentence about use of separately translated TUs to the end of the first note, where it seems most appropriate.  Move the rest of the note to the end of translation phase 8, where we are in a position to talk about preserving the separately translated TUs *and instantiation units* for linking in phase 9.