### PR TITLE
[dcl.type.auto.deduct] Change plural "occurrences" to singular

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2125,7 +2125,7 @@ a declaration of \tcode{std::initializer_list}
 shall precede\iref{basic.lookup.general}
 the \grammarterm{placeholder-type-specifier}.
 Obtain \tcode{P} from
-\tcode{T} by replacing the occurrences of
+\tcode{T} by replacing the occurrence of
 \opt{\grammarterm{type-constraint}} \keyword{auto} either with
 a new invented type template parameter \tcode{U} or,
 if the initialization is copy-list-initialization, with


### PR DESCRIPTION
The rules for decl-specifiers do not allow `auto` to appear more than once in the declared type of a variable, so the plural "occurrences" in this paragraph is potentially misleading.

This wording originates from [N1984](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2006/n1984.pdf). In the paper, "occurrence" is singular, but in [N2009](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2006/n2009.pdf) it somehow gained an "s".
