### PR TITLE
[expr.ref] Remove redundant bullet

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3774,9 +3774,6 @@ is ignored\iref{expr.prim.paren}.
 \end{note}
 \end{itemize}
 
-\item If \tcode{E2} is a nested type, the expression \tcode{E1.E2} is
-ill-formed.
-
 \item If \tcode{E2} is a member enumerator and the type of \tcode{E2}
 is \tcode{T}, the expression \tcode{E1.E2} is a prvalue of type \tcode{T}
 whose value is the value of the enumerator.


### PR DESCRIPTION
`E2` is grammatically an *id-expression*, which can't denote a type.