### PR TITLE
[ostream.formatted.reqmts] Insert space around & for consistency

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -6360,7 +6360,7 @@ in
 \tcode{*this}'s
 error state.
 If
-\tcode{(exceptions()\&badbit) != 0}
+\tcode{(exceptions() \& badbit) != 0}
 then the exception is rethrown.
 Whether or not an exception is thrown, the
 \tcode{sentry}


### PR DESCRIPTION
There exist 3 (exceptions() & badbit) in this draft, but only this one (exceptions()&badbit).