### PR TITLE
P3349R1 Converting contiguous iterators to pointers

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -693,6 +693,24 @@ The result of the application of library functions
 to invalid ranges is undefined.
 
 \pnum
+For an iterator \tcode{i} of a type that
+models \libconcept{contiguous_iterator}\iref{iterator.concept.contiguous},
+library functions are permitted
+to replace \range{i}{s} with
+\range{to_address(i)}{to_address(i + ranges::distance(i, s))}, and
+to replace \countedrange{i}{n} with \range{to_address(i)}{to_address(i + n)}.
+\begin{note}
+This means a program cannot rely on any side effects of
+dereferencing a contiguous iterator \tcode{i},
+because library functions might operate on
+pointers obtained by \tcode{to_address(i)}
+instead of operating on \tcode{i}.
+Similarly, a program cannot rely on any side effects of
+individual increments on a contiguous iterator \tcode{i},
+because library functions might advance \tcode{i} only once.
+\end{note}
+
+\pnum
 All the categories of iterators require only those functions that are realizable for a given category in
 constant time (amortized).
 Therefore, requirement tables and concept definitions for the iterators


### PR DESCRIPTION
Fixes #7664.
Also fixes cplusplus/papers#2067