### PR TITLE
[linalg.helpers.mandates] fix typos in linalg mandates section

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -12418,7 +12418,7 @@ template<class MDS1, class MDS2>
   bool @\exposid{compatible-static-extents}@(size_t r1, size_t r2) {         // \expos
     return MDS1::static_extent(r1) == dynamic_extent ||
            MDS2::static_extent(r2) == dynamic_extent ||
-           MDS1::static_extent(r1) == MDS2::static_extent(r2));
+           MDS1::static_extent(r1) == MDS2::static_extent(r2);
   }
 
 template<@\exposconcept{in-vector}@ In1, @\exposconcept{in-vector}@ In2, @\exposconcept{in-vector}@ Out>
@@ -12495,7 +12495,7 @@ constexpr bool @\exposid{multipliable}@( // \expos
 constexpr bool @\exposid{multipliable}@(                                     // \expos
   const @\exposconcept{in-matrix}@ auto& in_mat1, const @\exposconcept{in-matrix}@ auto& in_mat2, const @\exposconcept{in-matrix}@ auto& out_mat) {
   return out_mat.extent(0) == in_mat1.extent(0) && out_mat.extent(1) == in_mat2.extent(1) &&
-         in1_mat.extent(1) == in_mat2.extent(0);
+         in_mat1.extent(1) == in_mat2.extent(0);
 }
 \end{codeblock}
 


### PR DESCRIPTION
Fix for this bug: https://github.com/cplusplus/draft/issues/7371

redundant parenthesis in `MDS2::static_extent(r2));`

name mismatch in `in1_mat` -> `in_mat1`