### PR TITLE
[rand.eng.philox] Use normal font for superscript of "ith"

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -3177,7 +3177,7 @@ $i$ is an index for an element of the sequence $Y$.
 
 \pnum
 The generation algorithm returns $Y_i$,
-the value stored in the $i^{th}$ element of $Y$ after applying
+the value stored in the $i^\text{th}$ element of $Y$ after applying
 the transition algorithm.
 
 \pnum


### PR DESCRIPTION
Consistent with how we say <i>i</i><sup>th</sup> elsewhere, e.g. [tuple.cnstr].