### PR TITLE
[2025-02 CWG Motion 5] P2900R14 - Contracts for C++

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -62,6 +62,10 @@ Every name is introduced by a \defn{declaration}, which is a
 \grammarterm{identifier}
 in a structured binding declaration\iref{dcl.struct.bind},
 \item
+\grammarterm{identifier}
+in a \grammarterm{result-name-introducer}
+in a postcondition assertion\iref{dcl.contract.res},
+\item
 \grammarterm{init-capture}\iref{expr.prim.lambda.capture},
 \item
 \grammarterm{condition} with a \grammarterm{declarator}\iref{stmt.pre},
@@ -109,6 +113,7 @@ an object. The variable's name, if any, denotes the reference or object.
 \pnum
 An \defn{entity} is a value, object, reference,
 structured binding,
+result binding,
 function, enumerator, type,
 class member, bit-field, template, template specialization, namespace, or
 pack. An entity $E$ is denoted by the name (if any)
@@ -120,6 +125,7 @@ A \defnadj{local}{entity} is a variable with
 automatic storage duration\iref{basic.stc.auto},
 a structured binding\iref{dcl.struct.bind}
 whose corresponding variable is such an entity,
+a result binding\iref{dcl.contract.res},
 or the \tcode{*\keyword{this}} object\iref{expr.prim.this}.
 
 \pnum
@@ -143,7 +149,8 @@ If so, the
 declaration specifies the interpretation and semantic properties of these names.
 A declaration of an entity or \grammarterm{typedef-name} $X$ is
 a redeclaration of $X$
-if another declaration of $X$ is reachable from it\iref{module.reach}.
+if another declaration of $X$ is reachable from it\iref{module.reach};
+otherwise, it is a \defnadj{first}{declaration}.
 A declaration may also have effects including:
 \begin{itemize}
 \item a static assertion\iref{dcl.pre},
@@ -544,9 +551,10 @@ for each intervening scope\iref{basic.scope.scope}
 between the point at which the entity is introduced and the scope
 (where \tcode{*\keyword{this}} is considered to be introduced
 within the innermost enclosing class or non-lambda function definition scope),
-either:
+either
 \begin{itemize}
-\item the intervening scope is a block scope, or
+\item the intervening scope is a block scope,
+\item the intervening scope is a contract-assertion scope\iref{basic.scope.contract},
 \item the intervening scope is the function parameter scope of
 a \grammarterm{lambda-expression} or \grammarterm{requires-expression}, or
 \item the intervening scope is the lambda scope of
@@ -883,9 +891,11 @@ The \defnadj{global}{scope} contains the entire program;
 every other scope $S$ is introduced by a
 declaration,
 \grammarterm{parameter-declaration-clause},
-\grammarterm{statement}, or \grammarterm{handler}
+\grammarterm{statement},
+\grammarterm{handler}, or
+contract assertion
 (as described in the following subclauses of \ref{basic.scope})
-appearing in another scope which thereby contains $S$.
+appearing in another scope, which thereby contains $S$.
 An \defnadj{enclosing}{scope} at a program point is any scope that contains it;
 the smallest such scope is said to be the \defnadj{immediate}{scope}
 at that point.
@@ -1069,6 +1079,8 @@ a structured binding
 %FIXME:  that is not inhabiting a namespace scope,"
 with no \grammarterm{storage-class-specifier} and
 not inhabiting a namespace scope,
+\item
+a result binding\iref{dcl.contract.res},
 \item
 the variable introduced by an \grammarterm{init-capture}, or
 \item
@@ -1274,6 +1286,10 @@ template<class T
     N = 0> struct A { };
 \end{codeblock}
 \end{example}
+
+\pnum
+The locus of a \grammarterm{result-name-introducer}\iref{dcl.contract.res}
+is immediately after it.
 
 \pnum
 The locus of a \grammarterm{concept-definition}
@@ -1509,6 +1525,30 @@ Therefore, only template parameters belong to a template parameter scope, and
 only template parameter scopes have
 a template parameter scope as a parent scope.
 \end{note}
+
+\rSec2[basic.scope.contract]{Contract-assertion scope}%
+
+\pnum
+Each contract assertion\iref{basic.contract}
+$C$ introduces a \defnadj{contract-assertion}{scope}
+that includes $C$.
+
+\pnum
+If a \grammarterm{result-name-introducer}\iref{dcl.contract.res}
+that is not name-independent\iref{basic.scope.scope}
+and whose enclosing postcondition assertion
+is associated with a function \tcode{F}
+potentially conflicts with
+a declaration whose target scope is
+\begin{itemize}
+\item
+the function parameter scope of \tcode{F} or
+\item
+if associated with a \grammarterm{lambda-declarator},
+the nearest enclosing lambda scope
+of the precondition assertion\iref{expr.prim.lambda},
+\end{itemize}
+the program is ill-formed.
 
 \indextext{scope|)}
 
@@ -4152,13 +4192,8 @@ do not perform allocation or deallocation.
 \pnum
 The library provides default definitions for the global allocation and
 deallocation functions. Some global allocation and deallocation
-functions are replaceable\iref{new.delete};
-these are attached to the global module\iref{module.unit}.
-A \Cpp{} program shall
-provide at most one definition of a replaceable allocation or
-deallocation function. Any such function definition replaces the default
-version provided in the library\iref{replacement.functions}. The
-following allocation and deallocation functions\iref{support.dynamic}
+functions are replaceable\iref{dcl.fct.def.replace}.
+The following allocation and deallocation functions\iref{support.dynamic}
 are implicitly declared in global scope in each translation unit of a
 program.
 
@@ -4309,11 +4344,13 @@ or called indirectly through calls to the
 functions in the \Cpp{} standard library.
 \begin{note}
 In particular, a
-global allocation function is not called to allocate storage for objects
-with static storage duration\iref{basic.stc.static}, for objects or references
-with thread storage duration\iref{basic.stc.thread}, for objects of
-type \tcode{std::type_info}\iref{expr.typeid}, or for an
-exception object\iref{except.throw}.
+global allocation function is not called to allocate storage
+for objects with static storage duration\iref{basic.stc.static},
+for objects or references with thread storage duration\iref{basic.stc.thread},
+for objects of type \tcode{std::type_info}\iref{expr.typeid},
+for an object of type \tcode{std::contracts::contract_violation}
+when a contract violation occurs\iref{basic.contract.eval}, or
+for an exception object\iref{except.throw}.
 \end{note}
 
 \rSec4[basic.stc.dynamic.deallocation]{Deallocation functions}
@@ -4396,7 +4433,7 @@ Temporary objects are created
 \item
 when a prvalue is converted to an xvalue\iref{conv.rval} and
 \item
-when needed by the implementation to pass or return an object of trivially copyable type (see below).
+when needed by the implementation to pass or return an object of suitable type (see below).
 \end{itemize}
 Even when the creation of the temporary object is
 unevaluated\iref{expr.context},
@@ -4481,22 +4518,42 @@ of \tcode{X::operator=(const X\&)} can bind to it.
 \pnum
 When an object of class type \tcode{X}
 is passed to or returned from a potentially-evaluated function call,
-if \tcode{X} has at least one eligible copy or move constructor\iref{special},
-each such constructor is trivial,
+if \tcode{X} is
+\begin{itemize}
+\item
+a scalar type or
+\item
+a class type that
+has at least one eligible copy or move constructor\iref{special},
+where each such constructor is trivial,
 and the destructor of \tcode{X} is either trivial or deleted,
+\end{itemize}
 implementations are permitted
-to create a temporary object
-to hold the function parameter or result object.
-The temporary object is constructed
-from the function argument or return value, respectively,
-and the function's parameter or return object
-is initialized as if by
-using the eligible trivial constructor to copy the temporary
-(even if that constructor is inaccessible
+to create temporary objects
+to hold the function parameter or result object,
+as follows:
+\begin{itemize}
+\item
+The first such temporary object
+is constructed from the function argument or return value, respectively.
+\item
+Each successive temporary object
+is initialized from the previous one
+as if by direct-initialization if \tcode{X} is a scalar type,
+otherwise by using an eligible trivial constructor.
+\item
+The function parameter or return object is initialized
+from the final temporary
+as if by direct-initialization if \tcode{X} is a scalar type,
+otherwise by using an eligible trivial constructor.
+\end{itemize}
+(In all cases, the eligible constructor is used
+even if that constructor is inaccessible
 or would not be selected by overload resolution
 to perform a copy or move of the object).
 \begin{note}
-This latitude is granted to allow objects of class type to be passed to or returned from functions in registers.
+This latitude is granted to allow objects
+to be passed to or returned from functions in registers.
 \end{note}
 
 \pnum
@@ -5944,7 +6001,9 @@ including the constituent expressions of the initializer,
 \item
 an invocation of a destructor generated at the end of the lifetime
 of an object other than a temporary object\iref{class.temporary}
-whose lifetime has not been extended, or
+whose lifetime has not been extended,
+\item
+the predicate of a contract assertion\iref{basic.contract}, or
 \item
 an expression that is not a subexpression of another expression and
 that is not otherwise part of a full-expression.
@@ -6115,11 +6174,18 @@ void g(int i) {
 \end{example}
 
 \pnum
-When invoking a function (whether or not the function is inline),
+When invoking a function \placeholder{f} (whether or not the function is inline),
 every argument expression and
-the postfix expression designating the called function
-are sequenced before every expression or statement
-in the body of the called function.
+the postfix expression designating \placeholder{f}
+are sequenced before
+every precondition assertion of \placeholder{f}\iref{dcl.contract.func},
+which in turn are sequenced before
+every expression or statement
+in the body of \placeholder{f},
+which in turn are sequenced before
+every postcondition assertion of \placeholder{f}.
+
+\pnum
 For each
 \begin{itemize}
 \item function invocation,
@@ -6127,8 +6193,8 @@ For each
 \item evaluation of a \grammarterm{throw-expression}\iref{expr.throw}
 \end{itemize}
 \placeholder{F},
-each evaluation that does not occur within \placeholder{F} but
-is evaluated on the same thread and as part of the same signal handler (if any)
+each evaluation that does not occur within \placeholder{F}
+but is evaluated on the same thread and as part of the same signal handler (if any)
 is either sequenced before all evaluations that occur within \placeholder{F}
 or sequenced after all evaluations that occur within \placeholder{F};
 \begin{footnote}
@@ -6141,6 +6207,7 @@ subsequent to the previous suspension (if any) and
 prior to the next suspension (if any)
 are considered to occur within \placeholder{F}.
 
+\pnum
 Several contexts in \Cpp{} cause evaluation of a function call, even
 though no corresponding function call syntax appears in the translation
 unit.
@@ -6150,6 +6217,8 @@ and constructor functions; see~\ref{expr.new}. For another example,
 invocation of a conversion function\iref{class.conv.fct} can arise in
 contexts in which no function call syntax appears.
 \end{example}
+
+\pnum
 The sequencing constraints on the execution of the called function (as
 described above) are features of the function calls as evaluated,
 regardless of the syntax of the expression that calls the function.%
@@ -6935,9 +7004,10 @@ behavior.
 \pnum
 \indextext{termination!program}%
 \indextext{\idxcode{main} function!return from}%
-A \keyword{return} statement\iref{stmt.return} in \tcode{main} has the effect of leaving the main
-function (destroying any objects with automatic storage duration) and
-calling \tcode{std::exit} with the return value as the argument.
+A \keyword{return} statement\iref{stmt.return} in \tcode{main} has the effect of leaving the \tcode{main}
+function (destroying any objects with automatic storage duration
+and evaluating any postcondition assertions of \tcode{main})
+and calling \tcode{std::exit} with the return value as the argument.
 If control flows off the end of
 the \grammarterm{compound-statement} of \tcode{main},
 the effect is equivalent to a \keyword{return} with operand \tcode{0}
@@ -7269,3 +7339,442 @@ and without calling
 the functions passed to \tcode{std::atexit()} or \tcode{std::at_quick_exit()}.%
 \indextext{program!termination|)}
 \indextext{program execution|)}
+
+\rSec1[basic.contract]{Contract assertions}%
+\indextext{contract assertion|(}%
+
+\rSec2[basic.contract.general]{General}%
+
+\pnum
+\defnx{Contract assertions}{contract assertion}
+allow the programmer to specify
+properties of the state of the program
+that are expected to hold at
+certain points during execution.
+Contract assertions are introduced by
+\grammarterm{precondition-specifier}s,
+\grammarterm{postcondition-specifier}s\iref{dcl.contract.func}, and
+\grammarterm{assertion-statement}s\iref{stmt.contract.assert}.
+
+\pnum
+Each contract assertion has a \defnadjx{contract-assertion}{predicate}{predicate},
+which is an expression of type \tcode{bool}.
+
+\begin{note}
+The value of the predicate is used to identify program states that are
+expected.
+\end{note}
+
+\pnum
+An invocation of the macro \tcode{va_start}\iref{cstdarg.syn}
+shall not be a subexpression
+of the predicate of a contract assertion,
+no diagnostic required.
+
+\pnum
+\begin{note}
+Within the predicate of a contract assertion,
+\grammarterm{id-expression}s referring to
+variables declared outside the contract assertion
+are \keyword{const}\iref{expr.prim.id.unqual},
+\tcode{this} is a pointer to \keyword{const}\iref{expr.prim.this},
+and the result object can be named
+if a \grammarterm{result-name-introducer}\iref{dcl.contract.res} has been specified.
+\end{note}
+
+\rSec2[basic.contract.eval]{Evaluation}
+
+\pnum
+\indexdefn{evaluation semantics|see{contract evaluation semantics}}%
+\indexdefn{checking semantics|see{contract evaluation semantics!checking}}%
+\indexdefn{terminating semantics|see{contract evaluation semantics!terminating}}%
+An evaluation of a contract assertion
+uses one of the following four \defn{evaluation semantics}:
+\defnx{ignore}{contract evaluation semantics!ignore},
+\defnx{observe}{contract evaluation semantics!observe},
+\defnx{enforce}{contract evaluation semantics!enforce}, or
+\defnx{quick-enforce}{contract evaluation semantics!quick-enforce}.
+Observe, enforce, and quick-enforce are \defnx{checking semantics}{contract evaluation semantics!checking};
+enforce and quick-enforce are \defnx{terminating semantics}{contract evaluation semantics!terminating}.
+
+\pnum
+It is
+\impldef{evaluation semantic used for the evaluation of a contract assertion}
+which evaluation semantic is used
+for any given evaluation of a contract assertion.
+\begin{note}
+The range and flexibility of available choices of
+evaluation semantics depends on the implementation
+and need not allow all four evaluation semantics as possibilities.
+The evaluation semantics can differ
+for different evaluations of the same contract assertion,
+including evaluations during constant evaluation.
+\end{note}
+
+\pnum
+\recommended
+An implementation should provide
+the option to translate a program
+such that all evaluations of contract assertions use the ignore semantic
+as well as
+the option to translate a program
+such that all evaluations of contract assertions use the enforce semantic.
+By default,
+evaluations of contract assertions should use the enforce semantic.
+
+\pnum
+The evaluation of a contract assertion using the ignore semantic has no effect.
+\begin{note}
+The predicate is potentially evaluated\iref{basic.def.odr},
+but not evaluated.
+\end{note}
+
+\pnum
+The evaluation $A$ of a contract assertion
+using a checking semantic
+determines the value of the predicate.
+It is unspecified
+whether the predicate is evaluated.
+Let $B$ be the value that would result from evaluating the predicate.
+\begin{note}
+To determine whether a predicate would evaluate
+to \keyword{true} or \keyword{false},
+an alternative evaluation
+that produces the same value as the predicate
+but has no side effects
+can occur.
+\begin{example}
+\begin{codeblock}
+struct S {
+  mutable int g = 5;
+} s;
+void f()
+  pre(( s.g++, false ));    // \#1
+void g()
+{
+  f();  // Increment of \tcode{s.g} might not occur, even if \#1 uses a checking semantic.
+}
+\end{codeblock}
+\end{example}
+\end{note}
+
+\pnum
+There is an observablecheckpoint\iref{intro.abstract} $C$
+that happens before $A$
+such that any other operation $O$
+that happens before $A$
+also happens before $C$.
+
+\pnum
+A \defn{contract violation} occurs when
+\begin{itemize}
+\item
+$B$ is \keyword{false},
+\item
+the evaluation of the predicate
+exits via an exception, or
+\item
+the evaluation of the predicate
+is performed in a context that is
+manifestly constant-evaluated\iref{expr.const}
+and the predicate
+is not a core constant expression.
+\end{itemize}
+
+\begin{note}
+If $B$ is \keyword{true},
+no contract violation occurs and
+control flow continues normally
+after the point of evaluation of the contract assertion.
+The evaluation of the predicate
+can fail to produce a value
+without causing a contract violation,
+for example,
+by calling \tcode{longjmp}\iref{csetjmp.syn}
+or terminating the program.
+\end{note}
+
+\pnum
+\indexdefn{contract evaluation semantics!terminating}%
+If a contract violation occurs
+in a context that is manifestly constant-evaluate\iref{expr.const},
+and the evaluation semantic is
+a terminating semantic,
+the program is ill-formed.
+
+\begin{note}
+A diagnostic is produced
+if the evaluation semantic is observe\iref{intro.compliance}.
+\end{note}
+
+\begin{note}
+Different evaluation semantics
+chosen for the same contract assertion
+in different translation units
+can result in
+violations of the one-definition rule\iref{basic.def.odr}
+when a contract assertion has side effects
+that alter the value produced by a constant expression.
+\begin{example}
+\begin{codeblock}
+constexpr int f(int i)
+{
+  contract_assert((++const_cast<int&>(i), true));
+  return i;
+}
+inline void g()
+{
+  int a[f(1)];  // size dependent on the evaluation semantic of \tcode{contract_assert} above
+}
+\end{codeblock}
+\end{example}
+\end{note}
+
+\pnum
+When the program is \defn{contract-terminated},
+it is
+\impldef{method by which contract termination occurs}
+(depending on context) whether
+\begin{itemize}
+\item
+\tcode{std::terminate} is called,
+\item
+\tcode{std::abort} is called, or
+\item
+execution is terminated.
+
+\begin{note}
+No further execution steps occur\iref{intro.progress}.
+\end{note}
+\end{itemize}
+
+\begin{note}
+Performing the actions of
+\tcode{std::terminate} or \tcode{std::abort}
+without actually making a library call
+is a conforming implementation of
+contract-termination\iref{intro.abstract}.
+\end{note}
+
+\pnum
+\indextext{contract evaluation semantics!enforce}%
+\indextext{contract evaluation semantics!quick-enforce}%
+If a contract violation occurs
+in a context that is not manifestly constant-evaluated
+and the evaluation semantic is quick-enforce,
+the program is contract-terminated.
+
+\pnum
+\indextext{\idxcode{contract_violation}}%
+\indextext{contract evaluation semantics!enforce}%
+\indextext{contract evaluation semantics!observe}%
+\indexlibraryglobal{contract_violation}%
+If a contract violation occurs
+in a context that is not manifestly constant-evaluated
+and the evaluation semantic is enforce or observe,
+the contract-violation handler\iref{basic.contract.handler}
+is invoked with an lvalue referring to
+an object \tcode{v}
+of type \tcode{const std::contracts::contract_violation}\iref{support.contract.violation}
+containing information about the contract violation.
+Storage for \tcode{v}
+is allocated in an unspecified manner
+except as noted in \ref{basic.stc.dynamic.allocation}.
+The lifetime of \tcode{v}
+persists for the duration
+of the invocation of the contract-violation handler.
+
+\pnum
+If the contract violation occurred
+because the evaluation of the predicate
+exited via an exception,
+the contract-violation handler is invoked
+from within an active implicit handler
+for that exception\iref{except.handle}.
+If the contract-violation handler
+returns normally
+and the evaluation semantic is observe,
+that implicit handler
+is no longer considered active.
+
+\begin{note}
+The exception can be inspected or rethrown within the contract-violation handler.
+\end{note}
+
+\pnum
+\indextext{contract evaluation semantics!enforce}%
+If the contract-violation handler
+returns normally
+and the evaluation semantic is enforce,
+the program is contract-terminated;
+if violation occurred
+as the result of an uncaught exception
+from the evaluation of the predicate,
+the implicit handler
+remains active when contract termination occurs.
+
+\pnum
+\indextext{contract evaluation semantics!observe}%
+\begin{note}
+If the contract-violation handler
+returns normally
+and the evaluation semantic is observe,
+control flow continues normally
+after the point of evaluation of the contract assertion.
+\end{note}
+
+\pnum
+There is an observable checkpoint\iref{intro.abstract} $C$
+that happens after the contract-violation handler returns normally
+such that any other operation $O$
+that happens after the contract-violation handler returns
+also happens after $C$.
+
+\pnum
+\begin{note}
+The terminating semantics terminate the program
+if execution would otherwise continue normally
+past a contract violation:
+the enforce semantic provides the opportunity to
+log information about the contract violation
+before terminating the program
+or to throw an exception to avoid termination,
+and the quick-enforce semantic is intended
+to terminate the program as soon as possible
+as well as
+to minimize the impact of contract checks
+on the generated code size.
+Conversely,
+the observe semantic
+provides the opportunity to
+log information about the contract violation
+without having to terminate the program.
+\end{note}
+
+\pnum
+If a contract-violation handler
+invoked from the evaluation of a function contract assertion\iref{dcl.contract.func}
+exits via an exception,
+the behavior is as if
+the function body exits via that same exception.
+\begin{note}
+A \grammarterm{function-try-block}\iref{except.pre}
+is the function body when present
+and thus does not
+have an opportunity to catch the exception.
+If the function
+has a non-throwing exception specification,
+the function \tcode{std::terminate} is invoked\iref{except.terminate}.
+\end{note}
+
+\begin{note}
+If a contract-violation handler
+invoked from an \grammarterm{assertion-statement}\iref{stmt.contract.assert})
+exits via an exception,
+the search for a handler
+continues from the execution of that statement.
+\end{note}
+
+\pnum
+To \defn{evaluate in sequence} a list $R$ of contract assertions:
+\begin{itemize}
+\item
+Construct a list of contract assertions $S$ such that
+\begin{itemize}
+\item
+all elements of $R$ are in $S$,
+\item
+each element of $R$
+may be repeated an
+\impldef{maximum number of repeated evaluations of a contract assertion}
+number of times
+within $S$, and
+\item
+if a contract assertion $A$
+precedes another contract assertion $B$
+in $R$,
+then the
+first occurrence of $A$
+precedes the first occurrence of $B$
+in $S$.
+\end{itemize}
+\item
+Evaluate each element of $S$ such that,
+if a contract assertion $A$
+precedes a contract assertion $B$
+in $S$,
+then the evaluation of $A$
+is sequenced before
+the evaluation of $B$.
+\end{itemize}
+
+\begin{example}
+\begin{codeblock}
+void f(int i)
+{
+  contract_assert(i > 0);   // \#1
+  contract_assert(i < 10);  // \#2
+    // valid sequence of evaluations: \#1 \#2
+    // valid sequence of evaluations: \#1 \#1 \#2 \#2
+    // valid sequence of evaluations: \#1 \#2 \#1 \#2
+    // valid sequence of evaluations: \#1 \#2 \#2 \#1
+    // invalid sequence of evaluations: \#2 \#1
+}
+\end{codeblock}
+\end{example}
+
+\pnum
+\recommended
+An implementation should
+provide an option to perform
+a specified number of repeated evaluations
+for contract assertions.
+By default,
+no repeated evaluations should be performed.
+
+\rSec2[basic.contract.handler]{Contract-violation handler}
+
+\pnum
+\indextext{\idxcode{contract_violation}}%
+\indexlibraryglobal{contract_violation}%
+The \defn{contract-violation handler}
+of a program is a function named
+\tcode{::handle_contract_violation}.
+The contract-violation handler
+shall have a single parameter
+of type
+``lvalue reference to \keyword{const} \tcode{std::\-contracts::\-contract_violation}''
+and shall return \tcode{void}.
+The contract-violation handler
+may have a non-throwing exception specification.
+The implementation
+shall provide a definition of the contract-violation handler,
+called the \defnadj{default}{contract-violation handler}.
+\begin{note}
+No declaration
+for the default contract-violation handler
+is provided by
+any standard library header.
+\end{note}
+
+\pnum
+\recommended
+The default contract-violation handler
+should produce diagnostic output
+that suitably formats the most relevant contents
+of the \tcode{std::contracts::contract_violation} object,
+rate-limited for potentially repeated violations
+of observed contract assertions,
+and then return normally.
+
+\pnum
+It is
+\impldef{replaceability of the contract-violation handler}
+whether the contract-violation handler
+is replaceable\iref{dcl.fct.def.replace}.
+If the contract-violation handler
+is not replaceable,
+a declaration of a replacement function for the contract-violation handler
+is ill-formed, no diagnostic required.
+
+\indextext{contract assertion|)}

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -475,8 +475,8 @@ if its \grammarterm{template-name} names a class template.
 
 \begin{bnf}
 \nontermdef{member-declarator}\br
-    declarator \opt{virt-specifier-seq} \opt{pure-specifier}\br
-    declarator requires-clause\br
+    declarator \opt{virt-specifier-seq} \opt{function-contract-specifier-seq} \opt{pure-specifier}\br
+    declarator requires-clause \opt{function-contract-specifier-seq}\br
     declarator brace-or-equal-initializer\br
     \opt{identifier} \opt{attribute-specifier-seq} \terminal{:} constant-expression \opt{brace-or-equal-initializer}
 \end{bnf}
@@ -526,6 +526,12 @@ If the member declaration acquires a function type through
 template instantiation,
 the program is ill-formed; see~\ref{temp.spec.general}.
 \end{note}
+
+\pnum
+The optional \grammarterm{function-contract-specifier-seq}\iref{dcl.contract.func})
+in a \grammarterm{member-declarator}
+shall be present only if
+the \grammarterm{declarator} declares a function.
 
 \pnum
 \indextext{definition!class}%
@@ -618,7 +624,8 @@ A \defn{complete-class context} of a class (template) is a
 \item function body\iref{dcl.fct.def.general},
 \item default argument\iref{dcl.fct.default},
 \item default template argument\iref{temp.param},
-\item \grammarterm{noexcept-specifier}\iref{except.spec}, or
+\item \grammarterm{noexcept-specifier}\iref{except.spec},
+\item \grammarterm{function-contract-specifier}\iref{dcl.contract.func}, or
 \item default member initializer
 \end{itemize}
 within the \grammarterm{member-specification} of the class or class template.
@@ -4289,8 +4296,8 @@ conversion functions, and destructors.
 \begin{codeblock}
 class A {
   typedef int I;    // private member
-  I f();
-  friend I g(I);
+  I f() pre(A::x > 0);
+  friend I g(I) post(A::x <= 0);
   static I x;
   template<int> struct Q;
   template<int> friend struct R;
@@ -4298,8 +4305,8 @@ protected:
     struct B { };
 };
 
-A::I A::f() { return 0; }
-A::I g(A::I p = A::x);
+A::I A::f() pre(A::x > 0) { return 0; }
+A::I g(A::I p = A::x) post(A::x <= 0);
 A::I g(A::I p) { return 0; }
 A::I A::x = 0;
 template<A::I> struct A::Q { };
@@ -5715,18 +5722,27 @@ is created.
 \pnum
 \indextext{initialization!member function call during}%
 Member functions (including virtual member functions, \ref{class.virtual}) can be
-called for an object under construction.
-Similarly, an object under construction can be the operand of the
+called for an object under construction or destruction.
+Similarly, an object under construction or destruction can be the operand of the
 \tcode{typeid}
 operator\iref{expr.typeid} or of a
 \keyword{dynamic_cast}\iref{expr.dynamic.cast}.
-However, if these operations are performed in a
-\grammarterm{ctor-initializer}
+However, if these operations are performed
+during evaluation of
+\begin{itemize}
+\item
+a \grammarterm{ctor-initializer}
 (or in a function called directly or indirectly from a
 \grammarterm{ctor-initializer})
 before all the
 \grammarterm{mem-initializer}{s}
-for base classes have completed, the program has undefined behavior.
+for base classes have completed,
+\item
+a precondition assertion of a constructor, or
+\item
+a postcondition assertion of a destructor\iref{dcl.contract.func},
+\end{itemize}
+the program has undefined behavior.
 \begin{example}
 \begin{codeblock}
 class A {
@@ -6049,6 +6065,9 @@ When a virtual function is called directly or indirectly from a constructor
 or from a destructor,
 including during the construction or destruction of the class's non-static data
 members,
+or during the evaluation of
+a postcondition assertion of a constructor or
+a precondition assertion of a destructor\iref{dcl.contract.func},
 and the object to which the call applies is the object (call it \tcode{x}) under construction or
 destruction,
 the function called is the

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -11,6 +11,23 @@ Subclause \ref{diff.cpp23} lists the differences between \Cpp{} and
 ISO \CppXXIII{},
 by the chapters of this document.
 
+\rSec2[diff.cpp23.lex]{\ref{lex}: Lexical conventions}
+
+\diffref{lex.key}
+\change
+New keywords.
+\rationale
+Required for new features.
+\begin{itemize}
+\item
+The \keyword{contract_assert} keyword
+is added to introduce a contract assertion
+through an \grammarterm{assertion-statement}\iref{stmt.contract.assert}.
+\end{itemize}
+\effect
+Valid \CppXXIII{} code using \keyword{contract_assert} as an identifier
+is not valid in this revision of \Cpp{}.
+
 \rSec2[diff.cpp23.expr]{\ref{expr}: expressions}
 
 \diffref{expr.arith.conv}
@@ -182,6 +199,7 @@ New headers.
 New functionality.
 \effect
 The following \Cpp{} headers are new:
+\libheaderrefx{contracts}{support.contract},
 \libheaderref{debugging},
 \libheaderrefx{hazard_pointer}{hazard.pointer.syn},
 \libheaderrefx{inplace_vector}{inplace.vector.syn},

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1951,6 +1951,20 @@ auto sum(int i) {
 \end{example}
 
 \pnum
+A result binding never has
+an undeduced placeholder type\iref{dcl.contract.res}.
+\begin{example}
+\begin{codeblock}
+auto f()
+  post(r : r == 7)  // OK
+{
+  return 7;
+}
+\end{codeblock}
+\end{example}
+
+
+\pnum
 Return type deduction for a templated
 function with a placeholder in its
 declared type occurs when the definition is instantiated even if the function
@@ -2282,8 +2296,8 @@ each of which can have an initializer.
 
 \begin{bnf}
 \nontermdef{init-declarator}\br
-    declarator \opt{initializer}\br
-    declarator requires-clause
+    declarator initializer\br
+    declarator \opt{requires-clause} \opt{function-contract-specifier-seq}
 \end{bnf}
 
 \pnum
@@ -2374,6 +2388,12 @@ void g(int (*)() requires true);            // error: constraint on a \grammarte
 auto* p = new void(*)(char) requires true;  // error: not a function declaration
 \end{codeblock}
 \end{example}
+
+\pnum
+The optional \grammarterm{function-contract-specifier-seq}\iref{dcl.contract.func}
+in an \grammarterm{init-declarator}
+shall be present only if
+the \grammarterm{declarator} declares a function.
 
 \pnum
 Declarators have the syntax
@@ -4449,6 +4469,326 @@ void m() {
 \indextext{declaration!default argument|)}%
 \indextext{declarator!meaning of|)}
 
+\rSec1[dcl.contract]{Function contract specifiers}
+\rSec2[dcl.contract.func]{General}
+
+\indextext{contract assertion!function|(}%
+
+\begin{bnf}
+\nontermdef{function-contract-specifier-seq}\br
+    function-contract-specifier \opt{function-contract-specifier-seq}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{function-contract-specifier}\br
+  precondition-specifier\br
+  postcondition-specifier
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{precondition-specifier}
+  \terminal{pre} \opt{attribute-specifier-seq} \terminal{(} conditional-expression \terminal{)}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{postcondition-specifier}\br
+  \terminal{post} \opt{attribute-specifier-seq} \terminal{(} \opt{result-name-introducer} conditional-expression \terminal{)}
+\end{bnf}
+
+\pnum
+\indexdefn{contract assertion!postcondition|see{assertion, postcondition}}
+\indexdefn{contract assertion!precondition|see{assertion, precondition}}
+A \defnadj{function}{contract assertion}
+is a contract assertion\iref{basic.contract.general}
+associated with a function.
+A \grammarterm{precondition-specifier}
+introduces a \defnadj{precondition}{assertion},
+which is a function contract assertion
+associated with entering a function.
+A \grammarterm{postcondition-specifier}
+introduces a \defnadj{postcondition}{assertion},
+which is a function contract assertion
+associated with exiting a function normally.
+\begin{note}
+A postcondition assertion
+is not associated with exiting a function
+in any other fashion,
+such as via an exception\iref{expr.throw}
+or via a call to \tcode{longjmp}\iref{csetjmp.syn}.
+\end{note}
+
+\pnum
+The predicate\iref{basic.contract.general}
+of a function contract assertion
+is its \grammarterm{conditional-expression}
+contextually converted to \tcode{bool}.
+
+\pnum
+Each \grammarterm{function-contract-specifier}
+of a \grammarterm{function-contract-specifier-seq} (if any)
+of an unspecified first declaration\iref{basic.def}
+of a function
+introduces a corresponding function contract assertion for that function.
+The optional \grammarterm{attribute-specifier-seq}
+following \tcode{pre} or \tcode{post}
+appertains to the introduced contract assertion.
+\begin{note}
+The \grammarterm{function-contract-specifier-seq}
+of a \grammarterm{lambda-declarator}
+applies to the function call operator or operator template
+of the corresponding closure type\iref{expr.prim.lambda.closure}.
+\end{note}
+
+\pnum
+A declaration $D$
+of a function or function template \placeholder{f}
+that is not a first declaration shall have either
+no \grammarterm{function-contract-specifier-seq}
+or the same \grammarterm{function-contract-specifier-seq} (see below)
+as any first declaration $F$ reachable from $D$.
+If $D$ and $F$ are
+in different translation units,
+a diagnostic is required only if $D$ is attached to a named module.
+If a declaration $F_1$ is a
+first declaration of \tcode{f}
+in one translation unit and
+a declaration $F_2$ is a
+first declaration of \tcode{f} in another translation unit,
+$F_1$ and $F_2$ shall specify the same
+\grammarterm{function-contract-specifier-seq}, no diagnostic required.
+
+\pnum
+A \grammarterm{function-contract-specifier-seq} $S_1$
+is the same as
+a \grammarterm{function-contract-specifier-seq} $S_2$
+if $S_1$ and $S_2$ consist of
+the same \grammarterm{function-contract-specifier}s
+in the same order.
+A \grammarterm{function-contract-specifier} $C_1$
+on a function declaration $D_1$ is
+the same as
+a \grammarterm{function-contract-specifier} $C_2$
+on a function declaration $D_2$
+if
+\begin{itemize}
+\item
+their predicates $P_1$ and $P_2$ would
+satisfy the one-definition rule\iref{basic.def.odr}
+if placed in function definitions on
+the declarations $D_1$ and $D_2$, respectively, except for
+\begin{itemize}
+\item
+renaming of the parameters of \placeholder{f},
+\item
+renaming of template parameters of
+a template enclosing \placeholder{}, and
+\item
+renaming of the result binding\iref{dcl.contract.res}, if any,
+\end{itemize}
+and,
+if $D_1$ and $D_2$ are in different translation units,
+corresponding entities defined within each predicate
+behave as if there is a single entity with a single definition, and
+\item
+both $C_1$ and $C_2$
+specify a \grammarterm{result-name-introducer}
+or neither do.
+\end{itemize}
+If this condition is not met
+solely due to the comparison of two \grammarterm{lambda-expression}s
+that are contained within $P_1$ and $P_2$,
+no diagnostic is required.
+
+\begin{note}
+Equivalent
+\grammarterm{function-contract-specifier-seq}s
+apply to all uses and definitions
+of a function  across all translation units.
+\end{note}
+\begin{example}
+\begin{codeblock}
+
+bool b1, b2;
+
+void f() pre (b1) pre ([]{ return b2; }());
+void f();                       // OK, \grammarterm{function-contract-specifier}s omitted
+void f() pre (b1) pre ([]{ return b2; }()); // error: closures have different types.
+void f() pre (b1);              // error: \grammarterm{function-contract-specifier}s only partially repeated
+
+int g() post(r : b1);
+int g() post(b1);       // error: mismatched \grammarterm{result-name-introducer} presence
+
+namespace N {
+  void h() pre (b1);
+  bool b1;
+  void h() pre (b1);    // error: \grammarterm{function-contract-specifier}s differ according to
+                        // the one-definition rule\iref{basic.def.odr}.
+}
+\end{codeblock}
+\end{example}
+
+\pnum
+A virtual function\iref{class.virtual},
+a deleted function\iref{dcl.fct.def.delete},
+or a function defaulted on its first declaration\iref{dcl.fct.def.default}
+shall not have a \grammarterm{function-contract-specifier-seq}.
+
+\pnum
+If the predicate of a postcondition assertion
+of a function \placeholder{f}
+odr-uses\iref{basic.def.odr}
+a non-reference parameter of \placeholder{f},
+that parameter
+and the corresponding parameter on all declarations of \placeholder{f}
+shall have \keyword{const} type.
+\begin{note}
+This requirement applies
+even to declarations that do not specify the \grammarterm{postcondition-specifier}.
+Parameters with array or function type
+will decay to non-\keyword{const} types
+even if a \keyword{const} qualifier is present.
+\begin{example}
+\begin{codeblock}
+int f(const int i[10])
+  post(r : r == i[0]);  // error: \tcode{i} has type \tcode{const int *} (not \tcode{int* const}).
+\end{codeblock}
+\end{example}
+\end{note}
+
+\pnum
+\begin{note}
+The function contract assertions of a function
+are evaluated even when invoked indirectly,
+such as through a pointer to function or a pointer to member function.
+A pointer to function,
+pointer to member function,
+or function type alias
+cannot have a \grammarterm{function-contract-specifier-seq}
+associated directly with it.
+\end{note}
+
+\pnum
+The function contract assertions of a function
+are considered to be \defnx{needed}{needed!function contract assertion}\iref{temp.inst} when
+\begin{itemize}
+\item
+the function is odr-used\iref{basic.def.odr} or
+\item
+the function is defined.
+\end{itemize}
+\begin{note}
+Overload resolution does not consider
+\grammarterm{function-contract-specifier}s\iref{temp.deduct,temp.inst}.
+\begin{example}
+\begin{codeblock}
+template <typename T>  void f(T t) pre( t == "" );
+template <typename T>  void f(T&& t);
+void g()
+{
+  f(5);     // error: ambiguous
+}
+\end{codeblock}
+\end{example}
+\end{note}
+
+
+\rSec2[dcl.contract.res]{Referring to the result object}
+
+\begin{bnf}
+\nontermdef{attributed-identifier}\br
+  identifier \opt{attribute-specifier-seq}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{result-name-introducer}\br
+  attributed-identifier \terminal{:}
+\end{bnf}
+
+\pnum
+The \grammarterm{result-name-introducer}
+of a \grammarterm{postcondition-specifier}
+is a declaration.
+The \grammarterm{result-name-introducer}
+introduces the \grammarterm{identifier}
+as the name of a \defn{result binding}
+of the associated function.
+If a postcondition assertion has a \grammarterm{result-name-introducer}
+and the return type of the function is \cv{} \keyword{void},
+the program is ill-formed.
+A result binding denotes
+the object or reference returned by
+invocation of that function.
+The type of a result binding
+is the return type of its associated function
+The optional \grammarterm{attribute-specifier-seq}
+of the \grammarterm{attributed-identifier}
+in the \grammarterm{result-name-introducer}
+appertains to the result binding so introduced.
+\begin{note}
+An \grammarterm{id-expression}
+that names a result binding is a \keyword{const} lvalue\iref{expr.prim.id.unqual}.
+\end{note}
+
+\begin{example}
+\begin{codeblock}
+int f()
+  post(r : r == 1)
+{
+  return 1;
+}
+int i = f();    // Postcondition check succeeds.
+\end{codeblock}
+\end{example}
+
+\begin{example}
+\begin{codeblock}
+struct A {};
+struct B {
+  B() {}
+  B(const B&) {}
+};
+
+template <typename T>
+T f(T* const ptr)
+  post(r: &r == ptr)
+{
+  return {};
+}
+
+int main() {
+  A a = f(&a);  // The postcondition check can fail if the implementation introduces
+                // a temporary for the return value\iref{class.temporary}.
+  B b = f(&b);  // The postcondition check succeeds, no temporary is introduced.
+}
+\end{codeblock}
+\end{example}
+
+
+\pnum
+When the declared return type
+of a non-templated function
+contains a placeholder type,
+a \grammarterm{postcondition-specifier}
+with a \grammarterm{result-name-introducer}
+shall be present only on a definition.
+\begin{example}
+\begin{codeblock}
+auto g(auto&)
+  post (r: r >= 0);     // OK, \tcode{g} is a template.
+
+auto h()
+  post (r: r >= 0);     // error: cannot name the return value
+
+auto k()
+  post (r: r >= 0)      // OK
+{
+  return 0;
+}
+\end{codeblock}
+\end{example}
+
+\indextext{contract assertion!function|)}%
+
 \rSec1[dcl.init]{Initializers}%
 
 \rSec2[dcl.init.general]{General}%
@@ -6378,8 +6718,10 @@ Function definitions have the form
 %
 \begin{bnf}
 \nontermdef{function-definition}\br
-    \opt{attribute-specifier-seq} \opt{decl-specifier-seq} declarator \opt{virt-specifier-seq} function-body\br
-    \opt{attribute-specifier-seq} \opt{decl-specifier-seq} declarator requires-clause function-body
+    \opt{attribute-specifier-seq} \opt{decl-specifier-seq} declarator \opt{virt-specifier-seq}\br
+    \bnfindent \opt{function-contract-specifier-seq} function-body\br
+    \opt{attribute-specifier-seq} \opt{decl-specifier-seq} declarator requires-clause\br
+    \bnfindent \opt{function-contract-specifier-seq} function-body
 \end{bnf}
 
 \begin{bnf}
@@ -6809,7 +7151,13 @@ that denotes the parameter copy corresponding to $\tcode{p}_i$,
 as described below.
 
 \pnum
-A coroutine behaves as if its \grammarterm{function-body} were replaced by:
+A coroutine behaves as if
+the top-level cv-qualifiers in all
+\grammarterm{parameter-declaration}s in the declarator
+of its \grammarterm{function-definition}
+were removed and
+its \grammarterm{function-body} were replaced by
+the following \defnadj{replacement}{body}:
 \begin{ncsimplebnf}
 \terminal{\{}\br
 \bnfindent \placeholder{promise-type} \exposid{promise} \placeholder{promise-constructor-arguments} \terminal{;}\br
@@ -6875,6 +7223,13 @@ due to an exception exiting from \tcode{unhandled_exception()}.
 \end{itemize}
 
 \pnum
+\begin{note}
+An odr-use of a non-reference parameter
+in a postcondition assertion
+of a coroutine is ill-formed\iref{dcl.contract.func}.
+\end{note}
+
+\pnum
 If searches for the names \tcode{return_void} and \tcode{return_value}
 in the scope of the promise type each find any declarations,
 the program is ill-formed.
@@ -6907,7 +7262,8 @@ that is not suspended results in undefined behavior.
 \pnum
 An implementation may need to allocate additional storage for a coroutine.
 This storage is known as the \defn{coroutine state} and is obtained by calling
-a non-array allocation function\iref{basic.stc.dynamic.allocation}.
+a non-array allocation function\iref{basic.stc.dynamic.allocation}
+as part of the replacement body.
 The allocation function's name is looked up by searching for it in the scope of the promise type.
 \begin{itemize}
 \item
@@ -6915,7 +7271,9 @@ If the search finds any declarations,
 overload resolution is performed on a function call created by assembling an
 argument list. The first argument is the amount of space requested, and
 is a prvalue of type \tcode{std::size_t}.
-The lvalues $\tcode{p}_1 \dotsc \tcode{p}_n$ are the successive arguments.
+The lvalues $\tcode{p}_1 \dotsc \tcode{p}_n$
+with their original types (including cv-qualifiers)
+are the successive arguments.
 If no viable function is found\iref{over.match.viable},
 overload resolution is performed again
 on a function call created by passing just
@@ -7011,16 +7369,29 @@ the block is passed as the corresponding argument.
 
 \pnum
 When a coroutine is invoked,
-after initializing its parameters\iref{expr.call},
-a copy is created for each coroutine parameter.
-For a parameter of type \cv{}~\tcode{T},
-the copy is a variable of type \cv{}~\tcode{T}
+a copy is created for each coroutine parameter
+at the beginning of the replacement body.
+For a parameter
+whose original declaration specified the type \cv{}~\tcode{T},
+\begin{itemize}
+\item
+if \tcode{T} is a reference type,
+the copy is a reference of type
+\cv{}~\tcode{T}
+bound to the same object as a parameter;
+\item
+otherwise, the copy is a variable
+of type \cv{}~\tcode{T}
 with automatic storage duration that is direct-initialized
 from an xvalue of type \tcode{T} referring to the parameter.
+\end{itemize}
 \begin{note}
-An original parameter object is never
-a const or volatile object\iref{basic.type.qualifier}.
+An identifier in the \grammarterm{function-body}
+that names one of these parameters
+refers to the created copy,
+not the original parameter\iref{expr.prim.id.unqual}.
 \end{note}
+
 The initialization and destruction of each parameter copy occurs in the
 context of the called coroutine.
 Initializations of parameter copies are sequenced before the call to the
@@ -7043,6 +7414,45 @@ and the exception propagates to the caller or resumer.
 \pnum
 The expression \keyword{co_await} \tcode{\exposid{promise}.final_suspend()}
 shall not be potentially-throwing\iref{except.spec}.
+
+\rSec2[dcl.fct.def.replace]{Replaceable function definitions}
+
+\pnum
+Certain functions
+for which a definition is supplied by the implementation
+are \defn{replaceable}.
+A \Cpp{} program may
+provide a definition with the signature of a replaceable function,
+called a \defnadj{replacement}{function}.
+The replacement function
+is used instead of the default version
+supplied by the implementation.
+Such replacement occurs
+prior to program startup\iref{basic.def.odr,basic.start}.
+A declaration of the replacement function
+\begin{itemize}
+\item
+shall not be inline,
+\item
+shall be attached to the global module,
+\item
+shall have \Cpp{} language linkage,
+\item
+shall have the same return type as the replaceable function, and
+\item
+if the function is declared in a standard library header,
+shall be such that it would be valid as a redeclaration
+of the declaration in that header;
+\end{itemize}
+no diagnostic is required.
+\begin{note}
+The one-definition rule\iref{basic.def.odr})
+applies to the definitions of a replaceable function
+provided by the program.
+The implementation-supplied function definition
+is an otherwise-unnamed function with no linkage.
+\end{note}
+
 
 \rSec1[dcl.struct.bind]{Structured binding declarations}%
 \indextext{structured binding declaration}%
@@ -8800,7 +9210,7 @@ achieved.%
 \pnum
 \indextext{attribute!syntax and semantics}%
 Attributes specify additional information for various source constructs
-such as types, variables, names, blocks, or translation units.
+such as types, variables, names, contract assertions, blocks, or translation units.
 
 \begin{bnf}
 \nontermdef{attribute-specifier-seq}\br
@@ -9465,6 +9875,7 @@ The attribute may be applied to the declaration of a class,
 \grammarterm{typedef-name},
 variable (including a structured binding declaration),
 structured binding,
+result binding\iref{dcl.contract.res},
 non-static data member,
 function,
 enumeration, or

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -2478,11 +2478,6 @@ bool is_debugger_present() noexcept;
 
 \begin{itemdescr}
 \pnum
-\replaceable
-A \Cpp{} program may define a function with this function signature, and
-thereby displace the default version defined by the \Cpp{} standard library.
-
-\pnum
 \required
 This function has no preconditions.
 
@@ -2498,5 +2493,9 @@ systems, this can be achieved by calling the \tcode{::IsDebuggerPresent()} Win32
 function. On POSIX, this can be achieved by checking for a tracer parent process,
 with best effort determination that such a tracer parent process is a debugger.
 \end{note}
+
+\pnum
+\remarks
+This function is replaceable\iref{dcl.fct.def.replace}.
 
 \end{itemdescr}

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -639,7 +639,7 @@ of the same thread.
 \indextext{exception handling!terminate called@\tcode{terminate} called}%
 \indextext{\idxcode{terminate}!called}%
 If the search for a handler
-encounters the outermost block of a function with a
+exits the function body of a function with a
 non-throwing exception specification,
 the function \tcode{std::terminate}\iref{except.terminate} is invoked.
 \begin{note}
@@ -987,9 +987,7 @@ An exception specification is considered to be \defnx{needed}{needed!exception s
 \item in an expression, the function is selected by
 overload resolution\iref{over.match,over.over};
 
-\item the function is odr-used\iref{term.odr.use} or, if it appears in an
-unevaluated operand, would be odr-used if the expression were
-potentially-evaluated;
+\item the function is odr-used\iref{term.odr.use};
 
 \item the exception specification is compared to that of another
 declaration (e.g., an explicit specialization or an overriding virtual
@@ -1009,9 +1007,9 @@ the implicit exception specification to compare against.
 \end{itemize}
 The exception specification of a defaulted
 function is evaluated as described above only when needed; similarly, the
-\grammarterm{noexcept-specifier} of a specialization of a function
-template or member function of a class template is instantiated only when
-needed.
+\grammarterm{noexcept-specifier} of a specialization
+of a templated function
+is instantiated only when needed.
 %
 \indextext{exception specification|)}
 
@@ -1053,9 +1051,14 @@ via an exception, or
 \item%
 when the exception handling mechanism cannot find a handler for a thrown exception\iref{except.handle}, or
 
-\item when the search for a handler\iref{except.handle} encounters the
-outermost block of a function
-with a non-throwing exception specification\iref{except.spec}, or
+\item when the search for a handler\iref{except.handle}
+exits the function body of a function
+with a non-throwing exception specification\iref{except.spec},
+including when a contract-violation handler
+invoked from an evaluation of
+a function contract assertion\iref{basic.contract.eval} associated with the function
+exits via an exception,
+or
 
 \item%
 when the destruction of an object during stack unwinding\iref{except.ctor}
@@ -1135,8 +1138,8 @@ In the situation where no matching handler is found, it is
 \impldef{stack unwinding before invocation of \tcode{std::terminate}}
 whether or not the stack is unwound
 before \tcode{std::terminate} is invoked.
-In the situation where the search for a handler\iref{except.handle} encounters the
-outermost block of a function
+In the situation where the search for a handler\iref{except.handle}
+exits the function body of a function
 with a non-throwing exception specification\iref{except.spec}, it is
 \impldef{whether stack is unwound before invoking the function \tcode{std::terminate}
 when a \tcode{noexcept} specification is violated}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -233,13 +233,11 @@ a prvalue that has type \cv{}~\keyword{void} has no result.
 A prvalue whose result is the value \placeholder{V}
 is sometimes said to have or name the value \placeholder{V}.
 The \defn{result object} of a prvalue is the object initialized by the prvalue;
-a non-discarded prvalue
-that is used to compute the value of an operand of a built-in operator
-or a prvalue that has type \cv{}~\keyword{void}
+a prvalue that has type \cv{}~\keyword{void}
 has no result object.
 \begin{note}
 Except when the prvalue is the operand of a \grammarterm{decltype-specifier},
-a prvalue of class or array type always has a result object.
+a prvalue of object type always has a result object.
 For a discarded prvalue that has type other than \cv{}~\keyword{void},
 a temporary object is materialized; see \ref{expr.context}.
 \end{note}
@@ -267,9 +265,10 @@ created, which might then be promoted\iref{conv.prom}.
 
 \pnum
 Unless otherwise specified\iref{expr.reinterpret.cast, expr.const.cast},
-whenever a prvalue appears as an operand of an operator that
-expects a glvalue for that operand, the
-temporary materialization conversion\iref{conv.rval} is
+whenever a prvalue
+that is not the result of the lvalue-to-rvalue conversion\iref{conv.lval}
+appears as an operand of an operator,
+the temporary materialization conversion\iref{conv.rval} is
 applied to convert the expression to an xvalue.
 
 \pnum
@@ -1281,6 +1280,16 @@ A \grammarterm{lambda-expression} does not introduce a class scope.
 \end{note}
 
 \pnum
+If the expression \tcode{this}
+appears within the predicate of a contract assertion\iref{basic.contract.general}
+(including as the result of an implicit transformation\iref{expr.prim.id.general}
+and including in the bodies of nested \grammarterm{lambda-expression}s)
+and the current class
+encloses the contract assertion,
+\keyword{const} is combined with the \grammarterm{cv-qualifier-seq}
+used to generate the resulting type (see below).
+
+\pnum
 If a declaration declares a member function or member function template of a
 class \tcode{X}, the expression \keyword{this} is a prvalue of type ``pointer to
 \grammarterm{cv-qualifier-seq} \tcode{X}''
@@ -1390,6 +1399,10 @@ the unary \tcode{\&} operator\iref{expr.unary.op},
 \end{itemize}
 the \grammarterm{id-expression} is transformed into
 a class member access expression using \tcode{(*this)} as the object expression.
+If this transformation occurs
+in the predicate of a precondition assertion of a constructor of \tcode{X}
+or a postcondition assertion of a destructor of \tcode{X},
+the expression is ill-formed.
 \begin{note}
 If \tcode{C} is not \tcode{X} or a base class of \tcode{X},
 the class member access expression is ill-formed.
@@ -1399,6 +1412,16 @@ the class member access is ill-formed.
 \end{note}
 This transformation does not apply in
 the template definition context\iref{temp.dep.type}.
+\begin{example}
+\begin{codeblock}
+struct C {
+  bool b;
+  C() pre(b)                // error
+      pre(&this->b)         // OK
+      pre(sizeof(b) > 0);   // OK, \tcode{b} is not potentially evaluated.
+};
+\end{codeblock}
+\end{example}
 
 \pnum
 If an \grammarterm{id-expression} $E$ denotes
@@ -1501,8 +1524,6 @@ An \grammarterm{identifier} is only
 an \grammarterm{id-expression} if it has
 been suitably declared\iref{dcl}
 or if it appears as part of a \grammarterm{declarator-id}\iref{dcl.decl}.
-An \grammarterm{identifier} that names a coroutine parameter
-refers to the copy of the parameter\iref{dcl.fct.def.coroutine}.
 \begin{note}
 For \grammarterm{operator-function-id}{s}, see~\ref{over.oper}; for
 \grammarterm{conversion-function-id}{s}, see~\ref{class.conv.fct}; for
@@ -1533,21 +1554,28 @@ the component name of that construct that appears lexically last.
 \pnum
 The result is the entity denoted by
 the \grammarterm{unqualified-id}\iref{basic.lookup.unqual}.
-If the \grammarterm{unqualified-id} appears
-in a \grammarterm{lambda-expression} at program point $P$ and
-the entity is a local entity\iref{basic.pre} or a variable declared by
-an \grammarterm{init-capture}\iref{expr.prim.lambda.capture},
-then let $S$ be the \grammarterm{compound-statement} of
-the innermost enclosing \grammarterm{lambda-expression} of $P$.
-If naming the entity from outside of an unevaluated operand within $S$
-would refer to an entity
-captured by copy in some intervening \grammarterm{lambda-expression},
-then let $E$ be the innermost such \grammarterm{lambda-expression}.
+
+\pnum
+If
 \begin{itemize}
 \item
-If there is such a \grammarterm{lambda-expression} and
-if $P$ is in $E$'s function parameter scope
-but not its \grammarterm{parameter-declaration-clause}, then
+the \grammarterm{unqualified-id}
+appears in a \grammarterm{lambda-expression}
+at program point $P$,
+\item
+the entity is a local entity\iref{basic.pre}
+or a variable declared by an \grammarterm{init-capture}\iref{expr.prim.lambda.capture},
+\item
+naming the entity within the \grammarterm{compound-statement} of
+the innermost enclosing \grammarterm{lambda-expression} of $P$,
+but not in an unevaluated operand, would refer to an entity captured by copy
+in some intervening \grammarterm{lambda-expression}, and
+\item
+$P$ is in the function parameter scope,
+but not the \grammarterm{parameter-declaration-clause},
+of the innermost such \grammarterm{lambda-expression} $E$,
+\end{itemize}
+then
 the type of the expression is
 the type of a class member access expression\iref{expr.ref}
 naming the non-static data member
@@ -1557,26 +1585,166 @@ in the object parameter\iref{dcl.fct} of the function call operator of $E$.
 If $E$ is not declared \keyword{mutable},
 the type of such an identifier will typically be \keyword{const} qualified.
 \end{note}
+
+\pnum
+Otherwise,
+if the \grammarterm{unqualified-id}
+names a coroutine parameter,
+the type of the expression is
+that of the copy of the parameter\iref{dcl.fct.def.coroutine},
+and the result is that copy.
+
+\pnum
+Otherwise,
+if the \grammarterm{unqualified-id}
+names a result binding\iref{dcl.contract.res}
+attached to a function \placeholder{f}
+with return type \tcode{U},
+\begin{itemize}
 \item
-Otherwise (if there is no such \grammarterm{lambda-expression} or
-if $P$ either precedes $E$'s function parameter scope or
-is in $E$'s \grammarterm{parameter-declaration-clause}),
-the type of the expression is the type of the result.
+if \tcode{U} is ``reference to \tcode{T}'',
+then the type of the expression is
+\tcode{const T};
+\item
+otherwise,
+the type of the expression is \tcode{const U}.
 \end{itemize}
-If the entity is a template parameter object for
+
+\pnum
+Otherwise,
+if the \grammarterm{unqualified-id}
+appears in the predicate of a contract assertion $C$\iref{basic.contract}
+and the entity is
+\begin{itemize}
+\item
+a variable
+declared outside of $C$
+of object type \tcode{T},
+\item
+a variable or template parameter
+declared outside of $C$
+of type ``reference to \tcode{T}'', or
+\item
+a structured binding
+of type \tcode{T}
+whose corresponding variable
+is declared outside of $C$,
+\end{itemize}
+then the type of the expression is \keyword{const}~\tcode{T}.
+
+\pnum
+\begin{example}
+\begin{codeblock}
+int n = 0;
+struct X { bool m(); };
+
+struct Y {
+  int z = 0;
+
+  void f(int i, int* p, int& r, X x, X* px)
+    pre (++n)       // error: attempting to modify const lvalue
+    pre (++i)       // error: attempting to modify const lvalue
+    pre (++(*p))    // OK
+    pre (++r)       // error: attempting to modify const lvalue
+    pre (x.m())     // error: calling non-const member function
+    pre (px->m())   // OK
+    pre ([=,&i,*this] mutable {
+      ++n;          // error: attempting to modify const lvalue
+      ++i;          // error: attempting to modify const lvalue
+      ++p;          // OK, refers to member of closure type
+      ++r;          // OK, refers to non-reference member of closure type
+      ++this->z;    // OK, captured \tcode{*\keyword{this}}
+      ++z;          // OK, captured \tcode{*\keyword{this}}
+      int j = 17;
+      [&]{
+        int k = 34;
+        ++i;    // error: attempting to modify const lvalue
+        ++j;    // OK
+        ++k;    // OK
+      }();
+      return true;
+    }());
+
+  template <int N, int& R, int* P>
+  void g()
+    pre(++N)        // error: attempting to modify prvalue
+    pre(++R)        // error: attempting to modify const lvalue
+    pre(++(*P));    // OK
+
+  int h()
+    post(r : ++r)   // error: attempting to modify const lvalue
+    post(r: [=] mutable {
+       ++r;         // OK, refers to member of closure type
+       return true;
+     }());
+
+  int& k()
+    post(r : ++r);  // error: attempting to modify const lvalue
+};
+\end{codeblock}
+\end{example}
+
+\pnum
+Otherwise, if the entity is a template parameter object for
 a template parameter of type \tcode{T}\iref{temp.param},
 the type of the expression is \tcode{const T}.
+
+\pnum
 In all other cases, the type of the expression is the type of the entity.
+
+\pnum
 \begin{note}
 The type will be adjusted as described in \ref{expr.type}
 if it is cv-qualified or is a reference type.
 \end{note}
+
+\pnum
 The expression is an xvalue if it is move-eligible (see below);
 an lvalue
-if the entity is a function, variable, structured binding\iref{dcl.struct.bind}, data member, or
+if the entity is a
+function,
+variable,
+structured binding\iref{dcl.struct.bind},
+result binding\iref{dcl.contract.res},
+data member, or
 template parameter object;
 and a prvalue otherwise\iref{basic.lval};
 it is a bit-field if the identifier designates a bit-field.
+
+\pnum
+If an \grammarterm{id-expression} $E$
+appears in the predicate of
+a function contract assertion attached to a function \placeholder{f}
+and denotes
+a function parameter of \placeholder{f}
+and the implementation introduces any temporary objects
+to hold the value of that parameter as specified in \ref{class.temporary},
+\begin{itemize}
+\item
+if the contract assertion
+is a precondition assertion
+and the evaluation of the precondition assertion
+is sequenced before the initialization of the parameter object,
+$E$ refers to the most recently initialized such temporary object, and
+\item
+if the contract assertion
+is a postcondition assertion,
+it is unspecified whether $E$ refers to
+one of the temporary objects or the parameter object;
+the choice is consistent within a single evaluation of a postcondition assertion.
+\end{itemize}
+
+\pnum
+If an \grammarterm{id-expression} $E$
+names a result binding
+in a postcondition assertion
+and the implementation introduces any temporary objects
+to hold the result object as specified in \ref{class.temporary},
+and the postcondition assertion
+is sequenced before the initialization of the result object\iref{expr.call},
+$E$ refers to the most recently initialized such temporary object.
+
+
 \begin{example}
 \begin{codeblock}
 void f() {
@@ -1726,7 +1894,32 @@ nor of the form
 \pnum
 The result of a \grammarterm{qualified-id} $Q$ is
 the entity it denotes\iref{basic.lookup.qual}.
-The type of the expression is the type of the result.
+
+\pnum
+If $Q$ appears
+in the predicate of a contract assertion $C$\iref{basic.contract}
+and the entity is
+\begin{itemize}
+\item
+a variable
+declared outside of $C$
+of object type \tcode{T},
+\item
+a variable
+declared outside of $C$
+of type ``reference to \tcode{T}'', or
+\item
+a structured binding of type \tcode{T}
+whose corresponding variable
+is declared outside of $C$,
+\end{itemize}
+then the type of the expression is \keyword{const}~\tcode{T}.
+
+
+\pnum
+Otherwise, the type of the expression is the type of the result.
+
+\pnum
 The result is an lvalue if the member is
 \begin{itemize}
 \item
@@ -1826,10 +2019,11 @@ void f() {
 \begin{bnf}
 \nontermdef{lambda-declarator}\br
     lambda-specifier-seq \opt{noexcept-specifier} \opt{attribute-specifier-seq} \opt{trailing-return-type}\br
-    noexcept-specifier \opt{attribute-specifier-seq} \opt{trailing-return-type}\br
-    \opt{trailing-return-type}\br
+    \bnfindent \opt{function-contract-specifier-seq}\br
+    noexcept-specifier \opt{attribute-specifier-seq} \opt{trailing-return-type} \opt{function-contract-specifier-seq}\br
+    \opt{trailing-return-type} \opt{function-contract-specifier-seq}\br
     \terminal{(} parameter-declaration-clause \terminal{)} \opt{lambda-specifier-seq} \opt{noexcept-specifier} \opt{attribute-specifier-seq}\br
-    \bnfindent \opt{trailing-return-type} \opt{requires-clause}
+    \bnfindent \opt{trailing-return-type} \opt{requires-clause} \opt{function-contract-specifier-seq}
 \end{bnf}
 
 \begin{bnf}
@@ -2060,8 +2254,9 @@ that is declared
 followed by \keyword{mutable} and
 the \grammarterm{lambda-declarator} does not contain
 an explicit object parameter.
-It is neither virtual nor declared \tcode{volatile}. Any
-\grammarterm{noexcept-specifier} specified on a \grammarterm{lambda-expression}
+It is neither virtual nor declared \tcode{volatile}.
+Any \grammarterm{noexcept-specifier} or \grammarterm{function-contract-specifier}\iref{dcl.contract.func}
+specified on a \grammarterm{lambda-expression}
 applies to the corresponding function call operator or operator template.
 An \grammarterm{attribute-specifier-seq} in a \grammarterm{lambda-declarator} appertains
 to the type of the corresponding function call operator or operator template.
@@ -2139,6 +2334,51 @@ auto f = []<typename T1, C1 T2> requires C2<sizeof(T1) + sizeof(T2)>
 \end{codeblock}
 \end{example}
 \end{note}
+
+\pnum
+If all potential references
+to a local entity implicitly captured by a \grammarterm{lambda-expression} $L$
+occur within the function contract assertions\iref{dcl.contract.func}
+of the call operator or operator template of $L$
+or within \grammarterm{assertion-statement}s\iref{stmt.contract.assert}
+within the body of $L$,
+the program is ill-formed.
+\begin{note}
+Adding a contract assertion to an existing \Cpp{} program cannot
+cause additional captures.
+\end{note}
+\begin{example}
+\begin{codeblock}
+static int i = 0;
+
+void test() {
+  auto f1 = [=] pre(i > 0) {};  // OK, no local entities are captured.
+
+  int i = 1;
+  auto f2 = [=] pre(i > 0) {};  // error: cannot implicitly capture \tcode{i} here
+  auto f3 = [i] pre(i > 0) {};  // OK, \tcode{i} is captured explicitly.
+
+  auto f4 = [=] {
+    contract_assert(i > 0);     // error: cannot implicitly capture \tcode{i} here
+  };
+
+  auto f5 = [=] {
+    contract_assert(i > 0);     // OK, \tcode{i} is referenced elsewhere.
+    (void)i;
+  };
+
+  auto f6 = [=] pre(                // \#1
+    []{
+      bool x = true;
+      return [=]{ return x; }();    // OK, \#1 captures nothing.
+    }()) {};
+
+  bool y = true;
+  auto f7 = [=] pre([=]{ return y; }());    // error: outer capture of \tcode{y} is invalid.
+}
+\end{codeblock}
+\end{example}
+
 
 \pnum
 The closure type for a non-generic \grammarterm{lambda-expression} with no
@@ -2359,7 +2599,7 @@ named in a friend declaration\iref{class.friend}.
 
 \pnum
 The body of a \grammarterm{lambda-expression} may refer to local entities
-of enclosing block scopes by capturing those entities, as described
+of enclosing scopes by capturing those entities, as described
 below.
 
 \pnum
@@ -2400,10 +2640,19 @@ void S2::f(int i) {
 A \grammarterm{lambda-expression} shall not have
 a \grammarterm{capture-default} or \grammarterm{simple-capture}
 in its \grammarterm{lambda-introducer}
-unless its innermost enclosing scope is a block scope\iref{basic.scope.block}
-or it appears within a default member initializer
+unless
+\begin{itemize}
+\item
+its innermost enclosing scope is a block scope\iref{basic.scope.block},
+\item
+it appears within a default member initializer
 and its innermost enclosing scope is
-the corresponding class scope\iref{basic.scope.class}.
+the corresponding class scope\iref{basic.scope.class}, or
+\item
+it appears within a contract assertion
+and its innermost enclosing scope
+is the corresponding contract-assertion scope\iref{basic.scope.contract}.
+\end{itemize}
 
 \pnum
 The \grammarterm{identifier} in a \grammarterm{simple-capture}
@@ -3363,7 +3612,9 @@ and the function types are otherwise the same.
 \indextext{initialization!parameter}%
 When a function is called, each parameter\iref{dcl.fct} is
 initialized\iref{dcl.init,class.copy.ctor} with
-its corresponding argument.
+its corresponding argument,
+and each precondition assertion of the function
+is evaluated.\iref{dcl.contract.func}
 If the function is an explicit object member function and
 there is an implied object argument\iref{over.call.func},
 the list of provided arguments is preceded by the implied object argument
@@ -3399,7 +3650,7 @@ to have an incomplete or abstract class type.
 It is \impldef{whether a parameter is destroyed when the function
 exits or at the end of the enclosing full-expression}
 whether a parameter is destroyed
-when the function in which it is defined exits\iref{stmt.return, except.ctor}
+when the function in which it is defined exits\iref{stmt.return, except.ctor, expr.await}
 or at the end of the enclosing full-expression;
 parameters are always destroyed in the reverse order of their construction.
 The initialization and destruction of each parameter occurs
@@ -3423,9 +3674,21 @@ is not considered.
 The \grammarterm{postfix-expression} is sequenced before
 each \grammarterm{expression} in the \grammarterm{expression-list}
 and any default argument.
-The initialization of a parameter,
+The initialization of a parameter or,
+if the implementation introduces any temporary objects
+to hold the values of function parameters\iref{class.temporary},
+the initialization of those temporaries,
 including every associated value computation and side effect,
 is indeterminately sequenced with respect to that of any other parameter.
+These evaluations are
+sequenced before
+the evaluation of the precondition assertions of the function,
+which are evaluated in sequence\iref{dcl.contract.func}.
+For any temporaries
+introduced to hold the values of function parameters,
+the initialization of the parameter objects from those temporaries
+is indeterminately sequenced with respect to
+the evaluation of each precondition assertion.
 \begin{note}
 All side effects of
 argument evaluations are sequenced before the function is
@@ -3470,6 +3733,18 @@ except in a virtual function call if the return type of the
 final overrider is different from the return type of the statically
 chosen function, the value returned from the final overrider is
 converted to the return type of the statically chosen function.
+
+\pnum
+When the called function exits normally\iref{stmt.return,expr.await},
+all postcondition assertions of the function
+are evaluated in sequence\iref{dcl.contract.func}.
+If the implementation introduces any temporary objects
+to hold the result value as specified in \ref{class.temporary},
+the evaluation of each postcondition assertion
+is indeterminately sequenced with respect to
+the initialization of any of those temporaries or the result object.
+These evaluations, in turn, are sequenced before
+the destruction of any function parameters.
 
 \pnum
 \begin{note}
@@ -4896,6 +5171,9 @@ An \grammarterm{await-expression} shall not appear in a
 default argument\iref{dcl.fct.default}.
 An \grammarterm{await-expression} shall not appear in the initializer of
 a block variable with static or thread storage duration.
+An \grammarterm{await-expression} shall not be
+a potentially-evaluated subexpression
+of the predicate of a contract assertion\iref{basic.contract}.
 A context within a function where an \grammarterm{await-expression} can appear
 is called a \term{suspension context} of the function.
 
@@ -7579,17 +7857,26 @@ and for each constituent reference of \tcode{x} that refers to an object $o$,
 $o$ is constexpr-referenceable from $P$.
 
 \pnum
+\indextext{contract evaluation semantics!ignore}
 A variable \tcode{v} is \defn{constant-initializable} if
 \begin{itemize}
 \item
 the full-expression of its initialization is a constant expression
-when interpreted as a \grammarterm{constant-expression},
+when interpreted as a \grammarterm{constant-expression}
+with all contract assertions
+using the ignore evaluation semantic\iref{basic.contract.eval},
 \begin{note}
 Within this evaluation,
 \tcode{std::is_constant_evaluated()}\iref{meta.const.eval}
 returns \keyword{true}.
 \end{note}
-and
+\begin{note}
+The initialization, when evaluated,
+can still evaluate contract assertions
+with other evaluation semantics,
+resulting in a diagnostic or ill-formed program
+if a contract violation occurs.
+\end{note}
 \item
 immediately after the initializing declaration of \tcode{v},
 the object or reference \tcode{x} declared by \tcode{v}
@@ -8383,6 +8670,15 @@ template<class T>
 constexpr int k(int) {          // \tcode{k<int>} is not an immediate function because \tcode{A(42)} is a
   return A(42).y;               // constant expression and thus not immediate-escalating
 }
+
+constexpr int l(int c) pre(c >= 2) {
+  return (c % 2 == 0) ? c / 0 : c;
+}
+
+const int i0 = l(0);    // dynamic initialization; contract violation or undefined behavior
+const int i1 = l(1);    // static initialization; value of \tcode{1} or contract violation at compile time
+const int i2 = l(2);    // dynamic initialization; undefined behavior
+const int i3 = l(3);    // static initialization; value of \tcode{3}
 \end{codeblock}
 \end{example}
 
@@ -8401,7 +8697,10 @@ that is usable in constant expressions or
 has constant initialization\iref{basic.start.static}.
 \begin{footnote}
 Testing this condition
-can involve a trial evaluation of its initializer as described above.
+can involve a trial evaluation of its initializer,
+with evaluations of contract assertions
+using the ignore evaluation semantic\iref{basic.contract.eval},
+as described above.
 \end{footnote}
 \begin{example}
 \begin{codeblock}

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -762,17 +762,24 @@ with respect to that program.
 
 \item
 \indextext{message!diagnostic}%
+\indextext{contract evaluation semantics!checking}%
+\indextext{contract evaluation semantics!terminating}%
 Otherwise, if a program contains
 \begin{itemize}
 \item
 a violation of any diagnosable rule,
 \item
 a preprocessing translation unit with
-a \tcode{\#warning} preprocessing directive\iref{cpp.error}, or
+a \tcode{\#warning} preprocessing directive\iref{cpp.error},
 \item
 an occurrence
 of a construct described in this document as ``conditionally-supported'' when
-the implementation does not support that construct,
+the implementation does not support that construct, or
+\item
+a contract assertion\iref{basic.contract.eval}
+evaluated with a checking semantic
+in a manifestly constant-evaluated context \iref{expr.const}
+resulting in a contract violation,
 \end{itemize}
 a conforming implementation
 shall issue at least one diagnostic message.
@@ -788,10 +795,14 @@ shall not accept
 \begin{itemize}
 \item
 a preprocessing translation unit containing
-a \tcode{\#error} preprocessing directive\iref{cpp.error} or
+a \tcode{\#error} preprocessing directive\iref{cpp.error},
 \item
 a translation unit with
-a \grammarterm{static_assert-declaration} that fails\iref{dcl.pre}.
+a \grammarterm{static_assert-declaration} that fails\iref{dcl.pre}, or
+\item
+a contract assertion evaluated with a terminating semantic\iref{basic.contract.eval}
+in a manifestly constant-evaluated context\iref{expr.const}
+resulting in a contract violation.
 \end{itemize}
 
 \pnum
@@ -925,7 +936,9 @@ Certain events in the execution of a program
 are termed \defnadj{observable}{checkpoints}.
 \begin{note}
 A call to \tcode{std::observable}\iref{utility.undefined}
-is an observable checkpoint.
+is an observable checkpoint,
+as are certain parts of
+the evaluation of contract assertions\iref{basic.contract}.
 \end{note}
 
 \pnum

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -915,7 +915,7 @@ Unless otherwise specified, any ambiguity as to whether a given
 token as a regular \grammarterm{identifier}.
 
 \begin{multicolfloattable}{Identifiers with special meaning}{lex.name.special}
-{llll}
+{llllll}
 \keyword{final}           \\
 \columnbreak
 \keyword{import}          \\
@@ -923,6 +923,10 @@ token as a regular \grammarterm{identifier}.
 \keyword{module}          \\
 \columnbreak
 \keyword{override}        \\
+\columnbreak
+\keyword{post}            \\
+\columnbreak
+\keyword{pre}             \\
 \end{multicolfloattable}
 
 \pnum
@@ -996,6 +1000,7 @@ is reserved for future use.
 \keyword{constinit} \\
 \keyword{const_cast} \\
 \keyword{continue} \\
+\keyword{contract_assert} \\
 \keyword{co_await} \\
 \keyword{co_return} \\
 \keyword{co_yield} \\
@@ -1009,8 +1014,8 @@ is reserved for future use.
 \keyword{enum} \\
 \keyword{explicit} \\
 \keyword{export} \\
-\keyword{extern} \\
 \columnbreak
+\keyword{extern} \\
 \keyword{false} \\
 \keyword{float} \\
 \keyword{for} \\
@@ -1027,8 +1032,8 @@ is reserved for future use.
 \keyword{nullptr} \\
 \keyword{operator} \\
 \keyword{private} \\
-\keyword{protected} \\
 \columnbreak
+\keyword{protected} \\
 \keyword{public} \\
 \keyword{register} \\
 \keyword{reinterpret_cast} \\
@@ -1045,8 +1050,8 @@ is reserved for future use.
 \keyword{template} \\
 \keyword{this} \\
 \keyword{thread_local} \\
-\keyword{throw} \\
 \columnbreak
+\keyword{throw} \\
 \keyword{true} \\
 \keyword{try} \\
 \keyword{typedef} \\

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -373,6 +373,11 @@ and also define the function as deleted.
 the conditions
 that the function assumes to hold whenever it is called;
 violation of any preconditions results in undefined behavior.
+\begin{example}
+An implementation can express some such conditions
+via the use of a contract assertion,
+such as a precondition assertion\iref{dcl.contract.func}.
+\end{example}
 
 \item
 \effects
@@ -386,6 +391,11 @@ the synchronization operations\iref{intro.multithread} applicable to the functio
 \ensures
 the conditions (sometimes termed observable results)
 established by the function.
+\begin{example}
+An implementation can express some such conditions
+via the use of a contract assertion,
+such as a postcondition assertion\iref{dcl.contract.func}.
+\end{example}
 
 \item
 \result
@@ -1172,6 +1182,7 @@ shown in \tref{headers.cpp}.
 \tcode{<complex>} \\
 \tcode{<concepts>} \\
 \tcode{<condition_variable>} \\
+\tcode{<contracts>} \\
 \tcode{<coroutine>} \\
 \tcode{<debugging>} \\
 \tcode{<deque>} \\
@@ -1182,8 +1193,8 @@ shown in \tref{headers.cpp}.
 \tcode{<flat_map>} \\
 \tcode{<flat_set>} \\
 \tcode{<format>} \\
-\columnbreak
 \tcode{<forward_list>} \\
+\columnbreak
 \tcode{<fstream>} \\
 \tcode{<functional>} \\
 \tcode{<future>} \\
@@ -1206,8 +1217,8 @@ shown in \tref{headers.cpp}.
 \tcode{<mdspan>} \\
 \tcode{<memory>} \\
 \tcode{<memory_resource>} \\
-\columnbreak
 \tcode{<mutex>} \\
+\columnbreak
 \tcode{<new>} \\
 \tcode{<numbers>} \\
 \tcode{<numeric>} \\
@@ -1230,8 +1241,8 @@ shown in \tref{headers.cpp}.
 \tcode{<spanstream>} \\
 \tcode{<sstream>} \\
 \tcode{<stack>} \\
-\columnbreak
 \tcode{<stacktrace>} \\
+\columnbreak
 \tcode{<stdexcept>} \\
 \tcode{<stdfloat>} \\
 \tcode{<stop_token>} \\
@@ -1564,6 +1575,7 @@ include at least the headers shown in \tref{headers.cpp.fs}.
 \ref{support.exception}  & Exception handling        & \tcode{<exception>}        \\ \rowsep
 \ref{support.initlist}   & Initializer lists         & \tcode{<initializer_list>} \\ \rowsep
 \ref{cmp}                & Comparisons               & \tcode{<compare>}          \\ \rowsep
+\ref{support.contract}   & Contract-violation handling & \tcode{<contracts>}      \\ \rowsep
 \ref{support.coroutine}  & Coroutines support        & \tcode{<coroutine>}        \\ \rowsep
 \ref{support.runtime}    & Other runtime support     & \tcode{<cstdarg>}          \\ \rowsep
 \ref{concepts}           & Concepts library          & \tcode{<concepts>}         \\ \rowsep
@@ -3351,72 +3363,13 @@ library may be overridden in a derived class defined in the program\iref{class.v
 \rSec3[replacement.functions]{Replacement functions}
 
 \pnum
-\indextext{definition!alternate}%
+If a function defined in
 \ref{\firstlibchapter} through \ref{\lastlibchapter} and \ref{depr}
-describe the behavior of numerous functions defined by
-the \Cpp{} standard library.
-Under some circumstances,
-\indextext{library!\Cpp{} standard}%
-however, certain of these function descriptions also apply to replacement functions defined
-in the program.
+is specified as replaceable\iref{dcl.fct.def.replace},
+the description of function semantics apply
+to both the default version defined by the \Cpp{} standard library and
+the replacement function defined by the program.
 
-\pnum
-A \Cpp{} program may provide the definition for any of the following
-dynamic memory allocation function signatures declared in header
-\tcode{<new>}\iref{basic.stc.dynamic,new.syn}:
-
-\indextext{\idxcode{new}!\idxcode{operator}!replaceable}%
-\indexlibrarymember{new}{operator}%
-\begin{codeblock}
-operator new(std::size_t)
-operator new(std::size_t, std::align_val_t)
-operator new(std::size_t, const std::nothrow_t&)
-operator new(std::size_t, std::align_val_t, const std::nothrow_t&)
-\end{codeblock}%
-\indextext{\idxcode{delete}!\idxcode{operator}!replaceable}%
-\indexlibrarymember{delete}{operator}%
-\begin{codeblock}
-operator delete(void*)
-operator delete(void*, std::size_t)
-operator delete(void*, std::align_val_t)
-operator delete(void*, std::size_t, std::align_val_t)
-operator delete(void*, const std::nothrow_t&)
-operator delete(void*, std::align_val_t, const std::nothrow_t&)
-\end{codeblock}%
-\indextext{\idxcode{new}!\idxcode{operator}!replaceable}%
-\indexlibrarymember{new}{operator}%
-\begin{codeblock}
-operator new[](std::size_t)
-operator new[](std::size_t, std::align_val_t)
-operator new[](std::size_t, const std::nothrow_t&)
-operator new[](std::size_t, std::align_val_t, const std::nothrow_t&)
-\end{codeblock}%
-\indextext{\idxcode{delete}!\idxcode{operator}!replaceable}%
-\indexlibrarymember{delete}{operator}%
-\begin{codeblock}
-operator delete[](void*)
-operator delete[](void*, std::size_t)
-operator delete[](void*, std::align_val_t)
-operator delete[](void*, std::size_t, std::align_val_t)
-operator delete[](void*, const std::nothrow_t&)
-operator delete[](void*, std::align_val_t, const std::nothrow_t&)
-\end{codeblock}
-
-\pnum
-A \Cpp{} program may provide the definition of
-the following function signature declared in header \libheaderref{debugging}:
-\begin{codeblock}
-bool std::is_debugger_present() noexcept
-\end{codeblock}
-
-\pnum
-The program's definitions are used instead of the default versions supplied by
-the implementation\iref{new.delete}.
-Such replacement occurs prior to program startup\iref{basic.def.odr,basic.start}.
-\indextext{startup!program}%
-The program's declarations shall not be specified as
-\keyword{inline}.
-No diagnostic is required.
 
 \rSec3[handler.functions]{Handler functions}
 
@@ -3473,7 +3426,7 @@ In particular, the behavior is undefined in the following cases:
 
 \begin{itemize}
 \item
-For replacement functions\iref{new.delete}, if the installed replacement function does not
+For replacement functions\iref{replacement.functions}, if the installed replacement function does not
 implement the semantics of the applicable
 \required
 paragraph.
@@ -3938,6 +3891,15 @@ An implementation may strengthen the
 exception specification
 for a non-virtual function
 by adding a non-throwing exception specification.
+
+\rSec3[res.contract.assertions]{Contract assertions}
+
+\pnum
+Unless specified otherwise,
+an implementation may check
+the specified preconditions and postconditions of a function
+in the \Cpp{} standard library using contract
+assertions\iref{basic.contract,structure.specifications}.
 
 \rSec3[value.error.codes]{Value of error codes}
 

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -3554,12 +3554,18 @@ the program is ill-formed, no diagnostic required.
 Subclause \ref{conforming} describes the constraints upon, and latitude of, implementations of the \Cpp{} standard library.
 
 \pnum
-An implementation's use of headers is discussed in~\ref{res.on.headers}, its use
-of macros in~\ref{res.on.macro.definitions}, non-member functions
-in~\ref{global.functions}, member functions in~\ref{member.functions}, data race
-avoidance in~\ref{res.on.data.races}, access specifiers
-in~\ref{protection.within.classes}, class derivation in~\ref{derivation}, and
-exceptions in~\ref{res.on.exception.handling}.
+An implementation's use of
+\begin{itemize}
+\item headers is discussed in~\ref{res.on.headers},
+\item macros in~\ref{res.on.macro.definitions},
+\item non-member functions in~\ref{global.functions},
+\item member functions in~\ref{member.functions},
+\item data race avoidance in~\ref{res.on.data.races},
+\item access specifiers in~\ref{protection.within.classes},
+\item class derivation in~\ref{derivation},
+\item exceptions in~\ref{res.on.exception.handling}, and
+\item contract assertions in~\ref{res.contract.assertions}.
+\end{itemize}
 
 \rSec3[res.on.headers]{Headers}
 

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -376,7 +376,6 @@
 \newcommand{\errors}{\Fundesc{Error conditions}}
 \newcommand{\sync}{\Fundesc{Synchronization}}
 \newcommand{\implimits}{\Fundesc{Implementation limits}}
-\newcommand{\replaceable}{\Fundesc{Replaceable}}
 \newcommand{\result}{\Fundesc{Result}}
 \newcommand{\returntype}{\Fundesc{Return type}}
 \newcommand{\ctype}{\Fundesc{Type}}

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -464,11 +464,28 @@ in the call augmented by the addition of an implied object
 argument as in a qualified function call.
 If the current class is, or is derived from, \tcode{T}, and the keyword
 \keyword{this}\iref{expr.prim.this} refers to it,
-then the implied object argument is \tcode{(*this)}.
+\begin{itemize}
+\item
+if the unqualified function call
+appears in a precondition assertion of a constructor
+or a postcondition assertion of a destructor
+and overload resolution selects a non-static member function,
+the call is ill-formed;
+\item
+otherwise,
+the implied object argument is
+\tcode{(*\keyword{this})}.
+\end{itemize}
 Otherwise,
+\begin{itemize}
+\item
+if overload resolution selects a non-static member function,
+the call is ill-formed;
+\item
+otherwise,
 a contrived object of type
 \tcode{T}
-becomes the implied object argument;
+becomes the implied object argument.
 \begin{footnote}
 An implied object argument is contrived to
 correspond to the implicit object
@@ -482,12 +499,12 @@ object parameter, the contrived object will not be the cause to select or
 reject a
 function.
 \end{footnote}
-if overload resolution selects a non-static member function,
-the call is ill-formed.
+\end{itemize}
+
 \begin{example}
 \begin{codeblock}
 struct C {
-  void a();
+  bool a();
   void b() {
     a();                // OK, \tcode{(*this).a()}
   }
@@ -524,6 +541,15 @@ struct C {
   void m(this const C& c) {
     c.k();              // OK
   }
+
+  C()
+    pre(a())            // error: implied \keyword{this} in constructor precondition
+    pre(this->a())      // OK
+    post(a());          // OK
+  ~C()
+    pre(a())            // OK
+    post(a())           // error: implied \keyword{this} in destructor postcondition
+    post(this->a());    // OK
 };
 \end{codeblock}
 \end{example}

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1863,6 +1863,7 @@ an \impldef{text of \mname{TIME} when time of translation is not available} vali
 \defnxname{cpp_constexpr_in_decltype}             & \tcode{201711L} \\ \rowsep
 \defnxname{cpp_consteval}                         & \tcode{202211L} \\ \rowsep
 \defnxname{cpp_constinit}                         & \tcode{201907L} \\ \rowsep
+\defnxname{cpp_contracts}                         & \tcode{202502L} \\ \rowsep
 \defnxname{cpp_decltype}                          & \tcode{200707L} \\ \rowsep
 \defnxname{cpp_decltype_auto}                     & \tcode{201304L} \\ \rowsep
 \defnxname{cpp_deduction_guides}                  & \tcode{201907L} \\ \rowsep

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -19,6 +19,7 @@ Except as indicated, statements are executed in sequence\iref{intro.execution}.
     \opt{attribute-specifier-seq} selection-statement\br
     \opt{attribute-specifier-seq} iteration-statement\br
     \opt{attribute-specifier-seq} jump-statement\br
+    \opt{attribute-specifier-seq} assertion-statement\br
     declaration-statement\br
     \opt{attribute-specifier-seq} try-block
 \end{bnf}
@@ -946,6 +947,16 @@ destruction of temporaries at the end of the full-expression established
 by the operand of the \tcode{return} statement, which, in turn, is sequenced
 before the destruction of local variables\iref{stmt.jump} of the block
 enclosing the \tcode{return} statement.
+\begin{note}
+These operations
+are sequenced before the destruction of local variables
+in each remaining enclosing block of the function\iref{stmt.dcl},
+which, in turn,
+is sequenced before the evaluation of
+postcondition assertions of the function\iref{dcl.contract.func},
+which, in turn,
+is sequenced before the destruction of function parameters\iref{expr.call}.
+\end{note}
 
 \pnum
 In a function whose return type is a reference,
@@ -1030,6 +1041,48 @@ The \tcode{goto} statement unconditionally transfers control to the
 statement labeled by the identifier. The identifier shall be a
 \indextext{label}%
 label\iref{stmt.label} located in the current function.
+
+\rSec1[stmt.contract.assert]{Assertion statement}
+
+\begin{bnf}
+\nontermdef{assertion-statement}\br
+    \terminal{contract_assert} \opt{attribute-specifier-seq} \terminal{(} conditional-expression \terminal{)} \terminal{;}
+\end{bnf}
+
+\pnum
+\indexdefn{contract assertion!statement|see{assertion, statement}}
+\indextext{assertion!statement}
+An \grammarterm{assertion-statement}
+introduces a contract assertion\iref{basic.contract}.
+The optional \grammarterm{attribute-specifier-seq}
+appertains to the introduced contract assertion.
+
+\pnum
+The predicate\iref{basic.contract.general}
+of an \grammarterm{assertion-statement}
+is its \grammarterm{conditional-expression}
+contextually converted to \tcode{bool}.
+
+\pnum
+The evaluation of consecutive \grammarterm{assertion-statement}s
+is an evaluation in sequence\iref{basic.contract.eval} of
+the contract assertions introduced
+by those \grammarterm{assertion-statement}s.
+\begin{note}
+A sequence of \grammarterm{assertion-statement}s
+can thus be repeatedly evaluated as a group.
+\begin{example}
+\begin{codeblock}
+int f(int i)
+{
+  contract_assert(i == 0);  // \#1
+  contract_assert(i >= 0);  // \#2
+  return 0;
+}
+int g = f(0);   // can evaluate \#1, \#2, \#1, \#2
+\end{codeblock}
+\end{example}
+\end{note}
 
 \rSec1[stmt.dcl]{Declaration statement}%
 \indextext{statement!declaration}

--- a/source/support.tex
+++ b/source/support.tex
@@ -17,6 +17,7 @@ characteristics of the predefined types,
 functions supporting start and termination of a \Cpp{} program,
 support for dynamic memory management,
 support for dynamic type identification,
+support for contract-violation handling,
 support for exception processing, support for initializer lists,
 and other runtime support,
 as summarized in \tref{support.summary}.
@@ -32,6 +33,7 @@ as summarized in \tref{support.summary}.
 \ref{support.rtti}        & Type identification       &   \tcode{<typeinfo>}, \tcode{<typeindex>}  \\ \rowsep
 \ref{support.srcloc}      & Source location           &   \tcode{<source_location>} \\ \rowsep
 \ref{support.exception}   & Exception handling        &   \tcode{<exception>} \\ \rowsep
+\ref{support.contract}    & Contract-violation handling & \tcode{<contracts>} \\ \rowsep
 \ref{support.initlist}    & Initializer lists         & \tcode{<initializer_list>} \\ \rowsep
 \ref{cmp}                 & Comparisons               &   \tcode{<compare>}   \\ \rowsep
 \ref{support.coroutine}   & Coroutines                &   \tcode{<coroutine>} \\ \rowsep
@@ -628,6 +630,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_containers_ranges}@                 202202L
   // also in \libheader{vector}, \libheader{list}, \libheader{forward_list}, \libheader{map}, \libheader{set}, \libheader{unordered_map}, \libheader{unordered_set},
   // \libheader{deque}, \libheader{queue}, \libheader{stack}, \libheader{string}
+#define @\defnlibxname{cpp_lib_contracts}@                         202502L // freestanding, also in \libheader{contracts}
 #define @\defnlibxname{cpp_lib_copyable_function}@                 202306L // also in \libheader{functional}
 #define @\defnlibxname{cpp_lib_coroutine}@                         201902L // freestanding, also in \libheader{coroutine}
 #define @\defnlibxname{cpp_lib_debugging}@                         202403L // freestanding, also in \libheader{debugging}
@@ -2381,12 +2384,6 @@ as those calls are omitted\iref{expr.new}.
 If any of the default versions of the replaceable global allocation functions
 meet the requirements of a hosted implementation, they all should.
 
-\newcommand{\replaceabledesc}[1]{%
-A \Cpp{} program may define functions with #1 of these function signatures,
-and thereby displace the default versions defined by the
-\Cpp{} standard library.%
-}
-
 \rSec3[new.delete.single]{Single-object forms}
 
 \indexlibrarymember{new}{operator}%
@@ -2406,10 +2403,6 @@ to allocate
 \tcode{size} bytes of storage.
 The second form is called for a type with new-extended alignment, and
 the first form is called otherwise.
-
-\pnum
-\replaceable
-\replaceabledesc{either}
 
 \pnum
 \required
@@ -2447,6 +2440,10 @@ successful or when a called
 \tcode{new_handler}
 function does not return.
 \end{itemize}
+
+\pnum
+\remarks
+This function is replaceable\iref{dcl.fct.def.replace}.
 \end{itemdescr}
 
 \indexlibrarymember{new}{operator}%
@@ -2464,10 +2461,6 @@ when a \Cpp{} program prefers a null pointer result as an error indication,
 instead of a
 \tcode{bad_alloc}
 exception.
-
-\pnum
-\replaceable
-\replaceabledesc{either}
 
 \pnum
 \required
@@ -2496,6 +2489,10 @@ T* p1 = new T;                  // throws \tcode{bad_alloc} if it fails
 T* p2 = new(nothrow) T;         // returns \keyword{nullptr} if it fails
 \end{codeblock}
 \end{example}
+
+\pnum
+\remarks
+This function is replaceable\iref{dcl.fct.def.replace}.
 \end{itemdescr}
 
 \indexlibrarymember{delete}{operator}%
@@ -2539,20 +2536,6 @@ called by a
 to render the value of \tcode{ptr} invalid.
 
 \pnum
-\replaceable
-\replaceabledesc{any}
-If a function without a \tcode{size} parameter is defined,
-the program should also define
-the corresponding function with a \tcode{size} parameter.
-If a function with a \tcode{size} parameter is defined,
-the program shall also define
-the corresponding version without the \tcode{size} parameter.
-\begin{note}
-The default behavior below might change in the future, which will require
-replacing both deallocation functions when replacing the allocation function.
-\end{note}
-
-\pnum
 \required
 A call to an \tcode{operator delete}
 with a \tcode{size} parameter
@@ -2572,7 +2555,7 @@ The functions that have a \tcode{size} parameter
 forward their other parameters
 to the corresponding function without a \tcode{size} parameter.
 \begin{note}
-See the note in the above \replaceable paragraph.
+See the note in the below \remarks paragraph.
 \end{note}
 
 \pnum
@@ -2594,6 +2577,22 @@ or any of
 or
 \tcode{realloc},
 declared in \libheaderref{cstdlib}.
+This function is replaceable\iref{dcl.fct.def.replace}.
+If a replacement function
+without a \tcode{size} parameter
+is defined by the program,
+the program should also define the corresponding
+function with a \tcode{size} parameter.
+If a replacement function
+with a \tcode{size} parameter
+is defined by the program,
+the program shall also define the corresponding
+version without the \tcode{size} parameter.
+\begin{note}
+The default behavior above might change in the future,
+which will require replacing both deallocation functions
+when replacing the allocation function.
+\end{note}
 \end{itemdescr}
 
 \indexlibrarymember{delete}{operator}%
@@ -2633,14 +2632,14 @@ when the constructor invoked from a nothrow
 placement version of the \grammarterm{new-expression} throws an exception.
 
 \pnum
-\replaceable
-\replaceabledesc{either}
-
-\pnum
 \default
 Calls \tcode{operator delete(ptr)},
 or \tcode{operator delete(ptr, alignment)},
 respectively.
+
+\pnum
+\remarks
+This function is replaceable\iref{dcl.fct.def.replace}.
 \end{itemdescr}
 
 \rSec3[new.delete.array]{Array forms}
@@ -2681,10 +2680,6 @@ to obtain space to store supplemental information.
 \end{footnote}
 
 \pnum
-\replaceable
-\replaceabledesc{either}
-
-\pnum
 \required
 Same as for
 the corresponding single-object forms.
@@ -2697,6 +2692,10 @@ Returns
 or
 \tcode{operator new(size, alignment)},
 respectively.
+
+\pnum
+\remarks
+This function is replaceable\iref{dcl.fct.def.replace}.
 \end{itemdescr}
 
 \indexlibrarymember{new}{operator}%
@@ -2714,10 +2713,6 @@ when a \Cpp{} program prefers a null pointer result as an error indication,
 instead of a
 \tcode{bad_alloc}
 exception.
-
-\pnum
-\replaceable
-\replaceabledesc{either}
 
 \pnum
 \required
@@ -2738,6 +2733,10 @@ respectively.
 If the call returns normally,
 returns the result of that call.
 Otherwise, returns a null pointer.
+
+\pnum
+\remarks
+This function is replaceable\iref{dcl.fct.def.replace}.
 \end{itemdescr}
 
 \indexlibrarymember{delete}{operator}%
@@ -2781,20 +2780,6 @@ called by the array form of a
 to render the value of \tcode{ptr} invalid.
 
 \pnum
-\replaceable
-\replaceabledesc{any}
-If a function without a \tcode{size} parameter is defined,
-the program should also define
-the corresponding function with a \tcode{size} parameter.
-If a function with a \tcode{size} parameter is defined,
-the program shall also define
-the corresponding version without the \tcode{size} parameter.
-\begin{note}
-The default behavior below might change in the future, which will require
-replacing both deallocation functions when replacing the allocation function.
-\end{note}
-
-\pnum
 \required
 A call to an \tcode{operator delete[]}
 with a \tcode{size} parameter
@@ -2816,6 +2801,25 @@ to the corresponding function without a \tcode{size} parameter.
 The functions that do not have a \tcode{size} parameter
 forward their parameters
 to the corresponding \tcode{operator delete} (single-object) function.
+
+\pnum
+\remarks
+This function is replaceable\iref{dcl.fct.def.replace}.
+If a replacement function
+without a \tcode{size} parameter
+is defined by the program,
+the program should also define the corresponding
+function with a \tcode{size} parameter.
+If a replacement function
+with a \tcode{size} parameter
+is defined by the program,
+the program shall also define the corresponding
+version without the \tcode{size} parameter.
+\begin{note}
+The default behavior above might change in the future,
+which will require replacing both deallocation functions
+when replacing the allocation function.
+\end{note}
 \end{itemdescr}
 
 \indexlibrarymember{delete}{operator}%
@@ -2855,14 +2859,14 @@ when the constructor invoked from a nothrow
 placement version of the array \grammarterm{new-expression} throws an exception.
 
 \pnum
-\replaceable
-\replaceabledesc{either}
-
-\pnum
 \default
 Calls \tcode{operator delete[](ptr)},
 or \tcode{operator delete[](ptr, alignment)},
 respectively.
+
+\pnum
+\remarks
+This function is replaceable\iref{dcl.fct.def.replace}.
 \end{itemdescr}
 
 \rSec3[new.delete.placement]{Non-allocating forms}
@@ -4300,6 +4304,268 @@ Otherwise, performs:
 if (auto p = dynamic_cast<const nested_exception*>(addressof(e)))
   p->rethrow_nested();
 \end{codeblock}
+\end{itemdescr}
+
+\rSec1[support.contract]{Contract-violation handling}
+
+\rSec2[contracts.syn]{Header \tcode{<contracts>} synopsis}
+
+\pnum
+The header \libheader{contracts} defines types
+for reporting information about contract violations\iref{basic.contract.eval}.
+
+\indexheader{contracts}
+\indexlibraryglobal{contract_violation}%
+\begin{codeblock}
+// all freestanding
+namespace std::contracts {
+
+  enum class assertion_kind : @\unspec@ {
+    pre = 1,
+    post = 2,
+    assert = 3
+  };
+
+  enum class evaluation_semantic : @\unspec@ {
+    ignore = 1,
+    observe = 2,
+    enforce = 3,
+    quick_enforce = 4
+  };
+
+  enum class detection_mode : @\unspec@ {
+    predicate_false = 1,
+    evaluation_exception = 2
+  };
+
+  class contract_violation {
+    // no user-accessible constructor
+  public:
+    contract_violation(const contract_violation&) = delete;
+    contract_violation& operator=(const contract_violation&) = delete;
+
+    @\seebelow@ ~contract_violation();
+
+    const char* comment() const noexcept;
+    contracts::detection_mode detection_mode() const noexcept;
+    exception_ptr evaluation_exception() const noexcept;
+    bool is_terminating() const noexcept;
+    assertion_kind kind() const noexcept;
+    source_location location() const noexcept;
+    evaluation_semantic semantic() const noexcept;
+  };
+
+  void invoke_default_contract_violation_handler(const contract_violation&);
+}
+\end{codeblock}
+
+\rSec2[support.contract.enum]{Enumerations}
+
+\pnum
+\recommended
+For all enumerations in \ref{support.contract.enum},
+if implementation-defined enumerators are provided,
+they should have a minimum value of $1000$.
+
+\pnum
+The enumerators of \tcode{assertion_kind}
+correspond to
+the syntactic forms of a contract assertion\iref{basic.contract.general},
+with meanings listed in Table~\ref{tab:support.contract.enum.kind}.
+
+\begin{floattable}{Enum \tcode{assertion_kind}}{support.contract.enum.kind}
+{ll}
+\topline
+\lhdr{Name}    & \rhdr{Meaning}                        \\ \capsep
+\tcode{pre}    & A precondition assertion              \\ \rowsep
+\tcode{post}   & A postcondition assertion             \\ \rowsep
+\tcode{assert} & An \grammarterm{assertion-statement}  \\ \rowsep
+\end{floattable}
+
+\pnum
+The enumerators of \tcode{evaluation_semantic}
+correspond to
+the evaluation semantics with which
+a contract assertion may be evaluated\iref{basic.contract.eval},
+with meanings listed in Table~\ref{tab:support.contract.enum.semantic}.
+
+\begin{floattable}{Enum \tcode{evaluation_semantic}}{support.contract.enum.semantic}
+{ll}
+\topline
+\lhdr{Name}           & \rhdr{Meaning}                    \\ \capsep
+\tcode{ignore}        & Ignore evaluation semantic        \\ \rowsep
+\tcode{observe}       & Observe evaluation semantic       \\ \rowsep
+\tcode{enforce}       & Enforce evaluation semantic       \\ \rowsep
+\tcode{quick_enforce} & Quick-enforce evaluation semantic \\ \rowsep
+\end{floattable}
+
+\pnum
+The enumerators of \tcode{detection_mode} correspond to the manners in which a
+contract violation can be identified\iref{basic.contract.eval}, with
+meanings listed in \mbox{Table~\ref{tab:support.contract.enum.detection}}.
+
+\begin{floattable}{Enum \tcode{detection_mode}}{support.contract.enum.detection}
+{lp{.6\hsize}}
+\topline
+\lhdr{Name}                  & \rhdr{Meaning}                    \\ \capsep
+\tcode{predicate_false}      & The predicate of the contract assertion evaluated to \keyword{false} or would have evaluated to \keyword{false}. \\ \rowsep
+\tcode{evaluation_exception} & An uncaught exception occurred during evaluation of the contract assertion. \\ \rowsep
+\end{floattable}
+
+\rSec2[support.contract.violation]{Class \tcode{contract_violation}}
+
+\pnum
+\indexlibraryglobal{contract_violation}%
+The class \tcode{contract_violation}
+defines the type of objects used to represent
+a contract violation that has been detected
+during the evaluation of a contract assertion
+with a particular evaluation semantic\iref{basic.contract.eval}.
+Objects of this type can
+be created only by the implementation.
+It is
+\impldef{whether \tcode{contract_violation} has a virtual destructor}
+whether the destructor is virtual.
+
+\begin{itemdecl}
+const char* comment() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+An
+\impldef{the contents provided in the \tcode{comment} field of \tcode{contract_violation}}
+\ntmbs{} in
+the ordinary literal encoding\iref{lex.charset}.
+
+\pnum
+\recommended
+The string returned
+should contain a textual representation
+of the predicate of the violated contract assertion
+or an empty string if
+storing a textual representation is undesired.
+\begin{note}
+The string can represent a
+truncated, reformatted, or summarized rendering of the
+predicate, before or after preprocessing.
+\end{note}
+
+\end{itemdescr}
+
+\begin{itemdecl}
+contracts::detection_mode detection_mode() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+The enumerator value
+corresponding to
+the manner in which the contract violation was identified.
+
+\end{itemdescr}
+
+\begin{itemdecl}
+exception_ptr evaluation_exception() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+
+\pnum
+\returns
+If the contract violation occurred
+because the evaluation of the predicate exited via an exception,
+an \tcode{exception_ptr} object that refers to
+that exception or a copy of that exception;
+otherwise, a null \tcode{exception_ptr} object.
+
+\end{itemdescr}
+
+\begin{itemdecl}
+bool is_terminating() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\indextext{contract evaluation semantics!terminating}%
+\pnum
+\returns
+\keyword{true} if the evaluation semantic is
+a terminating semantic\iref{basic.contract.eval};
+otherwise, \tcode{false}.
+
+\end{itemdescr}
+
+\begin{itemdecl}
+assertion_kind kind() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+The enumerator value
+corresponding to
+the syntactic form of the violated contract assertion.
+
+\end{itemdescr}
+
+\begin{itemdecl}
+source_location location() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+A \tcode{source_location} object
+with
+\impldef{the contents provided in the \tcode{location} field of \tcode{contract_violation}}
+value.
+
+\pnum
+\recommended
+The value returned should be
+a default constructed \tcode{source_location} object
+or a value identifying the violated contract assertion:
+\begin{itemize}
+\item
+When possible,
+if the violated contract assertion was a precondition,
+the source location of the function invocation should be returned.
+\item
+Otherwise,
+the source location of the contract assertion should be returned.
+\end{itemize}
+
+\end{itemdescr}
+
+\begin{itemdecl}
+evaluation_semantic semantic() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+
+\pnum
+\returns
+The enumerator value
+corresponding to
+the evaluation semantic with which
+the violated contract assertion was evaluated.
+
+\end{itemdescr}
+
+\rSec2[support.contract.invoke]{Invoke default handler}
+
+\begin{itemdecl}
+void invoke_default_contract_violation_handler(const contract_violation& v);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Invokes the default contract-violation handler\iref{basic.contract.handler}
+with the argument \tcode{v}.
+
 \end{itemdescr}
 
 \rSec1[support.initlist]{Initializer lists}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -5383,6 +5383,10 @@ the
 \mname{func}\iref{dcl.fct.def.general}, where any enclosing function is a
 template, a member of a class template, or a generic lambda,
 \item
+associated by name lookup
+with a result binding\iref{dcl.contract.res} of a function
+whose return type is dependent,
+\item
 a \grammarterm{conversion-function-id} that specifies a dependent type, or
 \item
 dependent
@@ -6346,13 +6350,15 @@ void g(A a, A b, A c) {
 \end{example}
 
 \pnum
-The \grammarterm{noexcept-specifier} of a function template specialization
-is not instantiated along with the function declaration; it is instantiated
-when needed\iref{except.spec}. If such a
-\grammarterm{noexcept-specifier} is needed but has not yet been
+The \grammarterm{noexcept-specifier} and \grammarterm{function-contract-specifier}s
+of a function template specialization
+are not instantiated along with the function declaration;
+they are instantiated
+when needed\iref{except.spec,dcl.contract.func}. If such a
+specifier is needed but has not yet been
 instantiated, the dependent names are looked up, the semantics constraints are
 checked, and the instantiation of any template used in the
-\grammarterm{noexcept-specifier} is done as if it were being done as part
+specifier is done as if it were being done as part
 of instantiating the declaration of the specialization at that point.
 
 \pnum
@@ -6890,7 +6896,8 @@ is inline, constexpr, constinit, or consteval
 is determined by the explicit specialization and
 is independent of those properties of the template.
 Similarly,
-attributes appearing in the declaration of a template
+attributes and \grammarterm{function-contract-specifier}s
+appearing in the declaration of a template
 have no effect on an explicit specialization of that template.
 \begin{example}
 \begin{codeblock}
@@ -7436,8 +7443,13 @@ If substitution into different declarations of the same function template would
 cause template instantiations to occur in a different order or not at all,
 the program is ill-formed; no diagnostic required.
 \begin{note}
-The equivalent substitution in exception specifications is
-done only when the \grammarterm{noexcept-specifier} is instantiated,
+The equivalent substitution in
+exception specifications\iref{except.spec}
+and function contract assertions\iref{dcl.contract.func}
+is done only when
+the \grammarterm{noexcept-specifier}
+or \grammarterm{function-contract-specifier}, respectively,
+is instantiated,
 at which point a program is ill-formed
 if the substitution results in an invalid type or expression.
 \end{note}


### PR DESCRIPTION
Fixes: https://github.com/cplusplus/draft/issues/7655
Also Fixes: https://github.com/cplusplus/papers/issues/1648

I have put comments in starting with JMB (my initials) where an editorial change was made due to minor mistakes in P2900 (missing comma, rebasing, etc.)   as well as some places where I think we should have additional xrefs.

This is also based on the changes for P1494 (https://github.com/cplusplus/draft/pull/7681)  as we modify a paragraph added there.  That should certainly merge first, and I will keep this PR rebased on it.