### PR TITLE
Remove incorrect class.union.assignment.not.start.lifetime

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3237,7 +3237,7 @@ for each element \tcode{X} of $S($\tcode{E1}$)$ and
 each anonymous union member \tcode{X}\iref{class.union.anon} that
 is a member of a union and
 has such an element as an immediate subobject (recursively),
-if modification of \tcode{X} would have undefined behavior\ubdef{class.union.assignment.not.start.lifetime} under~\ref{basic.life},
+if modification of \tcode{X} would have undefined behavior under~\ref{basic.life},
 an object of the type of \tcode{X} is implicitly created
 in the nominated storage;
 no initialization is performed and

--- a/source/ub.tex
+++ b/source/ub.tex
@@ -1242,37 +1242,6 @@ int main() {
 \end{example}
 
 
-\rSec2[ub.class.union]{Unions}
-
-\pnum
-\ubxref{class.union.assignment.not.start.lifetime} \\
-Assigning to a union member may not start its lifetime, in that case using it will result in undefined behavior.
-
-\pnum
-\begin{example}
-\begin{codeblock}
-struct X {
-  const int a;
-  int b;
-};
-
-union Y {
-  X x;
-  int k;
-};
-
-void g() {
-  Y y = {{1, 2}};       // OK, \tcode{y.x} is active union member\iref{class.mem}
-  int n = y.x.a;
-  y.k = 4;              // OK, ends lifetime of \tcode{y.x}, \tcode{y.k} is active member of union
-  y.x.b = n;            // undefined behavior: \tcode{y.x.b} modified outside its lifetime,
-                        // \tcode{S(y.x.b)} is empty because \tcode{X}'s default constructor is deleted,
-                        // so union member \tcode{y.x}'s lifetime does not implicitly start
-}
-\end{codeblock}
-\end{example}
-
-
 \rSec2[ub.class.abstract]{Abstract classes}
 
 \pnum


### PR DESCRIPTION
This references undefined behavior specified elsewhere; it does not specify additional undefined behavior.