### PR TITLE
P3222R0 Fix C++26 by adding transposed special cases for P2642 layouts

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -13127,7 +13127,7 @@ for some \tcode{size_t} value \tcode{PaddingValue};
 otherwise,
 \begin{codeblock}
 R(a.data_handle(), ReturnMapping(@\exposid{transpose-extents}@(a.mapping().extents()),
-  a.stride(0)), a.accessor())
+  a.mapping().stride(0)), a.accessor())
 \end{codeblock}
 if \tcode{Layout} is \tcode{layout_right_padded<PaddingValue>}
 for some \tcode{size_t} value \tcode{PaddingValue};

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -13066,6 +13066,14 @@ where \tcode{ReturnLayout} is:
 \item
 otherwise, \tcode{layout_left} if \tcode{Layout} is \tcode{layout_right};
 \item
+otherwise, \tcode{layout_right_padded<PaddingValue>} if \tcode{Layout} is\newline
+\tcode{layout_left_padded<PaddingValue>}
+for some \tcode{size_t} value \tcode{PaddingValue};
+\item
+otherwise, \tcode{layout_left_padded<PaddingValue>} if \tcode{Layout} is\newline
+\tcode{layout_right_padded<PaddingValue>}
+for some \tcode{size_t} value \tcode{PaddingValue};
+\item
 otherwise, \tcode{layout_stride} if \tcode{Layout} is \tcode{layout_stride};
 \item
 otherwise,
@@ -13108,11 +13116,26 @@ R(a.data_handle(), ReturnMapping(@\exposid{transpose-extents}@(a.mapping().exten
   a.accessor())
 \end{codeblock}
 \item
+otherwise,
+\begin{codeblock}
+R(a.data_handle(), ReturnMapping(@\exposid{transpose-extents}@(a.mapping().extents()),
+  a.mapping().stride(1)), a.accessor())
+\end{codeblock}
+if \tcode{Layout} is \tcode{layout_left_padded<PaddingValue>}
+for some \tcode{size_t} value \tcode{PaddingValue};
+\item
+otherwise,
+\begin{codeblock}
+R(a.data_handle(), ReturnMapping(@\exposid{transpose-extents}@(a.mapping().extents()),
+  a.stride(0)), a.accessor())
+\end{codeblock}
+if \tcode{Layout} is \tcode{layout_right_padded<PaddingValue>}
+for some \tcode{size_t} value \tcode{PaddingValue};
+\item
 otherwise, if \tcode{Layout} is \tcode{layout_stride},
 \begin{codeblock}
 R(a.data_handle(), ReturnMapping(@\exposid{transpose-extents}@(a.mapping().extents()),
-                                 array{a.mapping().stride(1), a.mapping().stride(0)}),
-  a.accessor())
+  array{a.mapping().stride(1), a.mapping().stride(0)}), a.accessor())
 \end{codeblock}
 \item
 otherwise, if \tcode{Layout} is a specialization of \tcode{layout_transpose},

--- a/source/support.tex
+++ b/source/support.tex
@@ -710,7 +710,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_jthread}@                           201911L // also in \libheader{stop_token}, \libheader{thread}
 #define @\defnlibxname{cpp_lib_latch}@                             201907L // also in \libheader{latch}
 #define @\defnlibxname{cpp_lib_launder}@                           201606L // freestanding, also in \libheader{new}
-#define @\defnlibxname{cpp_lib_linalg}@                            202311L // also in \libheader{linalg}
+#define @\defnlibxname{cpp_lib_linalg}@                            202411L // also in \libheader{linalg}
 #define @\defnlibxname{cpp_lib_list_remove_return_type}@           201806L // also in \libheader{forward_list}, \libheader{list}
 #define @\defnlibxname{cpp_lib_logical_traits}@                    201510L // freestanding, also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_make_from_tuple}@                   201606L // freestanding, also in \libheader{tuple}


### PR DESCRIPTION
Fixes https://github.com/cplusplus/papers/issues/1870.
Fixes #7421.