### PR TITLE
P2865R6 Remove Deprecated Array Comparisons from C++26

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -33,6 +33,25 @@ auto x = true ? e : f;  // ill-formed; previously well-formed
 \end{codeblock}
 \end{example}
 
+\diffref{expr.rel,expr.eq}
+\change
+Comparing two objects of array type is no longer valid.
+\rationale
+The old behavior was confusing since it compared not the contents of the two
+arrays, but their addresses.
+\effect
+A valid \CppXXIII{} program directly comparing two array objects is rejected as
+ill-formed in this document.
+\begin{example}
+\begin{codeblock}
+int arr1[5];
+int arr2[5];
+bool same = arr1 == arr2;       // ill-formed; previously well-formed
+bool idem = arr1 == +arr2;      // compare addresses
+bool less = arr1 < +arr2;       // compare addresses, unspecified result
+\end{codeblock}
+\end{example}
+
 \diffref{expr.delete}
 \change
 Calling \tcode{delete} on a pointer to an incomplete class is ill-formed.
@@ -2924,6 +2943,30 @@ Deletion of semantically well-defined feature.
 Syntactic transformation.
 \howwide
 Seldom.
+
+\diffref{expr.rel,expr.eq}
+\change
+C allows directly comparing two objects of array type; \Cpp{} does not.
+\rationale
+The behavior is confusing because it compares not the contents of the two
+arrays, but their addresses.
+\effect
+Deletion of semantically well-defined feature that had unspecified behavior
+in common use cases.
+\difficulty
+Violations will be diagnosed by the \Cpp{} translator. The original behavior
+can be replicated by explicitly casting either array to a pointer, such as by
+using a unary \tcode{+}.
+\begin{example}
+\begin{codeblock}
+int arr1[5];
+int arr2[5];
+int same = arr1 == arr2;        // valid C, ill-formed C++
+int idem = arr1 == +arr2;       // valid in both C and C++
+\end{codeblock}
+\end{example}
+\howwide
+Rare.
 
 \diffref{expr.cond,expr.ass,expr.comma}
 \indextext{conversion!lvalue-to-rvalue}%

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6666,13 +6666,11 @@ The relational operators group left-to-right.
 \end{bnf}
 %
 The
-lvalue-to-rvalue\iref{conv.lval},
-array-to-pointer\iref{conv.array},
+lvalue-to-rvalue\iref{conv.lval}
 and function-to-pointer\iref{conv.func}
 standard conversions are performed on the operands.
-The comparison is deprecated if
-both operands were of array type
-prior to these conversions\iref{depr.array.comp}.
+If one of the operands is a pointer, the
+array-to-pointer conversion\iref{conv.array} is performed on the other operand.
 
 \pnum
 The converted operands shall have arithmetic, enumeration, or pointer type.
@@ -6684,7 +6682,7 @@ yield \keyword{false} or \keyword{true}. The type of the result is
 
 \pnum
 The usual arithmetic conversions\iref{expr.arith.conv} are performed on operands of arithmetic
-or enumeration type. If both operands are pointers,
+or enumeration type. If both converted operands are pointers,
 pointer conversions\iref{conv.ptr},
 function pointer conversions\iref{conv.fctptr}, and
 qualification conversions\iref{conv.qual}
@@ -6757,17 +6755,15 @@ and \keyword{false} if it is false.
 The \tcode{==} (equal to) and the \tcode{!=} (not equal to) operators
 group left-to-right.
 The
-lvalue-to-rvalue\iref{conv.lval},
-array-to-pointer\iref{conv.array},
+lvalue-to-rvalue\iref{conv.lval}
 and function-to-pointer\iref{conv.func}
 standard conversions are performed on the operands.
-The comparison is deprecated if
-both operands were of array type
-prior to these conversions\iref{depr.array.comp}.
+If one of the operands is a pointer or a null pointer constant\iref{conv.ptr},
+the array-to-pointer conversion\iref{conv.array} is performed
+on the other operand.
 
 \pnum
-The converted operands shall have arithmetic, enumeration, pointer,
-or pointer-to-member type, or type \tcode{std::nullptr_t}. The operators
+The converted operands shall have scalar type. The operators
 \tcode{==} and \tcode{!=} both yield \keyword{true} or \keyword{false}, i.e., a
 result of type \keyword{bool}. In each case below, the operands shall have the
 same type after the specified conversions have been applied.
@@ -6775,7 +6771,7 @@ same type after the specified conversions have been applied.
 \pnum
 \indextext{comparison!pointer}%
 \indextext{comparison!pointer to function}%
-If at least one of the operands is a pointer,
+If at least one of the converted operands is a pointer,
 pointer conversions\iref{conv.ptr},
 function pointer conversions\iref{conv.fctptr}, and
 qualification conversions\iref{conv.qual}

--- a/source/future.tex
+++ b/source/future.tex
@@ -116,25 +116,6 @@ void park(linhenykus alvarezsauroid) {
 \end{example}
 
 
-\rSec1[depr.array.comp]{Array comparisons}
-
-\pnum
-Equality and relational comparisons\iref{expr.eq,expr.rel}
-between two operands of array type
-are deprecated.
-\begin{note}
-Three-way comparisons\iref{expr.spaceship} between such operands are ill-formed.
-\end{note}
-\begin{example}
-\begin{codeblock}
-int arr1[5];
-int arr2[5];
-bool same = arr1 == arr2;       // deprecated, same as \tcode{\&arr1[0] == \&arr2[0]},
-                                // does not compare array contents
-auto cmp = arr1 <=> arr2;       // error
-\end{codeblock}
-\end{example}
-
 \rSec1[depr.impldec]{Implicit declaration of copy functions}
 
 \pnum

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -22,6 +22,9 @@
 % P2864R2 Remove deprecated arithmetic conversions
 \removedxref{depr.arith.conv.enum}
 
+% P2866R5 Remove deprecated array comparisons
+\removedxref{depr.array.comp}
+
 % P2871R3 Remove deprecated <codecvt> header
 \removedxref{depr.codecvt.syn}
 \removedxref{depr.locale.stdcvt}


### PR DESCRIPTION
P2865R6 Remove Deprecated Array Comparisons from C++26

Fixes #7410
Fixes cplusplus/papers#1555