### PR TITLE
[polymorphic.asgn] Remove a superfluous greater-than sign

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -7146,7 +7146,7 @@ constexpr polymorphic& operator=(polymorphic&& other)
 \begin{itemdescr}
 \pnum
 \mandates
-If \tcode{allocator_traits<Allocator>::is_always_equal::value>} is \tcode{false},
+If \tcode{allocator_traits<Allocator>::is_always_equal::value} is \tcode{false},
 \tcode{T} is a complete type.
 
 \pnum


### PR DESCRIPTION
[polymorphic.asgn] p5 says:

> _Mandates:_ If `allocator_traits<Allocator>::is_always_equal::value>` is `false`, `T` is a complete type.

There is a superfluous greater-than sign following `value`.