### PR TITLE
P0472R3 Put std::monostate in <utility>

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -220,6 +220,21 @@ namespace std {
       explicit nontype_t() = default;
     };
   template<auto V> constexpr nontype_t<V> nontype{};
+
+  // \ref{variant.monostate}, class \tcode{monostate}%
+\indexlibraryglobal{monostate}
+  struct monostate;
+
+  // \ref{variant.monostate.relops}, \tcode{monostate} relational operators%
+\indexlibrarymember{operator==}{monostate}%
+\indexlibrarymember{operator<=>}{monostate}
+  constexpr bool operator==(monostate, monostate) noexcept;
+  constexpr strong_ordering operator<=>(monostate, monostate) noexcept;
+
+  // \ref{variant.hash}, hash support%
+\indexlibrarymember{hash}{monostate}
+  template<class T> struct hash;
+  template<> struct hash<monostate>;
 }
 \end{codeblock}
 


### PR DESCRIPTION
Fixes #7663.
Fixes https://github.com/cplusplus/papers/issues/1993.

## New Wording
![image](https://github.com/user-attachments/assets/5d0c00d9-fea5-4aee-ab4e-c16e2d0cb3bd)

## Paper Wording
![image](https://github.com/user-attachments/assets/6031172e-7536-47ca-b843-8b46495fd0a8)
