### PR TITLE
[cstring.syn] Add example of implicit object creation in `memcpy` and `memmove`

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -5517,6 +5517,33 @@ in the destination region of storage
 immediately prior to copying the sequence of characters to the destination.
 Each of these functions returns a pointer to a suitable created object, if any,
 otherwise the value of the first parameter.
+\begin{example}
+\begin{codeblock}
+int x = 0;
+memmove(&x, &x, sizeof(int));
+assert(x == 0);                 // Passes.
+
+unsigned y;
+memcpy(&y, &x, sizeof(int));
+assert(y == 0);                 // Passes.
+
+unsigned char bytes[4] = {
+  0xff, 0xff, 0xff, 0xff
+};
+memcpy(&y, bytes, 4);
+assert(y == 0xffffffff);        // Passes, assuming that \tcode{sizeof(unsigned)} equals \tcode{4},
+                                // and that \tcode{CHAR_BIT} equals \tcode{8}.
+\end{codeblock}
+Both \tcode{x} and \tcode{y} are transparently replaced\iref{basic.life}
+with implicitly created objects in the storage of the old objects,
+and refer to the new respective objects.
+In the call to \tcode{memmove},
+the implicit object creation takes place after copying the bytes of \tcode{x}
+into a temporary array,
+and immediately before copying them into the implicitly created object.
+Since \tcode{int} is trivially copyable\iref{basic.types.general},
+\tcode{x} retains the value \tcode{0}.
+\end{example}
 
 \pnum
 \begin{note}


### PR DESCRIPTION
![grafik](https://github.com/user-attachments/assets/a5bd3eb4-756c-4e4f-8887-95dc3bc21280)

This example introduces some desperately needed clarity on a few problems.

Firstly, the `memcpy` from `bytes` into `y` demonstrates that bytes and integers don't have provenance. You can rely on trivially copyable objects behaving as expected, even if you copy bytes that you haven't previously copied out of another object. It works even if you start out with an `unsigned char[]`.

Secondly, it's not obvious that `memmove(&x, &x, sizeof(int))` would have the intended effect, and I've had a discussion about this today. After all, if an object is implicitly created, this would kill any bytes in the same place, possibly resulting in UB, so is an object impicitly created at all? In this case yes, because the copy takes place immediately before copying into the destination, but after the old bytes have already been saved into a temporary array.

Thirdly, this also clarifies that you can `memcpy` and `memmove` into existing objects without killing them thanks to transparent replacement (or at least, you can still use `x` and `y` afterwards, even if the original object is dead). I remember having a discussion about that in this repo, and the claim was that "scribbling over the object representation would kill the object", or something along those lines.

To be fair, we already have an example of the third point, but it's somewhere under lvalue-to-rvalue conversion, not where you'd be looking for it.