### PR TITLE
Follow-up to P2546, "Debugging Support"

### DIFF
--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -2497,9 +2497,9 @@ It is intended that, when tracing the execution of a program with a debugger, an
 implementation returns \tcode{true} with the use of an immediate query, as
 needed, to determine if the program is being traced by a debugger. On Windows or
 equivalent systems, this can be achieved by calling the
-\tcode{::IsDebuggerPresent()} Win32 function. On POSIX, this can be achieved by
-checking for a tracer parent process, with best effort determination that such a
-tracer parent process is a debugger.
+\tcode{::IsDebuggerPresent()} Win32 function. For systems compatible with
+ISO/IEC 23360:2021, this can be achieved by checking for a tracing process, with
+best effort determination that such a tracing process is a debugger.
 \end{note}
 
 \end{itemdescr}

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -2493,13 +2493,13 @@ This function has no preconditions.
 \impldef{default semantics of \tcode{is_debugger_present}}.
 
 \begin{note}
-It is intended that, when tracing the execution of a program with a debugger, an
-implementation returns \tcode{true} with the use of an immediate query, as
-needed, to determine if the program is being traced by a debugger. On Windows or
+It is intended that, using an immediate (uncached) query to determine if the
+program is being traced by a debugger, an implementation returns \tcode{true}
+only when tracing the execution of the program with a debugger. On Windows or
 equivalent systems, this can be achieved by calling the
 \tcode{::IsDebuggerPresent()} Win32 function. For systems compatible with
 ISO/IEC 23360:2021, this can be achieved by checking for a tracing process, with
-best effort determination that such a tracing process is a debugger.
+a best-effort determination that such a tracing process is a debugger.
 \end{note}
 
 \end{itemdescr}

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -2493,12 +2493,13 @@ This function has no preconditions.
 \impldef{default semantics of \tcode{is_debugger_present}}.
 
 \begin{note}
-When tracing the execution of a program with a debugger, an implementation
-returns \tcode{true}. An implementation performs an immediate query, as needed,
-to determine if the program is traced by a debugger. On Windows or equivalent
-systems, this can be achieved by calling the \tcode{::IsDebuggerPresent()} Win32
-function. On POSIX, this can be achieved by checking for a tracer parent process,
-with best effort determination that such a tracer parent process is a debugger.
+It is intended that, when tracing the execution of a program with a debugger, an
+implementation returns \tcode{true} with the use of an immediate query, as
+needed, to determine if the program is being traced by a debugger. On Windows or
+equivalent systems, this can be achieved by calling the
+\tcode{::IsDebuggerPresent()} Win32 function. On POSIX, this can be achieved by
+checking for a tracer parent process, with best effort determination that such a
+tracer parent process is a debugger.
 \end{note}
 
 \end{itemdescr}

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -2447,10 +2447,10 @@ void breakpoint() noexcept;
 The semantics of this function are \impldef{semantics of \tcode{breakpoint}}.
 
 \begin{note}
-When invoked, the execution of the program temporarily halts and execution is
-handed to the debugger until such a time as: The program is terminated by the
-debugger, or the debugger resumes execution of the program as if the function
-was not invoked.
+It is intended that, when invoked with a debugger present, the execution of the
+program temporarily halts and execution is handed to the debugger until the
+program is either terminated by the debugger or the debugger resumes execution
+of the program as if the function was not invoked.
 \end{note}
 
 \end{itemdescr}

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -2452,7 +2452,7 @@ program temporarily halts and execution is handed to the debugger until the
 program is either terminated by the debugger or the debugger resumes execution
 of the program as if the function was not invoked. In particular, there is no
 intent for a call to this function to accomodate resumption of the program in a
-different manner.
+different manner. If there is no debugger present, the program can abend.
 \end{note}
 
 \end{itemdescr}

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -2452,7 +2452,8 @@ program temporarily halts and execution is handed to the debugger until the
 program is either terminated by the debugger or the debugger resumes execution
 of the program as if the function was not invoked. In particular, there is no
 intent for a call to this function to accomodate resumption of the program in a
-different manner. If there is no debugger present, the program can abend.
+different manner. If there is no debugger present, execution of the program can
+end abnormally.
 \end{note}
 
 \end{itemdescr}

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -2450,7 +2450,9 @@ The semantics of this function are \impldef{semantics of \tcode{breakpoint}}.
 It is intended that, when invoked with a debugger present, the execution of the
 program temporarily halts and execution is handed to the debugger until the
 program is either terminated by the debugger or the debugger resumes execution
-of the program as if the function was not invoked.
+of the program as if the function was not invoked. In particular, there is no
+intent for a call to this function to accomodate resumption of the program in a
+different manner.
 \end{note}
 
 \end{itemdescr}


### PR DESCRIPTION
Follow-up to https://github.com/cplusplus/draft/pull/6681 (P2546R5) from thread beginning with edit/2023/11/0870.

- The notes in the paper make statements of fact about behaviour that, normatively, is implementation-defined. These should instead be statements of intent.
- The description of `breakpoint` assumes that a debugger is present (and should instead cover both cases).
- The odd restriction on how the debugger resumes execution of the program needs elaboration.
- The description of the implementation strategy of `is_debugger_present` for POSIX makes assumptions that are more appropriate for the LSB.
- The terminology used in the LSB is "tracing process", not "tracer parent process".
- The note in `is_debugger_present` implies the wrong trade-off when it is unknown whether a debugger is present. Clarify to prefer returning `false`.