### PR TITLE
[except.spec] Remove misleading restriction in list of examples

### DIFF
--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -846,7 +846,7 @@ $E$ implicitly invokes a function
 (such as an overloaded operator,
 an allocation function in a \grammarterm{new-expression},
 a constructor for a function argument,
-or a destructor if $E$ is a full-expression\iref{intro.execution})
+or a destructor)
 that has a potentially-throwing exception specification,
 or
 \item


### PR DESCRIPTION
Fixes #7473