### PR TITLE
[expected.bad.void] Editorial fix - syntax error in `bad_expected_access<void>`

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7392,7 +7392,7 @@ namespace std {
     bad_expected_access() noexcept;
     bad_expected_access(const bad_expected_access&) noexcept;
     bad_expected_access(bad_expected_access&&) noexcept;
-    bad_expected_access& operator=(const bad_expected_access& noexcept);
+    bad_expected_access& operator=(const bad_expected_access&) noexcept;
     bad_expected_access& operator=(bad_expected_access&&) noexcept;
     ~bad_expected_access();
 


### PR DESCRIPTION
This fixes obviously invalid syntax in the definition of `bad_expected_access<void>` class specialization
```c++
bad_expected_access& operator=(const bad_expected_access& noexcept);
```
