### PR TITLE
[string.view] Exposition-only formatting for `data_` and `size_`

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -732,8 +732,8 @@ Because \tcode{basic_string_view} refers to a constant sequence, \tcode{iterator
     constexpr size_type find_last_not_of(const charT* s, size_type pos = npos) const;
 
   private:
-    const_pointer data_;        // \expos
-    size_type size_;            // \expos
+    const_pointer @\exposid{data_}@;        // \expos
+    size_type @\exposid{size_}@;            // \expos
   };
 
   // \ref{string.view.deduct}, deduction guides
@@ -778,7 +778,7 @@ constexpr basic_string_view() noexcept;
 \begin{itemdescr}
 \pnum
 \ensures
-\tcode{size_ == 0} and \tcode{data_ == nullptr}.
+\tcode{\exposid{size_} == 0} and \tcode{\exposid{data_} == nullptr}.
 \end{itemdescr}
 
 \indexlibraryctor{basic_string_view}%
@@ -793,8 +793,8 @@ constexpr basic_string_view(const charT* str);
 
 \pnum
 \effects
-Constructs a \tcode{basic_string_view}, initializing \tcode{data_} with \tcode{str}
-and initializing \tcode{size_} with \tcode{traits::length(str)}.
+Constructs a \tcode{basic_string_view}, initializing \exposid{data_} with \tcode{str}
+and initializing \exposid{size_} with \tcode{traits::length(str)}.
 
 \pnum
 \complexity
@@ -813,8 +813,8 @@ constexpr basic_string_view(const charT* str, size_type len);
 
 \pnum
 \effects
-Constructs a \tcode{basic_string_view}, initializing \tcode{data_} with \tcode{str}
-and initializing \tcode{size_} with \tcode{len}.
+Constructs a \tcode{basic_string_view}, initializing \exposid{data_} with \tcode{str}
+and initializing \exposid{size_} with \tcode{len}.
 \end{itemdescr}
 
 \indexlibraryctor{basic_string_view}%
@@ -843,8 +843,8 @@ template<class It, class End>
 
 \pnum
 \effects
-Initializes \tcode{data_} with \tcode{to_address(begin)} and
-initializes \tcode{size_} with \tcode{end - begin}.
+Initializes \exposid{data_} with \tcode{to_address(begin)} and
+initializes \exposid{size_} with \tcode{end - begin}.
 
 \pnum
 \throws
@@ -880,8 +880,8 @@ is not a valid expression.
 
 \pnum
 \effects
-Initializes \tcode{data_} with \tcode{ranges::data(r)} and
-\tcode{size_} with \tcode{ranges::size(r)}.
+Initializes \exposid{data_} with \tcode{ranges::data(r)} and
+\exposid{size_} with \tcode{ranges::size(r)}.
 
 \pnum
 \throws
@@ -947,7 +947,7 @@ constexpr const_iterator cbegin() const noexcept;
 \returns
 An iterator such that
 \begin{itemize}
-\item if \tcode{!empty()}, \tcode{addressof(*begin()) == data_},
+\item if \tcode{!empty()}, \tcode{addressof(*begin()) == \exposid{data_}},
 \item otherwise, an unspecified value such that \range{begin()}{end()} is a valid range.
 \end{itemize}
 \end{itemdescr}
@@ -1003,7 +1003,7 @@ constexpr size_type length() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{size_}.
+\exposid{size_}.
 \end{itemdescr}
 
 
@@ -1026,7 +1026,7 @@ constexpr bool empty() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{size_ == 0}.
+\tcode{\exposid{size_} == 0}.
 \end{itemdescr}
 
 \rSec3[string.view.access]{Element access}
@@ -1046,7 +1046,7 @@ This precondition is stronger than the one on \tcode{basic_string::operator[]}.
 
 \pnum
 \returns
-\tcode{data_[pos]}.
+\tcode{\exposid{data_}[pos]}.
 
 \pnum
 \throws
@@ -1061,7 +1061,7 @@ constexpr const_reference at(size_type pos) const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{data_[pos]}.
+\tcode{\exposid{data_}[pos]}.
 
 \pnum
 \throws
@@ -1080,7 +1080,7 @@ constexpr const_reference front() const;
 
 \pnum
 \returns
-\tcode{data_[0]}.
+\tcode{\exposid{data_}[0]}.
 
 \pnum
 \throws
@@ -1099,7 +1099,7 @@ constexpr const_reference back() const;
 
 \pnum
 \returns
-\tcode{data_[size() - 1]}.
+\tcode{\exposid{data_}[size() - 1]}.
 
 \pnum
 \throws
@@ -1114,7 +1114,7 @@ constexpr const_pointer data() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{data_}.
+\exposid{data_}.
 
 \pnum
 \begin{note}
@@ -1138,7 +1138,7 @@ constexpr void remove_prefix(size_type n);
 
 \pnum
 \effects
-Equivalent to: \tcode{data_ += n; size_ -= n;}
+Equivalent to: \tcode{\exposid{data_} += n; \exposid{size_} -= n;}
 \end{itemdescr}
 
 \indexlibrarymember{remove_suffix}{basic_string_view}%
@@ -1153,7 +1153,7 @@ constexpr void remove_suffix(size_type n);
 
 \pnum
 \effects
-Equivalent to: \tcode{size_ -= n;}
+Equivalent to: \tcode{\exposid{size_} -= n;}
 \end{itemdescr}
 
 \indexlibrarymember{swap}{basic_string_view}%
@@ -1446,7 +1446,7 @@ Let \tcode{xpos} be the lowest position, if possible, such that the following co
 \item
 \tcode{xpos + str.size() <= size()}
 \item
-\tcode{traits::eq(data_[xpos + I], str[I])} for all elements \tcode{I} of the string referenced by \tcode{str}.
+\tcode{traits::eq(\exposid{data_}[xpos + I], str[I])} for all elements \tcode{I} of the string referenced by \tcode{str}.
 \end{itemize}
 
 \pnum
@@ -1473,7 +1473,7 @@ Let \tcode{xpos} be the highest position, if possible, such that the following c
 \item
 \tcode{xpos + str.size() <= size()}
 \item
-\tcode{traits::eq(data_[xpos + I], str[I])} for all elements \tcode{I} of the string referenced by \tcode{str}.
+\tcode{traits::eq(\exposid{data_}[xpos + I], str[I])} for all elements \tcode{I} of the string referenced by \tcode{str}.
 \end{itemize}
 
 \pnum
@@ -1500,7 +1500,7 @@ Let \tcode{xpos} be the lowest position, if possible, such that the following co
 \item
 \tcode{xpos < size()}
 \item
-\tcode{traits::eq(data_[xpos], str[I])} for some element \tcode{I} of the string referenced by \tcode{str}.
+\tcode{traits::eq(\exposid{data_}[xpos], str[I])} for some element \tcode{I} of the string referenced by \tcode{str}.
 \end{itemize}
 
 \pnum
@@ -1527,7 +1527,7 @@ Let \tcode{xpos} be the highest position, if possible, such that the following c
 \item
 \tcode{xpos < size()}
 \item
-\tcode{traits::eq(data_[xpos], str[I])} for some element \tcode{I} of the string referenced by \tcode{str}.
+\tcode{traits::eq(\exposid{data_}[xpos], str[I])} for some element \tcode{I} of the string referenced by \tcode{str}.
 \end{itemize}
 
 \pnum
@@ -1554,7 +1554,7 @@ Let \tcode{xpos} be the lowest position, if possible, such that the following co
 \item
 \tcode{xpos < size()}
 \item
-\tcode{traits::eq(data_[xpos], str[I])} for no element \tcode{I} of the string referenced by \tcode{str}.
+\tcode{traits::eq(\exposid{data_}[xpos], str[I])} for no element \tcode{I} of the string referenced by \tcode{str}.
 \end{itemize}
 
 \pnum
@@ -1580,7 +1580,7 @@ Let \tcode{xpos} be the highest position, if possible, such that the following c
 \item
 \tcode{xpos < size()}
 \item
-\tcode{traits::eq(data_[xpos], str[I])} for no element \tcode{I} of the string referenced by \tcode{str}.
+\tcode{traits::eq(\exposid{data_}[xpos], str[I])} for no element \tcode{I} of the string referenced by \tcode{str}.
 \end{itemize}
 
 \pnum


### PR DESCRIPTION
Makes exposition-only data members _`data_`_ and _`size_`_ of `basic_string_view` shown in italic style.