### PR TITLE
P3060R3 Add std::views::indices(n)

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -218,7 +218,10 @@ namespace std::ranges {
   template<class W, class Bound>
     constexpr bool @\libspec{enable_borrowed_range}{iota_view}@<iota_view<W, Bound>> = true;
 
-  namespace views { inline constexpr @\unspecnc@ iota = @\unspecnc@; }
+  namespace views {
+    inline constexpr @\unspecnc@ iota = @\unspecnc@;
+    inline constexpr @\unspecnc@ indices = @\unspecnc@;
+  }
 
   // \ref{range.repeat}, repeat view
   template<@\libconcept{move_constructible}@ T, @\libconcept{semiregular}@ Bound = unreachable_sentinel_t>
@@ -2801,6 +2804,17 @@ for (int i : views::iota(1, 10))
   cout << i << ' '; // prints \tcode{1 2 3 4 5 6 7 8 9}
 \end{codeblock}
 \end{example}
+
+\pnum
+\indexlibrarymember{indices}{views}%
+The name \tcode{views::indices} denotes a
+customization point object\iref{customization.point.object}.
+Given subexpression \tcode{E},
+let \tcode{T} be \tcode{remove_cvref_t<decltype((E))>}.
+\tcode{views::indices(E)} is expression-equivalent to
+\tcode{views::iota(T(0), E)}
+if \tcode{\exposid{is-integer-like}<T>} is \tcode{true},
+and ill-formed otherwise.
 
 \rSec3[range.iota.view]{Class template \tcode{iota_view}}
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -794,6 +794,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_ranges_find_last}@                  202207L // also in \libheader{algorithm}
 #define @\defnlibxname{cpp_lib_ranges_fold}@                       202207L // also in \libheader{algorithm}
 #define @\defnlibxname{cpp_lib_ranges_generate_random}@            202403L // also in \libheader{random}
+#define @\defnlibxname{cpp_lib_ranges_indices}@                    202506L // also in \libheader{ranges}
 #define @\defnlibxname{cpp_lib_ranges_iota}@                       202202L // also in \libheader{numeric}
 #define @\defnlibxname{cpp_lib_ranges_join_with}@                  202202L // freestanding, also in \libheader{ranges}
 #define @\defnlibxname{cpp_lib_ranges_repeat}@                     202207L // freestanding, also in \libheader{ranges}


### PR DESCRIPTION
Fixed "if T models is-integer-like" which is a category error because that's a variable template not a concept.

Fixes #7966 7966