### PR TITLE
 [associative.reqmts.general] Eliminate the final usage of “multiple keys”

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2738,7 +2738,7 @@ In this subclause,
 when \tcode{X} supports unique keys,
 \item
 \tcode{a_eq} denotes a value of type \tcode{X}
-when \tcode{X} supports multiple keys,
+when \tcode{X} supports equivalent keys,
 \item
 \tcode{a_tran} denotes a value of type \tcode{X} or \tcode{const X}
 when the \grammarterm{qualified-id}


### PR DESCRIPTION
Associative containers possibly containing multiple elements for each key are said to support “equivalent keys”, but there is one place in [containers] that uses the term “multiple keys”. We should eliminate that.