### PR TITLE
[stdbool.h.syn][depr.c.macros] Remove redundant macros

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -229,7 +229,6 @@ The header \libheaderref{stdalign.h} has the following macros:
 
 \pnum
 The header \libheaderref{stdbool.h} has the following macro:
-\indexhdr{stdbool.h}%
 \indexlibraryglobal{__bool_true_false_are_defined}%
 \begin{codeblock}
 #define @\xname{bool_true_false_are_defined}@ 1

--- a/source/support.tex
+++ b/source/support.tex
@@ -6327,7 +6327,6 @@ define a macro named \tcode{alignas}.
 \rSec2[stdbool.h.syn]{Header \tcode{<stdbool.h>} synopsis}
 
 \indexheader{stdbool.h}%
-\indexhdr{stdbool.h}%
 \pnum
 The contents of the \Cpp{} header \libheader{stdbool.h} are the same as the C
 standard library header \libheader{stdbool.h}, with the following changes:


### PR DESCRIPTION
The \indexhdr macro is subsumed by more appropriate macros in the same area.  These are the last two uses of the \indexhdr macro that have not been similarly subsumed.