### PR TITLE
[temp.mem.enum] Fix consistency of example with [temp.inst] (editorial)

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -2659,7 +2659,6 @@ template definition.
 template<class T> struct A {
   enum E : T;
 };
-A<int> a;
 template<class T> enum A<T>::E : T { e1, e2 };
 A<int>::E e = A<int>::e1;
 \end{codeblock}


### PR DESCRIPTION
The example is inconsistent with [[temp.inst] p3](https://wg21.link/temp.spec#temp.inst-3), which states the following: 

> The implicit instantiation of a class template specialization causes
> - the implicit instantiation of the declarations, but not of the definitions, of [...] scoped member enumerations [...]; and
> - the implicit instantiation of the definitions of [...] unscoped member enumerations [...]

Hence, the example can be fixed by either (1) omitting the instantiation or (2) by replacing the unscoped with a scoped enumeration. Since the implicit instantiation does not contribute to the point of [[temp.mem.enum]](https://wg21.link/temp.mem.enum), the inconsistency can be solved most easily with alternative (1).

The example was taken exactly as is from [DR1206](http://open-std.org/JTC1/SC22/WG21/docs/cwg_defects.html#1206), where it already seems to be an accidental copy-paste mishap because it is not important for the statement it is trying to make.
If one is willing to assume that, it is just an editorial issue.

Note: the example as is does not compile with any of the major compilers.
See here on Compiler Explorer: https://godbolt.org/z/xjM15MjP8