### PR TITLE
[editorial]: put `apply_sender` in code font in [exec.sync.wait]

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -4564,7 +4564,7 @@ apply_sender(@\exposid{get-domain-early}@(sndr), sync_wait, sndr)
 The type \tcode{\exposid{sync-wait-result-type}<Sndr>} is well-formed.
 \item
 \tcode{\libconcept{same_as}<decltype($e$), \exposid{sync-wait-result-type}<Sndr>>}
-is \tcode{true}, where $e$ is the apply_sender expression above.
+is \tcode{true}, where $e$ is the \tcode{apply_sender} expression above.
 \end{itemize}
 
 \pnum


### PR DESCRIPTION
`apply_sender` is the name of a customization point object. it should appear in code font.