### PR TITLE
P3378R2 constexpr exception types

### DIFF
--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -82,8 +82,8 @@ namespace std {
 namespace std {
   class logic_error : public exception {
   public:
-    explicit logic_error(const string& what_arg);
-    explicit logic_error(const char* what_arg);
+    constexpr explicit logic_error(const string& what_arg);
+    constexpr explicit logic_error(const char* what_arg);
   };
 }
 \end{codeblock}
@@ -98,7 +98,7 @@ invariants.
 
 \indexlibraryctor{logic_error}%
 \begin{itemdecl}
-logic_error(const string& what_arg);
+constexpr logic_error(const string& what_arg);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -109,7 +109,7 @@ logic_error(const string& what_arg);
 
 \indexlibraryctor{logic_error}%
 \begin{itemdecl}
-logic_error(const char* what_arg);
+constexpr logic_error(const char* what_arg);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -125,8 +125,8 @@ logic_error(const char* what_arg);
 namespace std {
   class domain_error : public logic_error {
   public:
-    explicit domain_error(const string& what_arg);
-    explicit domain_error(const char* what_arg);
+    constexpr explicit domain_error(const string& what_arg);
+    constexpr explicit domain_error(const char* what_arg);
   };
 }
 \end{codeblock}
@@ -139,7 +139,7 @@ exceptions by the implementation to report domain errors.
 
 \indexlibraryctor{domain_error}%
 \begin{itemdecl}
-domain_error(const string& what_arg);
+constexpr domain_error(const string& what_arg);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -150,7 +150,7 @@ domain_error(const string& what_arg);
 
 \indexlibraryctor{domain_error}%
 \begin{itemdecl}
-domain_error(const char* what_arg);
+constexpr domain_error(const char* what_arg);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -166,8 +166,8 @@ domain_error(const char* what_arg);
 namespace std {
   class invalid_argument : public logic_error {
   public:
-    explicit invalid_argument(const string& what_arg);
-    explicit invalid_argument(const char* what_arg);
+    constexpr explicit invalid_argument(const string& what_arg);
+    constexpr explicit invalid_argument(const char* what_arg);
   };
 }
 \end{codeblock}
@@ -179,7 +179,7 @@ defines the type of objects thrown as exceptions to report an invalid argument.
 
 \indexlibraryctor{invalid_argument}%
 \begin{itemdecl}
-invalid_argument(const string& what_arg);
+constexpr invalid_argument(const string& what_arg);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -190,7 +190,7 @@ invalid_argument(const string& what_arg);
 
 \indexlibraryctor{invalid_argument}%
 \begin{itemdecl}
-invalid_argument(const char* what_arg);
+constexpr invalid_argument(const char* what_arg);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -206,8 +206,8 @@ invalid_argument(const char* what_arg);
 namespace std {
   class length_error : public logic_error {
   public:
-    explicit length_error(const string& what_arg);
-    explicit length_error(const char* what_arg);
+    constexpr explicit length_error(const string& what_arg);
+    constexpr explicit length_error(const char* what_arg);
   };
 }
 \end{codeblock}
@@ -221,7 +221,7 @@ an object whose length exceeds its maximum allowable size.
 
 \indexlibraryctor{length_error}%
 \begin{itemdecl}
-length_error(const string& what_arg);
+constexpr length_error(const string& what_arg);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -232,7 +232,7 @@ length_error(const string& what_arg);
 
 \indexlibraryctor{length_error}%
 \begin{itemdecl}
-length_error(const char* what_arg);
+constexpr length_error(const char* what_arg);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -248,8 +248,8 @@ length_error(const char* what_arg);
 namespace std {
   class out_of_range : public logic_error {
   public:
-    explicit out_of_range(const string& what_arg);
-    explicit out_of_range(const char* what_arg);
+    constexpr explicit out_of_range(const string& what_arg);
+    constexpr explicit out_of_range(const char* what_arg);
   };
 }
 \end{codeblock}
@@ -263,7 +263,7 @@ argument value not in its expected range.
 
 \indexlibraryctor{out_of_range}%
 \begin{itemdecl}
-out_of_range(const string& what_arg);
+constexpr out_of_range(const string& what_arg);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -274,7 +274,7 @@ out_of_range(const string& what_arg);
 
 \indexlibraryctor{out_of_range}%
 \begin{itemdecl}
-out_of_range(const char* what_arg);
+constexpr out_of_range(const char* what_arg);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -290,8 +290,8 @@ out_of_range(const char* what_arg);
 namespace std {
   class runtime_error : public exception {
   public:
-    explicit runtime_error(const string& what_arg);
-    explicit runtime_error(const char* what_arg);
+    constexpr explicit runtime_error(const string& what_arg);
+    constexpr explicit runtime_error(const char* what_arg);
   };
 }
 \end{codeblock}
@@ -304,7 +304,7 @@ when the program executes.
 
 \indexlibraryctor{runtime_error}%
 \begin{itemdecl}
-runtime_error(const string& what_arg);
+constexpr runtime_error(const string& what_arg);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -315,7 +315,7 @@ runtime_error(const string& what_arg);
 
 \indexlibraryctor{runtime_error}%
 \begin{itemdecl}
-runtime_error(const char* what_arg);
+constexpr runtime_error(const char* what_arg);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -331,8 +331,8 @@ runtime_error(const char* what_arg);
 namespace std {
   class range_error : public runtime_error {
   public:
-    explicit range_error(const string& what_arg);
-    explicit range_error(const char* what_arg);
+    constexpr explicit range_error(const string& what_arg);
+    constexpr explicit range_error(const char* what_arg);
   };
 }
 \end{codeblock}
@@ -345,7 +345,7 @@ in internal computations.
 
 \indexlibraryctor{range_error}%
 \begin{itemdecl}
-range_error(const string& what_arg);
+constexpr range_error(const string& what_arg);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -356,7 +356,7 @@ range_error(const string& what_arg);
 
 \indexlibraryctor{range_error}%
 \begin{itemdecl}
-range_error(const char* what_arg);
+constexpr range_error(const char* what_arg);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -372,8 +372,8 @@ range_error(const char* what_arg);
 namespace std {
   class overflow_error : public runtime_error {
   public:
-    explicit overflow_error(const string& what_arg);
-    explicit overflow_error(const char* what_arg);
+    constexpr explicit overflow_error(const string& what_arg);
+    constexpr explicit overflow_error(const char* what_arg);
   };
 }
 \end{codeblock}
@@ -385,7 +385,7 @@ defines the type of objects thrown as exceptions to report an arithmetic overflo
 
 \indexlibraryctor{overflow_error}%
 \begin{itemdecl}
-overflow_error(const string& what_arg);
+constexpr overflow_error(const string& what_arg);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -396,7 +396,7 @@ overflow_error(const string& what_arg);
 
 \indexlibraryctor{overflow_error}%
 \begin{itemdecl}
-overflow_error(const char* what_arg);
+constexpr overflow_error(const char* what_arg);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -412,8 +412,8 @@ overflow_error(const char* what_arg);
 namespace std {
   class underflow_error : public runtime_error {
   public:
-    explicit underflow_error(const string& what_arg);
-    explicit underflow_error(const char* what_arg);
+    constexpr explicit underflow_error(const string& what_arg);
+    constexpr explicit underflow_error(const char* what_arg);
   };
 }
 \end{codeblock}
@@ -425,7 +425,7 @@ defines the type of objects thrown as exceptions to report an arithmetic underfl
 
 \indexlibraryctor{underflow_error}%
 \begin{itemdecl}
-underflow_error(const string& what_arg);
+constexpr underflow_error(const string& what_arg);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -436,7 +436,7 @@ underflow_error(const string& what_arg);
 
 \indexlibraryctor{underflow_error}%
 \begin{itemdecl}
-underflow_error(const char* what_arg);
+constexpr underflow_error(const char* what_arg);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/support.tex
+++ b/source/support.tex
@@ -613,7 +613,8 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_constexpr_complex}@                 202306L // also in \libheader{complex}
 #define @\defnlibxname{cpp_lib_constexpr_deque}@                   202502L // also in \libheader{deque}
 #define @\defnlibxname{cpp_lib_constexpr_dynamic_alloc}@           201907L // also in \libheader{memory}
-#define @\defnlibxname{cpp_lib_constexpr_exceptions}@              202411L // also in \libheader{exception}
+#define @\defnlibxname{cpp_lib_constexpr_exceptions}@              202502L
+  // also in \libheader{exception}, \libheader{stdexcept}, \libheader{expected}, \libheader{optional}, \libheader{variant}, and \libheader{format}
 #define @\defnlibxname{cpp_lib_constexpr_flat_map}@                202502L // also in \libheader{flat_map}
 #define @\defnlibxname{cpp_lib_constexpr_flat_set}@                202502L // also in \libheader{flat_set}
 #define @\defnlibxname{cpp_lib_constexpr_forward_list}@            202502L // also in \libheader{forward_list}

--- a/source/text.tex
+++ b/source/text.tex
@@ -8958,8 +8958,8 @@ An iterator past the end of the output range.
 namespace std {
   class format_error : public runtime_error {
   public:
-    explicit format_error(const string& what_arg);
-    explicit format_error(const char* what_arg);
+    constexpr explicit format_error(const string& what_arg);
+    constexpr explicit format_error(const char* what_arg);
   };
 }
 \end{codeblock}
@@ -8970,7 +8970,7 @@ exceptions to report errors from the formatting library.
 
 \indexlibraryctor{format_error}%
 \begin{itemdecl}
-format_error(const string& what_arg);
+constexpr format_error(const string& what_arg);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8981,7 +8981,7 @@ format_error(const string& what_arg);
 \indexlibraryctor{format_error}%
 \end{itemdescr}
 \begin{itemdecl}
-format_error(const char* what_arg);
+constexpr format_error(const char* what_arg);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -4466,7 +4466,7 @@ namespace std {
   class bad_optional_access : public exception {
   public:
     // see \ref{exception} for the specification of the special member functions
-    const char* what() const noexcept override;
+    constexpr const char* what() const noexcept override;
   };
 }
 \end{codeblock}
@@ -4476,13 +4476,15 @@ The class \tcode{bad_optional_access} defines the type of objects thrown as exce
 
 \indexlibrarymember{what}{bad_optional_access}%
 \begin{itemdecl}
-const char* what() const noexcept override;
+constexpr const char* what() const noexcept override;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \returns
-An \impldef{return value of \tcode{bad_optional_access::what}} \ntbs{}.
+An \impldef{return value of \tcode{bad_optional_access::what}} \ntbs{},
+which during constant evaluation is encoded with
+the ordinary literal encoding\iref{lex.ccon}.
 \end{itemdescr}
 
 \rSec2[optional.relops]{Relational operators}
@@ -6411,7 +6413,7 @@ namespace std {
   class bad_variant_access : public exception {
   public:
     // see \ref{exception} for the specification of the special member functions
-    const char* what() const noexcept override;
+    constexpr const char* what() const noexcept override;
   };
 }
 \end{codeblock}
@@ -6422,13 +6424,15 @@ accesses to the value of a \tcode{variant} object.
 
 \indexlibrarymember{what}{bad_variant_access}%
 \begin{itemdecl}
-const char* what() const noexcept override;
+constexpr const char* what() const noexcept override;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \returns
-An \impldef{return value of \tcode{bad_variant_access::what}} \ntbs{}.
+An \impldef{return value of \tcode{bad_variant_access::what}} \ntbs{},
+which during constant evaluation is encoded with
+the ordinary literal encoding\iref{lex.ccon}.
 \end{itemdescr}
 
 \rSec2[variant.hash]{Hash support}
@@ -7344,12 +7348,12 @@ namespace std {
   template<class E>
   class bad_expected_access : public bad_expected_access<void> {
   public:
-    explicit bad_expected_access(E);
-    const char* what() const noexcept override;
-    E& error() & noexcept;
-    const E& error() const & noexcept;
-    E&& error() && noexcept;
-    const E&& error() const && noexcept;
+    constexpr explicit bad_expected_access(E);
+    constexpr const char* what() const noexcept override;
+    constexpr E& error() & noexcept;
+    constexpr const E& error() const & noexcept;
+    constexpr E&& error() && noexcept;
+    constexpr const E&& error() const && noexcept;
 
   private:
     E @\exposidnc{unex}@;             // \expos
@@ -7365,7 +7369,7 @@ for which \tcode{has_value()} is \tcode{false}.
 
 \indexlibraryctor{bad_expected_access}%
 \begin{itemdecl}
-explicit bad_expected_access(E e);
+constexpr explicit bad_expected_access(E e);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7376,8 +7380,8 @@ Initializes \exposid{unex} with \tcode{std::move(e)}.
 
 \indexlibrarymember{error}{bad_expected_access}%
 \begin{itemdecl}
-const E& error() const & noexcept;
-E& error() & noexcept;
+constexpr const E& error() const & noexcept;
+constexpr E& error() & noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7388,8 +7392,8 @@ E& error() & noexcept;
 
 \indexlibrarymember{error}{bad_expected_access}%
 \begin{itemdecl}
-E&& error() && noexcept;
-const E&& error() const && noexcept;
+constexpr E&& error() && noexcept;
+constexpr const E&& error() const && noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7400,13 +7404,15 @@ const E&& error() const && noexcept;
 
 \indexlibrarymember{what}{bad_expected_access}%
 \begin{itemdecl}
-const char* what() const noexcept override;
+constexpr const char* what() const noexcept override;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \returns
-An implementation-defined \ntbs.
+An \impldef{return value of \tcode{bad_expected_access<E>::what}} \ntbs,
+which during constant evaluation is encoded with
+the ordinary literal encoding\iref{lex.ccon}.
 \end{itemdescr}
 
 \rSec2[expected.bad.void]{Class template specialization \tcode{bad_expected_access<void>}}
@@ -7416,28 +7422,30 @@ namespace std {
   template<>
   class bad_expected_access<void> : public exception {
   protected:
-    bad_expected_access() noexcept;
-    bad_expected_access(const bad_expected_access&) noexcept;
-    bad_expected_access(bad_expected_access&&) noexcept;
-    bad_expected_access& operator=(const bad_expected_access&) noexcept;
-    bad_expected_access& operator=(bad_expected_access&&) noexcept;
-    ~bad_expected_access();
+    constexpr bad_expected_access() noexcept;
+    constexpr bad_expected_access(const bad_expected_access&) noexcept;
+    constexpr bad_expected_access(bad_expected_access&&) noexcept;
+    constexpr bad_expected_access& operator=(const bad_expected_access&) noexcept;
+    constexpr bad_expected_access& operator=(bad_expected_access&&) noexcept;
+    constexpr ~bad_expected_access();
 
   public:
-    const char* what() const noexcept override;
+    constexpr const char* what() const noexcept override;
   };
 }
 \end{codeblock}
 
 \indexlibrarymember{what}{bad_expected_access}%
 \begin{itemdecl}
-const char* what() const noexcept override;
+constexpr const char* what() const noexcept override;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \returns
-An implementation-defined \ntbs.
+An \impldef{return value of \tcode{bad_expected_access<void>::what}} \ntbs,
+which during constant evaluation is encoded with
+the ordinary literal encoding\iref{lex.ccon}.
 \end{itemdescr}
 
 \rSec2[expected.expected]{Class template \tcode{expected}}


### PR DESCRIPTION
Fixes https://github.com/cplusplus/draft/issues/7666.
Fixes https://github.com/cplusplus/papers/issues/2071.