### PR TITLE
[projected] `projected` is now an alias template

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2515,10 +2515,10 @@ namespace std {
 }
 \end{codeblock}
 
-\rSec3[projected]{Class template \tcode{projected}}
+\rSec3[projected]{Alias template \tcode{projected}}
 
 \pnum
-Class template \tcode{projected} is used to constrain algorithms
+Alias template \tcode{projected} is used to constrain algorithms
 that accept callable objects and projections\iref{defns.projection}.
 It combines an \libconcept{indirectly_readable} type \tcode{I} and
 a callable object type \tcode{Proj} into a new \libconcept{indirectly_readable} type


### PR DESCRIPTION
Looks like that P2538R1 forgot changing the description.