### PR TITLE
[iterator.synopsis] Apply changes of P2538R1 to the synopsis of `<iterator>`

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -171,9 +171,6 @@ namespace std {
   template<@\libconcept{indirectly_readable}@ I, @\libconcept{indirectly_regular_unary_invocable}@<I> Proj>
     struct projected;                                                               // freestanding
 
-  template<@\libconcept{weakly_incrementable}@ I, class Proj>
-    struct incrementable_traits<projected<I, Proj>>;                                // freestanding
-
   template<@\libconcept{indirectly_readable}@ I, @\libconcept{indirectly_regular_unary_invocable}@<I> Proj>
   using projected_value_t =                                                         // freestanding
     remove_cvref_t<invoke_result_t<Proj&, iter_value_t<I>&>>;

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -169,7 +169,7 @@ namespace std {
 
   // \ref{projected}, projected
   template<@\libconcept{indirectly_readable}@ I, @\libconcept{indirectly_regular_unary_invocable}@<I> Proj>
-    struct projected;                                                               // freestanding
+    using projected = @\seebelow@;                                                    // freestanding
 
   template<@\libconcept{indirectly_readable}@ I, @\libconcept{indirectly_regular_unary_invocable}@<I> Proj>
   using projected_value_t =                                                         // freestanding


### PR DESCRIPTION
P2538R1 made `projected` an alias template and removed the `incrementable_traits<projected>` partial specialization, so the synopsis should be correspondingly updated.

Fixes #7837.