### PR TITLE
[support.srcloc.cons] Update xref to [class.mem.general]

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -3701,7 +3701,7 @@ static consteval source_location current() noexcept;
 \pnum
 \remarks
 Any call to \tcode{current} that appears
-as a default member initializer\iref{class.mem}, or
+as a default member initializer\iref{class.mem.general}, or
 as a subexpression thereof,
 should correspond to the location of
 the constructor definition or aggregate initialization


### PR DESCRIPTION
The cross-reference to [class.mem] was referring to a hanging paragraph that was fixed by 2850139be6285ba10a64fb718125a80ca967c631 so we should be referring to [class.mem.general] now.