### PR TITLE
[hash.requirements] clarify that Cpp17Hash does not imply stateless

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2076,7 +2076,7 @@ Given \tcode{Key} is an argument type for function objects of type \tcode{H}, in
   the program.
 \begin{note}
 Thus all evaluations of the expression \tcode{h(k)} with the
-  same value for \tcode{k} yield the same result for a given execution of the program.
+  same values for \tcode{h} and \tcode{k} yield the same result for a given execution of the program.
   \end{note}
   For two different
   values \tcode{t1} and \tcode{t2}, the probability that \tcode{h(t1)} and \tcode{h(t2)}


### PR DESCRIPTION
A colleague was mislead into thinking that the _Cpp17Hash_ requirements imply hash functions must be stateless, so that every `h` would produce the same value for `h(k)`. I think we can dispel that just by clarifying the note, so that it doesn't seem to imply that only the value of `k` matters.