### PR TITLE
Immediate understanding of non-type templ. param.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1773,7 +1773,7 @@ from an initializer.
 The type of a \grammarterm{parameter-declaration} of a
 function declaration\iref{dcl.fct},
 \grammarterm{lambda-expression}\iref{expr.prim.lambda}, or
-\grammarterm{template-parameter}\iref{temp.param}
+non-type \grammarterm{template-parameter}\iref{temp.param}
 can be declared using
 a \grammarterm{placeholder-type-specifier} of the form
 \opt{\grammarterm{type-constraint}} \keyword{auto}.
@@ -1789,7 +1789,7 @@ is a \defn{generic parameter type placeholder}
 of the
 function declaration,
 \grammarterm{lambda-expression}, or
-\grammarterm{template-parameter}, respectively.
+non-type \grammarterm{template-parameter}, respectively.
 \begin{note}
 Having a generic parameter type placeholder
 signifies that the function is


### PR DESCRIPTION
This PR is related to the **Issue** #7453 proposing multiple changes to clarify the text in [dcl.spec.auto.general]
However, a PR has been created for each specific change.

In **[dcl.spec.auto.general]-p2**, both occurrences of _template-parameter_ may be improved as _non-type template-parameter_.