### PR TITLE
P3309R3 constexpr atomic<T> and atomic_ref<T>

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -604,6 +604,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_concepts}@                          202207L
   // freestanding, also in \libheader{concepts}, \libheader{compare}
 #define @\defnlibxname{cpp_lib_constexpr_algorithms}@              202306L // also in \libheader{algorithm}, \libheader{utility}
+#define @\defnlibxname{cpp_lib_constexpr_atomic}@                  202411L // also in \libheader{atomic}
 #define @\defnlibxname{cpp_lib_constexpr_bitset}@                  202207L // also in \libheader{bitset}
 #define @\defnlibxname{cpp_lib_constexpr_charconv}@                202207L // freestanding, also in \libheader{charconv}
 #define @\defnlibxname{cpp_lib_constexpr_cmath}@                   202306L // also in \libheader{cmath}, \libheader{cstdlib}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -2401,7 +2401,7 @@ namespace std {
   inline constexpr memory_order memory_order_seq_cst = memory_order::seq_cst;       // freestanding
 
   template<class T>
-    T kill_dependency(T y) noexcept;                                                // freestanding
+    constexpr T kill_dependency(T y) noexcept;                                      // freestanding
 }
 
 // \ref{atomics.lockfree}, lock-free property
@@ -2437,57 +2437,58 @@ namespace std {
     void atomic_store(volatile atomic<T>*,                                          // freestanding
                       typename atomic<T>::value_type) noexcept;
   template<class T>
-    void atomic_store(atomic<T>*, typename atomic<T>::value_type) noexcept;         // freestanding
+    constexpr void atomic_store(atomic<T>*,                                         // freestanding
+                                typename atomic<T>::value_type) noexcept;
   template<class T>
     void atomic_store_explicit(volatile atomic<T>*,                                 // freestanding
-                               typename atomic<T>::value_type,
-                               memory_order) noexcept;
+                               typename atomic<T>::value_type, memory_order) noexcept;
   template<class T>
-    void atomic_store_explicit(atomic<T>*, typename atomic<T>::value_type,          // freestanding
-                               memory_order) noexcept;
+    constexpr void atomic_store_explicit(atomic<T>*,                                // freestanding
+                                         typename atomic<T>::value_type, memory_order) noexcept;
   template<class T>
     T atomic_load(const volatile atomic<T>*) noexcept;                              // freestanding
   template<class T>
-    T atomic_load(const atomic<T>*) noexcept;                                       // freestanding
+    constexpr T atomic_load(const atomic<T>*) noexcept;                             // freestanding
   template<class T>
     T atomic_load_explicit(const volatile atomic<T>*, memory_order) noexcept;       // freestanding
   template<class T>
-    T atomic_load_explicit(const atomic<T>*, memory_order) noexcept;                // freestanding
+    constexpr T atomic_load_explicit(const atomic<T>*, memory_order) noexcept;      // freestanding
   template<class T>
     T atomic_exchange(volatile atomic<T>*,                                          // freestanding
                       typename atomic<T>::value_type) noexcept;
   template<class T>
-    T atomic_exchange(atomic<T>*, typename atomic<T>::value_type) noexcept;         // freestanding
+    constexpr T atomic_exchange(atomic<T>*,                                         // freestanding
+                                typename atomic<T>::value_type) noexcept;
   template<class T>
     T atomic_exchange_explicit(volatile atomic<T>*,                                 // freestanding
-                               typename atomic<T>::value_type,
-                               memory_order) noexcept;
+                               typename atomic<T>::value_type, memory_order) noexcept;
   template<class T>
-    T atomic_exchange_explicit(atomic<T>*, typename atomic<T>::value_type,          // freestanding
-                               memory_order) noexcept;
+    constexpr T atomic_exchange_explicit(atomic<T>*,                                // freestanding
+                                         typename atomic<T>::value_type,
+                                         memory_order) noexcept;
   template<class T>
     bool atomic_compare_exchange_weak(volatile atomic<T>*,                          // freestanding
                                       typename atomic<T>::value_type*,
                                       typename atomic<T>::value_type) noexcept;
   template<class T>
-    bool atomic_compare_exchange_weak(atomic<T>*,                                   // freestanding
-                                      typename atomic<T>::value_type*,
-                                      typename atomic<T>::value_type) noexcept;
+    constexpr bool atomic_compare_exchange_weak(atomic<T>*,                         // freestanding
+                                                typename atomic<T>::value_type*,
+                                                typename atomic<T>::value_type) noexcept;
   template<class T>
     bool atomic_compare_exchange_strong(volatile atomic<T>*,                        // freestanding
                                         typename atomic<T>::value_type*,
                                         typename atomic<T>::value_type) noexcept;
   template<class T>
-    bool atomic_compare_exchange_strong(atomic<T>*,                                 // freestanding
-                                        typename atomic<T>::value_type*,
-                                        typename atomic<T>::value_type) noexcept;
+    constexpr bool atomic_compare_exchange_strong(atomic<T>*,                       // freestanding
+                                                  typename atomic<T>::value_type*,
+                                                  typename atomic<T>::value_type) noexcept;
   template<class T>
     bool atomic_compare_exchange_weak_explicit(volatile atomic<T>*,                 // freestanding
                                                typename atomic<T>::value_type*,
                                                typename atomic<T>::value_type,
                                                memory_order, memory_order) noexcept;
   template<class T>
-    bool atomic_compare_exchange_weak_explicit(atomic<T>*,                          // freestanding
+    constexpr bool atomic_compare_exchange_weak_explicit(atomic<T>*,                // freestanding
                                                typename atomic<T>::value_type*,
                                                typename atomic<T>::value_type,
                                                memory_order, memory_order) noexcept;
@@ -2497,7 +2498,7 @@ namespace std {
                                                  typename atomic<T>::value_type,
                                                  memory_order, memory_order) noexcept;
   template<class T>
-    bool atomic_compare_exchange_strong_explicit(atomic<T>*,                        // freestanding
+    constexpr bool atomic_compare_exchange_strong_explicit(atomic<T>*,              // freestanding
                                                  typename atomic<T>::value_type*,
                                                  typename atomic<T>::value_type,
                                                  memory_order, memory_order) noexcept;
@@ -2506,110 +2507,122 @@ namespace std {
     T atomic_fetch_add(volatile atomic<T>*,                                         // freestanding
                        typename atomic<T>::difference_type) noexcept;
   template<class T>
-    T atomic_fetch_add(atomic<T>*, typename atomic<T>::difference_type) noexcept;   // freestanding
+    constexpr T atomic_fetch_add(atomic<T>*,                                        // freestanding
+                                 typename atomic<T>::difference_type) noexcept;
   template<class T>
     T atomic_fetch_add_explicit(volatile atomic<T>*,                                // freestanding
                                 typename atomic<T>::difference_type,
                                 memory_order) noexcept;
   template<class T>
-    T atomic_fetch_add_explicit(atomic<T>*, typename atomic<T>::difference_type,    // freestanding
-                                memory_order) noexcept;
+    constexpr T atomic_fetch_add_explicit(atomic<T>*,                               // freestanding
+                                          typename atomic<T>::difference_type,
+                                          memory_order) noexcept;
   template<class T>
     T atomic_fetch_sub(volatile atomic<T>*,                                         // freestanding
                        typename atomic<T>::difference_type) noexcept;
   template<class T>
-    T atomic_fetch_sub(atomic<T>*, typename atomic<T>::difference_type) noexcept;   // freestanding
+    constexpr T atomic_fetch_sub(atomic<T>*,                                        // freestanding
+                                 typename atomic<T>::difference_type) noexcept;
   template<class T>
     T atomic_fetch_sub_explicit(volatile atomic<T>*,                                // freestanding
                                 typename atomic<T>::difference_type,
                                 memory_order) noexcept;
   template<class T>
-    T atomic_fetch_sub_explicit(atomic<T>*, typename atomic<T>::difference_type,    // freestanding
-                                memory_order) noexcept;
+    constexpr T atomic_fetch_sub_explicit(atomic<T>*,                               // freestanding
+                                          typename atomic<T>::difference_type,
+                                          memory_order) noexcept;
   template<class T>
     T atomic_fetch_and(volatile atomic<T>*,                                         // freestanding
                        typename atomic<T>::value_type) noexcept;
   template<class T>
-    T atomic_fetch_and(atomic<T>*, typename atomic<T>::value_type) noexcept;        // freestanding
+    constexpr T atomic_fetch_and(atomic<T>*,                                        // freestanding
+                                 typename atomic<T>::value_type) noexcept;
   template<class T>
     T atomic_fetch_and_explicit(volatile atomic<T>*,                                // freestanding
                                 typename atomic<T>::value_type,
                                 memory_order) noexcept;
   template<class T>
-    T atomic_fetch_and_explicit(atomic<T>*, typename atomic<T>::value_type,         // freestanding
-                                memory_order) noexcept;
+    constexpr T atomic_fetch_and_explicit(atomic<T>*,                               // freestanding
+                                          typename atomic<T>::value_type,
+                                          memory_order) noexcept;
   template<class T>
     T atomic_fetch_or(volatile atomic<T>*,                                          // freestanding
                       typename atomic<T>::value_type) noexcept;
   template<class T>
-    T atomic_fetch_or(atomic<T>*, typename atomic<T>::value_type) noexcept;         // freestanding
+    constexpr T atomic_fetch_or(atomic<T>*,                                         // freestanding
+                                typename atomic<T>::value_type) noexcept;
   template<class T>
     T atomic_fetch_or_explicit(volatile atomic<T>*,                                 // freestanding
                                typename atomic<T>::value_type,
                                memory_order) noexcept;
   template<class T>
-    T atomic_fetch_or_explicit(atomic<T>*, typename atomic<T>::value_type,          // freestanding
-                               memory_order) noexcept;
+    constexpr T atomic_fetch_or_explicit(atomic<T>*,                                // freestanding
+                                         typename atomic<T>::value_type,
+                                         memory_order) noexcept;
   template<class T>
     T atomic_fetch_xor(volatile atomic<T>*,                                         // freestanding
                        typename atomic<T>::value_type) noexcept;
   template<class T>
-    T atomic_fetch_xor(atomic<T>*, typename atomic<T>::value_type) noexcept;        // freestanding
+    constexpr T atomic_fetch_xor(atomic<T>*,                                        // freestanding
+                                 typename atomic<T>::value_type) noexcept;
   template<class T>
     T atomic_fetch_xor_explicit(volatile atomic<T>*,                                // freestanding
                                 typename atomic<T>::value_type,
                                 memory_order) noexcept;
   template<class T>
-    T atomic_fetch_xor_explicit(atomic<T>*, typename atomic<T>::value_type,         // freestanding
-                                memory_order) noexcept;
+    constexpr T atomic_fetch_xor_explicit(atomic<T>*,                               // freestanding
+                                          typename atomic<T>::value_type,
+                                          memory_order) noexcept;
   template<class T>
     T atomic_fetch_max(volatile atomic<T>*,                                         // freestanding
                        typename atomic<T>::value_type) noexcept;
   template<class T>
-    T atomic_fetch_max(atomic<T>*,                                                  // freestanding
+    constexpr T atomic_fetch_max(atomic<T>*,                                        // freestanding
                        typename atomic<T>::value_type) noexcept;
   template<class T>
     T atomic_fetch_max_explicit(volatile atomic<T>*,                                // freestanding
                                 typename atomic<T>::value_type,
                                 memory_order) noexcept;
   template<class T>
-    T atomic_fetch_max_explicit(atomic<T>*,                                         // freestanding
+    constexpr T atomic_fetch_max_explicit(atomic<T>*,                               // freestanding
                                 typename atomic<T>::value_type,
                                 memory_order) noexcept;
   template<class T>
     T atomic_fetch_min(volatile atomic<T>*,                                         // freestanding
                        typename atomic<T>::value_type) noexcept;
   template<class T>
-    T atomic_fetch_min(atomic<T>*,                                                  // freestanding
+    constexpr T atomic_fetch_min(atomic<T>*,                                        // freestanding
                        typename atomic<T>::value_type) noexcept;
   template<class T>
     T atomic_fetch_min_explicit(volatile atomic<T>*,                                // freestanding
                                 typename atomic<T>::value_type,
                                 memory_order) noexcept;
   template<class T>
-    T atomic_fetch_min_explicit(atomic<T>*,                                         // freestanding
+    constexpr T atomic_fetch_min_explicit(atomic<T>*,                               // freestanding
                                 typename atomic<T>::value_type,
                                 memory_order) noexcept;
   template<class T>
     void atomic_wait(const volatile atomic<T>*,                                     // freestanding
 	             typename atomic<T>::value_type) noexcept;
   template<class T>
-    void atomic_wait(const atomic<T>*, typename atomic<T>::value_type) noexcept;    // freestanding
+    constexpr void atomic_wait(const atomic<T>*,                                    // freestanding
+                               typename atomic<T>::value_type) noexcept;
   template<class T>
     void atomic_wait_explicit(const volatile atomic<T>*,                            // freestanding
                               typename atomic<T>::value_type,
                               memory_order) noexcept;
   template<class T>
-    void atomic_wait_explicit(const atomic<T>*, typename atomic<T>::value_type,     // freestanding
-                              memory_order) noexcept;
+    constexpr void atomic_wait_explicit(const atomic<T>*,                           // freestanding
+                                        typename atomic<T>::value_type,
+                                        memory_order) noexcept;
   template<class T>
     void atomic_notify_one(volatile atomic<T>*) noexcept;                           // freestanding
   template<class T>
-    void atomic_notify_one(atomic<T>*) noexcept;                                    // freestanding
+    constexpr void atomic_notify_one(atomic<T>*) noexcept;                          // freestanding
   template<class T>
     void atomic_notify_all(volatile atomic<T>*) noexcept;                           // freestanding
   template<class T>
-    void atomic_notify_all(atomic<T>*) noexcept;                                    // freestanding
+    constexpr void atomic_notify_all(atomic<T>*) noexcept;                          // freestanding
 
   // \ref{atomics.alias}, type aliases
   using atomic_bool           = atomic<bool>;                                       // freestanding
@@ -2670,35 +2683,37 @@ namespace std {
   struct atomic_flag;                                                               // freestanding
 
   bool atomic_flag_test(const volatile atomic_flag*) noexcept;                      // freestanding
-  bool atomic_flag_test(const atomic_flag*) noexcept;                               // freestanding
+  constexpr bool atomic_flag_test(const atomic_flag*) noexcept;                     // freestanding
   bool atomic_flag_test_explicit(const volatile atomic_flag*,                       // freestanding
                                  memory_order) noexcept;
-  bool atomic_flag_test_explicit(const atomic_flag*, memory_order) noexcept;        // freestanding
+  constexpr bool atomic_flag_test_explicit(const atomic_flag*,                      // freestanding
+                                           memory_order) noexcept;
   bool atomic_flag_test_and_set(volatile atomic_flag*) noexcept;                    // freestanding
-  bool atomic_flag_test_and_set(atomic_flag*) noexcept;                             // freestanding
+  constexpr bool atomic_flag_test_and_set(atomic_flag*) noexcept;                   // freestanding
   bool atomic_flag_test_and_set_explicit(volatile atomic_flag*,                     // freestanding
                                          memory_order) noexcept;
-  bool atomic_flag_test_and_set_explicit(atomic_flag*, memory_order) noexcept;      // freestanding
+  constexpr bool atomic_flag_test_and_set_explicit(atomic_flag*,                    // freestanding
+                                                   memory_order) noexcept;
   void atomic_flag_clear(volatile atomic_flag*) noexcept;                           // freestanding
-  void atomic_flag_clear(atomic_flag*) noexcept;                                    // freestanding
+  constexpr void atomic_flag_clear(atomic_flag*) noexcept;                          // freestanding
   void atomic_flag_clear_explicit(volatile atomic_flag*, memory_order) noexcept;    // freestanding
-  void atomic_flag_clear_explicit(atomic_flag*, memory_order) noexcept;             // freestanding
+  constexpr void atomic_flag_clear_explicit(atomic_flag*, memory_order) noexcept;   // freestanding
 
   void atomic_flag_wait(const volatile atomic_flag*, bool) noexcept;                // freestanding
-  void atomic_flag_wait(const atomic_flag*, bool) noexcept;                         // freestanding
+  constexpr void atomic_flag_wait(const atomic_flag*, bool) noexcept;               // freestanding
   void atomic_flag_wait_explicit(const volatile atomic_flag*,                       // freestanding
                                  bool, memory_order) noexcept;
-  void atomic_flag_wait_explicit(const atomic_flag*,                                // freestanding
+  constexpr void atomic_flag_wait_explicit(const atomic_flag*,                      // freestanding
                                  bool, memory_order) noexcept;
   void atomic_flag_notify_one(volatile atomic_flag*) noexcept;                      // freestanding
-  void atomic_flag_notify_one(atomic_flag*) noexcept;                               // freestanding
+  constexpr void atomic_flag_notify_one(atomic_flag*) noexcept;                     // freestanding
   void atomic_flag_notify_all(volatile atomic_flag*) noexcept;                      // freestanding
-  void atomic_flag_notify_all(atomic_flag*) noexcept;                               // freestanding
+  constexpr void atomic_flag_notify_all(atomic_flag*) noexcept;                     // freestanding
   #define ATOMIC_FLAG_INIT @\seebelownc@                                                // freestanding
 
   // \ref{atomics.fences}, fences
-  extern "C" void atomic_thread_fence(memory_order) noexcept;                       // freestanding
-  extern "C" void atomic_signal_fence(memory_order) noexcept;                       // freestanding
+  extern "C" constexpr void atomic_thread_fence(memory_order) noexcept;             // freestanding
+  extern "C" constexpr void atomic_signal_fence(memory_order) noexcept;             // freestanding
 }
 \end{codeblock}
 
@@ -2978,7 +2993,7 @@ within a reasonable amount of time.
 \indexlibraryglobal{kill_dependency}%
 \begin{itemdecl}
 template<class T>
-  T kill_dependency(T y) noexcept;
+  constexpr T kill_dependency(T y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3132,28 +3147,29 @@ namespace std {
     static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic_ref} type's operations are always lock free}@;
     bool is_lock_free() const noexcept;
 
-    explicit atomic_ref(T&);
-    atomic_ref(const atomic_ref&) noexcept;
+    constexpr explicit atomic_ref(T&);
+    constexpr atomic_ref(const atomic_ref&) noexcept;
     atomic_ref& operator=(const atomic_ref&) = delete;
 
-    void store(value_type, memory_order = memory_order::seq_cst) const noexcept;
-    value_type operator=(value_type) const noexcept;
-    value_type load(memory_order = memory_order::seq_cst) const noexcept;
-    operator value_type() const noexcept;
+    constexpr void store(value_type, memory_order = memory_order::seq_cst) const noexcept;
+    constexpr value_type operator=(value_type) const noexcept;
+    constexpr value_type load(memory_order = memory_order::seq_cst) const noexcept;
+    constexpr operator value_type() const noexcept;
 
-    value_type exchange(value_type, memory_order = memory_order::seq_cst) const noexcept;
-    bool compare_exchange_weak(value_type&, value_type,
-                               memory_order, memory_order) const noexcept;
-    bool compare_exchange_strong(value_type&, value_type,
-                                 memory_order, memory_order) const noexcept;
-    bool compare_exchange_weak(value_type&, value_type,
-                               memory_order = memory_order::seq_cst) const noexcept;
-    bool compare_exchange_strong(value_type&, value_type,
-                                 memory_order = memory_order::seq_cst) const noexcept;
+    constexpr value_type exchange(value_type,
+                                  memory_order = memory_order::seq_cst) const noexcept;
+    constexpr bool compare_exchange_weak(value_type&, value_type,
+                                         memory_order, memory_order) const noexcept;
+    constexpr bool compare_exchange_strong(value_type&, value_type,
+                                           memory_order, memory_order) const noexcept;
+    constexpr bool compare_exchange_weak(value_type&, value_type,
+                                         memory_order = memory_order::seq_cst) const noexcept;
+    constexpr bool compare_exchange_strong(value_type&, value_type,
+                                           memory_order = memory_order::seq_cst) const noexcept;
 
-    void wait(value_type, memory_order = memory_order::seq_cst) const noexcept;
-    void notify_one() const noexcept;
-    void notify_all() const noexcept;
+    constexpr void wait(value_type, memory_order = memory_order::seq_cst) const noexcept;
+    constexpr void notify_one() const noexcept;
+    constexpr void notify_all() const noexcept;
     constexpr T* address() const noexcept;
   };
 }
@@ -3258,7 +3274,7 @@ are lock-free,
 \indexlibrary{\idxcode{atomic_ref<\placeholder{integral-type}>}!constructor}%
 \indexlibrary{\idxcode{atomic_ref<\placeholder{floating-point-type}>}!constructor}%
 \begin{itemdecl}
-atomic_ref(T& obj);
+constexpr atomic_ref(T& obj);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3280,7 +3296,7 @@ Nothing.
 \indexlibrary{\idxcode{atomic_ref<\placeholder{integral-type}>}!constructor}%
 \indexlibrary{\idxcode{atomic_ref<\placeholder{floating-point-type}>}!constructor}%
 \begin{itemdecl}
-atomic_ref(const atomic_ref& ref) noexcept;
+constexpr atomic_ref(const atomic_ref& ref) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3294,7 +3310,8 @@ atomic_ref(const atomic_ref& ref) noexcept;
 \indexlibrarymember{store}{atomic_ref<\placeholder{integral-type}>}%
 \indexlibrarymember{store}{atomic_ref<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
-void store(value_type desired, memory_order order = memory_order::seq_cst) const noexcept;
+constexpr void store(value_type desired,
+                     memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3321,7 +3338,7 @@ Memory is affected according to the value of \tcode{order}.
 \indexlibrarymember{operator=}{atomic_ref<\placeholder{integral-type}>}%
 \indexlibrarymember{operator=}{atomic_ref<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
-value_type operator=(value_type desired) const noexcept;
+constexpr value_type operator=(value_type desired) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3343,7 +3360,7 @@ return desired;
 \indexlibrarymember{load}{atomic_ref<\placeholder{integral-type}>}%
 \indexlibrarymember{load}{atomic_ref<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
-value_type load(memory_order order = memory_order::seq_cst) const noexcept;
+constexpr value_type load(memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3369,7 +3386,7 @@ Atomically returns the value referenced by \tcode{*ptr}.
 \indexlibrarymember{operator \placeholder{integral-type}}{atomic_ref<\placeholder{integral-type}>}%
 \indexlibrarymember{operator \placeholder{floating-point-type}}{atomic_ref<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
-operator value_type() const noexcept;
+constexpr operator value_type() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3383,7 +3400,8 @@ Equivalent to: \tcode{return load();}
 \indexlibrarymember{exchange}{atomic_ref<\placeholder{integral-type}>}%
 \indexlibrarymember{exchange}{atomic_ref<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
-value_type exchange(value_type desired, memory_order order = memory_order::seq_cst) const noexcept;
+constexpr value_type exchange(value_type desired,
+                              memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3413,16 +3431,16 @@ immediately before the effects.
 \indexlibrarymember{compare_exchange_strong}{atomic_ref<\placeholder{integral-type}>}%
 \indexlibrarymember{compare_exchange_strong}{atomic_ref<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
-bool compare_exchange_weak(value_type& expected, value_type desired,
+constexpr bool compare_exchange_weak(value_type& expected, value_type desired,
                            memory_order success, memory_order failure) const noexcept;
 
-bool compare_exchange_strong(value_type& expected, value_type desired,
+constexpr bool compare_exchange_strong(value_type& expected, value_type desired,
                              memory_order success, memory_order failure) const noexcept;
 
-bool compare_exchange_weak(value_type& expected, value_type desired,
+constexpr bool compare_exchange_weak(value_type& expected, value_type desired,
                            memory_order order = memory_order::seq_cst) const noexcept;
 
-bool compare_exchange_strong(value_type& expected, value_type desired,
+constexpr bool compare_exchange_strong(value_type& expected, value_type desired,
                              memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
@@ -3494,7 +3512,7 @@ a strong one would not, the strong one is preferable.
 
 \indexlibrarymember{wait}{atomic_ref<T>}%
 \begin{itemdecl}
-void wait(value_type old, memory_order order = memory_order::seq_cst) const noexcept;
+constexpr void wait(value_type old, memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3528,7 +3546,7 @@ on atomic object \tcode{*ptr}.
 
 \indexlibrarymember{notify_one}{atomic_ref<T>}%
 \begin{itemdecl}
-void notify_one() const noexcept;
+constexpr void notify_one() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3550,7 +3568,7 @@ on atomic object \tcode{*ptr}.
 
 \indexlibrarymember{notify_all}{atomic_ref<T>}%
 \begin{itemdecl}
-void notify_all() const noexcept;
+constexpr void notify_all() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3613,47 +3631,54 @@ namespace std {
     static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic_ref} type's operations are always lock free}@;
     bool is_lock_free() const noexcept;
 
-    explicit atomic_ref(@\placeholder{integral-type}@&);
-    atomic_ref(const atomic_ref&) noexcept;
+    constexpr explicit atomic_ref(@\placeholder{integral-type}@&);
+    constexpr atomic_ref(const atomic_ref&) noexcept;
     atomic_ref& operator=(const atomic_ref&) = delete;
 
-    void store(value_type, memory_order = memory_order::seq_cst) const noexcept;
-    value_type operator=(value_type) const noexcept;
-    value_type load(memory_order = memory_order::seq_cst) const noexcept;
-    operator value_type() const noexcept;
+    constexpr void store(value_type, memory_order = memory_order::seq_cst) const noexcept;
+    constexpr value_type operator=(value_type) const noexcept;
+    constexpr value_type load(memory_order = memory_order::seq_cst) const noexcept;
+    constexpr operator value_type() const noexcept;
 
-    value_type exchange(value_type,
-                           memory_order = memory_order::seq_cst) const noexcept;
-    bool compare_exchange_weak(value_type&, value_type,
-                               memory_order, memory_order) const noexcept;
-    bool compare_exchange_strong(value_type&, value_type,
-                                 memory_order, memory_order) const noexcept;
-    bool compare_exchange_weak(value_type&, value_type,
-                               memory_order = memory_order::seq_cst) const noexcept;
-    bool compare_exchange_strong(value_type&, value_type,
-                                 memory_order = memory_order::seq_cst) const noexcept;
+    constexpr value_type exchange(value_type,
+                                  memory_order = memory_order::seq_cst) const noexcept;
+    constexpr bool compare_exchange_weak(value_type&, value_type,
+                                         memory_order, memory_order) const noexcept;
+    constexpr bool compare_exchange_strong(value_type&, value_type,
+                                           memory_order, memory_order) const noexcept;
+    constexpr bool compare_exchange_weak(value_type&, value_type,
+                                         memory_order = memory_order::seq_cst) const noexcept;
+    constexpr bool compare_exchange_strong(value_type&, value_type,
+                                           memory_order = memory_order::seq_cst) const noexcept;
 
-    value_type fetch_add(value_type, memory_order = memory_order::seq_cst) const noexcept;
-    value_type fetch_sub(value_type, memory_order = memory_order::seq_cst) const noexcept;
-    value_type fetch_and(value_type, memory_order = memory_order::seq_cst) const noexcept;
-    value_type fetch_or(value_type, memory_order = memory_order::seq_cst) const noexcept;
-    value_type fetch_xor(value_type, memory_order = memory_order::seq_cst) const noexcept;
-    value_type fetch_max(value_type, memory_order = memory_order::seq_cst) const noexcept;
-    value_type fetch_min(value_type, memory_order = memory_order::seq_cst) const noexcept;
+    constexpr value_type fetch_add(value_type,
+                                   memory_order = memory_order::seq_cst) const noexcept;
+    constexpr value_type fetch_sub(value_type,
+                                   memory_order = memory_order::seq_cst) const noexcept;
+    constexpr value_type fetch_and(value_type,
+                                   memory_order = memory_order::seq_cst) const noexcept;
+    constexpr value_type fetch_or(value_type,
+                                  memory_order = memory_order::seq_cst) const noexcept;
+    constexpr value_type fetch_xor(value_type,
+                                   memory_order = memory_order::seq_cst) const noexcept;
+    constexpr value_type fetch_max(value_type,
+                                   memory_order = memory_order::seq_cst) const noexcept;
+    constexpr value_type fetch_min(value_type,
+                                   memory_order = memory_order::seq_cst) const noexcept;
 
-    value_type operator++(int) const noexcept;
-    value_type operator--(int) const noexcept;
-    value_type operator++() const noexcept;
-    value_type operator--() const noexcept;
-    value_type operator+=(value_type) const noexcept;
-    value_type operator-=(value_type) const noexcept;
-    value_type operator&=(value_type) const noexcept;
-    value_type operator|=(value_type) const noexcept;
-    value_type operator^=(value_type) const noexcept;
+    constexpr value_type operator++(int) const noexcept;
+    constexpr value_type operator--(int) const noexcept;
+    constexpr value_type operator++() const noexcept;
+    constexpr value_type operator--() const noexcept;
+    constexpr value_type operator+=(value_type) const noexcept;
+    constexpr value_type operator-=(value_type) const noexcept;
+    constexpr value_type operator&=(value_type) const noexcept;
+    constexpr value_type operator|=(value_type) const noexcept;
+    constexpr value_type operator^=(value_type) const noexcept;
 
-    void wait(value_type, memory_order = memory_order::seq_cst) const noexcept;
-    void notify_one() const noexcept;
-    void notify_all() const noexcept;
+    constexpr void wait(value_type, memory_order = memory_order::seq_cst) const noexcept;
+    constexpr void notify_one() const noexcept;
+    constexpr void notify_all() const noexcept;
     constexpr @\placeholder{integral-type}@* address() const noexcept;
   };
 }
@@ -3676,7 +3701,7 @@ in \tref{atomic.types.int.comp}.
 \indexlibrarymember{fetch_sub}{atomic_ref<\placeholder{integral-type}>}%
 \indexlibrarymember{fetch_xor}{atomic_ref<\placeholder{integral-type}>}%
 \begin{itemdecl}
-value_type fetch_@\placeholdernc{key}@(value_type operand,
+constexpr value_type fetch_@\placeholdernc{key}@(value_type operand,
   memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
@@ -3723,7 +3748,7 @@ parameter as the arguments.
 \indexlibrarymember{operator"|=}{atomic_ref<\placeholder{integral-type}>}%
 \indexlibrarymember{operator\caret=}{atomic_ref<\placeholder{integral-type}>}%
 \begin{itemdecl}
-value_type operator @\placeholder{op}@=(value_type operand) const noexcept;
+constexpr value_type operator @\placeholder{op}@=(value_type operand) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3766,37 +3791,39 @@ namespace std {
     static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic_ref} type's operations are always lock free}@;
     bool is_lock_free() const noexcept;
 
-    explicit atomic_ref(@\placeholder{floating-point-type}@&);
-    atomic_ref(const atomic_ref&) noexcept;
+    constexpr explicit atomic_ref(@\placeholder{floating-point-type}@&);
+    constexpr atomic_ref(const atomic_ref&) noexcept;
     atomic_ref& operator=(const atomic_ref&) = delete;
 
-    void store(@\placeholdernc{floating-point-type}@, memory_order = memory_order::seq_cst) const noexcept;
-    value_type operator=(value_type) const noexcept;
-    value_type load(memory_order = memory_order::seq_cst) const noexcept;
-    operator @\placeholdernc{floating-point-type}@() const noexcept;
+    constexpr void store(@\placeholdernc{floating-point-type}@,
+                         memory_order = memory_order::seq_cst) const noexcept;
+    constexpr value_type operator=(value_type) const noexcept;
+    constexpr value_type load(memory_order = memory_order::seq_cst) const noexcept;
+    constexpr operator @\placeholdernc{floating-point-type}@() const noexcept;
 
-    value_type exchange(@\placeholdernc{floating-point-type}@,
+    constexpr value_type exchange(@\placeholdernc{floating-point-type}@,
                                  memory_order = memory_order::seq_cst) const noexcept;
-    bool compare_exchange_weak(value_type&, @\placeholdernc{floating-point-type}@,
+    constexpr bool compare_exchange_weak(value_type&, @\placeholdernc{floating-point-type}@,
                                memory_order, memory_order) const noexcept;
-    bool compare_exchange_strong(value_type&, @\placeholdernc{floating-point-type}@,
+    constexpr bool compare_exchange_strong(value_type&, @\placeholdernc{floating-point-type}@,
                                  memory_order, memory_order) const noexcept;
-    bool compare_exchange_weak(value_type&, @\placeholdernc{floating-point-type}@,
+    constexpr bool compare_exchange_weak(value_type&, @\placeholdernc{floating-point-type}@,
                                memory_order = memory_order::seq_cst) const noexcept;
-    bool compare_exchange_strong(value_type&, @\placeholdernc{floating-point-type}@,
+    constexpr bool compare_exchange_strong(value_type&, @\placeholdernc{floating-point-type}@,
                                  memory_order = memory_order::seq_cst) const noexcept;
 
-    value_type fetch_add(@\placeholdernc{floating-point-type}@,
+    constexpr value_type fetch_add(@\placeholdernc{floating-point-type}@,
                                   memory_order = memory_order::seq_cst) const noexcept;
-    value_type fetch_sub(@\placeholdernc{floating-point-type}@,
+    constexpr value_type fetch_sub(@\placeholdernc{floating-point-type}@,
                                   memory_order = memory_order::seq_cst) const noexcept;
 
-    value_type operator+=(value_type) const noexcept;
-    value_type operator-=(value_type) const noexcept;
+    constexpr value_type operator+=(value_type) const noexcept;
+    constexpr value_type operator-=(value_type) const noexcept;
 
-    void wait(@\placeholdernc{floating-point-type}@, memory_order = memory_order::seq_cst) const noexcept;
-    void notify_one() const noexcept;
-    void notify_all() const noexcept;
+    constexpr void wait(@\placeholdernc{floating-point-type}@,
+                        memory_order = memory_order::seq_cst) const noexcept;
+    constexpr void notify_one() const noexcept;
+    constexpr void notify_all() const noexcept;
     constexpr @\placeholder{floating-point-type}@* address() const noexcept;
   };
 }
@@ -3814,7 +3841,7 @@ in \tref{atomic.types.int.comp}.
 \indexlibrarymember{fetch_add}{atomic_ref<\placeholder{floating-point-type}>}%
 \indexlibrarymember{fetch_sub}{atomic_ref<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
-value_type fetch_@\placeholdernc{key}@(value_type operand,
+constexpr value_type fetch_@\placeholdernc{key}@(value_type operand,
                           memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
@@ -3852,7 +3879,7 @@ may be different than the calling thread's floating-point environment.
 \indexlibrarymember{operator+=}{atomic_ref<\placeholder{floating-point-type}>}%
 \indexlibrarymember{operator-=}{atomic_ref<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
-value_type operator @\placeholder{op}@=(value_type operand) const noexcept;
+constexpr value_type operator @\placeholder{op}@=(value_type operand) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3895,40 +3922,45 @@ namespace std {
     static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic_ref} type's operations are always lock free}@;
     bool is_lock_free() const noexcept;
 
-    explicit atomic_ref(@\placeholder{pointer-type}@&);
-    atomic_ref(const atomic_ref&) noexcept;
+    constexpr explicit atomic_ref(@\placeholder{pointer-type}@&);
+    constexpr atomic_ref(const atomic_ref&) noexcept;
     atomic_ref& operator=(const atomic_ref&) = delete;
 
-    void store(value_type, memory_order = memory_order::seq_cst) const noexcept;
-    value_type operator=(value_type) const noexcept;
-    value_type load(memory_order = memory_order::seq_cst) const noexcept;
-    operator value_type() const noexcept;
+    constexpr void store(value_type, memory_order = memory_order::seq_cst) const noexcept;
+    constexpr value_type operator=(value_type) const noexcept;
+    constexpr value_type load(memory_order = memory_order::seq_cst) const noexcept;
+    constexpr operator value_type() const noexcept;
 
-    value_type exchange(value_type, memory_order = memory_order::seq_cst) const noexcept;
-    bool compare_exchange_weak(value_type&, value_type,
-                               memory_order, memory_order) const noexcept;
-    bool compare_exchange_strong(value_type&, value_type,
-                                 memory_order, memory_order) const noexcept;
-    bool compare_exchange_weak(value_type&, value_type,
-                               memory_order = memory_order::seq_cst) const noexcept;
-    bool compare_exchange_strong(value_type&, value_type,
-                                 memory_order = memory_order::seq_cst) const noexcept;
+    constexpr value_type exchange(value_type,
+                                  memory_order = memory_order::seq_cst) const noexcept;
+    constexpr bool compare_exchange_weak(value_type&, value_type,
+                                         memory_order, memory_order) const noexcept;
+    constexpr bool compare_exchange_strong(value_type&, value_type,
+                                           memory_order, memory_order) const noexcept;
+    constexpr bool compare_exchange_weak(value_type&, value_type,
+                                         memory_order = memory_order::seq_cst) const noexcept;
+    constexpr bool compare_exchange_strong(value_type&, value_type,
+                                           memory_order = memory_order::seq_cst) const noexcept;
 
-    value_type fetch_add(difference_type, memory_order = memory_order::seq_cst) const noexcept;
-    value_type fetch_sub(difference_type, memory_order = memory_order::seq_cst) const noexcept;
-    value_type fetch_max(value_type, memory_order = memory_order::seq_cst) const noexcept;
-    value_type fetch_min(value_type, memory_order = memory_order::seq_cst) const noexcept;
+    constexpr value_type fetch_add(difference_type,
+                                   memory_order = memory_order::seq_cst) const noexcept;
+    constexpr value_type fetch_sub(difference_type,
+                                   memory_order = memory_order::seq_cst) const noexcept;
+    constexpr value_type fetch_max(value_type,
+                                   memory_order = memory_order::seq_cst) const noexcept;
+    constexpr value_type fetch_min(value_type,
+                                   memory_order = memory_order::seq_cst) const noexcept;
 
-    value_type operator++(int) const noexcept;
-    value_type operator--(int) const noexcept;
-    value_type operator++() const noexcept;
-    value_type operator--() const noexcept;
-    value_type operator+=(difference_type) const noexcept;
-    value_type operator-=(difference_type) const noexcept;
+    constexpr value_type operator++(int) const noexcept;
+    constexpr value_type operator--(int) const noexcept;
+    constexpr value_type operator++() const noexcept;
+    constexpr value_type operator--() const noexcept;
+    constexpr value_type operator+=(difference_type) const noexcept;
+    constexpr value_type operator-=(difference_type) const noexcept;
 
-    void wait(value_type, memory_order = memory_order::seq_cst) const noexcept;
-    void notify_one() const noexcept;
-    void notify_all() const noexcept;
+    constexpr void wait(value_type, memory_order = memory_order::seq_cst) const noexcept;
+    constexpr void notify_one() const noexcept;
+    constexpr void notify_all() const noexcept;
     constexpr @\placeholder{pointer-type}@* address() const noexcept;
   };
 }
@@ -3948,7 +3980,7 @@ in \tref{atomic.types.pointer.comp}.
 \indexlibrarymember{fetch_max}{atomic_ref<T*>}%
 \indexlibrarymember{fetch_min}{atomic_ref<T*>}%
 \begin{itemdecl}
-value_type fetch_@\placeholdernc{key}@(difference_type operand,
+constexpr value_type fetch_@\placeholdernc{key}@(difference_type operand,
                      memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
@@ -3995,7 +4027,7 @@ the \tcode{<} operator does not establish a strict weak ordering
 \indexlibrarymember{operator+=}{atomic_ref<T*>}%
 \indexlibrarymember{operator-=}{atomic_ref<T*>}%
 \begin{itemdecl}
-value_type operator @\placeholder{op}@=(difference_type operand) const noexcept;
+constexpr value_type operator @\placeholder{op}@=(difference_type operand) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4023,7 +4055,7 @@ for the specializations in \ref{atomics.ref.int}.
 \indexlibrarymember{operator++}{atomic_ref<T*>}%
 \indexlibrarymember{operator++}{atomic_ref<\placeholder{integral-type}>}%
 \begin{itemdecl}
-value_type operator++(int) const noexcept;
+constexpr value_type operator++(int) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4039,7 +4071,7 @@ Equivalent to: \tcode{return fetch_add(1);}
 \indexlibrarymember{operator--}{atomic_ref<T*>}%
 \indexlibrarymember{operator--}{atomic_ref<\placeholder{integral-type}>}%
 \begin{itemdecl}
-value_type operator--(int) const noexcept;
+constexpr value_type operator--(int) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4055,7 +4087,7 @@ Equivalent to: \tcode{return fetch_sub(1);}
 \indexlibrarymember{operator++}{atomic_ref<T*>}%
 \indexlibrarymember{operator++}{atomic_ref<\placeholder{integral-type}>}%
 \begin{itemdecl}
-value_type operator++() const noexcept;
+constexpr value_type operator++() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4071,7 +4103,7 @@ Equivalent to: \tcode{return fetch_add(1) + 1;}
 \indexlibrarymember{operator--}{atomic_ref<T*>}%
 \indexlibrarymember{operator--}{atomic_ref<\placeholder{integral-type}>}%
 \begin{itemdecl}
-value_type operator--() const noexcept;
+constexpr value_type operator--() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4107,31 +4139,31 @@ namespace std {
     atomic& operator=(const atomic&) volatile = delete;
 
     T load(memory_order = memory_order::seq_cst) const volatile noexcept;
-    T load(memory_order = memory_order::seq_cst) const noexcept;
+    constexpr T load(memory_order = memory_order::seq_cst) const noexcept;
     operator T() const volatile noexcept;
-    operator T() const noexcept;
+    constexpr operator T() const noexcept;
     void store(T, memory_order = memory_order::seq_cst) volatile noexcept;
-    void store(T, memory_order = memory_order::seq_cst) noexcept;
+    constexpr void store(T, memory_order = memory_order::seq_cst) noexcept;
     T operator=(T) volatile noexcept;
-    T operator=(T) noexcept;
+    constexpr T operator=(T) noexcept;
 
     T exchange(T, memory_order = memory_order::seq_cst) volatile noexcept;
-    T exchange(T, memory_order = memory_order::seq_cst) noexcept;
+    constexpr T exchange(T, memory_order = memory_order::seq_cst) noexcept;
     bool compare_exchange_weak(T&, T, memory_order, memory_order) volatile noexcept;
-    bool compare_exchange_weak(T&, T, memory_order, memory_order) noexcept;
+    constexpr bool compare_exchange_weak(T&, T, memory_order, memory_order) noexcept;
     bool compare_exchange_strong(T&, T, memory_order, memory_order) volatile noexcept;
-    bool compare_exchange_strong(T&, T, memory_order, memory_order) noexcept;
+    constexpr bool compare_exchange_strong(T&, T, memory_order, memory_order) noexcept;
     bool compare_exchange_weak(T&, T, memory_order = memory_order::seq_cst) volatile noexcept;
-    bool compare_exchange_weak(T&, T, memory_order = memory_order::seq_cst) noexcept;
+    constexpr bool compare_exchange_weak(T&, T, memory_order = memory_order::seq_cst) noexcept;
     bool compare_exchange_strong(T&, T, memory_order = memory_order::seq_cst) volatile noexcept;
-    bool compare_exchange_strong(T&, T, memory_order = memory_order::seq_cst) noexcept;
+    constexpr bool compare_exchange_strong(T&, T, memory_order = memory_order::seq_cst) noexcept;
 
     void wait(T, memory_order = memory_order::seq_cst) const volatile noexcept;
-    void wait(T, memory_order = memory_order::seq_cst) const noexcept;
+    constexpr void wait(T, memory_order = memory_order::seq_cst) const noexcept;
     void notify_one() volatile noexcept;
-    void notify_one() noexcept;
+    constexpr void notify_one() noexcept;
     void notify_all() volatile noexcept;
-    void notify_all() noexcept;
+    constexpr void notify_all() noexcept;
   };
 }
 \end{codeblock}
@@ -4260,7 +4292,7 @@ is consistent with the value of \tcode{is_always_lock_free} for the same type.
 \indexlibrarymember{store}{atomic<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
 void store(T desired, memory_order order = memory_order::seq_cst) volatile noexcept;
-void store(T desired, memory_order order = memory_order::seq_cst) noexcept;
+constexpr void store(T desired, memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4289,7 +4321,7 @@ with the value of \tcode{desired}. Memory is affected according to the value of
 \indexlibrarymember{operator=}{atomic<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
 T operator=(T desired) volatile noexcept;
-T operator=(T desired) noexcept;
+constexpr T operator=(T desired) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4315,7 +4347,7 @@ Equivalent to \tcode{store(desired)}.
 \indexlibrarymember{load}{atomic<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
 T load(memory_order order = memory_order::seq_cst) const volatile noexcept;
-T load(memory_order order = memory_order::seq_cst) const noexcept;
+constexpr T load(memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4347,7 +4379,7 @@ Atomically returns the value pointed to by \keyword{this}.
 \indexlibrarymember{operator \placeholder{floating-point-type}}{atomic<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
 operator T() const volatile noexcept;
-operator T() const noexcept;
+constexpr operator T() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4370,7 +4402,7 @@ Equivalent to: \tcode{return load();}
 \indexlibrarymember{exchange}{atomic<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
 T exchange(T desired, memory_order order = memory_order::seq_cst) volatile noexcept;
-T exchange(T desired, memory_order order = memory_order::seq_cst) noexcept;
+constexpr T exchange(T desired, memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4406,19 +4438,19 @@ Atomically returns the value pointed to by \keyword{this} immediately before the
 \begin{itemdecl}
 bool compare_exchange_weak(T& expected, T desired,
                            memory_order success, memory_order failure) volatile noexcept;
-bool compare_exchange_weak(T& expected, T desired,
+constexpr bool compare_exchange_weak(T& expected, T desired,
                            memory_order success, memory_order failure) noexcept;
 bool compare_exchange_strong(T& expected, T desired,
                              memory_order success, memory_order failure) volatile noexcept;
-bool compare_exchange_strong(T& expected, T desired,
+constexpr bool compare_exchange_strong(T& expected, T desired,
                              memory_order success, memory_order failure) noexcept;
 bool compare_exchange_weak(T& expected, T desired,
                            memory_order order = memory_order::seq_cst) volatile noexcept;
-bool compare_exchange_weak(T& expected, T desired,
+constexpr bool compare_exchange_weak(T& expected, T desired,
                            memory_order order = memory_order::seq_cst) noexcept;
 bool compare_exchange_strong(T& expected, T desired,
                              memory_order order = memory_order::seq_cst) volatile noexcept;
-bool compare_exchange_strong(T& expected, T desired,
+constexpr bool compare_exchange_strong(T& expected, T desired,
                              memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
@@ -4579,7 +4611,7 @@ bool party(pony desired) {
 \indexlibrarymember{wait}{atomic<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
 void wait(T old, memory_order order = memory_order::seq_cst) const volatile noexcept;
-void wait(T old, memory_order order = memory_order::seq_cst) const noexcept;
+constexpr void wait(T old, memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4616,7 +4648,7 @@ This function is an atomic waiting operation\iref{atomics.wait}.
 \indexlibrarymember{notify_one}{atomic<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
 void notify_one() volatile noexcept;
-void notify_one() noexcept;
+constexpr void notify_one() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4637,7 +4669,7 @@ This function is an atomic notifying operation\iref{atomics.wait}.
 \indexlibrarymember{notify_all}{atomic<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
 void notify_all() volatile noexcept;
-void notify_all() noexcept;
+constexpr void notify_all() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4697,89 +4729,89 @@ namespace std {
     atomic& operator=(const atomic&) volatile = delete;
 
     void store(@\placeholdernc{integral-type}@, memory_order = memory_order::seq_cst) volatile noexcept;
-    void store(@\placeholdernc{integral-type}@, memory_order = memory_order::seq_cst) noexcept;
+    constexpr void store(@\placeholdernc{integral-type}@, memory_order = memory_order::seq_cst) noexcept;
     @\placeholdernc{integral-type}@ operator=(@\placeholdernc{integral-type}@) volatile noexcept;
-    @\placeholdernc{integral-type}@ operator=(@\placeholdernc{integral-type}@) noexcept;
+    constexpr @\placeholdernc{integral-type}@ operator=(@\placeholdernc{integral-type}@) noexcept;
     @\placeholdernc{integral-type}@ load(memory_order = memory_order::seq_cst) const volatile noexcept;
-    @\placeholdernc{integral-type}@ load(memory_order = memory_order::seq_cst) const noexcept;
+    constexpr @\placeholdernc{integral-type}@ load(memory_order = memory_order::seq_cst) const noexcept;
     operator @\placeholdernc{integral-type}@() const volatile noexcept;
-    operator @\placeholdernc{integral-type}@() const noexcept;
+    constexpr operator @\placeholdernc{integral-type}@() const noexcept;
 
     @\placeholdernc{integral-type}@ exchange(@\placeholdernc{integral-type}@,
                            memory_order = memory_order::seq_cst) volatile noexcept;
-    @\placeholdernc{integral-type}@ exchange(@\placeholdernc{integral-type}@,
+    constexpr @\placeholdernc{integral-type}@ exchange(@\placeholdernc{integral-type}@,
                            memory_order = memory_order::seq_cst) noexcept;
     bool compare_exchange_weak(@\placeholder{integral-type}@&, @\placeholdernc{integral-type}@,
                                memory_order, memory_order) volatile noexcept;
-    bool compare_exchange_weak(@\placeholder{integral-type}@&, @\placeholdernc{integral-type}@,
+    constexpr bool compare_exchange_weak(@\placeholder{integral-type}@&, @\placeholdernc{integral-type}@,
                                memory_order, memory_order) noexcept;
     bool compare_exchange_strong(@\placeholder{integral-type}@&, @\placeholdernc{integral-type}@,
                                  memory_order, memory_order) volatile noexcept;
-    bool compare_exchange_strong(@\placeholder{integral-type}@&, @\placeholdernc{integral-type}@,
+    constexpr bool compare_exchange_strong(@\placeholder{integral-type}@&, @\placeholdernc{integral-type}@,
                                  memory_order, memory_order) noexcept;
     bool compare_exchange_weak(@\placeholder{integral-type}@&, @\placeholdernc{integral-type}@,
                                memory_order = memory_order::seq_cst) volatile noexcept;
-    bool compare_exchange_weak(@\placeholder{integral-type}@&, @\placeholdernc{integral-type}@,
+    constexpr bool compare_exchange_weak(@\placeholder{integral-type}@&, @\placeholdernc{integral-type}@,
                                memory_order = memory_order::seq_cst) noexcept;
     bool compare_exchange_strong(@\placeholder{integral-type}@&, @\placeholdernc{integral-type}@,
                                  memory_order = memory_order::seq_cst) volatile noexcept;
-    bool compare_exchange_strong(@\placeholder{integral-type}@&, @\placeholdernc{integral-type}@,
+    constexpr bool compare_exchange_strong(@\placeholder{integral-type}@&, @\placeholdernc{integral-type}@,
                                  memory_order = memory_order::seq_cst) noexcept;
 
     @\placeholdernc{integral-type}@ fetch_add(@\placeholdernc{integral-type}@,
                             memory_order = memory_order::seq_cst) volatile noexcept;
-    @\placeholdernc{integral-type}@ fetch_add(@\placeholdernc{integral-type}@,
+    constexpr @\placeholdernc{integral-type}@ fetch_add(@\placeholdernc{integral-type}@,
                             memory_order = memory_order::seq_cst) noexcept;
     @\placeholdernc{integral-type}@ fetch_sub(@\placeholdernc{integral-type}@,
                             memory_order = memory_order::seq_cst) volatile noexcept;
-    @\placeholdernc{integral-type}@ fetch_sub(@\placeholdernc{integral-type}@,
+    constexpr @\placeholdernc{integral-type}@ fetch_sub(@\placeholdernc{integral-type}@,
                             memory_order = memory_order::seq_cst) noexcept;
     @\placeholdernc{integral-type}@ fetch_and(@\placeholdernc{integral-type}@,
                             memory_order = memory_order::seq_cst) volatile noexcept;
-    @\placeholdernc{integral-type}@ fetch_and(@\placeholdernc{integral-type}@,
+    constexpr @\placeholdernc{integral-type}@ fetch_and(@\placeholdernc{integral-type}@,
                             memory_order = memory_order::seq_cst) noexcept;
     @\placeholdernc{integral-type}@ fetch_or(@\placeholdernc{integral-type}@,
                             memory_order = memory_order::seq_cst) volatile noexcept;
-    @\placeholdernc{integral-type}@ fetch_or(@\placeholdernc{integral-type}@,
+    constexpr @\placeholdernc{integral-type}@ fetch_or(@\placeholdernc{integral-type}@,
                             memory_order = memory_order::seq_cst) noexcept;
     @\placeholdernc{integral-type}@ fetch_xor(@\placeholdernc{integral-type}@,
                             memory_order = memory_order::seq_cst) volatile noexcept;
-    @\placeholdernc{integral-type}@ fetch_xor(@\placeholdernc{integral-type}@,
+    constexpr @\placeholdernc{integral-type}@ fetch_xor(@\placeholdernc{integral-type}@,
                             memory_order = memory_order::seq_cst) noexcept;
     @\placeholdernc{integral-type}@ fetch_max( @\placeholdernc{integral-type}@,
                             memory_order = memory_order::seq_cst) volatile noexcept;
-    @\placeholdernc{integral-type}@ fetch_max( @\placeholdernc{integral-type}@,
+    constexpr @\placeholdernc{integral-type}@ fetch_max( @\placeholdernc{integral-type}@,
                             memory_order = memory_order::seq_cst) noexcept;
     @\placeholdernc{integral-type}@ fetch_min( @\placeholdernc{integral-type}@,
                             memory_order = memory_order::seq_cst) volatile noexcept;
-    @\placeholdernc{integral-type}@ fetch_min( @\placeholdernc{integral-type}@,
+    constexpr @\placeholdernc{integral-type}@ fetch_min( @\placeholdernc{integral-type}@,
                             memory_order = memory_order::seq_cst) noexcept;
 
     @\placeholdernc{integral-type}@ operator++(int) volatile noexcept;
-    @\placeholdernc{integral-type}@ operator++(int) noexcept;
+    constexpr @\placeholdernc{integral-type}@ operator++(int) noexcept;
     @\placeholdernc{integral-type}@ operator--(int) volatile noexcept;
-    @\placeholdernc{integral-type}@ operator--(int) noexcept;
+    constexpr @\placeholdernc{integral-type}@ operator--(int) noexcept;
     @\placeholdernc{integral-type}@ operator++() volatile noexcept;
-    @\placeholdernc{integral-type}@ operator++() noexcept;
+    constexpr @\placeholdernc{integral-type}@ operator++() noexcept;
     @\placeholdernc{integral-type}@ operator--() volatile noexcept;
-    @\placeholdernc{integral-type}@ operator--() noexcept;
+    constexpr @\placeholdernc{integral-type}@ operator--() noexcept;
     @\placeholdernc{integral-type}@ operator+=(@\placeholdernc{integral-type}@) volatile noexcept;
-    @\placeholdernc{integral-type}@ operator+=(@\placeholdernc{integral-type}@) noexcept;
+    constexpr @\placeholdernc{integral-type}@ operator+=(@\placeholdernc{integral-type}@) noexcept;
     @\placeholdernc{integral-type}@ operator-=(@\placeholdernc{integral-type}@) volatile noexcept;
-    @\placeholdernc{integral-type}@ operator-=(@\placeholdernc{integral-type}@) noexcept;
+    constexpr @\placeholdernc{integral-type}@ operator-=(@\placeholdernc{integral-type}@) noexcept;
     @\placeholdernc{integral-type}@ operator&=(@\placeholdernc{integral-type}@) volatile noexcept;
-    @\placeholdernc{integral-type}@ operator&=(@\placeholdernc{integral-type}@) noexcept;
+    constexpr @\placeholdernc{integral-type}@ operator&=(@\placeholdernc{integral-type}@) noexcept;
     @\placeholdernc{integral-type}@ operator|=(@\placeholdernc{integral-type}@) volatile noexcept;
-    @\placeholdernc{integral-type}@ operator|=(@\placeholdernc{integral-type}@) noexcept;
+    constexpr @\placeholdernc{integral-type}@ operator|=(@\placeholdernc{integral-type}@) noexcept;
     @\placeholdernc{integral-type}@ operator^=(@\placeholdernc{integral-type}@) volatile noexcept;
-    @\placeholdernc{integral-type}@ operator^=(@\placeholdernc{integral-type}@) noexcept;
+    constexpr @\placeholdernc{integral-type}@ operator^=(@\placeholdernc{integral-type}@) noexcept;
 
     void wait(@\placeholdernc{integral-type}@, memory_order = memory_order::seq_cst) const volatile noexcept;
-    void wait(@\placeholdernc{integral-type}@, memory_order = memory_order::seq_cst) const noexcept;
+    constexpr void wait(@\placeholdernc{integral-type}@, memory_order = memory_order::seq_cst) const noexcept;
     void notify_one() volatile noexcept;
-    void notify_one() noexcept;
+    constexpr void notify_one() noexcept;
     void notify_all() volatile noexcept;
-    void notify_all() noexcept;
+    constexpr void notify_all() noexcept;
   };
 }
 \end{codeblock}
@@ -4853,7 +4885,7 @@ in \tref{atomic.types.int.comp}.
 \indexlibrarymember{fetch_xor}{atomic<\placeholder{integral-type}>}%
 \begin{itemdecl}
 T fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order::seq_cst) volatile noexcept;
-T fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order::seq_cst) noexcept;
+constexpr T fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4902,7 +4934,7 @@ as the arguments.
 \indexlibrarymember{operator\caret=}{atomic<\placeholder{integral-type}>}%
 \begin{itemdecl}
 T operator @\placeholder{op}@=(T operand) volatile noexcept;
-T operator @\placeholder{op}@=(T operand) noexcept;
+constexpr T operator @\placeholder{op}@=(T operand) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4943,55 +4975,56 @@ namespace std {
     atomic& operator=(const atomic&) volatile = delete;
 
     void store(@\placeholdernc{floating-point-type}@, memory_order = memory_order::seq_cst) volatile noexcept;
-    void store(@\placeholdernc{floating-point-type}@, memory_order = memory_order::seq_cst) noexcept;
+    constexpr void store(@\placeholdernc{floating-point-type}@, memory_order = memory_order::seq_cst) noexcept;
     @\placeholdernc{floating-point-type}@ operator=(@\placeholder{floating-point-type}@) volatile noexcept;
-    @\placeholdernc{floating-point-type}@ operator=(@\placeholder{floating-point-type}@) noexcept;
+    constexpr @\placeholdernc{floating-point-type}@ operator=(@\placeholder{floating-point-type}@) noexcept;
     @\placeholdernc{floating-point-type}@ load(memory_order = memory_order::seq_cst) volatile noexcept;
-    @\placeholdernc{floating-point-type}@ load(memory_order = memory_order::seq_cst) noexcept;
+    constexpr @\placeholdernc{floating-point-type}@ load(memory_order = memory_order::seq_cst) noexcept;
     operator @\placeholdernc{floating-point-type}@() volatile noexcept;
-    operator @\placeholdernc{floating-point-type}@() noexcept;
+    constexpr operator @\placeholdernc{floating-point-type}@() noexcept;
 
     @\placeholdernc{floating-point-type}@ exchange(@\placeholdernc{floating-point-type}@,
                                  memory_order = memory_order::seq_cst) volatile noexcept;
-    @\placeholdernc{floating-point-type}@ exchange(@\placeholdernc{floating-point-type}@,
+    constexpr @\placeholdernc{floating-point-type}@ exchange(@\placeholdernc{floating-point-type}@,
                                  memory_order = memory_order::seq_cst) noexcept;
     bool compare_exchange_weak(@\placeholder{floating-point-type}@&, @\placeholdernc{floating-point-type}@,
                                memory_order, memory_order) volatile noexcept;
-    bool compare_exchange_weak(@\placeholder{floating-point-type}@&, @\placeholdernc{floating-point-type}@,
+    constexpr bool compare_exchange_weak(@\placeholder{floating-point-type}@&, @\placeholdernc{floating-point-type}@,
                                memory_order, memory_order) noexcept;
     bool compare_exchange_strong(@\placeholder{floating-point-type}@&, @\placeholdernc{floating-point-type}@,
                                  memory_order, memory_order) volatile noexcept;
-    bool compare_exchange_strong(@\placeholder{floating-point-type}@&, @\placeholdernc{floating-point-type}@,
+    constexpr bool compare_exchange_strong(@\placeholder{floating-point-type}@&, @\placeholdernc{floating-point-type}@,
                                  memory_order, memory_order) noexcept;
     bool compare_exchange_weak(@\placeholder{floating-point-type}@&, @\placeholdernc{floating-point-type}@,
                                memory_order = memory_order::seq_cst) volatile noexcept;
-    bool compare_exchange_weak(@\placeholder{floating-point-type}@&, @\placeholdernc{floating-point-type}@,
+    constexpr bool compare_exchange_weak(@\placeholder{floating-point-type}@&, @\placeholdernc{floating-point-type}@,
                                memory_order = memory_order::seq_cst) noexcept;
     bool compare_exchange_strong(@\placeholder{floating-point-type}@&, @\placeholdernc{floating-point-type}@,
                                  memory_order = memory_order::seq_cst) volatile noexcept;
-    bool compare_exchange_strong(@\placeholder{floating-point-type}@&, @\placeholdernc{floating-point-type}@,
+    constexpr bool compare_exchange_strong(@\placeholder{floating-point-type}@&, @\placeholdernc{floating-point-type}@,
                                  memory_order = memory_order::seq_cst) noexcept;
 
     @\placeholdernc{floating-point-type}@ fetch_add(@\placeholdernc{floating-point-type}@,
                                   memory_order = memory_order::seq_cst) volatile noexcept;
-    @\placeholdernc{floating-point-type}@ fetch_add(@\placeholdernc{floating-point-type}@,
+    constexpr @\placeholdernc{floating-point-type}@ fetch_add(@\placeholdernc{floating-point-type}@,
                                   memory_order = memory_order::seq_cst) noexcept;
     @\placeholdernc{floating-point-type}@ fetch_sub(@\placeholdernc{floating-point-type}@,
                                   memory_order = memory_order::seq_cst) volatile noexcept;
-    @\placeholdernc{floating-point-type}@ fetch_sub(@\placeholdernc{floating-point-type}@,
+    constexpr @\placeholdernc{floating-point-type}@ fetch_sub(@\placeholdernc{floating-point-type}@,
                                   memory_order = memory_order::seq_cst) noexcept;
 
     @\placeholdernc{floating-point-type}@ operator+=(@\placeholder{floating-point-type}@) volatile noexcept;
-    @\placeholdernc{floating-point-type}@ operator+=(@\placeholder{floating-point-type}@) noexcept;
+    constexpr @\placeholdernc{floating-point-type}@ operator+=(@\placeholder{floating-point-type}@) noexcept;
     @\placeholdernc{floating-point-type}@ operator-=(@\placeholder{floating-point-type}@) volatile noexcept;
-    @\placeholdernc{floating-point-type}@ operator-=(@\placeholder{floating-point-type}@) noexcept;
+    constexpr @\placeholdernc{floating-point-type}@ operator-=(@\placeholder{floating-point-type}@) noexcept;
 
     void wait(@\placeholdernc{floating-point-type}@, memory_order = memory_order::seq_cst) const volatile noexcept;
-    void wait(@\placeholdernc{floating-point-type}@, memory_order = memory_order::seq_cst) const noexcept;
+    constexpr void wait(@\placeholdernc{floating-point-type}@,
+                        memory_order = memory_order::seq_cst) const noexcept;
     void notify_one() volatile noexcept;
-    void notify_one() noexcept;
+    constexpr void notify_one() noexcept;
     void notify_all() volatile noexcept;
-    void notify_all() noexcept;
+    constexpr void notify_all() noexcept;
   };
 }
 \end{codeblock}
@@ -5018,7 +5051,7 @@ in \tref{atomic.types.int.comp}.
 \indexlibrarymember{fetch_sub}{atomic<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
 T fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order::seq_cst) volatile noexcept;
-T fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order::seq_cst) noexcept;
+constexpr T fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5057,7 +5090,7 @@ calling thread's floating-point environment.
 \indexlibrarymember{operator-=}{atomic<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
 T operator @\placeholder{op}@=(T operand) volatile noexcept;
-T operator @\placeholder{op}@=(T operand) noexcept;
+constexpr T operator @\placeholder{op}@=(T operand) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5102,57 +5135,57 @@ namespace std {
     atomic& operator=(const atomic&) volatile = delete;
 
     void store(T*, memory_order = memory_order::seq_cst) volatile noexcept;
-    void store(T*, memory_order = memory_order::seq_cst) noexcept;
+    constexpr void store(T*, memory_order = memory_order::seq_cst) noexcept;
     T* operator=(T*) volatile noexcept;
-    T* operator=(T*) noexcept;
+    constexpr T* operator=(T*) noexcept;
     T* load(memory_order = memory_order::seq_cst) const volatile noexcept;
-    T* load(memory_order = memory_order::seq_cst) const noexcept;
+    constexpr T* load(memory_order = memory_order::seq_cst) const noexcept;
     operator T*() const volatile noexcept;
-    operator T*() const noexcept;
+    constexpr operator T*() const noexcept;
 
     T* exchange(T*, memory_order = memory_order::seq_cst) volatile noexcept;
-    T* exchange(T*, memory_order = memory_order::seq_cst) noexcept;
+    constexpr T* exchange(T*, memory_order = memory_order::seq_cst) noexcept;
     bool compare_exchange_weak(T*&, T*, memory_order, memory_order) volatile noexcept;
-    bool compare_exchange_weak(T*&, T*, memory_order, memory_order) noexcept;
+    constexpr bool compare_exchange_weak(T*&, T*, memory_order, memory_order) noexcept;
     bool compare_exchange_strong(T*&, T*, memory_order, memory_order) volatile noexcept;
-    bool compare_exchange_strong(T*&, T*, memory_order, memory_order) noexcept;
+    constexpr bool compare_exchange_strong(T*&, T*, memory_order, memory_order) noexcept;
     bool compare_exchange_weak(T*&, T*,
                                memory_order = memory_order::seq_cst) volatile noexcept;
-    bool compare_exchange_weak(T*&, T*,
+    constexpr bool compare_exchange_weak(T*&, T*,
                                memory_order = memory_order::seq_cst) noexcept;
     bool compare_exchange_strong(T*&, T*,
                                  memory_order = memory_order::seq_cst) volatile noexcept;
-    bool compare_exchange_strong(T*&, T*,
+    constexpr bool compare_exchange_strong(T*&, T*,
                                  memory_order = memory_order::seq_cst) noexcept;
 
     T* fetch_add(ptrdiff_t, memory_order = memory_order::seq_cst) volatile noexcept;
-    T* fetch_add(ptrdiff_t, memory_order = memory_order::seq_cst) noexcept;
+    constexpr T* fetch_add(ptrdiff_t, memory_order = memory_order::seq_cst) noexcept;
     T* fetch_sub(ptrdiff_t, memory_order = memory_order::seq_cst) volatile noexcept;
-    T* fetch_sub(ptrdiff_t, memory_order = memory_order::seq_cst) noexcept;
+    constexpr T* fetch_sub(ptrdiff_t, memory_order = memory_order::seq_cst) noexcept;
     T* fetch_max(T*, memory_order = memory_order::seq_cst) volatile noexcept;
-    T* fetch_max(T*, memory_order = memory_order::seq_cst) noexcept;
+    constexpr T* fetch_max(T*, memory_order = memory_order::seq_cst) noexcept;
     T* fetch_min(T*, memory_order = memory_order::seq_cst) volatile noexcept;
-    T* fetch_min(T*, memory_order = memory_order::seq_cst) noexcept;
+    constexpr T* fetch_min(T*, memory_order = memory_order::seq_cst) noexcept;
 
     T* operator++(int) volatile noexcept;
-    T* operator++(int) noexcept;
+    constexpr T* operator++(int) noexcept;
     T* operator--(int) volatile noexcept;
-    T* operator--(int) noexcept;
+    constexpr T* operator--(int) noexcept;
     T* operator++() volatile noexcept;
-    T* operator++() noexcept;
+    constexpr T* operator++() noexcept;
     T* operator--() volatile noexcept;
-    T* operator--() noexcept;
+    constexpr T* operator--() noexcept;
     T* operator+=(ptrdiff_t) volatile noexcept;
-    T* operator+=(ptrdiff_t) noexcept;
+    constexpr T* operator+=(ptrdiff_t) noexcept;
     T* operator-=(ptrdiff_t) volatile noexcept;
-    T* operator-=(ptrdiff_t) noexcept;
+    constexpr T* operator-=(ptrdiff_t) noexcept;
 
     void wait(T*, memory_order = memory_order::seq_cst) const volatile noexcept;
-    void wait(T*, memory_order = memory_order::seq_cst) const noexcept;
+    constexpr void wait(T*, memory_order = memory_order::seq_cst) const noexcept;
     void notify_one() volatile noexcept;
-    void notify_one() noexcept;
+    constexpr void notify_one() noexcept;
     void notify_all() volatile noexcept;
-    void notify_all() noexcept;
+    constexpr void notify_all() noexcept;
   };
 }
 \end{codeblock}
@@ -5208,7 +5241,7 @@ in \tref{atomic.types.pointer.comp}.
 \indexlibrarymember{fetch_sub}{atomic<T*>}%
 \begin{itemdecl}
 T* fetch_@\placeholdernc{key}@(ptrdiff_t operand, memory_order order = memory_order::seq_cst) volatile noexcept;
-T* fetch_@\placeholdernc{key}@(ptrdiff_t operand, memory_order order = memory_order::seq_cst) noexcept;
+constexpr T* fetch_@\placeholdernc{key}@(ptrdiff_t operand, memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5258,7 +5291,7 @@ the \tcode{<} operator does not establish a strict weak ordering
 \indexlibrarymember{operator-=}{atomic<T*>}%
 \begin{itemdecl}
 T* operator @\placeholder{op}@=(ptrdiff_t operand) volatile noexcept;
-T* operator @\placeholder{op}@=(ptrdiff_t operand) noexcept;
+constexpr T* operator @\placeholder{op}@=(ptrdiff_t operand) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5278,7 +5311,7 @@ Equivalent to: \tcode{return fetch_\placeholder{key}(operand) \placeholder{op} o
 \indexlibrarymember{operator++}{atomic<\placeholder{integral-type}>}%
 \begin{itemdecl}
 value_type operator++(int) volatile noexcept;
-value_type operator++(int) noexcept;
+constexpr value_type operator++(int) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5296,7 +5329,7 @@ Equivalent to: \tcode{return fetch_add(1);}
 \indexlibrarymember{operator--}{atomic<\placeholder{integral-type}>}%
 \begin{itemdecl}
 value_type operator--(int) volatile noexcept;
-value_type operator--(int) noexcept;
+constexpr value_type operator--(int) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5314,7 +5347,7 @@ Equivalent to: \tcode{return fetch_sub(1);}
 \indexlibrarymember{operator++}{atomic<\placeholder{integral-type}>}%
 \begin{itemdecl}
 value_type operator++() volatile noexcept;
-value_type operator++() noexcept;
+constexpr value_type operator++() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5332,7 +5365,7 @@ Equivalent to: \tcode{return fetch_add(1) + 1;}
 \indexlibrarymember{operator--}{atomic<\placeholder{integral-type}>}%
 \begin{itemdecl}
 value_type operator--() volatile noexcept;
-value_type operator--() noexcept;
+constexpr value_type operator--() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6085,18 +6118,18 @@ namespace std {
     atomic_flag& operator=(const atomic_flag&) volatile = delete;
 
     bool test(memory_order = memory_order::seq_cst) const volatile noexcept;
-    bool test(memory_order = memory_order::seq_cst) const noexcept;
+    constexpr bool test(memory_order = memory_order::seq_cst) const noexcept;
     bool test_and_set(memory_order = memory_order::seq_cst) volatile noexcept;
-    bool test_and_set(memory_order = memory_order::seq_cst) noexcept;
+    constexpr bool test_and_set(memory_order = memory_order::seq_cst) noexcept;
     void clear(memory_order = memory_order::seq_cst) volatile noexcept;
-    void clear(memory_order = memory_order::seq_cst) noexcept;
+    constexpr void clear(memory_order = memory_order::seq_cst) noexcept;
 
     void wait(bool, memory_order = memory_order::seq_cst) const volatile noexcept;
-    void wait(bool, memory_order = memory_order::seq_cst) const noexcept;
+    constexpr void wait(bool, memory_order = memory_order::seq_cst) const noexcept;
     void notify_one() volatile noexcept;
-    void notify_one() noexcept;
+    constexpr void notify_one() noexcept;
     void notify_all() volatile noexcept;
-    void notify_all() noexcept;
+    constexpr void notify_all() noexcept;
   };
 }
 \end{codeblock}
@@ -6128,13 +6161,13 @@ Initializes \tcode{*this} to the clear state.
 \indexlibrarymember{test}{atomic_flag}%
 \begin{itemdecl}
 bool atomic_flag_test(const volatile atomic_flag* object) noexcept;
-bool atomic_flag_test(const atomic_flag* object) noexcept;
+constexpr bool atomic_flag_test(const atomic_flag* object) noexcept;
 bool atomic_flag_test_explicit(const volatile atomic_flag* object,
                                memory_order order) noexcept;
-bool atomic_flag_test_explicit(const atomic_flag* object,
+constexpr bool atomic_flag_test_explicit(const atomic_flag* object,
                                memory_order order) noexcept;
 bool atomic_flag::test(memory_order order = memory_order::seq_cst) const volatile noexcept;
-bool atomic_flag::test(memory_order order = memory_order::seq_cst) const noexcept;
+constexpr bool atomic_flag::test(memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6163,11 +6196,11 @@ Atomically returns the value pointed to by \tcode{object} or \keyword{this}.
 \indexlibrarymember{test_and_set}{atomic_flag}%
 \begin{itemdecl}
 bool atomic_flag_test_and_set(volatile atomic_flag* object) noexcept;
-bool atomic_flag_test_and_set(atomic_flag* object) noexcept;
+constexpr bool atomic_flag_test_and_set(atomic_flag* object) noexcept;
 bool atomic_flag_test_and_set_explicit(volatile atomic_flag* object, memory_order order) noexcept;
-bool atomic_flag_test_and_set_explicit(atomic_flag* object, memory_order order) noexcept;
+constexpr bool atomic_flag_test_and_set_explicit(atomic_flag* object, memory_order order) noexcept;
 bool atomic_flag::test_and_set(memory_order order = memory_order::seq_cst) volatile noexcept;
-bool atomic_flag::test_and_set(memory_order order = memory_order::seq_cst) noexcept;
+constexpr bool atomic_flag::test_and_set(memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6186,11 +6219,11 @@ Atomically, the value of the object immediately before the effects.
 \indexlibrarymember{clear}{atomic_flag}%
 \begin{itemdecl}
 void atomic_flag_clear(volatile atomic_flag* object) noexcept;
-void atomic_flag_clear(atomic_flag* object) noexcept;
+constexpr void atomic_flag_clear(atomic_flag* object) noexcept;
 void atomic_flag_clear_explicit(volatile atomic_flag* object, memory_order order) noexcept;
-void atomic_flag_clear_explicit(atomic_flag* object, memory_order order) noexcept;
+constexpr void atomic_flag_clear_explicit(atomic_flag* object, memory_order order) noexcept;
 void atomic_flag::clear(memory_order order = memory_order::seq_cst) volatile noexcept;
-void atomic_flag::clear(memory_order order = memory_order::seq_cst) noexcept;
+constexpr void atomic_flag::clear(memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6212,14 +6245,14 @@ Atomically sets the value pointed to by \tcode{object} or by \keyword{this} to
 \indexlibrarymember{wait}{atomic_flag}%
 \begin{itemdecl}
 void atomic_flag_wait(const volatile atomic_flag* object, bool old) noexcept;
-void atomic_flag_wait(const atomic_flag* object, bool old) noexcept;
+constexpr void atomic_flag_wait(const atomic_flag* object, bool old) noexcept;
 void atomic_flag_wait_explicit(const volatile atomic_flag* object,
                                bool old, memory_order order) noexcept;
-void atomic_flag_wait_explicit(const atomic_flag* object,
+constexpr void atomic_flag_wait_explicit(const atomic_flag* object,
                                bool old, memory_order order) noexcept;
 void atomic_flag::wait(bool old, memory_order order =
                                    memory_order::seq_cst) const volatile noexcept;
-void atomic_flag::wait(bool old, memory_order order =
+constexpr void atomic_flag::wait(bool old, memory_order order =
                                    memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
@@ -6258,9 +6291,9 @@ This function is an atomic waiting operation\iref{atomics.wait}.
 
 \begin{itemdecl}
 void atomic_flag_notify_one(volatile atomic_flag* object) noexcept;
-void atomic_flag_notify_one(atomic_flag* object) noexcept;
+constexpr void atomic_flag_notify_one(atomic_flag* object) noexcept;
 void atomic_flag::notify_one() volatile noexcept;
-void atomic_flag::notify_one() noexcept;
+constexpr void atomic_flag::notify_one() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6277,9 +6310,9 @@ This function is an atomic notifying operation\iref{atomics.wait}.
 
 \begin{itemdecl}
 void atomic_flag_notify_all(volatile atomic_flag* object) noexcept;
-void atomic_flag_notify_all(atomic_flag* object) noexcept;
+constexpr void atomic_flag_notify_all(atomic_flag* object) noexcept;
 void atomic_flag::notify_all() volatile noexcept;
-void atomic_flag::notify_all() noexcept;
+constexpr void atomic_flag::notify_all() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6346,7 +6379,7 @@ release sequence headed by $A$.
 
 \indexlibraryglobal{atomic_thread_fence}%
 \begin{itemdecl}
-extern "C" void atomic_thread_fence(memory_order order) noexcept;
+extern "C" constexpr void atomic_thread_fence(memory_order order) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6368,7 +6401,7 @@ Depending on the value of \tcode{order}, this operation:
 
 \indexlibraryglobal{atomic_signal_fence}%
 \begin{itemdecl}
-extern "C" void atomic_signal_fence(memory_order order) noexcept;
+extern "C" constexpr void atomic_signal_fence(memory_order order) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Note: Based on the changes for motion 13 to avoid copious not-quite-conflicts.  Please rebase before applying!

Fixes #7428 
Also fixes cplusplus/papers#1960

