### PR TITLE
[cpp.embed.gen] “Implementation-resource-width” should not be a grammar term

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -882,13 +882,13 @@ The \grammarterm{pp-tokens} shall then have the form
 
 \pnum
 A resource is a source of data accessible from the translation environment.
-A resource has an \gterm{implementation-resource-width}, which is the
+A resource has an \defn{implementation-resource-width}, which is the
 \impldef{size in bits of a resource}
 size in bits of the resource.
-If the \gterm{implementation-resource-width} is not an integral multiple of
+If the implementation-resource-width is not an integral multiple of
 \libmacro{CHAR_BIT}, the program is ill-formed.
 Let \defn{implementation-resource-count} be
-\gterm{implementation-resource-width} divided by \libmacro{CHAR_BIT}.
+implementation-resource-width divided by \libmacro{CHAR_BIT}.
 Every resource also has a \defn{resource-count}, which is
 
 \begin{itemize}


### PR DESCRIPTION
“Implementation-resource-width” should be a regular term like “ implementation-resource-count”.