### PR TITLE
[editorial]: in [exec.recv.concepts] mark exposition-only concepts as such

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -1095,7 +1095,7 @@ namespace std::execution {
       @\libconcept{constructible_from}@<remove_cvref_t<Rcvr>, Rcvr>;   // lvalues are copyable
 
   template<class Signature, class Rcvr>
-    concept @\defexposconcept{valid-completion-for}@ =
+    concept @\defexposconcept{valid-completion-for}@ =                 // \expos
       requires (Signature* sig) {
         []<class Tag, class... Args>(Tag(*)(Args...))
             requires @\exposconcept{callable}@<Tag, remove_cvref_t<Rcvr>, Args...>
@@ -1103,7 +1103,7 @@ namespace std::execution {
       };
 
   template<class Rcvr, class Completions>
-    concept @\defexposconcept{has-completions}@ =
+    concept @\defexposconcept{has-completions}@ =                      // \expos
       requires (Completions* completions) {
         []<@\exposconcept{valid-completion-for}@<Rcvr>...Sigs>(completion_signatures<Sigs...>*)
         {}(completions);


### PR DESCRIPTION
the definitions of `valid-completions-for` and `has-completions` should be marked as exposition-only.