### PR TITLE
[uaxid.def.general] Replace non-`codeblock`s with `outputblock`s

### DIFF
--- a/source/uax31.tex
+++ b/source/uax31.tex
@@ -25,9 +25,9 @@ are either alternatives not taken or do not apply to this document.
 \UAX{31} specifies a default syntax for identifiers
 based on properties from the Unicode Character Database, \UAX{44}.
 The general syntax is
-\begin{codeblock}
+\begin{outputblock}
 <Identifier> := <Start> <Continue>* (<Medial> <Continue>+)*
-\end{codeblock}
+\end{outputblock}
 where \tcode{<Start>} has the XID_Start property,
 \tcode{<Continue>} has the XID_Continue property, and
 \tcode{<Medial>} is a list of characters permitted between continue characters.
@@ -36,11 +36,11 @@ to the set of permitted \tcode{<Start>} characters,
 the \tcode{<Medial>} set is empty, and
 the \tcode{<Continue>} characters are unmodified.
 In the grammar used in \UAX{31}, this is
-\begin{codeblock}
+\begin{outputblock}
 <Identifier> := <Start> <Continue>*
 <Start> := XID_Start + @\textrm{\ucode{005f}}@
 <Continue> := <Start> + XID_Continue
-\end{codeblock}
+\end{outputblock}
 
 \pnum
 This is described in the \Cpp{} grammar in \ref{lex.name},


### PR DESCRIPTION
These blocks are used for showing UAX syntax but not code, so presumably `outputblock` should be used.