### PR TITLE
[2025-02 LWG Motion 8] P3441R2 Rename simd_split to simd_chunk

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -16495,10 +16495,15 @@ namespace std {
   // \ref{simd.creation}, \tcode{basic_simd} and \tcode{basic_simd_mask} creation
   template<class T, class Abi>
     constexpr auto
-      simd_split(const basic_simd<typename T::value_type, Abi>& x) noexcept;
+      simd_chunk(const basic_simd<typename T::value_type, Abi>& x) noexcept;
   template<class T, class Abi>
     constexpr auto
-      simd_split(const basic_simd_mask<@\exposid{mask-element-size}@<T>, Abi>& x) noexcept;
+      simd_chunk(const basic_simd_mask<@\exposid{mask-element-size}@<T>, Abi>& x) noexcept;
+
+  template<size_t N, class T, class Abi>
+    constexpr auto simd_chunk(const basic_simd<T, Abi>& x) noexcept;
+  template<size_t N, size_t Bytes, class Abi>
+    constexpr auto simd_chunk(const basic_simd_mask<Bytes, Abi>& x) noexcept;
 
   template<class T, class... Abis>
     constexpr basic_simd<T, @\exposid{deduce-abi-t}@<T, (basic_simd<T, Abis>::size() + ...)>>
@@ -17930,9 +17935,9 @@ For all $i$ in the range of \range{0}{basic_simd<T, Abi>::size()}, if
 
 \begin{itemdecl}
 template<class T, class Abi>
-  constexpr auto simd_split(const basic_simd<typename T::value_type, Abi>& x) noexcept;
+  constexpr auto simd_chunk(const basic_simd<typename T::value_type, Abi>& x) noexcept;
 template<class T, class Abi>
-  constexpr auto simd_split(const basic_simd_mask<@\exposid{mask-element-size}@<T>, Abi>& x) noexcept;
+  constexpr auto simd_chunk(const basic_simd_mask<@\exposid{mask-element-size}@<T>, Abi>& x) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -17979,6 +17984,34 @@ Let $N$ be \tcode{x.size() / T::size()}.
    the $N^\text{th}$ \tcode{tuple} element is initialized to the value of the
    element in \tcode{x} with index \tcode{$i$ + $N$ * T::size()}.
 \end{itemize}
+\end{itemdescr}
+
+\begin{itemdecl}
+template<size_t N, class T, class Abi>
+  constexpr auto simd_chunk(const basic_simd<T, Abi>& x) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+return simd_chunk<resize_simd_t<N, basic_simd<T, Abi>>>(x);
+\end{codeblock}
+\end{itemdescr}
+
+\begin{itemdecl}
+template<size_t N, size_t Bytes, class Abi>
+  constexpr auto simd_chunk(const basic_simd_mask<Bytes, Abi>& x) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+return simd_chunk<resize_simd_t<N, basic_simd_mask<Bytes, Abi>>>(x);
+\end{codeblock}
 \end{itemdescr}
 
 \begin{itemdecl}


### PR DESCRIPTION
Fixes #7667 
Also fixes https://github.com/cplusplus/papers/issues/2105