### PR TITLE
change \exposid to \exposconcept for the concept valid-specializations

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -1630,7 +1630,7 @@ namespace std::execution {
   };
 
   template<class Sndr, class Rcvr, class Index>
-    requires @\exposid{valid-specialization}@<@\exposid{env-type}@, Index, Sndr, Rcvr>
+    requires @\exposconcept{valid-specialization}@<@\exposid{env-type}@, Index, Sndr, Rcvr>
   struct @\exposid{basic-receiver}@ {                                       // \expos
     using receiver_concept = receiver_t;
 


### PR DESCRIPTION
this makes the id link to the concept definition