### PR TITLE
[xrefdelta] Consolidate restored entries

### DIFF
--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -144,15 +144,15 @@
 \removedxref{depr.util.smartptr.shared.obs}
 
 % Deprecated <cfoo> headers were removed for some <foo.h> headers
-\movedxref{depr.ccomplex.syn}{depr.complex.h.syn}
-\movedxref{depr.cstdalign.syn}{depr.stdalign.h.syn}
-\movedxref{depr.cstdbool.syn}{depr.stdbool.h.syn}
-\movedxref{depr.ctgmath.syn}{depr.tgmath.h.syn}
+\removedxref{depr.ccomplex.syn}
+\removedxref{depr.cstdalign.syn}
+\removedxref{depr.cstdbool.syn}
+\removedxref{depr.ctgmath.syn}
 
 \movedxref{class.copy}{class.mem}
 
 % Top-level clause merging caused some Annex A subclauses to vanish.
-\movedxref{gram.decl}{gram.dcl.decl}
+\movedxref{gram.decl}{gram.dcl}
 \movedxref{gram.derived}{gram.class}
 \movedxref{gram.special}{gram.class}
 
@@ -191,7 +191,7 @@
 \movedxref{ios::seekdir}{ios.seekdir}
 \movedxref{ios::Init}{ios.init}
 
-\movedxref{thread.decaycopy}{expos.only.func}
+\removedxref{thread.decaycopy}
 
 \movedxref{iterator.container}{iterator.range}
 
@@ -372,7 +372,7 @@
 \movedxref{func.bind.front}{func.bind.partial}
 
 \movedxref{class.mfct.non-static}{class.mfct.non.static}
-\movedxref{defns.direct-non-list-init}{defns.direct.non.list.init}
+\movedxref{defns.direct-non-list-init}{dcl.init.list}
 \movedxref{defns.expression-equivalent}{defns.expression.equivalent}
 
 % P1467R9 Extended floating-point types and standard names
@@ -492,7 +492,7 @@
 %
 %   \deprxref{old.label}  (if moved to depr.old.label, otherwise use \movedxref)
 
-\deprxref{util.smartptr.shared.atomic}
-\deprxref{res.on.required}
+\removedxref{util.smartptr.shared.atomic}
+\removedxref{res.on.required}
 \deprxref{fs.path.factory}
 \movedxref{operators}{depr.relops}


### PR DESCRIPTION
Several entries in the restored larger delta referred to stable labels that has since moved again, or been removed.  This commit updates their cross-reference accordingly, or marks them as removed if appropriate.

The new cross-reference, or removal, was performed by confirming the difference against the C++17 standard, rather than assuming each forwarding link was still valid.