### PR TITLE
[tab:meta.trans.cv] Simplify wording for `add_{const,volatile,cv}`

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -1712,22 +1712,32 @@ add or remove cv-qualifications\iref{basic.type.qualifier}.
 \indexlibraryglobal{add_const}%
 \tcode{template<class T>\br
  struct add_const;}                 &
- If \tcode{T} is a reference, function, or top-level const-qualified
- type, then \tcode{type} denotes \tcode{T}, otherwise
- \tcode{T const}.                                                           \\  \rowsep
+ The member typedef \tcode{type} denotes \tcode{const T}.
+\begin{tailnote}
+\keyword{const} has no effect when \tcode{T} is a reference, function, or
+top-level const-qualified type.
+\end{tailnote}
+\\ \rowsep
 
 \indexlibraryglobal{add_volatile}%
 \tcode{template<class T>\br
  struct add_volatile;}                  &
- If \tcode{T} is a reference, function, or top-level volatile-qualified
- type, then \tcode{type} denotes \tcode{T}, otherwise
- \tcode{T volatile}.                                                            \\  \rowsep
+ The member typedef \tcode{type} denotes \tcode{volatile T}.
+\begin{tailnote}
+\keyword{volatile} has no effect when \tcode{T} is a reference, function, or
+top-level volatile-qualified type.
+\end{tailnote}
+\\ \rowsep
 
 \indexlibraryglobal{add_cv}%
 \tcode{template<class T>\br
  struct add_cv;}                    &
- The member typedef \tcode{type} denotes
- \tcode{add_const_t<add_volatile_t<T>>}.                               \\
+ The member typedef \tcode{type} denotes \tcode{const volatile T}.
+\begin{tailnote}
+\keyword{const} or \keyword{volatile} has no effect when \tcode{T} is a
+reference, function, or top-level const- or volatile-qualified type, respectively.
+\end{tailnote}
+\\
 \end{libreqtab2a}
 
 \rSec3[meta.trans.ref]{Reference modifications}


### PR DESCRIPTION
Also changes the style to west const.

Wordings about reference, function, or top-level _cv_-qualified types are moved to notes as they are redundant at least since C++11.