### PR TITLE
[lex] Provide unicode name for all control characters

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -140,9 +140,9 @@ or \tcode{>}. A partial comment
 would arise from a source file ending with an unclosed \tcode{/*}
 comment.
 \end{footnote}
-Each comment\iref{lex.comment} is replaced by one space character. New-line characters are
+Each comment\iref{lex.comment} is replaced by one \unicode{0020}{space} character. New-line characters are
 retained. Whether each nonempty sequence of whitespace characters other
-than new-line is retained or replaced by one space character is
+than new-line is retained or replaced by one \unicode{0020}{space} character is
 unspecified.
 As characters from the source file are consumed
 to form the next preprocessing token
@@ -477,7 +477,7 @@ The characters \tcode{/*} start a comment, which terminates with the
 characters \tcode{*/}. These comments do not nest.
 \indextext{comment!\tcode{//}}%
 The characters \tcode{//} start a comment, which terminates immediately before the
-next new-line character. If there is a form-feed or a vertical-tab
+next new-line character. If there is a \unicode{0009}{character tabulation} or a \unicode{000b}{line tabulation}
 character in such a comment, only whitespace characters shall appear
 between it and the new-line that terminates the comment; no diagnostic
 is required.
@@ -826,7 +826,7 @@ Literals include strings and character and numeric literals.
 \end{footnote}
 operators, and other separators.
 \indextext{whitespace}%
-Blanks, horizontal and vertical tabs, newlines, formfeeds, and comments
+Comments, \unicode{0020}{space}s, \unicode{0009}{character tabulation}s and \unicode{0009}{line tabulation}s, \unicode{000c}{form feed}s, and newlines
 (collectively, ``whitespace''), as described below, are ignored except
 as they serve to separate tokens.
 \begin{note}


### PR DESCRIPTION
This commit does not touch the new-line character as paper P2348.  It resricts itself to consistent use of the unicode character name for space, horizontal tab, and vertical tab. Compared to PR #7359 it deliberately does not touch the grammar that would necessitate a review by core review. The intent is to rebase that PR if this one lands.