### PR TITLE
[defns.argument.templ] Change 'template instantiation' to 'template'; mention braced-init-list

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -122,12 +122,10 @@ comma-separated list bounded by the parentheses
 \defncontext{throw expression} operand of \keyword{throw}
 
 \indexdefn{argument}%
-\indexdefn{argument!template instantiation}%
+\indexdefn{argument!template}%
 \definition{argument}{defns.argument.templ}
-\defncontext{template instantiation}
-\grammarterm{constant-expression},
-\grammarterm{type-id}, or
-\grammarterm{id-expression} in the comma-separated
+\defncontext{template}
+\grammarterm{template-argument} in the comma-separated
 list bounded by the angle brackets
 
 \indexdefn{block (execution)}%


### PR DESCRIPTION
Not all templates are instantiated, so limiting this definition to the process template instantiation seems wrong.

Adding *braced-init-list* updates the definition to match the changes made by [P2308](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2308r1.html).