### PR TITLE
Consistent Function Label Naming for Sections

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4259,7 +4259,7 @@ namespace std {
 \indexheader{print}%
 \begin{codeblock}
 namespace std {
-  // \ref{print.fun}, print functions
+  // \ref{print.func}, print functions
   template<class... Args>
     void print(format_string<Args...> fmt, Args&&... args);
   template<class... Args>
@@ -7692,7 +7692,7 @@ The expression \tcode{out << quoted(s, delim, escape)} has type
 \end{itemize}
 \end{itemdescr}
 
-\rSec2[print.fun]{Print functions}
+\rSec2[print.func]{Print functions}
 
 \indexlibraryglobal{print}%
 \begin{itemdecl}


### PR DESCRIPTION
Make `[print.fun]` consistent with other label names.

🔗 https://isocpp.org/files/papers/D3539R1.pdf