### PR TITLE
[fs.op.funcs] Remove empty parens when referring to functions by name

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -17515,7 +17515,7 @@ bool filesystem::create_directories(const path& p, error_code& ec);
 \begin{itemdescr}
 \pnum
 \effects
-Calls \tcode{create_directory()} for each element of \tcode{p}
+Calls \tcode{create_directory} for each element of \tcode{p}
   that does not exist.
 
 \pnum
@@ -17608,7 +17608,7 @@ void filesystem::create_directory_symlink(const path& to, const path& new_symlin
 \begin{itemdescr}
 \pnum
 \effects
-Establishes the postcondition, as if by POSIX \tcode{symlink()}.
+Establishes the postcondition, as if by POSIX \tcode{symlink}.
 
 \pnum
 \ensures
@@ -17623,7 +17623,7 @@ As specified in~\ref{fs.err.report}.
 \begin{note}
 Some operating systems require symlink creation to
 identify that the link is to a directory.
-Thus, \tcode{create_symlink()} (instead of \tcode{create_directory_symlink()})
+Thus, \tcode{create_symlink} (instead of \tcode{create_directory_symlink})
 cannot be used reliably to create directory symlinks.
 \end{note}
 
@@ -17649,7 +17649,7 @@ void filesystem::create_hard_link(const path& to, const path& new_hard_link,
 \begin{itemdescr}
 \pnum
 \effects
-Establishes the postcondition, as if by POSIX \tcode{link()}.
+Establishes the postcondition, as if by POSIX \tcode{link}.
 
 \pnum
 \ensures
@@ -17684,7 +17684,7 @@ void filesystem::create_symlink(const path& to, const path& new_symlink,
 \begin{itemdescr}
 \pnum
 \effects
-Establishes the postcondition, as if by POSIX \tcode{symlink()}.
+Establishes the postcondition, as if by POSIX \tcode{symlink}.
 
 \pnum
 \ensures
@@ -17717,7 +17717,7 @@ path filesystem::current_path(error_code& ec);
 \returns
 The absolute path of the current working directory,
   whose pathname in the native format is
-  obtained as if by POSIX \tcode{getcwd()}.
+  obtained as if by POSIX \tcode{getcwd}.
   The signature with argument \tcode{ec} returns \tcode{path()} if an
   error occurs.
 
@@ -17754,7 +17754,7 @@ void filesystem::current_path(const path& p, error_code& ec) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Establishes the postcondition, as if by POSIX \tcode{chdir()}.
+Establishes the postcondition, as if by POSIX \tcode{chdir}.
 
 \pnum
 \ensures
@@ -17787,7 +17787,7 @@ Two paths are considered to resolve to the same file system entity if two
   \begin{note}
   On POSIX platforms, this is
   determined as if by the values of the POSIX \tcode{stat} class,
-  obtained as if by \tcode{stat()} for the two paths, having equal \tcode{st_dev} values
+  obtained as if by \tcode{stat} for the two paths, having equal \tcode{st_dev} values
   and equal \tcode{st_ino} values.
   \end{note}
 
@@ -17865,7 +17865,7 @@ If \tcode{exists(p)} is \tcode{false}, an error is reported\iref{fs.err.report}.
 \item
   If \tcode{is_regular_file(p)}, the size in bytes of the file
   \tcode{p} resolves to, determined as if by the value of the POSIX \tcode{stat}
-  class member \tcode{st_size} obtained as if by POSIX \tcode{stat()}.
+  class member \tcode{st_size} obtained as if by POSIX \tcode{stat}.
 \item
   Otherwise, the result is \impldef{result of \tcode{filesystem::file_size}}.
 \end{itemize}
@@ -18227,7 +18227,7 @@ file_time_type filesystem::last_write_time(const path& p, error_code& ec) noexce
 \returns
 The time of last data modification of \tcode{p},
   determined as if by the value of the POSIX \tcode{stat} class member \tcode{st_mtime}
-  obtained as if by POSIX \tcode{stat()}.
+  obtained as if by POSIX \tcode{stat}.
   The signature with argument \tcode{ec} returns \tcode{file_time_type::min()}
   if an error occurs.
 
@@ -18247,7 +18247,7 @@ void filesystem::last_write_time(const path& p, file_time_type new_time,
 \pnum
 \effects
 Sets the time of last data modification of the file
-  resolved to by \tcode{p} to \tcode{new_time}, as if by POSIX \tcode{futimens()}.
+  resolved to by \tcode{p} to \tcode{new_time}, as if by POSIX \tcode{futimens}.
 
 \pnum
 \throws
@@ -18281,7 +18281,7 @@ Applies the action specified by \tcode{opts}
 to the file \tcode{p} resolves to,
 or to file \tcode{p} itself if \tcode{p} is a symbolic link
 and \tcode{perm_options::nofollow} is set in \tcode{opts}.
-The action is applied as if by POSIX \tcode{fchmodat()}.
+The action is applied as if by POSIX \tcode{fchmodat}.
 
 \pnum
 \begin{note}
@@ -18418,7 +18418,7 @@ bool filesystem::remove(const path& p, error_code& ec) noexcept;
 \pnum
 \effects
 If \tcode{exists(symlink_status(p, ec))}, the file \tcode{p} is
-  removed as if by POSIX \tcode{remove()}.
+  removed as if by POSIX \tcode{remove}.
 \begin{note}
 A symbolic link is itself removed, rather than the file it
   resolves to.
@@ -18453,7 +18453,7 @@ uintmax_t filesystem::remove_all(const path& p, error_code& ec);
 \pnum
 \effects
 Recursively deletes the contents of \tcode{p} if it exists,
-  then deletes file \tcode{p} itself, as if by POSIX \tcode{remove()}.
+  then deletes file \tcode{p} itself, as if by POSIX \tcode{remove}.
 \begin{note}
 A symbolic link is itself removed, rather than the file it
   resolves to.
@@ -18487,7 +18487,7 @@ void filesystem::rename(const path& old_p, const path& new_p, error_code& ec) no
 \pnum
 \effects
 Renames \tcode{old_p} to \tcode{new_p}, as if by
-  POSIX \tcode{rename()}.
+  POSIX \tcode{rename}.
 
 \begin{note}
 \begin{itemize}
@@ -18523,7 +18523,7 @@ void filesystem::resize_file(const path& p, uintmax_t new_size, error_code& ec) 
 \pnum
 \effects
 Causes the size that would be returned by \tcode{file_size(p)} to be
-equal to \tcode{new_size}, as if by POSIX \tcode{truncate()}.
+equal to \tcode{new_size}, as if by POSIX \tcode{truncate}.
 
 \pnum
 \throws
@@ -18610,14 +18610,14 @@ file_status filesystem::status(const path& p, error_code& ec) noexcept;
 \pnum
 \effects
 If possible, determines the attributes
-    of the file \tcode{p} resolves to, as if by using POSIX \tcode{stat()}
+    of the file \tcode{p} resolves to, as if by using POSIX \tcode{stat}
     to obtain a POSIX \tcode{struct stat}.
       If, during attribute determination, the underlying file system API reports
     an error, sets \tcode{ec} to indicate the specific error reported.
     Otherwise, \tcode{ec.clear()}.
 \begin{note}
 This allows users to inspect the specifics of underlying
-      API errors even when the value returned by \tcode{status()} is not
+      API errors even when the value returned by \tcode{status} is not
       \tcode{file_status(file_type::none)}.
 \end{note}
 
@@ -18711,9 +18711,9 @@ file_status filesystem::symlink_status(const path& p, error_code& ec) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Same as \tcode{status()}, above,
+Same as \tcode{status}, above,
   except that the attributes
-    of \tcode{p} are determined as if by using POSIX \tcode{lstat()}
+    of \tcode{p} are determined as if by using POSIX \tcode{lstat}
     to obtain a POSIX \tcode{struct stat}.
 
 \pnum
@@ -18723,7 +18723,7 @@ of the obtained \tcode{struct stat} to the type \tcode{perms}.
 
 \pnum
 \returns
-Same as \tcode{status()}, above, except
+Same as \tcode{status}, above, except
       that if the attributes indicate a symbolic link, as if by POSIX \tcode{S_ISLNK},
       returns \tcode{file_status(file_type::symlink, prms)}.
       The signature with argument \tcode{ec} returns
@@ -18792,14 +18792,14 @@ path filesystem::weakly_canonical(const path& p, error_code& ec);
 Using \tcode{status(p)} or \tcode{status(p, ec)}, respectively,
   to determine existence,
   return a path composed by \tcode{operator/=}
-  from the result of calling \tcode{canonical()}
+  from the result of calling \tcode{canonical}
   with a path argument composed of
   the leading elements of \tcode{p} that exist, if any, followed by
   the elements of \tcode{p} that do not exist, if any.
   For the first form,
-  \tcode{canonical()} is called without an \tcode{error_code} argument.
+  \tcode{canonical} is called without an \tcode{error_code} argument.
   For the second form,
-  \tcode{canonical()} is called
+  \tcode{canonical} is called
   with \tcode{ec} as an \tcode{error_code} argument, and
   \tcode{path()} is returned at the first error occurrence, if any.
 


### PR DESCRIPTION
As per the Specification Style Guidelines.

https://github.com/cplusplus/draft/wiki/Specification-Style-Guidelines#describing-function-calls