### PR TITLE
[2025-02 CWG Motion 2] P3542R0 Abolish the term "converting constructor"

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -2315,8 +2315,6 @@ A constructor that is not explicit\iref{dcl.fct.spec}
 specifies a conversion from
 the types of its parameters (if any)
 to the type of its class.
-Such a constructor is called a
-\defnadj{converting}{constructor}.
 \begin{example}
 \indextext{Jessie}%
 \begin{codeblock}
@@ -2365,13 +2363,6 @@ Z a5 = static_cast<Z>(1);       // OK, explicit cast used
 Z a6 = { 3, 4 };                // error: no implicit conversion
 \end{codeblock}
 \end{example}
-\end{note}
-
-\pnum
-\begin{note}
-A non-explicit copy/move constructor\iref{class.copy.ctor},
-including one implicitly declared,
-is a converting constructor.
 \end{note}
 
 \rSec3[class.conv.fct]{Conversion functions}%

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1006,7 +1006,7 @@ the candidate functions are
 all the constructors of the class of the object being
 initialized.
 Otherwise, the candidate functions are all
-the converting constructors\iref{class.conv.ctor} of that
+the non-explicit constructors\iref{class.conv.ctor} of that
 class.
 The argument list is the
 \grammarterm{expression-list} or \grammarterm{assignment-expression}
@@ -1037,7 +1037,7 @@ the candidate functions are selected as follows:
 
 \begin{itemize}
 \item
-The converting constructors\iref{class.conv.ctor} of
+The non-explicit constructors\iref{class.conv.ctor} of
 \tcode{T}
 are candidate functions.
 \item
@@ -1173,7 +1173,7 @@ In copy-list-initialization, if an explicit constructor is
 chosen, the initialization is ill-formed.
 \begin{note}
 This differs from other situations\iref{over.match.ctor,over.match.copy},
-where only converting constructors are considered for copy-initialization.
+where only non-explicit constructors are considered for copy-initialization.
 This restriction only
 applies if this initialization is part of the final result of overload
 resolution.


### PR DESCRIPTION
Fixes #7652
Also fixes cplusplus/papers#2179