### PR TITLE
[check] Fix MacOS build by sorting all input files for the comparison

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         cfg:
           - { name: 'Linux', os: 'ubuntu-24.04' }
-          # - { name: 'MacOS', os: 'macos-15' }
+          - { name: 'MacOS', os: 'macos-15' }
 
     steps:
       - name: checkout

--- a/tools/check-output.sh
+++ b/tools/check-output.sh
@@ -91,7 +91,7 @@ done
 function indexentries() { sed 's,\\glossaryentry{\(.*\)@.*,\1,' "$1" | LANG=C sort; }
 function removals() { diff -u "$1" "$2" | grep '^-' | grep -v '^---' | sed 's/^-//'; }
 function difference() { diff -u "$1" "$2" | grep '^[-+]' | grep -v '^\(---\|+++\)'; }
-XREFDELTA="$(difference <(indexentries xrefdelta.glo) <(removals <(cat xrefprev) <(indexentries xrefindex.glo)))"
+XREFDELTA="$(difference <(indexentries xrefdelta.glo) <(removals <(LANG=C sort < xrefprev) <(indexentries xrefindex.glo)))"
 if [ -n "$XREFDELTA" ]; then
   echo "incorrect entries in xrefdelta.tex:" >&2
   echo "$XREFDELTA" | sed 's,^-,spurious ,; s,^+,missing ,;' >&2


### PR DESCRIPTION
This makes us independent from any particular sort order a tool might prefer.