### PR TITLE
 [indirect.asgn] std::indirect does not have a “contained value”

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -6282,7 +6282,7 @@ remains unchanged.
 If an exception is thrown during
 the call to \tcode{T}{'s} selected copy constructor, no effect.
 If an exception is thrown during the call to \tcode{T}{'s} copy assignment,
-the state of its contained value
+the state of its owned object
 is as defined by the exception safety guarantee of
 \tcode{T}{'s} copy assignment.
 \end{itemdescr}


### PR DESCRIPTION
 [indirect.asgn] p4 says:

> If an exception is thrown during the call to `T`’s copy assignment, the state of its **contained value** is as defined by the exception safety guarantee of `T`’s copy assignment.

The wording is copied from the description of the copy assignment operator of `std::optional`, which has a contained value (defined in [optional.optional.general] p1). For `std::indirect`, there is no “contained value”, “owned object” should be used instead.