### PR TITLE
[conv.general] Remove duplicate cross-reference to [dcl.init]

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -559,7 +559,7 @@ Certain language constructs require that an expression be converted to a Boolean
 value. An expression $E$ appearing in such a context is said to be
 \defnx{contextually converted to \tcode{bool}}{conversion!contextual to \tcode{bool}} and is well-formed if and only if
 the declaration \tcode{\keyword{bool} t($E$);} is well-formed, for some invented temporary
-variable \tcode{t}\iref{dcl.init}.
+variable \tcode{t}.
 
 \pnum
 Certain language constructs require conversion to a value having


### PR DESCRIPTION
The previous paragraph already contains the same `\iref{dcl.init}`, and normally, we don't duplicate these.

I'm also not sure whether this `\iref` is all that good in general, but I don't see any obvious improvement.