### PR TITLE
[sequence.reqmts] Use \range instead of \tcode throughout the standard

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -7565,7 +7565,7 @@ The elements \tcode{e} of \range{first}{last}
 are partitioned with respect to the expressions
 \tcode{bool(invoke(comp, invoke(proj, e), value))} and
 \tcode{!bool(invoke(comp, value, invoke(proj, e)))}.
-Also, for all elements \tcode{e} of \tcode{[first, last)},
+Also, for all elements \tcode{e} of \range{first}{last},
 \tcode{bool(comp(e, value))} implies \tcode{!bool(comp(\brk{}value, e))}
 for the overloads in namespace \tcode{std}.
 
@@ -7632,7 +7632,7 @@ The elements \tcode{e} of \range{first}{last}
 are partitioned with respect to the expressions
 \tcode{bool(invoke(comp, invoke(proj, e), value))} and
 \tcode{!bool(invoke(comp, value, invoke(proj, e)))}.
-Also, for all elements \tcode{e} of \tcode{[first, last)},
+Also, for all elements \tcode{e} of \range{first}{last},
 \tcode{bool(comp(e, value))} implies \tcode{!bool(comp(\brk{}value, e))}
 for the overloads in namespace \tcode{std}.
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1309,7 +1309,7 @@ type\iref{temp.deduct} and
 denote iterators that meet the \oldconcept{InputIterator} requirements
 and refer to elements implicitly convertible to \tcode{value_type},
 \item
-\tcode{[i, j)} denotes a valid range,
+\range{i}{j} denotes a valid range,
 \item
 \tcode{rg} denotes a value of a type \tcode{R}
 that models \tcode{\exposconcept{container-compatible-range}<T>},
@@ -1322,7 +1322,7 @@ that models \tcode{\exposconcept{container-compatible-range}<T>},
 \item
 \tcode{q} denotes a valid dereferenceable constant iterator to \tcode{a},
 \item
-\tcode{[q1, q2)} denotes a valid range of constant iterators in \tcode{a},
+\range{q1}{q2} denotes a valid range of constant iterators in \tcode{a},
 \item
 \tcode{t} denotes an lvalue or a const rvalue of \tcode{X::value_type}, and
 \item
@@ -1384,7 +1384,7 @@ the \oldconcept{ForwardIterator} requirements\iref{forward.iterators},
 
 \pnum
 \effects
-Constructs a sequence container equal to the range \tcode{[i, j)}.
+Constructs a sequence container equal to the range \range{i}{j}.
 Each iterator in the range \range{i}{j} is dereferenced exactly once.
 
 \pnum
@@ -1578,7 +1578,7 @@ Neither \tcode{i} nor \tcode{j} are iterators into \tcode{a}.
 
 \pnum
 \effects
-Inserts copies of elements in \tcode{[i, j)} before \tcode{p}.
+Inserts copies of elements in \range{i}{j} before \tcode{p}.
 Each iterator in the range \range{i}{j} shall be dereferenced exactly once.
 
 \pnum
@@ -1675,7 +1675,7 @@ For \tcode{vector}, \tcode{inplace_vector}, and \tcode{deque},
 
 \pnum
 \effects
-Erases the elements in the range \tcode{[q1, q2)}.
+Erases the elements in the range \range{q1}{q2}.
 
 \pnum
 \returns
@@ -1732,7 +1732,7 @@ Neither \tcode{i} nor \tcode{j} are iterators into \tcode{a}.
 
 \pnum
 \effects
-Replaces elements in \tcode{a} with a copy of \tcode{[i, j)}.
+Replaces elements in \tcode{a} with a copy of \range{i}{j}.
 Invalidates all references, pointers and iterators
 referring to the elements of \tcode{a}.
 For \tcode{vector} and \tcode{deque},
@@ -2690,7 +2690,7 @@ that models \tcode{\exposconcept{container-compatible-range}<value_type>},
 \item
 \tcode{r} denotes a valid dereferenceable iterator to \tcode{a},
 \item
-\tcode{[q1, q2)} denotes a valid range of constant iterators in \tcode{a},
+\range{q1}{q2} denotes a valid range of constant iterators in \tcode{a},
 \item
 \tcode{il} designates an object of type \tcode{initializer_list<value_type>},
 \item
@@ -4179,7 +4179,7 @@ In this subclause,
 \tcode{i} and \tcode{j} denote input iterators
   that refer to \tcode{value_type},
 \item
-\tcode{[i, j)} denotes a valid range,
+\range{i}{j} denotes a valid range,
 \item
 \tcode{rg} denotes a value of a type \tcode{R}
 that models \tcode{\exposconcept{container-compatible-range}<value_type>},
@@ -4191,7 +4191,7 @@ that models \tcode{\exposconcept{container-compatible-range}<value_type>},
 \item
 \tcode{r} denotes a valid dereferenceable iterator to \tcode{a},
 \item
-\tcode{[q1, q2)} denotes a valid range in \tcode{a},
+\range{q1}{q2} denotes a valid range in \tcode{a},
 \item
 \tcode{il} denotes a value of type \tcode{initializer_list<value_type>},
 \item
@@ -5003,7 +5003,7 @@ Neither \tcode{i} nor \tcode{j} are iterators into \tcode{a}.
 
 \pnum
 \effects
-Equivalent to \tcode{a.insert(t)} for each element in \tcode{[i,j)}.
+Equivalent to \tcode{a.insert(t)} for each element in \range{i}{j}.
 
 \pnum
 \complexity
@@ -5366,7 +5366,7 @@ a.erase(q1, q2)
 
 \pnum
 \effects
-Erases all elements in the range \tcode{[q1, q2)}.
+Erases all elements in the range \range{q1}{q2}.
 
 \pnum
 \returns
@@ -5602,7 +5602,7 @@ b.bucket(k)
 The index of the bucket
 in which elements with keys equivalent to \tcode{k} would be found,
 if any such element existed.
-The return value is in the range \tcode{[0, b.bucket_count())}.
+The return value is in the range \range{0}{b.bucket_count()}.
 
 \pnum
 \complexity
@@ -5625,7 +5625,7 @@ a_tran.bucket(ke)
 
 \pnum
 \ensures
-The return value is in the range \tcode{[0, a_tran.bucket_count())}.
+The return value is in the range \range{0}{a_tran.bucket_count()}.
 
 \pnum
 \returns
@@ -5650,7 +5650,7 @@ b.bucket_size(n)
 
 \pnum
 \expects
-\tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.
+\tcode{n} shall be in the range \range{0}{b.bucket_count()}.
 
 \pnum
 \returns
@@ -5673,7 +5673,7 @@ b.begin(n)
 
 \pnum
 \expects
-\tcode{n} is in the range \tcode{[0, b.bucket_count())}.
+\tcode{n} is in the range \range{0}{b.bucket_count()}.
 
 \pnum
 \returns
@@ -5697,7 +5697,7 @@ b.end(n)
 
 \pnum
 \expects
-\tcode{n} is in the range \tcode{[0, b.bucket_count())}.
+\tcode{n} is in the range \range{0}{b.bucket_count()}.
 
 \pnum
 \returns
@@ -5720,7 +5720,7 @@ b.cbegin(n)
 
 \pnum
 \expects
-\tcode{n} shall be in the range \tcode{[0, b.bucket_count())}.
+\tcode{n} shall be in the range \range{0}{b.bucket_count()}.
 
 \pnum
 \returns
@@ -5744,7 +5744,7 @@ b.cend(n)
 
 \pnum
 \expects
-\tcode{n} is in the range \tcode{[0, b.bucket_count())}.
+\tcode{n} is in the range \range{0}{b.bucket_count()}.
 
 \pnum
 \returns
@@ -8363,7 +8363,7 @@ void splice(const_iterator position, list&& x, const_iterator first,
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{[first, last)} is a valid range in \tcode{x}.
+\range{first}{last} is a valid range in \tcode{x}.
 \tcode{position} is not an iterator in the range \range{first}{last}.
 
 \pnum

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -140,31 +140,31 @@ whether \tcode{c} is to be treated as equal to \tcode{d}.   &   constant    \\ \
 whether \tcode{c} is to be treated as less than \tcode{d}.  &   constant    \\ \rowsep
 \tcode{X::compare(p,q,n)}   &   \tcode{int}     &
  \returns
-\tcode{0} if for each \tcode{i} in \tcode{[0,n)}, \tcode{X::eq(p[i],q[i])}
-is \tcode{true}; else, a negative value if, for some \tcode{j} in \tcode{[0,n)},
-\tcode{X::lt(p[j],q[j])} is \tcode{true} and for each \tcode{i} in \tcode{[0,j)}
+\tcode{0} if for each \tcode{i} in \range{0}{n}, \tcode{X::eq(p[i],q[i])}
+is \tcode{true}; else, a negative value if, for some \tcode{j} in \range{0}{n},
+\tcode{X::lt(p[j],q[j])} is \tcode{true} and for each \tcode{i} in \range{0}{j}
 \tcode{X::eq(p[i],q[i])} is \tcode{true}; else a positive value.            &   linear      \\ \rowsep
 \tcode{X::length(p)}    &   \tcode{size_t}     &
  \returns
 the smallest \tcode{i} such that \tcode{X::eq(p[i],charT())} is \tcode{true}.  &   linear  \\ \rowsep
 \tcode{X::find(p,n,c)}  &   \tcode{const X::char_type*} &
  \returns
-the smallest \tcode{q} in \tcode{[p,p+n)} such that
+the smallest \tcode{q} in \range{p}{p+n} such that
 \tcode{X::eq(*q,c)} is \tcode{true}, \tcode{nullptr} otherwise.                &   linear      \\ \rowsep
 \tcode{X::move(s,p,n)}  &   \tcode{X::char_type*}   &
-for each \tcode{i} in \tcode{[0,n)}, performs \tcode{X::assign(s[i],p[i])}.
-Copies correctly even where the ranges \tcode{[p,p+n)} and \tcode{[s,s+n)} overlap.\br \returns \tcode{s}.    &   linear  \\ \rowsep
+for each \tcode{i} in \range{0}{n}, performs \tcode{X::assign(s[i],p[i])}.
+Copies correctly even where the ranges \range{p}{p+n} and \range{s}{s+n} overlap.\br \returns \tcode{s}.    &   linear  \\ \rowsep
 \tcode{X::copy(s,p,n)}  &   \tcode{X::char_type*}   &
  \expects
 The ranges \range{p}{p+n} and \range{s}{s+n} do not overlap.\par
  \returns
 \tcode{s}.\br
 for each \tcode{i} in
-\tcode{[0,n)}, performs \tcode{X::assign(s[i],p[i])}.               &   linear      \\ \rowsep
+\range{0}{n}, performs \tcode{X::assign(s[i],p[i])}.               &   linear      \\ \rowsep
 \tcode{X::assign(r,d)}  &   (not used)          &
 assigns \tcode{r=d}.                            &   constant        \\ \rowsep
 \tcode{X::assign\-(s,n,c)}  &   \tcode{X::char_type*}   &
-for each \tcode{i} in \tcode{[0,n)}, performs
+for each \tcode{i} in \range{0}{n}, performs
 \tcode{X::assign(s[i],c)}.\br
  \returns
 \tcode{s}.                       &   linear      \\ \rowsep
@@ -3917,7 +3917,7 @@ constexpr iterator erase(const_iterator first, const_iterator last);
 \pnum
 \effects
 Removes the characters in the range
-\tcode{[first, last)}.
+\range{first}{last}.
 
 \pnum
 \returns

--- a/source/text.tex
+++ b/source/text.tex
@@ -12419,7 +12419,7 @@ iterator then returns \tcode{*this}.
 In all cases in which the call to \tcode{regex_search} returns \tcode{true},
 \tcode{match.prefix().first} shall be equal to the previous value of
 \tcode{match[0].second}, and for each index \tcode{i} in the half-open range
-\tcode{[0, match.size())} for which \tcode{match[i].matched} is \tcode{true},
+\range{0}{match.size()} for which \tcode{match[i].matched} is \tcode{true},
 \tcode{match.position(i)}
 shall return \tcode{distance(begin, match[i].\brk{}first)}.
 


### PR DESCRIPTION
In various cases, the standard used `\tcode{[i, j)}` instead of `\range{i}{j}` to specify a left-closed right-open range of items, thus causing a visible difference. For example: `[sequence.reqmts]/2.6` (using `\tcode`) versus `[associative.reqmts.general]/7.10` (using `\range`):
![CleanShot 2025-02-10 at 21 28 58@2x](https://github.com/user-attachments/assets/0fd24301-3f00-4dc1-841c-a1d825f20124)
![CleanShot 2025-02-10 at 21 29 09@2x](https://github.com/user-attachments/assets/fe7cbeaa-c94c-4992-b2d3-4105f4a14ba4)

Thus this PR seeks to change all occurrences of such `\tcode` ranges in the standard to actually use `\range` instead.

