### PR TITLE
Use template-parameter and template parameter more consistently

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2097,8 +2097,8 @@ members of the set, i.e., the entities associated with its
 parameter types and return type.
 Additionally, if the aforementioned overload set is named with
 a \grammarterm{template-id}, its associated entities also include
-its template \grammarterm{template-argument}{s} and
-those associated with its type \grammarterm{template-argument}s.
+its template template arguments and
+those associated with its type template arguments.
 
 \pnum
 The \term{associated namespaces} for a call are

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -773,7 +773,7 @@ is the \grammarterm{declaration} of a \grammarterm{template-declaration}.
 \indextext{class name!\idxcode{typedef}}%
 A \grammarterm{simple-template-id} is only a \grammarterm{typedef-name}
 if its \grammarterm{template-name} names
-an alias template or a template \grammarterm{template-parameter}.
+an alias template or a template template parameter.
 \begin{note}
 A \grammarterm{simple-template-id} that names a class template specialization
 is a \grammarterm{class-name}\iref{class.name}.
@@ -1652,8 +1652,8 @@ naming a structured binding\iref{dcl.struct.bind},
 the specification of the structured binding declaration;
 
 \item otherwise, if $E$ is an unparenthesized \grammarterm{id-expression}
-naming a non-type \grammarterm{template-parameter}\iref{temp.param},
-\tcode{decltype($E$)} is the type of the \grammarterm{template-parameter}
+naming a non-type template parameter\iref{temp.param},
+\tcode{decltype($E$)} is the type of the template parameter
 after performing any necessary
 type deduction\iref{dcl.spec.auto,dcl.type.class.deduct};
 
@@ -3994,7 +3994,7 @@ one or more generic parameter type placeholders\iref{dcl.spec.auto}.
 An abbreviated function template is equivalent to
 a function template\iref{temp.fct}
 whose \grammarterm{template-parameter-list} includes
-one invented type \grammarterm{template-parameter}
+one invented \grammarterm{type-parameter}
 for each generic parameter type placeholder
 of the function declaration, in order of appearance.
 For a \grammarterm{placeholder-type-specifier} of the form \keyword{auto},
@@ -4004,7 +4004,7 @@ For a \grammarterm{placeholder-type-specifier} of the form
 \grammarterm{type-constraint} \keyword{auto},
 the invented parameter is a \grammarterm{type-parameter} with
 that \grammarterm{type-constraint}.
-The invented type \grammarterm{template-parameter} is
+The invented \grammarterm{type-parameter} is
 a template parameter pack
 if the corresponding \grammarterm{parameter-declaration}
 declares a function parameter pack.
@@ -4013,7 +4013,7 @@ the program is ill-formed.
 The adjusted function parameters of an abbreviated function template
 are derived from the \grammarterm{parameter-declaration-clause} by
 replacing each occurrence of a placeholder with
-the name of the corresponding invented \grammarterm{template-parameter}.
+the name of the corresponding invented \grammarterm{type-parameter}.
 \begin{example}
 \begin{codeblock}
 template<typename T>     concept C1 = /* ... */;
@@ -4041,7 +4041,7 @@ template<> void g1<int>(const int*, const double&); // OK, specialization of \tc
 
 \pnum
 An abbreviated function template can have a \grammarterm{template-head}.
-The invented \grammarterm{template-parameter}{s} are
+The invented \grammarterm{type-parameter}{s} are
 appended to the \grammarterm{template-parameter-list} after
 the explicitly declared \grammarterm{template-parameter}{s}.
 \begin{example}

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3113,8 +3113,7 @@ the return value of a function, operator function, or conversion\iref{stmt.retur
 \item
 an explicit type conversion\iref{expr.type.conv,expr.static.cast,expr.cast}, or
 \item
-a non-type
-\grammarterm{template-parameter}\iref{temp.arg.nontype}.
+a non-type template parameter\iref{temp.arg.nontype}.
 \end{itemize}
 The \grammarterm{id-expression} can be preceded by the \tcode{\&} operator.
 \begin{note}
@@ -4098,7 +4097,8 @@ with element type \tcode{char}.
 A \defnx{string literal operator template}{literal!operator!template string}
 is a literal operator template whose \grammarterm{template-parameter-list}
 comprises
-a single non-type \grammarterm{template-parameter} of class type.
+a single \grammarterm{parameter-declaration} that declares a
+non-type template parameter of class type.
 The declaration of a literal operator template
 shall have an empty \grammarterm{parameter-declaration-clause}
 and shall declare either a numeric literal operator template

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -289,7 +289,7 @@ names a template type parameter.
 \keyword{typename}
 followed by a
 \grammarterm{qualified-id}
-denotes the type in a non-type
+denotes the type in a
 \begin{footnote}
 Since template
 \grammarterm{template-parameter}{s}
@@ -310,17 +310,17 @@ class T { @\commentellip@ };
 int i;
 
 template<class T, T i> void f(T t) {
-  T t1 = i;         // template-parameters \tcode{T} and \tcode{i}
+  T t1 = i;         // template parameters \tcode{T} and \tcode{i}
   ::T t2 = ::i;     // global namespace members \tcode{T} and \tcode{i}
 }
 \end{codeblock}
-Here, the template \tcode{f} has a \grammarterm{type-parameter}
+Here, the template \tcode{f} has a type template parameter
 called \tcode{T}, rather than an unnamed non-type
-\grammarterm{template-parameter} of class \tcode{T}.
+template parameter of class \tcode{T}.
 \end{example}
-A \grammarterm{template-parameter} declaration shall not
+A template parameter declaration shall not
 have a \grammarterm{storage-class-specifier}.
-Types shall not be defined in a \grammarterm{template-parameter}
+Types shall not be defined in a template parameter
 declaration.
 
 \pnum
@@ -389,7 +389,7 @@ template<C3<int>... T> struct s5;       // associates \tcode{(C3<T, int> \&\& ..
 \end{example}
 
 \pnum
-A non-type \grammarterm{template-parameter}
+A non-type template parameter
 shall have one of the following (possibly cv-qualified) types:
 \begin{itemize}
 \item a structural type (see below),
@@ -420,17 +420,17 @@ structural types or (possibly multidimensional) arrays thereof.
 
 \pnum
 An \grammarterm{id-expression} naming
-a non-type \grammarterm{template-parameter} of class type \tcode{T}
+a non-type template parameter of class type \tcode{T}
 denotes a static storage duration object of type \tcode{const T},
 known as a \defn{template parameter object},
 which is template-argument-equivalent\iref{temp.type} to
 the corresponding template argument
 after it has been converted
-to the type of the \grammarterm{template-parameter}\iref{temp.arg.nontype}.
+to the type of the template parameter\iref{temp.arg.nontype}.
 No two template parameter objects are template-argument-equivalent.
 \begin{note}
 If an \grammarterm{id-expression} names
-a non-type non-reference \grammarterm{template-parameter},
+a non-reference non-type template parameter,
 then it is a prvalue if it has non-class type.
 Otherwise, if it is of class type \tcode{T},
 it is an lvalue and has type \tcode{const T}\iref{expr.prim.id.unqual}.
@@ -440,10 +440,10 @@ it is an lvalue and has type \tcode{const T}\iref{expr.prim.id.unqual}.
 using X = int;
 struct A {};
 template<const X& x, int i, A a> void f() {
-  i++;                          // error: change of \grammarterm{template-parameter} value
+  i++;                          // error: change of template parameter value
 
   &x;                           // OK
-  &i;                           // error: address of non-reference template-parameter
+  &i;                           // error: address of non-reference template parameter
   &a;                           // OK
   int& ri = i;                  // error: attempt to bind non-const reference to temporary
   const int& cri = i;           // OK, const reference binds to temporary
@@ -454,8 +454,7 @@ template<const X& x, int i, A a> void f() {
 
 \pnum
 \begin{note}
-A non-type
-\grammarterm{template-parameter}
+A non-type template parameter
 cannot be declared to have type \cv{} \keyword{void}.
 \begin{example}
 \begin{codeblock}
@@ -466,8 +465,7 @@ template<void* pv> class Y;     // OK
 \end{note}
 
 \pnum
-A non-type
-\grammarterm{template-parameter}
+A non-type template parameter
 \indextext{array!template parameter of type}%
 of type ``array of \tcode{T}'' or
 \indextext{function!template parameter of type}%
@@ -498,7 +496,7 @@ A \defnadj{default}{template argument} is
 a template argument \iref{temp.arg} specified after \tcode{=}
 in a \grammarterm{template-parameter}.
 A default template argument may be specified for
-any kind of \grammarterm{template-parameter} (type, non-type, template)
+any kind of template parameter
 that is not a template parameter pack\iref{temp.variadic}.
 A default template argument may be specified in a template declaration.
 A default template argument shall not be specified in
@@ -535,14 +533,15 @@ of a class template, variable template, or alias template has
 a default template argument,
 each subsequent \grammarterm{template-parameter}
 shall either have a default template argument supplied or
-be a template parameter pack.
+declare a template parameter pack.
 If a \grammarterm{template-parameter} of
 a primary class template, primary variable template, or alias template
-is a template parameter pack,
+declares a template parameter pack,
 it shall be the last \grammarterm{template-parameter}.
-A template parameter pack of a function template
-shall not be followed by another template parameter
-unless that template parameter can be deduced from the
+If a \grammarterm{template-parameter} of a function template
+declares a template parameter pack, it
+shall not be followed by another \grammarterm{template-parameter}
+unless that template parameter is deducible from the
 parameter-type-list\iref{dcl.fct} of the function template or
 has a default argument\iref{temp.deduct}.
 A template parameter of a deduction guide template\iref{temp.deduct.guide}
@@ -561,7 +560,7 @@ template<class... T, class U> void g() { }      // error
 \indextext{\idxcode{<}!template and}%
 \pnum
 When parsing a default template argument
-for a non-type \grammarterm{template-parameter},
+for a non-type template-parameter,
 the first non-nested \tcode{>} is taken as
 the end of the \grammarterm{template-parameter-list}
 rather than a greater-than operator.
@@ -606,7 +605,7 @@ pack\iref{dcl.fct}, then the \grammarterm{template-parameter}
 is a template parameter pack\iref{temp.variadic}.
 A template parameter pack that is a \grammarterm{parameter-declaration} whose type
 contains one or more unexpanded packs is a pack expansion. Similarly,
-a template parameter pack that is a \grammarterm{type-parameter} with a
+a template parameter pack that is a template template parameter with a
 \grammarterm{template-parameter-list} containing one or more unexpanded
 packs is a pack expansion.
 A type parameter pack with a \grammarterm{type-constraint} that
@@ -820,7 +819,7 @@ A \grammarterm{template-id} is \defnx{valid}{\idxgram{template-id}!valid} if
 
 \item
   each \grammarterm{template-argument} matches the corresponding
-  \grammarterm{template-parameter}\iref{temp.arg},
+  template parameter \iref{temp.arg},
 
 \item
   substitution of each template argument into the following
@@ -851,7 +850,7 @@ When the \grammarterm{template-name}
 of a \grammarterm{simple-template-id}
 names a constrained non-function template
 or
-a constrained template \grammarterm{template-parameter},
+a constrained template template parameter,
 and
 all \grammarterm{template-argument}{s}
 in the \grammarterm{simple-template-id}
@@ -1000,8 +999,8 @@ void g() {
 \begin{note}
 Names used in a \grammarterm{template-argument}
 are subject to access control where they appear.
-Because a \grammarterm{template-parameter} is not a class member,
-no access control applies.
+Because a template parameter is not a class member,
+no access control applies where the template parameter is used.
 \end{note}
 \begin{example}
 \begin{codeblock}
@@ -1110,14 +1109,12 @@ The default argument for \tcode{U} is instantiated to form the type \tcode{S<boo
 A \grammarterm{template-argument} followed by an ellipsis is
 a pack expansion\iref{temp.variadic}.
 
-\rSec2[temp.arg.type]{Template type arguments}
+\rSec2[temp.arg.type]{Type Template arguments}
 
 \pnum
 A
 \grammarterm{template-argument}
-for a
-\grammarterm{template-parameter}
-which is a type
+for a type template parameter
 shall be a
 \grammarterm{type-id}.
 
@@ -1146,10 +1143,10 @@ void f() {
 A template type argument can be an incomplete type\iref{term.incomplete.type}.
 \end{note}
 
-\rSec2[temp.arg.nontype]{Template non-type arguments}
+\rSec2[temp.arg.nontype]{non-type template arguments}
 
 \pnum
-If the type \tcode{T} of a \grammarterm{template-parameter}\iref{temp.param}
+If the type \tcode{T} of a non-type template parameter\iref{temp.param}
 contains a placeholder type\iref{dcl.spec.auto}
 or a placeholder for a deduced class type\iref{dcl.type.class.deduct},
 the type of the parameter is the type deduced
@@ -1163,11 +1160,11 @@ $E$ is a \grammarterm{template-argument} or
 (for a default template argument) an \grammarterm{initializer-clause}.
 \end{note}
 If a deduced parameter type is not permitted
-for a \grammarterm{template-parameter} declaration\iref{temp.param},
+for a non-type template parameter \iref{temp.param},
 the program is ill-formed.
 
 \pnum
-The value of a non-type \grammarterm{template-parameter} $P$
+The value of a non-type template parameter $P$
 of (possibly deduced) type \tcode{T}
 is determined from its template argument $A$ as follows.
 If \tcode{T} is not a class type and
@@ -1211,9 +1208,9 @@ the program is ill-formed.
 Otherwise, the value of $P$ is that of v.
 
 \pnum
-For a non-type \grammarterm{template-parameter} of reference or pointer type,
+For a non-type template parameter of reference or pointer type,
 or for each non-static data member of reference or pointer type
-in a non-type \grammarterm{template-parameter} of class type or subobject thereof,
+in a non-type template parameter of class type or subobject thereof,
 the reference or pointer value shall not refer
 or point to (respectively):
 \begin{itemize}
@@ -1274,7 +1271,7 @@ B<J2{}> j2;     // error: template parameter object not template-argument-equiva
 \begin{note}
 A \grammarterm{string-literal}\iref{lex.string} is
 not an acceptable \grammarterm{template-argument}
-for a \grammarterm{template-parameter} of non-class type.
+for a non-type template parameter of non-class type.
 \begin{example}
 \begin{codeblock}
 template<class T, T p> class X {
@@ -1302,7 +1299,7 @@ A temporary object
 is not an acceptable
 \grammarterm{template-argument}
 when the corresponding
-\grammarterm{template-parameter}
+template parameter
 has reference type.
 \begin{example}
 \begin{codeblock}
@@ -1328,7 +1325,7 @@ C<Y{X{1}.n}> c;                 // error: subobject of temporary object used to 
 A
 \grammarterm{template-argument}
 for a template
-\grammarterm{template-parameter}
+template parameter
 shall be the name of a class template or an alias template, expressed as
 \grammarterm{id-expression}.
 Only primary templates are considered when matching the template template
@@ -1339,9 +1336,7 @@ parameter.
 \pnum
 Any partial specializations\iref{temp.spec.partial} associated with the
 primary template are considered when a
-specialization based on the template
-\grammarterm{template-parameter}
-is instantiated.
+specialization based on the template template parameter is instantiated.
 If a specialization is not reachable from the point of instantiation,
 and it would have been selected had it been reachable, the program is ill-formed,
 no diagnostic required.
@@ -1363,23 +1358,23 @@ C<A> c;             // \tcode{V<int>} within \tcode{C<A>} uses the primary templ
 \end{example}
 
 \pnum
-A \grammarterm{template-argument} matches a template
-\grammarterm{template-parameter} \tcode{P} when
-\tcode{P} is at least as specialized as the \grammarterm{template-argument} \tcode{A}.
-In this comparison, if \tcode{P} is unconstrained,
-the constraints on \tcode{A} are not considered.
+A template \grammarterm{template-argument} \tcode{A} matches a template
+template parameter \tcode{P} when
+\tcode{P} is at least as specialized as \tcode{A}, ignoring constraints
+on \tcode{A} if \tcode{P} is unconstrained.
 If \tcode{P} contains a template parameter pack, then \tcode{A} also matches \tcode{P}
 if each of \tcode{A}'s template parameters
-matches the corresponding template parameter in the
+matches the corresponding template parameter declared in the
 \grammarterm{template-head} of \tcode{P}.
-Two template parameters match if they are of the same kind (type, non-type, template),
-for non-type \grammarterm{template-parameter}{s}, their types are
-equivalent\iref{temp.over.link}, and for template \grammarterm{template-parameter}{s},
-each of their corresponding \grammarterm{template-parameter}{s} matches, recursively.
-When \tcode{P}'s \grammarterm{template-head} contains a template parameter
+Two template parameters match if they are of the same kind,
+for non-type template parameters, their types are
+equivalent\iref{temp.over.link}, and for template template parameters,
+each of their corresponding template parameters matches, recursively.
+When \tcode{P}'s \grammarterm{template-head} contains a \grammarterm{template-parameter}
+that declares a template parameter
 pack\iref{temp.variadic}, the template parameter pack will match zero or more template
-parameters or template parameter packs in the \grammarterm{template-head} of
-\tcode{A} with the same type and form as the template parameter pack in \tcode{P}
+parameters or template parameter packs declared in the \grammarterm{template-head} of
+\tcode{A} with the same type and form as the template parameter pack declared in \tcode{P}
 (ignoring whether those template parameters are template parameter packs).
 
 \begin{example}
@@ -1439,7 +1434,7 @@ S<Z> s3;            // OK, \tcode{P} is at least as specialized as \tcode{Z}
 \end{example}
 
 \pnum
-A template \grammarterm{template-parameter} \tcode{P} is
+A template template parameter \tcode{P} is
 at least as specialized as a template \grammarterm{template-argument} \tcode{A}
 if, given the following rewrite to two function templates,
 the function template corresponding to \tcode{P}
@@ -1461,12 +1456,12 @@ Each function template has a single function parameter
 whose type is a specialization of \tcode{X}
 with template arguments corresponding to the template parameters
 from the respective function template where,
-for each template parameter \tcode{PP}
+for each \grammarterm{template-parameter} \tcode{PP}
 in the \grammarterm{template-head} of the function template,
-a corresponding template argument \tcode{AA} is formed.
+a corresponding \grammarterm{template-argument} \tcode{AA} is formed.
 If \tcode{PP} declares a template parameter pack,
 then \tcode{AA} is the pack expansion \tcode{PP...}\iref{temp.variadic};
-otherwise, \tcode{AA} is the \grammarterm{id-expression} \tcode{PP}.
+otherwise, \tcode{AA} is an \grammarterm{id-expression} denoting \tcode{PP}.
 \end{itemize}
 If the rewrite produces an invalid type,
 then \tcode{P} is not at least as specialized as \tcode{A}.
@@ -4376,7 +4371,7 @@ The first declared template parameter of a concept definition is its
 \indextext{type concept|see{concept, type}}%
 A \defnx{type concept}{concept!type}
 is a concept whose prototype parameter
-is a type \grammarterm{template-parameter}.
+is a type template-parameter.
 
 \rSec1[temp.res]{Name resolution}
 
@@ -4729,7 +4724,7 @@ injected-class-name can be used
 as a \grammarterm{template-name} or a \grammarterm{type-name}.
 When it is used with a
 \grammarterm{template-argument-list},
-as a \grammarterm{template-argument} for a template \grammarterm{template-parameter},
+as a \grammarterm{template-argument} for a template template parameter,
 or as the final identifier in the \grammarterm{elaborated-type-specifier} of
 a friend class template declaration,
 it is a \grammarterm{template-name} that refers to the
@@ -4823,21 +4818,21 @@ template<class T> class X {
 \end{example}
 
 \pnum
-The name of a \grammarterm{template-parameter}
+The name of a template parameter
 shall not be bound to any following declaration
 whose locus is contained by the scope
-to which the template-parameter belongs.
+to which the template parameter belongs.
 \begin{example}
 \begin{codeblock}
 template<class T, int i> class Y {
-  int T;                                // error: \grammarterm{template-parameter} hidden
+  int T;                                // error: template parameter hidden
   void f() {
-    char T;                             // error: \grammarterm{template-parameter} hidden
+    char T;                             // error: template parameter hidden
   }
   friend void T();                      // OK, no name bound
 };
 
-template<class X> class X;              // error: hidden by \grammarterm{template-parameter}
+template<class X> class X;              // error: hidden by template parameter
 \end{codeblock}
 \end{example}
 
@@ -5288,7 +5283,7 @@ associated by name lookup with one or more declarations
 declared with a dependent type,
 \item
 associated by name lookup with
-a non-type \grammarterm{template-parameter}
+a non-type template parameter
 declared with a type
 that contains a placeholder type\iref{dcl.spec.auto},
 \item
@@ -5508,14 +5503,14 @@ expression it specifies is value-dependent.
 \pnum
 Furthermore, a non-type
 \grammarterm{template-argument}
-is dependent if the corresponding non-type \grammarterm{template-parameter}
+is dependent if the corresponding non-type template parameter
 is of reference or pointer type and the \grammarterm{template-argument}
 designates or points to a member of the current instantiation or a member of
 a dependent type.
 
 \pnum
-A template \grammarterm{template-parameter} is dependent if
-it names a \grammarterm{template-parameter} or
+A template template parameter is dependent if
+it names a template parameter or
 its terminal name is dependent.
 
 \rSec2[temp.dep.res]{Dependent name resolution}
@@ -7104,13 +7099,12 @@ int l = f<>(1);                 // uses \#1
 
 \pnum
 Template arguments that are present shall be specified in the declaration
-order of their corresponding
-\grammarterm{template-parameter}{s}.
+order of their corresponding template parameters.
 The template argument list shall not specify more
 \grammarterm{template-argument}{s}
 than there are corresponding
 \grammarterm{template-parameter}{s}
-unless one of the \grammarterm{template-parameter}{s} is a template
+unless one of the \grammarterm{template-parameter}{s} declares a template
 parameter pack.
 \begin{example}
 \begin{codeblock}
@@ -7129,8 +7123,7 @@ void g() {
 \pnum
 Implicit conversions\iref{conv} will be performed on a function argument
 to convert it to the type of the corresponding function parameter if
-the parameter type contains no
-\grammarterm{template-parameter}{s}
+the parameter type contains no template parameters
 that participate in template argument deduction.
 \begin{note}
 Template parameters do not participate in template argument deduction if
@@ -7587,7 +7580,7 @@ int i2 = f<1>(0);               // ambiguous; not narrowing
 Template argument deduction is done by comparing each function
 template parameter type (call it
 \tcode{P})
-that contains \grammarterm{template-parameter}{s} that participate in template argument deduction
+that contains template parameters that participate in template argument deduction
 with the type of the corresponding argument of the call (call it
 \tcode{A})
 as described below.
@@ -7834,8 +7827,7 @@ If they yield more than one possible deduced
 \tcode{A},
 the type deduction fails.
 \begin{note}
-If a
-\grammarterm{template-parameter}
+If a template parameter
 is not used in any of the function parameters of a function template,
 or is used only in a non-deduced context, its corresponding
 \grammarterm{template-argument}
@@ -8262,7 +8254,7 @@ if it is not otherwise deduced.
 A given type
 \tcode{P}
 can be composed from a number of other
-types, templates, and non-type values:
+types, templates, and non-type template argument values:
 
 \begin{itemize}
 \item
@@ -8274,7 +8266,7 @@ and the type of the member pointed to.
 \item
 A type that is a specialization of a class template (e.g.,
 \tcode{A<int>})
-includes the types, templates, and non-type values referenced by the
+includes the types, templates, and non-type template argument values referenced by the
 template argument list of the specialization.
 \item
 An array type includes the array element type and the value of the
@@ -8282,7 +8274,7 @@ array bound.
 \end{itemize}
 
 \pnum
-In most cases, the types, templates, and non-type values that are used
+In most cases, the types, templates, and non-type template argument values that are used
 to compose
 \tcode{P}
 participate in template argument deduction.
@@ -8298,7 +8290,7 @@ If a template parameter is used only in non-deduced contexts and is not
 explicitly specified, template argument deduction fails.
 \begin{note}
 Under \ref{temp.deduct.call},
-if \tcode{P} contains no \grammarterm{template-parameter}{s} that appear
+if \tcode{P} contains no template parameters that appear
 in deduced contexts, no deduction is done, so \tcode{P} and \tcode{A}
 need not have the same form.
 \end{note}
@@ -8795,9 +8787,7 @@ If \tcode{P} has a form that contains \tcode{[i]}, and if the type of
 \begin{footnote}
 Although the
 \grammarterm{template-argument}
-corresponding to a
-\grammarterm{template-parameter}
-of type
+corresponding to a template parameter of type
 \tcode{bool}
 can be deduced from an array bound, the resulting value will always be
 \tcode{true}
@@ -8865,8 +8855,7 @@ void g() {
 \pnum
 The
 \grammarterm{template-argument}
-corresponding to a template
-\grammarterm{template-parameter}
+corresponding to a template template parameter
 is deduced from the type of the
 \grammarterm{template-argument}
 of a class template specialization used in the argument list of a function call.
@@ -9003,8 +8992,7 @@ for
 \pnum
 \begin{example}
 Here is an example involving conversions on a function argument involved in
-\grammarterm{template-argument}
-deduction:
+template argument deduction:
 \begin{codeblock}
 template<class T> struct B { @\commentellip@ };
 template<class T> struct D : public B<T> { @\commentellip@ };
@@ -9020,8 +9008,7 @@ void g(B<int>& bi, D<int>& di) {
 \pnum
 \begin{example}
 Here is an example involving conversions on a function argument not involved in
-\grammarterm{template-parameter}
-deduction:
+template argument deduction:
 \begin{codeblock}
 template<class T> void f(T*,int);       // \#1
 template<class T> void f(T,char);       // \#2


### PR DESCRIPTION
Try to use template-parameter only when we refer to a grammar construct, and to 'template parameter' everywhere else.

Adopt the same logic to template-argument/template argument.

This change might not be  exhaustive.

The aim is to editorially adopt some of the wording changes made in P2841R5 to ease its review in core.