### PR TITLE
[editorial]: in [exec.snd.transform] put exposition-only `transformed-sndr` in italics

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -2287,7 +2287,7 @@ Let \exposid{final-sndr} be the expression \exposid{transformed-sndr}
 if \exposid{transformed-sndr} and \exposid{sndr}
 have the same type ignoring cv-qualifiers;
 otherwise, it is
-the expression \tcode{transform_sender(dom, transformed-sndr, env...)}.
+the expression \tcode{transform_sender(dom, \exposid{transformed-sndr}, env...)}.
 
 \pnum
 \returns


### PR DESCRIPTION
wrap `transformed-sndr` in `\exposid{...}`.