### PR TITLE
[mdspan.layout.right.obs] Add missing constexpr to required_span_size.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -22491,7 +22491,7 @@ Direct-non-list-initializes \exposid{extents_} with \tcode{other.extents()}.
 
 \indexlibrarymember{required_span_size}{layout_right::mapping}%
 \begin{itemdecl}
-index_type required_span_size() const noexcept;
+constexpr index_type required_span_size() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
The missing `constexpr` looks like a typo, because it's present in the overview; and every other method is constexpr.