### PR TITLE
[dcl.type.auto.deduct] Make `f1` example well-formed

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -2182,7 +2182,7 @@ auto           x6a = { 1, 2 };  // \tcode{decltype(x6a)} is \tcode{std::initiali
 decltype(auto) x6d = { 1, 2 };  // error: \tcode{\{ 1, 2 \}} is not an expression
 auto          *x7a = &i;        // \tcode{decltype(x7a)} is \tcode{int*}
 decltype(auto)*x7d = &i;        // error: declared type is not plain \tcode{decltype(auto)}
-auto f1(int x) -> decltype((x)) { return (x); }         // return type is \tcode{int\&}
+auto f1(int x) -> decltype((x));                        // return type is \tcode{int\&}
 auto f2(int x) -> decltype(auto) { return (x); }        // return type is \tcode{int\&\&}
 \end{codeblock}
 \end{example}


### PR DESCRIPTION
@W-E-Brown reports that in the example in [dcl.type.auto.deduct], my [P2266 "Simpler implicit move"](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2266r3.html#wording) introduced an example which, while correct in the point it's illustrating, is ill-formed for another reason.

    auto f1(int x) -> decltype((x)) { return (x); }  // return type is int&
    auto f2(int x) -> decltype(auto) { return (x); }  // return type is int&&

GCC rightly complains about `f1`:
```
error: cannot bind non-const lvalue reference of type 'int&' to an rvalue of type 'int'
 8 | auto f1( int x ) -> decltype( (x) ) { return (x); }
```

That is, the Standard's example is correct that `f1`'s deduced return type is `int&`, but then the function body is ill-formed because you can't bind that `int&` to the rvalue expression `(x)`.

`f1`'s function body exists at all here only to create a sort of tutorial parallelism to `f2`. We can discard that parallelism; then `f1` becomes well-formed, while still illustrating the same point.

---

Question for discussion: Walter also points out that even though `f2` is well-formed, it invariably returns a dangling reference to function parameter `x`. (GCC correctly detects this, and warns.) Is this a bad thing? If it is a bad thing, then can anyone think of a way to adjust the example so that it still illustrates something useful here, but doesn't have a dangling reference?