### PR TITLE
[bit.cast] Rename "behaviour" to "behavior" for consistency

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15152,7 +15152,7 @@ otherwise has an erroneous value.
 \item
 Otherwise, if $b$ is indeterminate, the behavior is undefined.
 \item
-Otherwise, the behaviour is erroneous, and the result is as specified above.
+Otherwise, the behavior is erroneous, and the result is as specified above.
 \end{itemize}
 The result does not otherwise contain any indeterminate or erroneous values.
 


### PR DESCRIPTION
There exist 579 "behavior" in the draft, but only this one "behaviour".