### PR TITLE
[temp.constr.concept] Fix example

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1847,7 +1847,6 @@ the parameter mapping of \tcode{CD} and the arguments of \tcode{CI}.
 Checking whether \tcode{CI$''$} is satisfied
 can lead to further normalization of concept-dependent constraints.
 \end{note}
-%FIXME: "_" in the example below is not a valid identifier.
 \begin{example}
 \begin{codeblock}
 template<typename>
@@ -1856,22 +1855,22 @@ concept C = true;
 template<typename T, template<typename> concept CC>
 concept D = CC<T>;
 
-template<typename T,
+template<typename U,
          template<typename> concept CT,
          template<typename, template<typename> concept> concept CU>
-int f() requires CU<T, CT>;
-int _ = f<int, C, D>();
+int f() requires CU<U, CT>;
+int i = f<int, C, D>();
 \end{codeblock}
-In this example, the associated constraint of \tcode{f}
-is a concept-dependent constraint $CI$
-whose expression is the concept-id \tcode{CU<T, CT>} with the mapping
-$\tcode{T} \mapsto \tcode{T}, \tcode{CT} \mapsto \tcode{CT}, \tcode{CU} \mapsto \tcode{CU}$.\\
-$CI'$ is the result of substituting \tcode{D} into $CI$.\\
-We consider the normal form $CI''$ of \tcode{D<T, CT>},
+In this example, the associated constraints of \tcode{f}
+consist of a concept-dependent constraint
+whose expression is the concept-id \tcode{CU<U, CT>} with the mapping
+$\tcode{U} \mapsto \tcode{U}, \tcode{CT} \mapsto \tcode{CT}, \tcode{CU} \mapsto \tcode{CU}$.
+The result of substituting \tcode{D} into this expression is \tcode{D<U, CT>}.
+We consider the normal form of the resulting concept-id,
 which is \tcode{CC<T>} with the mapping
-$\tcode{T} \mapsto \tcode{T}, \tcode{CC} \mapsto \tcode{CC}$.\\
-By recursion, \tcode{C} is substituted in \tcode{CC<T>} and then
-normalized to the atomic constraint \tcode{true}, which is satisfied.
+$\tcode{T} \mapsto \tcode{U}, \tcode{CC} \mapsto \tcode{CT}$.
+By recursion, \tcode{C} is substituted into \tcode{CC<T>}, and the result
+is normalized to the atomic constraint \tcode{true}, which is satisfied.
 \end{example}
 
 \rSec3[temp.constr.fold]{Fold expanded constraint}


### PR DESCRIPTION
* Give all template parameters a unique name for clarity
* Replace use a of a reserved identifier
* Fix the example's accompanying text, in particular the parameter mapping of the normal form of the concept-id after substitution