### PR TITLE
[execpol.type] Drop "see below" from `is_execution_policy`

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -640,7 +640,7 @@ parameters for efficient execution.
 
 \indexlibraryglobal{is_execution_policy}%
 \begin{itemdecl}
-template<class T> struct is_execution_policy : bool_constant<@\seebelow@> { };
+template<class T> struct is_execution_policy;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -640,7 +640,7 @@ parameters for efficient execution.
 
 \indexlibraryglobal{is_execution_policy}%
 \begin{itemdecl}
-template<class T> struct is_execution_policy { @\seebelow@ };
+template<class T> struct is_execution_policy : bool_constant<@\seebelow@> { };
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
In order to make `is_execution_policy` satisfity the requirements, an implementation should determine the base class (which is either `true_type` or `false_type`) for each specialization, but not add things into the `{}`.

This PR makes the intent clearer.