### PR TITLE
[expr.ass] Rename problematic stable label

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -674,7 +674,7 @@ type \tcode{T}, or
 is defined\iref{basic.def} or called\iref{expr.call}, or
 \item a class with a base class of type \tcode{T} is
 defined\iref{class.derived}, or
-\item an lvalue of type \tcode{T} is assigned to\iref{expr.ass}, or
+\item an lvalue of type \tcode{T} is assigned to\iref{expr.assign}, or
 \item the type \tcode{T} is the subject of an
 \keyword{alignof} expression\iref{expr.alignof}, or
 \item an \grammarterm{exception-declaration} has type \tcode{T}, reference to
@@ -3907,7 +3907,7 @@ independently of the state of the program.
 \end{itemize}
 If no initialization is performed for an object (including subobjects),
 such a byte retains its initial value
-until that value is replaced\iref{dcl.init.general,expr.ass}.
+until that value is replaced\iref{dcl.init.general,expr.assign}.
 If any bit in the value representation has an indeterminate value,
 the object has an indeterminate value;
 otherwise, if any bit in the value representation has an erroneous value,
@@ -3949,7 +3949,7 @@ the result of the evaluation is the value so produced but is not erroneous:
   If an indeterminate or erroneous value of
   unsigned ordinary character type or \tcode{std::byte} type
   is produced by the evaluation of
-  the right operand of a simple assignment operator\iref{expr.ass}
+  the right operand of a simple assignment operator\iref{expr.assign}
   whose first operand is an lvalue of
   unsigned ordinary character type or \tcode{std::byte} type,
   an indeterminate value or that erroneous value, respectively, replaces

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3117,7 +3117,7 @@ and empty otherwise.
 Otherwise, $S(\mathtt{E})$ is empty.
 \end{itemize}
 In an assignment expression of the form \tcode{E1 = E2}
-that uses either the built-in assignment operator\iref{expr.ass}
+that uses either the built-in assignment operator\iref{expr.assign}
 or a trivial assignment operator\iref{class.copy.assign},
 for each element \tcode{X} of $S($\tcode{E1}$)$ and
 each anonymous union member \tcode{X}\iref{class.union.anon} that

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -150,7 +150,7 @@ are not so constrained.
 
 \pnum
 \begin{note}
-Class objects can be assigned\iref{over.ass,class.copy.assign},
+Class objects can be assigned\iref{over.assign,class.copy.assign},
 passed as arguments to functions\iref{dcl.init,class.copy.ctor}, and
 returned by functions (except objects of classes for which copying or moving has
 been restricted; see~\ref{dcl.fct.def.delete} and \ref{class.access}).
@@ -1804,7 +1804,7 @@ overload resolution\iref{over.match,over.over}.
 Because a copy/move assignment operator is implicitly declared for a class
 if not declared by the user,
 a base class copy/move assignment operator is always hidden
-by the corresponding assignment operator of a derived class\iref{over.ass}.
+by the corresponding assignment operator of a derived class\iref{over.assign}.
 \begin{note}
 A \grammarterm{using-declaration} in a derived class \tcode{C}
 that names an assignment operator from a base class
@@ -5223,7 +5223,7 @@ complex g = { 1, 2 };           // initialized by calling \tcode{complex(double,
 \end{example}
 \begin{note}
 \indextext{initialization!overloaded assignment and}%
-Overloading of the assignment operator\iref{over.ass}
+Overloading of the assignment operator\iref{over.assign}
 has no effect on initialization.
 \end{note}
 

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2969,7 +2969,7 @@ int idem = arr1 == +arr2;       // valid in both C and C++
 \howwide
 Rare.
 
-\diffref{expr.cond,expr.ass,expr.comma}
+\diffref{expr.cond,expr.assign,expr.comma}
 \indextext{conversion!lvalue-to-rvalue}%
 \indextext{rvalue!lvalue conversion to}%
 \indextext{lvalue}%

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1277,7 +1277,7 @@ subverted without casting\iref{expr.const.cast}.
 
 \pnum
 \indextext{const object!undefined change to}%
-Any attempt to modify\iref{expr.ass,expr.post.incr,expr.pre.incr} a
+Any attempt to modify\iref{expr.assign,expr.post.incr,expr.pre.incr} a
 const object\iref{basic.type.qualifier} during its
 lifetime\iref{basic.life} results in undefined behavior.
 \begin{example}
@@ -3007,7 +3007,7 @@ or allow it to be changed through a cv-unqualified pointer later, for example:
 \end{example}
 
 \pnum
-See also~\ref{expr.ass} and~\ref{dcl.init}.
+See also~\ref{expr.assign} and~\ref{dcl.init}.
 
 \pnum
 \begin{note}
@@ -5684,7 +5684,7 @@ void f() {
 A reference cannot be changed to refer to another object after initialization.
 \indextext{assignment!reference}%
 \begin{note}
-Assignment to a reference assigns to the object referred to by the reference\iref{expr.ass}.
+Assignment to a reference assigns to the object referred to by the reference\iref{expr.assign}.
 \end{note}
 \indextext{argument passing!reference and}%
 Argument passing\iref{expr.call}
@@ -5939,7 +5939,7 @@ List-initialization can be used
 \item as an argument to a constructor invocation\iref{dcl.init,expr.type.conv},
 \item as an initializer for a non-static data member\iref{class.mem},
 \item in a \grammarterm{mem-initializer}\iref{class.base.init}, or
-\item on the right-hand side of an assignment\iref{expr.ass}.
+\item on the right-hand side of an assignment\iref{expr.assign}.
 \end{itemize}
 
 \begin{example}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -131,7 +131,7 @@ thereby.
 \begin{footnote}
 The cast and assignment operators must still perform their specific
 conversions as described in~\ref{expr.type.conv}, \ref{expr.cast},
-\ref{expr.static.cast} and~\ref{expr.ass}.
+\ref{expr.static.cast} and~\ref{expr.assign}.
 \end{footnote}
 
 \rSec1[expr.prop]{Properties of expressions}
@@ -297,7 +297,7 @@ or is a function type.
 \begin{note}
 A program that attempts
 to modify an object through a nonmodifiable lvalue or through an rvalue
-is ill-formed\iref{expr.ass,expr.post.incr,expr.pre.incr}.
+is ill-formed\iref{expr.assign,expr.post.incr,expr.pre.incr}.
 \end{note}
 
 \pnum
@@ -4864,7 +4864,7 @@ shall not be of type \cv{}~\tcode{bool}.
 An operand with volatile-qualified type is deprecated;
 see~\ref{depr.volatile.type}.
 The expression \tcode{++x} is otherwise equivalent to \tcode{x+=1} and
-the expression \tcode{--x} is otherwise equivalent to \tcode{x-=1}\iref{expr.ass}.
+the expression \tcode{--x} is otherwise equivalent to \tcode{x-=1}\iref{expr.assign}.
 \begin{note}
 For postfix increment and decrement, see~\ref{expr.post.incr}.
 \end{note}
@@ -7296,7 +7296,7 @@ try {
 \end{codeblock}
 \end{example}
 
-\rSec2[expr.ass]{Assignment and compound assignment operators}%
+\rSec2[expr.assign]{Assignment and compound assignment operators}%
 \indextext{expression!assignment and compound assignment}
 
 \pnum
@@ -7827,7 +7827,7 @@ points to an object whose type is similar to \tcode{T};
 a \keyword{reinterpret_cast}\iref{expr.reinterpret.cast};
 
 \item
-a modification of an object\iref{expr.ass,expr.post.incr,expr.pre.incr}
+a modification of an object\iref{expr.assign,expr.post.incr,expr.pre.incr}
 unless it is applied to a non-volatile lvalue of literal type
 that refers to a non-volatile object
 whose lifetime began within the evaluation of $E$;

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -7413,7 +7413,7 @@ declared and initialized as \tcode{T t = $B$}.
 \item
 an assignment to an object of class type, in which case $B$
 is passed as the argument to the assignment operator function selected by
-overload resolution\iref{over.ass,over.match}.
+overload resolution\iref{over.assign,over.match}.
 \end{itemize}
 
 \begin{example}

--- a/source/future.tex
+++ b/source/future.tex
@@ -73,7 +73,7 @@ volatile int velociraptor;
 \pnum
 Certain assignments
 where the left operand is a volatile-qualified non-class type
-are deprecated; see~\ref{expr.ass}.
+are deprecated; see~\ref{expr.assign}.
 
 \begin{example}
 \begin{codeblock}

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -92,7 +92,7 @@ read or modify the value of an object
 Only glvalues of scalar type can be used to access objects.
 Reads of scalar objects are described in \ref{conv.lval} and
 modifications of scalar objects are described in
-\ref{expr.ass}, \ref{expr.post.incr}, and \ref{expr.pre.incr}.
+\ref{expr.assign}, \ref{expr.post.incr}, and \ref{expr.pre.incr}.
 Attempts to read or modify an object of class type
 typically invoke a constructor\iref{class.ctor}
 or assignment operator\iref{class.copy.assign};

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -676,7 +676,7 @@ for the built-in operator\iref{expr.compound}.
 \hdstyle{Subclause} &   \hdstyle{Expression} &   \hdstyle{As member function} &   \hdstyle{As non-member function} \\ \capsep
 \ref{over.unary}    &   \tcode{@a}   &   \tcode{(a).\keyword{operator}@ (\,)}  &   \tcode{\keyword{operator}@(a)}    \\
 \ref{over.binary}   &   \tcode{a@b}  &   \tcode{(a).\keyword{operator}@ (b)}   &   \tcode{\keyword{operator}@(a, b)} \\
-\ref{over.ass}      &   \tcode{a=b}  &   \tcode{(a).\keyword{operator}= (b)}   &                           \\
+\ref{over.assign}   &   \tcode{a=b}  &   \tcode{(a).\keyword{operator}= (b)}   &                           \\
 \ref{over.sub}      &   \tcode{a[b]} &   \tcode{(a).\keyword{operator}[](b)}   &                           \\
 \ref{over.ref}      &   \tcode{a->}  &   \tcode{(a).\keyword{operator}->(\,)}  &                           \\
 \ref{over.inc}      &   \tcode{a@}   &   \tcode{(a).\keyword{operator}@ (0)}   &   \tcode{\keyword{operator}@(a, 0)} \\
@@ -3403,7 +3403,7 @@ number required for the corresponding operator, as
 described in the rest of \ref{over.oper}.
 
 \pnum
-Operators not mentioned explicitly in subclauses~\ref{over.ass} through~\ref{over.inc}
+Operators not mentioned explicitly in subclauses~\ref{over.assign} through~\ref{over.inc}
 act as ordinary unary and binary
 operators obeying the rules of~\ref{over.unary} or~\ref{over.binary}.%
 \indextext{overloading!resolution!best viable function|)}%
@@ -3484,7 +3484,7 @@ an equality operator function,
 a relational operator function, or
 a three-way comparison operator function.
 
-\rSec3[over.ass]{Simple assignment}
+\rSec3[over.assign]{Simple assignment}
 \indextext{assignment operator!overloaded}%
 \indextext{overloading!assignment operator}
 

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3093,7 +3093,7 @@ The target can be
 \item
 an object or reference being initialized\iref{dcl.init,dcl.init.ref,dcl.init.list},
 \item
-the left side of an assignment\iref{expr.ass},
+the left side of an assignment\iref{expr.assign},
 \item
 a parameter of a function\iref{expr.call},
 \item

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -103,6 +103,7 @@
 
 % https://github.com/cplusplus/draft/pull/7524
 \movedxref{expr.ass}{expr.assign}
+\movedxref{over.ass}{over.assign}
 
 %%% Deprecated features.
 %%% Example:

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -101,6 +101,9 @@
 % https://github.com/cplusplus/draft/pull/7345
 \movedxref{basic.stc.inherit}{basic.stc.general}
 
+% https://github.com/cplusplus/draft/pull/7524
+\movedxref{expr.ass}{expr.assign}
+
 %%% Deprecated features.
 %%% Example:
 %


### PR DESCRIPTION
As more folks from outside the technically focused WG21 committee pay attention to our standard, some language starts to gain attention as problematic.  This commit fixes one such case.