### PR TITLE
[type.info] Remove comments explaining deleted members

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -3250,8 +3250,8 @@ namespace std {
     size_t hash_code() const noexcept;
     const char* name() const noexcept;
 
-    type_info(const type_info&) = delete;                   // cannot be copied
-    type_info& operator=(const type_info&) = delete;        // cannot be copied
+    type_info(const type_info&) = delete;
+    type_info& operator=(const type_info&) = delete;
   };
 }
 \end{codeblock}


### PR DESCRIPTION
The standard is not a tutorial.