### PR TITLE
Avoid incorrect sentence parsing option on types

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1771,9 +1771,11 @@ from an initializer.
 
 \pnum
 The type of a \grammarterm{parameter-declaration} of a
-function declaration\iref{dcl.fct},
-\grammarterm{lambda-expression}\iref{expr.prim.lambda}, or
-\grammarterm{template-parameter}\iref{temp.param}
+\begin{itemize}
+  \item function declaration\iref{dcl.fct},
+  \item \grammarterm{lambda-expression}\iref{expr.prim.lambda}, or
+  \item \grammarterm{template-parameter}\iref{temp.param}
+\end{itemize}
 can be declared using
 a \grammarterm{placeholder-type-specifier} of the form
 \opt{\grammarterm{type-constraint}} \keyword{auto}.


### PR DESCRIPTION
This PR is related to the **Issue** #7453 proposing multiple changes to clarify the text in [dcl.spec.auto.general]
However, a PR has been created for each specific change.

In **[dcl.spec.auto.general]-p2**, the verbal form
_The type of a parameter-declaration of a function declaration, lambda-expression, or template-
parameter ..._
may be ambiguous in the sense that it may be interpreted both as the type of any of three things (incorrect) or the type of a parameter of any of three things (correct).
In a discussion on _std-discussion_, it was highlighted that the former interpretation does not make sense as a lambda expression has never an explicit type, however it was still agreed that the verbal syntax should be improved (https://lists.isocpp.org/std-discussion/2024/11/2724.php).