### PR TITLE
[iterator.requirements.general] Revert `indirectly_writable` to *writ…

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -539,7 +539,7 @@ called the
 \defn{value type}
 of the iterator.
 An output iterator \tcode{i} has a non-empty set of types that are
-\libconcept{indirectly_writable} to the iterator;
+\defn{writable} to the iterator;
 for each such type \tcode{T}, the expression \tcode{*i = o}
 is valid where \tcode{o} is a value of type \tcode{T}.
 For every iterator type


### PR DESCRIPTION
…able* definition

This fixes a misapplication of the 2019 Belfast meeting LWG motion 9 (P1878R1), which erroneously replaced the *writable* definition by the `indirectly_writable` concept (See issue #7470).

Fixes #7470