### PR TITLE
[mdspan.layout.leftpad], [mdspan.layout.rightpad] Fix malformed expression

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -22176,7 +22176,7 @@ constexpr index_type required_span_size() const noexcept;
 \item
 \tcode{0} if the multidimensional index space \exposid{extents_} is empty,
 \item
-otherwise, \tcode{*this(((\exposid{extents_}(P_rank) - index_type(1))...)) + 1}.
+otherwise, \tcode{(*this)(\exposid{extents_}.extent(P_rank) - index_type(1)...) + 1}.
 \end{itemize}
 \end{itemdescr}
 
@@ -22802,7 +22802,7 @@ constexpr index_type required_span_size() const noexcept;
 \pnum
 \returns
 \tcode{0} if the multidimensional index space \exposid{extents_} is empty,
-otherwise \tcode{*this(((\exposid{extents_}(P_rank) - index_type(1))...)) + 1}.
+otherwise \tcode{(*this)(\exposid{extents_}.extent(P_rank) - index_type(1)...) + 1}.
 \end{itemdescr}
 
 \indexlibrarymember{layout_right_padded::mapping}{operator()}%


### PR DESCRIPTION
* Add missing parentheses around `*this`
* Remove superfluous parentheses from function argument list
* Add missing `.extent` after *`extents_`*
