### PR TITLE
[polymorphic.general] Fix paragraph 3

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -6633,7 +6633,7 @@ allocate and free storage for the owned object as needed.
 \pnum
 Constructing an owned object of type \tcode{U} with \tcode{args...}
 using the allocator \tcode{a} means calling
-\tcode{allocator_traits<Allocator>::cop, args...)} where
+\tcode{allocator_traits<Allocator>::construct(a, \exposid{p}, args...)} where
 \tcode{args} is an expression pack,
 \tcode{a} is an allocator, and
 \exposid{p} points to storage suitable for an owned object of type \tcode{U}.


### PR DESCRIPTION
[polymorphic.general] paragraph 3 has a broken expression `allocator_traits<Allocator>::cop, args...)`. It should be the same expression used in [indirect.general].