### PR TITLE
[algorithms, numerics] Replace "exactly" with "at most" in Complexity

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -4638,7 +4638,7 @@ If the type of \tcode{first} meets the requirements of a mutable iterator,
 
 \pnum
 \complexity
-Applies \tcode{f} exactly \tcode{last - first} times.
+Applies \tcode{f} at most \tcode{last - first} times.
 
 \pnum
 \remarks
@@ -4669,7 +4669,7 @@ If the type of \tcode{first} meets the requirements of a mutable iterator,
 
 \pnum
 \complexity
-Applies \tcode{f} exactly \tcode{last - first} times.
+Applies \tcode{f} at most \tcode{last - first} times.
 
 \pnum
 \remarks
@@ -4714,7 +4714,7 @@ If the result of \tcode{invoke(proj, *i)} is a mutable reference,
 
 \pnum
 \complexity
-Applies \tcode{f} and \tcode{proj} exactly \tcode{last - first} times.
+Applies \tcode{f} and \tcode{proj} at most \tcode{last - first} times.
 
 \pnum
 \remarks
@@ -5362,7 +5362,7 @@ Returns \tcode{last} if no such iterator is found.
 \pnum
 \complexity
 For the non-parallel algorithm overloads,
-exactly \[ \min(\tcode{(i - first) + 1}, \ \tcode{(last - first) - 1}) \]
+at most \[ \min(\tcode{(i - first) + 1}, \ \tcode{(last - first) - 1}) \]
 applications of the corresponding predicate,
 where \tcode{i} is \tcode{adjacent_find}'s return value.
 For the parallel algorithm overloads,
@@ -5457,7 +5457,7 @@ for which $E$ holds.
 
 \pnum
 \complexity
-Exactly \tcode{last - first} applications
+At most \tcode{last - first} applications
 of the corresponding predicate and any projection.
 \end{itemdescr}
 
@@ -5749,7 +5749,7 @@ No applications of the corresponding predicate
 if \tcode{ForwardIterator1} and \tcode{Forward\-Iter\-ator2}
 meet the requirements of random access iterators and
 \tcode{last1 - first1 != last2 - first2}.
-Otherwise, exactly \tcode{last1 - first1} applications
+Otherwise, at most \tcode{last1 - first1} applications
 of the corresponding predicate
 if \tcode{equal(first1, last1, first2, last2, pred)} would return \tcode{true};
 otherwise, at worst \bigoh{N^2}, where $N$ has the value \tcode{last1 - first1}.
@@ -5799,7 +5799,7 @@ for the second overload,
 \tcode{R1} and \tcode{R2} each model \libconcept{sized_range}, and
 \tcode{ranges::distance(r1) != ranges::distance(r2)}.
 \end{itemize}
-Otherwise, exactly \tcode{last1 - first1} applications
+Otherwise, at most \tcode{last1 - first1} applications
 of the corresponding predicate and projections
 if \tcode{ranges::equal(\brk{}first1, last1, first2, last2, pred, proj1, proj2)}
 would return \tcode{true};
@@ -6384,7 +6384,7 @@ performs \tcode{*(result + $n$) = *(first + $n$)}.
 
 \pnum
 \complexity
-Exactly $N$ assignments.
+At most $N$ assignments.
 \end{itemdescr}
 
 \indexlibraryglobal{copy}%
@@ -6436,7 +6436,7 @@ performs \tcode{*(result + $n$) = *(first + $n$)}.
 
 \pnum
 \complexity
-Exactly $N$ assignments.
+At most $N$ assignments.
 \end{itemdescr}
 
 \indexlibraryglobal{copy_n}%
@@ -6495,7 +6495,7 @@ performs \tcode{*(result + $i$) = *(first + $i$)}.
 
 \pnum
 \complexity
-Exactly $N$ assignments.
+At most $N$ assignments.
 \end{itemdescr}
 
 \indexlibraryglobal{copy_if}%
@@ -6660,7 +6660,7 @@ performs \tcode{*(result - $n$) = *(last - $n$)}.
 
 \pnum
 \complexity
-Exactly $N$ assignments.
+At most $N$ assignments.
 \end{itemdescr}
 
 \rSec2[alg.move]{Move}
@@ -6718,7 +6718,7 @@ For each non-negative integer $n < N$, performs \tcode{*(result + $n$) = $E(n)$}
 
 \pnum
 \complexity
-Exactly $N$ assignments.
+At most $N$ assignments.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{move}!algorithm}%
@@ -6783,7 +6783,7 @@ performs \tcode{*(result + $n$) = $E(n)$}.
 
 \pnum
 \complexity
-Exactly $N$ assignments.
+At most $N$ assignments.
 \end{itemdescr}
 
 \indexlibraryglobal{move_backward}%
@@ -6845,7 +6845,7 @@ performs \tcode{*(result - $n$) = $E(n)$}.
 
 \pnum
 \complexity
-Exactly $N$ assignments.
+At most $N$ assignments.
 \end{itemdescr}
 
 \rSec2[alg.swap]{Swap}
@@ -6926,7 +6926,7 @@ For each non-negative integer $n < M$ performs:
 
 \pnum
 \complexity
-Exactly $M$ swaps.
+At most $M$ swaps.
 \end{itemdescr}
 
 \indexlibraryglobal{iter_swap}%
@@ -7113,7 +7113,7 @@ a new corresponding value equal to $E(\tcode{i})$.
 
 \pnum
 \complexity
-Exactly $N$ applications of \tcode{op} or \tcode{binary_op}, and
+At most $N$ applications of \tcode{op} or \tcode{binary_op}, and
 any projections.
 This requirement also applies to the parallel algorithm overloads.
 
@@ -7225,7 +7225,7 @@ when $E(\tcode{i})$ is \tcode{true}.
 
 \pnum
 \complexity
-Exactly \tcode{last - first} applications
+At most \tcode{last - first} applications
 of the corresponding predicate and any projection.
 \end{itemdescr}
 
@@ -7383,7 +7383,7 @@ a new corresponding value
 
 \pnum
 \complexity
-Exactly $N$ applications
+At most $N$ applications
 of the corresponding predicate and any projection.
 \end{itemdescr}
 
@@ -7451,7 +7451,7 @@ through all the iterators in the range \range{first}{first + $N$}.
 
 \pnum
 \complexity
-Exactly $N$ assignments.
+At most $N$ assignments.
 \end{itemdescr}
 
 \rSec2[alg.generate]{Generate}
@@ -7516,7 +7516,7 @@ through each iterator in the range \range{first}{first + $N$}.
 
 \pnum
 \complexity
-Exactly $N$ evaluations of \tcode{gen()} and assignments.
+At most $N$ evaluations of \tcode{gen()} and assignments.
 
 \pnum
 \remarks
@@ -7621,7 +7621,7 @@ Let $j$ be the end of the resulting range. Returns:
 
 \pnum
 \complexity
-Exactly \tcode{last - first} applications
+At most \tcode{last - first} applications
 of the corresponding predicate and any projection.
 
 \pnum
@@ -7872,7 +7872,7 @@ Let $j$ be the end of the resulting range. Returns:
 
 \pnum
 \complexity
-For nonempty ranges, exactly \tcode{(last - first) - 1} applications
+For nonempty ranges, at most \tcode{(last - first) - 1} applications
 of the corresponding predicate and
 no more than twice as many applications of any projection.
 \end{itemdescr}
@@ -8080,7 +8080,7 @@ to all pairs of iterators \tcode{first + i, (last - i) - 1}.
 
 \pnum
 \complexity
-Exactly \tcode{(last - first)/2} swaps.
+At most \tcode{(last - first)/2} swaps.
 \end{itemdescr}
 
 \indexlibraryglobal{reverse_copy}%
@@ -8132,7 +8132,7 @@ the following assignment takes place:
 
 \pnum
 \complexity
-Exactly $N$ assignments.
+At most $N$ assignments.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -8172,7 +8172,7 @@ the following assignment takes place:
 
 \pnum
 \complexity
-Exactly $N$ assignments.
+At most $N$ assignments.
 \end{itemdescr}
 
 \rSec2[alg.rotate]{Rotate}
@@ -8304,7 +8304,7 @@ the following assignment takes place:
 
 \pnum
 \complexity
-Exactly $N$ assignments.
+At most $N$ assignments.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -8348,7 +8348,7 @@ the following assignment takes place:
 
 \pnum
 \complexity
-Exactly $N$ assignments.
+At most $N$ assignments.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -8512,7 +8512,7 @@ has equal probability of appearance.
 
 \pnum
 \complexity
-Exactly \tcode{(last - first) - 1} swaps.
+At most \tcode{(last - first) - 1} swaps.
 
 \pnum
 \remarks
@@ -9736,7 +9736,7 @@ Let $N = \tcode{last - first}$:
 \begin{itemize}
 \item
   For the non-parallel algorithm overloads,
-  exactly $N$ applications of the predicate and projection.
+  at most $N$ applications of the predicate and projection.
   At most $N / 2$ swaps if the type of \tcode{first} meets
   the \oldconcept{BidirectionalIterator} requirements
   for the overloads in namespace \tcode{std} or
@@ -9824,7 +9824,7 @@ Let $N$ = \tcode{last - first}:
   For the non-parallel algorithm overloads,
   at most $N \log_2 N$ swaps,
   but only \bigoh{N} swaps if there is enough extra memory.
-  Exactly $N$ applications of the predicate and projection.
+  At most $N$ applications of the predicate and projection.
 \item
   For the parallel algorithm overloads,
   \bigoh{N \log N} swaps and \bigoh{N} applications of the predicate.
@@ -11296,7 +11296,7 @@ Returns the first argument when the arguments are equivalent.
 
 \pnum
 \complexity
-Exactly one comparison and two applications of the projection, if any.
+At most one comparison and two applications of the projection, if any.
 
 \pnum
 \remarks
@@ -11344,7 +11344,7 @@ when several elements are equivalent to the smallest.
 
 \pnum
 \complexity
-Exactly \tcode{ranges::distance(r) - 1} comparisons
+At most \tcode{ranges::distance(r) - 1} comparisons
 and twice as many applications of the projection, if any.
 
 \pnum
@@ -11379,7 +11379,7 @@ Returns the first argument when the arguments are equivalent.
 
 \pnum
 \complexity
-Exactly one comparison and two applications of the projection, if any.
+At most one comparison and two applications of the projection, if any.
 
 \pnum
 \remarks
@@ -11427,7 +11427,7 @@ when several elements are equivalent to the largest.
 
 \pnum
 \complexity
-Exactly \tcode{ranges::distance(r) - 1} comparisons
+At most \tcode{ranges::distance(r) - 1} comparisons
 and twice as many applications of the projection, if any.
 
 \pnum
@@ -11464,7 +11464,7 @@ For the first form, \tcode{T} meets the
 
 \pnum
 \complexity
-Exactly one comparison and two applications of the projection, if any.
+At most one comparison and two applications of the projection, if any.
 
 \pnum
 \remarks
@@ -11579,7 +11579,7 @@ Returns \tcode{last} if \tcode{first == last}.
 
 \pnum
 \complexity
-Exactly $\max(\tcode{last - first - 1}, 0)$ comparisons and
+At most $\max(\tcode{last - first - 1}, 0)$ comparisons and
 twice as many projections.
 \end{itemdescr}
 
@@ -11636,7 +11636,7 @@ Returns \tcode{last} if \tcode{first == last}.
 
 \pnum
 \complexity
-Exactly $\max(\tcode{last - first - 1}, 0)$ comparisons and
+At most $\max(\tcode{last - first - 1}, 0)$ comparisons and
 twice as many projections.
 \end{itemdescr}
 
@@ -12692,7 +12692,7 @@ and the result is assigned to \tcode{*(result + (i - first))}.
 
 \pnum
 \complexity
-Exactly \tcode{(last - first) - 1} applications of the binary operation.
+At most \tcode{(last - first) - 1} applications of the binary operation.
 
 \pnum
 \remarks
@@ -13204,7 +13204,7 @@ performs \tcode{*(result + d) = binary_op(*(first + d), *(first + (d - 1)))}.
 
 \pnum
 \complexity
-Exactly \tcode{(last - first) - 1} applications of the binary operation.
+At most \tcode{(last - first) - 1} applications of the binary operation.
 
 \pnum
 \remarks
@@ -13239,7 +13239,7 @@ as if by \tcode{++value}.
 
 \pnum
 \complexity
-Exactly \tcode{last - first} increments and assignments.
+At most \tcode{last - first} increments and assignments.
 \end{itemdescr}
 
 \indexlibraryglobal{iota}%

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -3122,7 +3122,7 @@ linear_congruential_engine<uint_least32_t, 40014u, 0u, 2147483563u> e(
 
 \pnum
 \complexity
-Exactly $n \cdot \tcode{r}$ invocations
+At most $n \cdot \tcode{r}$ invocations
  of \tcode{e}.
 \end{itemdescr}
 
@@ -4447,7 +4447,7 @@ What and when \tcode{g} throws.
 
 \pnum
 \complexity
-Exactly $k$ invocations of \tcode{g} per attempt.
+At most $k$ invocations of \tcode{g} per attempt.
 
 \pnum
 \begin{note}


### PR DESCRIPTION
Fixes #5636.

Per the discussion in that issue, I think this can be editorial. Although it seems to me that some "exactly" are actually exact.