### PR TITLE
[linalg.helpers] Rename template parameter for poison pills

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -12240,7 +12240,7 @@ otherwise, \tcode{abs(E)},
 if that expression is valid,
 with overload resolution performed in a context that includes the declaration
 \begin{codeblock}
-template<class T> T abs(T) = delete;
+template<class U> U abs(U) = delete;
 \end{codeblock}
 If the function selected by overload resolution
 does not return the absolute value of its input,
@@ -12260,7 +12260,7 @@ if \tcode{T} is not an arithmetic type and
 the expression \tcode{conj(E)} is valid,
 with overload resolution performed in a context that includes the declaration
 \begin{codeblock}
-template<class T> T conj(const T&) = delete;
+template<class U> U conj(const U&) = delete;
 \end{codeblock}
 If the function selected by overload resolution
 does not return the complex conjugate of its input,
@@ -12282,7 +12282,7 @@ if \tcode{T} is not an arithmetic type and
 the expression \tcode{real(E)} is valid,
 with overload resolution performed in a context that includes the declaration
 \begin{codeblock}
-template<class T> T real(const T&) = delete;
+template<class U> U real(const U&) = delete;
 \end{codeblock}
 If the function selected by overload resolution
 does not return the real part of its input,
@@ -12304,7 +12304,7 @@ if \tcode{T} is not an arithmetic type and the expression \tcode{imag(E)}
 is valid, with overload resolution performed in a context
 that includes the declaration
 \begin{codeblock}
-template<class T> T imag(const T&) = delete;
+template<class U> U imag(const U&) = delete;
 \end{codeblock}
 If the function selected by overload resolution
 does not return the imaginary part of its input,


### PR DESCRIPTION
This avoids reusing `T` which is also used for the type of the subexpression E.

Fixes #7494