### PR TITLE
[tab:cpp.cond.ha] Add attribute 'indeterminate' CWG3020

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -482,6 +482,7 @@ that the availability of an attribute can be detected by any non-zero result.
 \tcode{assume}                & \tcode{202207L} \\
 \tcode{deprecated}            & \tcode{201309L} \\
 \tcode{fallthrough}           & \tcode{201603L} \\
+\tcode{indeterminate}         & \tcode{202403L} \\
 \tcode{likely}                & \tcode{201803L} \\
 \tcode{maybe_unused}          & \tcode{201603L} \\
 \tcode{no_unique_address}     & \tcode{201803L} \\


### PR DESCRIPTION
P2795R5, approved in March, 2024, added the [[indeterminate]] attribute, but neglected to amend the table of attributes supported by __has_cpp_attribute.