### PR TITLE
[basic.types.general] Simplify phrasing of 'complete object'

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4839,7 +4839,7 @@ std::memcpy(t1p, t2p, sizeof(T));
 The \defnx{object representation}{representation!object}
 of a complete object type \tcode{T} is the
 sequence of \placeholder{N} \tcode{\keyword{unsigned} \keyword{char}} objects taken up
-by a non-bit-field complete object of type \tcode{T},
+by a complete object of type \tcode{T},
 where \placeholder{N} equals
 \tcode{\keyword{sizeof}(T)}.
 The \defnx{value representation}{representation!value}
@@ -4847,7 +4847,7 @@ of a type \tcode{T} is the set of bits
 in the object representation of \tcode{T}
 that participate in representing a value of type \tcode{T}.
 The object and value representation of
-a non-bit-field complete object of type \tcode{T} are
+a complete object of type \tcode{T} are
 the bytes and bits, respectively, of
 the object corresponding to the object and value representation of its type.
 The object representation of a bit-field object is


### PR DESCRIPTION
A complete object can't be a bit-field, so saying 'non-bit-field complete object' is unnecessary.