### PR TITLE
[mem.composite.types] Replace \oldconceptname with \oldconcept

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -5820,7 +5820,7 @@ may be an incomplete type.
 
 \pnum
 The template parameter \tcode{Allocator} of \tcode{indirect}
-shall meet the \oldconceptname{Allocator} requirements.
+shall meet the \oldconcept{Allocator} requirements.
 
 \pnum
 If a program declares an explicit or partial specialization of \tcode{indirect},
@@ -6480,7 +6480,7 @@ constexpr void swap(indirect& other)
 If
 \tcode{allocator_traits<Allocator>::propagate_on_container_swap::value}
 is \tcode{true}, then
-\tcode{Allocator} meets the \oldconceptname{Swappable} requirements.
+\tcode{Allocator} meets the \oldconcept{Swappable} requirements.
 Otherwise \tcode{get_allocator() == other.\linebreak{}get_allocator()} is \tcode{true}.
 
 \pnum
@@ -6677,7 +6677,7 @@ may be an incomplete type.
 
 \pnum
 The template parameter \tcode{Allocator} of \tcode{polymorphic}
-shall meet the requirements of \oldconceptname{Allocator}.
+shall meet the requirements of \oldconcept{Allocator}.
 
 \pnum
 If a program declares an explicit or
@@ -7271,7 +7271,7 @@ constexpr void swap(polymorphic& other)
 \expects
 If \tcode{allocator_traits<Allocator>::propagate_on_container_swap::value}
 is \tcode{true}, then
-\tcode{Allocator} meets the \oldconceptname{Swappable} requirements.
+\tcode{Allocator} meets the \oldconcept{Swappable} requirements.
 Otherwise \tcode{get_allocator() == other.\linebreak{}get_allocator()} is \tcode{true}.
 
 \pnum


### PR DESCRIPTION
[PR#7708](https://github.com/cplusplus/draft/pull/7708) used `\oldconceptname` for the old requirements, `\oldconcept` should be used instead.