### PR TITLE
[stdckdint.h.syn,stdbit.h.syn] Add proper indexing for header definition

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -3641,7 +3641,6 @@ and are not introduced as macros
 by \libheaderref{iso646.h}.
 
 \rSec3[diff.header.stdalign.h]{Header \tcode{<stdalign.h>}}
-\indexhdr{stdalign.h}%
 
 \pnum
 The token \keyword{alignas} is a keyword in \Cpp{}\iref{lex.key},
@@ -3649,7 +3648,6 @@ and is not introduced as a macro
 by \libheaderref{stdalign.h}.
 
 \rSec3[diff.header.stdbool.h]{Header \tcode{<stdbool.h>}}
-\indexhdr{stdbool.h}%
 
 \pnum
 The tokens \keyword{bool}, \keyword{true}, and \keyword{false}

--- a/source/future.tex
+++ b/source/future.tex
@@ -221,7 +221,6 @@ static constexpr bool has_denorm_loss = false;
 
 \pnum
 The header \libheaderref{stdalign.h} has the following macros:
-\indexheader{stdalign.h}%
 \indexlibraryglobal{__alignas_is_defined}%
 \begin{codeblock}
 #define @\xname{alignas_is_defined}@ 1
@@ -230,7 +229,6 @@ The header \libheaderref{stdalign.h} has the following macros:
 
 \pnum
 The header \libheaderref{stdbool.h} has the following macro:
-\indexheader{stdbool.h}%
 \indexhdr{stdbool.h}%
 \indexlibraryglobal{__bool_true_false_are_defined}%
 \begin{codeblock}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -18952,6 +18952,7 @@ constexpr @\exposid{simd-size-type}@ reduce_max_index(same_as<bool> auto x);
 
 \rSec2[stdckdint.h.syn]{Header \tcode{<stdckdint.h>} synopsis}
 
+\indexheader{stdckdint.h}%
 \begin{codeblock}
 #define @\libglobal{__STDC_VERSION_STDCKDINT_H__}@ 202311L
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15483,6 +15483,7 @@ to either \tcode{endian::big} or \tcode{endian::little}.
 
 \rSec1[stdbit.h.syn]{Header \tcode{<stdbit.h>} synopsis}
 
+\indexheader{stdbit.h}%
 \begin{codeblock}
 #define @\libglobal{__STDC_VERSION_STDBIT_H__}@ 202311L
 

--- a/tools/check-output.sh
+++ b/tools/check-output.sh
@@ -48,6 +48,12 @@ cat std-grammarindex.ind |
     sed 's/^\(.*\)$/grammar non-terminal \1 has no definition/' |
     fail || failed=1
 
+# Find header index entries missing a definition
+cat std-headerindex.ind |
+    awk 'BEGIN { def=1 } /^  .item/ { if (def==0) { gsub("[{},]", "", item); print item } i=NF; while (i > 0 && $i !~ "<[a-z_.]*>") { --i; } item=$i; def=0; next } /hyperindexformat/ { def=1 }' |
+    sed 's/^\(.*\)$/header \1 has no definition/' |
+    fail || failed=1
+
 # Find concept index entries missing a definition
 cat std-conceptindex.ind |
     sed 's/.hyperindexformat/\nhyperindexformat/;s/.hyperpage/hyperpage/' |


### PR DESCRIPTION
Also add a check to prevent future oversights.