### PR TITLE
[tab:cpp17.destructible] Use the correct placeholder in requirement expression

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1857,7 +1857,7 @@ If \tcode{a == b} and \tcode{b == c}, then \tcode{a == c}.
 {p{1in}p{4.15in}}
 \topline
 \hdstyle{Expression}      &   \hdstyle{Post-condition}  \\ \capsep
-\tcode{u.\~T()} &   All resources owned by \tcode{u} are reclaimed, no exception is propagated. \\ \rowsep
+\tcode{a.\~T()} &   All resources owned by \tcode{a} are reclaimed, no exception is propagated. \\ \rowsep
 \multicolumn{2}{|l|}{
   \begin{tailnote}
   Array types and non-object types are not \oldconcept{Destructible}.


### PR DESCRIPTION
`u` is defined simply as "[an identifier](https://eel.is/c++draft/utility.arg.requirements#1.4)", but here it is clearly meant to denote a `T` object.
