### PR TITLE
Fix function type name in [exec.let]

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -3536,7 +3536,7 @@ except with duplicate types removed.
 Given a type \tcode{Tag} and a pack \tcode{Args},
 let \exposid{as-sndr2} be an alias template
 such that \tcode{\exposid{as-sndr2}<Tag(Args...)>} denotes
-the type \tcode{\exposid{call-result-t}<Fn, decay_t<Args>\&...>}.
+the type \tcode{\exposid{call-result-t}<F, decay_t<Args>\&...>}.
 Then \tcode{ops2_variant_t} denotes
 the type
 \begin{codeblock}


### PR DESCRIPTION
The specification of `let_value(sndr,fn)` and friends refers to the type of `fn` as "`Fn`". But when introducing the types, we give it the name "`F`". This fixes the inconsistency.