### PR TITLE
P3050R2 Fix C++26 by optimizing linalg::conjugated for noncomplex value types

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -12808,21 +12808,40 @@ constexpr typename offset_policy::data_handle_type offset(data_handle_type p, si
 \begin{itemdescr}
 \pnum
 Let \tcode{A} be
+\begin{itemize}
+\item
 \tcode{remove_cvref_t<decltype(a.accessor().nested_accessor())>}
-if \tcode{Accessor} is a specialization of \tcode{conjugated_accessor}, and
-otherwise \tcode{conjugated_accessor<Accessor>}.
+if \tcode{Accessor} is a specialization of \tcode{conjugated_accessor}; otherwise,
+\item
+\tcode{Accessor} if \tcode{remove_cvref_t<ElementType>} is an arithmetic type; otherwise,
+\item
+\tcode{Accessor} if the expression \tcode{conj(E)} is not valid for any subexpression \tcode{E}
+whose type \tcode{T} is expression-equivalent to \tcode{remove_cvref_t<ElementType>}
+with overload resolution performed in a context that includes the declaration
+\tcode{template<class T> conj(const T\&) = delete;}; and otherwise,
+\item
+\tcode{conjugated_accessor<Accessor>}.
+\end{itemize}
 
 \pnum
 \returns
 \begin{itemize}
 \item
-If \tcode{Accessor} is a specialization of \tcode{conjugated_accessor},
+The value
 \begin{codeblock}
 mdspan<typename A::element_type, Extents, Layout, A>(a.data_handle(), a.mapping(),
                                                      a.accessor().nested_accessor())
 \end{codeblock}
+if \tcode{Accessor} is a specialization of \tcode{conjugated_accessor}; otherwise,
 \item
-otherwise,
+\tcode{a} if \tcode{remove_cvref_t<ElementType>} is an arithmetic type; otherwise,
+\item
+\tcode{a} if the expression \tcode{conj(E)} is not valid for any subexpression \tcode{E}
+whose type \tcode{T} is expression-equivalent to \tcode{remove_cvref_t<ElementType>}
+with overload resolution performed in a context that includes the declaration
+\tcode{template<class T> conj(const T\&) = delete;}; and otherwise,
+\item
+the value
 \begin{codeblock}
 mdspan<typename A::element_type, Extents, Layout, A>(a.data_handle(), a.mapping(),
                                                      conjugated_accessor(a.accessor()))

--- a/source/support.tex
+++ b/source/support.tex
@@ -710,7 +710,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_jthread}@                           201911L // also in \libheader{stop_token}, \libheader{thread}
 #define @\defnlibxname{cpp_lib_latch}@                             201907L // also in \libheader{latch}
 #define @\defnlibxname{cpp_lib_launder}@                           201606L // freestanding, also in \libheader{new}
-#define @\defnlibxname{cpp_lib_linalg}@                            202411L // also in \libheader{linalg}
+#define @\defnlibxname{cpp_lib_linalg}@                            202412L // also in \libheader{linalg}
 #define @\defnlibxname{cpp_lib_list_remove_return_type}@           201806L // also in \libheader{forward_list}, \libheader{list}
 #define @\defnlibxname{cpp_lib_logical_traits}@                    201510L // freestanding, also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_make_from_tuple}@                   201606L // freestanding, also in \libheader{tuple}


### PR DESCRIPTION
Fixes https://github.com/cplusplus/papers/issues/1719.
Fixes #7422.