### PR TITLE
[locale.money.put.members] Fix typo

### DIFF
--- a/source/text.tex
+++ b/source/text.tex
@@ -4339,7 +4339,7 @@ iter_type put(iter_type s, bool intl, ios_base& f, char_type fill, const string_
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{do_put(s, intl, f, loc, quant)}.
+\tcode{do_put(s, intl, f, fill, quant)}.
 \end{itemdescr}
 
 \rSec5[locale.money.put.virtuals]{Virtual functions}


### PR DESCRIPTION
There's nothing named `loc` in this context. Apparently `fill` should be passed instead.