### PR TITLE
 [print.fun] Follow up P1494R5

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -7933,6 +7933,7 @@ While holding the lock on \tcode{stream},
 writes the character representation of
 formatting arguments provided by \tcode{args}
 formatted according to specifications given in \tcode{fmt} to \tcode{stream}.
+Then establishes an observable checkpoint\iref{intro.abstract}.
 
 \pnum
 \throws


### PR DESCRIPTION
P1494R5 (and PR[#7681](https://github.com/cplusplus/draft/pull/7681)) overlooked the `vprint_nonunicode` overload taking `FILE*`. This PR fixes that.