### PR TITLE
[range.sized] Add \libconcept for range

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1407,7 +1407,7 @@ have type \tcode{const bool}.
 
 \pnum
 \begin{note}
-\tcode{disable_sized_range} allows use of range types with the library
+\tcode{disable_sized_range} allows use of \libconcept{range} types with the library
 that satisfy but do not in fact model \libconcept{sized_range}.
 \end{note}
 \end{itemdescr}


### PR DESCRIPTION
This is consistent with "`range` type" elsewhere.