### PR TITLE
[indirect.asgn], [polymorphic.asgn] Combine related bullets

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -6258,8 +6258,6 @@ using either the allocator in \tcode{*this} or
 %FIXME: Concept "allocator needs updating" not defined/referenced.
 %FIXME: Same for all usages below.
 the allocator in \tcode{other} if the allocator needs updating.
-
-\item
 The previously owned object in \tcode{*this}, if any,
 is destroyed using \tcode{allocator_traits<Allocator>::\linebreak{}destroy} and
 then the storage is deallocated.
@@ -6336,8 +6334,6 @@ using either
 the allocator in \tcode{*this} or
 the allocator in \tcode{other}
 if the allocator needs updating.
-
-\item
 The previously owned object in \tcode{*this}, if any,
 is destroyed using \tcode{allocator_traits<Allocator>::\linebreak{}destroy} and
 then the storage is deallocated.
@@ -7115,8 +7111,6 @@ a new owned object is constructed in \tcode{*this} using
 the owned object from \tcode{other} as the argument, using either
 the allocator in \tcode{*this} or
 the allocator in \tcode{other} if the allocator needs updating.
-
-\item
 The previously owned object in \tcode{*this}, if any,
 is destroyed using \tcode{allocator_traits<Allocator>::\linebreak{}destroy} and
 then the storage is deallocated.
@@ -7179,8 +7173,6 @@ using \tcode{allocator_traits<Allocator>::construct} with
 the owned object from \tcode{other} as the argument as an rvalue,
 using either the allocator in \tcode{*this} or
 the allocator in \tcode{other} if the allocator needs updating.
-
-\item
 The previously owned object in \tcode{*this}, if any,
 is destroyed using \tcode{allocator_traits<Allocator>::\linebreak{}destroy} and
 then the storage is deallocated.


### PR DESCRIPTION
The bullet talking about destroying the previously owned object is only applicable to the bullet immediately before it. The current structure makes it appear to be applicable to all three of the cases that are separated by "otherwise" and are mutually exclusive.