### PR TITLE
move para about write-env into write-env's itemdescr

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -1901,9 +1901,9 @@ returns an object \tcode{e} such that
 \tcode{decltype(e)} models \exposconcept{queryable} and
 \item
 given a query object \tcode{q},
-the expression \tcode{e.query(q)} is expression-equivalent
+the expression \tcode{e.query(q)} is ex\-pres\-sion-equiv\-alent
 to \tcode{state.query(q)} if that expression is valid,
-otherwise, \tcode{e.query(q)} is expression-equivalent
+otherwise, \tcode{e.query(q)} is ex\-pres\-sion-equiv\-alent
 to \tcode{get_env(rcvr).query(q)}.
 \end{itemize}
 \end{itemdescr}

--- a/source/exec.tex
+++ b/source/exec.tex
@@ -1893,7 +1893,6 @@ struct @\exposid{impls-for}@<@\exposid{write-env-t}@> : @\exposid{default-impls}
     };
 };
 \end{codeblock}
-\end{itemdescr}
 Invocation of
 \tcode{\exposid{impls-for}<\exposid{write-env-t}>::\exposid{get-env}}
 returns an object \tcode{e} such that
@@ -1907,6 +1906,7 @@ to \tcode{state.query(q)} if that expression is valid,
 otherwise, \tcode{e.query(q)} is expression-equivalent
 to \tcode{get_env(rcvr).query(q)}.
 \end{itemize}
+\end{itemdescr}
 
 \rSec2[exec.snd.concepts]{Sender concepts}
 


### PR DESCRIPTION
a paragraph about _`write-env`_ from P3396R1 got accidentally added outside of _`write-env`_'s `itemdescr`. move it inside.