### PR TITLE
[vector.modifiers] Old concepts cannot be “modeled”

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10083,7 +10083,7 @@ is the distance between
 and
 \tcode{last})
 and no reallocations if
-\tcode{InputIterator} meets the requirements of \oldconcept{ForwardIterator}.
+\tcode{InputIterator} meets the \oldconcept{ForwardIterator} requirements.
 It makes order
 $N$
 calls to the copy constructor of
@@ -10386,7 +10386,7 @@ performs at most one reallocation if:
 \end{itemize}
 For the declarations taking a pair of \tcode{InputIterator},
 performs at most one reallocation if
-\tcode{InputItera\-tor} meets the requirements of \oldconcept{ForwardIterator}.
+\tcode{InputItera\-tor} meets the \oldconcept{ForwardIterator} requirements.
 \end{itemdescr}
 
 \indexlibrarymember{erase}{vector}%

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10082,7 +10082,8 @@ is the distance between
 \tcode{first}
 and
 \tcode{last})
-and no reallocations if iterators \tcode{first} and \tcode{last} are of forward, bidirectional, or random access categories.
+and no reallocations if
+\tcode{InputIterator} meets the requirements of \oldconcept{ForwardIterator}.
 It makes order
 $N$
 calls to the copy constructor of
@@ -10385,7 +10386,7 @@ performs at most one reallocation if:
 \end{itemize}
 For the declarations taking a pair of \tcode{InputIterator},
 performs at most one reallocation if
-\tcode{InputItera\-tor} models \oldconcept{ForwardIterator}.
+\tcode{InputItera\-tor} meets the requirements of \oldconcept{ForwardIterator}.
 \end{itemdescr}
 
 \indexlibrarymember{erase}{vector}%


### PR DESCRIPTION
[vector.modifiers] p3 says:

> For the declarations taking a pair of `InputIterator`, performs at most one reallocation if `InputIterator` models _Cpp17ForwardIterator_.

“Model” should not be used on old _Cpp17XXX_ concepts, “meet the requirements of” should be used instead.

 [vector.cons] p10 is also updated for consistency.