### PR TITLE
Avoid ambiguity of placeholder on nested parameter

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1779,8 +1779,13 @@ a \grammarterm{placeholder-type-specifier} of the form
 \opt{\grammarterm{type-constraint}} \keyword{auto}.
 The placeholder type shall appear
 as one of the \grammarterm{decl-specifier}{s} in
-the \grammarterm{decl-specifier-seq} or
-as one of the \grammarterm{type-specifier}{s} in
+the \grammarterm{decl-specifier-seq}
+directly related to the parameter
+\begin{note}
+  not to a nested parameter in case of
+  function pointer or reference type
+\end{note}
+or as one of the \grammarterm{type-specifier}{s} in
 a \grammarterm{trailing-return-type}
 that specifies the type that replaces such
 a \grammarterm{decl-specifier} (see below);
@@ -1817,6 +1822,11 @@ This use is allowed
 in an initializing declaration\iref{dcl.init} of a variable.
 The placeholder type shall appear as one of the
 \grammarterm{decl-specifier}{s} in the \grammarterm{decl-specifier-seq}
+directly related to the variable
+\begin{note}
+  not to a nested parameter in case of
+  function pointer or reference type
+\end{note}
 or as one of the
 \grammarterm{type-specifier}{s} in a \grammarterm{trailing-return-type}
 that specifies the type that replaces such a \grammarterm{decl-specifier};


### PR DESCRIPTION
This PR is related to the Issue https://github.com/cplusplus/draft/issues/7453 proposing multiple changes to clarify the text in [dcl.spec.auto.general]
However, a PR has been created for each specific change.

In **[dcl.spec.auto.general]-p2** and **p5**, an additional text about the case of function type, may avoid the general interpretation of using a placeholder type for nested parameters.