### PR TITLE
[expr.sub] Add missing cross-references

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3241,12 +3241,12 @@ followed by square brackets containing
 a possibly empty, comma-separated list of \grammarterm{initializer-clause}s
 that constitute the arguments to the subscript operator.
 The \grammarterm{postfix-expression} and
-the initialization of the object parameter of
-any applicable subscript operator function is sequenced before
+the initialization of the object parameter\iref{dcl.fct} of
+any applicable subscript operator function\iref{over.sub} is sequenced before
 each expression in the \grammarterm{expression-list} and also before
-any default argument.
+any default argument\iref{dcl.fct.default}.
 The initialization of a non-object parameter of
-a subscript operator function \tcode{S}\iref{over.sub},
+a subscript operator function \tcode{S},
 including every associated value computation and side effect,
 is indeterminately sequenced with respect to that of
 any other non-object parameter of \tcode{S}.
@@ -3257,7 +3257,7 @@ an \grammarterm{expression-list} shall be present,
 consisting of a single \grammarterm{assignment-expression}.
 One of the expressions shall be a glvalue of type ``array of
 \tcode{T}'' or a prvalue of type ``pointer
-to \tcode{T}'' and the other shall be a prvalue of unscoped enumeration or integral type.
+to \tcode{T}'' and the other shall be a prvalue of unscoped enumeration\iref{dcl.enum} or integral type.
 The result is of type ``\tcode{T}''.
 \indextext{type!incomplete}%
 The type ``\tcode{T}'' shall be a completely-defined object type.%


### PR DESCRIPTION
This patch adds several cross-references to Declarations section, and moves reference to [over.sub] to an earlier occurrence of the term "subscript operator function".