### PR TITLE
[cpp] Correctly identify preprocessor tokens vs, tokens

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -137,7 +137,7 @@
 A \defn{preprocessing directive} consists of a sequence of preprocessing tokens
 that satisfies the following constraints:
 At the start of translation phase 4,
-the first token in the sequence,
+the first preprocessing token in the sequence,
 referred to as a \defnadj{directive-introducing}{token},
 begins with the first character in the source file
 (optionally after whitespace containing no new-line characters) or
@@ -172,7 +172,7 @@ immediately followed on the same logical source line by
 one of the two preceding forms.
 \end{itemize}
 
-The last token in the sequence is the first token within the sequence that
+The last preprocessing token in the sequence is the first preprocessing token within the sequence that
 is immediately followed by whitespace containing a new-line character.
 \begin{footnote}
 Thus,
@@ -439,7 +439,7 @@ are replaced
 \tcode{defined}
 unary operator),
 just as in normal text.
-If the token
+If the preprocessing token
 \tcode{defined}
 is generated as a result of this replacement process
 or use of the
@@ -756,7 +756,7 @@ directives:
 \pnum
 A \grammarterm{pp-module} shall not
 appear in a context where \tcode{module}
-or (if it is the first token of the \grammarterm{pp-module}) \tcode{export}
+or (if it is the first preprocessing token of the \grammarterm{pp-module}) \tcode{export}
 is an identifier defined as an object-like macro.
 
 \pnum
@@ -817,7 +817,7 @@ so it is not removed at the end of phase 4.
 \pnum
 A \grammarterm{pp-import} shall not
 appear in a context where \tcode{import}
-or (if it is the first token of the \grammarterm{pp-import}) \tcode{export}
+or (if it is the first preprocessing token of the \grammarterm{pp-import}) \tcode{export}
 is an identifier defined as an object-like macro.
 
 \pnum
@@ -1202,7 +1202,7 @@ been identified, argument substitution takes place.
 For each parameter in the replacement list that is neither
 preceded by a \tcode{\#} or \tcode{\#\#} preprocessing token nor
 followed by a \tcode{\#\#} preprocessing token, the preprocessing tokens
-naming the parameter are replaced by a token sequence determined as follows:
+naming the parameter are replaced by a preprocessing token sequence determined as follows:
 \begin{itemize}
 \item
   If the parameter is of the form \grammarterm{va-opt-replacement},
@@ -1408,7 +1408,7 @@ a \grammarterm{universal-character-name}\iref{lex.charset}.
 \end{note}
 If the result is not a valid preprocessing token,
 the behavior is undefined.
-The resulting token is available for further macro replacement.
+The resulting preprocessing token is available for further macro replacement.
 The order of evaluation of
 \tcode{\#\#}
 operators is unspecified.
@@ -1451,7 +1451,7 @@ fputs("strncmp(@\textbackslash@"abc@\textbackslash\textbackslash@0d@\textbacksla
 "hello, world"
 \end{codeblock}
 
-Space around the \tcode{\#} and \tcode{\#\#} tokens in the macro definition
+Space around the \tcode{\#} and \tcode{\#\#} preprocessing tokens in the macro definition
 is optional.
 \end{example}
 
@@ -1477,8 +1477,8 @@ mkstr(x ## y)
 "x ## y"
 \end{codeblock}
 
-In other words, expanding \tcode{hash_hash} produces a new token,
-consisting of two adjacent sharp signs, but this new token is not the
+In other words, expanding \tcode{hash_hash} produces a new preprocessing token,
+consisting of two adjacent sharp signs, but this new preprocessing token is not the
 \tcode{\#\#} operator.
 \end{example}
 
@@ -1603,7 +1603,7 @@ The
 of the current source line is one greater than
 the number of new-line characters read or introduced
 in translation phase 1\iref{lex.phases}
-while processing the source file to the current token.
+while processing the source file to the current preprocessing token.
 
 \pnum
 A preprocessing directive of the form


### PR DESCRIPTION
Most references to tokens in [cpp] correctly refer to preprocessing tokens that a materially different thng to a regular token.  This commit addresses the last few places referring to a plain token where they should instead be referring to a preprocessing token. The remining usage of plain token where evaludating the predicate to  directives is intentional, and trying to change to a preproccessing token would be an actual error.