### PR TITLE
[range.approximately.sized] Move to before [range.sized]

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1146,46 +1146,6 @@ Whenever \tcode{ranges::reserve_hint(E)} is a valid expression,
 its type is integer-like.
 \end{note}
 
-\rSec2[range.approximately.sized]{Approximately sized ranges}
-
-\pnum
-The \libconcept{approximately_sized_range} concept refines \libconcept{range}
-with the requirement that
-an approximation of the number of elements in the range
-can be determined in amortized constant time using \tcode{ranges::reserve_hint}.
-
-\begin{itemdecl}
-template<class T>
-  concept @\deflibconcept{approximately_sized_range}@ =
-    @\libconcept{range}@<T> && requires(T& t) { ranges::reserve_hint(t); };
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-Given an lvalue \tcode{t} of type \tcode{remove_reference_t<T>},
-\tcode{T} models \libconcept{approximately_sized_range} only if
-\begin{itemize}
-\item
-\tcode{ranges::reserve_hint(t)} is amortized \bigoh{1},
-does not modify \tcode{t}, and
-has a value that
-is not negative and is representable in \tcode{range_difference_t<T>}, and
-\item
-if \tcode{iterator_t<T>} models \libconcept{forward_iterator},
-\tcode{ranges::reserve_hint(t)} is well-defined
-regardless of the evaluation of \tcode{ranges::begin(t)}.
-\begin{note}
-\tcode{ranges::reserve_hint(t)} is otherwise not required to be well-defined
-after evaluating \tcode{ranges::\linebreak begin(t)}.
-For example,
-it is possible for \tcode{ranges::reserve_hint(t)} to be well-defined for
-an \libconceptx{approximate\-ly_sized_range}{approximately_sized_range} whose
-iterator type does not model \libconcept{forward_iterator}
-only if evaluated before the first call to \tcode{ranges::begin(t)}.
-\end{note}
-\end{itemize}
-\end{itemdescr}
-
 \rSec2[range.prim.empty]{\tcode{ranges::empty}}
 \indexlibraryglobal{empty}%
 
@@ -1461,6 +1421,46 @@ do not have validity tied to the lifetime of an \tcode{S} object
 because they are ``borrowed'' from some other range.
 \end{itemize}
 \end{example}
+\end{itemdescr}
+
+\rSec2[range.approximately.sized]{Approximately sized ranges}
+
+\pnum
+The \libconcept{approximately_sized_range} concept refines \libconcept{range}
+with the requirement that
+an approximation of the number of elements in the range
+can be determined in amortized constant time using \tcode{ranges::reserve_hint}.
+
+\begin{itemdecl}
+template<class T>
+  concept @\deflibconcept{approximately_sized_range}@ =
+    @\libconcept{range}@<T> && requires(T& t) { ranges::reserve_hint(t); };
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Given an lvalue \tcode{t} of type \tcode{remove_reference_t<T>},
+\tcode{T} models \libconcept{approximately_sized_range} only if
+\begin{itemize}
+\item
+\tcode{ranges::reserve_hint(t)} is amortized \bigoh{1},
+does not modify \tcode{t}, and
+has a value that
+is not negative and is representable in \tcode{range_difference_t<T>}, and
+\item
+if \tcode{iterator_t<T>} models \libconcept{forward_iterator},
+\tcode{ranges::reserve_hint(t)} is well-defined
+regardless of the evaluation of \tcode{ranges::begin(t)}.
+\begin{note}
+\tcode{ranges::reserve_hint(t)} is otherwise not required to be well-defined
+after evaluating \tcode{ranges::\linebreak begin(t)}.
+For example,
+it is possible for \tcode{ranges::reserve_hint(t)} to be well-defined for
+an \libconceptx{approximate\-ly_sized_range}{approximately_sized_range} whose
+iterator type does not model \libconcept{forward_iterator}
+only if evaluated before the first call to \tcode{ranges::begin(t)}.
+\end{note}
+\end{itemize}
 \end{itemdescr}
 
 \rSec2[range.sized]{Sized ranges}


### PR DESCRIPTION
This is an unfortunate application of P2846R6.

Fixes #7769