### PR TITLE
[expr.await] Define 'suspend' as a term of power for coroutines

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5437,7 +5437,7 @@ For postfix increment and decrement, see~\ref{expr.post.incr}.
 \indextext{\idxcode{co_await}}%
 
 \pnum
-The \keyword{co_await} expression is used to suspend evaluation of a
+The \keyword{co_await} expression is used to \defnx{suspend}{suspend a coroutine} evaluation of a
 coroutine\iref{dcl.fct.def.coroutine} while awaiting completion of
 the computation represented by the operand expression.
 Suspending the evaluation of a coroutine


### PR DESCRIPTION
This PR fixes #7377.

Many parts of the standard refer to whether a coroutine is suspended as if it were a term of power, but there is no \defn that defines it as such. This PR places the definition on the only use that I could find where a suspended state was not defined in terms of other suspended states, so may be the transition into suspension.  It is likely that folks with a better eye to Core wording will know a better place, that may need a little rewording to sneak in the word 'suspended' to properly define it.