### PR TITLE
[meta.trans.other] Fix off-by-one references to meta.rqmts

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -2150,7 +2150,7 @@ Otherwise, there shall be no member \tcode{type}.
 \end{itemize}
 
 \pnum
-Notwithstanding the provisions of \ref{meta.type.synop}, and
+Notwithstanding the provisions of \ref{meta.rqmts}, and
 pursuant to \ref{namespace.std},
 a program may specialize \tcode{common_type<T1, T2>}
 for types \tcode{T1} and \tcode{T2} such that
@@ -2216,7 +2216,7 @@ present as follows:
 \end{itemize}
 
 \pnum
-Notwithstanding the provisions of \ref{meta.type.synop}, and
+Notwithstanding the provisions of \ref{meta.rqmts}, and
 pursuant to \ref{namespace.std}, a program may partially specialize
 \tcode{basic_common_reference<T, U, TQual, UQual>}
 for types \tcode{T} and \tcode{U} such that


### PR DESCRIPTION
The (normative) wording indicates that provisions of subclause 21.3.3 [meta.type.synop] are overridden. It is unclear what provisions of [meta.type.synop] are being overriden.

Instead, the wording rather clearly overrides provisions of subclause 21.3.2 [meta.rqmts].

Address the probable off-by-one errors by changing the references to point to [meta.rqmts].