### PR TITLE
[expected.object.cons] Reorder arguments of is_same_v for consistency

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -7789,7 +7789,7 @@ template<class U = remove_cv_t<T>>
 \item
 \tcode{is_same_v<remove_cvref_t<U>, in_place_t>} is \tcode{false}; and
 \item
-\tcode{is_same_v<expected, remove_cvref_t<U>>} is \tcode{false}; and
+\tcode{is_same_v<remove_cvref_t<U>>, expected} is \tcode{false}; and
 \item
 \tcode{remove_cvref_t<U>} is not a specialization of \tcode{unexpected}; and
 \item


### PR DESCRIPTION
During the discussion of LWG 4222 it was noticed that [expected.object.cons] bullet (23.2) uses an atypical order of the is_same_v arguments, especially since this issue adds another bullet. To enforce consistency, the `remove_cvref_t<U>` argument is no also used as first (instead of second) argument in that bullet.