### PR TITLE
P2664R11 Extend std::simd with permutation API

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -16623,14 +16623,14 @@ namespace std::datapar {
     constexpr M compress(const M& v, const type_identity_t<M>& selector);
   template<@\exposconcept{simd-type}@ V>
     constexpr V compress(const V& v, const typename V::mask_type& selector,
-                          const typename V::value_type& fill_value);
+                         const typename V::value_type& fill_value);
   template<@\exposconcept{simd-mask-type}@ M>
     constexpr M compress(const M& v, const type_identity_t<M>& selector,
-                          const typename V::value_type& fill_value);
+                         const typename V::value_type& fill_value);
 
   template<@\exposconcept{simd-type}@ V>
-  constexpr V expand(const V& v, const typename V::mask_type& selector,
-                      const V& original = {});
+    constexpr V expand(const V& v, const typename V::mask_type& selector,
+                       const V& original = {});
   template<@\exposconcept{simd-mask-type}@ M>
     constexpr M expand(const M& v, const type_identity_t<M>& selector, const M& original = {});
 
@@ -18692,10 +18692,9 @@ For all $i$ in the range of \range{0}{basic_simd<T, Abi>::size()}, if
 
 \begin{itemdecl}
 template<@\exposid{simd-size-type}@ N = @\seebelow@, @\exposconcept{simd-type}@ V, class IdxMap>
-constexpr resize_t<N, V> permute(const V& v, IdxMap&& idxmap);
-
+  constexpr resize_t<N, V> permute(const V& v, IdxMap&& idxmap);
 template<@\exposid{simd-size-type}@ N = @\seebelow@, @\exposconcept{simd-mask-type}@ M, class IdxMap>
-constexpr resize_t<N, M> permute(const M& v, IdxMap&& idxmap);
+  constexpr resize_t<N, M> permute(const M& v, IdxMap&& idxmap);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -18719,7 +18718,7 @@ typename V::value_type @\exposid{perm-fn}@() {
 \pnum
 \constraints
 \tcode{integral<invoke_result_t<IdxMap\&, \exposid{simd-size-type}>> ||
-integral<invoke_result_t<IdxMap\&, \exposid{simd-size-type},
+integral<invoke_re\-sult_t<IdxMap\&, \exposid{simd-size-type},
 \exposid{simd-size-type}>>} is \tcode{true}.
 
 \pnum
@@ -18744,7 +18743,6 @@ The default argument for template parameter \tcode{N} is \tcode{V::size()}.
 \begin{itemdecl}
 template<@\exposconcept{simd-type}@ V, @\exposconcept{simd-integral}@ I>
   constexpr resize_t<I::size(), V> permute(const V& v, const I& indices);
-
 template<@\exposconcept{simd-mask-type}@ M, @\exposconcept{simd-integral}@ I>
   constexpr resize_t<I::size(), M> permute(const M& v, const I& indices);
 \end{itemdecl}
@@ -18766,7 +18764,6 @@ the range \range{0}{I::size()}.
 \begin{itemdecl}
 template<@\exposconcept{simd-type}@ V>
   constexpr V compress(const V& v, const typename V::mask_type& selector);
-
 template<@\exposconcept{simd-mask-type}@ M>
   constexpr M compress(const M& v, const type_identity_t<M>& selector);
 \end{itemdecl}
@@ -18795,7 +18792,6 @@ for all $i$ in the range \range{0}{V::size()}.
 template<@\exposconcept{simd-type}@ V>
   constexpr V compress(const V& v, const typename V::mask_type& selector,
                        const typename V::value_type& fill_value);
-
 template<@\exposconcept{simd-mask-type}@ M>
   constexpr M compress(const M& v, const type_identity_t<M>& selector,
                        const typename M::value_type& fill_value);
@@ -18821,9 +18817,7 @@ for all $i$ in the range \range{0}{V::size()}.
 
 \begin{itemdecl}
 template<@\exposconcept{simd-type}@ V>
-  constexpr V expand(const V& v, const typename V::mask_type& selector,
-                     const V& original = {});
-
+  constexpr V expand(const V& v, const typename V::mask_type& selector, const V& original = {});
 template<@\exposconcept{simd-mask-type}@ M>
   constexpr M expand(const M& v, const type_identity_t<M>& selector, const M& original = {});
 \end{itemdecl}
@@ -18851,13 +18845,10 @@ for all $i$ in the range \range{0}{V::size()}.
 \rSec3[simd.permute.memory]{\tcode{simd} memory permute}
 
 \begin{itemdecl}
-template<class V = @\seebelow@,
-         ranges::@\libconcept{contiguous_range}@ R, @\exposconcept{simd-integral}@ I, class... Flags>
+template<class V = @\seebelow@, ranges::@\libconcept{contiguous_range}@ R, @\exposconcept{simd-integral}@ I, class... Flags>
   requires ranges::@\libconcept{sized_range}@<R>
   constexpr V unchecked_gather_from(R&& in, const I& indices, flags<Flags...> f = {});
-
-template<class V = @\seebelow@,
-         ranges::@\libconcept{contiguous_range}@ R, @\exposconcept{simd-integral}@ I, class... Flags>
+template<class V = @\seebelow@, ranges::@\libconcept{contiguous_range}@ R, @\exposconcept{simd-integral}@ I, class... Flags>
   requires ranges::@\libconcept{sized_range}@<R>
   constexpr V unchecked_gather_from(R&& in, const typename I::mask_type& mask,
                                     const I& indices, flags<Flags...> f = {});
@@ -18884,13 +18875,10 @@ The default argument for template parameter \tcode{V} is
 \end{itemdescr}
 
 \begin{itemdecl}
-template<class V = @\seebelow@,
-         ranges::@\libconcept{contiguous_range}@ R, @\exposconcept{simd-integral}@ I, class... Flags>
+template<class V = @\seebelow@, ranges::@\libconcept{contiguous_range}@ R, @\exposconcept{simd-integral}@ I, class... Flags>
   requires ranges::@\libconcept{sized_range}@<R>
   constexpr V partial_gather_from(R&& in, const I& indices, flags<Flags...> f = {});
-
-template<class V = @\seebelow@,
-         ranges::@\libconcept{contiguous_range}@ R, @\exposconcept{simd-integral}@ I, class... Flags>
+template<class V = @\seebelow@, ranges::@\libconcept{contiguous_range}@ R, @\exposconcept{simd-integral}@ I, class... Flags>
   requires ranges::@\libconcept{sized_range}@<R>
   constexpr V partial_gather_from(R&& in, const typename I::mask_type& mask,
                                   const I& indices, flags<Flags...> f = {});
@@ -18929,8 +18917,10 @@ no \tcode{mask} parameter.
 \returns
 A \tcode{basic_simd} or \tcode{basic_simd_mask} object where the $i^\text{th}$
 element is initialized to the result of \tcode{mask[$i$] \&\& indices[$i$] <
-ranges::size(in) ? static_cast<V::value_type>(ranges::data(in)[indices[$i$]]) :
-typename V::value_type()} for all $i$ in the range \range{0}{I::size()}.
+ranges::size(in) ? static_cast<typename
+V::value_type>(range::\brk{}data(in)[indices[$i$]]) : typename
+V::value_type()} for all $i$ in the range \range{0}{I::size()}.
+% FIXME: the above \tcode{...} is too long => Overfull \hbox. codeblock?
 
 \pnum
 \remarks
@@ -18939,18 +18929,14 @@ The default argument for template parameter \tcode{V} is
 \end{itemdescr}
 
 \begin{itemdecl}
-template<@\exposconcept{simd-type}@ V, ranges::@\libconcept{contiguous_range}@ R,
-         @\exposconcept{simd-integral}@ I, class... Flags>
+template<@\exposconcept{simd-type}@ V, ranges::@\libconcept{contiguous_range}@ R, @\exposconcept{simd-integral}@ I, class... Flags>
   requires ranges::@\libconcept{sized_range}@<R>
-  constexpr void unchecked_scatter_to(const V& v, R&& out, const I& indices, flags<Flags...> f = {});
-
-template<@\exposconcept{simd-type}@ V, ranges::@\libconcept{contiguous_range}@ R,
-         @\exposconcept{simd-integral}@ I, class... Flags>
+  constexpr void unchecked_scatter_to(const V& v, R&& out, const I& indices,
+                                      flags<Flags...> f = {});
+template<@\exposconcept{simd-type}@ V, ranges::@\libconcept{contiguous_range}@ R, @\exposconcept{simd-integral}@ I, class... Flags>
   requires ranges::@\libconcept{sized_range}@<R>
-  constexpr void
-  unchecked_scatter_to(const V& v, R&& out,
-                       const typename I::mask_type& mask,
-                       const I& indices, flags<Flags...> f = {});
+  constexpr void unchecked_scatter_to(const V& v, R&& out, const typename I::mask_type& mask,
+                                      const I& indices, flags<Flags...> f = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -18969,15 +18955,11 @@ Equivalent to: \tcode{partial_scatter_to(v, out, mask, indices, f);}
 \end{itemdescr}
 
 \begin{itemdecl}
-template<@\exposconcept{simd-type}@ V, ranges::@\libconcept{contiguous_range}@ R,
-         @\exposconcept{simd-integral}@ I, class... Flags>
+template<@\exposconcept{simd-type}@ V, ranges::@\libconcept{contiguous_range}@ R, @\exposconcept{simd-integral}@ I, class... Flags>
   requires ranges::@\libconcept{sized_range}@<R>
   constexpr void
   partial_scatter_to(const V& v, R&& out, const I& indices, flags<Flags...> f = {});
-
-template<@\exposconcept{simd-type}@ V,
-         ranges::@\libconcept{contiguous_range}@ R,
-         @\exposconcept{simd-integral}@ I, class... Flags>
+template<@\exposconcept{simd-type}@ V, ranges::@\libconcept{contiguous_range}@ R, @\exposconcept{simd-integral}@ I, class... Flags>
   requires ranges::@\libconcept{sized_range}@<R>
   constexpr void
   partial_scatter_to(const V& v, R&& out,

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -19354,7 +19354,7 @@ Let $N$ be the width of \tcode{unsigned long long}.
 \pnum
 \expects
 \begin{itemize}
-\item \tcode{size() <= $N$} is \tcode{true}, or
+\item \tcode{size()} $\le N$, or
 \item for all $i$ in the range \range{$N$}{size()}, \tcode{operator[]($i$)} returns \tcode{false}.
 \end{itemize}
 

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -17187,6 +17187,262 @@ template<class... Other>
   specialization \tcode{\exposid{overaligned-flag}<std::min(N1, N2)>}.
 \end{itemdescr}
 
+\rSec2[simd.iterator]{Class \exposid{simd-iterator}}
+\begin{codeblock}
+namespace std::datapar {
+  template<class V>
+  class @\exposidnc{simd-iterator}@ {         // \expos
+    V* @\exposidnc{data_}@ = nullptr;         // \expos
+    @\exposidnc{simd-size-type} \exposidnc{offset_}@ = 0; // \expos
+
+    constexpr @\exposid{simd-iterator}@(V& d, @\exposid{simd-size-type}@ off) noexcept; // \expos
+
+  public:
+    using value_type = typename V::value_type;
+    using iterator_category = input_iterator_tag;
+    using iterator_concept = random_access_iterator_tag;
+    using difference_type = @\exposid{simd-size-type}@;
+
+    constexpr @\exposid{simd-iterator}@() = default;
+
+    constexpr @\exposid{simd-iterator}@(const @\exposid{simd-iterator}@&) = default;
+    constexpr @\exposid{simd-iterator}@& operator=(const @\exposid{simd-iterator}@&) = default;
+
+    constexpr @\exposid{simd-iterator}@(const @\exposid{simd-iterator}@<remove_const_t<V>>&) requires is_const_v<V>;
+
+    constexpr value_type operator*() const;
+
+    constexpr @\exposid{simd-iterator}@& operator++();
+    constexpr @\exposid{simd-iterator}@ operator++(int);
+    constexpr @\exposid{simd-iterator}@& operator--();
+    constexpr @\exposid{simd-iterator}@ operator--(int);
+
+    constexpr @\exposid{simd-iterator}@& operator+=(difference_type n);
+    constexpr @\exposid{simd-iterator}@& operator-=(difference_type n);
+
+    constexpr value_type operator[](difference_type n) const;
+
+    friend constexpr bool operator==(@\exposid{simd-iterator}@ a, @\exposid{simd-iterator}@ b) = default;
+    friend constexpr bool operator==(@\exposid{simd-iterator}@ a, default_sentinel_t) noexcept;
+    friend constexpr auto operator<=>(@\exposid{simd-iterator}@ a, @\exposid{simd-iterator}@ b);
+
+    friend constexpr @\exposid{simd-iterator}@ operator+(@\exposid{simd-iterator}@ i, difference_type n);
+    friend constexpr @\exposid{simd-iterator}@ operator+(difference_type n, @\exposid{simd-iterator}@ i);
+    friend constexpr @\exposid{simd-iterator}@ operator-(@\exposid{simd-iterator}@ i, difference_type n);
+
+    friend constexpr difference_type operator-(@\exposid{simd-iterator}@ a, @\exposid{simd-iterator}@ b);
+    friend constexpr difference_type operator-(@\exposid{simd-iterator}@ i, default_sentinel_t) noexcept;
+    friend constexpr difference_type operator-(default_sentinel_t, @\exposid{simd-iterator}@ i) noexcept;
+  };
+}
+\end{codeblock}
+
+\begin{itemdecl}
+constexpr @\exposid{simd-iterator}@(V& d, @\exposid{simd-size-type}@ off) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Initializes \exposid{data_} with \tcode{addressof(d)} and \exposid{offset_} with \tcode{off}.
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr @\exposid{simd-iterator}@(const @\exposid{simd-iterator}@<remove_const_t<V>>& i) requires is_const_v<V>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Initializes \exposid{data_} with \tcode{i.\exposid{data_}} and \exposid{offset_} with \tcode{i.\exposid{offset_}}.
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr value_type operator*() const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return (*\exposid{data_})[\exposid{offset_}];}
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr @\exposid{simd-iterator}@& operator++();
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return *this += 1;}
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr @\exposid{simd-iterator}@ operator++(int);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+@\exposid{simd-iterator}@ tmp = *this;
+*this += 1;
+return tmp;
+\end{codeblock}
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr @\exposid{simd-iterator}@& operator--();
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return *this -= 1;}
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr @\exposid{simd-iterator}@ operator--(int);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+@\exposid{simd-iterator}@ tmp = *this;
+*this -= 1;
+return tmp;
+\end{codeblock}
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr @\exposid{simd-iterator}@& operator+=(difference_type n);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{\exposid{offset_} + n} is in the range \crange{0}{V::size()}.
+
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+@\exposid{offset_}@ += n;
+return *this;
+\end{codeblock}
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr @\exposid{simd-iterator}@& operator-=(difference_type n);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{\exposid{offset_} - n} is in the range \crange{0}{V::size()}.
+
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+@\exposid{offset_}@ -= n;
+return *this;
+\end{codeblock}
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr value_type operator[](difference_type n) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return (*\exposid{data_})[\exposid{offset_} + n];}
+\end{itemdescr}
+
+\begin{itemdecl}
+friend constexpr bool operator==(@\exposid{simd-iterator}@ i, default_sentinel_t) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return i.\exposid{offset_} == V::size();}
+\end{itemdescr}
+
+\begin{itemdecl}
+friend constexpr auto operator<=>(@\exposid{simd-iterator}@ a, @\exposid{simd-iterator}@ b);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{a.\exposid{data_} == b.\exposid{data_}} is \tcode{true}.
+
+\pnum
+\effects
+Equivalent to: \tcode{return a.\exposid{offset_} <=> b.\exposid{offset_};}
+\end{itemdescr}
+
+\begin{itemdecl}
+friend constexpr @\exposid{simd-iterator}@ operator+(@\exposid{simd-iterator}@ i, difference_type n);
+friend constexpr @\exposid{simd-iterator}@ operator+(difference_type n, @\exposid{simd-iterator}@ i);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return i += n;}
+\end{itemdescr}
+
+\begin{itemdecl}
+friend constexpr @\exposid{simd-iterator}@ operator-(@\exposid{simd-iterator}@ i, difference_type n);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return i -= n;}
+\end{itemdescr}
+
+\begin{itemdecl}
+friend constexpr difference_type operator-(@\exposid{simd-iterator}@ a, @\exposid{simd-iterator}@ b);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{a.\exposid{data_} == b.\exposid{data_}} is \tcode{true}.
+
+\pnum
+\effects
+Equivalent to: \tcode{return a.\exposid{offset_} - b.\exposid{offset_};}
+\end{itemdescr}
+
+\begin{itemdecl}
+friend constexpr difference_type operator-(@\exposid{simd-iterator}@ i, default_sentinel_t) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return i.\exposid{offset_} - V::size();}
+\end{itemdescr}
+
+
+\begin{itemdecl}
+friend constexpr difference_type operator-(default_sentinel_t, @\exposid{simd-iterator}@ i) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return V::size() - i.\exposid{offset_};}
+\end{itemdescr}
+
 \rSec2[simd.class]{Class template \tcode{basic_simd}}
 
 \rSec3[simd.overview]{Class template \tcode{basic_simd} overview}
@@ -17198,6 +17454,14 @@ namespace std::datapar {
     using value_type = T;
     using mask_type = basic_simd_mask<sizeof(T), Abi>;
     using abi_type = Abi;
+    using iterator = \exposid{simd-iterator}<basic_simd>;
+    using const_iterator = \exposid{simd-iterator}<const basic_simd>;
+
+    constexpr iterator begin() noexcept { return {*this, 0}; }
+    constexpr const_iterator begin() const noexcept { return {*this, 0}; }
+    constexpr const_iterator cbegin() const noexcept { return {*this, 0}; }
+    constexpr default_sentinel_t end() const noexcept { return {}; }
+    constexpr default_sentinel_t cend() const noexcept { return {}; }
 
     static constexpr integral_constant<@\exposid{simd-size-type}@, @\exposid{simd-size-v}@<T, Abi>> size {};
 
@@ -19084,6 +19348,14 @@ namespace std::datapar {
   public:
     using value_type = bool;
     using abi_type = Abi;
+    using iterator = \exposid{simd-iterator}<basic_simd_mask>;
+    using const_iterator = \exposid{simd-iterator}<const basic_simd_mask>;
+
+    constexpr iterator begin() noexcept { return {*this, 0}; }
+    constexpr const_iterator begin() const noexcept { return {*this, 0}; }
+    constexpr const_iterator cbegin() const noexcept { return {*this, 0}; }
+    constexpr default_sentinel_t end() const noexcept { return {}; }
+    constexpr default_sentinel_t cend() const noexcept { return {}; }
 
     static constexpr integral_constant<@\exposid{simd-size-type}@, @\exposid{simd-size-v}@<@\exposid{integer-from}@<Bytes>, Abi>>
       size {};

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -18691,11 +18691,6 @@ For all $i$ in the range of \range{0}{basic_simd<T, Abi>::size()}, if
 \rSec3[simd.permute.static]{\tcode{simd} static permute}
 
 \begin{itemdecl}
-static constexpr @\exposid{simd-size-type}@ zero_element   = @\impdefx{value of \tcode{simd::zero_element}}@;
-static constexpr @\exposid{simd-size-type}@ uninit_element = @\impdefx{value of \tcode{simd::uninit_element}}@;
-\end{itemdecl}
-
-\begin{itemdecl}
 template<@\exposid{simd-size-type}@ N = @\seebelow@, @\exposconcept{simd-type}@ V, class IdxMap>
 constexpr resize_t<N, V> permute(const V& v, IdxMap&& idxmap);
 

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -16221,6 +16221,11 @@ template<class V>
     is_default_constructible_v<V>;
 
 template<class V>
+  concept @\defexposconceptnc{simd-mask-type}@ =                                           // \expos
+    @\libconcept{same_as}@<V, basic_simd_mask<@\exposid{mask-element-size}@<V>, typename V::abi_type>> &&
+    is_default_constructible_v<V>;
+
+template<class V>
   concept @\defexposconceptnc{simd-floating-point}@ =                                      // \expos
     @\exposconcept{simd-type}@<V> && @\libconcept{floating_point}@<typename V::value_type>;
 
@@ -16591,6 +16596,94 @@ namespace std::datapar {
     requires @\libconcept{indirectly_writable}@<I, T>
     constexpr void partial_store(const basic_simd<T, Abi>& v, I first, S last,
       const typename basic_simd<T, Abi>::mask_type& mask, flags<Flags...> f = {});
+
+  // \ref{simd.permute.static}, Permute by static index generator
+  static constexpr @\exposid{simd-size-type}@ zero_element   = @\impdefx{value of \tcode{simd::zero_element}}@;
+  static constexpr @\exposid{simd-size-type}@ uninit_element = @\impdefx{value of \tcode{simd::uninit_element}}@;
+
+  template<@\exposid{simd-size-type}@ N = @\seebelow@, @\exposconcept{simd-type}@ V, class IdxMap>
+    constexpr resize_t<N, V> permute(const V& v, IdxMap&& idxmap);
+  template<@\exposid{simd-size-type}@ N = @\seebelow@, @\exposconcept{simd-mask-type}@ M, class IdxMap>
+    constexpr resize_t<N, M> permute(const M& v, IdxMap&& idxmap);
+
+  // \ref{simd.permute.dynamic}, Permute by dynamic index
+  template<@\exposconcept{simd-type}@ V, @\exposconcept{simd-integral}@ I>
+    constexpr resize_t<I::size(), V> permute(const V& v, const I& indices);
+  template<@\exposconcept{simd-mask-type}@ V, @\exposconcept{simd-integral}@ I>
+    constexpr resize_t<I::size(), V> permute(const V& v, const I& indices);
+
+  // \ref{simd.permute.mask}, Permute by active mask bits
+  template<@\exposconcept{simd-type}@ V>
+    constexpr V compress(const V& v, const typename V::mask_type& selector);
+  template<@\exposconcept{simd-mask-type}@ V>
+    constexpr V compress(const V& v, const type_identity_t<V>& selector);
+  template<@\exposconcept{simd-type}@ V>
+    constexpr V compress(const V& v, const typename V::mask_type& selector,
+                          const typename V::value_type& fill_value);
+  template<@\exposconcept{simd-mask-type}@ V>
+    constexpr V compress(const V& v, const type_identity_t<V>& selector,
+                          const typename V::value_type& fill_value);
+
+  template<@\exposconcept{simd-type}@ V>
+  constexpr V expand(const V& v, const typename V::mask_type& selector,
+                      const V& original = {});
+  template<@\exposconcept{simd-mask-type}@ V>
+    constexpr V expand(const V& v, const type_identity_t<V>& selector, const V& original = {});
+
+    // \ref{simd.permute.memory}, Permute to and from memory
+  template<class V = @\seebelow@,
+           ranges::@\libconcept{contiguous_range}@ R, @\exposconcept{simd-integral}@ I, class... Flags>
+    requires ranges::@\libconcept{sized_range}@<R>
+    constexpr V
+      unchecked_gather_from(R&& in, const I& indices, flags<Flags...> f = {});
+  template<class V = @\seebelow@,
+           ranges::@\libconcept{contiguous_range}@ R, @\exposconcept{simd-integral}@ I, class... Flags>
+    requires ranges::@\libconcept{sized_range}@<R>
+    constexpr V
+      unchecked_gather_from(R&& in, const typename I::mask_type& mask,
+                            const I& indices, flags<Flags...> f = {});
+
+  template<class V = @\seebelow@,
+     ranges::@\libconcept{contiguous_range}@ R, @\exposconcept{simd-integral}@ I, class... Flags>
+    requires ranges::@\libconcept{sized_range}@<R>
+    constexpr V
+      partial_gather_from(R&& in, const I& indices, flags<Flags...> f = {});
+  template<class V = @\seebelow@,
+             ranges::@\libconcept{contiguous_range}@ R, @\exposconcept{simd-integral}@ I, class... Flags>
+    requires ranges::@\libconcept{sized_range}@<R>
+    constexpr V
+      partial_gather_from(R&& in, const typename I::mask_type& mask,
+                          const I& indices, flags<Flags...> f = {});
+
+  template<@\exposconcept{simd-type}@ V,
+           ranges::@\libconcept{contiguous_range}@ R,
+           @\exposconcept{simd-integral}@ I, class... Flags>
+    requires ranges::@\libconcept{sized_range}@<R>
+    constexpr void
+      unchecked_scatter_to(const V& v, R&& out, const I& indices, flags<Flags...> f = {});
+  template<@\exposconcept{simd-type}@ V,
+           ranges::@\libconcept{contiguous_range}@ R,
+           @\exposconcept{simd-integral}@ I, class... Flags>
+    requires ranges::@\libconcept{sized_range}@<R>
+    constexpr void
+      unchecked_scatter_to(const V& v, R&& out,
+                           const typename I::mask_type& mask,
+                           const I& indices, flags<Flags...> f = {});
+
+  template<@\exposconcept{simd-type}@ V,
+           ranges::@\libconcept{contiguous_range}@ R,
+           @\exposconcept{simd-integral}@ I, class... Flags>
+    requires ranges::@\libconcept{sized_range}@<R>
+    constexpr void
+      partial_scatter_to(const V& v, R&& out, const I& indices, flags<Flags...> f = {});
+  template<@\exposconcept{simd-type}@ V,
+           ranges::@\libconcept{contiguous_range}@ R,
+           @\exposconcept{simd-integral}@ I, class... Flags>
+    requires ranges::@\libconcept{sized_range}@<R>
+    constexpr void
+      partial_scatter_to(const V& v, R&& out,
+                         const typename I::mask_type& mask,
+                         const I& indices, flags<Flags...> f = {});
 
   // \ref{simd.creation}, \tcode{basic_simd} and \tcode{basic_simd_mask} creation
   template<class T, class Abi>
@@ -17481,6 +17574,8 @@ namespace std::datapar {
 
     // \ref{simd.subscr}, \tcode{basic_simd} subscript operators
     constexpr value_type operator[](@\exposid{simd-size-type}@) const;
+    template<@\exposconcept{simd-integral}@ I>
+      constexpr resize_t<I::size(), basic_simd> operator[](const I& indices) const;
 
     // \ref{simd.unary}, \tcode{basic_simd} unary operators
     constexpr basic_simd& operator++() noexcept;
@@ -17799,6 +17894,17 @@ The value of the $i^\text{th}$ element.
 \pnum
 \throws
 Nothing.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<@\exposconcept{simd-integral}@ I>
+  constexpr resize_t<I::size(), basic_simd> operator[](const I& indices) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return permute(*this, indices);}
 \end{itemdescr}
 
 \rSec3[simd.unary]{\tcode{basic_simd} unary operators}
@@ -18576,6 +18682,346 @@ Let
 For all $i$ in the range of \range{0}{basic_simd<T, Abi>::size()}, if
 \tcode{mask[$i$] \&\& $i$ < ranges::\brk{}size(r)} is \tcode{true}, evaluates
 \tcode{ranges::data(r)[$i$] = v[$i$]}.
+\end{itemdescr}
+
+\rSec3[simd.permute.static]{\tcode{simd} static permute}
+
+\begin{itemdecl}
+static constexpr @\exposid{simd-size-type}@ zero_element   = @\impdefx{value of \tcode{simd::zero_element}}@;
+static constexpr @\exposid{simd-size-type}@ uninit_element = @\impdefx{value of \tcode{simd::uninit_element}}@;
+\end{itemdecl}
+
+\begin{itemdecl}
+template<@\exposid{simd-size-type}@ N = @\seebelow@, @\exposconcept{simd-type}@ V, class IdxMap>
+constexpr resize_t<N, V> permute(const V& v, IdxMap&& idxmap);
+
+template<@\exposid{simd-size-type}@ N = @\seebelow@, @\exposconcept{simd-mask-type}@ V, class IdxMap>
+constexpr resize_t<N, V> permute(const V& v, IdxMap&& idxmap);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let:
+\begin{itemize}
+\item \tcode{\exposid{gen-fn}($i$)} be \tcode{idxmap($i$, V::size())}
+    if that expression is well-formed, and \tcode{idxmap($i$)} otherwise.
+\item \tcode{perm-fn} be the following exposition-only function template:
+\begin{codeblock}
+template<@\exposid{simd-size-type}@ I>
+typename V::value_type @\exposid{perm-fn}@() {
+    constexpr auto src_index = @\exposid{gen-fn}@(I);
+    if constexpr (src_index == zero_element) return typename V::value_type();
+    else if constexpr (src_index == uninit_element) return @\exposid{unspecified-value}@;
+    else return v[src_index];
+}
+\end{codeblock}
+\end{itemize}
+
+\pnum
+\constraints
+\tcode{integral<invoke_result_t<IdxMap\&, \exposid{simd-size-type}>> ||
+integral<invoke_result_t<IdxMap\&, \exposid{simd-size-type},
+\exposid{simd-size-type}>>} is \tcode{true}.
+
+\pnum
+\mandates
+\tcode{\exposid{gen-fn}($i$)} is a constant expression whose value is
+\tcode{zero_element}, \tcode{uninit_element}, or in the range
+\range{0}{V::size()}, for all $i$ in the range \range{0}{N}.
+
+\pnum
+\returns
+A \tcode{basic_simd} or \tcode{basic_simd_mask} object where the
+$i^\text{th}$ element is initialized to the result of
+\tcode{\exposid{perm-fn}<$i$>()} for all $i$ in the range \range{0}{N}.
+
+\pnum
+\remarks
+The default argument for template parameter \tcode{N} is \tcode{V::size()}.
+\end{itemdescr}
+
+\rSec3[simd.permute.dynamic]{\tcode{simd} dynamic permute}
+
+\begin{itemdecl}
+template<@\exposconcept{simd-type}@ V, @\exposconcept{simd-integral}@ I>
+  constexpr resize_t<I::size(), V> permute(const V& v, const I& indices);
+
+template<@\exposconcept{simd-mask-type}@ V, @\exposconcept{simd-integral}@ I>
+  constexpr resize_t<I::size(), V> permute(const V& v, const I& indices);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+All values in \tcode{indices} are in the range \range{0}{V::size()}.
+
+\pnum
+\returns
+A \tcode{basic_simd} or \tcode{basic_simd_mask} object where the $i^\text{th}$
+element is initialized to the result of \tcode{v[indices[$i$]]} for all $i$ in
+the range \range{0}{I::size()}.
+\end{itemdescr}
+
+\rSec3[simd.permute.mask]{\tcode{simd} mask permute}
+
+\begin{itemdecl}
+template<@\exposconcept{simd-type}@ V>
+  constexpr V compress(const V& v, const typename V::mask_type& selector);
+
+template<@\exposconcept{simd-mask-type}@ V>
+  constexpr V compress(const V& v, const type_identity_t<V>& selector);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let:
+\begin{itemize}
+\item \tcode{\exposid{bit-index}($i$)} be a function which returns the index
+  of the $i$'th element of \tcode{selector} that is \tcode{true}.
+\item \tcode{\exposid{select-value}($i$)} be a function which returns
+  \tcode{v[\exposid{bit-index}($i$)]} for $i$ in the range
+  \range{0}{reduce_count(selector)} and a valid but unspecified value
+  otherwise. [*Note*: Different calls to \tcode{select-value} can return
+  different unspecified values. - *end note*]
+\end{itemize}
+
+\pnum
+\returns
+A \tcode{basic_simd} or \tcode{basic_simd_mask} object where the $i^\text{th}$
+element is initialized to the result of \tcode{\exposid{select-value}($i$)}
+for all $i$ in the range \range{0}{V::size()}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<@\exposconcept{simd-type}@ V>
+  constexpr V compress(const V& v, const typename V::mask_type& selector,
+                       const typename V::value_type& fill_value);
+
+template<@\exposconcept{simd-mask-type}@ V>
+  constexpr V compress(const V& v, const type_identity_t<V>& selector,
+                       const typename V::value_type& fill_value);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let:
+\begin{itemize}
+\item \tcode{\exposid{bit-index}($i$)} be a function which returns the index
+  of the $i$'th element of \tcode{selector} that is \tcode{true}.
+\item \tcode{\exposid{select-value}($i$)} be a function which returns
+  \tcode{v[\exposid{bit-index}($i$)]} for $i$ in the range
+  \range{0}{reduce_count(selector)} and \tcode{fill_value} otherwise.
+\end{itemize}
+
+\pnum
+\returns
+A \tcode{basic_simd} or \tcode{basic_simd_mask} object where the $i^\text{th}$
+element is initialized to the result of \tcode{\exposid{select-value}($i$)}
+for all $i$ in the range \range{0}{V::size()}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<@\exposconcept{simd-type}@ V>
+  constexpr V expand(const V& v, const typename V::mask_type& selector,
+                     const V& original = {});
+
+template<@\exposconcept{simd-mask-type}@ V>
+  constexpr V expand(const V& v, const type_identity_t<V>& selector, const V& original = {});
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let:
+\begin{itemize}
+\item \tcode{set-indices} be a list of the index positions of \tcode{true}
+  elements in \tcode{selector}.
+\item \tcode{\exposid{bit-lookup}(b)} be a function which returns the index
+  where \tcode{b} appears in \tcode{\exposid{set-indices}}.
+\item \tcode{\exposid{select-value}($i$)} be a function which returns
+  \tcode{v[\exposid{bit-lookup}($i$)]} if \tcode{selector[$i$]} is
+  \tcode{true}, otherwise returns \tcode{original[$i$]}.
+\end{itemize}
+
+\pnum
+\returns
+A \tcode{basic_simd} or \tcode{basic_simd_mask} object where the $i^\text{th}$
+element is initialized to the result of \tcode{\exposid{select-value}($i$)}
+for all $i$ in the range \range{0}{V::size()}.
+\end{itemdescr}
+
+\rSec3[simd.permute.memory]{\tcode{simd} memory permute}
+
+\begin{itemdecl}
+template<class V = @\seebelow@,
+         ranges::@\libconcept{contiguous_range}@ R, @\exposconcept{simd-integral}@ I, class... Flags>
+  requires ranges::@\libconcept{sized_range}@<R>
+  constexpr V unchecked_gather_from(R&& in, const I& indices, flags<Flags...> f = {});
+
+template<class V = @\seebelow@,
+         ranges::@\libconcept{contiguous_range}@ R, @\exposconcept{simd-integral}@ I, class... Flags>
+  requires ranges::@\libconcept{sized_range}@<R>
+  constexpr V unchecked_gather_from(R&& in, const typename I::mask_type& mask,
+                                    const I& indices, flags<Flags...> f = {});
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{mask} be \tcode{typename I::mask_type(true)} for the overload with
+no \tcode{mask} parameter.
+
+\pnum
+\expects
+All values in \tcode{select(mask, indices, typename I::value_type())} are in
+the range \range{0}{ranges::size(in)}.
+
+\pnum
+\effects
+Equivalent to: \tcode{return partial_gather_from<V>(in, mask, indices, f);}
+
+\pnum
+\remarks
+The default argument for template parameter \tcode{V} is
+\tcode{simd<ranges::range_value_t<R>, I::size()>}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class V = @\seebelow@,
+         ranges::@\libconcept{contiguous_range}@ R, @\exposconcept{simd-integral}@ I, class... Flags>
+  requires ranges::@\libconcept{sized_range}@<R>
+  constexpr V partial_gather_from(R&& in, const I& indices, flags<Flags...> f = {});
+
+template<class V = @\seebelow@,
+         ranges::@\libconcept{contiguous_range}@ R, @\exposconcept{simd-integral}@ I, class... Flags>
+  requires ranges::@\libconcept{sized_range}@<R>
+  constexpr V partial_gather_from(R&& in, const typename I::mask_type& mask,
+                                  const I& indices, flags<Flags...> f = {});
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{mask} be \tcode{typename I::mask_type(true)} for the overload with
+no \tcode{mask} parameter.
+
+\pnum
+\mandates
+\begin{itemize}
+\item \tcode{ranges::range_value_t<R>} is a vectorizable type,
+\item \tcode{same_as<remove_cvref_t<V>, V>} is \tcode{true},
+\item \tcode{V} is an enabled specialization of \tcode{basic_simd},
+\item \tcode{V::size() == I::size()} is \tcode{true}, and
+\item if the template parameter pack \tcode{Flags} does not contain
+  \tcode{convert-flag}, then the conversion from
+  \tcode{ranges::range_value_t<R>} to \tcode{V::value_type} is
+  value-preserving.
+\end{itemize}
+
+\pnum
+\expects
+\begin{itemize}
+\item If the template parameter pack \tcode{Flags} contains
+  \tcode{aligned-flag}, \tcode{ranges::data(in)} points to storage aligned by
+  \tcode{alignment_v<V, ranges::range_value_t<R>>}.
+\item If the template parameter pack \tcode{Flags} contains
+  \tcode{\exposid{overaligned-flag}<N>}, \tcode{ranges::data(in)} points to
+  storage aligned by \tcode{N}.
+\end{itemize}
+
+\pnum
+\returns
+A \tcode{basic_simd} or \tcode{basic_simd_mask} object where the $i^\text{th}$
+element is initialized to the result of \tcode{mask[$i$] \&\& indices[$i$] <
+ranges::size(in) ? static_cast<V::value_type>(ranges::data(in)[indices[$i$]]) :
+typename V::value_type()} for all $i$ in the range \range{0}{I::size()}.
+
+\pnum
+\remarks
+The default argument for template parameter \tcode{V} is
+\tcode{simd<ranges::range_value_t<R>, I::size()>}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<@\exposconcept{simd-type}@ V, ranges::@\libconcept{contiguous_range}@ R,
+         @\exposconcept{simd-integral}@ I, class... Flags>
+  requires ranges::@\libconcept{sized_range}@<R>
+  constexpr void unchecked_scatter_to(const V& v, R&& out, const I& indices, flags<Flags...> f = {});
+
+template<@\exposconcept{simd-type}@ V, ranges::@\libconcept{contiguous_range}@ R,
+         @\exposconcept{simd-integral}@ I, class... Flags>
+  requires ranges::@\libconcept{sized_range}@<R>
+  constexpr void
+  unchecked_scatter_to(const V& v, R&& out,
+                       const typename I::mask_type& mask,
+                       const I& indices, flags<Flags...> f = {});
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{mask} be \tcode{typename I::mask_type(true)} for the overload with
+no \tcode{mask} parameter.
+
+\pnum
+\expects
+All values in \tcode{select(mask, indices, typename I::value_type())} are in
+the range \range{0}{ranges::size(out)}.
+
+\pnum
+\effects
+Equivalent to: \tcode{partial_scatter_to(v, out, mask, indices, f);}
+\end{itemdescr}
+
+\begin{itemdecl}
+template<@\exposconcept{simd-type}@ V, ranges::@\libconcept{contiguous_range}@ R,
+         @\exposconcept{simd-integral}@ I, class... Flags>
+  requires ranges::@\libconcept{sized_range}@<R>
+  constexpr void
+  partial_scatter_to(const V& v, R&& out, const I& indices, flags<Flags...> f = {});
+
+template<@\exposconcept{simd-type}@ V,
+         ranges::@\libconcept{contiguous_range}@ R,
+         @\exposconcept{simd-integral}@ I, class... Flags>
+  requires ranges::@\libconcept{sized_range}@<R>
+  constexpr void
+  partial_scatter_to(const V& v, R&& out,
+                     const typename I::mask_type& mask,
+                     const I& indices, flags<Flags...> f = {});
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{mask} be \tcode{typename I::mask_type(true)} for the overload with
+no \tcode{mask} parameter.
+
+\pnum
+\constraints
+\tcode{V::size() == I::size()} is \tcode{true}.
+
+\pnum
+\mandates
+\begin{itemize}
+\item \tcode{ranges::range_value_t<R>} is a vectorizable type, and
+\item if the template parameter pack \tcode{Flags} does not contain
+  \tcode{convert-flag}, then the conversion from \tcode{V::value_type} to
+  \tcode{ranges::range_value_t<R>} is value-preserving.
+\end{itemize}
+
+\pnum
+\expects
+\begin{itemize}
+\item For all selected indices *$i$* the values \tcode{indices[$i$]} are
+  unique.
+\item If the template parameter pack \tcode{Flags} contains
+  \tcode{aligned-flag}, \tcode{ranges::data(out)} points to storage aligned by
+  \tcode{alignment_v<V, ranges::range_value_t<R>>}.
+\item If the template parameter pack \tcode{Flags} contains
+  \tcode{\exposid{overaligned-flag}<N>}, \tcode{ranges::data(out)} points to
+  storage aligned by \tcode{N}.
+\end{itemize}
+
+\pnum
+\effects
+For all $i$ in the range \range{0}{I::size()}, if \tcode{mask[$i$] \&\&
+(indices[$i$] < ranges::size(out))} is \tcode{true}, evaluates
+\tcode{ranges::data(out)[indices[$i$]] = v[$i$]}.
 \end{itemdescr}
 
 \rSec3[simd.creation]{\tcode{basic_simd} and \tcode{basic_simd_mask} creation}
@@ -19372,6 +19818,8 @@ namespace std::datapar {
 
     // \ref{simd.mask.subscr}, \tcode{basic_simd_mask} subscript operators
     constexpr value_type operator[](@\exposid{simd-size-type}@) const;
+    template<@\exposconcept{simd-integral}@ I>
+      constexpr resize_t<I::size(), basic_simd_mask> operator[](const I& indices) const;
 
     // \ref{simd.mask.unary}, \tcode{basic_simd_mask} unary operators
     constexpr basic_simd_mask operator!() const noexcept;
@@ -19562,6 +20010,17 @@ The value of the $i^\text{th}$ element.
 \pnum
 \throws
 Nothing.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<@\exposconcept{simd-integral}@ I>
+  constexpr resize_t<I::size(), basic_simd_mask> operator[](const I& indices) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return permute(*this, indices);}
 \end{itemdescr}
 
 \rSec3[simd.mask.unary]{\tcode{basic_simd_mask} unary operators}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -19267,7 +19267,7 @@ constexpr explicit basic_simd_mask(@\libconcept{unsigned_integral}@ auto val) no
 \effects
 Initializes the first $M$ elements to the corresponding bit values in
 \tcode{val}, where $M$ is the smaller of \tcode{size()} and the number of bits in
-the value representation \iref{basic.types.general} of the type of \tcode{val}. If
+the value representation\iref{basic.types.general} of the type of \tcode{val}. If
 $M$ is less than \tcode{size()}, the remaining elements are initialized to
 zero.
 \end{itemdescr}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -16613,26 +16613,26 @@ namespace std::datapar {
   // \ref{simd.permute.dynamic}, Permute by dynamic index
   template<@\exposconcept{simd-type}@ V, @\exposconcept{simd-integral}@ I>
     constexpr resize_t<I::size(), V> permute(const V& v, const I& indices);
-  template<@\exposconcept{simd-mask-type}@ V, @\exposconcept{simd-integral}@ I>
-    constexpr resize_t<I::size(), V> permute(const V& v, const I& indices);
+  template<@\exposconcept{simd-mask-type}@ M, @\exposconcept{simd-integral}@ I>
+    constexpr resize_t<I::size(), M> permute(const M& v, const I& indices);
 
   // \ref{simd.permute.mask}, Permute by active mask bits
   template<@\exposconcept{simd-type}@ V>
     constexpr V compress(const V& v, const typename V::mask_type& selector);
-  template<@\exposconcept{simd-mask-type}@ V>
-    constexpr V compress(const V& v, const type_identity_t<V>& selector);
+  template<@\exposconcept{simd-mask-type}@ M>
+    constexpr M compress(const M& v, const type_identity_t<M>& selector);
   template<@\exposconcept{simd-type}@ V>
     constexpr V compress(const V& v, const typename V::mask_type& selector,
                           const typename V::value_type& fill_value);
-  template<@\exposconcept{simd-mask-type}@ V>
-    constexpr V compress(const V& v, const type_identity_t<V>& selector,
+  template<@\exposconcept{simd-mask-type}@ M>
+    constexpr M compress(const M& v, const type_identity_t<M>& selector,
                           const typename V::value_type& fill_value);
 
   template<@\exposconcept{simd-type}@ V>
   constexpr V expand(const V& v, const typename V::mask_type& selector,
                       const V& original = {});
-  template<@\exposconcept{simd-mask-type}@ V>
-    constexpr V expand(const V& v, const type_identity_t<V>& selector, const V& original = {});
+  template<@\exposconcept{simd-mask-type}@ M>
+    constexpr M expand(const M& v, const type_identity_t<M>& selector, const M& original = {});
 
     // \ref{simd.permute.memory}, Permute to and from memory
   template<class V = @\seebelow@,
@@ -18694,8 +18694,8 @@ For all $i$ in the range of \range{0}{basic_simd<T, Abi>::size()}, if
 template<@\exposid{simd-size-type}@ N = @\seebelow@, @\exposconcept{simd-type}@ V, class IdxMap>
 constexpr resize_t<N, V> permute(const V& v, IdxMap&& idxmap);
 
-template<@\exposid{simd-size-type}@ N = @\seebelow@, @\exposconcept{simd-mask-type}@ V, class IdxMap>
-constexpr resize_t<N, V> permute(const V& v, IdxMap&& idxmap);
+template<@\exposid{simd-size-type}@ N = @\seebelow@, @\exposconcept{simd-mask-type}@ M, class IdxMap>
+constexpr resize_t<N, M> permute(const M& v, IdxMap&& idxmap);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -18745,8 +18745,8 @@ The default argument for template parameter \tcode{N} is \tcode{V::size()}.
 template<@\exposconcept{simd-type}@ V, @\exposconcept{simd-integral}@ I>
   constexpr resize_t<I::size(), V> permute(const V& v, const I& indices);
 
-template<@\exposconcept{simd-mask-type}@ V, @\exposconcept{simd-integral}@ I>
-  constexpr resize_t<I::size(), V> permute(const V& v, const I& indices);
+template<@\exposconcept{simd-mask-type}@ M, @\exposconcept{simd-integral}@ I>
+  constexpr resize_t<I::size(), M> permute(const M& v, const I& indices);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -18767,8 +18767,8 @@ the range \range{0}{I::size()}.
 template<@\exposconcept{simd-type}@ V>
   constexpr V compress(const V& v, const typename V::mask_type& selector);
 
-template<@\exposconcept{simd-mask-type}@ V>
-  constexpr V compress(const V& v, const type_identity_t<V>& selector);
+template<@\exposconcept{simd-mask-type}@ M>
+  constexpr M compress(const M& v, const type_identity_t<M>& selector);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -18796,9 +18796,9 @@ template<@\exposconcept{simd-type}@ V>
   constexpr V compress(const V& v, const typename V::mask_type& selector,
                        const typename V::value_type& fill_value);
 
-template<@\exposconcept{simd-mask-type}@ V>
-  constexpr V compress(const V& v, const type_identity_t<V>& selector,
-                       const typename V::value_type& fill_value);
+template<@\exposconcept{simd-mask-type}@ M>
+  constexpr M compress(const M& v, const type_identity_t<M>& selector,
+                       const typename M::value_type& fill_value);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -18824,8 +18824,8 @@ template<@\exposconcept{simd-type}@ V>
   constexpr V expand(const V& v, const typename V::mask_type& selector,
                      const V& original = {});
 
-template<@\exposconcept{simd-mask-type}@ V>
-  constexpr V expand(const V& v, const type_identity_t<V>& selector, const V& original = {});
+template<@\exposconcept{simd-mask-type}@ M>
+  constexpr M expand(const M& v, const type_identity_t<M>& selector, const M& original = {});
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -16230,6 +16230,10 @@ template<class V>
     @\exposconcept{simd-type}@<V> && @\libconcept{floating_point}@<typename V::value_type>;
 
 template<class V>
+  concept @\defexposconceptnc{simd-integral}@ =                                            // \expos
+    @\exposconcept{simd-type}@<V> && @\libconcept{integral}@<typename V::value_type>;
+
+template<class V>
   using @\exposidnc{simd-complex-value-type}@ = typename V::value_type::value_type; // \expos
 
 template<class V>

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -19095,6 +19095,8 @@ namespace std::datapar {
     template<size_t UBytes, class UAbi>
       constexpr explicit basic_simd_mask(const basic_simd_mask<UBytes, UAbi>&) noexcept;
     template<class G> constexpr explicit basic_simd_mask(G&& gen) noexcept;
+    constexpr basic_simd_mask(const bitset<size()>& b) noexcept;
+    constexpr explicit basic_simd_mask(@\libconcept{unsigned_integral}@ auto val) noexcept;
 
     // \ref{simd.mask.subscr}, \tcode{basic_simd_mask} subscript operators
     constexpr value_type operator[](@\exposid{simd-size-type}@) const;
@@ -19108,6 +19110,10 @@ namespace std::datapar {
     // \ref{simd.mask.conv}, \tcode{basic_simd_mask} conversion operators
     template<class U, class A>
       constexpr explicit(sizeof(U) != Bytes) operator basic_simd<U, A>() const noexcept;
+
+    // \ref{simd.mask.namedconv}, \tcode{basic_simd_mask} named type convertors
+    constexpr bitset<size()> to_bitset() const noexcept;
+    constexpr unsigned long long to_ullong() const;
 
     // \ref{simd.mask.binary}, \tcode{basic_simd_mask} binary operators
     friend constexpr basic_simd_mask
@@ -19241,6 +19247,31 @@ the range of \range{0}{size()}.
 \tcode{gen} is invoked exactly once for each $i$, in increasing order of $i$.
 \end{itemdescr}
 
+\begin{itemdecl}
+constexpr basic_simd_mask(const bitset<size()>& b) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Initializes the $i^\text{th}$ element with \tcode{b[$i$]} for all $i$ in the
+range \range{0}{size()}.
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr explicit basic_simd_mask(@\libconcept{unsigned_integral}@ auto val) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Initializes the first $M$ elements to the corresponding bit values in
+\tcode{val}, where $M$ is the smaller of \tcode{size()} and the number of bits in
+the value representation \iref{basic.types.general} of the type of \tcode{val}. If
+$M$ is less than \tcode{size()}, the remaining elements are initialized to
+zero.
+\end{itemdescr}
+
 \rSec3[simd.mask.subscr]{\tcode{basic_simd_mask} subscript operator}
 
 \begin{itemdecl}
@@ -19297,6 +19328,43 @@ template<class U, class A>
 \returns
 A data-parallel object where the $i^\text{th}$ element is initialized to
 \tcode{static_cast<U>(operator[]($i$))}.
+\end{itemdescr}
+
+\rSec3[simd.mask.namedconv]{\tcode{basic_simd_mask} named conversion operators}
+
+\begin{itemdecl}
+constexpr bitset<size()> to_bitset() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+A \tcode{bitset<size()>} object where the $i^\text{th}$ element is initialized to
+\tcode{operator[]($i$)} for all $i$ in the range \range{0}{size()}.
+\end{itemdescr}
+
+\begin{itemdecl}
+constexpr unsigned long long to_ullong() const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let $N$ be the width of \tcode{unsigned long long}.
+
+\pnum
+\expects
+\begin{itemize}
+\item \tcode{size() <= $N$} is \tcode{true}, or
+\item for all $i$ in the range \range{$N$}{size()}, \tcode{operator[]($i$)} returns \tcode{false}.
+\end{itemize}
+
+\pnum
+\returns
+The integral value corresponding to the bits in \tcode{*this}.
+
+\pnum
+\throws
+Nothing.
 \end{itemdescr}
 
 \rSec2[simd.mask.nonmembers]{Non-member operations}

--- a/source/support.tex
+++ b/source/support.tex
@@ -807,6 +807,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_shift}@                             202202L // also in \libheader{algorithm}
 #define @\defnlibxname{cpp_lib_simd}@                              202506L // also in \libheader{simd}
 #define @\defnlibxname{cpp_lib_simd_complex}@                      202502L // also in \libheader{simd}
+#define @\defnlibxname{cpp_lib_simd_permutations}@                 202506L // also in \libheader{simd}
 #define @\defnlibxname{cpp_lib_smart_ptr_for_overwrite}@           202002L // also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_smart_ptr_owner_equality}@          202306L // also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_source_location}@                   201907L // freestanding, also in \libheader{source_location}

--- a/source/support.tex
+++ b/source/support.tex
@@ -805,7 +805,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_shared_ptr_weak_type}@              201606L // also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_shared_timed_mutex}@                201402L // also in \libheader{shared_mutex}
 #define @\defnlibxname{cpp_lib_shift}@                             202202L // also in \libheader{algorithm}
-#define @\defnlibxname{cpp_lib_simd}@                              202502L // also in \libheader{simd}
+#define @\defnlibxname{cpp_lib_simd}@                              202506L // also in \libheader{simd}
 #define @\defnlibxname{cpp_lib_simd_complex}@                      202502L // also in \libheader{simd}
 #define @\defnlibxname{cpp_lib_smart_ptr_for_overwrite}@           202002L // also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_smart_ptr_owner_equality}@          202306L // also in \libheader{memory}


### PR DESCRIPTION
Fixes: #7949
Fixes: cplusplus/papers#1383

I left a FIXME for an overfull \hbox that I don't know how to fix.