### PR TITLE
[ifstream.members] Remove mistakenly added `@`

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -11958,7 +11958,7 @@ basic_filebuf<charT, traits>* rdbuf() const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{const_cast<basic_filebuf<charT, traits>*>(addressof(@\exposid{sb}@))}.
+\tcode{const_cast<basic_filebuf<charT, traits>*>(addressof(\exposid{sb}))}.
 \end{itemdescr}
 
 \indexlibrarymember{native_handle}{basic_ifstream}%


### PR DESCRIPTION
`@` should be in blocks but not [ifstream.members]/1. Fixes a mis-addition in #7208.