### PR TITLE
[stopsource.general] Restore accidentally deleted members in class definition

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -919,6 +919,9 @@ namespace std {
     // \ref{stopsource.mem}, member functions
     void swap(stop_source&) noexcept;
 
+    stop_token get_token() const noexcept;
+    bool stop_possible() const noexcept;
+    bool stop_requested() const noexcept;
     bool request_stop() noexcept;
 
     bool operator==(const stop_source& rhs) noexcept = default;


### PR DESCRIPTION
These were removed in error in the application of P2300R10.