### PR TITLE
[fs.rec.dir.itr.members] Merge adjacent \tcode commands

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -17085,7 +17085,7 @@ void disable_recursion_pending();
 
 \pnum
 \begin{note}
-\tcode{disable_recursion_pending}\tcode{()} is used to prevent
+\tcode{disable_recursion_pending()} is used to prevent
   unwanted recursion into a directory.
 \end{note}
 \end{itemdescr}


### PR DESCRIPTION
Apparently I added this in f325daf919ffebf58fb9b133db79f4c60ce64034 - maybe because the original HTML source of the TS had separate `<code>` tags here and I scripted the conversion. There doesn't seem to be any reason for it to be this way.