### PR TITLE
[locale.time.get.virtuals] Fix decades-old typo from misapplication of LWG 461

### DIFF
--- a/source/text.tex
+++ b/source/text.tex
@@ -3826,11 +3826,11 @@ as shown in \tref{locale.time.get.dogetdate}.
 
 \begin{libtab2}{\tcode{do_get_date} effects}{locale.time.get.dogetdate}
 {ll}{\tcode{date_order()}}{Format}
-\tcode{no_order}  & \tcode{"\%m\%d\%y"} \\
-\tcode{dmy}       & \tcode{"\%d\%m\%y"} \\
-\tcode{mdy}       & \tcode{"\%m\%d\%y"} \\
-\tcode{ymd}       & \tcode{"\%y\%m\%d"} \\
-\tcode{ydm}       & \tcode{"\%y\%d\%m"} \\
+\tcode{no_order}  & \tcode{"\%m/\%d/\%y"} \\
+\tcode{dmy}       & \tcode{"\%d/\%m/\%y"} \\
+\tcode{mdy}       & \tcode{"\%m/\%d/\%y"} \\
+\tcode{ymd}       & \tcode{"\%y/\%m/\%d"} \\
+\tcode{ydm}       & \tcode{"\%y/\%d/\%m"} \\
 \end{libtab2}
 
 \pnum


### PR DESCRIPTION
The proposed resolution of [LWG 461](https://cplusplus.github.io/LWG/issue461) has slashes between conversion specifiers, but these slash characters are lost when the resolution got applied to the draft standard.

As recorded in [N1908], LWG 461 was moved to WP status at the 2005-10 Mont Tremblant meeting. [N1905], the post-Tremblant draft standard, already contains this mistake.

[N1908]: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2005/n1908.html
[N1905]: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2005/n1905.pdf