### PR TITLE
Merge 2024-11 LWG Motion 18 - P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -16034,3 +16034,2479 @@ triangular_matrix_matrix_right_solve(std::forward<ExecutionPolicy>(exec),
                                      A, t, d, B, divides<void>{});
 \end{codeblock}
 \end{itemdescr}
+
+\rSec1[simd]{Data-parallel types}
+\rSec2[simd.general]{General}
+
+\newcommand\foralli[1][]{for all $i$ in the range of \range{0}{#1size()}}
+\newcommand\Foralli[1][]{For all $i$ in the range of \range{0}{#1size()}}
+\newcommand\forallmaskedi{for all selected indices $i$ of \tcode{mask}}
+
+\newcommand\ConstraintUnaryOperatorWellFormed[2][const ]{%
+  \constraints \tcode{requires (#1value_type a) \{ #2; \}} is \tcode{true}.
+}
+
+\newcommand\ConstraintOperatorTWellFormed{%
+  \constraints \tcode{requires (value_type a, value_type b) \{ a \placeholder{op} b; \}} is \tcode{true}.
+}
+
+\pnum
+[simd] defines data-parallel types and operations on these types.
+\begin{note}
+The intent is to support acceleration through data-parallel execution resources
+where available, such as SIMD registers and instructions or execution units
+driven by a common instruction decoder.
+\end{note}
+
+\pnum
+The set of \defn{vectorizable types} comprises all standard integer types,
+character types, and the types \tcode{float} and \tcode{double}
+([basic.fundamental]).
+In addition, \tcode{std::float16_t}, \tcode{std::float32_t}, and
+\tcode{std::float64_t} are vectorizable types if defined ([basic.extended.fp]).
+
+\pnum
+The term \defn{data-parallel type} refers to all enabled specializations of
+the \tcode{basic_simd} and \tcode{basic_simd_mask} class templates. A \defn{data-parallel object} is
+an object of \term{data-parallel type}.
+
+\pnum
+Each specialization of \tcode{basic_simd} or \tcode{basic_simd_mask} is either enabled or disabled,
+as described in \ref{simd.overview} and \ref{simd.mask.overview}.
+
+\pnum
+A data-parallel type consists of one or more elements of an underlying vectorizable type,
+called the \defn{element type}.
+The number of elements is a constant for each data-parallel type and called the
+\defn{width} of that type.
+The elements in a data-parallel type are indexed from 0 to $\textrm{width} - 1$.
+
+\pnum
+An \defn{element-wise operation} applies a specified operation to the elements of one or more
+data-parallel objects. Each such application is unsequenced with respect to the others. A
+\defn{unary element-wise operation} is an element-wise operation that applies a unary operation to
+each element of a data-parallel object. A \defn{binary element-wise operation} is an element-wise
+operation that applies a binary operation to corresponding elements of two data-parallel objects.
+
+\pnum
+Given a \tcode{basic_simd_mask<Bytes, Abi>} object \tcode{mask}, the
+\defn{selected indices} signify the integers $i$ in the range
+\range{0}{mask.size()} for which \tcode{mask[$i$]} is \tcode{true}.
+Given a data-parallel object \tcode{data}, the \defn{selected elements} signify the elements
+\tcode{data[$i$]} for all selected indices $i$.
+
+\pnum
+The conversion from an arithmetic type \tcode{U} to a vectorizable type \tcode{T} is
+\defn{value-preserving} if
+all possible values of \tcode{U} can be represented with type \tcode{T}.
+
+\rSec2[simd.expos]{Exposition only types, variables, and concepts}
+
+\begin{codeblock}
+using @\exposid{simd-size-type}@ = @\seebelow@;                                 // \expos
+template<size_t Bytes> using @\exposid{integer-from}@ = @\seebelow@;            // \expos
+
+template<class T, class Abi>
+  constexpr @\exposid{simd-size-type}\ \exposid{simd-size-v}@ = @\seebelow@;               // \expos
+template<class T> constexpr size_t @\exposid{mask-element-size}@ = @\seebelow@; // \expos
+
+template<class T>
+  concept @\exposconcept{constexpr-wrapper-like}@ =                                // \expos
+    convertible_to<T, decltype(T::value)> &&
+    equality_comparable_with<T, decltype(T::value)> &&
+    bool_constant<T() == T::value>::value &&
+    bool_constant<static_cast<decltype(T::value)>(T()) == T::value>::value;
+
+template<class T> using @\exposid{deduced-simd-t}@ = @\seebelow@;               // \expos
+
+template<class V, class T> using @\exposid{make-compatible-simd-t}@ = @\seebelow@; // \expos
+
+template<class V>
+  concept @\exposconcept{simd-floating-point}@ =                                   // \expos
+    same_as<V, basic_simd<typename V::value_type, typename V::abi_type>> &&
+    is_default_constructible_v<V> && floating_point<typename V::value_type>;
+
+template<class... Ts>
+  concept @\exposconcept{math-floating-point}@ =                                   // \expos
+    = (@\exposconcept{simd-floating-point}@<@\exposid{deduced-simd-t}@<Ts>> || ...);
+
+template<class... Ts>
+  requires @\exposconcept{math-floating-point}@<Ts...>
+    using @\exposid{math-common-simd-t}@ = @\seebelow@;                         // \expos
+
+template<class BinaryOperation, class T>
+  concept @\exposconcept{reduction-binary-operation}@ = @\seebelow@;                 // \expos
+
+// \ref{simd.expos.abi}, \tcode{simd} ABI tags
+template<class T> using @\exposid{native-abi}@ = @\seebelow@;                   // \expos
+template<class T, @\exposid{simd-size-type}@ N> using @\exposid{deduce-abi-t}@ = @\seebelow@; // \expos
+
+// \ref{simd.flags}, Load and store flags
+struct @\exposid{convert-flag}@;                                              // \expos
+struct @\exposid{aligned-flag}@;                                              // \expos
+template<size_t N> struct @\exposid{overaligned-flag}@;                       // \expos
+\end{codeblock}
+
+\begin{itemdecl}
+using @\exposid{simd-size-type}@ = @\seebelow@; // \expos
+\end{itemdecl}
+\begin{itemdescr}
+  \pnum
+  \exposid{simd-size-type}{} is an alias for a signed integer type.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<size_t Bytes> using @\exposid{integer-from}@ = @\seebelow@; // \expos
+\end{itemdecl}
+\begin{itemdescr}
+  \pnum
+  \tcode{\exposid{integer-from}<Bytes>} is an alias for a signed integer type \tcode{T} such that
+  \tcode{sizeof(T)} equals \tcode{Bytes}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class T, class Abi>
+  constexpr @\exposid{simd-size-type}\ \exposid{simd-size-v}@ = @\seebelow@; // \expos
+\end{itemdecl}
+\begin{itemdescr}
+  \pnum
+  \tcode{\exposid{simd-size-v}<T, Abi>} denotes the width of \tcode{basic_simd<T, Abi>} if
+  the specialization \tcode{basic_simd<T, Abi>} is enabled, or \tcode{0} otherwise.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class T> constexpr size_t @\exposid{mask-element-size}@ = @\seebelow@; // \expos
+\end{itemdecl}
+\begin{itemdescr}
+  \pnum
+  \tcode{\exposid{mask-element-size}<basic_simd_mask<Bytes, Abi>>} has the value \tcode{Bytes}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class T> using @\exposid{deduced-simd-t}@ = @\seebelow@; // \expos
+\end{itemdecl}
+\begin{itemdescr}
+  \pnum Let \tcode{x} denote an lvalue of type \tcode{const T}.
+
+  \pnum \tcode{\exposid{deduced-simd-t}<T>} is an alias for
+  \begin{itemize}
+    \item \tcode{decltype(x + x)},
+      if the type of \tcode{x + x} is an enabled specialization of \tcode{basic_simd};
+      otherwise
+
+    \item \tcode{void}.
+  \end{itemize}
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class V, class T> using @\exposid{make-compatible-simd-t}@ = @\seebelow@; // \expos
+\end{itemdecl}
+\begin{itemdescr}
+  \pnum
+  Let \tcode{x} denote an lvalue of type \tcode{const T}.
+
+  \pnum \tcode{\exposid{make-compatible-simd-t}<V, T>} is an alias for
+  \begin{itemize}
+    \item \tcode{\exposid{deduced-simd-t}<T>}, if that type is not \tcode{void}, otherwise
+    \item \tcode{simd<decltype(x + x), V::size()>}.
+  \end{itemize}
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class... Ts>
+  requires @\exposconcept{math-floating-point}@<Ts...>
+    using @\exposid{math-common-simd-t}@ = @\seebelow@; // \expos
+\end{itemdecl}
+\begin{itemdescr}
+  \pnum
+  Let \tcode{T0} denote \tcode{Ts...[0]}.
+  Let \tcode{T1} denote \tcode{Ts...[1]}.
+  Let \tcode{TRest} denote a pack such that \tcode{T0, T1, TRest...} is equivalent to \tcode{Ts...}.
+
+  \pnum
+  Let \tcode{\exposid{math-common-simd-t}<Ts...>} be an alias for
+  \begin{itemize}
+    \item \tcode{\exposid{deduced-simd-t}<T0>}, if \tcode{sizeof...(Ts)} equals $1$; otherwise
+
+    \item \tcode{common_type_t<\exposid{deduced-simd-t}<T0>, \exposid{deduced-simd-t}<T1>>}, if \tcode{sizeof...(Ts)}
+      equals $2$ and \tcode{\exposconcept{math-floating-point}<T0> \&\& \exposconcept{math-floating-point}<T1>} is \tcode{true};
+      otherwise
+
+    \item \tcode{common_type_t<\exposid{deduced-simd-t}<T0>, T1>}, if \tcode{sizeof...(Ts)}
+      equals $2$ and \tcode{\exposconcept{math-floating-point}<T0>} is \tcode{true}; otherwise
+
+    \item \tcode{common_type_t<T0, \exposid{deduced-simd-t}<T1>>}, if \tcode{sizeof...(Ts)}
+      equals $2$; otherwise
+
+    \item \tcode{common_type_t<\exposid{math-common-simd-t}<T0, T1>, TRest...>}, if \tcode{\exposid{math-common-simd-t}<T0,
+      T1>} is valid and denotes a type; otherwise
+
+    \item \tcode{common_type_t<\exposid{math-common-simd-t}<TRest...>, T0, T1>}.
+  \end{itemize}
+\end{itemdescr}
+
+
+\begin{itemdecl}
+template<class BinaryOperation, class T>
+  concept @\exposconcept{reduction-binary-operation}@ =  // \expos
+    requires (const BinaryOperation binary_op, const simd<T, 1> v) {
+      { binary_op(v, v) } -> same_as<simd<T, 1>>;
+    };
+\end{itemdecl}
+\begin{itemdescr}
+\pnum
+Types \tcode{BinaryOperation} and \tcode{T} model \tcode{\exposconcept{reduction-binary-operation}<BinaryOperation, T>}
+only if:
+\begin{itemize}
+  \item \tcode{BinaryOperation} is a binary element-wise operation and the operation is commutative.
+
+  \item An object of type \tcode{BinaryOperation} can be invoked with two arguments of type
+    \tcode{basic_simd<T, Abi>}, with unspecified ABI tag \tcode{Abi}, returning a \tcode{basic_simd<T,
+    Abi>}.
+\end{itemize}
+\end{itemdescr}
+
+\rSec3[simd.expos.abi]{\tcode{simd} ABI tags}
+
+\begin{itemdecl}
+template<class T> using @\exposid{native-abi}@ = @\seebelow@; // \expos
+template<class T, @\exposid{simd-size-type}@ N> using @\exposid{deduce-abi-t}@ = @\seebelow@; // \expos
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+An \defn{ABI tag} is a type that indicates a choice of size and binary
+representation for objects of data-parallel type.
+\begin{note}
+  The intent is for the size and binary representation to depend on the target
+  architecture and compiler flags.
+  The ABI tag, together with a given element type, implies the width.
+\end{note}
+
+\pnum
+\begin{note}
+The ABI tag is orthogonal to selecting the machine instruction set.
+The selected machine instruction set limits the usable ABI tag types, though
+(see \ref{simd.overview}).
+The ABI tags enable users to safely pass objects of data-parallel type between
+translation unit boundaries (e.g. function calls or I/O).
+\end{note}
+
+\pnum
+An implementation defines ABI tag types as necessary for the following aliases.
+
+\pnum
+\tcode{\exposid{deduce-abi-t}<T, N>} is defined if
+\begin{itemize}
+  \item \tcode{T} is a vectorizable type,
+  \item \tcode{N} is greater than zero, and
+  \item \tcode{N} is not larger than an implementation-defined maximum.
+\end{itemize}
+The implementation-defined maximum for \tcode{N} is not smaller than 64
+and can differ depending on \tcode{T}.
+
+\pnum
+Where present, \tcode{\exposid{deduce-abi-t}<T, N>} names an ABI tag type such that
+\begin{itemize}
+  \item \tcode{\exposid{simd-size-v}<T, \exposid{deduce-abi-t}<T, N>>} equals \tcode{N},
+  \item \tcode{basic_simd<T, \exposid{deduce-abi-t}<T, N>>} is enabled (see \ref{simd.overview}), and
+  \item \tcode{basic_simd_mask<sizeof(T), \exposid{deduce-abi-t}<\exposid{integer-from}<sizeof(T)>, N>>} is enabled (see
+    \ref{simd.overview}).
+\end{itemize}
+
+\pnum
+\tcode{\exposid{native-abi}<T>} is an implementation-defined alias for an ABI tag.
+\tcode{basic_simd<T, \exposid{native-abi}<T>>} is an enabled specialization.
+\begin{note}
+The intent is to use the ABI tag producing the most efficient data-parallel
+execution for the element type \tcode{T} on the currently
+targeted system.
+For target architectures with ISA extensions, compiler flags can change the
+type of the \tcode{\exposid{native-abi}<T>} alias.
+\end{note}
+\begin{example}
+  Consider a target architecture supporting the ABI tags
+  \tcode{__simd128} and \tcode{__simd256}, where hardware support for
+  \tcode{__simd256} exists only for floating-point types.
+  The implementation therefore defines \tcode{\exposid{native-abi}<T>} as an alias for
+  \begin{itemize}
+    \item \tcode{__simd256} if \tcode{T} is a floating-point type, and
+    \item \tcode{__simd128} otherwise.
+  \end{itemize}
+\end{example}
+\end{itemdescr}
+
+\rSec2[simd.syn]{Header \texorpdfstring{\tcode{<simd>}}{<simd>} synopsis}
+
+%\indexhdr{simd}
+\begin{codeblock}
+namespace std {
+  // \ref{simd.traits}, \tcode{simd} type traits
+  template<class T, class U = typename T::value_type> struct simd_alignment;
+  template<class T, class U = typename T::value_type>
+    constexpr size_t simd_alignment_v = simd_alignment<T, U>::value;
+
+  template<class T, class V> struct rebind_simd { using type = @\seebelow@; };
+  template<class T, class V> using rebind_simd_t = typename rebind_simd<T, V>::type;
+  template<@\exposid{simd-size-type}@ N, class V> struct resize_simd { using type = @\seebelow@; };
+  template<@\exposid{simd-size-type}@ N, class V> using resize_simd_t = typename resize_simd<N, V>::type;
+
+  // \ref{simd.flags}, Load and store flags
+  template<class... Flags> struct simd_flags;
+  inline constexpr simd_flags<> simd_flag_default{};
+  inline constexpr simd_flags<@\exposid{convert-flag}@> simd_flag_convert{};
+  inline constexpr simd_flags<@\exposid{aligned-flag}@> simd_flag_aligned{};
+  template<size_t N> requires (has_single_bit(N))
+    constexpr simd_flags<@\exposid{overaligned-flag}<N>@> simd_flag_overaligned{};
+
+  // \ref{simd.class}, Class template \tcode{basic_simd}
+  template<class T, class Abi = @\exposid{native-abi}@<T>> class basic_simd;
+  template<class T, @\exposid{simd-size-type}@ N = @\exposid{simd-size-v}@<T, @\exposid{native-abi}@<T>>>
+    using simd = basic_simd<T, @\exposid{deduce-abi-t}@<T, N>>;
+
+  // \ref{simd.mask.class}, Class template \tcode{basic_simd_mask}
+  template<size_t Bytes, class Abi = @\exposid{native-abi}@<@\exposid{integer-from}@<Bytes>>> class basic_simd_mask;
+  template<class T, @\exposid{simd-size-type}@ N = @\exposid{simd-size-v}@<T, @\exposid{native-abi}@<T>>>
+    using simd_mask = basic_simd_mask<sizeof(T), @\exposid{deduce-abi-t}@<T, N>>;
+
+  // \ref{simd.loadstore}, \tcode{basic_simd} load and store functions
+  template<class V = @\seebelow@, ranges::contiguous_range R, class... Flags>
+    requires ranges::sized_range<R>
+    constexpr V simd_unchecked_load(R&& r, simd_flags<Flags...> f = {});
+  template<class V = @\seebelow@, ranges::contiguous_range R, class... Flags>
+    requires ranges::sized_range<R>
+    constexpr V simd_unchecked_load(R&& r, const typename V::mask_type& k,
+                                    simd_flags<Flags...> f = {});
+  template<class V = @\seebelow@, contiguous_iterator I, class... Flags>
+    constexpr V simd_unchecked_load(I first, iter_difference_t<I> n, simd_flags<Flags...> f = {});
+  template<class V = @\seebelow@, contiguous_iterator I, class... Flags>
+    constexpr V simd_unchecked_load(I first, iter_difference_t<I> n,
+                                    const typename V::mask_type& k, simd_flags<Flags...> f = {});
+  template<class V = @\seebelow@, contiguous_iterator I, sized_sentinel_for<I> S, class... Flags>
+    constexpr V simd_unchecked_load(I first, S last, simd_flags<Flags...> f = {});
+  template<class V = @\seebelow@, contiguous_iterator I, sized_sentinel_for<I> S, class... Flags>
+    constexpr V simd_unchecked_load(I first, S last, const typename V::mask_type& k,
+                                    simd_flags<Flags...> f = {});
+
+  template<class V = @\seebelow@, ranges::contiguous_range R, class... Flags>
+    requires ranges::sized_range<R>
+    constexpr V simd_partial_load(R&& r, simd_flags<Flags...> f = {});
+  template<class V = @\seebelow@, ranges::contiguous_range R, class... Flags>
+    requires ranges::sized_range<R>
+    constexpr V simd_partial_load(R&& r, const typename V::mask_type& k,
+                                  simd_flags<Flags...> f = {});
+  template<class V = @\seebelow@, contiguous_iterator I, class... Flags>
+    constexpr V simd_partial_load(I first, iter_difference_t<I> n, simd_flags<Flags...> f = {});
+  template<class V = @\seebelow@, contiguous_iterator I, class... Flags>
+    constexpr V simd_partial_load(I first, iter_difference_t<I> n,
+                                  const typename V::mask_type& k, simd_flags<Flags...> f = {});
+  template<class V = @\seebelow@, contiguous_iterator I, sized_sentinel_for<I> S, class... Flags>
+    constexpr V simd_partial_load(I first, S last, simd_flags<Flags...> f = {});
+  template<class V = @\seebelow@, contiguous_iterator I, sized_sentinel_for<I> S, class... Flags>
+    constexpr V simd_partial_load(I first, S last, const typename V::mask_type& k,
+                                  simd_flags<Flags...> f = {});
+
+  template<class T, class Abi, ranges::contiguous_range R, class... Flags>
+    requires ranges::sized_range<R> && indirectly_writable<ranges::iterator_t<R>, T>
+    constexpr void simd_unchecked_store(const basic_simd<T, Abi>& v, R&& r,
+                                        simd_flags<Flags...> f = {});
+  template<class T, class Abi, ranges::contiguous_range R, class... Flags>
+    requires ranges::sized_range<R> && indirectly_writable<ranges::iterator_t<R>, T>
+    constexpr void simd_unchecked_store(const basic_simd<T, Abi>& v, R&& r,
+      const typename basic_simd<T, Abi>::mask_type& mask, simd_flags<Flags...> f = {});
+  template<class T, class Abi, contiguous_iterator I, class... Flags>
+    requires indirectly_writable<I, T>
+    constexpr void simd_unchecked_store(const basic_simd<T, Abi>& v, I first,
+                                        iter_difference_t<I> n, simd_flags<Flags...> f = {});
+  template<class T, class Abi, contiguous_iterator I, class... Flags>
+    requires indirectly_writable<I, T>
+    constexpr void simd_unchecked_store(const basic_simd<T, Abi>& v, I first,
+      iter_difference_t<I> n, const typename basic_simd<T, Abi>::mask_type& mask,
+      simd_flags<Flags...> f = {});
+  template<class T, class Abi, contiguous_iterator I, sized_sentinel_for<I> S, class... Flags>
+    requires indirectly_writable<I, T>
+    constexpr void simd_unchecked_store(const basic_simd<T, Abi>& v, I first, S last,
+                                        simd_flags<Flags...> f = {});
+  template<class T, class Abi, contiguous_iterator I, sized_sentinel_for<I> S, class... Flags>
+    requires indirectly_writable<I, T>
+    constexpr void simd_unchecked_store(const basic_simd<T, Abi>& v, I first, S last,
+      const typename basic_simd<T, Abi>::mask_type& mask, simd_flags<Flags...> f = {});
+
+  template<class T, class Abi, ranges::contiguous_range R, class... Flags>
+    requires ranges::sized_range<R> && indirectly_writable<ranges::iterator_t<R>, T>
+    constexpr void simd_partial_store(const basic_simd<T, Abi>& v, R&& r,
+                                      simd_flags<Flags...> f = {});
+  template<class T, class Abi, ranges::contiguous_range R, class... Flags>
+    requires ranges::sized_range<R> && indirectly_writable<ranges::iterator_t<R>, T>
+    constexpr void simd_partial_store(const basic_simd<T, Abi>& v, R&& r,
+      const typename basic_simd<T, Abi>::mask_type& mask, simd_flags<Flags...> f = {});
+  template<class T, class Abi, contiguous_iterator I, class... Flags>
+    requires indirectly_writable<I, T>
+    constexpr void simd_partial_store(const basic_simd<T, Abi>& v, I first, iter_difference_t<I> n,
+                                      simd_flags<Flags...> f = {});
+  template<class T, class Abi, contiguous_iterator I, class... Flags>
+    requires indirectly_writable<I, T>
+    constexpr void simd_partial_store(const basic_simd<T, Abi>& v, I first, iter_difference_t<I> n,
+      const typename basic_simd<T, Abi>::mask_type& mask, simd_flags<Flags...> f = {});
+  template<class T, class Abi, contiguous_iterator I, sized_sentinel_for<I> S, class... Flags>
+    requires indirectly_writable<I, T>
+    constexpr void simd_partial_store(const basic_simd<T, Abi>& v, I first, S last,
+      simd_flags<Flags...> f = {});
+  template<class T, class Abi, contiguous_iterator I, sized_sentinel_for<I> S, class... Flags>
+    requires indirectly_writable<I, T>
+    constexpr void simd_partial_store(const basic_simd<T, Abi>& v, I first, S last,
+      const typename basic_simd<T, Abi>::mask_type& mask, simd_flags<Flags...> f = {});
+
+  // \ref{simd.creation}, \tcode{basic_simd} and \tcode{basic_simd_mask} creation
+  template<class T, class Abi>
+    constexpr auto
+      simd_split(const basic_simd<typename T::value_type, Abi>& x) noexcept;
+  template<class T, class Abi>
+    constexpr auto
+      simd_split(const basic_simd_mask<@\exposid{mask-element-size}@<T>, Abi>& x) noexcept;
+
+  template<class T, class... Abis>
+    constexpr basic_simd<T, @\exposid{deduce-abi-t}@<T, (basic_simd<T, Abis>::size() + ...)>>
+      simd_cat(const basic_simd<T, Abis>&...) noexcept;
+  template<size_t Bytes, class... Abis>
+    constexpr basic_simd_mask<Bytes, @\exposid{deduce-abi-t}@<@\exposid{integer-from}@<Bytes>,
+                              (basic_simd_mask<Bytes, Abis>::size() + ...)>>
+      simd_cat(const basic_simd_mask<Bytes, Abis>&...) noexcept;
+
+  // \ref{simd.mask.reductions}, \tcode{basic_simd_mask} reductions
+  template<size_t Bytes, class Abi>
+    constexpr bool all_of(const basic_simd_mask<Bytes, Abi>&) noexcept;
+  template<size_t Bytes, class Abi>
+    constexpr bool any_of(const basic_simd_mask<Bytes, Abi>&) noexcept;
+  template<size_t Bytes, class Abi>
+    constexpr bool none_of(const basic_simd_mask<Bytes, Abi>&) noexcept;
+  template<size_t Bytes, class Abi>
+    constexpr @\exposid{simd-size-type}@ reduce_count(const basic_simd_mask<Bytes, Abi>&) noexcept;
+  template<size_t Bytes, class Abi>
+    constexpr @\exposid{simd-size-type}@ reduce_min_index(const basic_simd_mask<Bytes, Abi>&);
+  template<size_t Bytes, class Abi>
+    constexpr @\exposid{simd-size-type}@ reduce_max_index(const basic_simd_mask<Bytes, Abi>&);
+
+  constexpr bool all_of(same_as<bool> auto) noexcept;
+  constexpr bool any_of(same_as<bool> auto) noexcept;
+  constexpr bool none_of(same_as<bool> auto) noexcept;
+  constexpr @\exposid{simd-size-type}@ reduce_count(same_as<bool> auto) noexcept;
+  constexpr @\exposid{simd-size-type}@ reduce_min_index(same_as<bool> auto);
+  constexpr @\exposid{simd-size-type}@ reduce_max_index(same_as<bool> auto);
+
+  // \ref{simd.reductions}, \tcode{basic_simd} reductions
+  template<class T, class Abi, class BinaryOperation = plus<>>
+    constexpr T reduce(const basic_simd<T, Abi>&, BinaryOperation = {});
+  template<class T, class Abi, class BinaryOperation = plus<>>
+    constexpr T reduce(
+      const basic_simd<T, Abi>& x, const typename basic_simd<T, Abi>::mask_type& mask,
+      BinaryOperation binary_op = {}, type_identity_t<T> identity_element = @\seebelow@);
+
+  template<class T, class Abi>
+    constexpr T reduce_min(const basic_simd<T, Abi>&) noexcept;
+  template<class T, class Abi>
+    constexpr T reduce_min(const basic_simd<T, Abi>&,
+                           const typename basic_simd<T, Abi>::mask_type&) noexcept;
+  template<class T, class Abi>
+    constexpr T reduce_max(const basic_simd<T, Abi>&) noexcept;
+  template<class T, class Abi>
+    constexpr T reduce_max(const basic_simd<T, Abi>&,
+                           const typename basic_simd<T, Abi>::mask_type&) noexcept;
+
+  // \ref{simd.alg}, Algorithms
+  template<class T, class Abi>
+    constexpr basic_simd<T, Abi>
+      min(const basic_simd<T, Abi>& a, const basic_simd<T, Abi>& b) noexcept;
+  template<class T, class Abi>
+    constexpr basic_simd<T, Abi>
+      max(const basic_simd<T, Abi>& a, const basic_simd<T, Abi>& b) noexcept;
+  template<class T, class Abi>
+    constexpr pair<basic_simd<T, Abi>, basic_simd<T, Abi>>
+      minmax(const basic_simd<T, Abi>& a, const basic_simd<T, Abi>& b) noexcept;
+  template<class T, class Abi>
+    constexpr basic_simd<T, Abi>
+      clamp(const basic_simd<T, Abi>& v, const basic_simd<T, Abi>& lo,
+            const basic_simd<T, Abi>& hi);
+
+  template<class T, class U>
+    constexpr auto simd_select(bool c, const T& a, const U& b)
+    -> remove_cvref_t<decltype(c ? a : b)>;
+  template<size_t Bytes, class Abi, class T, class U>
+    constexpr auto simd_select(const basic_simd_mask<Bytes, Abi>& c, const T& a, const U& b)
+    noexcept -> decltype(@\exposid{simd-select-impl}@(c, a, b));
+
+  // \ref{simd.math}, Mathematical functions
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> acos(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> asin(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> atan(const V& x);
+  template<class V0, class V1>
+    constexpr @\exposid{math-common-simd-t}@<V0, V1> atan2(const V0& y, const V1& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> cos(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> sin(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> tan(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> acosh(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> asinh(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> atanh(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> cosh(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> sinh(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> tanh(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> exp(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> exp2(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> expm1(const V& x);
+  template<@\exposconcept{math-floating-point}@ V>
+    constexpr @\exposid{deduced-simd-t}@<V>
+      frexp(const V& value, rebind_simd_t<int, @\exposid{deduced-simd-t}@<V>>* exp);
+  template<@\exposconcept{math-floating-point}@ V>
+    constexpr rebind_simd_t<int, @\exposid{deduced-simd-t}@<V>> ilogb(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> ldexp(const V& x, const
+  rebind_simd_t<int, @\exposid{deduced-simd-t}@<V>>& exp);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> log(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> log10(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> log1p(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> log2(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> logb(const V& x);
+  template<class T, class Abi>
+    constexpr basic_simd<T, Abi> modf(const type_identity_t<basic_simd<T, Abi>>& value,
+                                      basic_simd<T, Abi>* iptr);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> scalbn(const V& x, const
+  rebind_simd_t<int, @\exposid{deduced-simd-t}@<V>>& n);
+  template<@\exposconcept{math-floating-point}@ V>
+    constexpr @\exposid{deduced-simd-t}@<V> scalbln(
+      const V& x, const rebind_simd_t<long int, @\exposid{deduced-simd-t}@<V>>& n);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> cbrt(const V& x);
+  template<signed_integral T, class Abi>
+    constexpr basic_simd<T, Abi> abs(const basic_simd<T, Abi>& j);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> abs(const V& j);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> fabs(const V& x);
+  template<class V0, class V1>
+    constexpr @\exposid{math-common-simd-t}@<V0, V1> hypot(const V0& x, const V1& y);
+  template<class V0, class V1, class V2>
+    constexpr @\exposid{math-common-simd-t}@<V0, V1, V2> hypot(const V0& x, const V1& y, const V2& z);
+  template<class V0, class V1>
+    constexpr @\exposid{math-common-simd-t}@<V0, V1> pow(const V0& x, const V1& y);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> sqrt(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> erf(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> erfc(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> lgamma(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> tgamma(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> ceil(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> floor(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-simd-t}@<V> nearbyint(const V& x);
+  template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-simd-t}@<V> rint(const V& x);
+  template<@\exposconcept{math-floating-point}@ V>
+    rebind_simd_t<long int, @\exposid{deduced-simd-t}@<V>> lrint(const V& x);
+  template<@\exposconcept{math-floating-point}@ V>
+    rebind_simd_t<long long int, V> llrint(const @\exposid{deduced-simd-t}@<V>& x);
+  template<@\exposconcept{math-floating-point}@ V>
+    constexpr @\exposid{deduced-simd-t}@<V> round(const V& x);
+  template<@\exposconcept{math-floating-point}@ V>
+    constexpr rebind_simd_t<long int, @\exposid{deduced-simd-t}@<V>> lround(const V& x);
+  template<@\exposconcept{math-floating-point}@ V>
+    constexpr rebind_simd_t<long long int, @\exposid{deduced-simd-t}@<V>> llround(const V& x);
+  template<@\exposconcept{math-floating-point}@ V>
+    constexpr @\exposid{deduced-simd-t}@<V> trunc(const V& x);
+  template<class V0, class V1>
+    constexpr @\exposid{math-common-simd-t}@<V0, V1> fmod(const V0& x, const V1& y);
+  template<class V0, class V1>
+    constexpr @\exposid{math-common-simd-t}@<V0, V1> remainder(const V0& x, const V1& y);
+  template<class V0, class V1>
+    constexpr @\exposid{math-common-simd-t}@<V0, V1>
+      remquo(const V0& x, const V1& y, rebind_simd_t<int, @\exposid{math-common-simd-t}@<V0, V1>>* quo);
+  template<class V0, class V1>
+    constexpr @\exposid{math-common-simd-t}@<V0, V1> copysign(const V0& x, const V1& y);
+  template<class V0, class V1>
+    constexpr @\exposid{math-common-simd-t}@<V0, V1> nextafter(const V0& x, const V1& y);
+  template<class V0, class V1>
+    constexpr @\exposid{math-common-simd-t}@<V0, V1> fdim(const V0& x, const V1& y);
+  template<class V0, class V1>
+    constexpr @\exposid{math-common-simd-t}@<V0, V1> fmax(const V0& x, const V1& y);
+  template<class V0, class V1>
+    constexpr @\exposid{math-common-simd-t}@<V0, V1> fmin(const V0& x, const V1& y);
+  template<class V0, class V1, class V2>
+    constexpr @\exposid{math-common-simd-t}@<V0, V1, V2> fma(const V0& x, const V1& y, const V2& z);
+  template<class V0, class V1, class V2>
+    constexpr @\exposid{math-common-simd-t}@<V0, V1, V2> lerp(const V0& a, const V1& b, const V2& t) noexcept;
+  template<@\exposconcept{math-floating-point}@ V>
+    constexpr rebind_simd_t<int, @\exposid{deduced-simd-t}@<V>> fpclassify(const V& x);
+  template<@\exposconcept{math-floating-point}@ V>
+    constexpr typename @\exposid{deduced-simd-t}@<V>::mask_type isfinite(const V& x);
+  template<@\exposconcept{math-floating-point}@ V>
+    constexpr typename @\exposid{deduced-simd-t}@<V>::mask_type isinf(const V& x);
+  template<@\exposconcept{math-floating-point}@ V>
+    constexpr typename @\exposid{deduced-simd-t}@<V>::mask_type isnan(const V& x);
+  template<@\exposconcept{math-floating-point}@ V>
+    constexpr typename @\exposid{deduced-simd-t}@<V>::mask_type isnormal(const V& x);
+  template<@\exposconcept{math-floating-point}@ V>
+    constexpr typename @\exposid{deduced-simd-t}@<V>::mask_type signbit(const V& x);
+  template<class V0, class V1>
+    constexpr typename @\exposid{math-common-simd-t}@<V0, V1>::mask_type
+      isgreater(const V0& x, const V1& y);
+  template<class V0, class V1>
+    constexpr typename @\exposid{math-common-simd-t}@<V0, V1>::mask_type
+      isgreaterequal(const V0& x, const V1& y);
+  template<class V0, class V1>
+    constexpr typename @\exposid{math-common-simd-t}@<V0, V1>::mask_type
+      isless(const V0& x, const V1& y);
+  template<class V0, class V1>
+    constexpr typename @\exposid{math-common-simd-t}@<V0, V1>::mask_type
+      islessequal(const V0& x, const V1& y);
+  template<class V0, class V1>
+    constexpr typename @\exposid{math-common-simd-t}@<V0, V1>::mask_type
+      islessgreater(const V0& x, const V1& y);
+  template<class V0, class V1>
+    constexpr typename @\exposid{math-common-simd-t}@<V0, V1>::mask_type
+      isunordered(const V0& x, const V1& y);
+  template<@\exposconcept{math-floating-point}@ V>
+    @\exposid{deduced-simd-t}@<V> assoc_laguerre(const rebind_simd_t<unsigned, @\exposid{deduced-simd-t}@<V>>& n, const
+      rebind_simd_t<unsigned, @\exposid{deduced-simd-t}@<V>>& m,
+                     const V& x);
+  template<@\exposconcept{math-floating-point}@ V>
+    @\exposid{deduced-simd-t}@<V> assoc_legendre(const rebind_simd_t<unsigned, @\exposid{deduced-simd-t}@<V>>& l, const
+      rebind_simd_t<unsigned, @\exposid{deduced-simd-t}@<V>>& m,
+                     const V& x);
+  template<class V0, class V1>
+    @\exposid{math-common-simd-t}@<V0, V1> beta(const V0& x, const V1& y);
+  template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-simd-t}@<V> comp_ellint_1(const V& k);
+  template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-simd-t}@<V> comp_ellint_2(const V& k);
+  template<class V0, class V1>
+    @\exposid{math-common-simd-t}@<V0, V1> comp_ellint_3(const V0& k, const V1& nu);
+  template<class V0, class V1>
+    @\exposid{math-common-simd-t}@<V0, V1> cyl_bessel_i(const V0& nu, const V1& x);
+  template<class V0, class V1>
+    @\exposid{math-common-simd-t}@<V0, V1> cyl_bessel_j(const V0& nu, const V1& x);
+  template<class V0, class V1>
+    @\exposid{math-common-simd-t}@<V0, V1> cyl_bessel_k(const V0& nu, const V1& x);
+  template<class V0, class V1>
+    @\exposid{math-common-simd-t}@<V0, V1> cyl_neumann(const V0& nu, const V1& x);
+  template<class V0, class V1>
+    @\exposid{math-common-simd-t}@<V0, V1> ellint_1(const V0& k, const V1& phi);
+  template<class V0, class V1>
+    @\exposid{math-common-simd-t}@<V0, V1> ellint_2(const V0& k, const V1& phi);
+  template<class V0, class V1, class V2>
+    @\exposid{math-common-simd-t}@<V0, V1, V2> ellint_3(const V0& k, const V1& nu, const V2& phi);
+  template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-simd-t}@<V> expint(const V& x);
+  template<@\exposconcept{math-floating-point}@ V>
+    @\exposid{deduced-simd-t}@<V> hermite(const rebind_simd_t<unsigned, @\exposid{deduced-simd-t}@<V>>& n, const V& x);
+  template<@\exposconcept{math-floating-point}@ V>
+    @\exposid{deduced-simd-t}@<V> laguerre(const rebind_simd_t<unsigned, @\exposid{deduced-simd-t}@<V>>& n, const V& x);
+  template<@\exposconcept{math-floating-point}@ V>
+    @\exposid{deduced-simd-t}@<V> legendre(const rebind_simd_t<unsigned, @\exposid{deduced-simd-t}@<V>>& l, const V& x);
+  template<@\exposconcept{math-floating-point}@ V>
+    @\exposid{deduced-simd-t}@<V> riemann_zeta(const V& x);
+  template<@\exposconcept{math-floating-point}@ V>
+    @\exposid{deduced-simd-t}@<V> sph_bessel(const rebind_simd_t<unsigned, @\exposid{deduced-simd-t}@<V>>& n, const V& x);
+  template<@\exposconcept{math-floating-point}@ V>
+    @\exposid{deduced-simd-t}@<V> sph_legendre(const rebind_simd_t<unsigned, @\exposid{deduced-simd-t}@<V>>& l,
+      const rebind_simd_t<unsigned, @\exposid{deduced-simd-t}@<V>>& m, const V& theta);
+  template<@\exposconcept{math-floating-point}@ V>
+    @\exposid{deduced-simd-t}@<V>
+      sph_neumann(const rebind_simd_t<unsigned, @\exposid{deduced-simd-t}@<V>>& n, const V& x);
+}
+\end{codeblock}
+
+\rSec2[simd.traits]{\tcode{simd} type traits}
+
+\begin{itemdecl}
+template<class T, class U = typename T::value_type> struct simd_alignment { @\seebelow@ };
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\tcode{simd_alignment<T, U>} has a member \tcode{value} if and only if
+\begin{itemize}
+  \item \tcode{T} is a specialization of \tcode{basic_simd_mask} and \tcode{U} is \tcode{bool}, or
+  \item \tcode{T} is a specialization of \tcode{basic_simd} and \tcode{U} is a vectorizable type.
+\end{itemize}
+
+\pnum
+If \tcode{value} is present, the type \tcode{simd_alignment<T, U>} is a \tcode{BinaryTypeTrait} with
+a base characteristic of \tcode{integral_constant<size_t, N>} for some unspecified
+\tcode{N} (see \ref{simd.ctor} and \ref{simd.loadstore}). \begin{note}\tcode{value} identifies the
+alignment restrictions on pointers used for (converting) loads and stores for the given type
+\tcode{T} on arrays of type \tcode{U}.\end{note}
+
+\pnum
+The behavior of a program that adds specializations for \tcode{simd_alignment} is undefined.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class T, class V> struct rebind_simd { using type = @\seebelow@; };
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum
+  The member \tcode{type} is present if and only if
+  \begin{itemize}
+    \item \tcode{V} is a data-parallel type,
+    \item \tcode{T} is a vectorizable type, and
+    \item \tcode{\exposid{deduce-abi-t}<T, V::size()>} has a member type \tcode{type}.
+  \end{itemize}
+
+  \pnum
+  If \tcode V is a specialization of \tcode{basic_simd} let \tcode{Abi1} denote an ABI tag such that
+  \tcode{basic_simd<T, Abi1>::size()} equals \tcode{V::size()}.
+  If \tcode V is a specialization of \tcode{basic_simd_mask} let \tcode{Abi1} denote an ABI tag such
+  that \tcode{basic_simd_mask<sizeof(T), Abi1>::size()} equals \tcode{V::size()}.
+
+  \pnum
+  Where present, the member typedef \tcode{type} names \tcode{basic_simd<T, Abi1>} if \tcode V is a
+  specialization of \tcode{basic_simd} or \tcode{basic_simd_mask<sizeof(T), Abi1>} if \tcode V is a
+  specialization of \tcode{basic_simd_mask}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<@\exposid{simd-size-type}@ N, class V> struct resize_simd { using type = @\seebelow@; };
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum Let \tcode{T} denote
+  \begin{itemize}
+    \item \tcode{typename V::value_type} if \tcode{V} is a specialization of
+      \tcode{basic_simd}, otherwise
+    \item \tcode{\exposid{integer-from}<\exposid{mask-element-size}<V>>} if \tcode{V} is a
+      specialization of \tcode{basic_simd_mask}.
+  \end{itemize}
+
+  \pnum
+  The member \tcode{type} is present if and only if
+  \begin{itemize}
+    \item \tcode{V} is a data-parallel type, and
+    \item \tcode{\exposid{deduce-abi-t}<T, N>} has a member type \tcode{type}.
+  \end{itemize}
+
+  \pnum
+  If \tcode V is a specialization of \tcode{basic_simd} let \tcode{Abi1} denote an ABI tag such that
+  \tcode{basic_simd<T, Abi1>::size()} equals \tcode{V::size()}.
+  If \tcode V is a specialization of \tcode{basic_simd_mask} let \tcode{Abi1} denote an ABI tag such
+  that \tcode{basic_simd_mask<sizeof(T), Abi1>::size()} equals \tcode{V::size()}.
+
+  \pnum
+  Where present, the member typedef \tcode{type} names \tcode{basic_simd<T,
+  Abi1>} if \tcode V is a specialization of \tcode{basic_simd} or
+  \tcode{basic_simd_mask<sizeof(T), Abi1>} if \tcode V is a specialization of
+  \tcode{basic_simd_mask}.
+\end{itemdescr}
+
+\rSec2[simd.flags]{Load and store flags}
+
+\rSec3[simd.flags.overview]{Class template \tcode{simd_flags} overview}
+
+\begin{codeblock}
+template<class... Flags> struct simd_flags {
+  // \ref{simd.flags.oper}, \tcode{simd_flags} operators
+  template<class... Other>
+    friend consteval auto operator|(simd_flags, simd_flags<Other...>);
+};
+\end{codeblock}
+
+\pnum
+\begin{note}
+The class template \tcode{simd_flags} acts like an integer bit-flag for types.
+\end{note}
+
+\pnum\constraints
+Every type in the parameter pack \tcode{Flags} is one of \tcode{\exposid{convert-flag}},
+\tcode{\exposid{aligned-flag}}, or \tcode{\exposid{overaligned-flag}<N>}.
+
+\rSec3[simd.flags.oper]{\tcode{simd_flags} operators}
+
+\begin{itemdecl}
+template<class... Other>
+  friend consteval auto operator|(simd_flags a, simd_flags<Other...> b);
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\returns
+  A default-initialized object of type \tcode{simd_flags<Flags2...>} for some
+  \tcode{Flags2} where every type in \tcode{Flags2} is present either in template parameter pack
+  \tcode{Flags} or in template parameter pack \tcode{Other}, and every type in template parameter
+  packs \tcode{Flags} and \tcode{Other} is present in \tcode{Flags2}.
+  If the packs \tcode{Flags} and \tcode{Other} contain two
+  different specializations \tcode{\exposid{overaligned-flag}<N1>} and
+  \tcode{\exposid{overaligned-flag}<N2>}, \tcode{Flags2} is not required to contain the
+  specialization \tcode{\exposid{overaligned-flag}<std::min(N1, N2)>}.
+\end{itemdescr}
+
+\rSec2[simd.class]{Class template \tcode{basic_simd}}
+
+\rSec3[simd.overview]{Class template \tcode{basic_simd} overview}
+
+\begin{codeblock}
+template<class T, class Abi> class basic_simd {
+public:
+  using value_type = T;
+  using mask_type = basic_simd_mask<sizeof(T), Abi>;
+  using abi_type = Abi;
+
+  static constexpr integral_constant<@\exposid{simd-size-type}@, @\exposid{simd-size-v}@<T, Abi>> size {};
+
+  constexpr basic_simd() noexcept = default;
+
+  // \ref{simd.ctor}, \tcode{basic_simd} constructors
+  template<class U> constexpr basic_simd(U&& value) noexcept;
+  template<class U, class UAbi>
+    constexpr explicit(@\seebelow@) basic_simd(const basic_simd<U, UAbi>&) noexcept;
+  template<class G> constexpr explicit basic_simd(G&& gen) noexcept;
+  template<class R, class... Flags>
+    constexpr basic_simd(R&& range, simd_flags<Flags...> = {});
+  template<class R, class... Flags>
+    constexpr basic_simd(R&& range, const mask_type& mask, simd_flags<Flags...> = {});
+
+  // \ref{simd.subscr}, \tcode{basic_simd} subscript operators
+  constexpr value_type operator[](@\exposid{simd-size-type}@) const;
+
+  // \ref{simd.unary}, \tcode{basic_simd} unary operators
+  constexpr basic_simd& operator++() noexcept;
+  constexpr basic_simd operator++(int) noexcept;
+  constexpr basic_simd& operator--() noexcept;
+  constexpr basic_simd operator--(int) noexcept;
+  constexpr mask_type operator!() const noexcept;
+  constexpr basic_simd operator~() const noexcept;
+  constexpr basic_simd operator+() const noexcept;
+  constexpr basic_simd operator-() const noexcept;
+
+  // \ref{simd.binary}, \tcode{basic_simd} binary operators
+  friend constexpr basic_simd operator+(const basic_simd&, const basic_simd&) noexcept;
+  friend constexpr basic_simd operator-(const basic_simd&, const basic_simd&) noexcept;
+  friend constexpr basic_simd operator*(const basic_simd&, const basic_simd&) noexcept;
+  friend constexpr basic_simd operator/(const basic_simd&, const basic_simd&) noexcept;
+  friend constexpr basic_simd operator%(const basic_simd&, const basic_simd&) noexcept;
+  friend constexpr basic_simd operator&(const basic_simd&, const basic_simd&) noexcept;
+  friend constexpr basic_simd operator|(const basic_simd&, const basic_simd&) noexcept;
+  friend constexpr basic_simd operator^(const basic_simd&, const basic_simd&) noexcept;
+  friend constexpr basic_simd operator<<(const basic_simd&, const basic_simd&) noexcept;
+  friend constexpr basic_simd operator>>(const basic_simd&, const basic_simd&) noexcept;
+  friend constexpr basic_simd operator<<(const basic_simd&, @\exposid{simd-size-type}@) noexcept;
+  friend constexpr basic_simd operator>>(const basic_simd&, @\exposid{simd-size-type}@) noexcept;
+
+  // \ref{simd.cassign}, \tcode{basic_simd} compound assignment
+  friend constexpr basic_simd& operator+=(basic_simd&, const basic_simd&) noexcept;
+  friend constexpr basic_simd& operator-=(basic_simd&, const basic_simd&) noexcept;
+  friend constexpr basic_simd& operator*=(basic_simd&, const basic_simd&) noexcept;
+  friend constexpr basic_simd& operator/=(basic_simd&, const basic_simd&) noexcept;
+  friend constexpr basic_simd& operator%=(basic_simd&, const basic_simd&) noexcept;
+  friend constexpr basic_simd& operator&=(basic_simd&, const basic_simd&) noexcept;
+  friend constexpr basic_simd& operator|=(basic_simd&, const basic_simd&) noexcept;
+  friend constexpr basic_simd& operator^=(basic_simd&, const basic_simd&) noexcept;
+  friend constexpr basic_simd& operator<<=(basic_simd&, const basic_simd&) noexcept;
+  friend constexpr basic_simd& operator>>=(basic_simd&, const basic_simd&) noexcept;
+  friend constexpr basic_simd& operator<<=(basic_simd&, @\exposid{simd-size-type}@) noexcept;
+  friend constexpr basic_simd& operator>>=(basic_simd&, @\exposid{simd-size-type}@) noexcept;
+
+  // \ref{simd.comparison}, \tcode{basic_simd} compare operators
+  friend constexpr mask_type operator==(const basic_simd&, const basic_simd&) noexcept;
+  friend constexpr mask_type operator!=(const basic_simd&, const basic_simd&) noexcept;
+  friend constexpr mask_type operator>=(const basic_simd&, const basic_simd&) noexcept;
+  friend constexpr mask_type operator<=(const basic_simd&, const basic_simd&) noexcept;
+  friend constexpr mask_type operator>(const basic_simd&, const basic_simd&) noexcept;
+  friend constexpr mask_type operator<(const basic_simd&, const basic_simd&) noexcept;
+
+  // \ref{simd.cond}, \tcode{basic_simd} exposition only conditional operators
+  friend constexpr basic_simd @\exposid{simd-select-impl}@( // \expos
+    const mask_type&, const basic_simd&, const basic_simd&) noexcept;
+};
+
+template<class R, class... Ts>
+  basic_simd(R&& r, Ts...) -> @\seebelow@;
+\end{codeblock}
+
+\pnum
+Every specialization of \tcode{basic_simd} is a complete type.
+The specialization of \tcode{basic_simd<T, Abi>} is
+\begin{itemize}
+  \item enabled, if \tcode{T} is a vectorizable type, and there exists value \tcode{N} in the range
+    \crange{1}{64}, such that \tcode{Abi} is \tcode{\exposid{deduce-abi-t}<T, N>},
+  \item otherwise, disabled, if \tcode{T} is not a vectorizable type,
+  \item otherwise, it is implementation-defined if such a specialization is enabled.
+\end{itemize}
+
+If \tcode{basic_simd<T, Abi>} is disabled, the specialization has a
+deleted default constructor, deleted destructor, deleted copy constructor, and
+deleted copy assignment.
+In addition only the \tcode{value_type}, \tcode{abi_type}, and
+\tcode{mask_type} members are present.
+
+If \tcode{basic_simd<T, Abi>} is enabled, \tcode{basic_simd<T, Abi>} is
+trivially copyable.
+
+\pnum\recommended
+Implementations should support explicit conversions between specializations of
+\tcode{basic_simd} and appropriate implementation-defined types.
+\begin{note}
+  The appropriate vector types which are available in the implementation.
+\end{note}
+
+\rSec3[simd.ctor]{\tcode{basic_simd} constructors}
+
+\begin{itemdecl}
+template<class U> constexpr basic_simd(U&&) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum Let \tcode{From} denote the type \tcode{remove_cvref_t<U>}.
+
+  \pnum\constraints
+  \tcode{From} satisfies \tcode{convertible_to<value_type>}, and either
+  \begin{itemize}
+    \item \tcode{From} is an arithmetic type and the conversion from
+      \tcode{From} to \tcode{value_type} is value-preserving
+      (\ref{simd.general}), or
+
+    \item \tcode{From} is not an arithmetic type and does not satisfy
+      \tcode{\exposconcept{constexpr-wrapper-like}}, or
+
+    \item \tcode{From} satisfies \tcode{\exposconcept{constexpr-wrapper-like}} (\ref{simd.syn}),
+      \tcode{remove_const_t<decltype(From::value)>} is an arithmetic type, and \tcode{From::value}
+      is representable by \tcode{value_type}.
+  \end{itemize}
+
+  \pnum\effects
+  Initializes each element to the value of the argument after conversion to \tcode{value_type}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class U, class UAbi>
+  constexpr explicit(@\seebelow@) basic_simd(const basic_simd<U, UAbi>& x) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\constraints
+  \tcode{\exposid{simd-size-v}<U, UAbi> == size()} is \tcode{true}.
+
+  \pnum\effects
+  Initializes the $i^\text{th}$ element with \tcode{static_cast<T>(x[$i$])} \foralli.
+
+  \pnum\remarks
+  The expression inside \tcode{explicit} evaluates to \tcode{true} if either
+  \begin{itemize}
+    \item the conversion from \tcode{U} to \tcode{value_type} is not
+      value-preserving, or
+
+    \item both \tcode{U} and \tcode{value_type} are integral types and the
+      integer conversion rank (\iref{conv.rank}) of \tcode{U} is greater than
+      the integer conversion rank of \tcode{value_type}, or
+
+    \item both \tcode{U} and \tcode{value_type} are floating-point types and
+      the floating-point conversion rank (\iref{conv.rank}) of \tcode{U} is
+      greater than the floating-point conversion rank of \tcode{value_type}.
+  \end{itemize}
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class G> constexpr explicit basic_simd(G&& gen) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum Let \tcode{From}$_i$ denote the type
+  \tcode{decltype(gen(integral_constant<\exposid{simd-size-type}, $i$>()))}.
+
+  \pnum\constraints
+  \tcode{From}$_i$ satisfies \tcode{convertible_to<value_type>} \foralli.
+  In addition, \foralli, if \tcode{From}$_i$ is an arithmetic type, conversion from
+  \tcode{From}$_i$ to \tcode{value_type} is value-preserving.
+
+  \pnum\effects
+  Initializes the $i^\text{th}$ element with
+  \tcode{static_cast<value_type>(gen(integral_constant<\exposid{simd-size-type}, i>()))} \foralli.
+
+  \pnum\remarks
+    The calls to \tcode{gen} are unsequenced with respect to each other.
+    Vectorization-unsafe (\iref{algorithms.parallel.defns}) standard library
+    functions may not be invoked by \tcode{gen}.
+    \tcode{gen} is invoked exactly once for each $i$.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class R, class... Flags>
+  constexpr basic_simd(R&& r, simd_flags<Flags...> = {});
+template<class R, class... Flags>
+  constexpr basic_simd(R&& r, const mask_type& mask, simd_flags<Flags...> = {});
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum
+  Let \tcode{mask} be \tcode{mask_type(true)} for the overload with no \tcode{mask} parameter.
+
+  \pnum\constraints
+  \begin{itemize}
+    \item \tcode{R} models \tcode{ranges::contiguous_range} and \tcode{ranges::sized_range},
+    \item \tcode{ranges::size(r)} is a constant expression, and
+    \item \tcode{ranges::size(r)} is equal to \tcode{size()}.
+  \end{itemize}
+
+  \pnum\mandates
+  \begin{itemize}
+    \item \tcode{ranges::range_value_t<R>} is a vectorizable type, and
+    \item if the template parameter pack \tcode{Flags} does not contain \tcode{\exposid{convert-flag}}, then
+      the conversion from \tcode{ranges::range_value_t<R>} to \tcode{value_type} is
+      value-preserving.
+  \end{itemize}
+
+  \pnum\expects
+  \begin{itemize}
+    \item If the template parameter pack \tcode{Flags} contains \tcode{\exposid{aligned-flag}},
+      \tcode{ranges::data(range)} points to storage aligned by \tcode{simd_alignment_v<basic_simd,
+      ranges::range_value_t<R>>}.
+    \item If the template parameter pack \tcode{Flags} contains \tcode{\exposid{overaligned-flag}<N>},
+      \tcode{ranges::data(range)} points to storage aligned by \tcode{N}.
+  \end{itemize}
+
+  \pnum\effects
+    Initializes the $i^\text{th}$ element with \tcode{mask[$i$] ?
+    static_cast<T>(ranges::data(range)[$i$]) : T()} \foralli.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class R, class... Ts>
+  basic_simd(R&& r, Ts...) -> @\seebelow@;
+\end{itemdecl}
+\begin{itemdescr}
+  \pnum\constraints
+  \begin{itemize}
+    \item \tcode{R} models \tcode{ranges::contiguous_range} and \tcode{ranges::sized_range}, and
+    \item \tcode{ranges::size(r)} is a constant expression.
+  \end{itemize}
+
+  \pnum\remarks
+  The deduced type is equivalent to \tcode{simd<ranges::range_value_t<R>, ranges::size(r)>}.
+\end{itemdescr}
+
+\rSec3[simd.subscr]{\tcode{basic_simd} subscript operator}
+
+\begin{itemdecl}
+constexpr value_type operator[](@\exposid{simd-size-type}@ i) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\expects
+  \tcode{i >= 0 \&\& i < size()} is \tcode{true}.
+
+  \pnum\returns
+  The value of the $i^\text{th}$ element.
+
+  \pnum\throws Nothing.
+\end{itemdescr}
+
+\rSec3[simd.unary]{\tcode{basic_simd} unary operators}
+
+\pnum
+Effects in [simd.unary] are applied as unary element-wise operations.
+
+\begin{itemdecl}
+constexpr basic_simd& operator++() noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\ConstraintUnaryOperatorWellFormed[]{++a}
+
+  \pnum\effects
+  Increments every element by one.
+
+  \pnum\returns
+  \tcode{*this}.
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr basic_simd operator++(int) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\ConstraintUnaryOperatorWellFormed[]{a++}
+
+  \pnum\effects
+  Increments every element by one.
+
+  \pnum\returns
+  A copy of \tcode{*this} before incrementing.
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr basic_simd& operator--() noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\ConstraintUnaryOperatorWellFormed[]{--a}
+
+  \pnum\effects
+  Decrements every element by one.
+
+  \pnum\returns
+  \tcode{*this}.
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr basic_simd operator--(int) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\ConstraintUnaryOperatorWellFormed[]{a--}
+
+  \pnum\effects
+  Decrements every element by one.
+
+  \pnum\returns
+  A copy of \tcode{*this} before decrementing.
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr mask_type operator!() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\ConstraintUnaryOperatorWellFormed{!a}
+
+  \pnum\returns
+  A \tcode{basic_simd_mask} object with the $i^\text{th}$ element set to \tcode{!operator[]($i$)}
+  \foralli.
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr basic_simd operator~() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\ConstraintUnaryOperatorWellFormed{\~{}a}
+
+  \pnum\returns
+  A \tcode{basic_simd} object with the $i^\text{th}$ element set to \tcode{\~{}operator[]($i$)}
+  \foralli.
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr basic_simd operator+() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\ConstraintUnaryOperatorWellFormed{+a}
+
+  \pnum\returns
+  \tcode{*this}.
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr basic_simd operator-() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\ConstraintUnaryOperatorWellFormed{-a}
+
+  \pnum\returns
+  A \tcode{basic_simd} object where the $i^\text{th}$ element is initialized to
+  \tcode{-operator[]($i$)} \foralli.
+\end{itemdescr}
+
+\rSec2[simd.nonmembers]{\tcode{basic_simd} non-member operations}
+
+\rSec3[simd.binary]{\tcode{basic_simd} binary operators}
+
+\begin{itemdecl}
+friend constexpr basic_simd operator+(const basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr basic_simd operator-(const basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr basic_simd operator*(const basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr basic_simd operator/(const basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr basic_simd operator%(const basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr basic_simd operator&(const basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr basic_simd operator|(const basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr basic_simd operator^(const basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr basic_simd operator<<(const basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr basic_simd operator>>(const basic_simd& lhs, const basic_simd& rhs) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum Let \placeholder{op} be the operator.
+
+  \pnum\ConstraintOperatorTWellFormed
+
+  \pnum\returns
+  A \tcode{basic_simd} object initialized with the results of applying \placeholder{op} to \tcode{lhs} and
+  \tcode{rhs} as a binary element-wise operation.
+\end{itemdescr}
+
+\begin{itemdecl}
+friend constexpr basic_simd operator<<(const basic_simd& v, @\exposid{simd-size-type}@ n) noexcept;
+friend constexpr basic_simd operator>>(const basic_simd& v, @\exposid{simd-size-type}@ n) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum Let \placeholder{op} be the operator.
+
+  \pnum\constraints
+  \tcode{requires (value_type a, \exposid{simd-size-type}{} b) \{ a \placeholder{op} b; \}} is \tcode{true}.
+
+  \pnum\returns
+  A \tcode{basic_simd} object where the $i^\text{th}$ element is initialized to the result of
+  applying \placeholder{op} to \tcode{v[$i$]} and \tcode{n} \foralli.
+\end{itemdescr}
+
+\rSec3[simd.cassign]{\tcode{basic_simd} compound assignment}
+
+\begin{itemdecl}
+friend constexpr basic_simd& operator+=(basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr basic_simd& operator-=(basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr basic_simd& operator*=(basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr basic_simd& operator/=(basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr basic_simd& operator%=(basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr basic_simd& operator&=(basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr basic_simd& operator|=(basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr basic_simd& operator^=(basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr basic_simd& operator<<=(basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr basic_simd& operator>>=(basic_simd& lhs, const basic_simd& rhs) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum Let \placeholder{op} be the operator.
+
+  \pnum\ConstraintOperatorTWellFormed
+
+  \pnum\effects
+  These operators apply the indicated operator to \tcode{lhs} and \tcode{rhs} as an element-wise
+  operation.
+
+  \pnum\returns
+  \tcode{lhs}.
+\end{itemdescr}
+
+\begin{itemdecl}
+friend constexpr basic_simd& operator<<=(basic_simd& lhs, @\exposid{simd-size-type}@ n) noexcept;
+friend constexpr basic_simd& operator>>=(basic_simd& lhs, @\exposid{simd-size-type}@ n) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum Let \placeholder{op} be the operator.
+
+  \pnum\constraints
+  \tcode{requires (value_type a, \exposid{simd-size-type}{} b) \{ a \placeholder{op} b; \}} is \tcode{true}.
+
+  \pnum\effects
+  Equivalent to: \tcode{return operator \placeholder{op} (lhs, basic_simd(n));}
+\end{itemdescr}
+
+\rSec3[simd.comparison]{\tcode{basic_simd} compare operators}
+
+\begin{itemdecl}
+friend constexpr mask_type operator==(const basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr mask_type operator!=(const basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr mask_type operator>=(const basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr mask_type operator<=(const basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr mask_type operator>(const basic_simd& lhs, const basic_simd& rhs) noexcept;
+friend constexpr mask_type operator<(const basic_simd& lhs, const basic_simd& rhs) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum Let \placeholder{op} be the operator.
+
+  \pnum\ConstraintOperatorTWellFormed
+
+  \pnum\returns
+  A \tcode{basic_simd_mask} object initialized with the results of applying \placeholder{op} to \tcode{lhs} and
+  \tcode{rhs} as a binary element-wise operation.
+\end{itemdescr}
+
+\rSec3[simd.cond]{\tcode{basic_simd} exposition only conditional operators}
+
+\begin{itemdecl}
+friend constexpr basic_simd
+@\exposid{simd-select-impl}@(const mask_type& mask, const basic_simd& a, const basic_simd& b) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\returns
+  A \tcode{basic_simd} object where the $i^\text{th}$ element equals \tcode{mask[$i$] ? a[$i$] :
+  b[$i$]} \foralli.
+\end{itemdescr}
+
+\rSec3[simd.reductions]{\tcode{basic_simd} reductions}
+
+\begin{itemdecl}
+template<class T, class Abi, class BinaryOperation = plus<>>
+  constexpr T reduce(const basic_simd<T, Abi>& x, BinaryOperation binary_op = {});
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\constraints
+  \tcode{BinaryOperation} models \tcode{\exposconcept{reduction-binary-operation}<T>}.
+
+  \pnum\expects
+  \tcode{binary_op} does not modify \tcode{x}.
+
+  \pnum\returns
+  \tcode{\placeholdernc{GENERALIZED_SUM}(binary_op, simd<T, 1>(x[0]), $\ldots$, simd<T, 1>(x[x.size() - 1])[0]}
+  (\iref{numerics.defns}).
+
+  \pnum\throws
+  Any exception thrown from \tcode{binary_op}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class T, class Abi, class BinaryOperation = plus<>>
+  constexpr T reduce(
+    const basic_simd<T, Abi>& x, const typename basic_simd<T, Abi>::mask_type& mask,
+    BinaryOperation binary_op = {}, type_identity_t<T> identity_element = @\seebelow@);
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\constraints
+  \begin{itemize}
+    \item \tcode{BinaryOperation} models \tcode{\exposconcept{reduction-binary-operation}<T>}.
+
+    \item An argument for \tcode{identity_element} is provided for the invocation, unless
+      \tcode{BinaryOperation} is one of \tcode{plus<>}, \tcode{multiplies<>}, \tcode{bit_and<>},
+      \tcode{bit_or<>}, or \tcode{bit_xor<>}.
+  \end{itemize}
+
+  \pnum\expects
+  \begin{itemize}
+    \item \tcode{binary_op} does not modify \tcode{x}.
+
+    \item For all finite values \tcode{y} representable by \tcode{T}, the results of
+      \tcode{y == binary_op(simd<T, 1>(identity_element), simd<T, 1>(y))[0]} and
+      \tcode{y == binary_op(simd<T, 1>(y), simd<T, 1>(identity_element))[0]} are \tcode{true}.
+  \end{itemize}
+
+  \pnum\returns
+  If \tcode{none_of(mask)} is \tcode{true}, returns \tcode{identity_element}.
+  Otherwise, returns \tcode{\placeholdernc{GENERALIZED_SUM}(binary_op, simd<T, 1>(x[$k_0$]),
+  $\ldots$, simd<T, 1>(x[$k_n$]))[0]} where $k_0, \ldots, k_n$ are the selected indices of
+  \tcode{mask}.
+
+  \pnum\throws
+  Any exception thrown from \tcode{binary_op}.
+
+  \pnum\remarks
+  The default argument for \tcode{identity_element} is equal to
+  \begin{itemize}
+    \item \tcode{T()} if \tcode{BinaryOperation} is \tcode{plus<>},
+    \item \tcode{T(1)} if \tcode{BinaryOperation} is \tcode{multiplies<>},
+    \item \tcode{T(\~{}T())} if \tcode{BinaryOperation} is \tcode{bit_and<>},
+    \item \tcode{T()} if \tcode{BinaryOperation} is \tcode{bit_or<>}, or
+    \item \tcode{T()} if \tcode{BinaryOperation} is \tcode{bit_xor<>}.
+  \end{itemize}
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class T, class Abi> constexpr T reduce_min(const basic_simd<T, Abi>& x) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\constraints
+  \tcode{T} models \tcode{totally_ordered}.
+
+  \pnum\returns
+  The value of an element \tcode{x[$j$]} for which \tcode{x[$i$] < x[$j$]} is \tcode{false}
+  \foralli[basic_simd<T, Abi>::].
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class T, class Abi>
+  constexpr T reduce_min(
+    const basic_simd<T, Abi>&, const typename basic_simd<T, Abi>::mask_type&) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\constraints
+  \tcode{T} models \tcode{totally_ordered}.
+
+  \pnum\returns
+  If \tcode{none_of(mask)} is \tcode{true}, returns \tcode{numeric_limits<T>::max()}.
+  Otherwise, returns the value of a selected element \tcode{x[$j$]} for which \tcode{x[$i$] <
+  x[$j$]} is \tcode{false} \forallmaskedi.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class T, class Abi> constexpr T reduce_max(const basic_simd<T, Abi>& x) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\constraints
+  \tcode{T} models \tcode{totally_ordered}.
+
+  \pnum\returns
+  The value of an element \tcode{x[$j$]} for which \tcode{x[$j$] < x[$i$]} is \tcode{false}
+  \foralli[basic_simd<T, Abi>::].
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class T, class Abi>
+  constexpr T reduce_max(
+    const basic_simd<T, Abi>&, const typename basic_simd<T, Abi>::mask_type&) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\constraints
+  \tcode{T} models \tcode{totally_ordered}.
+
+  \pnum\returns
+  If \tcode{none_of(mask)} is \tcode{true}, returns \tcode{numeric_limits<V::value_type>::lowest()}.
+  Otherwise, returns the value of a selected element \tcode{x[$j$]} for which \tcode{x[$j$] <
+  x[$i$]} is \tcode{false} \forallmaskedi.
+\end{itemdescr}
+
+\rSec3[simd.loadstore]{\tcode{basic_simd} load and store functions}
+
+\begin{itemdecl}
+template<class V = @\seebelow@, ranges::contiguous_range R, class... Flags>
+  requires ranges::sized_range<R>
+  constexpr V simd_unchecked_load(R&& r, simd_flags<Flags...> f = {});
+template<class V = @\seebelow@, ranges::contiguous_range R, class... Flags>
+  requires ranges::sized_range<R>
+  constexpr V simd_unchecked_load(R&& r, const typename V::mask_type& mask, simd_flags<Flags...> f = {});
+template<class V = @\seebelow@, contiguous_iterator I, class... Flags>
+  constexpr V simd_unchecked_load(I first, iter_difference_t<I> n, simd_flags<Flags...> f = {});
+template<class V = @\seebelow@, contiguous_iterator I, class... Flags>
+  constexpr V simd_unchecked_load(I first, iter_difference_t<I> n, const typename V::mask_type& mask,
+                        simd_flags<Flags...> f = {});
+template<class V = @\seebelow@, contiguous_iterator I, sized_sentinel_for<I> S, class... Flags>
+  constexpr V simd_unchecked_load(I first, S last, simd_flags<Flags...> f = {});
+template<class V = @\seebelow@, contiguous_iterator I, sized_sentinel_for<I> S, class... Flags>
+  constexpr V simd_unchecked_load(I first, S last, const typename V::mask_type& mask,
+                        simd_flags<Flags...> f = {});
+\end{itemdecl}
+\begin{itemdescr}
+  \pnum
+  Let
+  \begin{itemize}
+    \item \tcode{mask} be \tcode{V::mask_type(true)} for the overloads with no \tcode{mask} parameter;
+    \item \tcode{R} be \tcode{span<const iter_value_t<I>>} for the overloads with no template parameter
+      \tcode{R};
+    \item \tcode{r} be \tcode{R(first, n)} for the overloads with an \tcode{n} parameter and
+      \tcode{R(first, last)} for the overloads with a \tcode{last} parameter.
+  \end{itemize}
+
+  \pnum\mandates
+    If \tcode{ranges::size(r)} is a constant expression then \tcode{ranges::size(r)} $\ge$
+    \tcode{V::size()}.
+
+  \pnum\expects
+  \begin{itemize}
+    \item \range{first}{first + n} is a valid range for the overloads with an \tcode{n} parameter.
+    \item \range{first}{last} is a valid range for the overloads with a \tcode{last} parameter.
+    \item \tcode{ranges::size(r)} $\ge$ \tcode{V::size()}
+  \end{itemize}
+
+  \pnum\effects
+  Equivalent to: \tcode{return simd_partial_load<V>(r, mask, f);}
+
+  \pnum\remarks
+  The default argument for template parameter \tcode{V} is
+  \tcode{basic_simd<ranges::range_value_t<R>>}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class V = @\seebelow@, ranges::contiguous_range R, class... Flags>
+  requires ranges::sized_range<R>
+  constexpr V simd_partial_load(R&& r, simd_flags<Flags...> f = {});
+template<class V = @\seebelow@, ranges::contiguous_range R, class... Flags>
+  requires ranges::sized_range<R>
+  constexpr V simd_partial_load(R&& r, const typename V::mask_type& mask, simd_flags<Flags...> f = {});
+template<class V = @\seebelow@, contiguous_iterator I, class... Flags>
+  constexpr V simd_partial_load(I first, iter_difference_t<I> n, simd_flags<Flags...> f = {});
+template<class V = @\seebelow@, contiguous_iterator I, class... Flags>
+  constexpr V simd_partial_load(I first, iter_difference_t<I> n, const typename V::mask_type& mask,
+                        simd_flags<Flags...> f = {});
+template<class V = @\seebelow@, contiguous_iterator I, sized_sentinel_for<I> S, class... Flags>
+  constexpr V simd_partial_load(I first, S last, simd_flags<Flags...> f = {});
+template<class V = @\seebelow@, contiguous_iterator I, sized_sentinel_for<I> S, class... Flags>
+  constexpr V simd_partial_load(I first, S last, const typename V::mask_type& mask,
+                        simd_flags<Flags...> f = {});
+\end{itemdecl}
+\begin{itemdescr}
+  \pnum
+  Let
+  \begin{itemize}
+    \item \tcode{mask} be \tcode{V::mask_type(true)} for the overloads with no \tcode{mask} parameter;
+    \item \tcode{R} be \tcode{span<const iter_value_t<I>>} for the overloads with no template parameter
+      \tcode{R};
+    \item \tcode{r} be \tcode{R(first, n)} for the overloads with an \tcode{n} parameter and
+      \tcode{R(first, last)} for the overloads with a \tcode{last} parameter.
+  \end{itemize}
+
+  \pnum\mandates
+  \begin{itemize}
+    \item \tcode{ranges::range_value_t<R>} is a vectorizable type,
+    \item \tcode{same_as<remove_cvref_t<V>, V>} is \tcode{true},
+    \item \tcode{V} is an enabled specialization of \tcode{basic_simd}, and
+    \item if the template parameter pack \tcode{Flags} does not contain \tcode{\exposid{convert-flag}}, then
+      the conversion from \tcode{ranges::range_value_t<R>} to \tcode{V::value_type} is
+      value-preserving.
+  \end{itemize}
+
+  \pnum\expects
+  \begin{itemize}
+    \item \range{first}{first + n} is a valid range for the overloads with an \tcode{n} parameter.
+    \item \range{first}{last} is a valid range for the overloads with a \tcode{last} parameter.
+    \item If the template parameter pack \tcode{Flags} contains \tcode{\exposid{aligned-flag}},
+      \tcode{ranges::data(r)} points to storage aligned by \tcode{simd_alignment_v<V,
+      ranges::range_value_t<R>>}.
+    \item If the template parameter pack \tcode{Flags} contains \tcode{\exposid{overaligned-flag}<N>},
+      \tcode{ranges::data(r)} points to storage aligned by \tcode{N}.
+  \end{itemize}
+
+  \pnum\effects
+  Initializes the $i^\text{th}$ element with \tcode{mask[$i$] \&\& $i$ < ranges::size(r) ?
+  static_cast<T>(ranges::data(r)[$i$]) : T()} \foralli[V::].
+
+  \pnum\remarks
+  The default argument for template parameter \tcode{V} is
+  \tcode{basic_simd<ranges::range_value_t<R>>}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class T, class Abi, ranges::contiguous_range R, class... Flags>
+  requires ranges::sized_range<R> && indirectly_writable<ranges::iterator_t<R>, T>
+  constexpr void simd_unchecked_store(const basic_simd<T, Abi>& v, R&& r, simd_flags<Flags...> f = {});
+template<class T, class Abi, ranges::contiguous_range R, class... Flags>
+  requires ranges::sized_range<R> && indirectly_writable<ranges::iterator_t<R>, T>
+  constexpr void simd_unchecked_store(const basic_simd<T, Abi>& v, R&& r,
+                          const typename basic_simd<T, Abi>::mask_type& mask,
+                          simd_flags<Flags...> f = {});
+template<class T, class Abi, contiguous_iterator I, class... Flags>
+  requires indirectly_writable<I, T>
+  constexpr void simd_unchecked_store(const basic_simd<T, Abi>& v, I first, iter_difference_t<I> n,
+                          simd_flags<Flags...> f = {});
+template<class T, class Abi, contiguous_iterator I, class... Flags>
+  requires indirectly_writable<I, T>
+  constexpr void simd_unchecked_store(const basic_simd<T, Abi>& v, I first, iter_difference_t<I> n,
+                          const typename basic_simd<T, Abi>::mask_type& mask,
+                          simd_flags<Flags...> f = {});
+template<class T, class Abi, contiguous_iterator I, sized_sentinel_for<I> S, class... Flags>
+  requires indirectly_writable<I, T>
+  constexpr void simd_unchecked_store(const basic_simd<T, Abi>& v, I first, S last, simd_flags<Flags...> f = {});
+template<class T, class Abi, contiguous_iterator I, sized_sentinel_for<I> S, class... Flags>
+  requires indirectly_writable<I, T>
+  constexpr void simd_unchecked_store(const basic_simd<T, Abi>& v, I first, S last,
+                          const typename basic_simd<T, Abi>::mask_type& mask,
+                          simd_flags<Flags...> f = {});
+\end{itemdecl}
+\begin{itemdescr}
+  \pnum
+  Let
+  \begin{itemize}
+    \item \tcode{mask} be \tcode{basic_simd<T, Abi>::mask_type(true)} for the overloads with no
+      \tcode{mask} parameter;
+    \item \tcode{R} be \tcode{span<iter_value_t<I>>} for the overloads with no template parameter
+      \tcode{R};
+    \item \tcode{r} be \tcode{R(first, n)} for the overloads with an \tcode{n} parameter and
+      \tcode{R(first, last)} for the overloads with a \tcode{last} parameter.
+  \end{itemize}
+
+  \pnum\mandates
+  If \tcode{ranges::size(r)} is a constant expression then \tcode{ranges::size(r)} $\ge$
+  \tcode{\exposid{simd-size-v}<T, Abi>}.
+
+  \pnum\expects
+  \begin{itemize}
+    \item \range{first}{first + n} is a valid range for the overloads with an \tcode{n} parameter.
+    \item \range{first}{last} is a valid range for the overloads with a \tcode{last} parameter.
+    \item \tcode{ranges::size(r)} $\ge$ \tcode{\exposid{simd-size-v}<T, Abi>}
+  \end{itemize}
+
+  \pnum\effects
+  Equivalent to: \tcode{simd_partial_store(v, r, mask, f)}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class T, class Abi, ranges::contiguous_range R, class... Flags>
+  requires ranges::sized_range<R> && indirectly_writable<ranges::iterator_t<R>, T>
+  constexpr void simd_partial_store(const basic_simd<T, Abi>& v, R&& r, simd_flags<Flags...> f = {});
+template<class T, class Abi, ranges::contiguous_range R, class... Flags>
+  requires ranges::sized_range<R> && indirectly_writable<ranges::iterator_t<R>, T>
+  constexpr void simd_partial_store(const basic_simd<T, Abi>& v, R&& r,
+                          const typename basic_simd<T, Abi>::mask_type& mask,
+                          simd_flags<Flags...> f = {});
+template<class T, class Abi, contiguous_iterator I, class... Flags>
+  requires indirectly_writable<I, T>
+  constexpr void simd_partial_store(const basic_simd<T, Abi>& v, I first, iter_difference_t<I> n,
+                          simd_flags<Flags...> f = {});
+template<class T, class Abi, contiguous_iterator I, class... Flags>
+  requires indirectly_writable<I, T>
+  constexpr void simd_partial_store(const basic_simd<T, Abi>& v, I first, iter_difference_t<I> n,
+                          const typename basic_simd<T, Abi>::mask_type& mask,
+                          simd_flags<Flags...> f = {});
+template<class T, class Abi, contiguous_iterator I, sized_sentinel_for<I> S, class... Flags>
+  requires indirectly_writable<I, T>
+  constexpr void simd_partial_store(const basic_simd<T, Abi>& v, I first, S last, simd_flags<Flags...> f = {});
+template<class T, class Abi, contiguous_iterator I, sized_sentinel_for<I> S, class... Flags>
+  requires indirectly_writable<I, T>
+  constexpr void simd_partial_store(const basic_simd<T, Abi>& v, I first, S last,
+                          const typename basic_simd<T, Abi>::mask_type& mask,
+                          simd_flags<Flags...> f = {});
+\end{itemdecl}
+\begin{itemdescr}
+  \pnum
+  Let
+  \begin{itemize}
+    \item \tcode{mask} be \tcode{basic_simd<T, Abi>::mask_type(true)} for the overloads with no
+      \tcode{mask} parameter;
+    \item \tcode{R} be \tcode{span<iter_value_t<I>>} for the overloads with no template parameter
+      \tcode{R};
+    \item \tcode{r} be \tcode{R(first, n)} for the overloads with an \tcode{n} parameter and
+      \tcode{R(first, last)} for the overloads with a \tcode{last} parameter.
+  \end{itemize}
+
+  \pnum\mandates
+  \begin{itemize}
+    \item \tcode{ranges::range_value_t<R>} is a vectorizable type, and
+    \item if the template parameter pack \tcode{Flags} does not contain \tcode{\exposid{convert-flag}}, then
+      the conversion from \tcode{T} to \tcode{ranges::range_value_t<R>} is value-preserving.
+  \end{itemize}
+
+  \pnum\expects
+  \begin{itemize}
+    \item \range{first}{first + n} is a valid range for the overloads with an \tcode{n} parameter.
+    \item \range{first}{last} is a valid range for the overloads with a \tcode{last} parameter.
+    \item If the template parameter pack \tcode{Flags} contains \tcode{\exposid{aligned-flag}},
+      \tcode{ranges::data(r)} points to storage aligned by \tcode{simd_alignment_v<basic_simd<T,
+        Abi>, ranges::range_value_t<R>>}.
+    \item If the template parameter pack \tcode{Flags} contains \tcode{\exposid{overaligned-flag}<N>},
+      \tcode{ranges::data(r)} points to storage aligned by \tcode{N}.
+  \end{itemize}
+
+  \pnum\effects
+  \Foralli[basic_simd<T, Abi>::], if \tcode{mask[$i$] \&\& $i$ < ranges::size(r)} is \tcode{true},
+  evaluates \tcode{ranges::data(r)[$i$] = v[$i$]}.
+\end{itemdescr}
+
+\rSec3[simd.creation]{\tcode{basic_simd} and \tcode{basic_simd_mask} creation}
+
+\begin{itemdecl}
+template<class T, class Abi>
+  constexpr auto simd_split(const basic_simd<typename T::value_type, Abi>& x) noexcept;
+template<class T, class Abi>
+  constexpr auto simd_split(const basic_simd_mask<@\exposid{mask-element-size}@<T>, Abi>& x) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\constraints
+  \begin{itemize}
+    \item For the first overload \tcode{T} is an enabled specialization of \tcode{basic_simd}. If
+      \tcode{basic_simd<typename T::value_type, Abi>::size() \% T::size()} is
+      not \tcode{0} then \tcode{resize_simd_t<basic_simd<typename T::value_type,
+      Abi>::size() \% T::size(), T>} is valid and denotes a type.
+
+    \item For the second overload \tcode{T} is an enabled specialization of \tcode{basic_simd_mask}.
+      If \tcode{basic_simd_mask<\exposid{mask-element-size}<T>, Abi>::size() \% T::size()} is not
+      \tcode{0} then \tcode{resize_simd_t<basic_simd_mask<\brk{}\exposid{mask-element-size}<T>,
+      Abi>::size() \% T::size(), T>} is valid and denotes a type.
+  \end{itemize}
+
+  \pnum Let $N$ be \tcode{x.size() / T::size()}.
+
+    \pnum\returns
+    \begin{itemize}
+      \item If \tcode{x.size() \% T::size() == 0} is \tcode{true}, an \tcode{array<T, $N$>} with
+        the $i^\text{th}$ \tcode{basic_simd} or \tcode{basic_simd_mask} element of the $j^\text{th}$ \tcode{array}
+        element initialized to the value of the element in \tcode{x} with index
+        \tcode{$i$ + $j$ * T::size()}.
+
+      \item Otherwise, a \tcode{tuple} of $N$ objects of type \tcode{T} and one
+        object of type \tcode{resize_simd_t<x.size() \% T::size(), T>}.
+        The $i^\text{th}$ \tcode{basic_simd} or \tcode{basic_simd_mask} element of the $j^\text{th}$
+        \tcode{tuple} element of type \tcode{T} is initialized to the value of
+        the element in \tcode{x} with index \tcode{$i$ + $j$ * T::size()}.
+        The $i^\text{th}$ \tcode{basic_simd} or \tcode{basic_simd_mask} element of the $N^\text{th}$
+        \tcode{tuple} element is initialized to the value of the element in
+        \tcode{x} with index \tcode{$i$ + $N$ * T::size()}.
+    \end{itemize}
+  \end{itemdescr}
+
+\begin{itemdecl}
+template<class T, class... Abis>
+  constexpr simd<T, (basic_simd<T, Abis>::size() + ...)>
+    simd_cat(const basic_simd<T, Abis>&... xs) noexcept;
+template<size_t Bytes, class... Abis>
+  constexpr simd_mask<@\exposid{deduce-abi-t}@<@\exposid{integer-from}@<Bytes>, (basic_simd_mask<Bytes, Abis>::size() + ...)>
+    simd_cat(const basic_simd_mask<Bytes, Abis>&... xs) noexcept;
+
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\constraints
+  \begin{itemize}
+    \item For the first overload \tcode{simd<T, (basic_simd<T, Abis>::size() + ...)>} is enabled.
+
+    \item For the second overload \tcode{simd_mask<\exposid{deduce-abi-t}<\exposid{integer-from}<Bytes>,
+      (basic_simd_mask<Bytes, Abis>::size() + ...)>} is enabled.
+  \end{itemize}
+
+  \pnum\returns
+  A data-parallel object initialized with the concatenated values in the \tcode{xs} pack of
+  data-parallel objects: The $i^\text{th}$ \tcode{basic_simd}/\tcode{basic_simd_mask} element of the
+  $j^\text{th}$ parameter in the \tcode{xs} pack is copied to the return value's element with index
+  $i$ + the sum of the width of the first $j$ parameters in the \tcode{xs} pack.
+\end{itemdescr}
+
+\rSec3[simd.alg]{Algorithms}
+
+\begin{itemdecl}
+template<class T, class Abi>
+  constexpr basic_simd<T, Abi> min(const basic_simd<T, Abi>& a,
+                                   const basic_simd<T, Abi>& b) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\constraints
+  \tcode{T} models \tcode{totally_ordered}.
+
+  \pnum\returns
+  The result of the element-wise application of \tcode{min(a[$i$], b[$i$])} \foralli[basic_simd<T,
+  Abi>::].
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class T, class Abi>
+  constexpr basic_simd<T, Abi> max(const basic_simd<T, Abi>& a,
+                                   const basic_simd<T, Abi>& b) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\constraints
+  \tcode{T} models \tcode{totally_ordered}.
+
+  \pnum\returns
+  The result of the element-wise application of \tcode{max(a[$i$], b[$i$])} \foralli[basic_simd<T,
+  Abi>::].
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class T, class Abi>
+  constexpr pair<basic_simd<T, Abi>, basic_simd<T, Abi>>
+  minmax(const basic_simd<T, Abi>& a, const basic_simd<T, Abi>& b) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\effects
+  Equivalent to: \tcode{return pair\{min(a, b), max(a, b)\};}
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class T, class Abi>
+  constexpr basic_simd<T, Abi> clamp(
+    const basic_simd<T, Abi>& v, const basic_simd<T, Abi>& lo, const basic_simd<T, Abi>& hi);
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\constraints
+  \tcode{T} models \tcode{totally_ordered}.
+
+  \pnum\expects
+  No element in \tcode{lo} shall be greater than the corresponding element in \tcode{hi}.
+
+  \pnum\returns
+  The result of element-wise application of \tcode{clamp(v[$i$], lo[$i$], hi[$i$])}
+  \foralli[basic_simd<T, Abi>::].
+\end{itemdescr}
+
+\begin{itemdecl}
+  template<class T, class U>
+    constexpr auto simd_select(bool c, const T& a, const U& b)
+    -> remove_cvref_t<decltype(c ? a : b)>;
+\end{itemdecl}
+
+\begin{itemdescr}
+    \pnum\effects
+    Equivalent to: \tcode{return c ? a : b;}
+\end{itemdescr}
+
+\begin{itemdecl}
+  template<size_t Bytes, class Abi, class T, class U>
+    constexpr auto simd_select(const basic_simd_mask<Bytes, Abi>& c, const T& a, const U& b)
+    noexcept -> decltype(@\exposid{simd-select-impl}@(c, a, b));
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\effects
+  Equivalent to:
+  \begin{codeblock}
+return @\exposid{simd-select-impl}@(c, a, b);
+  \end{codeblock}
+  where \tcode{\exposid{simd-select-impl}} is found by argument-dependent lookup \iref{basic.lookup.argdep}
+  contrary to \iref{contents}.
+\end{itemdescr}
+
+\rSec3[simd.math]{Mathematical functions}
+
+\begin{itemdecl}
+template<@\exposconcept{math-floating-point}@ V> constexpr rebind_simd_t<int, @\exposid{deduced-simd-t}@<V>> ilogb(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> ldexp(const V& x, const
+rebind_simd_t<int, @\exposid{deduced-simd-t}@<V>>& exp);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> scalbn(const V& x, const
+rebind_simd_t<int, @\exposid{deduced-simd-t}@<V>>& n);
+template<@\exposconcept{math-floating-point}@ V>
+  constexpr @\exposid{deduced-simd-t}@<V> scalbln(const V& x, const rebind_simd_t<long int, @\exposid{deduced-simd-t}@<V>>& n);
+template<signed_integral T, class Abi>
+  constexpr basic_simd<T, Abi> abs(const basic_simd<T, Abi>& j);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> abs(const V& j);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> fabs(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> ceil(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> floor(const V& x);
+template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-simd-t}@<V> nearbyint(const V& x);
+template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-simd-t}@<V> rint(const V& x);
+template<@\exposconcept{math-floating-point}@ V> rebind_simd_t<long int, @\exposid{deduced-simd-t}@<V>> lrint(const V& x);
+template<@\exposconcept{math-floating-point}@ V> rebind_simd_t<long long int, @\exposid{deduced-simd-t}@<V>> llrint(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> round(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr rebind_simd_t<long int, @\exposid{deduced-simd-t}@<V>> lround(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr rebind_simd_t<long long int, @\exposid{deduced-simd-t}@<V>> llround(const V& x);
+template<class V0, class V1>
+  constexpr @\exposid{math-common-simd-t}@<V0, V1> fmod(const V0& x, const V1& y);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> trunc(const V& x);
+template<class V0, class V1>
+  constexpr @\exposid{math-common-simd-t}@<V0, V1> remainder(const V0& x, const V1& y);
+template<class V0, class V1>
+  constexpr @\exposid{math-common-simd-t}@<V0, V1> copysign(const V0& x, const V1& y);
+template<class V0, class V1>
+  constexpr @\exposid{math-common-simd-t}@<V0, V1> nextafter(const V0& x, const V1& y);
+template<class V0, class V1>
+  constexpr @\exposid{math-common-simd-t}@<V0, V1> fdim(const V0& x, const V1& y);
+template<class V0, class V1>
+  constexpr @\exposid{math-common-simd-t}@<V0, V1> fmax(const V0& x, const V1& y);
+template<class V0, class V1>
+  constexpr @\exposid{math-common-simd-t}@<V0, V1> fmin(const V0& x, const V1& y);
+template<class V0, class V1, class V2>
+  constexpr @\exposid{math-common-simd-t}@<V0, V1, V2> fma(const V0& x, const V1& y, const V2& z);
+template<@\exposconcept{math-floating-point}@ V> constexpr rebind_simd_t<int, @\exposid{deduced-simd-t}@<V>> fpclassify(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr typename @\exposid{deduced-simd-t}@<V>::mask_type isfinite(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr typename @\exposid{deduced-simd-t}@<V>::mask_type isinf(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr typename @\exposid{deduced-simd-t}@<V>::mask_type isnan(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr typename @\exposid{deduced-simd-t}@<V>::mask_type isnormal(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr typename @\exposid{deduced-simd-t}@<V>::mask_type signbit(const V& x);
+template<class V0, class V1>
+  constexpr typename @\exposid{math-common-simd-t}@<V0, V1>::mask_type isgreater(const V0& x, const V1& y);
+template<class V0, class V1>
+  constexpr typename @\exposid{math-common-simd-t}@<V0, V1>::mask_type isgreaterequal(const V0& x, const V1& y);
+template<class V0, class V1>
+  constexpr typename @\exposid{math-common-simd-t}@<V0, V1>::mask_type isless(const V0& x, const V1& y);
+template<class V0, class V1>
+  constexpr typename @\exposid{math-common-simd-t}@<V0, V1>::mask_type islessequal(const V0& x, const V1& y);
+template<class V0, class V1>
+  constexpr typename @\exposid{math-common-simd-t}@<V0, V1>::mask_type islessgreater(const V0& x, const V1& y);
+template<class V0, class V1>
+  constexpr typename @\exposid{math-common-simd-t}@<V0, V1>::mask_type isunordered(const V0& x, const V1& y);
+\end{itemdecl}
+\begin{itemdescr}
+  \pnum
+  Let \tcode{Ret} denote the return type of the specialization of a function template with the name
+  \placeholder{math-func}.
+  Let \placeholder{math-func-simd} denote:
+  \begin{codeblock}
+template<class... Args>
+Ret @\placeholder{math-func-simd}@(Args... args) {
+  return Ret([&](@\exposid{simd-size-type}@ i) {
+      @\placeholder{math-func}@(@\exposid{make-compatible-simd-t}@<Ret, Args>(args)[i]...);
+  });
+}
+  \end{codeblock}
+
+  \pnum\returns
+  A value \tcode{ret} of type \tcode{Ret}, that is element-wise equal to the result of calling
+  \placeholder{math-func-simd} with the arguments of the above functions.
+  If in an invocation of a scalar overload of \placeholder{math-func} for index \tcode{i} in
+  \placeholder{math-func-simd} a domain, pole, or range error would occur, the value of \tcode{ret[i]} is
+  unspecified.
+
+  \pnum\remarks
+  It is unspecified whether \tcode{errno} (\iref{errno}) is accessed.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> acos(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> asin(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> atan(const V& x);
+template<class V0, class V1>
+  constexpr @\exposid{math-common-simd-t}@<V0, V1> atan2(const V0& y, const V1& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> cos(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> sin(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> tan(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> acosh(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> asinh(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> atanh(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> cosh(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> sinh(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> tanh(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> exp(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> exp2(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> expm1(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> log(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> log10(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> log1p(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> log2(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> logb(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> cbrt(const V& x);
+template<class V0, class V1>
+  constexpr @\exposid{math-common-simd-t}@<V0, V1> hypot(const V0& x, const V1& y);
+template<class V0, class V1, class V2>
+  constexpr @\exposid{math-common-simd-t}@<V0, V1, V2> hypot(const V0& x, const V1& y, const V2& z);
+template<class V0, class V1>
+  constexpr @\exposid{math-common-simd-t}@<V0, V1> pow(const V0& x, const V1& y);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> sqrt(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> erf(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> erfc(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> lgamma(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-simd-t}@<V> tgamma(const V& x);
+template<class V0, class V1, class V2>
+  constexpr @\exposid{math-common-simd-t}@<V0, V1, V2> lerp(const V0& a, const V1& b, const V2& t) noexcept;
+template<@\exposconcept{math-floating-point}@ V>
+  @\exposid{deduced-simd-t}@<V> assoc_laguerre(const rebind_simd_t<unsigned, @\exposid{deduced-simd-t}@<V>>& n, const
+    rebind_simd_t<unsigned, @\exposid{deduced-simd-t}@<V>>& m,
+                   const V& x);
+template<@\exposconcept{math-floating-point}@ V>
+  @\exposid{deduced-simd-t}@<V> assoc_legendre(const rebind_simd_t<unsigned, @\exposid{deduced-simd-t}@<V>>& l, const
+    rebind_simd_t<unsigned, @\exposid{deduced-simd-t}@<V>>& m,
+                   const V& x);
+template<class V0, class V1>
+  @\exposid{math-common-simd-t}@<V0, V1> beta(const V0& x, const V1& y);
+template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-simd-t}@<V> comp_ellint_1(const V& k);
+template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-simd-t}@<V> comp_ellint_2(const V& k);
+template<class V0, class V1>
+  @\exposid{math-common-simd-t}@<V0, V1> comp_ellint_3(const V0& k, const V1& nu);
+template<class V0, class V1>
+  @\exposid{math-common-simd-t}@<V0, V1> cyl_bessel_i(const V0& nu, const V1& x);
+template<class V0, class V1>
+  @\exposid{math-common-simd-t}@<V0, V1> cyl_bessel_j(const V0& nu, const V1& x);
+template<class V0, class V1>
+  @\exposid{math-common-simd-t}@<V0, V1> cyl_bessel_k(const V0& nu, const V1& x);
+template<class V0, class V1>
+  @\exposid{math-common-simd-t}@<V0, V1> cyl_neumann(const V0& nu, const V1& x);
+template<class V0, class V1>
+  @\exposid{math-common-simd-t}@<V0, V1> ellint_1(const V0& k, const V1& phi);
+template<class V0, class V1>
+  @\exposid{math-common-simd-t}@<V0, V1> ellint_2(const V0& k, const V1& phi);
+template<class V0, class V1, class V2>
+  @\exposid{math-common-simd-t}@<V0, V1, V2> ellint_3(const V0& k, const V1& nu, const V2& phi);
+template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-simd-t}@<V> expint(const V& x);
+template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-simd-t}@<V> hermite(const rebind_simd_t<unsigned,
+@\exposid{deduced-simd-t}@<V>>& n, const V& x);
+template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-simd-t}@<V> laguerre(const rebind_simd_t<unsigned,
+@\exposid{deduced-simd-t}@<V>>& n, const V& x);
+template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-simd-t}@<V> legendre(const rebind_simd_t<unsigned,
+@\exposid{deduced-simd-t}@<V>>& l, const V& x);
+template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-simd-t}@<V> riemann_zeta(const V& x);
+template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-simd-t}@<V> sph_bessel(const rebind_simd_t<unsigned,
+@\exposid{deduced-simd-t}@<V>>& n, const V& x);
+template<@\exposconcept{math-floating-point}@ V>
+  @\exposid{deduced-simd-t}@<V> sph_legendre(const rebind_simd_t<unsigned, @\exposid{deduced-simd-t}@<V>>& l,
+                                 const rebind_simd_t<unsigned, @\exposid{deduced-simd-t}@<V>>& m,
+                                 const V& theta);
+template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-simd-t}@<V> sph_neumann(const rebind_simd_t<unsigned,
+@\exposid{deduced-simd-t}@<V>>& n, const V& x);
+\end{itemdecl}
+\begin{itemdescr}
+  \pnum
+  Let \tcode{Ret} denote the return type of the specialization of a function template with the name
+  \placeholder{math-func}.
+  Let \placeholder{math-func-simd} denote:
+  \begin{codeblock}
+template<class... Args>
+Ret @\placeholder{math-func-simd}@(Args... args) {
+  return Ret([&](@\exposid{simd-size-type}@ i) {
+      @\placeholder{math-func}@(@\exposid{make-compatible-simd-t}@<Ret, Args>(args)[i]...);
+  });
+}
+  \end{codeblock}
+
+  \pnum\returns
+  A value \tcode{ret} of type \tcode{Ret}, that is element-wise approximately equal to the result of
+  calling \placeholder{math-func-simd} with the arguments of the above functions.
+  If in an invocation of a scalar overload of \placeholder{math-func} for index \tcode{i} in
+  \placeholder{math-func-simd} a domain, pole, or range error would occur, the value of \tcode{ret[i]} is
+  unspecified.
+
+  \pnum\remarks
+  It is unspecified whether \tcode{errno} (\iref{errno}) is accessed.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<@\exposconcept{math-floating-point}@ V>
+  constexpr @\exposid{deduced-simd-t}@<V> frexp(const V& value, rebind_simd_t<int, @\exposid{deduced-simd-t}@<V>>* exp);
+\end{itemdecl}
+\begin{itemdescr}
+  \pnum
+  Let \tcode{Ret} be \tcode{\exposid{deduced-simd-t}<V>}.
+  Let \placeholder{frexp-simd} denote:
+  \begin{codeblock}
+template<class V>
+  pair<Ret, rebind_simd_t<int, Ret>> @\placeholder{frexp-simd}@(const V& x) {
+    int r1[Ret::size()];
+    Ret r0([&](@\exposid{simd-size-type}@ i) {
+      frexp(@\exposid{make-compatible-simd-t}@<Ret, V>(x)[i], &r1[i]);
+    });
+    return {r0, rebind_simd_t<int, Ret>(r1)};
+  }
+  \end{codeblock}
+  Let \tcode{ret} be a value of type \tcode{pair<Ret, rebind_simd_t<int, Ret>>} that is the same
+  value as the result of calling \placeholder{frexp-simd}\tcode{(x)}.
+
+  \pnum\effects
+  Sets \tcode{*exp} to \tcode{ret.second}.
+
+  \pnum\returns \tcode{ret.first}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class V0, class V1>
+  constexpr @\exposid{math-common-simd-t}@<V0, V1> remquo(const V0& x, const V1& y,
+                                              rebind_simd_t<int, @\exposid{math-common-simd-t}@<V0, V1>>* quo);
+\end{itemdecl}
+\begin{itemdescr}
+  \pnum
+  Let \tcode{Ret} be \tcode{\exposid{math-common-simd-t}<V0, V1>}.
+  Let \placeholder{remquo-simd} denote:
+  \begin{codeblock}
+template<class V0, class V1>
+  pair<Ret, rebind_simd_t<int, Ret>> @\placeholder{remquo-simd}@(const V0& x, const V1& y) {
+    int r1[Ret::size()];
+    Ret r0([&](@\exposid{simd-size-type}@ i) {
+      remquo(@\exposid{make-compatible-simd-t}@<Ret, V0>(x)[i],
+             @\exposid{make-compatible-simd-t}@<Ret, V1>(y)[i], &r1[i]);
+    });
+    return {r0, rebind_simd_t<int, Ret>(r1)};
+  }
+  \end{codeblock}
+  Let \tcode{ret} be a value of type \tcode{pair<Ret, rebind_simd_t<int, Ret>>} that is the same
+  value as the result of calling \placeholder{remquo-simd}\tcode{(x, y)}.
+  If in an invocation of a scalar overload of \tcode{remquo} for index \tcode{i} in
+  \placeholder{remquo-simd} a domain, pole, or range error would occur, the value of \tcode{ret[i]} is
+  unspecified.
+
+  \pnum\effects
+  Sets \tcode{*quo} to \tcode{ret.second}.
+
+  \pnum\returns \tcode{ret.first}.
+
+  \pnum\remarks
+  It is unspecified whether \tcode{errno} (\iref{errno}) is accessed.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class T, class Abi>
+  constexpr basic_simd<T, Abi> modf(const type_identity_t<basic_simd<T, Abi>>& value,
+                                    basic_simd<T, Abi>* iptr);
+\end{itemdecl}
+\begin{itemdescr}
+  \pnum
+  Let \tcode{V} be \tcode{basic_simd<T, Abi>}.
+  Let \placeholder{modf-simd} denote:
+  \begin{codeblock}
+pair<V, V> @\placeholder{modf-simd}@(const V& x) {
+  T r1[Ret::size()];
+  V r0([&](@\exposid{simd-size-type}@ i) {
+    modf(V(x)[i], &r1[i]);
+  });
+  return {r0, V(r1)};
+}
+  \end{codeblock}
+  Let \tcode{ret} be a value of type \tcode{pair<V, V>} that is the same value as the result of
+  calling \placeholder{modf-simd}\tcode{(value)}.
+
+  \pnum\effects
+  Sets \tcode{*iptr} to \tcode{ret.second}.
+
+  \pnum\returns \tcode{ret.first}.
+\end{itemdescr}
+
+\rSec2[simd.mask.class]{Class template \tcode{basic_simd_mask}}
+
+\rSec3[simd.mask.overview]{Class template \tcode{basic_simd_mask} overview}
+
+\begin{codeblock}
+template<size_t Bytes, class Abi> class basic_simd_mask {
+public:
+  using value_type = bool;
+  using abi_type = Abi;
+
+  static constexpr integral_constant<@\exposid{simd-size-type}@, @\exposid{simd-size-v}@<@\exposid{integer-from}@<Bytes>, Abi>>
+    size {};
+
+  constexpr basic_simd_mask() noexcept = default;
+
+  // \ref{simd.mask.ctor}, \tcode{basic_simd_mask} constructors
+  constexpr explicit basic_simd_mask(value_type) noexcept;
+  template<size_t UBytes, class UAbi>
+    constexpr explicit basic_simd_mask(const basic_simd_mask<UBytes, UAbi>&) noexcept;
+  template<class G> constexpr explicit basic_simd_mask(G&& gen) noexcept;
+
+  // \ref{simd.mask.subscr}, \tcode{basic_simd_mask} subscript operators
+  constexpr value_type operator[](@\exposid{simd-size-type}@) const;
+
+  // \ref{simd.mask.unary}, \tcode{basic_simd_mask} unary operators
+  constexpr basic_simd_mask operator!() const noexcept;
+  constexpr basic_simd<@\exposid{integer-from}@<Bytes>, Abi> operator+() const noexcept;
+  constexpr basic_simd<@\exposid{integer-from}@<Bytes>, Abi> operator-() const noexcept;
+  constexpr basic_simd<@\exposid{integer-from}@<Bytes>, Abi> operator~() const noexcept;
+
+  // \ref{simd.mask.conv}, \tcode{basic_simd_mask} conversion operators
+  template<class U, class A>
+    constexpr explicit(sizeof(U) != Bytes) operator basic_simd<U, A>() const noexcept;
+
+  // \ref{simd.mask.binary}, \tcode{basic_simd_mask} binary operators
+  friend constexpr basic_simd_mask
+    operator&&(const basic_simd_mask&, const basic_simd_mask&) noexcept;
+  friend constexpr basic_simd_mask
+    operator||(const basic_simd_mask&, const basic_simd_mask&) noexcept;
+  friend constexpr basic_simd_mask
+    operator&(const basic_simd_mask&, const basic_simd_mask&) noexcept;
+  friend constexpr basic_simd_mask
+    operator|(const basic_simd_mask&, const basic_simd_mask&) noexcept;
+  friend constexpr basic_simd_mask
+    operator^(const basic_simd_mask&, const basic_simd_mask&) noexcept;
+
+  // \ref{simd.mask.cassign}, \tcode{basic_simd_mask} compound assignment
+  friend constexpr basic_simd_mask&
+    operator&=(basic_simd_mask&, const basic_simd_mask&) noexcept;
+  friend constexpr basic_simd_mask&
+    operator|=(basic_simd_mask&, const basic_simd_mask&) noexcept;
+  friend constexpr basic_simd_mask&
+    operator^=(basic_simd_mask&, const basic_simd_mask&) noexcept;
+
+  // \ref{simd.mask.comparison}, \tcode{basic_simd_mask} comparisons
+  friend constexpr basic_simd_mask
+    operator==(const basic_simd_mask&, const basic_simd_mask&) noexcept;
+  friend constexpr basic_simd_mask
+    operator!=(const basic_simd_mask&, const basic_simd_mask&) noexcept;
+  friend constexpr basic_simd_mask
+    operator>=(const basic_simd_mask&, const basic_simd_mask&) noexcept;
+  friend constexpr basic_simd_mask
+    operator<=(const basic_simd_mask&, const basic_simd_mask&) noexcept;
+  friend constexpr basic_simd_mask
+    operator>(const basic_simd_mask&, const basic_simd_mask&) noexcept;
+  friend constexpr basic_simd_mask
+    operator<(const basic_simd_mask&, const basic_simd_mask&) noexcept;
+
+  // \ref{simd.mask.cond}, \tcode{basic_simd_mask} exposition only conditional operators
+  friend constexpr basic_simd_mask @\exposid{simd-select-impl}@( // \expos
+    const basic_simd_mask&, const basic_simd_mask&, const basic_simd_mask&) noexcept;
+  friend constexpr basic_simd_mask @\exposid{simd-select-impl}@( // \expos
+    const basic_simd_mask&, same_as<bool> auto, same_as<bool> auto) noexcept;
+  template<class T0, class T1>
+    friend constexpr simd<@\seebelow@, size()>
+      @\exposid{simd-select-impl}@(const basic_simd_mask&, const T0&, const T1&) noexcept; // \expos
+};
+\end{codeblock}
+
+\pnum
+Every specialization of \tcode{basic_simd_mask} is a complete type.
+The specialization of \tcode{basic_simd_mask<Bytes, Abi>} is:
+\begin{itemize}
+  \item disabled, if there is no vectorizable type \tcode{T} such that \tcode{Bytes} is
+    equal to \tcode{sizeof(T)},
+  \item otherwise, enabled, if there exists a vectorizable type \tcode{T} and a value \tcode{N} in
+    the range \crange{1}{64} such that \tcode{Bytes} is equal to \tcode{sizeof(T)} and \tcode{Abi}
+    is \tcode{\exposid{deduce-abi-t}<T, N>},
+  \item otherwise, it is implementation-defined if such a specialization is enabled.
+\end{itemize}
+
+If \tcode{basic_simd_mask<Bytes, Abi>} is disabled, the specialization has a deleted
+default constructor, deleted destructor, deleted copy constructor, and deleted copy assignment.
+In addition only the \tcode{value_type} and \tcode{abi_type} members are present.
+
+If \tcode{basic_simd_mask<Bytes, Abi>} is enabled, \tcode{basic_simd_mask<Bytes, Abi>} is
+trivially copyable.
+
+\pnum\recommended
+Implementations should support explicit conversions between specializations of
+\tcode{basic_simd_mask} and appropriate implementation-defined types.
+\begin{note}
+  The appropriate vector types which are available in the implementation.
+\end{note}
+
+\rSec3[simd.mask.ctor]{\tcode{basic_simd_mask} constructors}
+
+\begin{itemdecl}
+constexpr explicit basic_simd_mask(value_type x) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\effects
+  Initializes each element with \tcode{x}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<size_t UBytes, class UAbi>
+  constexpr explicit basic_simd_mask(const basic_simd_mask<UBytes, UAbi>& x) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\constraints
+  \tcode{basic_simd_mask<UBytes, UAbi>::size() == size()} is \tcode{true}.
+
+  \pnum\effects
+  Initializes the $i^\text{th}$ element with \tcode{x[$i$]} \foralli.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class G> constexpr explicit basic_simd_mask(G&& gen) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\constraints
+  The expression \tcode{gen(integral_constant<\exposid{simd-size-type}, i>())} is well-formed and its type is
+  \tcode{bool} \foralli.
+
+  \pnum\effects
+  Initializes the $i^\text{th}$ element with
+  \tcode{gen(integral_constant<\exposid{simd-size-type}, i>())} \foralli.
+
+  \pnum\remarks
+    The calls to \tcode{gen} are unsequenced with respect to each other.
+    Vectorization-unsafe (\iref{algorithms.parallel.defns}) standard library
+    functions may not be invoked by \tcode{gen}.
+    \tcode{gen} is invoked exactly once for each $i$.
+\end{itemdescr}
+
+\rSec3[simd.mask.subscr]{\tcode{basic_simd_mask} subscript operator}
+
+\begin{itemdecl}
+constexpr value_type operator[](@\exposid{simd-size-type}@ i) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\expects
+  \tcode{i >= 0 \&\& i < size()} is \tcode{true}.
+
+  \pnum\returns
+  The value of the $i^\text{th}$ element.
+
+  \pnum\throws Nothing.
+\end{itemdescr}
+
+\rSec3[simd.mask.unary]{\tcode{basic_simd_mask} unary operators}
+
+\begin{itemdecl}
+constexpr basic_simd_mask operator!() const noexcept;
+constexpr basic_simd<@\exposid{integer-from}@<Bytes>, Abi> operator+() const noexcept;
+constexpr basic_simd<@\exposid{integer-from}@<Bytes>, Abi> operator-() const noexcept;
+constexpr basic_simd<@\exposid{integer-from}@<Bytes>, Abi> operator~() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum Let \placeholder{op} be the operator.
+
+  \pnum\returns
+  A data-parallel object where the $i^\text{th}$ element is initialized to the results of applying
+  \placeholder{op} to \tcode{operator[]($i$)} \foralli.
+\end{itemdescr}
+
+\rSec3[simd.mask.conv]{\tcode{basic_simd_mask} conversion operators}
+
+\begin{itemdecl}
+template<class U, class A>
+  constexpr explicit(sizeof(U) != Bytes) operator basic_simd<U, A>() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\constraints
+  \tcode{\exposid{simd-size-v}<U, A> == \exposid{simd-size-v}<T, Abi>}.
+
+  \pnum\returns
+  A data-parallel object where the $i^\text{th}$ element is initialized to
+  \tcode{static_cast<U>(operator[]($i$))}.
+\end{itemdescr}
+
+\rSec2[simd.mask.nonmembers]{Non-member operations}
+
+\rSec3[simd.mask.binary]{\tcode{basic_simd_mask} binary operators}
+
+\begin{itemdecl}
+friend constexpr basic_simd_mask
+  operator&&(const basic_simd_mask& lhs, const basic_simd_mask& rhs) noexcept;
+friend constexpr basic_simd_mask
+  operator||(const basic_simd_mask& lhs, const basic_simd_mask& rhs) noexcept;
+friend constexpr basic_simd_mask
+  operator& (const basic_simd_mask& lhs, const basic_simd_mask& rhs) noexcept;
+friend constexpr basic_simd_mask
+  operator| (const basic_simd_mask& lhs, const basic_simd_mask& rhs) noexcept;
+friend constexpr basic_simd_mask
+  operator^ (const basic_simd_mask& lhs, const basic_simd_mask& rhs) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum Let \placeholder{op} be the operator.
+
+  \pnum\returns
+  A \tcode{basic_simd_mask} object initialized with the results of applying \placeholder{op}
+  to \tcode{lhs} and \tcode{rhs} as a binary element-wise operation.
+\end{itemdescr}
+
+\rSec3[simd.mask.cassign]{\tcode{basic_simd_mask} compound assignment}
+
+\begin{itemdecl}
+friend constexpr basic_simd_mask&
+  operator&=(basic_simd_mask& lhs, const basic_simd_mask& rhs) noexcept;
+friend constexpr basic_simd_mask&
+  operator|=(basic_simd_mask& lhs, const basic_simd_mask& rhs) noexcept;
+friend constexpr basic_simd_mask&
+  operator^=(basic_simd_mask& lhs, const basic_simd_mask& rhs) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum Let \placeholder{op} be the operator.
+
+  \pnum\effects
+  These operators apply \placeholder{op} to \tcode{lhs} and \tcode{rhs} as a binary
+  element-wise operation.
+
+  \pnum\returns
+  \tcode{lhs}.
+\end{itemdescr}
+
+\rSec3[simd.mask.comparison]{\tcode{basic_simd_mask} comparisons}
+
+\begin{itemdecl}
+friend constexpr basic_simd_mask
+  operator==(const basic_simd_mask&, const basic_simd_mask&) noexcept;
+friend constexpr basic_simd_mask
+  operator!=(const basic_simd_mask&, const basic_simd_mask&) noexcept;
+friend constexpr basic_simd_mask
+  operator>=(const basic_simd_mask&, const basic_simd_mask&) noexcept;
+friend constexpr basic_simd_mask
+  operator<=(const basic_simd_mask&, const basic_simd_mask&) noexcept;
+friend constexpr basic_simd_mask
+  operator>(const basic_simd_mask&, const basic_simd_mask&) noexcept;
+friend constexpr basic_simd_mask
+  operator<(const basic_simd_mask&, const basic_simd_mask&) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum Let \placeholder{op} be the operator.
+
+  \pnum\returns
+  A \tcode{basic_simd_mask} object initialized with the results of applying \placeholder{op}
+  to \tcode{lhs} and \tcode{rhs} as a binary element-wise operation.
+\end{itemdescr}
+
+\rSec3[simd.mask.cond]{\tcode{basic_simd_mask} exposition only conditional operators}
+
+\begin{itemdecl}
+friend constexpr basic_simd_mask @\exposid{simd-select-impl}@(
+  const basic_simd_mask& mask, const basic_simd_mask& a, const basic_simd_mask& b) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\returns
+  A \tcode{basic_simd_mask} object where the $i^\text{th}$ element equals \tcode{mask[$i$] ? a[$i$]
+  : b[$i$]} \foralli.
+\end{itemdescr}
+
+\begin{itemdecl}
+friend constexpr basic_simd_mask
+@\exposid{simd-select-impl}@(const basic_simd_mask& mask, same_as<bool> auto a, same_as<bool> auto b) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\returns
+  A \tcode{basic_simd_mask} object where the $i^\text{th}$ element equals \tcode{mask[$i$] ? a : b}
+  \foralli.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class T0, class T1>
+  friend constexpr simd<@\seebelow@, size()>
+    @\exposid{simd-select-impl}@(const basic_simd_mask& mask, const T0& a, const T1& b) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\constraints
+  \begin{itemize}
+    \item \tcode{same_as<T0, T1>} is \tcode{true},
+    \item \tcode{T0} is a vectorizable type, and
+    \item \tcode{sizeof(T0) == Bytes}.
+  \end{itemize}
+
+  \pnum\returns
+  A \tcode{simd<T0, size()>} object where the $i^\text{th}$ element equals \tcode{mask[$i$] ? a :
+  b} \foralli.
+\end{itemdescr}
+
+\rSec3[simd.mask.reductions]{\tcode{basic_simd_mask} reductions}
+
+\begin{itemdecl}
+template<size_t Bytes, class Abi>
+  constexpr bool all_of(const basic_simd_mask<Bytes, Abi>& k) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\returns
+  \tcode{true} if all boolean elements in \tcode{k} are \tcode{true}, otherwise \tcode{false}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<size_t Bytes, class Abi>
+  constexpr bool any_of(const basic_simd_mask<Bytes, Abi>& k) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\returns
+  \tcode{true} if at least one boolean element in \tcode{k} is \tcode{true}, otherwise
+  \tcode{false}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<size_t Bytes, class Abi>
+  constexpr bool none_of(const basic_simd_mask<Bytes, Abi>& k) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\returns \tcode{!any_of(k)}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<size_t Bytes, class Abi>
+  constexpr @\exposid{simd-size-type}@ reduce_count(const basic_simd_mask<Bytes, Abi>& k) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\returns
+  The number of boolean elements in \tcode{k} that are \tcode{true}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<size_t Bytes, class Abi>
+  constexpr @\exposid{simd-size-type}@ reduce_min_index(const basic_simd_mask<Bytes, Abi>& k);
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\expects
+  \tcode{any_of(k)} is \tcode{true}.
+
+  \pnum\returns
+  The lowest element index $i$ where \tcode{k[$i$]} is \tcode{true}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<size_t Bytes, class Abi>
+  constexpr @\exposid{simd-size-type}@ reduce_max_index(const basic_simd_mask<Bytes, Abi>& k);
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\expects
+  \tcode{any_of(k)} is \tcode{true}.
+
+  \pnum\returns
+  The greatest element index $i$ where \tcode{k[$i$]} is \tcode{true}.
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr bool all_of(same_as<bool> auto x) noexcept;
+constexpr bool any_of(same_as<bool> auto x) noexcept;
+constexpr @\exposid{simd-size-type}@ reduce_count(same_as<bool> auto x) noexcept;
+\end{itemdecl}
+\begin{itemdescr}
+  \pnum\returns \tcode{x}.
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr bool none_of(same_as<bool> auto x) noexcept;
+\end{itemdecl}
+\begin{itemdescr}
+  \pnum\returns \tcode{!x}.
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr @\exposid{simd-size-type}@ reduce_min_index(same_as<bool> auto x);
+constexpr @\exposid{simd-size-type}@ reduce_max_index(same_as<bool> auto x);
+\end{itemdecl}
+
+\begin{itemdescr}
+  \pnum\expects \tcode{x} is \tcode{true}.
+
+  \pnum\returns \tcode{0}.
+\end{itemdescr}


### PR DESCRIPTION
Fixes #7430
Fixes cplusplus/papers#670

This is still work-in-progress. Several overfull hboxes to be fixed. Also, I assume the local use of `\newcommand` macros is not something I should keep, yes?