### PR TITLE
[stmt.dcl] Mirror changes from CWG2791

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -1075,7 +1075,8 @@ The transfer from the condition of a \keyword{switch} statement to a
 \end{footnote}
 When a \grammarterm{declaration-statement} is executed,
 $P$ and $Q$ are the points immediately before and after it;
-when a function returns, $Q$ is after its body.
+when a function returns control to the caller,
+$Q$ is after its body.
 \begin{example}
 \begin{codeblock}
 void f() {


### PR DESCRIPTION
In CWG2791, we've turned unclear "function returns" into clear "function returns control" phrasing.

This edit mirrors that change in [stmt.dcl], which is a part of wording that I've simply missed back when submitting the issue.

Related reflector discussion: https://lists.isocpp.org/core/2025/02/17349.php