### PR TITLE
[headerindex] Add missing defining index entries for stdbit.h/stdckdint.h/stdbool.h.

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -6233,7 +6233,7 @@ void f(bool b[], size_t n);
 \libheader{stdbit.h} \\
 \libheader{stdbool.h} \\
 \columnbreak
-\libheader{stdckdint.h} \\
+\libheaderdef{stdckdint.h} \\
 \libheaderdef{stddef.h} \\
 \libheaderdef{stdint.h} \\
 \libheaderdef{stdio.h} \\
@@ -6301,7 +6301,7 @@ define a macro named \tcode{alignas}.
 \indexheader{stdbool.h}%
 \indexhdr{stdbool.h}%
 \pnum
-The contents of the \Cpp{} header \libheader{stdbool.h} are the same as the C
+The contents of the \Cpp{} header \libheaderdef{stdbool.h} are the same as the C
 standard library header \libheader{stdbool.h}, with the following changes:
 The header \libheader{stdbool.h} does not
 define macros named \tcode{bool}, \tcode{true}, or \tcode{false}.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15604,7 +15604,7 @@ specified in \IsoCUndated{}:2024, 7.18.  %% change to \xrefc{7.18}
 
 \pnum
 Otherwise,
-the contents and meaning of the header \libheader{stdbit.h} are the same as
+the contents and meaning of the header \libheaderdef{stdbit.h} are the same as
 the C standard library header \tcode{<stdbit.h>}.
 
 \xref{\IsoCUndated{}:2024, 7.18}   %% TODO: change to \xrefc{7.18}


### PR DESCRIPTION
Detected by cxxdraft-htmlgen.