### PR TITLE
[basic.align], [obj.lifetime], [new.delete] Clarify uses of "suitably aligned"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3547,6 +3547,7 @@ Some functions in the \Cpp{} standard library implicitly create objects%
 \indextext{object model|)}
 
 \rSec2[basic.align]{Alignment}
+\indextext{suitably aligned}%
 
 \pnum
 Object types have \defnx{alignment requirements}{alignment requirement!implementation-defined}\iref{basic.fundamental,basic.compound}

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -948,7 +948,7 @@ and not an incomplete type\iref{term.incomplete.type}.
 that is
 a subset of the region of storage
 reachable through\iref{basic.compound} \tcode{p} and
-suitably aligned for the type \tcode{T}.
+suitably aligned\iref{basic.align} for the type \tcode{T}.
 
 \pnum
 \effects
@@ -995,7 +995,7 @@ template<class T>
 
 \pnum
 \expects
-\tcode{p} is suitably aligned for an array of \tcode{T} or is null.
+\tcode{p} is suitably aligned\iref{basic.align} for an array of \tcode{T} or is null.
 \tcode{n <= size_t(-1) / sizeof(T)} is \tcode{true}.
 If \tcode{n > 0} is \tcode{true},
 \range{(char*)p}{(char*)p + (n * sizeof(T))} denotes
@@ -1039,7 +1039,7 @@ template<class T>
 \item
   \range{result}{result + (last - first)} denotes a region of storage that
   is a subset of the region reachable through \tcode{result}\iref{basic.compound}
-  and suitably aligned for the type \tcode{T}.
+  and suitably aligned\iref{basic.align} for the type \tcode{T}.
 \item
   No element in the range \range{first}{last} is a potentially-overlapping subobject.
 \end{itemize}
@@ -1101,7 +1101,7 @@ template<class T>
 \item
   \range{result}{result + (last - first)} denotes a region of storage that is
   a subset of the region reachable through \tcode{result}\iref{basic.compound}
-  and suitably aligned for the type \tcode{T}.
+  and suitably aligned\iref{basic.align} for the type \tcode{T}.
 \item
   No element in the range \range{first}{last} is a potentially-overlapping
   subobject.

--- a/source/support.tex
+++ b/source/support.tex
@@ -2452,7 +2452,8 @@ the first form is called otherwise.
 
 \pnum
 \required
-Return a non-null pointer to suitably aligned storage\iref{basic.stc.dynamic},
+Return a non-null pointer to storage
+aligned as described in \ref{basic.stc.dynamic.allocation},
 or else throw a
 \tcode{bad_alloc}
 \indexlibraryglobal{bad_alloc}%
@@ -2510,7 +2511,8 @@ exception.
 
 \pnum
 \required
-Return a non-null pointer to suitably aligned storage\iref{basic.stc.dynamic},
+Return a non-null pointer to storage
+aligned as described in \ref{basic.stc.dynamic.allocation},
 or else return a null pointer.
 Each of these nothrow versions of
 \tcode{operator new}
@@ -2762,7 +2764,8 @@ exception.
 
 \pnum
 \required
-Return a non-null pointer to suitably aligned storage\iref{basic.stc.dynamic},
+Return a non-null pointer to storage
+aligned as described in \ref{basic.stc.dynamic.allocation},
 or else return a null pointer.
 Each of these nothrow versions of
 \tcode{operator new[]}


### PR DESCRIPTION
As discussed in #7843, there are certain uses of "suitably X" which aren't as clear as they should be. We use "suitably aligned" in a number of places, but that is not a formal term, and it is not in the index.

To clarify these uses of the term, this PR adds an `\indextext{suitably aligned}`, adds references to [basic.align] in [obj.lifetime], and rewords parts of [new.delete].

The last of these is the biggest change. The original wording is
```tex
Return a non-null pointer to suitably aligned storage\iref{basic.stc.dynamic}
```
This is confusing because it looks like "suitably aligned storage" is a defined term which would be found in [basic.stdc.dynamic]. In reality, it's not a defined term, and there are merely some rules more specifically found in [basic.stc.dynamic.allocation].