### PR TITLE
Update Ubuntu version, disable MacOS runner

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - { name: 'Linux', os: 'ubuntu-22.04' }
-          - { name: 'MacOS', os: 'macos-13' }
+          - { name: 'Linux', os: 'ubuntu-24.04' }
+          # - { name: 'MacOS', os: 'macos-13' }
 
     steps:
       - name: checkout
@@ -39,11 +39,11 @@ jobs:
           brew update
 
       - name: update-apt-cache
-        if: matrix.cfg.os == 'ubuntu-22.04'
+        if: matrix.cfg.os == 'ubuntu-24.04'
         run: sudo apt-get update
 
       - name: install (Linux)
-        if: matrix.cfg.os == 'ubuntu-22.04'
+        if: matrix.cfg.os == 'ubuntu-24.04'
         run: sudo apt-get install latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended lmodern
 
       - name: install (MacOS)
@@ -56,7 +56,7 @@ jobs:
           sudo tlmgr install latexmk isodate substr relsize ulem fixme rsfs extract layouts enumitem l3packages l3kernel imakeidx splitindex xstring
 
       - name: make (Linux)
-        if: matrix.cfg.os == 'ubuntu-22.04'
+        if: matrix.cfg.os == 'ubuntu-24.04'
         run: make quiet
 
       - name: make (MacOS)
@@ -67,7 +67,7 @@ jobs:
         run: ../tools/check-output.sh
 
       - name: upload PDF
-        if: matrix.cfg.os == 'ubuntu-22.04'
+        if: matrix.cfg.os == 'ubuntu-24.04'
         uses: actions/upload-artifact@v4
         with:
           name: draft-snapshot


### PR DESCRIPTION
The MacOS runner (in all versions, 13, 14, 15) is currently broken, and we need to investigate. The various errors don't look familiar, but _could_ be related to the bad `extract` package.

(Insights from anyone with a Mac would be welcome!)