### PR TITLE
Use `\dotsc` in more places

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -9894,24 +9894,24 @@ to specify requirements throughout \ref{numeric.ops} is intentional.
 
 \indexlibrary{generalized_noncommutative_sum@\tcode{\placeholder{GENERALIZED_NONCOMMUTATIVE_SUM}}}%
 \pnum
-Define \tcode{\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(op, a1, ..., aN)}
+Define \tcode{\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(op, a1, $\dotsc$, aN)}
 as follows:
 \begin{itemize}
 \item
 \tcode{a1} when \tcode{N} is \tcode{1}, otherwise
 
 \item
-\tcode{op(\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(op, a1, ..., aK),} \\
-\tcode{\phantom{op(}\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(op, aM, ..., aN))}
+\tcode{op(\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(op, a1, $\dotsc$, aK),} \\
+\tcode{\phantom{op(}\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(op, aM, $\dotsc$, aN))}
 for any \tcode{K} where $1 < \mathtt{K}+1 = \mathtt{M} \leq \mathtt{N}$.
 \end{itemize}
 
 \indexlibrary{generalized_sum@\tcode{\placeholder{GENERALIZED_SUM}}}%
 \pnum
-Define \tcode{\placeholdernc{GENERALIZED_SUM}(op, a1, ..., aN)} as
-\tcode{\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(op, b1, ..., bN)},
-where
-\tcode{b1, ..., bN} may be any permutation of \tcode{a1, ..., aN}.
+Define \tcode{\placeholdernc{GENERALIZED_SUM}(op, a1, $\dotsc$, aN)} as
+\tcode{\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(op, b1, $\dotsc$, bN)},
+\linebreak{}where
+\tcode{b1, $\dotsc$, bN} may be any permutation of \tcode{a1, $\dotsc$, aN}.
 
 \rSec2[accumulate]{Accumulate}
 
@@ -10059,7 +10059,7 @@ are convertible to \tcode{T}.
 
 \pnum
 \returns
-\tcode{\placeholdernc{GENERALIZED_SUM}(binary_op, init, *i, ...)}
+\tcode{\placeholdernc{GENERALIZED_SUM}(binary_op, init, *i, $\dotsc$)}
 for every \tcode{i} in \range{first}{last}.
 
 \pnum
@@ -10201,7 +10201,7 @@ All of
 \pnum
 \returns
 \begin{codeblock}
-@\placeholdernc{GENERALIZED_SUM}@(binary_op1, init, binary_op2(*i, *(first2 + (i - first1))), ...)
+@\placeholdernc{GENERALIZED_SUM}@(binary_op1, init, binary_op2(*i, *(first2 + (i - first1))), @$\dotsc$@)
 \end{codeblock}
 for every iterator \tcode{i} in \range{first1}{last1}.
 
@@ -10250,7 +10250,7 @@ template<class ExecutionPolicy,
 \pnum
 \returns
 \begin{codeblock}
-@\placeholdernc{GENERALIZED_SUM}@(binary_op, init, unary_op(*i), ...)
+@\placeholdernc{GENERALIZED_SUM}@(binary_op, init, unary_op(*i), @$\dotsc$@)
 \end{codeblock}
 for every iterator \tcode{i} in \range{first}{last}.
 
@@ -10403,7 +10403,7 @@ For each integer \tcode{K} in \range{0}{last - first}
 assigns through \tcode{result + K} the value of:
 \begin{codeblock}
 @\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}@(
-    binary_op, init, *(first + 0), *(first + 1), ..., *(first + K - 1))
+    binary_op, init, *(first + 0), *(first + 1), @$\dotsc$@, *(first + K - 1))
 \end{codeblock}
 
 \pnum
@@ -10527,10 +10527,10 @@ assigns through \tcode{result + K} the value of
 \begin{itemize}
 \item
   \tcode{\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(\\\phantom{\tcode{\ \ \ \ }}binary_op,
-  init, *(first + 0), *(first + 1), ..., *(first + K))}\\if \tcode{init} is provided, or
+  init, *(first + 0), *(first + 1), $\dotsc$, *(first + K))}\\if \tcode{init} is provided, or
 \item
   \tcode{\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(\\\phantom{\tcode{\ \ \ \ }}binary_op,
-  *(first + 0), *(first + 1), ..., *(first + K))}\\otherwise.
+  *(first + 0), *(first + 1), $\dotsc$, *(first + K))}\\otherwise.
 \end{itemize}
 
 \pnum
@@ -10604,7 +10604,7 @@ assigns through \tcode{result + K} the value of:
 \begin{codeblock}
 @\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}@(
     binary_op, init,
-    unary_op(*(first + 0)), unary_op(*(first + 1)), ..., unary_op(*(first + K - 1)))
+    unary_op(*(first + 0)), unary_op(*(first + 1)), @$\dotsc$@, unary_op(*(first + K - 1)))
 \end{codeblock}
 
 \pnum
@@ -10704,10 +10704,10 @@ For each integer \tcode{K} in \range{0}{last - first}
 assigns through \tcode{result + K} the value of
 \begin{itemize}
 \item
-  \tcode{\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(\\\phantom{\tcode{\ \ \ \ }}binary_op, init,\\\phantom{\tcode{\ \ \ \ }}unary_op(*(first + 0)), unary_op(*(first + 1)), ..., unary_op(*(first + K)))}\\
+  \tcode{\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(\\\phantom{\tcode{\ \ \ \ }}binary_op, init,\\\phantom{\tcode{\ \ \ \ }}unary_op(*(first + 0)), unary_op(*(first + 1)), $\dotsc$, unary_op(*(first + K)))}\\
   if \tcode{init} is provided, or
 \item
-  \tcode{\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(\\\phantom{\tcode{\ \ \ \ }}binary_op,\\\phantom{\tcode{\ \ \ \ }}unary_op(*(first + 0)), unary_op(*(first + 1)), ..., unary_op(*(first + K)))}\\
+  \tcode{\placeholdernc{GENERALIZED_NONCOMMUTATIVE_SUM}(\\\phantom{\tcode{\ \ \ \ }}binary_op,\\\phantom{\tcode{\ \ \ \ }}unary_op(*(first + 0)), unary_op(*(first + 1)), $\dotsc$, unary_op(*(first + K)))}\\
   otherwise.
 \end{itemize}
 

--- a/source/exec.tex
+++ b/source/exec.tex
@@ -1491,11 +1491,11 @@ struct @\exposid{on-stop-request}@ {
 
 \pnum
 \begin{codeblock}
-template<class T@$_0$@, class T@$_1$@, @...,@ class T@$_n$@>
+template<class T@$_0$@, class T@$_1$@, @$\dotsc$,@ class T@$_n$@>
 struct @\exposid{product-type}@ {       // \expos
   T@$_0$@ t@$_0$@;                // \expos
   T@$_1$@ t@$_1$@;                // \expos
-    @...@
+    @\vdots@
   T@$_n$@ t@$_n$@;                // \expos
 
   template<size_t I, class Self>

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -61,7 +61,7 @@ The alias template
 \tcode{make_integer_sequence} denotes a specialization of
 \tcode{integer_sequence} with \tcode{N} constant template arguments.
 The type \tcode{make_integer_sequence<T, N>} is an alias for the type
-\tcode{integer_sequence<T, 0, 1, ..., N - 1>}.
+\tcode{integer_sequence<T, 0, 1, $\dotsc$, N - 1>}.
 \begin{note}
 \tcode{make_integer_sequence<int, 0>} is an alias for the type
 \tcode{integer_sequence<int>}.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1927,7 +1927,7 @@ template<class... UTypes> constexpr explicit(@\seebelow@) tuple(const tuple<UTyp
 
 \begin{itemdescr}
 \pnum
-Let \tcode{I} be the pack \tcode{0, 1, ..., (sizeof...(Types) - 1)}.\newline
+Let \tcode{I} be the pack \tcode{0, 1, $\dotsc$, (sizeof...(Types) - 1)}.\newline
 Let \tcode{\exposid{FWD}(u)} be \tcode{static_cast<decltype(u)>(u)}.
 
 \pnum
@@ -2016,7 +2016,7 @@ template<@\exposconcept{tuple-like}@ UTuple>
 
 \begin{itemdescr}
 \pnum
-Let \tcode{I} be the pack \tcode{0, 1, \ldots, (sizeof...(Types) - 1)}.
+Let \tcode{I} be the pack \tcode{0, 1, $\dotsc$, (sizeof...(Types) - 1)}.
 
 \pnum
 \constraints
@@ -2686,7 +2686,7 @@ return @\placeholdernc{apply-impl}@(std::forward<F>(f), std::forward<Tuple>(t),
 \pnum
 \remarks
 Let \tcode{I} be the pack
-\tcode{0, 1, ..., (tuple_size_v<remove_reference_t<Tuple>> - 1)}.
+\tcode{0, 1, $\dotsc$, (tuple_size_v<remove_reference_t<Tuple>> - 1)}.
 The exception specification is equivalent to:
 \begin{codeblock}
 noexcept(invoke(std::forward<F>(f), get<I>(std::forward<Tuple>(t))...))


### PR DESCRIPTION
And `\vdots` in [[exec.snd.expos]](https://eel.is/c++draft/exec.snd.expos#17).

A `\linebreak` was added in [[numerics.defns]](https://eel.is/c++draft/numerics.defns#2) to avoid an overfull `\hbox`.
