### PR TITLE
Extend examples for [dcl.spec.auto.general]

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1836,6 +1836,15 @@ auto f() -> int;                // OK, \tcode{f} returns \tcode{int}
 auto g() { return 0.0; }        // OK, \tcode{g} returns \tcode{double}
 auto (*fp)() -> auto = f;       // OK
 auto h();                       // OK, \tcode{h}'s return type will be deduced when it is defined
+auto j() -> auto;               // OK, deduction of \tcode{j}'s return type postponed at the definition
+auto (*jp)() -> auto = j;       // error, cannot use \tcode{j}'s before deducing its return type
+auto (*kp)() -> auto;           // error, not a function declaration; needs an initializer
+constexpr auto l =
+  [](auto (*fp)() -> auto)      // OK, \tcode{l}'s parameter \tcode{fp} is a function pointer,
+  { return fp; };               // whose return type will be deduced when \tcode{l} is invoked
+int foo();
+static_assert(l(foo) == foo);   // OK
+
 \end{codeblock}
 \end{example}
 The \keyword{auto} \grammarterm{type-specifier}


### PR DESCRIPTION
This PR is related to the Issue #7453 proposing multiple changes to clarify the text in [dcl.spec.auto.general]
However, a PR has been created for each specific change.

In **[dcl.spec.auto.general]-p5**, further examples might be added to cover also p2 and all cases of p4, whereas it currently covers p5, p3, and partially p4.
In this PR no modification applied about having Example 1 as a fully separated part, because after it there is a further sentence for p5. Would it be better as separated part after such sentence ?