### PR TITLE
[locale.time.put.members] Remove outdated footnote

### DIFF
--- a/source/text.tex
+++ b/source/text.tex
@@ -4021,9 +4021,6 @@ where \tcode{ct} is a reference to \tcode{ctype<charT>}
 obtained from \tcode{str.getloc()}.
 The first character of each sequence is equal to \tcode{'\%'},
 followed by an optional modifier character \tcode{mod}
-\begin{footnote}
-Although the C programming language defines no modifiers, most vendors do.
-\end{footnote}
 and a format specifier character \tcode{spec}
 as defined for the function \tcode{strftime}.
 If no modifier character is present, \tcode{mod} is zero.


### PR DESCRIPTION
C99 defines two modifiers for `strftime`, namely `'E'` and `'O'`.