### PR TITLE
[basic.scope.scope] Update the note about special cases

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -933,8 +933,9 @@ other friend declarations and
 certain \grammarterm{elaborated-type-specifier}s\iref{dcl.type.elab}
 target a larger enclosing scope.
 \item
-Block-scope extern declarations target a larger enclosing scope
-but bind a name in their immediate scope.
+Declarations in block scope that have \tcode{extern} specifier
+or declare a function target an innermost namespace scope
+but bind a name in their immediate scope\iref{dcl.meaning}.
 \item
 The names of unscoped enumerators are bound
 in the two innermost enclosing scopes\iref{dcl.enum}.


### PR DESCRIPTION
[basic.scope.scope] has a lengthy note about declarations that target a different scope than the scope they inhabit. This patch updates a bullet about declarations inhabiting a block scope in accordance with [[dcl.meaning]/3.5](https://eel.is/c++draft/dcl.meaning#general-3.5) to make the note more complete:
> If the declaration inhabits a block scope S and declares a function ([[dcl.fct]](https://eel.is/c++draft/dcl.meaning#dcl.fct)) or uses the extern specifier, the declaration shall not be attached to a named module ([[module.unit]](https://eel.is/c++draft/module.unit)); its target scope is the innermost enclosing namespace scope, but the name is bound in S[.](https://eel.is/c++draft/dcl.meaning#general-3.5.sentence-1)