### PR TITLE
[editorial] ranges "which" hunt

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1511,8 +1511,8 @@ for any other type \tcode{V}.
 \remarks
 Pursuant to \ref{namespace.std}, users may specialize \tcode{enable_view}
 to \tcode{true}
-for cv-unqualified program-defined types which model \libconcept{view},
-and \tcode{false} for types which do not.
+for cv-unqualified program-defined types that model \libconcept{view},
+and \tcode{false} for types that do not.
 Such specializations shall
 be usable in constant expressions\iref{expr.const} and
 have type \tcode{const bool}.


### PR DESCRIPTION
replaces incorrect uses of "which" with "that" in the specification of `enable_view`. it should be possible to drop a phrase introduced with "which" without changing the meaning of the sentence. if the phrase is essential to the point, "that" is more correct.

(this is a pet peeve of mine.)