### PR TITLE
escape semantically meaningful braces in [exec.getcomplsigs]

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -2373,7 +2373,7 @@ such that \tcode{decltype((sndr))} is \tcode{Sndr}, and
 let \tcode{env} be an expression
 such that \tcode{decltype((env))} is \tcode{Env}.
 Let \tcode{new_sndr} be the expression
-\tcode{transform_sender(decltype(\exposid{get-domain-late}(sndr, env)){}, sndr, env)}, and
+\tcode{transform_sender(decltype(\exposid{get-domain-late}(sndr, env))\{\}, sndr, env)}, and
 let \tcode{NewSndr} be \tcode{decltype((new_sndr))}.
 Then \tcode{get_completion_signatures(sndr, env)} is expression-equivalent to
 \tcode{(void(sndr), void(env), CS())}


### PR DESCRIPTION
[P2300R10 [exec.getcomplsigs]](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html#spec-execution.getcomplsigs) para 1 contains the following in code font:

```
transform_sender(decltype(get-domain-late(sndr, env)){}, sndr, env)
```

In the current working draft, this is rendered as:

```
transform_sender(decltype(get-domain-late(sndr, env)), sndr, env)
```

Note the missing braces. This is an editing mistake where the braces are not escaped for LaTeX, and hence are ignored.