### PR TITLE
Typo

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1776,7 +1776,7 @@ chosen in an \impldef{choice of larger or smaller value of
 
 \begin{bnf}
 \nontermdef{d-char-sequence}\br
-    d-char\opt{d-char-sequence}
+    d-char \opt{d-char-sequence}
 \end{bnf}
 
 \begin{bnf}


### PR DESCRIPTION
Typo.
May you be wondering how I  found this : At this moment I am experimenting with the idea how much of the informal grammar in appendix A can be imported with a little script into antlr4 without any need for more editing. 

There is a cpp14 grammar for antlr4 but I need something more modern. I am not done yet with this experiment but it is going really well, most difficult part being the lexical section and possible token ambiguities, and how to get around that with as less as possible extra editing or rewriting. 

In the meantime antlr4 found this typo.

So you get this now from me.

Kind regards and have a nice day,
Ondrej