### PR TITLE
[alg.copy], [alg.move] Rename ExecutionPolicy parameters

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -5062,7 +5062,7 @@ Exactly $N$ assignments.
 \indexlibraryglobal{copy}%
 \begin{itemdecl}
 template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-  ForwardIterator2 copy(ExecutionPolicy&& policy,
+  ForwardIterator2 copy(ExecutionPolicy&& exec,
                         ForwardIterator1 first, ForwardIterator1 last,
                         ForwardIterator2 result);
 \end{itemdecl}
@@ -5325,7 +5325,7 @@ Exactly $N$ assignments.
 \indexlibrary{\idxcode{move}!algorithm}%
 \begin{itemdecl}
 template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-  ForwardIterator2 move(ExecutionPolicy&& policy,
+  ForwardIterator2 move(ExecutionPolicy&& exec,
                         ForwardIterator1 first, ForwardIterator1 last,
                         ForwardIterator2 result);
 \end{itemdecl}


### PR DESCRIPTION
This makes them consistent with all other parallel algorithms.