### PR TITLE
[intro.defs], [dcl.attr.deprecated], [cpp.error] Define the term "warning" and use where appropriate

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -9598,9 +9598,10 @@ Redeclarations using different forms of the attribute (with or without the
 
 \pnum
 \recommended
-Implementations should use the \tcode{deprecated} attribute to produce a diagnostic
-message in case the program refers to a name or entity other than to declare it, after a
-declaration that specifies the attribute. The diagnostic message should include the text provided
+Implementations should use the \tcode{deprecated} attribute to produce a warning
+in case the program refers to a name or entity other than to declare it, after a
+declaration that specifies the attribute.
+The warning should include the text provided
 within the \grammarterm{attribute-argument-clause} of any \tcode{deprecated} attribute applied
 to the name or entity.
 The value of

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -694,6 +694,18 @@ and \tcode{x.front()} can be called only if \tcode{x.empty()} returns
 \tcode{false}.
 \end{example}
 
+\indexdefn{warning}%
+\definition{warning}{defns.warning}
+message belonging to a subset of
+\termref{defns.diagnostic}{diagnostic message}{s}
+produced to provide the user with information about the program,
+not as a consequence of a \Cpp{} program being rejected
+
+\begin{example}
+The \tcode{#warning} directive produces a warning.
+The \tcode{#error} directive produces a diagnostic message that is not a warning\iref{cpp.error}.
+\end{example}
+
 \indexdefn{program!well-formed}%
 \definition{well-formed program}{defns.well.formed}
 \Cpp{} program constructed according to the syntax and semantic rules

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -2098,7 +2098,7 @@ A preprocessing directive of the form
 \begin{ncsimplebnf}
 \terminal{\# warning} \opt{pp-tokens} new-line
 \end{ncsimplebnf}
-requires the implementation to produce at least one diagnostic message
+requires the implementation to produce at least one warning
 for the preprocessing translation unit\iref{intro.compliance.general}.
 \recommended
 Any diagnostic message caused by either of these directives


### PR DESCRIPTION
Closes #7730.
Closes #7728.

The standard currently uses the term "warning" and "diagnostic message", but only the latter term is defined. It would be possible to purge "warning", but @jwakely suggested instead to keep both terms to retain the standard's expressiveness.

I agree with this direction, and the fix is simple.

The overwhelming majority of diagnostic messages are part of IF or IFNDR behavior, or part of an assertion or erroneous behavior, etc.. Only [cpp.error] (`#warning`) and [dcl.attr.deprecated] (`[[deprecated]]`) say "diagnostic message" when they could clearly say "warning".