### PR TITLE
[algorithm.syn] Fix-up synopsis for `ranges::find_last`

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -970,10 +970,12 @@ namespace std {
 
   // \ref{alg.find.last}, find last
   namespace ranges {
-    template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T, class Proj = identity>
+    template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
+             class T = projected_value_t<I, Proj>>
       requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T*>
       constexpr subrange<I> find_last(I first, S last, const T& value, Proj proj = {});
-    template<@\libconcept{forward_range}@ R, class T, class Proj = identity>
+    template<@\libconcept{forward_range}@ R, class Proj = identity,
+             class T = projected_value_t<iterator_t<R>, Proj>>
       requires
         @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
       constexpr borrowed_subrange_t<R> find_last(R&& r, const T& value, Proj proj = {});


### PR DESCRIPTION
Adds missed corresponding editorial changes in [algorithm.syn] for P3217R0 (which updated `ranges::find_last`).

Fixes #7802.