### PR TITLE
[container.adaptors] Avoid naming `sorted_{equivalent,unique}_t` tag parameters

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -17138,9 +17138,9 @@ namespace std {
         : @\exposid{c}@(), @\exposid{compare}@(comp) { insert(first, last); }
 
     template<class InputIterator>
-      constexpr flat_map(sorted_unique_t s, InputIterator first, InputIterator last,
+      constexpr flat_map(sorted_unique_t, InputIterator first, InputIterator last,
                          const key_compare& comp = key_compare())
-        : @\exposid{c}@(), @\exposid{compare}@(comp) { insert(s, first, last); }
+        : @\exposid{c}@(), @\exposid{compare}@(comp) { insert(sorted_unique, first, last); }
 
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       constexpr flat_map(from_range_t, R&& rg)
@@ -17152,9 +17152,9 @@ namespace std {
     constexpr flat_map(initializer_list<value_type> il, const key_compare& comp = key_compare())
         : flat_map(il.begin(), il.end(), comp) { }
 
-    constexpr flat_map(sorted_unique_t s, initializer_list<value_type> il,
+    constexpr flat_map(sorted_unique_t, initializer_list<value_type> il,
                        const key_compare& comp = key_compare())
-        : flat_map(s, il.begin(), il.end(), comp) { }
+        : flat_map(sorted_unique, il.begin(), il.end(), comp) { }
 
     // \ref{flat.map.cons.alloc}, constructors with allocators
 
@@ -17265,8 +17265,8 @@ namespace std {
 
     constexpr void insert(initializer_list<value_type> il)
       { insert(il.begin(), il.end()); }
-    constexpr void insert(sorted_unique_t s, initializer_list<value_type> il)
-      { insert(s, il.begin(), il.end()); }
+    constexpr void insert(sorted_unique_t, initializer_list<value_type> il)
+      { insert(sorted_unique, il.begin(), il.end()); }
 
     constexpr containers extract() &&;
     constexpr void replace(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
@@ -17518,10 +17518,10 @@ Same as \tcode{flat_map(key_cont, mapped_cont)} and
 \indexlibraryctor{flat_map}%
 \begin{itemdecl}
 template<class Alloc>
-  constexpr flat_map(sorted_unique_t s, const key_container_type& key_cont,
+  constexpr flat_map(sorted_unique_t, const key_container_type& key_cont,
                      const mapped_container_type& mapped_cont, const Alloc& a);
 template<class Alloc>
-  constexpr flat_map(sorted_unique_t s, const key_container_type& key_cont,
+  constexpr flat_map(sorted_unique_t, const key_container_type& key_cont,
                      const mapped_container_type& mapped_cont, const key_compare& comp,
                      const Alloc& a);
 \end{itemdecl}
@@ -17529,8 +17529,8 @@ template<class Alloc>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to \tcode{flat_map(s, key_cont, mapped_cont)} and
-\tcode{flat_map(s, key_cont, \linebreak{}mapped_cont, comp)}, respectively,
+Equivalent to \tcode{flat_map(sorted_unique, key_cont, mapped_cont)} and
+\tcode{flat_map(sorted_unique, key_cont, \linebreak{}mapped_cont, comp)}, respectively,
 except that \tcode{\exposid{c}.keys} and \tcode{\exposid{c}.values} are constructed
 with uses-allocator construction\iref{allocator.uses.construction}.
 
@@ -18334,9 +18334,9 @@ namespace std {
         { insert(first, last); }
 
     template<class InputIterator>
-      constexpr flat_multimap(sorted_equivalent_t s, InputIterator first, InputIterator last,
+      constexpr flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
                               const key_compare& comp = key_compare())
-        : @\exposid{c}@(), @\exposid{compare}@(comp) { insert(s, first, last); }
+        : @\exposid{c}@(), @\exposid{compare}@(comp) { insert(sorted_equivalent, first, last); }
 
     template<@\exposconcept{container-compatible-range}@<value_type> R>
       constexpr flat_multimap(from_range_t, R&& rg)
@@ -18349,9 +18349,9 @@ namespace std {
                             const key_compare& comp = key_compare())
         : flat_multimap(il.begin(), il.end(), comp) { }
 
-    constexpr flat_multimap(sorted_equivalent_t s, initializer_list<value_type> il,
+    constexpr flat_multimap(sorted_equivalent_t, initializer_list<value_type> il,
                             const key_compare& comp = key_compare())
-        : flat_multimap(s, il.begin(), il.end(), comp) { }
+        : flat_multimap(sorted_equivalent, il.begin(), il.end(), comp) { }
 
     // \ref{flat.multimap.cons.alloc}, constructors with allocators
 
@@ -18453,8 +18453,8 @@ namespace std {
 
     constexpr void insert(initializer_list<value_type> il)
       { insert(il.begin(), il.end()); }
-    constexpr void insert(sorted_equivalent_t s, initializer_list<value_type> il)
-      { insert(s, il.begin(), il.end()); }
+    constexpr void insert(sorted_equivalent_t, initializer_list<value_type> il)
+      { insert(sorted_equivalent, il.begin(), il.end()); }
 
     constexpr containers extract() &&;
     constexpr void replace(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
@@ -18673,10 +18673,10 @@ Same as \tcode{flat_multimap(key_cont, mapped_cont)} and
 \indexlibraryctor{flat_multimap}%
 \begin{itemdecl}
 template<class Alloc>
-  constexpr flat_multimap(sorted_equivalent_t s, const key_container_type& key_cont,
+  constexpr flat_multimap(sorted_equivalent_t, const key_container_type& key_cont,
                 const mapped_container_type& mapped_cont, const Alloc& a);
 template<class Alloc>
-  constexpr flat_multimap(sorted_equivalent_t s, const key_container_type& key_cont,
+  constexpr flat_multimap(sorted_equivalent_t, const key_container_type& key_cont,
                 const mapped_container_type& mapped_cont, const key_compare& comp,
                 const Alloc& a);
 \end{itemdecl}
@@ -18684,8 +18684,8 @@ template<class Alloc>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to \tcode{flat_multimap(s, key_cont, mapped_cont)} and
-\tcode{flat_multimap(s, key_cont, mapped_cont, comp)}, respectively,
+Equivalent to \tcode{flat_multimap(sorted_equivalent, key_cont, mapped_cont)} and
+\tcode{flat_multimap(sorted_equivalent, key_cont, mapped_cont, comp)}, respectively,
 except that \tcode{\exposid{c}.keys} and \tcode{\exposid{c}.val\-ues} are constructed
 with uses-allocator construction\iref{allocator.uses.construction}.
 
@@ -18962,9 +18962,9 @@ namespace std {
     constexpr flat_set(initializer_list<value_type> il, const key_compare& comp = key_compare())
         : flat_set(il.begin(), il.end(), comp) { }
 
-    constexpr flat_set(sorted_unique_t s, initializer_list<value_type> il,
+    constexpr flat_set(sorted_unique_t, initializer_list<value_type> il,
              const key_compare& comp = key_compare())
-        : flat_set(s, il.begin(), il.end(), comp) { }
+        : flat_set(sorted_unique, il.begin(), il.end(), comp) { }
 
     // \ref{flat.set.cons.alloc}, constructors with allocators
 
@@ -19059,8 +19059,8 @@ namespace std {
 
     constexpr void insert(initializer_list<value_type> il)
       { insert(il.begin(), il.end()); }
-    constexpr void insert(sorted_unique_t s, initializer_list<value_type> il)
-      { insert(s, il.begin(), il.end()); }
+    constexpr void insert(sorted_unique_t, initializer_list<value_type> il)
+      { insert(sorted_unique, il.begin(), il.end()); }
 
     constexpr container_type extract() &&;
     constexpr void replace(container_type&&);
@@ -19228,9 +19228,9 @@ Same as \tcode{flat_set(cont)} and \tcode{flat_set(cont, comp)}, respectively.
 \indexlibraryctor{flat_set}%
 \begin{itemdecl}
 template<class Alloc>
-  constexpr flat_set(sorted_unique_t s, const container_type& cont, const Alloc& a);
+  constexpr flat_set(sorted_unique_t, const container_type& cont, const Alloc& a);
 template<class Alloc>
-  constexpr flat_set(sorted_unique_t s, const container_type& cont,
+  constexpr flat_set(sorted_unique_t, const container_type& cont,
                      const key_compare& comp, const Alloc& a);
 \end{itemdecl}
 
@@ -19238,7 +19238,7 @@ template<class Alloc>
 \pnum
 \effects
 Equivalent to
-\tcode{flat_set(s, cont)} and \tcode{flat_set(s, cont, comp)}, respectively,
+\tcode{flat_set(sorted_unique, cont)} and \tcode{flat_set(sorted_unique, cont, comp)}, respectively,
 except that \exposid{c} is constructed with
 uses-allocator construction\iref{allocator.uses.construction}.
 
@@ -19632,9 +19632,9 @@ namespace std {
                             const key_compare& comp = key_compare())
       : flat_multiset(il.begin(), il.end(), comp) { }
 
-    constexpr flat_multiset(sorted_equivalent_t s, initializer_list<value_type> il,
+    constexpr flat_multiset(sorted_equivalent_t, initializer_list<value_type> il,
                             const key_compare& comp = key_compare())
-        : flat_multiset(s, il.begin(), il.end(), comp) { }
+        : flat_multiset(sorted_equivalent, il.begin(), il.end(), comp) { }
 
     // \ref{flat.multiset.cons.alloc}, constructors with allocators
 
@@ -19729,8 +19729,8 @@ namespace std {
 
     constexpr void insert(initializer_list<value_type> il)
       { insert(il.begin(), il.end()); }
-    constexpr void insert(sorted_equivalent_t s, initializer_list<value_type> il)
-      { insert(s, il.begin(), il.end()); }
+    constexpr void insert(sorted_equivalent_t, initializer_list<value_type> il)
+      { insert(sorted_equivalent, il.begin(), il.end()); }
 
     constexpr container_type extract() &&;
     constexpr void replace(container_type&&);
@@ -19898,17 +19898,17 @@ Same as \tcode{flat_multiset(cont)} and
 \indexlibraryctor{flat_multiset}%
 \begin{itemdecl}
 template<class Alloc>
-  constexpr flat_multiset(sorted_equivalent_t s, const container_type& cont, const Alloc& a);
+  constexpr flat_multiset(sorted_equivalent_t, const container_type& cont, const Alloc& a);
 template<class Alloc>
-  constexpr flat_multiset(sorted_equivalent_t s, const container_type& cont,
+  constexpr flat_multiset(sorted_equivalent_t, const container_type& cont,
                           const key_compare& comp, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to \tcode{flat_multiset(s, cont)} and
-\tcode{flat_multiset(s, cont, comp)}, respectively,
+Equivalent to \tcode{flat_multiset(sorted_equivalent, cont)} and
+\tcode{flat_multiset(sorted_equivalent, cont, comp)}, respectively,
 except that \exposid{c} is constructed with
 uses-allocator construction\iref{allocator.uses.construction}.
 


### PR DESCRIPTION
Follows up #7398.