### PR TITLE
[2025-02 LWG Motion 11] P3430R3 simd issues: explicit, unsequenced, identity-element position, and members of disabled simd

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -17204,7 +17204,7 @@ namespace std::datapar {
     constexpr basic_simd() noexcept = default;
 
     // \ref{simd.ctor}, \tcode{basic_simd} constructors
-    template<class U> constexpr basic_simd(U&& value) noexcept;
+    template<class U> constexpr explicit(@\seebelow@) basic_simd(U&& value) noexcept;
     template<class U, class UAbi>
       constexpr explicit(@\seebelow@) basic_simd(const basic_simd<U, UAbi>&) noexcept;
     template<class G> constexpr explicit basic_simd(G&& gen) noexcept;
@@ -17310,7 +17310,7 @@ all elements\iref{dcl.init.general}.
 
 \pnum
 \recommended
-Implementations should support explicit conversions between specializations of
+Implementations should support implicit conversions between specializations of
 \tcode{basic_simd} and appropriate \impldef{conversions of \tcode{basic_simd}
 from/to implementation-specific vector types} types.
 \begin{note}
@@ -17321,7 +17321,7 @@ implementation.
 \rSec3[simd.ctor]{\tcode{basic_simd} constructors}
 
 \begin{itemdecl}
-template<class U> constexpr basic_simd(U&&) noexcept;
+template<class U> constexpr explicit(@\seebelow@) basic_simd(U&& value) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -17330,24 +17330,29 @@ Let \tcode{From} denote the type \tcode{remove_cvref_t<U>}.
 
 \pnum
 \constraints
-\tcode{From} satisfies \tcode{convertible_to<value_type>}, and either
-\begin{itemize}
- \item
-   \tcode{From} is an arithmetic type and the conversion from \tcode{From} to
-   \tcode{value_type} is value-preserving\iref{simd.general}, or
- \item
-   \tcode{From} is not an arithmetic type and does not satisfy
-   \tcode{\exposconcept{constexpr-wrapper-like}}, or
- \item
-   \tcode{From} satisfies \tcode{\exposconcept{constexpr-wrapper-like}},
-   \tcode{remove_const_t<decltype(From::value)>} is an arithmetic type, and
-   \tcode{From::value} is representable by \tcode{value_type}.
-\end{itemize}
+\tcode{value_type} satisfies \tcode{constructible_from<U>}.
 
 \pnum
 \effects
 Initializes each element to the value of the argument after conversion to
 \tcode{value_type}.
+
+\pnum
+\remarks
+The expression inside \tcode{explicit} evaluates to \tcode{false} if and only if
+\tcode{U} satisfies \tcode{convertible_to<value_type>}, and either
+\begin{itemize}
+ \item
+   \tcode{From} is not an arithmetic type and does not satisfy
+   \exposconcept{constexpr-wrapper-like},
+ \item
+   \tcode{From} is an arithmetic type and the conversion from \tcode{From} to
+   \tcode{value_type} is value-preserving\iref{simd.general}, or
+ \item
+   \tcode{From} satisfies \exposconcept{constexpr-wrapper-like},
+   \tcode{remove_const_t<decltype(From::value)>} is an arithmetic type, and
+   \tcode{From::value} is representable by \tcode{value_type}.
+\end{itemize}
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -17384,7 +17389,7 @@ The expression inside \tcode{explicit} evaluates to \tcode{true} if either
 \end{itemdescr}
 
 \begin{itemdecl}
-template<class G> constexpr explicit basic_simd(G&& gen) noexcept;
+template<class G> constexpr explicit basic_simd(G&& gen);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -17408,10 +17413,7 @@ i>()))} for all $i$ in the range of \range{0}{size()}.
 
 \pnum
 \remarks
-The calls to \tcode{gen} are unsequenced with respect to each other.
-Vectorization-unsafe\iref{algorithms.parallel.defns} standard library functions
-may not be invoked by \tcode{gen}.
-\tcode{gen} is invoked exactly once for each $i$.
+\tcode{gen} is invoked exactly once for each $i$, in increasing order of $i$.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -19180,7 +19182,7 @@ If \tcode{basic_simd_mask<Bytes, Abi>} is enabled,
 \tcode{basic_simd_mask<Bytes, Abi>} is trivially copyable.
 
 \pnum
-\recommended Implementations should support explicit conversions between
+\recommended Implementations should support implicit conversions between
 specializations of \tcode{basic_simd_mask} and appropriate \impldef{conversions
 of \tcode{basic_simd_mask} from/to implementation-specific vector types} types.
 \begin{note}
@@ -19218,7 +19220,7 @@ range of \range{0}{size()}.
 \end{itemdescr}
 
 \begin{itemdecl}
-template<class G> constexpr explicit basic_simd_mask(G&& gen) noexcept;
+template<class G> constexpr explicit basic_simd_mask(G&& gen);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -19236,10 +19238,7 @@ the range of \range{0}{size()}.
 
 \pnum
 \remarks
-The calls to \tcode{gen} are unsequenced with respect to each other.
-Vectorization-unsafe\iref{algorithms.parallel.defns} standard library
-functions may not be invoked by \tcode{gen}.
-\tcode{gen} is invoked exactly once for each $i$.
+\tcode{gen} is invoked exactly once for each $i$, in increasing order of $i$.
 \end{itemdescr}
 
 \rSec3[simd.mask.subscr]{\tcode{basic_simd_mask} subscript operator}


### PR DESCRIPTION
Fixes #7670
Also fixes https://github.com/cplusplus/papers/issues/2097