### PR TITLE
[cstdint.syn] Index <cstdint> macros

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -1885,6 +1885,34 @@ macros that specify limits of integer types.
 \indexlibraryglobal{uint_least64_t}%
 \indexlibraryglobal{uintmax_t}%
 \indexlibraryglobal{uintptr_t}%
+\indexlibraryglobal{INTN_MIN}%
+\indexlibraryglobal{INTN_MAX}%
+\indexlibraryglobal{UINTN_MAX}%
+\indexlibraryglobal{INT_FASTN_MIN}%
+\indexlibraryglobal{INT_FASTN_MAX}%
+\indexlibraryglobal{UINT_FASTN_MAX}%
+\indexlibraryglobal{INT_LEASTN_MIN}%
+\indexlibraryglobal{INT_LEASTN_MAX}%
+\indexlibraryglobal{UINT_LEASTN_MAX}%
+\indexlibraryglobal{INTMAX_MIN}%
+\indexlibraryglobal{INTMAX_MAX}%
+\indexlibraryglobal{UINTMAX_MAX}%
+\indexlibraryglobal{INTPTR_MIN}%
+\indexlibraryglobal{INTPTR_MAX}%
+\indexlibraryglobal{UINTPTR_MAX}%
+\indexlibraryglobal{PTRDIFF_MIN}%
+\indexlibraryglobal{PTRDIFF_MAX}%
+\indexlibraryglobal{SIZE_MAX}%
+\indexlibraryglobal{SIG_ATOMIC_MIN}%
+\indexlibraryglobal{SIG_ATOMIC_MAX}%
+\indexlibraryglobal{WCHAR_MAX}%
+\indexlibraryglobal{WCHAR_MIN}%
+\indexlibraryglobal{WINT_MIN}%
+\indexlibraryglobal{WINT_MAX}%
+\indexlibraryglobal{INTN_C}%
+\indexlibraryglobal{UINTN_C}%
+\indexlibraryglobal{INTMAX_C}%
+\indexlibraryglobal{UINTMAX_C}%
 \begin{codeblock}
 // all freestanding
 namespace std {


### PR DESCRIPTION
As far as I can tell, these are the last macro definitions that are missing from the index of library names.