### PR TITLE
[cpp.predefined] Place the __STDC_EMBED macros in the unconditionally defined paragraph

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -2191,6 +2191,16 @@ The presumed line number can be changed by the \tcode{\#line} directive.
 \end{footnote}
 
 \item
+\indextext{stdc__embed_not_found__@\mname{STDC_EMBED_NOT_FOUND}}%
+\indextext{stdc__embed_found__@\mname{STDC_EMBED_FOUND}}%
+\indextext{stdc__embed_empty__@\mname{STDC_EMBED_EMPTY}}%
+\mname{STDC_EMBED_NOT_FOUND}, \mname{STDC_EMBED_FOUND}, and \mname{STDC_EMBED_EMPTY}\\
+The integer literals \tcode{0}, \tcode{1}, and \tcode{2}, respectively.
+\begin{note}
+These represent values replaced from \grammarterm{has-embed-expression}{s}\iref{cpp.cond}.
+\end{note}
+
+\item
 \indextext{__stdc_hosted__@\mname{STDC_HOSTED}}%
 \indextext{implementation!hosted}%
 \indextext{implementation!freestanding}%
@@ -2362,16 +2372,6 @@ The following macro names are conditionally defined by the implementation:
 \mname{STDC}\\
 Whether \mname{STDC} is predefined and if so, what its value is,
 are \impldef{definition and meaning of \mname{STDC}}.
-
-\item
-\indextext{stdc__embed_not_found__@\mname{STDC_EMBED_NOT_FOUND}}%
-\indextext{stdc__embed_found__@\mname{STDC_EMBED_FOUND}}%
-\indextext{stdc__embed_empty__@\mname{STDC_EMBED_EMPTY}}%
-\mname{STDC_EMBED_NOT_FOUND}, \mname{STDC_EMBED_FOUND}, and \mname{STDC_EMBED_EMPTY}\\
-The integer literals \tcode{0}, \tcode{1}, and \tcode{2}, respectively.
-\begin{note}
-These represent values replaced from \grammarterm{has-embed-expression}{s}\iref{cpp.cond}.
-\end{note}
 
 \item
 \indextext{__stdc_mb_might_neq_wc__@\mname{STDC_MB_MIGHT_NEQ_WC}}%


### PR DESCRIPTION
The incoming paper did not explicitly specify their placement, but they are clearly meant to be defined unconditionally.