### PR TITLE
[expr.prim.lambda.capture], [expr.const], [ostream.formatted.print] Clarify automatic variable

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2656,7 +2656,7 @@ void f(const int*);
 void g() {
   const int N = 10;
   [=] {
-    int arr[N];     // OK, not an odr-use, refers to automatic variable
+    int arr[N];     // OK, not an odr-use, refers to variable with automatic storage duration
     f(&N);          // OK, causes \tcode{N} to be captured; \tcode{\&N} points to
                     // the corresponding member of the closure type
   };
@@ -7609,7 +7609,8 @@ void g() {
 \begin{note}
 If the odr-use occurs in an invocation
 of a function call operator of a closure type,
-it no longer refers to \keyword{this} or to an enclosing automatic variable
+it no longer refers to \keyword{this} or to an enclosing
+variable with automatic storage duration
 due to the transformation\iref{expr.prim.lambda.capture}
 of the \grammarterm{id-expression} into
 an access of the corresponding data member.

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -6855,7 +6855,7 @@ without regard to the value of \tcode{os.exceptions()} and
 without turning on \tcode{ios_base::badbit} in the error state of \tcode{os}.
 \end{itemize}
 After constructing a \tcode{sentry} object,
-the function initializes an automatic variable via
+the function initializes a variable with automatic storage duration via
 \begin{codeblock}
 string out = vformat(os.getloc(), fmt, args);
 \end{codeblock}


### PR DESCRIPTION
In three places in the standard, we have the term "automatic variable".

This term is never defined and unconventional, but most likely means
> variable with automatic storage duration