### PR TITLE
[util.smartptr.atomic.{shared,weak}] Fix wording for initialization

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -5493,7 +5493,7 @@ constexpr atomic() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{p\{\}}.
+Value-initializes \tcode{p}.
 \end{itemdescr}
 
 \indexlibraryctor{atomic<shared_ptr<T>>}%
@@ -5821,7 +5821,7 @@ constexpr atomic() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{p\{\}}.
+Value-initializes \tcode{p}.
 \end{itemdescr}
 
 \indexlibraryctor{atomic<weak_ptr<T>>}%


### PR DESCRIPTION
By using more conventional "value-initializes".

Fixes #7522.