### PR TITLE
[sequence.reqmts] Remove unnecessary qualification of which new element

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1478,8 +1478,7 @@ before \tcode{p}.
 
 \pnum
 \returns
-An iterator that points to
-the new element constructed from \tcode{args} into \tcode{a}.
+An iterator that points to the new element.
 \end{itemdescr}
 
 \indexcont{insert}%


### PR DESCRIPTION
There is only one new element, and this avoids having to decide whether it should say `args...`.

LWG asked for the same change to be made in the `hive` paper which had copied this wording.