### PR TITLE
[expr.const] Forward-reference [dcl.constexpr] for "constexpr destructor"

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -8119,7 +8119,7 @@ An object \tcode{a} is said to have \defnadj{constant}{destruction} if
   it is not of class type nor (possibly multidimensional) array thereof, or
 \item
   it is of class type or (possibly multidimensional) array thereof,
-  that class type has a constexpr destructor, and
+  that class type has a constexpr destructor\iref{dcl.constexpr}, and
   for a hypothetical expression $E$
   whose only effect is to destroy \tcode{a},
   $E$ would be a core constant expression


### PR DESCRIPTION
This change is in part by P3421R1 discussion in CWG at Hagenberg.

If accepted, "constexpr destructor" and "`constexpr` destructor" no longer mean the same, and referencing the formal term may be helpful.