### PR TITLE
[lex.ccon][except.spec] Remove trailing linebreak from grammar

### DIFF
--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -751,7 +751,7 @@ as a suffix of a function declarator\iref{dcl.fct}.
 \begin{bnf}
 \nontermdef{noexcept-specifier}\br
     \keyword{noexcept} \terminal{(} constant-expression \terminal{)}\br
-    \keyword{noexcept}\br
+    \keyword{noexcept}
 \end{bnf}
 
 \pnum

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1426,7 +1426,7 @@ is ill-formed if it cannot be represented by \tcode{std::size_t}.
     \terminal{\textbackslash} octal-digit\br
     \terminal{\textbackslash} octal-digit octal-digit\br
     \terminal{\textbackslash} octal-digit octal-digit octal-digit\br
-    \terminal{\textbackslash o\{} simple-octal-digit-sequence \terminal{\}}\br
+    \terminal{\textbackslash o\{} simple-octal-digit-sequence \terminal{\}}
 \end{bnf}
 
 \begin{bnf}


### PR DESCRIPTION
There are two grammar entries that end with a trailing `\br` in their specification.  This trailing linebreak does not seem to be intended, showing up only as a wider spacing between adjecent grammars --- most notably in Annex A where otherwise non-adject grammars pick up neighbours.