### PR TITLE
[lex.phases] Reorder the first two sentences of phase 7

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -178,10 +178,10 @@ that common \grammarterm{encoding-prefix}.
 \item
 Adjacent \grammarterm{string-literal} tokens are concatenated\iref{lex.string}.
 
-\item Whitespace characters separating tokens are no longer
-significant. Each preprocessing token is converted into a
-token\iref{lex.token}. The resulting tokens
-constitute a \defn{translation unit} and
+\item
+Each preprocessing token is converted into a token\iref{lex.token}.
+Whitespace characters separating tokens are no longer significant.
+The resulting tokens constitute a \defn{translation unit} and
 are syntactically and
 semantically analyzed and translated.
 \begin{note}


### PR DESCRIPTION
As suggested by Jens Maurer.  The first sentence refers to "tokens" that do not exist until after the second sentence.  Rather than change normaitve meaning by referring to the extant "preprocessing tokens" is seems best to preserve the clear intent, and simply reverse their order.