### PR TITLE
[temp.res.general] Clean up LaTeX

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -4515,7 +4515,7 @@ the program is ill-formed, no diagnostic required.
 \begin{bnf}
 \nontermdef{typename-specifier}\br
   \keyword{typename} nested-name-specifier identifier\br
-  \keyword{typename} nested-name-specifier \terminal{\opt{template}} simple-template-id
+  \keyword{typename} nested-name-specifier \opt{\terminal{template}} simple-template-id
 \end{bnf}
 
 \pnum


### PR DESCRIPTION
Modify LaTeX code from `\terminal{\opt{...}}` form into standard `\opt{\terminal{...}}`
This is the only occurrence of the unusual ordering in the repository