### PR TITLE
[exec.util.cmplsig.trans] Replace verbose `add_lvalue_reference_t` with plain `&`

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -4910,8 +4910,7 @@ leaving the other completion signatures alone.
 \begin{codeblock}
 template<class... Args>
   using my_set_value_t =
-    completion_signatures<
-      set_value_t(add_lvalue_reference_t<Args>...)>;
+    completion_signatures<set_value_t(Args&...)>;
 
 using my_completion_signatures =
   transform_completion_signatures<


### PR DESCRIPTION
In the example in [exec.util.cmplsig.trans], the fallback mechanism of `add_lvalue_reference_t` doesn't make sense, because when `set_value_t(Args&...)` is an invalid type, `set_value_t(add_lvalue_reference_t<Args>...)` can't be valid. Although use of `add_lvalue_reference_t` possibly triggers more accepts-invalid compiler bugs.

Note that other uses of `add_lvalue_reference_t` are meaningful:
- For `common_with` and `common_referene`, uses of `add_lvalue_reference_t` are necessary to make `common_with<void, void>` satisfied.
- For `unique_ptr`, it is possible to form a `unique_ptr<void, D>` whose `operator*` is well-formed and returns `void`, as `D::pointer` can also have an `operator*` returning `void` ([demo](https://godbolt.org/z/Ph1e1rsfP)).