### PR TITLE
[stringbuf.members], [ostringstream.cons], [stringstream.cons] spaces

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -8568,7 +8568,7 @@ template<class SAlloc>
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{is_same_v<SAlloc,Allocator>} is \tcode{false}.
+\tcode{is_same_v<SAlloc, Allocator>} is \tcode{false}.
 
 \pnum
 \effects
@@ -9434,7 +9434,7 @@ template<class SAlloc>
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{is_same_v<SAlloc,Allocator>} is \tcode{false}.
+\tcode{is_same_v<SAlloc, Allocator>} is \tcode{false}.
 
 \pnum
 \effects
@@ -9812,7 +9812,7 @@ template<class SAlloc>
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{is_same_v<SAlloc,Allocator>} is \tcode{false}.
+\tcode{is_same_v<SAlloc, Allocator>} is \tcode{false}.
 
 \pnum
 \effects


### PR DESCRIPTION
In #4335 this change was done for [stringbuf.cons] but these cases were missed.