### PR TITLE
[time.format] A minor update for LWG 4124

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -10784,14 +10784,14 @@ the locale's alternate time representation.
 \\ \rowsep
 \tcode{\%y} &
 The last two decimal digits of the year.
-If the result is a single digit it is prefixed by \tcode{0}.
+If the result is a single digit, it is prefixed by \tcode{0}.
 The modified command \tcode{\%Oy} produces the locale's alternative representation.
 The modified command \tcode{\%Ey} produces the locale's alternative representation
 of offset from \tcode{\%EC} (year only).
 \\ \rowsep
 \tcode{\%Y} &
 The year as a decimal number.
-If the result is less than four digits
+If the result is less than four digits,
 it is left-padded with \tcode{0} to four digits.
 The modified command \tcode{\%EY} produces
 the locale's alternative full year representation.
@@ -10816,7 +10816,8 @@ A \tcode{\%} character.
 \end{LongTable}
 
 \pnum
-If the \fmtgrammarterm{chrono-specs} is omitted,
+Unless otherwise specified,
+if the \fmtgrammarterm{chrono-specs} is omitted,
 the chrono object is formatted
 as if by streaming it to \tcode{basic_ostring\-stream<charT> os}
 with the formatting locale imbued


### PR DESCRIPTION
The resolution of [LWG 4124](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3504r0.html#4124) added an exception rule for “omitting _chrono-specs_”, therefore [time.format] p7 should begin with “unless otherwise specified” to avoid conflicts.

This PR also added two missing commas in [time.format].