### PR TITLE
[temp.over.link] Remove redundant wording

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -4207,9 +4207,7 @@ under the following conditions:
 they have equivalent types
 ignoring the use of \grammarterm{type-constraint}{s} for placeholder types, and
 \item if they declare template template parameters,
-%FIXME: What are "their kinds"? And what does it mean for kinds to be the same?
-%FIXME: We refer to "kinds" in [temp.param]/p2 but never define it.
-their kinds are the same and their \grammarterm{template-head}{s} are equivalent.
+their \grammarterm{template-head}{s} are equivalent.
 \end{itemize}
 When determining whether types or \grammarterm{type-constraint}{s}
 are equivalent, the rules above are used to compare expressions


### PR DESCRIPTION
This part of the wording is redundant with the first bullet of this list.

There's still an outstanding issue here that the *concept-tt-parameter* production lacks a *template-head*.