### PR TITLE
P3223R2 Making std::istream::ignore less surprising

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -330,6 +330,28 @@ auto s = std::to_string(1e-7);  // \tcode{"1e-07"}
 \end{codeblock}
 \end{example}
 
+\rSec2[diff.cpp23.io]{\ref{input.output}: input/output library}
+
+\diffref{istream.unformatted}
+\change
+Overloaded \tcode{std::basic_istream<char, traits>::ignore}.
+\rationale
+Allow \tcode{char} values to be used as delimiters.
+\effect
+Calls to \tcode{istream::ignore} with a second argument of \tcode{char} type
+can change behavior.
+Calls to \tcode{istream::ignore} with a second argument that is neither
+\tcode{int} nor \tcode{char} type can become ill-formed.
+\begin{example}
+\begin{codeblock}
+std::istringstream in("\xF0\x9F\xA4\xA1 Clown Face");
+in.ignore(100, '\xA1');     // ignore up to \tcode{'\textbackslash{}xA1'} delimiter,
+                            // previously might have ignored to EOF
+in.ignore(100, -1L);        // ambiguous overload,
+                            // previously equivalent to \tcode{(int)-1L}
+\end{codeblock}
+\end{example}
+
 \rSec2[diff.cpp23.depr]{\ref{depr}: compatibility features}
 
 \nodiffref

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4363,6 +4363,7 @@ namespace std {
     basic_istream& getline(char_type* s, streamsize n, char_type delim);
 
     basic_istream& ignore(streamsize n = 1, int_type delim = traits::eof());
+    basic_istream& ignore(streamsize n, char_type delim);
     int_type       peek();
     basic_istream& read    (char_type* s, streamsize n);
     streamsize     readsome(char_type* s, streamsize n);
@@ -5424,6 +5425,21 @@ The last condition will never occur if
 \pnum
 \returns
 \tcode{*this}.
+\end{itemdescr}
+
+\indexlibrarymember{ignore}{basic_istream}%
+\begin{itemdecl}
+basic_istream& ignore(streamsize n, char_type delim);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{is_same_v<char_type, char>} is \tcode{true}.
+
+\pnum
+\effects
+Equivalent to: \tcode{return ignore(n, traits::to_int_type(delim));}
 \end{itemdescr}
 
 \indexlibrarymember{peek}{basic_istream}%


### PR DESCRIPTION
Fixes #7968
Fixes cplusplus/papers#1871