### PR TITLE
rename tparam of `schedule_result_t`

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -611,8 +611,8 @@ namespace std::execution {
   inline constexpr schedule_t @\libglobal{schedule}@{};
   inline constexpr @\unspec@ @\libglobal{read_env}@{};
 
-  template<@\libconcept{scheduler}@ Sndr>
-    using @\libglobal{schedule_result_t}@ = decltype(schedule(declval<Sndr>()));
+  template<@\libconcept{scheduler}@ Sch>
+    using @\libglobal{schedule_result_t}@ = decltype(schedule(declval<Sch>()));
 
   // \ref{exec.adapt}, sender adaptors
   template<@\exposconcept{class-type}@ D>


### PR DESCRIPTION
in [exec], `Sndr` is used consistently to be the type of a sender, and `Sch` is used consistently as the type of a scheduler. in [execution.syn], the definition of the `schedule_result_t` is using `Sndr` where it should be using `Sch`.