### PR TITLE
[dcl.link] p10 objects vs. entities

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -8699,8 +8699,8 @@ which the resulting lvalue refers is considered a C function.
 \pnum
 \indextext{object!linkage specification}%
 \indextext{linkage!implementation-defined object}%
-Linkage from \Cpp{} to objects defined in other languages and to objects
-defined in \Cpp{} from other languages is \impldef{linkage of objects between \Cpp{} and other languages} and
+Linkage from \Cpp{} to entities defined in other languages and to entities
+defined in \Cpp{} from other languages is \impldef{linkage of entities between \Cpp{} and other languages} and
 language-dependent. Only where the object layout strategies of two
 language implementations are similar enough can such linkage be
 achieved.%


### PR DESCRIPTION
[dcl.link] p10 says: 
>Linkage from C++ to objects defined in other languages and to objects defined in C++ from other languages is implementation-defined and language-dependent[.](https://eel.is/c++draft/dcl.link#10.sentence-1)
Only where the object layout strategies of two language implementations are similar enough can such linkage be achieved[.](https://eel.is/c++draft/dcl.link#10.sentence-2)

The objects should be changed to entities, which includes both objects and functions for which the linkage is applied.

> Linkage from C++ to entities defined in other languages and to entities defined in C++ from other languages is implementation-defined and language-dependent.