### PR TITLE
[tuple.syn] fix ignore-type::operator= return type

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1549,7 +1549,7 @@ namespace std {
 
   // \tcode{ignore}
   struct @\exposidnc{ignore-type}@ {                      // \expos
-    constexpr const @\exposid{ignore-type}@
+    constexpr const @\exposid{ignore-type}@ &
       operator=(const auto &) const noexcept { return *this; }
   };
   inline constexpr @\exposid{ignore-type}@ ignore;

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1549,7 +1549,7 @@ namespace std {
 
   // \tcode{ignore}
   struct @\exposidnc{ignore-type}@ {                      // \expos
-    constexpr const @\exposid{ignore-type}@ &
+    constexpr const @\exposid{ignore-type}@&
       operator=(const auto &) const noexcept { return *this; }
   };
   inline constexpr @\exposid{ignore-type}@ ignore;


### PR DESCRIPTION
`ignore-type`'s `operator=` is currently specified as
```cpp
constexpr const ignore-type operator=(const auto &) const noexcept { return *this; }
```
this should instead return `const ignore-type&`. 

@Eisenwave noted [P2968R2](https://wg21.link/p2968r2) specifies `ignore-type` as
```diff
+// ignore
+struct ignore-type { // exposition only
+  constexpr const ignore-type&
+    operator=(const auto &) const noexcept
+      { return *this; }
+};
+inline constexpr ignore-type ignore;
// 22.4.5, tuple creation functions
-inline constexpr unspecified ignore;
```

however, https://github.com/cplusplus/draft/pull/7109 drops the reference qualification on `ignore-type::operator=`'s return type. Therefore I believe this is an editorial issue.

