### PR TITLE
[list.erasure, list.erasure] Separate code into another line for better formatting

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -7869,7 +7869,10 @@ template<class T, class Allocator, class U = T>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return erase_if(c, [\&](const auto\& elem) -> bool \{ return elem == value; \});}
+Equivalent to:
+\begin{codeblock}
+return erase_if(c, [&](const auto& elem) -> bool { return elem == value; });
+\end{codeblock}
 \end{itemdescr}
 
 \indexlibrarymember{erase_if}{forward_list}%
@@ -9761,7 +9764,10 @@ template<class T, class Allocator, class U = T>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return erase_if(c, [\&](const auto\& elem) -> bool \{ return elem == value; \});}
+Equivalent to:
+\begin{codeblock}
+return erase_if(c, [&](const auto& elem) -> bool { return elem == value; });
+\end{codeblock}
 \end{itemdescr}
 
 \indexlibrarymember{erase_if}{list}%


### PR DESCRIPTION
The code is too long and has been truncated, so it would be better to put it on its own line.