### PR TITLE
[cmath.syn] Consolidate std namespaces

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -9304,11 +9304,6 @@ An iterator referencing one past the last value in the array.
 \indexlibraryglobal{truncf}%
 \indexlibraryglobal{truncl}%
 \begin{codeblock}
-namespace std {
-  using float_t = @\seebelow@;
-  using double_t = @\seebelow@;
-}
-
 #define @\libmacro{HUGE_VAL}@ @\seebelow@
 #define @\libmacro{HUGE_VALF}@ @\seebelow@
 #define @\libmacro{HUGE_VALL}@ @\seebelow@
@@ -9330,6 +9325,9 @@ namespace std {
 #define @\libmacro{math_errhandling}@ @\seebelow@
 
 namespace std {
+  using float_t = @\seebelow@;
+  using double_t = @\seebelow@;
+
   constexpr @\placeholdernc{floating-point-type}@ acos(@\placeholdernc{floating-point-type}@ x);
   constexpr float               acosf(float x);
   constexpr long double         acosl(long double x);


### PR DESCRIPTION
There is no ordering dependency between the two typedefs in namespace std, the macros that follow, and teh next opening of namespace std, so move the two typedefs to avoid repeatedly opening an closing the namespace.

Note that we could have done this without moving
the typedefs as macros are not bound by namespaces, but our convention very sensibly avoids confusing
readers by keeping macro definitions outside of
namespaces.