### PR TITLE
Wrap keywords that were \terminal{} with \keyword{} instead

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2588,7 +2588,7 @@ named in a friend declaration\iref{class.friend}.
     identifier \opt{\terminal{...}}\br
     \terminal{\&} identifier \opt{\terminal{...}}\br
     \keyword{this}\br
-    \terminal{*} \terminal{this}
+    \terminal{*} \keyword{this}
 \end{bnf}
 
 \begin{bnf}
@@ -3449,8 +3449,8 @@ Postfix expressions group left-to-right.
     typename-specifier \terminal{(} \opt{expression-list} \terminal{)}\br
     simple-type-specifier braced-init-list\br
     typename-specifier braced-init-list\br
-    postfix-expression \terminal{.} \opt{\terminal{template}} id-expression\br
-    postfix-expression \terminal{->} \opt{\terminal{template}} id-expression\br
+    postfix-expression \terminal{.} \opt{\keyword{template}} id-expression\br
+    postfix-expression \terminal{->} \opt{\keyword{template}} id-expression\br
     postfix-expression \terminal{++}\br
     postfix-expression \terminal{--}\br
     \keyword{dynamic_cast} \terminal{<} type-id \terminal{>} \terminal{(} expression \terminal{)}\br
@@ -5153,7 +5153,7 @@ transfers control to its caller or resumer.
 
 \begin{bnf}
 \nontermdef{await-expression}\br
-    \terminal{co_await} cast-expression
+    \keyword{co_await} cast-expression
 \end{bnf}
 
 \pnum
@@ -7473,8 +7473,8 @@ that type and the other is a null pointer constant. The result is of type
 
 \begin{bnf}
   \nontermdef{yield-expression}\br
-  \terminal{co_yield} assignment-expression\br
-  \terminal{co_yield} braced-init-list
+  \keyword{co_yield} assignment-expression\br
+  \keyword{co_yield} braced-init-list
 \end{bnf}
 
 \pnum

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -2079,8 +2079,8 @@ its interpretation depends on the context in which it appears.
 \indextext{literal!boolean}%
 \begin{bnf}
 \nontermdef{boolean-literal}\br
-    \terminal{false}\br
-    \terminal{true}
+    \keyword{false}\br
+    \keyword{true}
 \end{bnf}
 
 \pnum
@@ -2093,7 +2093,7 @@ Such literals have type \tcode{bool}.
 \indextext{literal!pointer}%
 \begin{bnf}
 \nontermdef{pointer-literal}\br
-    \terminal{nullptr}
+    \keyword{nullptr}
 \end{bnf}
 
 \pnum

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -589,7 +589,7 @@ returning \tcode{R}'', a \defn{surrogate call function} with the unique name
 and having the form
 \begin{ncbnf}
 \terminal{R} \placeholder{call-function} \terminal{(} conversion-type-id \ %
-\terminal{F, P$_1$ a$_1$, $\dotsc$, P$_n$ a$_n$)} \terminal{\{ return F (a$_1$, $\dotsc$, a$_n$); \}}
+\terminal{F, P$_1$ a$_1$, $\dotsc$, P$_n$ a$_n$)} \terminal{\{} \keyword{return} \terminal{F (a$_1$, $\dotsc$, a$_n$); \}}
 \end{ncbnf}
 is also considered as a candidate function.
 Similarly, surrogate
@@ -3309,7 +3309,7 @@ the operator named in its
 %% Ed. note: character protrusion would misalign various operators.
 \microtypesetup{protrusion=false}
 \nontermdef{operator} \textnormal{one of}\br
-    \terminal{new \ \ \ \ \ delete \ \ new[] \ \ \ delete[] co_await (\rlap{\,)} \ \ \ \ \ \ \ [\rlap{\,]} \ \ \ \ \ \ \ -> \ \ \ \ \ \ ->*}\br
+    \terminal{\keyword{new} \ \ \ \ \ \keyword{delete} \ \ \keyword{new}[] \ \ \ \keyword{delete}[] \keyword{co_await} (\rlap{\,)} \ \ \ \ \ \ \ [\rlap{\,]} \ \ \ \ \ \ \ -> \ \ \ \ \ \ ->*}\br
     \terminal{\~ \ \ \ \ \ \ \ ! \ \ \ \ \ \ \ + \ \ \ \ \ \ \ - \ \ \ \ \ \ \ * \ \ \ \ \ \ \ / \ \ \ \ \ \ \ \% \ \ \ \ \ \ \ \caret{} \ \ \ \ \ \ \ \&}\br
     \terminal{| \ \ \ \ \ \ \ = \ \ \ \ \ \ \ += \ \ \ \ \ \ -= \ \ \ \ \ \ *= \ \ \ \ \ \ /= \ \ \ \ \ \ \%= \ \ \ \ \ \ \caret{}= \ \ \ \ \ \ \&=}\br
     \terminal{|= \ \ \ \ \ \ == \ \ \ \ \ \ != \ \ \ \ \ \ < \ \ \ \ \ \ \ > \ \ \ \ \ \ \ <= \ \ \ \ \ \ >= \ \ \ \ \ \ <=> \ \ \ \ \ \&\&}\br

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -793,7 +793,7 @@ is replaced with \tcode{import} directive}
 whether the \tcode{\#include} preprocessing directive
 is instead replaced by an \tcode{import} directive\iref{cpp.import} of the form
 \begin{ncbnf}
-\terminal{import} header-name \terminal{;} new-line
+\keyword{import} header-name \terminal{;} new-line
 \end{ncbnf}
 
 \pnum

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -988,7 +988,7 @@ auto&& f3() {
 
 \begin{bnf}
 \nontermdef{coroutine-return-statement}\br
-    \terminal{co_return} \opt{expr-or-braced-init-list} \terminal{;}
+    \keyword{co_return} \opt{expr-or-braced-init-list} \terminal{;}
 \end{bnf}
 
 \pnum
@@ -1008,7 +1008,7 @@ Let \placeholder{p} be an lvalue naming the coroutine
 promise object\iref{dcl.fct.def.coroutine}.
 A \keyword{co_return} statement is equivalent to:
 \begin{ncsimplebnf}
-\terminal{\{} S\terminal{;} \terminal{goto} \exposid{final-suspend}\terminal{;} \terminal{\}}
+\terminal{\{} S\terminal{;} \keyword{goto} \exposid{final-suspend}\terminal{;} \terminal{\}}
 \end{ncsimplebnf}
 where \exposid{final-suspend} is the exposition-only label
 defined in \ref{dcl.fct.def.coroutine}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -4782,7 +4782,7 @@ the program is ill-formed, no diagnostic required.
 \begin{bnf}
 \nontermdef{typename-specifier}\br
   \keyword{typename} nested-name-specifier identifier\br
-  \keyword{typename} nested-name-specifier \opt{\terminal{template}} simple-template-id
+  \keyword{typename} nested-name-specifier \opt{\keyword{template}} simple-template-id
 \end{bnf}
 
 \pnum


### PR DESCRIPTION
My impression is that keywords should be `\keyword{<string>}` usually, no surrounding command, except in `one of`  grammar definitions, where they should be wrapped in a `\terminal{...}`

Didn't do this on a couple occurences in preprocessor.tex (`if` and `else` are in `\terminal{}` args):
```
\begin{bnf}\obeyspaces
\nontermdef{else-group}\br
    \terminal{\# else   } new-line \opt{group}
\end{bnf}
```

```
\begin{ncsimplebnf}\obeyspaces
\indextext{\idxcode{\#if}}%
\terminal{\# if     } constant-expression new-line \opt{group}\br
\indextext{\idxcode{\#elif}}%
\terminal{\# elif   } constant-expression new-line \opt{group}
\end{ncsimplebnf}
```

```
\begin{bnf}\obeyspaces
\nontermdef{if-group}\br
    \terminal{\# if     } constant-expression new-line \opt{group}\br
    \terminal{\# ifdef  } identifier new-line \opt{group}\br
    \terminal{\# ifndef } identifier new-line \opt{group}
\end{bnf}
```

I don't think these are quite the same meaning as keyword if

Also, there are many instances of keywords not being \keyword-ed in \tcode{} parts, this PR does not touch those

Additionally some minor cleanup
* expressions.tex: `\keyword{U}` -> `\tcode{U}`
* lex.tex: removed space between command and argument