### PR TITLE
Replace "of [...] storage duration" with "with [...] storage duration"

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4675,7 +4675,7 @@ of reference type is ill-formed.
 
 \pnum
 \begin{note}
-For every object of static storage duration,
+For every object with static storage duration,
 static initialization\iref{basic.start.static} is performed
 at program startup before any other initialization takes place.
 In some cases, additional initialization is done later.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1587,7 +1587,7 @@ void f() {
 
 \pnum
 An \defnadj{implicitly movable}{entity} is
-a variable of automatic storage duration
+a variable with automatic storage duration
 that is either a non-volatile object or
 an rvalue reference to a non-volatile object type.
 In the following contexts,

--- a/source/future.tex
+++ b/source/future.tex
@@ -889,7 +889,7 @@ Equivalent to: \tcode{atomic_store_explicit(object, desired, memory_order::relax
 \begin{itemdescr}
 \pnum
 The macro expands to a token sequence suitable for constant initialization of
-an atomic variable of static storage duration of a type that
+an atomic variable with static storage duration of a type that
 is initialization-compatible with \tcode{value}.
 \begin{note}
 This operation possibly needs to initialize locks.

--- a/source/support.tex
+++ b/source/support.tex
@@ -2043,7 +2043,7 @@ This function has the semantics specified in the C standard library.
 
 \pnum
 \remarks
-The program is terminated without executing destructors for objects of automatic,
+The program is terminated without executing destructors for objects with automatic,
 thread, or static storage duration and without calling functions passed to
 \tcode{atexit()}\iref{basic.start.term}.
 \indextext{signal-safe!\idxcode{_Exit}}%

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -8762,7 +8762,7 @@ or \tcode{wait_until}) threads.
 \effects
 Transfers ownership of the lock associated with \tcode{lk} into
 internal storage and schedules \tcode{cond} to be notified when the current
-thread exits, after all objects of thread storage duration associated with
+thread exits, after all objects with thread storage duration associated with
 the current thread have been destroyed. This notification is equivalent to:
 \begin{codeblock}
 lk.unlock();
@@ -10895,7 +10895,7 @@ void promise<void>::set_value_at_thread_exit();
 \effects
 Stores the value \tcode{r} in the shared state without making that
 state ready immediately. Schedules that state to be made ready when the current
-thread exits, after all objects of thread storage duration associated with the
+thread exits, after all objects with thread storage duration associated with the
 current thread have been destroyed.
 
 \pnum
@@ -10930,7 +10930,7 @@ void set_exception_at_thread_exit(exception_ptr p);
 \effects
 Stores the exception pointer \tcode{p} in the shared state without
 making that state ready immediately. Schedules that state to be made ready when
-the current thread exits, after all objects of thread storage duration
+the current thread exits, after all objects with thread storage duration
 associated with the current thread have been destroyed.
 
 \pnum
@@ -12064,7 +12064,7 @@ the return value is stored as the asynchronous result in the shared state of
 \tcode{*this}, otherwise the exception thrown by the task is stored. In either
 case, this is done without making that state ready\iref{futures.state} immediately. Schedules
 the shared state to be made ready when the current thread exits,
-after all objects of thread storage duration associated with the current thread
+after all objects with thread storage duration associated with the current thread
 have been destroyed.
 
 \pnum


### PR DESCRIPTION
We currently have two different prepositions in relation to "storage duration"
- with [...] storage duration
- of [...] storage duration

For the purpose of uniformity and grepability, we should settle on one convention. To say "with [...] storage duration" is overwhelmingly more common, so it should be preferred.