### PR TITLE
[tuple.helper] Remove redundant public before base class

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2751,7 +2751,7 @@ for some \tcode{N}.
 \indexlibraryglobal{tuple_size}%
 \begin{itemdecl}
 template<class... Types>
-  struct tuple_size<tuple<Types...>> : public integral_constant<size_t, sizeof...(Types)> { };
+  struct tuple_size<tuple<Types...>> : integral_constant<size_t, sizeof...(Types)> { };
 \end{itemdecl}
 
 \indexlibraryglobal{tuple_element}%


### PR DESCRIPTION
tuple_size is defined as a struct, so defaults to public inheritance.  Every similar type trait leans into this implicit default-to-public, and tuple_size is the only outlier.