### PR TITLE
[flat.map.defn, flat.set.defn] Avoid naming the `from_range_t` tag

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -15893,8 +15893,8 @@ namespace std {
         : c(), compare(comp) { insert(s, first, last); }
 
     template<@\exposconcept{container-compatible-range}@<value_type> R>
-      flat_map(from_range_t fr, R&& rg)
-        : flat_map(fr, std::forward<R>(rg), key_compare()) { }
+      flat_map(from_range_t, R&& rg)
+        : flat_map(from_range, std::forward<R>(rg), key_compare()) { }
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       flat_map(from_range_t, R&& rg, const key_compare& comp)
         : flat_map(comp) { insert_range(std::forward<R>(rg)); }
@@ -17079,8 +17079,8 @@ namespace std {
         : c(), compare(comp) { insert(s, first, last); }
 
     template<@\exposconcept{container-compatible-range}@<value_type> R>
-      flat_multimap(from_range_t fr, R&& rg)
-        : flat_multimap(fr, std::forward<R>(rg), key_compare()) { }
+      flat_multimap(from_range_t, R&& rg)
+        : flat_multimap(from_range, std::forward<R>(rg), key_compare()) { }
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       flat_multimap(from_range_t, R&& rg, const key_compare& comp)
         : flat_multimap(comp) { insert_range(std::forward<R>(rg)); }
@@ -17680,8 +17680,8 @@ namespace std {
         : @\exposid{c}@(first, last), @\exposid{compare}@(comp) { }
 
     template<@\exposconcept{container-compatible-range}@<value_type> R>
-      flat_set(from_range_t fr, R&& rg)
-        : flat_set(fr, std::forward<R>(rg), key_compare()) { }
+      flat_set(from_range_t, R&& rg)
+        : flat_set(from_range, std::forward<R>(rg), key_compare()) { }
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       flat_set(from_range_t, R&& rg, const key_compare& comp)
         : flat_set(comp)
@@ -18341,8 +18341,8 @@ namespace std {
         : @\exposid{c}@(first, last), @\exposid{compare}@(comp) { }
 
     template<@\exposconcept{container-compatible-range}@<value_type> R>
-      flat_multiset(from_range_t fr, R&& rg)
-        : flat_multiset(fr, std::forward<R>(rg), key_compare()) { }
+      flat_multiset(from_range_t, R&& rg)
+        : flat_multiset(from_range, std::forward<R>(rg), key_compare()) { }
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       flat_multiset(from_range_t, R&& rg, const key_compare& comp)
         : flat_multiset(comp)


### PR DESCRIPTION
Naming `from_range_t` is a bit weird, we should use the `from_range` variable directly. This is consistent with other parts of the standard.