### PR TITLE
[basic.types.general] Change ordering to "non-variant non-static"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4982,7 +4982,7 @@ A type is a \defnadj{literal}{type} if it is:
 has all of the following properties:
 \begin{itemize}
 \item it has a constexpr destructor\iref{dcl.constexpr},
-\item all of its non-static non-variant data members and base classes are of non-volatile literal types, and
+\item all of its non-variant non-static data members and base classes are of non-volatile literal types, and
 \item it
 \begin{itemize}
 \item is a closure type\iref{expr.prim.lambda.closure},


### PR DESCRIPTION
The definition of literal type is the only place where "non-static non-variant data member" is used as opposed to "non-variant non-static data member".

Change to use the canonical ordering.