### PR TITLE
[thread.lock.unique.general] Remove extraneous space in `operator bool ()`

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -7588,7 +7588,7 @@ namespace std {
 
     // \ref{thread.lock.unique.obs}, observers
     bool owns_lock() const noexcept;
-    explicit operator bool () const noexcept;
+    explicit operator bool() const noexcept;
     mutex_type* mutex() const noexcept;
 
   private:


### PR DESCRIPTION
This space is inconsistent with library style, and with the redeclaration of this member in [thread.lock.unique.obs].