### PR TITLE
[diff.cpp23.strings] Move Clause 27 changes after Clause 23 changes

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -240,25 +240,6 @@ Valid \CppXXIII{} code that defines \tcode{replaceable_if_eligible} or
 \tcode{trivially_relocatable_if_eligible} as macros is invalid
 in this revision of \Cpp{}.
 
-\rSec2[diff.cpp23.strings]{\ref{strings}: strings library}
-
-\diffref{string.conversions}
-\change
-Output of floating-point overloads of \tcode{to_string} and \tcode{to_wstring}.
-\rationale
-Prevent loss of information and improve consistency with other formatting
-facilities.
-\effect
-\tcode{to_string} and \tcode{to_wstring} function calls that take
-floating-point arguments may produce a different output.
-\begin{example}
-\begin{codeblock}
-auto s = std::to_string(1e-7);  // \tcode{"1e-07"}
-                                // previously \tcode{"0.000000"} with \tcode{'.'} possibly
-                                // changed according to the global C locale
-\end{codeblock}
-\end{example}
-
 \rSec2[diff.cpp23.containers]{\ref{containers}: containers library}
 
 \diffref{span.overview}
@@ -282,6 +263,25 @@ void *a[10];
 int x = span<void* const>{a, 0}.size();     // \tcode{x} is \tcode{2}; previously \tcode{0}
 any b[10];
 int y = span<const any>{b, b + 10}.size();  // \tcode{y} is \tcode{2}; previously \tcode{10}
+\end{codeblock}
+\end{example}
+
+\rSec2[diff.cpp23.strings]{\ref{strings}: strings library}
+
+\diffref{string.conversions}
+\change
+Output of floating-point overloads of \tcode{to_string} and \tcode{to_wstring}.
+\rationale
+Prevent loss of information and improve consistency with other formatting
+facilities.
+\effect
+\tcode{to_string} and \tcode{to_wstring} function calls that take
+floating-point arguments may produce a different output.
+\begin{example}
+\begin{codeblock}
+auto s = std::to_string(1e-7);  // \tcode{"1e-07"}
+                                // previously \tcode{"0.000000"} with \tcode{'.'} possibly
+                                // changed according to the global C locale
 \end{codeblock}
 \end{example}
 


### PR DESCRIPTION
The 'Strings' clause was moved before the new 'Text processing' clause, so it's now after the 'Containers' clause. The order of the [diff.cpp23] subclauses should reflect that.