### PR TITLE
[expr.cond] Simplify phrasing of the `nullptr_t` case

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -7461,8 +7461,8 @@ are performed to bring them to their composite
 pointer type\iref{expr.type}. The result is of the composite pointer type.
 
 \item
-Both the second and third operands have type \tcode{std::nullptr_t} or one has
-that type and the other is a null pointer constant. The result is of type
+One of the second and third operands has type \tcode{std::nullptr_t}
+and the other is a null pointer constant. The result is of type
 \tcode{std::nullptr_t}.
 
 \end{itemize}


### PR DESCRIPTION
The case where both the second and third operands have the same type is handled by the first bullet of this list.