### PR TITLE
[expr.const] Add non-breaking space after `\cv`

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -7750,7 +7750,7 @@ an lvalue-to-rvalue conversion\iref{conv.lval} unless
 it is applied to
 \begin{itemize}
   \item
-  a glvalue of type \cv \tcode{std::nullptr_t},
+  a glvalue of type \cv{}~\tcode{std::nullptr_t},
 
   \item
   a non-volatile glvalue that refers to an object that is


### PR DESCRIPTION
`\cv \tcode{std::nullptr_t}` produces roughly "*cv*`std::nullptr_t`" with no space in-between. This PR adds a non-breaking space.