### PR TITLE
[lex.icon,depr.locale.category] Remove duplicate 'table' in front of table references

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -707,7 +707,7 @@ constexpr pointer operator->() const;
 \pnum
 The \tcode{ctype} locale category includes the following facets
 as if they were specified
-in table \tref{locale.category.facets} of \ref{locale.category}.
+in \tref{locale.category.facets} of \ref{locale.category}.
 
 \begin{codeblock}
 codecvt<char16_t, char, mbstate_t>
@@ -719,7 +719,7 @@ codecvt<char32_t, char8_t, mbstate_t>
 \pnum
 The \tcode{ctype} locale category includes the following facets
 as if they were specified
-in table \tref{locale.spec} of \ref{locale.category}.
+in \tref{locale.spec} of \ref{locale.category}.
 
 \begin{codeblock}
 codecvt_byname<char16_t, char, mbstate_t>

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1214,7 +1214,7 @@ the sequence of
 \grammarterm{octal-digit}s,
 \grammarterm{digit}s, or
 \grammarterm{hexadecimal-digit}s
-is interpreted as a base $N$ integer as shown in table \tref{lex.icon.base};
+is interpreted as a base $N$ integer as shown in \tref{lex.icon.base};
 the lexically first digit of the sequence of digits is the most significant.
 \begin{note}
 The prefix and any optional separating single quotes are ignored


### PR DESCRIPTION
Fixes #7527 