### PR TITLE
[expr.const] Re-apply CWG2909

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -7608,7 +7608,7 @@ that follows the initializing declaration of \tcode{v}.
 \pnum
 A constant-initializable variable is \defn{constant-initialized}
 if either it has an initializer or
-its default-initialization results in some initialization being performed.
+its type is const-default-constructible\iref{dcl.init.general}.
 \begin{example}
 \begin{codeblock}
 void f() {


### PR DESCRIPTION
#7468 accidently reverted the resolution of CWG2909 (applied in commit 317160060b890edeaeb931366f5ae04680c87084). I think we should editorially re-apply it.

Fixes #7581.