### PR TITLE
[allocator.requirements.general] Change "pointer" to "value".

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2086,7 +2086,7 @@ any \cv-unqualified object type\iref{term.object.type},
 \item
 \tcode{b} denotes a value of type \tcode{Y},
 \item
-\tcode{c} denotes a pointer of type \tcode{C*}
+\tcode{c} denotes a value of type \tcode{C*}
 through which indirection is valid,
 \item
 \tcode{p} denotes a value of type \tcode{XX::pointer}


### PR DESCRIPTION
Technically a pointer is a type, this should mean "a pointer value". And "a pointer value of type `C*`" is somewhat confusing between `C*` and `C**` at the first glance. Hence, "a value of" suffice. This is also more consistent to other entries.
