### PR TITLE
[lib] Replace uses of `add_meow_t` with plain cv-qualifiers

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -11400,7 +11400,7 @@ template<class InputIterator>
     tuple_element_t<1, @\exposid{iter-value-type}@<InputIterator>>;                 // \expos
 template<class InputIterator>
   using @\placeholder{iter-to-alloc-type}@ = pair<
-    add_const_t<tuple_element_t<0, @\exposid{iter-value-type}@<InputIterator>>>,
+    const tuple_element_t<0, @\exposid{iter-value-type}@<InputIterator>>,
     tuple_element_t<1, @\exposid{iter-value-type}@<InputIterator>>>;                // \expos
 template<ranges::@\libconcept{input_range}@ Range>
   using @\exposid{range-key-type}@ =
@@ -11409,7 +11409,7 @@ template<ranges::@\libconcept{input_range}@ Range>
   using @\exposid{range-mapped-type}@ = typename ranges::range_value_t<Range>::second_type; // \expos
 template<ranges::@\libconcept{input_range}@ Range>
   using @\exposid{range-to-alloc-type}@ =
-    pair<add_const_t<typename ranges::range_value_t<Range>::first_type>,
+    pair<const typename ranges::range_value_t<Range>::first_type,
          typename ranges::range_value_t<Range>::second_type>;           // \expos
 \end{codeblock}
 

--- a/source/future.tex
+++ b/source/future.tex
@@ -561,8 +561,8 @@ Then specializations of each of the two templates meet
 the \oldconcept{TransformationTrait} requirements
 with a member typedef \tcode{type} that names the following type:
 \begin{itemize}
-\item for the first specialization, \tcode{add_volatile_t<TE>}, and
-\item for the second specialization, \tcode{add_cv_t<TE>}.
+\item for the first specialization, \tcode{volatile TE}, and
+\item for the second specialization, \tcode{const volatile TE}.
 \end{itemize}
 
 \pnum
@@ -616,8 +616,8 @@ Then specializations of each of the two templates meet
 the \oldconcept{TransformationTrait} requirements
 with a member typedef \tcode{type} that names the following type:
 \begin{itemize}
-\item for the first specialization, \tcode{add_volatile_t<VA::type>}, and
-\item for the second specialization, \tcode{add_cv_t<VA::type>}.
+\item for the first specialization, \tcode{volatile VA::type}, and
+\item for the second specialization, \tcode{const volatile VA::type}.
 \end{itemize}
 \end{itemdescr}
 

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -12594,7 +12594,7 @@ namespace std::linalg {
   class @\libglobal{scaled_accessor}@ {
   public:
     using element_type =
-      add_const_t<decltype(declval<ScalingFactor>() * declval<NestedAccessor::element_type>())>;
+      const decltype(declval<ScalingFactor>() * declval<NestedAccessor::element_type>());
     using reference = remove_const_t<element_type>;
     using data_handle_type = NestedAccessor::data_handle_type;
     using offset_policy = scaled_accessor<ScalingFactor, NestedAccessor::offset_policy>;
@@ -12766,7 +12766,7 @@ namespace std::linalg {
   class @\libglobal{conjugated_accessor}@ {
   public:
     using element_type =
-      add_const_t<decltype(@\exposid{conj-if-needed}@(declval<NestedAccessor::element_type>()))>;
+      const decltype(@\exposid{conj-if-needed}@(declval<NestedAccessor::element_type>()));
     using reference = remove_const_t<element_type>;
     using data_handle_type = typename NestedAccessor::data_handle_type;
     using offset_policy = conjugated_accessor<NestedAccessor::offset_policy>;

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -63,7 +63,7 @@ namespace std {
 
   // \ref{utility.as.const}, \tcode{as_const}
   template<class T>
-    constexpr add_const_t<T>& as_const(T& t) noexcept;
+    constexpr const T& as_const(T& t) noexcept;
   template<class T>
     void as_const(const T&&) = delete;
 
@@ -495,7 +495,7 @@ template<class T> constexpr conditional_t<
 
 \indexlibraryglobal{as_const}%
 \begin{itemdecl}
-template<class T> constexpr add_const_t<T>& as_const(T& t) noexcept;
+template<class T> constexpr const T& as_const(T& t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2849,7 +2849,7 @@ template<size_t I, class T> struct tuple_element<I, const T>;
 \pnum
 Let \tcode{TE} denote \tcode{tuple_element_t<I, T>} of the cv-unqualified type \tcode{T}. Then
 each specialization of the template meets the \oldconcept{TransformationTrait} requirements\iref{meta.rqmts}
-with a member typedef \tcode{type} that names the type \tcode{add_const_t<TE>}.
+with a member typedef \tcode{type} that names the type \tcode{const TE}.
 
 \pnum
 In addition to being available via inclusion of the \libheader{tuple} header,
@@ -5937,7 +5937,7 @@ template<size_t I, class T> struct variant_alternative<I, const T>;
 Let \tcode{VA} denote \tcode{variant_alternative<I, T>} of the
 cv-unqualified type \tcode{T}. Then each specialization of the template
 meets the \oldconcept{TransformationTrait} requirements\iref{meta.rqmts} with a
-member typedef \tcode{type} that names the type \tcode{add_const_t<VA::type>}.
+member typedef \tcode{type} that names the type \tcode{const VA::type}.
 \end{itemdescr}
 
 \indexlibraryglobal{variant_alternative}%


### PR DESCRIPTION
...except for [tab:meta.trans.cv]. Because the wording change for `add_cv` seems a bit non-trivial.

Fixes #7845.