### PR TITLE
[syntax] to [intro.syntax] to match the other subclause stable names

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -1029,7 +1029,7 @@ semantics can be defined by each implementation.
 \indextext{standard!structure of}%
 \ref{lex} through \ref{\lastcorechapter} describe the \Cpp{} programming
 language. That description includes detailed syntactic specifications in
-a form described in~\ref{syntax}. For convenience, \ref{gram}
+a form described in~\ref{intro.syntax}. For convenience, \ref{gram}
 repeats all such syntactic specifications.
 
 \pnum
@@ -1050,7 +1050,7 @@ published description, and explains in detail the differences between
 purposes; \ref{depr} describes those features.
 \indextext{standard!structure of|)}
 
-\rSec1[syntax]{Syntax notation}
+\rSec1[intro.syntax]{Syntax notation}
 
 \pnum
 \indextext{notation!syntax|(}%

--- a/source/preface.tex
+++ b/source/preface.tex
@@ -16,4 +16,4 @@ that are unaffected by changes of subclause numbering.
 
 Aspects of the language syntax of \Cpp{} are distinguished typographically
 by the use of \fakegrammarterm{italic, sans-serif} type
-or \tcode{constant width} type to avoid ambiguities; see \ref{syntax}.
+or \tcode{constant width} type to avoid ambiguities; see \ref{intro.syntax}.


### PR DESCRIPTION
The stable names for other subclauses in this clause are prepended with "intro." Make the [syntax] stable name follow the same pattern by changing it to [intro.syntax].