### PR TITLE
[defns.valid] Elaborate on cause in example and add cross-references

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -665,8 +665,10 @@ value of an object that is not specified except that the object's invariants are
 met and operations on the object behave as specified for its type
 
 \begin{example}
-If an object \tcode{x} of type \tcode{std::vector<int>} is in a
-valid but unspecified state, \tcode{x.empty()} can be called unconditionally,
+If an object \tcode{x} of type \tcode{std::vector<int>} enters a
+valid but unspecified state through say,
+a move operation\iref{lib.types.movedfrom,class.copy.ctor,class.copy.assign},
+\tcode{x.empty()} can be called unconditionally,
 and \tcode{x.front()} can be called only if \tcode{x.empty()} returns
 \tcode{false}.
 \end{example}


### PR DESCRIPTION
To be honest, all I wanted to do is add a forward reference to [lib.types.movedfrom] to make the relevant section in the library intro easier to find, but that also required some wording changes to the example to make it less awkward.