### PR TITLE
Remove useless text reference

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1783,7 +1783,7 @@ the \grammarterm{decl-specifier-seq} or
 as one of the \grammarterm{type-specifier}{s} in
 a \grammarterm{trailing-return-type}
 that specifies the type that replaces such
-a \grammarterm{decl-specifier} (see below);
+a \grammarterm{decl-specifier};
 the placeholder type
 is a \defn{generic parameter type placeholder}
 of the


### PR DESCRIPTION
This PR is related to the Issue #7453 proposing multiple changes to clarify the text in [dcl.spec.auto.general]
However, a PR has been created for each specific change.

In **[dcl.spec.auto.general]-p2**, the reference _...(see below)..._ seems useless.
It was likely a reference toward p3 but, by then, p3 does not remove or add any option for the case of a parameter having a function pointer type.