### PR TITLE
[lex.digraph] Swap alternative token representations in table

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -744,7 +744,7 @@ are converted into tokens for operators and punctuators:
 \microtypesetup{protrusion=false}\obeyspaces
 \nontermdef{operator-or-punctuator} \textnormal{one of}\br
     \terminal{\{        \}        [        ]        (        )}\br
-    \terminal{<:       :>       <\%       \%>       ;        :        ...}\br
+    \terminal{<\%       \%>       <:       :>       ;        :        ...}\br
     \terminal{?        ::       .        .*       ->       ->*      \~}\br
     \terminal{!        +        -        *        /        \%        \caret{}        \&        |}\br
     \terminal{=        +=       -=       *=       /=       \%=       \caret{}=       \&=       |=}\br


### PR DESCRIPTION
It is better to specify them in this order so that the alternative representation is directly underneath the primary representation.

Currently, `<:` is underneath `{` and `<%` is underneath `[`, which is "the wrong way around".