### PR TITLE
[lex.phases] Update implementation defined text

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1493,8 +1493,9 @@ Prevents accidental uses of trigraphs in non-raw string literals and comments.
 Valid \CppXIV{} code that uses trigraphs may not be valid or may have different
 semantics in this revision of \Cpp{}. Implementations may choose to
 translate trigraphs as specified in \CppXIV{} if they appear outside of a raw
-string literal, as part of the \impldef{mapping input source file characters
-to translation character set} mapping from input source file characters to
+string literal, as part of the
+\impldef{mapping input file characters to translation character set}
+mapping from input source file characters to
 the translation character set.
 
 \diffref{lex.ppnumber}

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -102,7 +102,7 @@ is replaced by a single new-line character.
 
 For any other kind of input file supported by the implementation,
 characters are mapped, in an
-\impldef{mapping physical source file characters to translation character set} manner,
+\impldef{mapping input file characters to translation character set} manner,
 to a sequence of translation character set elements,
 representing end-of-line indicators as new-line characters.
 


### PR DESCRIPTION
Since C++23 we no longer have physical source files, but rather input files.  Update the two implementation-defined references to the mapping from input file to translation character set using the same phrasing so that they provide the same entry in the index of implementation-defined behavior, just as they did in C++20, before getting out of sync when the terminology changed.