### PR TITLE
[locale.ctype.virtuals] Fix a decade-old typo

### DIFF
--- a/source/text.tex
+++ b/source/text.tex
@@ -1615,7 +1615,7 @@ The only characters for which unique transformations are required
 are those in the basic character set\iref{lex.charset}.
 
 For any named \tcode{ctype} category with
-a \tcode{ctype<charT>} facet \tcode{ctc} and
+a \tcode{ctype<char>} facet \tcode{ctc} and
 valid \tcode{ctype_base::mask} value \tcode{M},
 \tcode{(ctc.\brk{}is(M, c) || !is(M, do_widen(c)) )} is \tcode{true}.
 \begin{footnote}


### PR DESCRIPTION
This sentence comes from [LWG 379](https://cplusplus.github.io/LWG/issue379), but it seems that there's a mistake when applying the proposed resolution to the draft standard: the proposed resolution says "For any named ctype category with a ctype&lt;char> facet ctc", but the draft standard says "For any named ctype category with a ctype<char<ins>***T***</ins>> facet ctc".

