### PR TITLE
[temp.constr.normal] Fix example

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -2208,9 +2208,9 @@ template<typename U,
 template<typename U>
   void g() requires CC<U*, C>;
 \end{codeblock}
-The normal form of the associated constraints of \tcode{f} is
-the concept-dependent constraint \tcode{CT<T, C>}.\\
-The normal form of the associated constraints of \tcode{g} is
+The associated constraints of \tcode{f} consist of
+the concept-dependent constraint \tcode{CT<U*, C>}.\\
+The associated constraints of \tcode{g} consist of
 the atomic constraint \tcode{true}.
 \end{example}
 


### PR DESCRIPTION
* Avoid talking about the "normal form" of constraints
* Fix typo