### PR TITLE
[expr.const] Properly merge P2686R5

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -8206,7 +8206,7 @@ satisfies the following constraints:
 \item
 each constituent reference refers to an object or a non-immediate function,
 \item
-no constituent value of scalar type is an indeterminate value\iref{basic.indet},
+no constituent value of scalar type is an indeterminate or erroneous value\iref{basic.indet},
 \item
 no constituent value of pointer type is a pointer to an immediate function or
 an invalid pointer value\iref{basic.compound}, and


### PR DESCRIPTION
P2686R5 (applied by commit e220906b71df01f09fe60921e8fac39b80558f78) accidentally reverted a change considering erroneous values made by P2795R5.

Fixes cplusplus/CWG#662