### PR TITLE
[tab:headers.cpp.fs] Fix header name for `is_execution_policy(_v)`

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1630,7 +1630,7 @@ include at least the headers shown in \tref{headers.cpp.fs}.
 \ref{iterators}          & Iterators library         & \tcode{<iterator>}         \\ \rowsep
 \ref{ranges}             & Ranges library            & \tcode{<ranges>}           \\ \rowsep
 \ref{algorithms}         & Algorithms library        & \tcode{<algorithm>}, \tcode{<numeric>} \\ \rowsep
-\ref{execpol}            & Execution policies        & \tcode{<execpol>}          \\ \rowsep
+\ref{execpol}            & Execution policies        & \tcode{<execution>}        \\ \rowsep
 \ref{string.view}        & String view classes       & \tcode{<string_view>}      \\ \rowsep
 \ref{string.classes}     & String classes            & \tcode{<string>}           \\ \rowsep
 \ref{c.strings}          & Null-terminated sequence utilities & \tcode{<cstring>}, \tcode{<cwchar>} \\ \rowsep


### PR DESCRIPTION
#7706 mistakenly listed the header for `is_execution_policy(_v)` as `<execpol>`. The correct header is `<execution>`.