### PR TITLE
[basic.scope.scope] Replace "warning" with "diagnostic message"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1077,7 +1077,7 @@ a non-static data member of other than an anonymous union.
 \end{itemize}
 
 \recommended
-Implementations should not emit a warning
+Implementations should not emit a diagnostic message
 that a name-independent declaration is used or unused.
 
 \pnum


### PR DESCRIPTION
We don't usually say "warning", not even in https://eel.is/c++draft/cpp.error#:preprocessing_directive,warning. Everywhere else, the standard talks about diagnostic messages.