### PR TITLE
P2862R1 text_encoding::name() should never return null values

### DIFF
--- a/source/text.tex
+++ b/source/text.tex
@@ -5115,7 +5115,7 @@ An object \tcode{e} of type \tcode{text_encoding} such that
 \tcode{e.mib() == text_encoding::id::other} is \tcode{false}
 maintains the following invariants:
 \begin{itemize}
-\item \tcode{e.name() == nullptr} is \tcode{false}, and
+\item \tcode{*e.name() == '\textbackslash 0'} is \tcode{false}, and
 \item \tcode{e.mib() == text_encoding(e.name()).mib()} is \tcode{true}.
 \end{itemize}
 
@@ -5215,13 +5215,10 @@ constexpr const char* name() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\exposid{name_} if \tcode{(\exposid{name_}[0] != '\textbackslash 0')}
-is \tcode{true}, and
-\keyword{nullptr} otherwise.
+\exposid{name_}.
 
 \pnum
 \remarks
-If \tcode{name() == nullptr} is \tcode{false},
 \tcode{name()} is an \ntbs{} and
 accessing elements of \exposid{name_}
 outside of the range \countedrange{name()}{strlen(name()) + 1}


### PR DESCRIPTION
Fixes #7418 
Also fixes cplusplus/papers#1521