### PR TITLE
Make SCHED-ENV an exposid in [exec.let]

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -3404,7 +3404,7 @@ let \tcode{\exposid{let-env}(sndr)} be expression-equivalent to
 the first well-formed expression below:
 \begin{itemize}
 \item
-\tcode{SCHED-ENV(get_completion_scheduler<\exposid{decayed-typeof}<\exposid{set-cpo}>>(get_env(sndr)))}
+\tcode{\exposid{SCHED-ENV}(get_completion_scheduler<\exposid{decayed-typeof}<\exposid{set-cpo}>>(get_env(sndr)))}
 \item
 \tcode{\exposid{MAKE-ENV}(get_domain, get_domain(get_env(sndr)))}
 \item


### PR DESCRIPTION
SCHED-ENV is an exposition-only pseudo-macro