### PR TITLE
[basic.compound] Update introduction

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5391,7 +5391,7 @@ Compound types can be constructed in the following ways:
 \item \defnx{arrays}{type!array} of objects of a given type, \ref{dcl.array};
 
 \item \defnx{functions}{type!function}, which have parameters of given types and return
-\keyword{void} or references or objects of a given type, \ref{dcl.fct};
+\keyword{void} or a result of a given type, \ref{dcl.fct};
 
 \item \defnx{pointers}{type!pointer} to \cv{}~\keyword{void} or objects or functions (including
 static members of classes) of a given type, \ref{dcl.ptr};
@@ -5407,9 +5407,8 @@ type, \ref{dcl.ref}. There are two types of references:
 \end{itemize}
 
 \item
-\defnx{classes}{class} containing a sequence of objects of various types\iref{class},
-a set of types, enumerations and functions for
-manipulating these objects\iref{class.mfct}, and a set of restrictions
+\defnx{classes}{class} containing a sequence of class members\iref{class,class.mem},
+and a set of restrictions
 on the access to these entities\iref{class.access};
 
 \item


### PR DESCRIPTION
This PR cleans up a few wording discrepancies in the introduction to compound types:

1. We don't like to say that "functions return references". Any such case would mean that the function is declared with reference return type, but the reference would be transformed into an lvalue or xvalue designating the object upon the call. If we just say "a result", we keep it vague and correct.

2. The list of what classes contain tries to be exhaustive without much benefit. We can just say that classes contain class members, which does not miss many things not listed here, such as `static_assert`, `template`, etc.