### PR TITLE
Rename non-type template parameter/argument to "constant"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2104,7 +2104,7 @@ the templates used as template template arguments; and
 the classes of which any member templates used as template template
 arguments are members.
 \begin{note}
-Non-type template arguments do not
+Constant template arguments do not
 contribute to the set of associated entities.
 \end{note}
 

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -1646,12 +1646,12 @@ B b(42L);           // now calls \tcode{B(int)}, used to call \tcode{B<long>(lon
 
 \diffref{temp.deduct.type}
 \change
-Allowance to deduce from the type of a non-type template argument.
+Allowance to deduce from the type of a constant template argument.
 \rationale
 In combination with the ability to declare
-non-type template arguments with placeholder types,
+constant template arguments with placeholder types,
 allows partial specializations to decompose
-from the type deduced for the non-type template argument.
+from the type deduced for the constant template argument.
 \effect
 Valid \CppXIV{} code may fail to compile
 or produce different results in this revision of \Cpp{}.

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -7185,7 +7185,7 @@ If a search for the name \tcode{get}
 in the scope of \tcode{E}\iref{class.member.lookup}
 finds at least one declaration
 that is a function template whose first template parameter
-is a constant parameter,
+is a constant template parameter,
 the initializer is
 \tcode{\exposidnc{e}.get<i>()}. Otherwise, the initializer is \tcode{get<i>(\exposid{e})},
 where \tcode{get} undergoes argument-dependent lookup\iref{basic.lookup.argdep}.

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1671,7 +1671,7 @@ naming a structured binding\iref{dcl.struct.bind},
 the specification of the structured binding declaration;
 
 \item otherwise, if $E$ is an unparenthesized \grammarterm{id-expression}
-naming a non-type template parameter\iref{temp.param},
+naming a constant template parameter\iref{temp.param},
 \tcode{decltype($E$)} is the type of the template parameter
 after performing any necessary
 type deduction\iref{dcl.spec.auto,dcl.type.class.deduct};
@@ -2106,9 +2106,9 @@ a single \grammarterm{assignment-expression}
 and $E$ is the \grammarterm{assignment-expression}.
 \end{itemize}
 \item
-For a non-type template parameter declared with a type
+For a constant template parameter declared with a type
 that contains a placeholder type,
-\tcode{T} is the declared type of the non-type template parameter
+\tcode{T} is the declared type of the constant template parameter
 and $E$ is the corresponding template argument.
 \end{itemize}
 
@@ -7185,7 +7185,7 @@ If a search for the name \tcode{get}
 in the scope of \tcode{E}\iref{class.member.lookup}
 finds at least one declaration
 that is a function template whose first template parameter
-is a non-type parameter,
+is a constant parameter,
 the initializer is
 \tcode{\exposidnc{e}.get<i>()}. Otherwise, the initializer is \tcode{get<i>(\exposid{e})},
 where \tcode{get} undergoes argument-dependent lookup\iref{basic.lookup.argdep}.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -8186,7 +8186,7 @@ Such expressions can be used in \keyword{new}
 expressions\iref{expr.new}, as case expressions\iref{stmt.switch},
 as enumerator initializers if the underlying type is
 fixed\iref{dcl.enum}, as array bounds\iref{dcl.array}, and
-as non-type template
+as constant template
 arguments\iref{temp.arg}.
 \end{note}
 \indextext{contextually converted constant expression of type \tcode{bool}|see{conversion, contextual}}%

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -2218,7 +2218,7 @@ let \placeholder{str} be the literal without its \grammarterm{ud-suffix}
 and let \placeholder{len} be the number of code units in \placeholder{str}
 (i.e., its length excluding the terminating null character).
 If \placeholder{S} contains a literal operator template with
-a non-type template parameter for which \placeholder{str} is
+a constant template parameter for which \placeholder{str} is
 a well-formed \grammarterm{template-argument},
 the literal \placeholder{L} is treated as a call of the form
 \begin{codeblock}

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -59,7 +59,7 @@ $\tcode{N} \geq 0$.
 \pnum
 The alias template
 \tcode{make_integer_sequence} denotes a specialization of
-\tcode{integer_sequence} with \tcode{N} non-type template arguments.
+\tcode{integer_sequence} with \tcode{N} constant template arguments.
 The type \tcode{make_integer_sequence<T, N>} is an alias for the type
 \tcode{integer_sequence<T, 0, 1, ..., N-1>}.
 \begin{note}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -2564,7 +2564,7 @@ are not shown in the synopses.
 \pnum
 Each template specified in \ref{rand.eng}
 requires one or more relationships,
-involving the value(s) of its non-type template parameter(s), to hold.
+involving the value(s) of its constant template parameter(s), to hold.
 A program instantiating any of these templates
 is ill-formed
 if any such required relationship fails to hold.
@@ -3356,7 +3356,7 @@ are not shown in the synopses.
 \pnum
 Each template specified in \ref{rand.adapt}
 requires one or more relationships,
-involving the value(s) of its non-type template parameter(s), to hold.
+involving the value(s) of its constant template parameter(s), to hold.
 A program instantiating any of these templates
 is ill-formed
 if any such required relationship fails to hold.

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3103,7 +3103,7 @@ the return value of a function, operator function, or conversion\iref{stmt.retur
 \item
 an explicit type conversion\iref{expr.type.conv,expr.static.cast,expr.cast}, or
 \item
-a non-type template parameter\iref{temp.arg.nontype}.
+a constant template parameter\iref{temp.arg.nontype}.
 \end{itemize}
 If the target type contains a placeholder type,
 placeholder type deduction is performed\iref{dcl.type.auto.deduct}, and
@@ -4094,13 +4094,13 @@ whose type is \tcode{const char*}.
 A \defnx{numeric literal operator template}{literal!operator!template numeric}
 is a literal operator template whose \grammarterm{template-parameter-list}
 has a single \grammarterm{template-parameter}
-that is a non-type template parameter pack\iref{temp.variadic}
+that is a constant template parameter pack\iref{temp.variadic}
 with element type \tcode{char}.
 A \defnx{string literal operator template}{literal!operator!template string}
 is a literal operator template whose \grammarterm{template-parameter-list}
 comprises
 a single \grammarterm{parameter-declaration} that declares a
-non-type template parameter of class type.
+constant template parameter of class type.
 The declaration of a literal operator template
 shall have an empty \grammarterm{parameter-declaration-clause}
 and shall declare either a numeric literal operator template

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -296,10 +296,10 @@ Since template
 and template
 \grammarterm{template-argument}{s}
 are treated as types for descriptive purposes, the terms
-\term{non-type parameter}
+\term{constant parameter}
 and
-\term{non-type argument}
-are used to refer to non-type, non-template parameters and arguments.
+\term{constant argument}
+are used to refer to constant, non-template parameters and arguments.
 \end{footnote}
 \grammarterm{parameter-declaration}.
 A \grammarterm{template-parameter} of the form
@@ -315,7 +315,7 @@ template<class T, T i> void f(T t) {
 }
 \end{codeblock}
 Here, the template \tcode{f} has a type template parameter
-called \tcode{T}, rather than an unnamed non-type
+called \tcode{T}, rather than an unnamed constant
 template parameter of class \tcode{T}.
 \end{example}
 The \grammarterm{parameter-declaration} of a \grammarterm{template-parameter}
@@ -389,7 +389,7 @@ template<C3<int>... T> struct s5;       // associates \tcode{(C3<T, int> \&\& ..
 \end{example}
 
 \pnum
-A non-type template parameter
+A constant template parameter
 shall have one of the following (possibly cv-qualified) types:
 \begin{itemize}
 \item a structural type (see below),
@@ -420,7 +420,7 @@ structural types or (possibly multidimensional) arrays thereof.
 
 \pnum
 An \grammarterm{id-expression} naming
-a non-type template parameter of class type \tcode{T}
+a constant template parameter of class type \tcode{T}
 denotes a static storage duration object of type \tcode{const T},
 known as a \defn{template parameter object},
 which is template-argument-equivalent\iref{temp.type} to
@@ -430,7 +430,7 @@ to the type of the template parameter\iref{temp.arg.nontype}.
 No two template parameter objects are template-argument-equivalent.
 \begin{note}
 If an \grammarterm{id-expression} names
-a non-reference non-type template parameter,
+a non-reference constant template parameter,
 then it is a prvalue if it has non-class type.
 Otherwise, if it is of class type \tcode{T},
 it is an lvalue and has type \tcode{const T}\iref{expr.prim.id.unqual}.
@@ -454,7 +454,7 @@ template<const X& x, int i, A a> void f() {
 
 \pnum
 \begin{note}
-A non-type template parameter
+A constant template parameter
 cannot be declared to have type \cv{} \keyword{void}.
 \begin{example}
 \begin{codeblock}
@@ -465,7 +465,7 @@ template<void* pv> class Y;     // OK
 \end{note}
 
 \pnum
-A non-type template parameter
+A constant template parameter
 \indextext{array!template parameter of type}%
 of type ``array of \tcode{T}'' or
 \indextext{function!template parameter of type}%
@@ -485,7 +485,7 @@ S<v> z;                         // OK due to both adjustment and conversion
 \end{example}
 
 \pnum
-A non-type template parameter declared with a type that
+A constant template parameter declared with a type that
 contains a placeholder type with a \grammarterm{type-constraint}
 introduces the immediately-declared constraint
 of the \grammarterm{type-constraint}
@@ -560,7 +560,7 @@ template<class... T, class U> void g() { }      // error
 \indextext{\idxcode{<}!template and}%
 \pnum
 When parsing a default template argument
-for a non-type template parameter,
+for a constant template parameter,
 the first non-nested \tcode{>} is taken as
 the end of the \grammarterm{template-parameter-list}
 rather than a greater-than operator.
@@ -618,12 +618,12 @@ expansion shall not expand a template parameter pack declared in the same
 template <class... Types>                       // \tcode{Types} is a template type parameter pack
    class Tuple;                                 // but not a pack expansion
 
-template <class T, int... Dims>                 // \tcode{Dims} is a non-type template parameter pack
+template <class T, int... Dims>                 // \tcode{Dims} is a constant template parameter pack
    struct multi_array;                          // but not a pack expansion
 
 template <class... T>
   struct value_holder {
-    template <T... Values> struct apply { };    // \tcode{Values} is a non-type template parameter pack
+    template <T... Values> struct apply { };    // \tcode{Values} is a constant template parameter pack
   };                                            // and a pack expansion
 
 template <class... T, T... Values>              // error: \tcode{Values} expands template type parameter
@@ -923,7 +923,7 @@ There are three forms of
 \grammarterm{template-argument},
 corresponding to the three forms of
 \grammarterm{template-parameter}:
-type, non-type and template.
+type, constant and template.
 The type and form of each
 \grammarterm{template-argument}
 specified in a
@@ -1147,7 +1147,7 @@ A template type argument can be an incomplete type\iref{term.incomplete.type}.
 
 \pnum
 A template argument $E$ for
-a non-type template parameter with declared type \tcode{T}
+a constant template parameter with declared type \tcode{T}
 shall be such that the invented declaration
 \begin{codeblock}
 T x = @$E$@ ;
@@ -1166,7 +1166,7 @@ for a template parameter declaration\iref{temp.param},
 the program is ill-formed.
 
 \pnum
-The value of a non-type template parameter $P$
+The value of a constant template parameter $P$
 of (possibly deduced) type \tcode{T}
 is determined from its template argument $A$ as follows.
 If \tcode{T} is not a class type and
@@ -1210,9 +1210,9 @@ the program is ill-formed.
 Otherwise, the value of $P$ is that of v.
 
 \pnum
-For a non-type template parameter of reference or pointer type,
+For a constant template parameter of reference or pointer type,
 or for each non-static data member of reference or pointer type
-in a non-type template parameter of class type or subobject thereof,
+in a constant template parameter of class type or subobject thereof,
 the reference or pointer value shall not refer
 or point to (respectively):
 \begin{itemize}
@@ -1286,7 +1286,7 @@ B<J2{}> j2;     // error: template parameter object not template-argument-equiva
 \begin{note}
 A \grammarterm{string-literal}\iref{lex.string} is
 not an acceptable \grammarterm{template-argument}
-for a non-type template parameter of non-class type.
+for a constant template parameter of non-class type.
 \begin{example}
 \begin{codeblock}
 template<class T, T p> class X {
@@ -1382,7 +1382,7 @@ if each of \tcode{A}'s template parameters
 matches the corresponding template parameter declared in the
 \grammarterm{template-head} of \tcode{P}.
 Two template parameters match if they are of the same kind,
-for non-type template parameters, their types are
+for constant template parameters, their types are
 equivalent\iref{temp.over.link}, and for template template parameters,
 each of their corresponding template parameters matches, recursively.
 When \tcode{P}'s \grammarterm{template-head} contains a \grammarterm{template-parameter}
@@ -2177,7 +2177,7 @@ are the same type, and
 
 \item
 the template parameter values determined by
-their corresponding non-type template arguments\iref{temp.arg.nontype}
+their corresponding constant template arguments\iref{temp.arg.nontype}
 are template-argument-equivalent (see below), and
 
 \item
@@ -2997,7 +2997,7 @@ follows:
 \item
 if the pack is a template parameter pack, the element is
 an \grammarterm{id-expression}
-(for a non-type template parameter pack),
+(for a constant template parameter pack),
 a \grammarterm{typedef-name}
 (for a type template parameter pack declared without \tcode{template}), or
 a \grammarterm{template-name}
@@ -3453,9 +3453,9 @@ A<int,int*> a;      // uses the partial specialization, which is found through t
 \end{example}
 
 \pnum
-A non-type argument is non-specialized if it is the name of a non-type
+A constant argument is non-specialized if it is the name of a constant
 parameter.
-All other non-type arguments are specialized.
+All other constant arguments are specialized.
 
 \pnum
 Within the argument list of a partial specialization,
@@ -3463,7 +3463,7 @@ the following restrictions apply:
 
 \begin{itemize}
 \item
-The type of a template parameter corresponding to a specialized non-type argument
+The type of a template parameter corresponding to a specialized constant argument
 shall not be dependent on a parameter of the partial specialization.
 \begin{example}
 \begin{codeblock}
@@ -3851,7 +3851,7 @@ template <int I, int J> A<I-J> f(A<I>, A<J>);   // different from \#1
 \end{codeblock}
 \end{example}
 \begin{note}
-Most expressions that use template parameters use non-type template
+Most expressions that use template parameters use constant template
 parameters, but it is possible for an expression to reference a type
 parameter.
 For example, a template type parameter can be used in the
@@ -3951,7 +3951,7 @@ under the following conditions:
 \begin{itemize}
 \item they declare template parameters of the same kind,
 \item if either declares a template parameter pack, they both do,
-\item if they declare non-type template parameters,
+\item if they declare constant template parameters,
 they have equivalent types
 ignoring the use of \grammarterm{type-constraint}{s} for placeholder types, and
 \item if they declare template template parameters, their template
@@ -4051,14 +4051,14 @@ If both deductions succeed, the partial ordering selects
 the more constrained template (if one exists) as determined below.
 
 \pnum
-To produce the transformed template, for each type, non-type, or template
+To produce the transformed template, for each type, constant, or template
 template parameter (including template parameter packs\iref{temp.variadic}
 thereof) synthesize a unique type, value, or class template
 respectively and substitute it for each occurrence of that parameter
 in the function type of the template.
 \begin{note}
 The type replacing the placeholder
-in the type of the value synthesized for a non-type template parameter
+in the type of the value synthesized for a constant template parameter
 is also a unique synthesized type.
 \end{note}
 Each function template $M$ that is a member function
@@ -4598,7 +4598,7 @@ appears in a default argument,
 \item \grammarterm{parameter-declaration} in a \grammarterm{lambda-declarator}
 or \grammarterm{requirement-parameter-list},
 unless that \grammarterm{parameter-declaration} appears in a default argument, or
-\item \grammarterm{parameter-declaration} of a (non-type) \grammarterm{template-parameter}.
+\item \grammarterm{parameter-declaration} of a (constant) \grammarterm{template-parameter}.
 \end{itemize}
 \end{itemize}
 \begin{example}
@@ -5054,7 +5054,7 @@ template parameter in a reference to the current instantiation.
 For a template \grammarterm{type-parameter},
 a template argument is equivalent to a template parameter
 if it denotes the same type.
-For a non-type template parameter,
+For a constant template parameter,
 a template argument is equivalent to a template parameter
 if it is an \grammarterm{identifier} that names a variable
 that is equivalent to the template parameter.
@@ -5339,7 +5339,7 @@ associated by name lookup with one or more declarations
 declared with a dependent type,
 \item
 associated by name lookup with
-a non-type template parameter
+a constant template parameter
 declared with a type
 that contains a placeholder type\iref{dcl.spec.auto},
 \item
@@ -5496,7 +5496,7 @@ it is a concept-id and any of its arguments are dependent,
 \item
 it is type-dependent,
 \item
-it is the name of a non-type template parameter,
+it is the name of a constant template parameter,
 \item
 it names a static data member that is a dependent member of the current
 instantiation and is not initialized in a \grammarterm{member-declarator},
@@ -5587,15 +5587,15 @@ A type
 is dependent if the type it specifies is dependent.
 
 \pnum
-A non-type
+A constant
 \grammarterm{template-argument}
 is dependent if its type is dependent or the constant
 expression it specifies is value-dependent.
 
 \pnum
-Furthermore, a non-type
+Furthermore, a constant
 \grammarterm{template-argument}
-is dependent if the corresponding non-type template parameter
+is dependent if the corresponding constant template parameter
 is of reference or pointer type and the \grammarterm{template-argument}
 designates or points to a member of the current instantiation or a member of
 a dependent type.
@@ -7568,7 +7568,7 @@ the specified member is not a type where a type is required, or
 \item
 the specified member is not a template where a template is required, or
 \item
-the specified member is not a non-type where a non-type is required.
+the specified member is not a constant where a constant is required.
 \end{itemize}
 \begin{example}
 \begin{codeblock}
@@ -7590,7 +7590,7 @@ int main() {
   // Deduction fails in each of these cases:
   f<A>(0);          // \tcode{A} does not contain a member \tcode{Y}
   f<B>(0);          // The \tcode{Y} member of \tcode{B} is not a type
-  g<C>(0);          // The \tcode{N} member of \tcode{C} is not a non-type
+  g<C>(0);          // The \tcode{N} member of \tcode{C} is not a constant
   h<D>(0);          // The \tcode{TT} member of \tcode{D} is not a template
 }
 \end{codeblock}
@@ -7609,7 +7609,7 @@ int i = f<int>(0);
 \end{codeblock}
 \end{example}
 \item
-Attempting to give an invalid type to a non-type template parameter.
+Attempting to give an invalid type to a constant template parameter.
 \begin{example}
 \begin{codeblock}
 template <class T, T> struct S {};
@@ -7617,7 +7617,7 @@ template <class T> int f(S<T, T{}>*);   // \#1
 class X {
   int m;
 };
-int i0 = f<X>(0);   // \#1 uses a value of non-structural type \tcode{X} as a non-type template argument
+int i0 = f<X>(0);   // \#1 uses a value of non-structural type \tcode{X} as a constant template argument
 \end{codeblock}
 \end{example}
 
@@ -7685,7 +7685,7 @@ performed instead for each element of the initializer list independently,
 taking $\tcode{P}'$
 as separate function template parameter types $\tcode{P}'_i$
 and the $i^\text{th}$ initializer element as the corresponding argument.
-In the $\tcode{P}'\tcode{[N]}$ case, if \tcode{N} is a non-type template parameter,
+In the $\tcode{P}'\tcode{[N]}$ case, if \tcode{N} is a constant template parameter,
 \tcode{N} is deduced from the length of the initializer list.
 Otherwise, an initializer list argument causes the
 parameter to be considered a non-deduced context\iref{temp.deduct.type}.
@@ -8325,7 +8325,7 @@ in each case a type that is specified in terms of template parameters
 is compared with an actual type (call it
 \tcode{A}),
 and an attempt is made to find template argument values (a type for a type
-parameter, a value for a non-type parameter, or a template for a
+parameter, a value for a constant parameter, or a template for a
 template parameter) that will make
 \tcode{P},
 after substitution of the deduced values (call it the deduced
@@ -8362,7 +8362,7 @@ if it is not otherwise deduced.
 A given type
 \tcode{P}
 can be composed from a number of other
-types, templates, and non-type template argument values:
+types, templates, and constant template argument values:
 
 \begin{itemize}
 \item
@@ -8374,7 +8374,7 @@ and the type of the member pointed to.
 \item
 A type that is a specialization of a class template (e.g.,
 \tcode{A<int>})
-includes the types, templates, and non-type template argument values referenced by the
+includes the types, templates, and constant template argument values referenced by the
 template argument list of the specialization.
 \item
 An array type includes the array element type and the value of the
@@ -8382,7 +8382,7 @@ array bound.
 \end{itemize}
 
 \pnum
-In most cases, the types, templates, and non-type template argument values that are used
+In most cases, the types, templates, and constant template argument values that are used
 to compose
 \tcode{P}
 participate in template argument deduction.
@@ -8418,7 +8418,7 @@ A \grammarterm{pack-index-specifier} or a \grammarterm{pack-index-expression}.
 \item
 The \grammarterm{expression} of a \grammarterm{decltype-specifier}.
 \item
-A non-type template argument or an array bound in which a subexpression
+A constant template argument or an array bound in which a subexpression
 references a template parameter.
 \item
 A template parameter used in the parameter type of a function parameter that
@@ -8580,7 +8580,7 @@ A template type argument
 \tcode{T},
 a template template argument
 \tcode{TT},
-or a template non-type argument
+or a template constant argument
 \tcode{i}
 can be deduced if
 \tcode{P}
@@ -8768,7 +8768,7 @@ constructs other than the ones specified above.
 
 \pnum
 When the value of the argument
-corresponding to a non-type template parameter \tcode{P}
+corresponding to a constant template parameter \tcode{P}
 that is declared with a dependent type
 is deduced from an expression,
 the template parameters in the type of \tcode{P}
@@ -8850,8 +8850,8 @@ void g() {
 
 \pnum
 \begin{note}
-If, in the declaration of a function template with a non-type
-template parameter, the non-type template parameter
+If, in the declaration of a function template with a constant
+template parameter, the constant template parameter
 is used in a subexpression in the function parameter list,
 the expression is a non-deduced context as specified above.
 \begin{example}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -299,7 +299,7 @@ are treated as types for descriptive purposes, the terms
 \term{constant template parameter}
 and
 \term{constant template argument}
-are used to refer to constant, non-template parameters and arguments.
+are used to refer to non-type, non-template parameters and arguments.
 \end{footnote}
 \grammarterm{parameter-declaration}.
 A \grammarterm{template-parameter} of the form

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -296,9 +296,9 @@ Since template
 and template
 \grammarterm{template-argument}{s}
 are treated as types for descriptive purposes, the terms
-\term{constant parameter}
+\term{constant template parameter}
 and
-\term{constant argument}
+\term{constant template argument}
 are used to refer to constant, non-template parameters and arguments.
 \end{footnote}
 \grammarterm{parameter-declaration}.
@@ -3453,8 +3453,8 @@ A<int,int*> a;      // uses the partial specialization, which is found through t
 \end{example}
 
 \pnum
-A constant argument is non-specialized if it is the name of a constant
-parameter.
+A constant template argument is non-specialized if it is the name of a constant
+template parameter.
 All other constant arguments are specialized.
 
 \pnum
@@ -3463,8 +3463,8 @@ the following restrictions apply:
 
 \begin{itemize}
 \item
-The type of a template parameter corresponding to a specialized constant argument
-shall not be dependent on a parameter of the partial specialization.
+The type of a template parameter corresponding to a specialized constant template
+argument shall not be dependent on a parameter of the partial specialization.
 \begin{example}
 \begin{codeblock}
 template <class T, T t> struct C {};
@@ -8325,7 +8325,7 @@ in each case a type that is specified in terms of template parameters
 is compared with an actual type (call it
 \tcode{A}),
 and an attempt is made to find template argument values (a type for a type
-parameter, a value for a constant parameter, or a template for a
+parameter, a value for a constant template parameter, or a template for a
 template parameter) that will make
 \tcode{P},
 after substitution of the deduced values (call it the deduced
@@ -8580,7 +8580,7 @@ A template type argument
 \tcode{T},
 a template template argument
 \tcode{TT},
-or a template constant argument
+or a constant template argument
 \tcode{i}
 can be deduced if
 \tcode{P}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -291,11 +291,7 @@ followed by a
 \grammarterm{qualified-id}
 denotes the type in a
 \begin{footnote}
-Since template
-\grammarterm{template-parameter}{s}
-and template
-\grammarterm{template-argument}{s}
-are treated as types for descriptive purposes, the terms
+The terms
 \term{constant template parameter}
 and
 \term{constant template argument}
@@ -4598,7 +4594,8 @@ appears in a default argument,
 \item \grammarterm{parameter-declaration} in a \grammarterm{lambda-declarator}
 or \grammarterm{requirement-parameter-list},
 unless that \grammarterm{parameter-declaration} appears in a default argument, or
-\item \grammarterm{parameter-declaration} of a (constant) \grammarterm{template-parameter}.
+\item \grammarterm{parameter-declaration} of a \grammarterm{template-parameter}
+that declares a constant template parameter.
 \end{itemize}
 \end{itemize}
 \begin{example}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -4595,7 +4595,7 @@ appears in a default argument,
 or \grammarterm{requirement-parameter-list},
 unless that \grammarterm{parameter-declaration} appears in a default argument, or
 \item \grammarterm{parameter-declaration} of a \grammarterm{template-parameter}
-that declares a constant template parameter.
+(which necessarily declares a constant template parameter).
 \end{itemize}
 \end{itemize}
 \begin{example}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -3455,7 +3455,7 @@ A<int,int*> a;      // uses the partial specialization, which is found through t
 \pnum
 A constant template argument is non-specialized if it is the name of a constant
 template parameter.
-All other constant arguments are specialized.
+All other constant template arguments are specialized.
 
 \pnum
 Within the argument list of a partial specialization,
@@ -7568,7 +7568,8 @@ the specified member is not a type where a type is required, or
 \item
 the specified member is not a template where a template is required, or
 \item
-the specified member is not a constant where a constant is required.
+the specified member is not a non-type, non-template where a non-type,
+non-template is required.
 \end{itemize}
 \begin{example}
 \begin{codeblock}
@@ -7590,7 +7591,7 @@ int main() {
   // Deduction fails in each of these cases:
   f<A>(0);          // \tcode{A} does not contain a member \tcode{Y}
   f<B>(0);          // The \tcode{Y} member of \tcode{B} is not a type
-  g<C>(0);          // The \tcode{N} member of \tcode{C} is not a constant
+  g<C>(0);          // The \tcode{N} member of \tcode{C} is not a non-type, non-template name
   h<D>(0);          // The \tcode{TT} member of \tcode{D} is not a template
 }
 \end{codeblock}
@@ -8326,7 +8327,7 @@ is compared with an actual type (call it
 \tcode{A}),
 and an attempt is made to find template argument values (a type for a type
 parameter, a value for a constant template parameter, or a template for a
-template parameter) that will make
+template template parameter) that will make
 \tcode{P},
 after substitution of the deduced values (call it the deduced
 \tcode{A}),

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1143,7 +1143,7 @@ void f() {
 A template type argument can be an incomplete type\iref{term.incomplete.type}.
 \end{note}
 
-\rSec2[temp.arg.nontype]{Non-type template arguments}
+\rSec2[temp.arg.nontype]{Constant template arguments}
 
 \pnum
 A template argument $E$ for


### PR DESCRIPTION
As previously discussed by CWG.
The aim is to editorially adopt some of the wording changes made in P2841R5 to ease its review in core.

Note that not all-instance of non-type have been
mechanically replaced as [dcl] and [diff] use
the term to refer to anything that is not a type
in the context of lookup