### PR TITLE
[lex.phases] Use preprocessing token consistently

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -170,14 +170,14 @@ source file to be processed from phase 1 through phase 4, recursively.
 All preprocessing directives are then deleted.
 
 \item
-For a sequence of two or more adjacent \grammarterm{string-literal} tokens,
+For a sequence of two or more adjacent \grammarterm{string-literal} preprocessing tokens,
 a common \grammarterm{encoding-prefix} is determined
 as specified in \ref{lex.string}.
-Each such \grammarterm{string-literal} token is then considered to have
+Each such \grammarterm{string-literal} preprocessing token is then considered to have
 that common \grammarterm{encoding-prefix}.
 
 \item
-Adjacent \grammarterm{string-literal} tokens are concatenated\iref{lex.string}.
+Adjacent \grammarterm{string-literal} preprocessing tokens are concatenated\iref{lex.string}.
 
 \item
 Each preprocessing token is converted into a token\iref{lex.token}.


### PR DESCRIPTION
Prior to converting preprocessing tokens to tokens in phase 7, all tokens are strictly preprocessing tokens.  Add the missing qualification is appropriate through the phases of translation up to that point of conversion.