### PR TITLE
[conv.rank] Remove mention of `char` from the first bullet

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5704,9 +5704,8 @@ has the top-level cv-qualifier \keyword{volatile}.
 Every integer type has an \term{integer conversion rank} defined as follows:
 
 \begin{itemize}
-\item No two signed integer types other than \keyword{char} and \tcode{\keyword{signed}
-\keyword{char}} (if \keyword{char} is signed) have the same rank, even if they have
-the same representation.
+\item No two signed integer types have the same rank,
+even if they have the same representation.
 
 \item The rank of a signed integer type is greater than the rank
 of any signed integer type with a smaller width.


### PR DESCRIPTION
According to [[basic.fundamental]/1](https://eel.is/c++draft/basic.fundamental#1), `char` is not a signed integer type.
