### PR TITLE
P3037R6 constexpr std::shared_ptr and friends

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -436,18 +436,22 @@ namespace std {
     constexpr bool operator==(const unique_ptr<T1, D1>& x,                          // freestanding
                               const unique_ptr<T2, D2>& y);
   template<class T1, class D1, class T2, class D2>
-    bool operator<(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);       // freestanding
+    constexpr bool operator<(const unique_ptr<T1, D1>& x,                           // freestanding
+                             const unique_ptr<T2, D2>& y);
   template<class T1, class D1, class T2, class D2>
-    bool operator>(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);       // freestanding
+    constexpr bool operator>(const unique_ptr<T1, D1>& x,                           // freestanding
+                             const unique_ptr<T2, D2>& y);
   template<class T1, class D1, class T2, class D2>
-    bool operator<=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);      // freestanding
+    constexpr bool operator<=(const unique_ptr<T1, D1>& x,                          // freestanding
+                              const unique_ptr<T2, D2>& y);
   template<class T1, class D1, class T2, class D2>
-    bool operator>=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);      // freestanding
+    constexpr bool operator>=(const unique_ptr<T1, D1>& x,                          // freestanding
+                              const unique_ptr<T2, D2>& y);
   template<class T1, class D1, class T2, class D2>
     requires @\libconcept{three_way_comparable_with}@<typename unique_ptr<T1, D1>::pointer,
                                        typename unique_ptr<T2, D2>::pointer>
-    compare_three_way_result_t<typename unique_ptr<T1, D1>::pointer,
-                               typename unique_ptr<T2, D2>::pointer>
+    constexpr compare_three_way_result_t<typename unique_ptr<T1, D1>::pointer,
+                                         typename unique_ptr<T2, D2>::pointer>
       operator<=>(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);        // freestanding
 
   template<class T, class D>
@@ -484,69 +488,71 @@ namespace std {
 
   // \ref{util.smartptr.shared.create}, \tcode{shared_ptr} creation
   template<class T, class... Args>
-    shared_ptr<T> make_shared(Args&&... args);                                  // \tcode{T} is not array
+    constexpr shared_ptr<T> make_shared(Args&&... args);                        // \tcode{T} is not array
   template<class T, class A, class... Args>
-    shared_ptr<T> allocate_shared(const A& a, Args&&... args);                  // \tcode{T} is not array
+    constexpr shared_ptr<T> allocate_shared(const A& a, Args&&... args);        // \tcode{T} is not array
 
   template<class T>
-    shared_ptr<T> make_shared(size_t N);                                        // \tcode{T} is \tcode{U[]}
+    constexpr shared_ptr<T> make_shared(size_t N);                                  // \tcode{T} is \tcode{U[]}
   template<class T, class A>
-    shared_ptr<T> allocate_shared(const A& a, size_t N);                        // \tcode{T} is \tcode{U[]}
+    constexpr shared_ptr<T> allocate_shared(const A& a, size_t N);                  // \tcode{T} is \tcode{U[]}
 
   template<class T>
-    shared_ptr<T> make_shared();                                                // \tcode{T} is \tcode{U[N]}
+    constexpr shared_ptr<T> make_shared();                                          // \tcode{T} is \tcode{U[N]}
   template<class T, class A>
-    shared_ptr<T> allocate_shared(const A& a);                                  // \tcode{T} is \tcode{U[N]}
+    constexpr shared_ptr<T> allocate_shared(const A& a);                            // \tcode{T} is \tcode{U[N]}
 
   template<class T>
-    shared_ptr<T> make_shared(size_t N, const remove_extent_t<T>& u);           // \tcode{T} is \tcode{U[]}
+    constexpr shared_ptr<T> make_shared(size_t N, const remove_extent_t<T>& u);     // \tcode{T} is \tcode{U[]}
   template<class T, class A>
-    shared_ptr<T> allocate_shared(const A& a, size_t N,
-                                  const remove_extent_t<T>& u);                 // \tcode{T} is \tcode{U[]}
+    constexpr shared_ptr<T> allocate_shared(const A& a, size_t N,
+                                            const remove_extent_t<T>& u);           // \tcode{T} is \tcode{U[]}
 
   template<class T>
-    shared_ptr<T> make_shared(const remove_extent_t<T>& u);                     // \tcode{T} is \tcode{U[N]}
+    constexpr shared_ptr<T> make_shared(const remove_extent_t<T>& u);               // \tcode{T} is \tcode{U[N]}
   template<class T, class A>
-    shared_ptr<T> allocate_shared(const A& a, const remove_extent_t<T>& u);     // \tcode{T} is \tcode{U[N]}
+    constexpr shared_ptr<T> allocate_shared(const A& a,                             // \tcode{T} is \tcode{U[N]}
+                                            const remove_extent_t<T>& u);
 
   template<class T>
-    shared_ptr<T> make_shared_for_overwrite();                                  // \tcode{T} is not \tcode{U[]}
+    constexpr shared_ptr<T> make_shared_for_overwrite();                            // \tcode{T} is not \tcode{U[]}
   template<class T, class A>
-    shared_ptr<T> allocate_shared_for_overwrite(const A& a);                    // \tcode{T} is not \tcode{U[]}
+    constexpr shared_ptr<T> allocate_shared_for_overwrite(const A& a);              // \tcode{T} is not \tcode{U[]}
 
   template<class T>
-    shared_ptr<T> make_shared_for_overwrite(size_t N);                          // \tcode{T} is \tcode{U[]}
+    constexpr shared_ptr<T> make_shared_for_overwrite(size_t N);                    // \tcode{T} is \tcode{U[]}
   template<class T, class A>
-    shared_ptr<T> allocate_shared_for_overwrite(const A& a, size_t N);          // \tcode{T} is \tcode{U[]}
+    constexpr shared_ptr<T> allocate_shared_for_overwrite(const A& a, size_t N);    // \tcode{T} is \tcode{U[]}
 
   // \ref{util.smartptr.shared.cmp}, \tcode{shared_ptr} comparisons
   template<class T, class U>
-    bool operator==(const shared_ptr<T>& a, const shared_ptr<U>& b) noexcept;
+    constexpr bool operator==(const shared_ptr<T>& a, const shared_ptr<U>& b) noexcept;
   template<class T, class U>
-    strong_ordering operator<=>(const shared_ptr<T>& a, const shared_ptr<U>& b) noexcept;
+    constexpr strong_ordering operator<=>(const shared_ptr<T>& a,
+                                          const shared_ptr<U>& b) noexcept;
 
   template<class T>
-    bool operator==(const shared_ptr<T>& x, nullptr_t) noexcept;
+    constexpr bool operator==(const shared_ptr<T>& x, nullptr_t) noexcept;
   template<class T>
-    strong_ordering operator<=>(const shared_ptr<T>& x, nullptr_t) noexcept;
+    constexpr strong_ordering operator<=>(const shared_ptr<T>& x, nullptr_t) noexcept;
 
   // \ref{util.smartptr.shared.spec}, \tcode{shared_ptr} specialized algorithms
   template<class T>
-    void swap(shared_ptr<T>& a, shared_ptr<T>& b) noexcept;
+    constexpr void swap(shared_ptr<T>& a, shared_ptr<T>& b) noexcept;
 
   // \ref{util.smartptr.shared.cast}, \tcode{shared_ptr} casts
   template<class T, class U>
-    shared_ptr<T> static_pointer_cast(const shared_ptr<U>& r) noexcept;
+    constexpr shared_ptr<T> static_pointer_cast(const shared_ptr<U>& r) noexcept;
   template<class T, class U>
-    shared_ptr<T> static_pointer_cast(shared_ptr<U>&& r) noexcept;
+    constexpr shared_ptr<T> static_pointer_cast(shared_ptr<U>&& r) noexcept;
   template<class T, class U>
-    shared_ptr<T> dynamic_pointer_cast(const shared_ptr<U>& r) noexcept;
+    constexpr shared_ptr<T> dynamic_pointer_cast(const shared_ptr<U>& r) noexcept;
   template<class T, class U>
-    shared_ptr<T> dynamic_pointer_cast(shared_ptr<U>&& r) noexcept;
+    constexpr shared_ptr<T> dynamic_pointer_cast(shared_ptr<U>&& r) noexcept;
   template<class T, class U>
-    shared_ptr<T> const_pointer_cast(const shared_ptr<U>& r) noexcept;
+    constexpr shared_ptr<T> const_pointer_cast(const shared_ptr<U>& r) noexcept;
   template<class T, class U>
-    shared_ptr<T> const_pointer_cast(shared_ptr<U>&& r) noexcept;
+    constexpr shared_ptr<T> const_pointer_cast(shared_ptr<U>&& r) noexcept;
   template<class T, class U>
     shared_ptr<T> reinterpret_pointer_cast(const shared_ptr<U>& r) noexcept;
   template<class T, class U>
@@ -554,7 +560,7 @@ namespace std {
 
   // \ref{util.smartptr.getdeleter}, \tcode{shared_ptr} \tcode{get_deleter}
   template<class D, class T>
-    D* get_deleter(const shared_ptr<T>& p) noexcept;
+    constexpr D* get_deleter(const shared_ptr<T>& p) noexcept;
 
   // \ref{util.smartptr.shared.io}, \tcode{shared_ptr} I/O
   template<class E, class T, class Y>
@@ -564,7 +570,7 @@ namespace std {
   template<class T> class weak_ptr;
 
   // \ref{util.smartptr.weak.spec}, \tcode{weak_ptr} specialized algorithms
-  template<class T> void swap(weak_ptr<T>& a, weak_ptr<T>& b) noexcept;
+  template<class T> constexpr void swap(weak_ptr<T>& a, weak_ptr<T>& b) noexcept;
 
   // \ref{util.smartptr.ownerless}, class template \tcode{owner_less}
   template<class T = void> struct owner_less;
@@ -594,7 +600,7 @@ namespace std {
 
   // \ref{out.ptr}, function template \tcode{out_ptr}
   template<class Pointer = void, class Smart, class... Args>
-    auto out_ptr(Smart& s, Args&&... args);                                         // freestanding
+    constexpr auto out_ptr(Smart& s, Args&&... args);                               // freestanding
 
   // \ref{inout.ptr.t}, class template \tcode{inout_ptr_t}
   template<class Smart, class Pointer, class... Args>
@@ -602,7 +608,7 @@ namespace std {
 
   // \ref{inout.ptr}, function template \tcode{inout_ptr}
   template<class Pointer = void, class Smart, class... Args>
-    auto inout_ptr(Smart& s, Args&&... args);                                       // freestanding
+    constexpr auto inout_ptr(Smart& s, Args&&... args);                             // freestanding
 
   // \ref{indirect}, class template \tcode{indirect}
   template<class T, class Allocator = allocator<T>>
@@ -3131,7 +3137,7 @@ template<class T1, class D1, class T2, class D2>
 \indexlibrarymember{operator<}{unique_ptr}%
 \begin{itemdecl}
 template<class T1, class D1, class T2, class D2>
-  bool operator<(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
+  constexpr bool operator<(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3163,7 +3169,7 @@ induces a strict weak ordering\iref{alg.sorting} on the pointer values.
 \indexlibrarymember{operator>}{unique_ptr}%
 \begin{itemdecl}
 template<class T1, class D1, class T2, class D2>
-  bool operator>(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
+  constexpr bool operator>(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3175,7 +3181,7 @@ template<class T1, class D1, class T2, class D2>
 \indexlibrarymember{operator<=}{unique_ptr}%
 \begin{itemdecl}
 template<class T1, class D1, class T2, class D2>
-  bool operator<=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
+  constexpr bool operator<=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3187,7 +3193,7 @@ template<class T1, class D1, class T2, class D2>
 \indexlibrarymember{operator>=}{unique_ptr}%
 \begin{itemdecl}
 template<class T1, class D1, class T2, class D2>
-  bool operator>=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
+  constexpr bool operator>=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3201,8 +3207,8 @@ template<class T1, class D1, class T2, class D2>
 template<class T1, class D1, class T2, class D2>
   requires @\libconcept{three_way_comparable_with}@<typename unique_ptr<T1, D1>::pointer,
                                      typename unique_ptr<T2, D2>::pointer>
-  compare_three_way_result_t<typename unique_ptr<T1, D1>::pointer,
-                             typename unique_ptr<T2, D2>::pointer>
+  constexpr compare_three_way_result_t<typename unique_ptr<T1, D1>::pointer,
+                                       typename unique_ptr<T2, D2>::pointer>
     operator<=>(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y);
 \end{itemdecl}
 
@@ -3345,7 +3351,7 @@ namespace std {
   class bad_weak_ptr : public exception {
   public:
     // see \ref{exception} for the specification of the special member functions
-    const char* what() const noexcept override;
+    constexpr const char* what() const noexcept override;
   };
 }
 \end{codeblock}
@@ -3356,7 +3362,7 @@ constructor taking a \tcode{weak_ptr}.
 
 \indexlibrarymember{what}{bad_weak_ptr}%
 \begin{itemdecl}
-const char* what() const noexcept override;
+constexpr const char* what() const noexcept override;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3388,69 +3394,69 @@ namespace std {
     constexpr shared_ptr() noexcept;
     constexpr shared_ptr(nullptr_t) noexcept : shared_ptr() { }
     template<class Y>
-      explicit shared_ptr(Y* p);
+      constexpr explicit shared_ptr(Y* p);
     template<class Y, class D>
-      shared_ptr(Y* p, D d);
+      constexpr shared_ptr(Y* p, D d);
     template<class Y, class D, class A>
-      shared_ptr(Y* p, D d, A a);
+      constexpr shared_ptr(Y* p, D d, A a);
     template<class D>
-      shared_ptr(nullptr_t p, D d);
+      constexpr shared_ptr(nullptr_t p, D d);
     template<class D, class A>
-      shared_ptr(nullptr_t p, D d, A a);
+      constexpr shared_ptr(nullptr_t p, D d, A a);
     template<class Y>
-      shared_ptr(const shared_ptr<Y>& r, element_type* p) noexcept;
+      constexpr shared_ptr(const shared_ptr<Y>& r, element_type* p) noexcept;
     template<class Y>
-      shared_ptr(shared_ptr<Y>&& r, element_type* p) noexcept;
-    shared_ptr(const shared_ptr& r) noexcept;
+      constexpr shared_ptr(shared_ptr<Y>&& r, element_type* p) noexcept;
+    constexpr shared_ptr(const shared_ptr& r) noexcept;
     template<class Y>
-      shared_ptr(const shared_ptr<Y>& r) noexcept;
-    shared_ptr(shared_ptr&& r) noexcept;
+      constexpr shared_ptr(const shared_ptr<Y>& r) noexcept;
+    constexpr shared_ptr(shared_ptr&& r) noexcept;
     template<class Y>
-      shared_ptr(shared_ptr<Y>&& r) noexcept;
+      constexpr shared_ptr(shared_ptr<Y>&& r) noexcept;
     template<class Y>
-      explicit shared_ptr(const weak_ptr<Y>& r);
+      constexpr explicit shared_ptr(const weak_ptr<Y>& r);
     template<class Y, class D>
-      shared_ptr(unique_ptr<Y, D>&& r);
+      constexpr shared_ptr(unique_ptr<Y, D>&& r);
 
     // \ref{util.smartptr.shared.dest}, destructor
-    ~shared_ptr();
+    constexpr ~shared_ptr();
 
     // \ref{util.smartptr.shared.assign}, assignment
-    shared_ptr& operator=(const shared_ptr& r) noexcept;
+    constexpr shared_ptr& operator=(const shared_ptr& r) noexcept;
     template<class Y>
-      shared_ptr& operator=(const shared_ptr<Y>& r) noexcept;
-    shared_ptr& operator=(shared_ptr&& r) noexcept;
+      constexpr shared_ptr& operator=(const shared_ptr<Y>& r) noexcept;
+    constexpr shared_ptr& operator=(shared_ptr&& r) noexcept;
     template<class Y>
-      shared_ptr& operator=(shared_ptr<Y>&& r) noexcept;
+      constexpr shared_ptr& operator=(shared_ptr<Y>&& r) noexcept;
     template<class Y, class D>
-      shared_ptr& operator=(unique_ptr<Y, D>&& r);
+      constexpr shared_ptr& operator=(unique_ptr<Y, D>&& r);
 
     // \ref{util.smartptr.shared.mod}, modifiers
-    void swap(shared_ptr& r) noexcept;
-    void reset() noexcept;
+    constexpr void swap(shared_ptr& r) noexcept;
+    constexpr void reset() noexcept;
     template<class Y>
-      void reset(Y* p);
+      constexpr void reset(Y* p);
     template<class Y, class D>
-      void reset(Y* p, D d);
+      constexpr void reset(Y* p, D d);
     template<class Y, class D, class A>
-      void reset(Y* p, D d, A a);
+      constexpr void reset(Y* p, D d, A a);
 
     // \ref{util.smartptr.shared.obs}, observers
-    element_type* get() const noexcept;
-    T& operator*() const noexcept;
-    T* operator->() const noexcept;
-    element_type& operator[](ptrdiff_t i) const;
-    long use_count() const noexcept;
-    explicit operator bool() const noexcept;
+    constexpr element_type* get() const noexcept;
+    constexpr T& operator*() const noexcept;
+    constexpr T* operator->() const noexcept;
+    constexpr element_type& operator[](ptrdiff_t i) const;
+    constexpr long use_count() const noexcept;
+    constexpr explicit operator bool() const noexcept;
     template<class U>
-      bool owner_before(const shared_ptr<U>& b) const noexcept;
+      constexpr bool owner_before(const shared_ptr<U>& b) const noexcept;
     template<class U>
-      bool owner_before(const weak_ptr<U>& b) const noexcept;
+      constexpr bool owner_before(const weak_ptr<U>& b) const noexcept;
     size_t owner_hash() const noexcept;
     template<class U>
-      bool owner_equal(const shared_ptr<U>& b) const noexcept;
+      constexpr bool owner_equal(const shared_ptr<U>& b) const noexcept;
     template<class U>
-      bool owner_equal(const weak_ptr<U>& b) const noexcept;
+      constexpr bool owner_equal(const weak_ptr<U>& b) const noexcept;
   };
 
   template<class T>
@@ -3527,7 +3533,7 @@ constexpr shared_ptr() noexcept;
 
 \indexlibraryctor{shared_ptr}%
 \begin{itemdecl}
-template<class Y> explicit shared_ptr(Y* p);
+template<class Y> constexpr explicit shared_ptr(Y* p);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3578,10 +3584,10 @@ constructor fails} exception when a resource other than memory cannot be obtaine
 
 \indexlibraryctor{shared_ptr}%
 \begin{itemdecl}
-template<class Y, class D> shared_ptr(Y* p, D d);
-template<class Y, class D, class A> shared_ptr(Y* p, D d, A a);
-template<class D> shared_ptr(nullptr_t p, D d);
-template<class D, class A> shared_ptr(nullptr_t p, D d, A a);
+template<class Y, class D> constexpr shared_ptr(Y* p, D d);
+template<class Y, class D, class A> constexpr shared_ptr(Y* p, D d, A a);
+template<class D> constexpr shared_ptr(nullptr_t p, D d);
+template<class D, class A> constexpr shared_ptr(nullptr_t p, D d, A a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3633,8 +3639,8 @@ when a resource other than memory cannot be obtained.
 
 \indexlibraryctor{shared_ptr}%
 \begin{itemdecl}
-template<class Y> shared_ptr(const shared_ptr<Y>& r, element_type* p) noexcept;
-template<class Y> shared_ptr(shared_ptr<Y>&& r, element_type* p) noexcept;
+template<class Y> constexpr shared_ptr(const shared_ptr<Y>& r, element_type* p) noexcept;
+template<class Y> constexpr shared_ptr(shared_ptr<Y>&& r, element_type* p) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3666,8 +3672,8 @@ This constructor allows creation of an empty
 
 \indexlibraryctor{shared_ptr}%
 \begin{itemdecl}
-shared_ptr(const shared_ptr& r) noexcept;
-template<class Y> shared_ptr(const shared_ptr<Y>& r) noexcept;
+constexpr shared_ptr(const shared_ptr& r) noexcept;
+template<class Y> constexpr shared_ptr(const shared_ptr<Y>& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3688,8 +3694,8 @@ a \tcode{shared_ptr} object that shares ownership with \tcode{r}.
 
 \indexlibraryctor{shared_ptr}%
 \begin{itemdecl}
-shared_ptr(shared_ptr&& r) noexcept;
-template<class Y> shared_ptr(shared_ptr<Y>&& r) noexcept;
+constexpr shared_ptr(shared_ptr&& r) noexcept;
+template<class Y> constexpr shared_ptr(shared_ptr<Y>&& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3710,7 +3716,7 @@ Move constructs a \tcode{shared_ptr} instance from \tcode{r}.
 \indexlibraryctor{shared_ptr}%
 \indexlibraryglobal{weak_ptr}%
 \begin{itemdecl}
-template<class Y> explicit shared_ptr(const weak_ptr<Y>& r);
+template<class Y> constexpr explicit shared_ptr(const weak_ptr<Y>& r);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3736,7 +3742,7 @@ If an exception is thrown, the constructor has no effect.
 \indexlibraryctor{shared_ptr}%
 \indexlibraryglobal{unique_ptr}%
 \begin{itemdecl}
-template<class Y, class D> shared_ptr(unique_ptr<Y, D>&& r);
+template<class Y, class D> constexpr shared_ptr(unique_ptr<Y, D>&& r);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3758,7 +3764,7 @@ If an exception is thrown, the constructor has no effect.
 
 \indexlibrarydtor{shared_ptr}%
 \begin{itemdecl}
-~shared_ptr();
+constexpr ~shared_ptr();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3792,8 +3798,8 @@ than its previous value.
 
 \indexlibrarymember{operator=}{shared_ptr}%
 \begin{itemdecl}
-shared_ptr& operator=(const shared_ptr& r) noexcept;
-template<class Y> shared_ptr& operator=(const shared_ptr<Y>& r) noexcept;
+constexpr shared_ptr& operator=(const shared_ptr& r) noexcept;
+template<class Y> constexpr shared_ptr& operator=(const shared_ptr<Y>& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3824,8 +3830,8 @@ both assignments can be no-ops.
 
 \indexlibrarymember{operator=}{shared_ptr}%
 \begin{itemdecl}
-shared_ptr& operator=(shared_ptr&& r) noexcept;
-template<class Y> shared_ptr& operator=(shared_ptr<Y>&& r) noexcept;
+constexpr shared_ptr& operator=(shared_ptr&& r) noexcept;
+template<class Y> constexpr shared_ptr& operator=(shared_ptr<Y>&& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3840,7 +3846,7 @@ Equivalent to \tcode{shared_ptr(std::move(r)).swap(*this)}.
 
 \indexlibrarymember{operator=}{shared_ptr}%
 \begin{itemdecl}
-template<class Y, class D> shared_ptr& operator=(unique_ptr<Y, D>&& r);
+template<class Y, class D> constexpr shared_ptr& operator=(unique_ptr<Y, D>&& r);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3857,7 +3863,7 @@ Equivalent to \tcode{shared_ptr(std::move(r)).swap(*this)}.
 
 \indexlibrarymember{swap}{shared_ptr}%
 \begin{itemdecl}
-void swap(shared_ptr& r) noexcept;
+constexpr void swap(shared_ptr& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3869,7 +3875,7 @@ Exchanges the contents of \tcode{*this} and \tcode{r}.
 
 \indexlibrarymember{reset}{shared_ptr}%
 \begin{itemdecl}
-void reset() noexcept;
+constexpr void reset() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3880,7 +3886,7 @@ Equivalent to \tcode{shared_ptr().swap(*this)}.
 
 \indexlibrarymember{reset}{shared_ptr}%
 \begin{itemdecl}
-template<class Y> void reset(Y* p);
+template<class Y> constexpr void reset(Y* p);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3891,7 +3897,7 @@ Equivalent to \tcode{shared_ptr(p).swap(*this)}.
 
 \indexlibrarymember{reset}{shared_ptr}%
 \begin{itemdecl}
-template<class Y, class D> void reset(Y* p, D d);
+template<class Y, class D> constexpr void reset(Y* p, D d);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3902,7 +3908,7 @@ Equivalent to \tcode{shared_ptr(p, d).swap(*this)}.
 
 \indexlibrarymember{reset}{shared_ptr}%
 \begin{itemdecl}
-template<class Y, class D, class A> void reset(Y* p, D d, A a);
+template<class Y, class D, class A> constexpr void reset(Y* p, D d, A a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3914,7 +3920,7 @@ Equivalent to \tcode{shared_ptr(p, d, a).swap(*this)}.
 \rSec4[util.smartptr.shared.obs]{Observers}
 \indexlibrarymember{get}{shared_ptr}%
 \begin{itemdecl}
-element_type* get() const noexcept;
+constexpr element_type* get() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3925,7 +3931,7 @@ The stored pointer.
 
 \indexlibrarymember{operator*}{shared_ptr}%
 \begin{itemdecl}
-T& operator*() const noexcept;
+constexpr T& operator*() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3948,7 +3954,7 @@ definition) of the function shall be well-formed.
 
 \indexlibrarymember{operator->}{shared_ptr}%
 \begin{itemdecl}
-T* operator->() const noexcept;
+constexpr T* operator->() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3971,7 +3977,7 @@ of the function shall be well-formed.
 
 \indexlibrarymember{operator[]}{shared_ptr}%
 \begin{itemdecl}
-element_type& operator[](ptrdiff_t i) const;
+constexpr element_type& operator[](ptrdiff_t i) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3999,7 +4005,7 @@ of the function shall be well-formed.
 
 \indexlibrarymember{use_count}{shared_ptr}%
 \begin{itemdecl}
-long use_count() const noexcept;
+constexpr long use_count() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4037,7 +4043,7 @@ a previously destroyed \tcode{shared_ptr} have in any sense completed.
 
 \indexlibrarymember{operator bool}{shared_ptr}%
 \begin{itemdecl}
-explicit operator bool() const noexcept;
+constexpr explicit operator bool() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4048,8 +4054,8 @@ explicit operator bool() const noexcept;
 
 \indexlibrarymember{owner_before}{shared_ptr}%
 \begin{itemdecl}
-template<class U> bool owner_before(const shared_ptr<U>& b) const noexcept;
-template<class U> bool owner_before(const weak_ptr<U>& b) const noexcept;
+template<class U> constexpr bool owner_before(const shared_ptr<U>& b) const noexcept;
+template<class U> constexpr bool owner_before(const weak_ptr<U>& b) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4081,9 +4087,9 @@ for any object \tcode{x} where \tcode{owner_equal(x)} is \tcode{true},
 \indexlibrarymember{owner_equal}{shared_ptr}%
 \begin{itemdecl}
 template<class U>
-  bool owner_equal(const shared_ptr<U>& b) const noexcept;
+  constexpr bool owner_equal(const shared_ptr<U>& b) const noexcept;
 template<class U>
-  bool owner_equal(const weak_ptr<U>& b) const noexcept;
+  constexpr bool owner_equal(const weak_ptr<U>& b) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4112,13 +4118,13 @@ unless specified otherwise, are described below.
 \indexlibraryglobal{allocate_shared}%
 \begin{itemdecl}
 template<class T, ...>
-  shared_ptr<T> make_shared(@\placeholdernc{args}@);
+  constexpr shared_ptr<T> make_shared(@\placeholdernc{args}@);
 template<class T, class A, ...>
-  shared_ptr<T> allocate_shared(const A& a, @\placeholdernc{args}@);
+  constexpr shared_ptr<T> allocate_shared(const A& a, @\placeholdernc{args}@);
 template<class T, ...>
-  shared_ptr<T> make_shared_for_overwrite(@\placeholdernc{args}@);
+  constexpr shared_ptr<T> make_shared_for_overwrite(@\placeholdernc{args}@);
 template<class T, class A, ...>
-  shared_ptr<T> allocate_shared_for_overwrite(const A& a, @\placeholdernc{args}@);
+  constexpr shared_ptr<T> allocate_shared_for_overwrite(const A& a, @\placeholdernc{args}@);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4254,9 +4260,9 @@ allow for internal bookkeeping structures such as reference counts.
 \indexlibraryglobal{allocate_shared}%
 \begin{itemdecl}
 template<class T, class... Args>
-  shared_ptr<T> make_shared(Args&&... args);                    // \tcode{T} is not array
+  constexpr shared_ptr<T> make_shared(Args&&... args);                    // \tcode{T} is not array
 template<class T, class A, class... Args>
-  shared_ptr<T> allocate_shared(const A& a, Args&&... args);    // \tcode{T} is not array
+  constexpr shared_ptr<T> allocate_shared(const A& a, Args&&... args);    // \tcode{T} is not array
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4288,10 +4294,10 @@ shared_ptr<vector<int>> q = make_shared<vector<int>>(16, 1);
 \indexlibraryglobal{make_shared}%
 \indexlibraryglobal{allocate_shared}%
 \begin{itemdecl}
-template<class T> shared_ptr<T>
-  make_shared(size_t N);                                        // \tcode{T} is \tcode{U[]}
+template<class T>
+  constexpr shared_ptr<T> make_shared(size_t N);                          // \tcode{T} is \tcode{U[]}
 template<class T, class A>
-  shared_ptr<T> allocate_shared(const A& a, size_t N);          // \tcode{T} is \tcode{U[]}
+  constexpr shared_ptr<T> allocate_shared(const A& a, size_t N);          // \tcode{T} is \tcode{U[]}
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4320,9 +4326,9 @@ shared_ptr<double[][2][2]> q = make_shared<double[][2][2]>(6);
 \indexlibraryglobal{allocate_shared}%
 \begin{itemdecl}
 template<class T>
-  shared_ptr<T> make_shared();                                  // \tcode{T} is \tcode{U[N]}
+  constexpr shared_ptr<T> make_shared();                                  // \tcode{T} is \tcode{U[N]}
 template<class T, class A>
-  shared_ptr<T> allocate_shared(const A& a);                    // \tcode{T} is \tcode{U[N]}
+  constexpr shared_ptr<T> allocate_shared(const A& a);                    // \tcode{T} is \tcode{U[N]}
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4350,11 +4356,11 @@ shared_ptr<double[6][2][2]> q = make_shared<double[6][2][2]>();
 \indexlibraryglobal{allocate_shared}%
 \begin{itemdecl}
 template<class T>
-  shared_ptr<T> make_shared(size_t N,
-                            const remove_extent_t<T>& u);       // \tcode{T} is \tcode{U[]}
+  constexpr shared_ptr<T> make_shared(size_t N,
+                                      const remove_extent_t<T>& u);     // \tcode{T} is \tcode{U[]}
 template<class T, class A>
-  shared_ptr<T> allocate_shared(const A& a, size_t N,
-                                const remove_extent_t<T>& u);   // \tcode{T} is \tcode{U[]}
+  constexpr shared_ptr<T> allocate_shared(const A& a, size_t N,
+                                          const remove_extent_t<T>& u); // \tcode{T} is \tcode{U[]}
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4385,10 +4391,10 @@ shared_ptr<vector<int>[]> r = make_shared<vector<int>[]>(4, {1, 2});
 \indexlibraryglobal{allocate_shared}%
 \begin{itemdecl}
 template<class T>
-  shared_ptr<T> make_shared(const remove_extent_t<T>& u);       // \tcode{T} is \tcode{U[N]}
+  constexpr shared_ptr<T> make_shared(const remove_extent_t<T>& u);       // \tcode{T} is \tcode{U[N]}
 template<class T, class A>
-  shared_ptr<T> allocate_shared(const A& a,
-                                const remove_extent_t<T>& u);   // \tcode{T} is \tcode{U[N]}
+  constexpr shared_ptr<T> allocate_shared(const A& a,
+                                          const remove_extent_t<T>& u);   // \tcode{T} is \tcode{U[N]}
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4419,9 +4425,9 @@ shared_ptr<vector<int>[4]> r = make_shared<vector<int>[4]>({1, 2});
 \indexlibraryglobal{allocate_shared}%
 \begin{itemdecl}
 template<class T>
-  shared_ptr<T> make_shared_for_overwrite();
+  constexpr shared_ptr<T> make_shared_for_overwrite();
 template<class T, class A>
-  shared_ptr<T> allocate_shared_for_overwrite(const A& a);
+  constexpr shared_ptr<T> allocate_shared_for_overwrite(const A& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4450,9 +4456,9 @@ shared_ptr<double[1024]> q = make_shared_for_overwrite<double[1024]>();
 \indexlibraryglobal{allocate_shared}%
 \begin{itemdecl}
 template<class T>
-  shared_ptr<T> make_shared_for_overwrite(size_t N);
+  constexpr shared_ptr<T> make_shared_for_overwrite(size_t N);
 template<class T, class A>
-  shared_ptr<T> allocate_shared_for_overwrite(const A& a, size_t N);
+  constexpr shared_ptr<T> allocate_shared_for_overwrite(const A& a, size_t N);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4479,7 +4485,7 @@ shared_ptr<double[]> p = make_shared_for_overwrite<double[]>(1024);
 \indexlibrarymember{operator==}{shared_ptr}%
 \begin{itemdecl}
 template<class T, class U>
-  bool operator==(const shared_ptr<T>& a, const shared_ptr<U>& b) noexcept;
+  constexpr bool operator==(const shared_ptr<T>& a, const shared_ptr<U>& b) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4491,7 +4497,7 @@ template<class T, class U>
 \indexlibrarymember{operator==}{shared_ptr}%
 \begin{itemdecl}
 template<class T>
-  bool operator==(const shared_ptr<T>& a, nullptr_t) noexcept;
+  constexpr bool operator==(const shared_ptr<T>& a, nullptr_t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4503,7 +4509,7 @@ template<class T>
 \indexlibrarymember{operator<=>}{shared_ptr}%
 \begin{itemdecl}
 template<class T, class U>
-  strong_ordering operator<=>(const shared_ptr<T>& a, const shared_ptr<U>& b) noexcept;
+  constexpr strong_ordering operator<=>(const shared_ptr<T>& a, const shared_ptr<U>& b) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4521,7 +4527,7 @@ to be used as keys in associative containers.
 \indexlibrarymember{operator<=>}{shared_ptr}%
 \begin{itemdecl}
 template<class T>
-  strong_ordering operator<=>(const shared_ptr<T>& a, nullptr_t) noexcept;
+  constexpr strong_ordering operator<=>(const shared_ptr<T>& a, nullptr_t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4537,7 +4543,7 @@ compare_three_way()(a.get(), static_cast<typename shared_ptr<T>::element_type*>(
 \indexlibrarymember{swap}{shared_ptr}%
 \begin{itemdecl}
 template<class T>
-  void swap(shared_ptr<T>& a, shared_ptr<T>& b) noexcept;
+  constexpr void swap(shared_ptr<T>& a, shared_ptr<T>& b) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4551,9 +4557,9 @@ Equivalent to \tcode{a.swap(b)}.
 \indexlibrarymember{static_pointer_cast}{shared_ptr}%
 \begin{itemdecl}
 template<class T, class U>
-  shared_ptr<T> static_pointer_cast(const shared_ptr<U>& r) noexcept;
+  constexpr shared_ptr<T> static_pointer_cast(const shared_ptr<U>& r) noexcept;
 template<class T, class U>
-  shared_ptr<T> static_pointer_cast(shared_ptr<U>&& r) noexcept;
+  constexpr shared_ptr<T> static_pointer_cast(shared_ptr<U>&& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4581,9 +4587,9 @@ same object twice.
 \indexlibrarymember{dynamic_pointer_cast}{shared_ptr}%
 \begin{itemdecl}
 template<class T, class U>
-  shared_ptr<T> dynamic_pointer_cast(const shared_ptr<U>& r) noexcept;
+  constexpr shared_ptr<T> dynamic_pointer_cast(const shared_ptr<U>& r) noexcept;
 template<class T, class U>
-  shared_ptr<T> dynamic_pointer_cast(shared_ptr<U>&& r) noexcept;
+  constexpr shared_ptr<T> dynamic_pointer_cast(shared_ptr<U>&& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4618,9 +4624,9 @@ undefined behavior, attempting to delete the same object twice.
 \indexlibrarymember{const_pointer_cast}{shared_ptr}%
 \begin{itemdecl}
 template<class T, class U>
-  shared_ptr<T> const_pointer_cast(const shared_ptr<U>& r) noexcept;
+  constexpr shared_ptr<T> const_pointer_cast(const shared_ptr<U>& r) noexcept;
 template<class T, class U>
-  shared_ptr<T> const_pointer_cast(shared_ptr<U>&& r) noexcept;
+  constexpr shared_ptr<T> const_pointer_cast(shared_ptr<U>&& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4678,7 +4684,7 @@ undefined behavior, attempting to delete the same object twice.
 \indexlibrarymember{get_deleter}{shared_ptr}%
 \begin{itemdecl}
 template<class D, class T>
-  D* get_deleter(const shared_ptr<T>& p) noexcept;
+  constexpr D* get_deleter(const shared_ptr<T>& p) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4735,44 +4741,44 @@ namespace std {
     // \ref{util.smartptr.weak.const}, constructors
     constexpr weak_ptr() noexcept;
     template<class Y>
-      weak_ptr(const shared_ptr<Y>& r) noexcept;
-    weak_ptr(const weak_ptr& r) noexcept;
+      constexpr weak_ptr(const shared_ptr<Y>& r) noexcept;
+    constexpr weak_ptr(const weak_ptr& r) noexcept;
     template<class Y>
-      weak_ptr(const weak_ptr<Y>& r) noexcept;
-    weak_ptr(weak_ptr&& r) noexcept;
+      constexpr weak_ptr(const weak_ptr<Y>& r) noexcept;
+    constexpr weak_ptr(weak_ptr&& r) noexcept;
     template<class Y>
-      weak_ptr(weak_ptr<Y>&& r) noexcept;
+      constexpr weak_ptr(weak_ptr<Y>&& r) noexcept;
 
     // \ref{util.smartptr.weak.dest}, destructor
-    ~weak_ptr();
+    constexpr ~weak_ptr();
 
     // \ref{util.smartptr.weak.assign}, assignment
-    weak_ptr& operator=(const weak_ptr& r) noexcept;
+    constexpr weak_ptr& operator=(const weak_ptr& r) noexcept;
     template<class Y>
-      weak_ptr& operator=(const weak_ptr<Y>& r) noexcept;
+      constexpr weak_ptr& operator=(const weak_ptr<Y>& r) noexcept;
     template<class Y>
-      weak_ptr& operator=(const shared_ptr<Y>& r) noexcept;
-    weak_ptr& operator=(weak_ptr&& r) noexcept;
+      constexpr weak_ptr& operator=(const shared_ptr<Y>& r) noexcept;
+    constexpr weak_ptr& operator=(weak_ptr&& r) noexcept;
     template<class Y>
-      weak_ptr& operator=(weak_ptr<Y>&& r) noexcept;
+      constexpr weak_ptr& operator=(weak_ptr<Y>&& r) noexcept;
 
     // \ref{util.smartptr.weak.mod}, modifiers
-    void swap(weak_ptr& r) noexcept;
-    void reset() noexcept;
+    constexpr void swap(weak_ptr& r) noexcept;
+    constexpr void reset() noexcept;
 
     // \ref{util.smartptr.weak.obs}, observers
-    long use_count() const noexcept;
-    bool expired() const noexcept;
-    shared_ptr<T> lock() const noexcept;
+    constexpr long use_count() const noexcept;
+    constexpr bool expired() const noexcept;
+    constexpr shared_ptr<T> lock() const noexcept;
     template<class U>
-      bool owner_before(const shared_ptr<U>& b) const noexcept;
+      constexpr bool owner_before(const shared_ptr<U>& b) const noexcept;
     template<class U>
-      bool owner_before(const weak_ptr<U>& b) const noexcept;
+      constexpr bool owner_before(const weak_ptr<U>& b) const noexcept;
     size_t owner_hash() const noexcept;
     template<class U>
-      bool owner_equal(const shared_ptr<U>& b) const noexcept;
+      constexpr bool owner_equal(const shared_ptr<U>& b) const noexcept;
     template<class U>
-      bool owner_equal(const weak_ptr<U>& b) const noexcept;
+      constexpr bool owner_equal(const weak_ptr<U>& b) const noexcept;
   };
 
   template<class T>
@@ -4805,9 +4811,9 @@ Constructs an empty \tcode{weak_ptr} object that stores a null pointer value.
 
 \indexlibraryctor{weak_ptr}%
 \begin{itemdecl}
-weak_ptr(const weak_ptr& r) noexcept;
-template<class Y> weak_ptr(const weak_ptr<Y>& r) noexcept;
-template<class Y> weak_ptr(const shared_ptr<Y>& r) noexcept;
+constexpr weak_ptr(const weak_ptr& r) noexcept;
+template<class Y> constexpr weak_ptr(const weak_ptr<Y>& r) noexcept;
+template<class Y> constexpr weak_ptr(const shared_ptr<Y>& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4830,8 +4836,8 @@ with \tcode{r} and stores a copy of the pointer stored in \tcode{r}.
 
 \indexlibraryctor{weak_ptr}%
 \begin{itemdecl}
-weak_ptr(weak_ptr&& r) noexcept;
-template<class Y> weak_ptr(weak_ptr<Y>&& r) noexcept;
+constexpr weak_ptr(weak_ptr&& r) noexcept;
+template<class Y> constexpr weak_ptr(weak_ptr<Y>&& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4853,7 +4859,7 @@ Move constructs a \tcode{weak_ptr} instance from \tcode{r}.
 
 \indexlibrarydtor{weak_ptr}%
 \begin{itemdecl}
-~weak_ptr();
+constexpr ~weak_ptr();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4867,9 +4873,9 @@ effect on the object its stored pointer points to.
 
 \indexlibrarymember{operator=}{weak_ptr}%
 \begin{itemdecl}
-weak_ptr& operator=(const weak_ptr& r) noexcept;
-template<class Y> weak_ptr& operator=(const weak_ptr<Y>& r) noexcept;
-template<class Y> weak_ptr& operator=(const shared_ptr<Y>& r) noexcept;
+constexpr weak_ptr& operator=(const weak_ptr& r) noexcept;
+template<class Y> constexpr weak_ptr& operator=(const weak_ptr<Y>& r) noexcept;
+template<class Y> constexpr weak_ptr& operator=(const shared_ptr<Y>& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4889,8 +4895,8 @@ implied guarantees) via different means, without creating a temporary object.
 
 \indexlibrarymember{operator=}{weak_ptr}%
 \begin{itemdecl}
-weak_ptr& operator=(weak_ptr&& r) noexcept;
-template<class Y> weak_ptr& operator=(weak_ptr<Y>&& r) noexcept;
+constexpr weak_ptr& operator=(weak_ptr&& r) noexcept;
+template<class Y> constexpr weak_ptr& operator=(weak_ptr<Y>&& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4906,7 +4912,7 @@ Equivalent to \tcode{weak_ptr(std::move(r)).swap(*this)}.
 \rSec4[util.smartptr.weak.mod]{Modifiers}
 \indexlibrarymember{swap}{weak_ptr}%
 \begin{itemdecl}
-void swap(weak_ptr& r) noexcept;
+constexpr void swap(weak_ptr& r) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4917,7 +4923,7 @@ Exchanges the contents of \tcode{*this} and \tcode{r}.
 
 \indexlibrarymember{reset}{weak_ptr}%
 \begin{itemdecl}
-void reset() noexcept;
+constexpr void reset() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4929,7 +4935,7 @@ Equivalent to \tcode{weak_ptr().swap(*this)}.
 \rSec4[util.smartptr.weak.obs]{Observers}
 \indexlibrarymember{use_count}{weak_ptr}%
 \begin{itemdecl}
-long use_count() const noexcept;
+constexpr long use_count() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4942,7 +4948,7 @@ that share ownership with \tcode{*this}.
 
 \indexlibrarymember{expired}{weak_ptr}%
 \begin{itemdecl}
-bool expired() const noexcept;
+constexpr bool expired() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4953,7 +4959,7 @@ bool expired() const noexcept;
 
 \indexlibrarymember{lock}{weak_ptr}%
 \begin{itemdecl}
-shared_ptr<T> lock() const noexcept;
+constexpr shared_ptr<T> lock() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4964,8 +4970,8 @@ shared_ptr<T> lock() const noexcept;
 
 \indexlibrarymember{owner_before}{weak_ptr}%
 \begin{itemdecl}
-template<class U> bool owner_before(const shared_ptr<U>& b) const noexcept;
-template<class U> bool owner_before(const weak_ptr<U>& b) const noexcept;
+template<class U> constexpr bool owner_before(const shared_ptr<U>& b) const noexcept;
+template<class U> constexpr bool owner_before(const weak_ptr<U>& b) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4996,9 +5002,9 @@ for any object \tcode{x} where \tcode{owner_equal(x)} is \tcode{true},
 \indexlibrarymember{owner_equal}{weak_ptr}%
 \begin{itemdecl}
 template<class U>
-  bool owner_equal(const shared_ptr<U>& b) const noexcept;
+  constexpr bool owner_equal(const shared_ptr<U>& b) const noexcept;
 template<class U>
-  bool owner_equal(const weak_ptr<U>& b) const noexcept;
+  constexpr bool owner_equal(const weak_ptr<U>& b) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5018,7 +5024,7 @@ Otherwise returns \tcode{false}.
 \indexlibrarymember{swap}{weak_ptr}%
 \begin{itemdecl}
 template<class T>
-  void swap(weak_ptr<T>& a, weak_ptr<T>& b) noexcept;
+  constexpr void swap(weak_ptr<T>& a, weak_ptr<T>& b) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5039,26 +5045,26 @@ namespace std {
   template<class T = void> struct owner_less;
 
   template<class T> struct owner_less<shared_ptr<T>> {
-    bool operator()(const shared_ptr<T>&, const shared_ptr<T>&) const noexcept;
-    bool operator()(const shared_ptr<T>&, const weak_ptr<T>&) const noexcept;
-    bool operator()(const weak_ptr<T>&, const shared_ptr<T>&) const noexcept;
+    constexpr bool operator()(const shared_ptr<T>&, const shared_ptr<T>&) const noexcept;
+    constexpr bool operator()(const shared_ptr<T>&, const weak_ptr<T>&) const noexcept;
+    constexpr bool operator()(const weak_ptr<T>&, const shared_ptr<T>&) const noexcept;
   };
 
   template<class T> struct owner_less<weak_ptr<T>> {
-    bool operator()(const weak_ptr<T>&, const weak_ptr<T>&) const noexcept;
-    bool operator()(const shared_ptr<T>&, const weak_ptr<T>&) const noexcept;
-    bool operator()(const weak_ptr<T>&, const shared_ptr<T>&) const noexcept;
+    constexpr bool operator()(const weak_ptr<T>&, const weak_ptr<T>&) const noexcept;
+    constexpr bool operator()(const shared_ptr<T>&, const weak_ptr<T>&) const noexcept;
+    constexpr bool operator()(const weak_ptr<T>&, const shared_ptr<T>&) const noexcept;
   };
 
   template<> struct owner_less<void> {
     template<class T, class U>
-      bool operator()(const shared_ptr<T>&, const shared_ptr<U>&) const noexcept;
+      constexpr bool operator()(const shared_ptr<T>&, const shared_ptr<U>&) const noexcept;
     template<class T, class U>
-      bool operator()(const shared_ptr<T>&, const weak_ptr<U>&) const noexcept;
+      constexpr bool operator()(const shared_ptr<T>&, const weak_ptr<U>&) const noexcept;
     template<class T, class U>
-      bool operator()(const weak_ptr<T>&, const shared_ptr<U>&) const noexcept;
+      constexpr bool operator()(const weak_ptr<T>&, const shared_ptr<U>&) const noexcept;
     template<class T, class U>
-      bool operator()(const weak_ptr<T>&, const weak_ptr<U>&) const noexcept;
+      constexpr bool operator()(const weak_ptr<T>&, const weak_ptr<U>&) const noexcept;
 
     using is_transparent = @\unspec@;
   };
@@ -5130,13 +5136,13 @@ ownership-based mixed equality comparisons of shared and weak pointers.
 namespace std {
   struct owner_equal {
     template<class T, class U>
-      bool operator()(const shared_ptr<T>&, const shared_ptr<U>&) const noexcept;
+      constexpr bool operator()(const shared_ptr<T>&, const shared_ptr<U>&) const noexcept;
     template<class T, class U>
-      bool operator()(const shared_ptr<T>&, const weak_ptr<U>&) const noexcept;
+      constexpr bool operator()(const shared_ptr<T>&, const weak_ptr<U>&) const noexcept;
     template<class T, class U>
-      bool operator()(const weak_ptr<T>&, const shared_ptr<U>&) const noexcept;
+      constexpr bool operator()(const weak_ptr<T>&, const shared_ptr<U>&) const noexcept;
     template<class T, class U>
-      bool operator()(const weak_ptr<T>&, const weak_ptr<U>&) const noexcept;
+      constexpr bool operator()(const weak_ptr<T>&, const weak_ptr<U>&) const noexcept;
 
     using is_transparent = @\unspec@;
   };
@@ -5146,13 +5152,13 @@ namespace std {
 \indexlibrarymember{operator()}{owner_equal}%
 \begin{itemdecl}
 template<class T, class U>
-  bool operator()(const shared_ptr<T>& x, const shared_ptr<U>& y) const noexcept;
+  constexpr bool operator()(const shared_ptr<T>& x, const shared_ptr<U>& y) const noexcept;
 template<class T, class U>
-  bool operator()(const shared_ptr<T>& x, const weak_ptr<U>& y) const noexcept;
+  constexpr bool operator()(const shared_ptr<T>& x, const weak_ptr<U>& y) const noexcept;
 template<class T, class U>
-  bool operator()(const weak_ptr<T>& x, const shared_ptr<U>& y) const noexcept;
+  constexpr bool operator()(const weak_ptr<T>& x, const shared_ptr<U>& y) const noexcept;
 template<class T, class U>
-  bool operator()(const weak_ptr<T>& x, const weak_ptr<U>& y) const noexcept;
+  constexpr bool operator()(const weak_ptr<T>& x, const weak_ptr<U>& y) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5194,15 +5200,15 @@ namespace std {
   template<class T> class enable_shared_from_this {
   protected:
     constexpr enable_shared_from_this() noexcept;
-    enable_shared_from_this(const enable_shared_from_this&) noexcept;
-    enable_shared_from_this& operator=(const enable_shared_from_this&) noexcept;
-    ~enable_shared_from_this();
+    constexpr enable_shared_from_this(const enable_shared_from_this&) noexcept;
+    constexpr enable_shared_from_this& operator=(const enable_shared_from_this&) noexcept;
+    constexpr ~enable_shared_from_this();
 
   public:
-    shared_ptr<T> shared_from_this();
-    shared_ptr<T const> shared_from_this() const;
-    weak_ptr<T> weak_from_this() noexcept;
-    weak_ptr<T const> weak_from_this() const noexcept;
+    constexpr shared_ptr<T> shared_from_this();
+    constexpr shared_ptr<T const> shared_from_this() const;
+    constexpr weak_ptr<T> weak_from_this() noexcept;
+    constexpr weak_ptr<T const> weak_from_this() const noexcept;
 
   private:
     mutable weak_ptr<T> @\exposid{weak-this}@;  // \expos
@@ -5217,7 +5223,7 @@ may be an incomplete type.
 \indexlibraryctor{enable_shared_from_this}%
 \begin{itemdecl}
 constexpr enable_shared_from_this() noexcept;
-enable_shared_from_this(const enable_shared_from_this<T>&) noexcept;
+constexpr enable_shared_from_this(const enable_shared_from_this<T>&) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5228,7 +5234,7 @@ Value-initializes \exposid{weak-this}.
 
 \indexlibrarymember{operator=}{enable_shared_from_this}%
 \begin{itemdecl}
-enable_shared_from_this<T>& operator=(const enable_shared_from_this<T>&) noexcept;
+constexpr enable_shared_from_this<T>& operator=(const enable_shared_from_this<T>&) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5245,8 +5251,8 @@ enable_shared_from_this<T>& operator=(const enable_shared_from_this<T>&) noexcep
 \indexlibraryglobal{shared_ptr}%
 \indexlibrarymember{shared_from_this}{enable_shared_from_this}%
 \begin{itemdecl}
-shared_ptr<T>       shared_from_this();
-shared_ptr<T const> shared_from_this() const;
+constexpr shared_ptr<T>       shared_from_this();
+constexpr shared_ptr<T const> shared_from_this() const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5258,8 +5264,8 @@ shared_ptr<T const> shared_from_this() const;
 \indexlibraryglobal{weak_ptr}%
 \indexlibrarymember{weak_from_this}{enable_shared_from_this}%
 \begin{itemdecl}
-weak_ptr<T>       weak_from_this() noexcept;
-weak_ptr<T const> weak_from_this() const noexcept;
+constexpr weak_ptr<T>       weak_from_this() noexcept;
+constexpr weak_ptr<T const> weak_from_this() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5344,12 +5350,12 @@ namespace std {
   template<class Smart, class Pointer, class... Args>
   class out_ptr_t {
   public:
-    explicit out_ptr_t(Smart&, Args...);
+    constexpr explicit out_ptr_t(Smart&, Args...);
     out_ptr_t(const out_ptr_t&) = delete;
 
-    ~out_ptr_t();
+    constexpr ~out_ptr_t();
 
-    operator Pointer*() const noexcept;
+    constexpr operator Pointer*() const noexcept;
     operator void**() const noexcept;
 
   private:
@@ -5383,7 +5389,7 @@ on the same object may conflict\iref{intro.races}.
 
 \indexlibraryctor{out_ptr_t}%
 \begin{itemdecl}
-explicit out_ptr_t(Smart& smart, Args... args);
+constexpr explicit out_ptr_t(Smart& smart, Args... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5427,7 +5433,7 @@ avoid any other exceptions.
 
 \indexlibrarydtor{out_ptr_t}%
 \begin{itemdecl}
-~out_ptr_t();
+constexpr ~out_ptr_t();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5466,7 +5472,7 @@ otherwise, the program is ill-formed.
 \end{itemdescr}
 
 \begin{itemdecl}
-operator Pointer*() const noexcept;
+constexpr operator Pointer*() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5526,7 +5532,7 @@ can be a viable implementation strategy for some implementations.
 \indexlibraryglobal{out_ptr}%
 \begin{itemdecl}
 template<class Pointer = void, class Smart, class... Args>
-  auto out_ptr(Smart& s, Args&&... args);
+  constexpr auto out_ptr(Smart& s, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5584,12 +5590,12 @@ namespace std {
   template<class Smart, class Pointer, class... Args>
   class inout_ptr_t {
   public:
-    explicit inout_ptr_t(Smart&, Args...);
+    constexpr explicit inout_ptr_t(Smart&, Args...);
     inout_ptr_t(const inout_ptr_t&) = delete;
 
-    ~inout_ptr_t();
+    constexpr ~inout_ptr_t();
 
-    operator Pointer*() const noexcept;
+    constexpr operator Pointer*() const noexcept;
     operator void**() const noexcept;
 
   private:
@@ -5620,7 +5626,7 @@ may conflict\iref{intro.races}.
 
 \indexlibraryctor{inout_ptr_t}%
 \begin{itemdecl}
-explicit inout_ptr_t(Smart& smart, Args... args);
+constexpr explicit inout_ptr_t(Smart& smart, Args... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5649,7 +5655,7 @@ can allocate in the constructor and safely fail with an exception.
 
 \indexlibrarydtor{inout_ptr_t}%
 \begin{itemdecl}
-~inout_ptr_t();
+constexpr ~inout_ptr_t();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5702,7 +5708,7 @@ otherwise, the program is ill-formed.
 \end{itemdescr}
 
 \begin{itemdecl}
-operator Pointer*() const noexcept;
+constexpr operator Pointer*() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5762,7 +5768,7 @@ can be a viable implementation strategy for some implementations.
 \indexlibraryglobal{inout_ptr}%
 \begin{itemdecl}
 template<class Pointer = void, class Smart, class... Args>
-  auto inout_ptr(Smart& s, Args&&... args);
+  constexpr auto inout_ptr(Smart& s, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/support.tex
+++ b/source/support.tex
@@ -635,7 +635,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_constexpr_iterator}@                201811L // freestanding, also in \libheader{iterator}
 #define @\defnlibxname{cpp_lib_constexpr_list}@                    202502L // also in \libheader{list}
 #define @\defnlibxname{cpp_lib_constexpr_map}@                     202502L // also in \libheader{map}
-#define @\defnlibxname{cpp_lib_constexpr_memory}@                  202202L // freestanding, also in \libheader{memory}
+#define @\defnlibxname{cpp_lib_constexpr_memory}@                  202506L // freestanding, also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_constexpr_new}@                     202406L // freestanding, also in \libheader{new}
 #define @\defnlibxname{cpp_lib_constexpr_numeric}@                 201911L // also in \libheader{numeric}
 #define @\defnlibxname{cpp_lib_constexpr_queue}@                   202502L // also in \libheader{queue}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -5407,30 +5407,32 @@ namespace std {
 
     constexpr atomic() noexcept;
     constexpr atomic(nullptr_t) noexcept : atomic() { }
-    atomic(shared_ptr<T> desired) noexcept;
+    constexpr atomic(shared_ptr<T> desired) noexcept;
     atomic(const atomic&) = delete;
     void operator=(const atomic&) = delete;
 
-    shared_ptr<T> load(memory_order order = memory_order::seq_cst) const noexcept;
-    operator shared_ptr<T>() const noexcept;
-    void store(shared_ptr<T> desired, memory_order order = memory_order::seq_cst) noexcept;
-    void operator=(shared_ptr<T> desired) noexcept;
-    void operator=(nullptr_t) noexcept;
+    constexpr shared_ptr<T> load(memory_order order = memory_order::seq_cst) const noexcept;
+    constexpr operator shared_ptr<T>() const noexcept;
+    constexpr void store(shared_ptr<T> desired,
+                         memory_order order = memory_order::seq_cst) noexcept;
+    constexpr void operator=(shared_ptr<T> desired) noexcept;
+    constexpr void operator=(nullptr_t) noexcept;
 
-    shared_ptr<T> exchange(shared_ptr<T> desired,
-                           memory_order order = memory_order::seq_cst) noexcept;
-    bool compare_exchange_weak(shared_ptr<T>& expected, shared_ptr<T> desired,
-                               memory_order success, memory_order failure) noexcept;
-    bool compare_exchange_strong(shared_ptr<T>& expected, shared_ptr<T> desired,
-                                 memory_order success, memory_order failure) noexcept;
-    bool compare_exchange_weak(shared_ptr<T>& expected, shared_ptr<T> desired,
-                               memory_order order = memory_order::seq_cst) noexcept;
-    bool compare_exchange_strong(shared_ptr<T>& expected, shared_ptr<T> desired,
-                                 memory_order order = memory_order::seq_cst) noexcept;
+    constexpr shared_ptr<T> exchange(shared_ptr<T> desired,
+                                     memory_order order = memory_order::seq_cst) noexcept;
+    constexpr bool compare_exchange_weak(shared_ptr<T>& expected, shared_ptr<T> desired,
+                                         memory_order success, memory_order failure) noexcept;
+    constexpr bool compare_exchange_strong(shared_ptr<T>& expected, shared_ptr<T> desired,
+                                           memory_order success, memory_order failure) noexcept;
+    constexpr bool compare_exchange_weak(shared_ptr<T>& expected, shared_ptr<T> desired,
+                                         memory_order order = memory_order::seq_cst) noexcept;
+    constexpr bool compare_exchange_strong(shared_ptr<T>& expected, shared_ptr<T> desired,
+                                           memory_order order = memory_order::seq_cst) noexcept;
 
-    void wait(shared_ptr<T> old, memory_order order = memory_order::seq_cst) const noexcept;
-    void notify_one() noexcept;
-    void notify_all() noexcept;
+    constexpr void wait(shared_ptr<T> old,
+                        memory_order order = memory_order::seq_cst) const noexcept;
+    constexpr void notify_one() noexcept;
+    constexpr void notify_all() noexcept;
 
   private:
     shared_ptr<T> p;            // \expos
@@ -5451,7 +5453,7 @@ Value-initializes \tcode{p}.
 
 \indexlibraryctor{atomic<shared_ptr<T>>}%
 \begin{itemdecl}
-atomic(shared_ptr<T> desired) noexcept;
+constexpr atomic(shared_ptr<T> desired) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5473,7 +5475,7 @@ This results in undefined behavior.
 
 \indexlibrarymember{store}{atomic<shared_ptr<T>>}%
 \begin{itemdecl}
-void store(shared_ptr<T> desired, memory_order order = memory_order::seq_cst) noexcept;
+constexpr void store(shared_ptr<T> desired, memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5493,7 +5495,7 @@ Memory is affected according to the value of \tcode{order}.
 
 \indexlibrarymember{operator=}{atomic<shared_ptr<T>>}%
 \begin{itemdecl}
-void operator=(shared_ptr<T> desired) noexcept;
+constexpr void operator=(shared_ptr<T> desired) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5504,7 +5506,7 @@ Equivalent to \tcode{store(desired)}.
 
 \indexlibrarymember{operator=}{atomic<shared_ptr<T>>}%
 \begin{itemdecl}
-void operator=(nullptr_t) noexcept;
+constexpr void operator=(nullptr_t) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5515,7 +5517,7 @@ Equivalent to \tcode{store(nullptr)}.
 
 \indexlibrarymember{load}{atomic<shared_ptr<T>>}%
 \begin{itemdecl}
-shared_ptr<T> load(memory_order order = memory_order::seq_cst) const noexcept;
+constexpr shared_ptr<T> load(memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5537,7 +5539,7 @@ Atomically returns \tcode{p}.
 
 \indexlibrarymember{operator shared_ptr<T>}{atomic<shared_ptr<T>>}%
 \begin{itemdecl}
-operator shared_ptr<T>() const noexcept;
+constexpr operator shared_ptr<T>() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5548,7 +5550,8 @@ Equivalent to: \tcode{return load();}
 
 \indexlibrarymember{exchange}{atomic<shared_ptr<T>>}%
 \begin{itemdecl}
-shared_ptr<T> exchange(shared_ptr<T> desired, memory_order order = memory_order::seq_cst) noexcept;
+constexpr shared_ptr<T> exchange(shared_ptr<T> desired,
+                                 memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5567,10 +5570,10 @@ Atomically returns the value of \tcode{p} immediately before the effects.
 \indexlibrarymember{compare_exchange_weak}{atomic<shared_ptr<T>>}%
 \indexlibrarymember{compare_exchange_strong}{atomic<shared_ptr<T>>}%
 \begin{itemdecl}
-bool compare_exchange_weak(shared_ptr<T>& expected, shared_ptr<T> desired,
-                           memory_order success, memory_order failure) noexcept;
-bool compare_exchange_strong(shared_ptr<T>& expected, shared_ptr<T> desired,
-                             memory_order success, memory_order failure) noexcept;
+constexpr bool compare_exchange_weak(shared_ptr<T>& expected, shared_ptr<T> desired,
+                                     memory_order success, memory_order failure) noexcept;
+constexpr bool compare_exchange_strong(shared_ptr<T>& expected, shared_ptr<T> desired,
+                                       memory_order success, memory_order failure) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5617,8 +5620,8 @@ is not required to be part of the atomic operation.
 
 \indexlibrarymember{compare_exchange_weak}{atomic<shared_ptr<T>>}%
 \begin{itemdecl}
-bool compare_exchange_weak(shared_ptr<T>& expected, shared_ptr<T> desired,
-                           memory_order order = memory_order::seq_cst) noexcept;
+constexpr bool compare_exchange_weak(shared_ptr<T>& expected, shared_ptr<T> desired,
+                                     memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5637,8 +5640,8 @@ shall be replaced by the value \tcode{memory_order::relaxed}.
 
 \indexlibrarymember{compare_exchange_strong}{atomic<shared_ptr<T>>}%
 \begin{itemdecl}
-bool compare_exchange_strong(shared_ptr<T>& expected, shared_ptr<T> desired,
-                             memory_order order = memory_order::seq_cst) noexcept;
+constexpr bool compare_exchange_strong(shared_ptr<T>& expected, shared_ptr<T> desired,
+                                       memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5657,7 +5660,7 @@ shall be replaced by the value \tcode{memory_order::relaxed}.
 
 \indexlibrarymember{wait}{atomic<shared_ptr<T>>}%
 \begin{itemdecl}
-void wait(shared_ptr<T> old, memory_order order = memory_order::seq_cst) const noexcept;
+constexpr void wait(shared_ptr<T> old, memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5690,7 +5693,7 @@ This function is an atomic waiting operation\iref{atomics.wait}.
 
 \indexlibrarymember{notify_one}{atomic<shared_ptr<T>>}%
 \begin{itemdecl}
-void notify_one() noexcept;
+constexpr void notify_one() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5707,7 +5710,7 @@ This function is an atomic notifying operation\iref{atomics.wait}.
 
 \indexlibrarymember{notify_all}{atomic<shared_ptr<T>>}%
 \begin{itemdecl}
-void notify_all() noexcept;
+constexpr void notify_all() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5733,29 +5736,31 @@ namespace std {
     bool is_lock_free() const noexcept;
 
     constexpr atomic() noexcept;
-    atomic(weak_ptr<T> desired) noexcept;
+    constexpr atomic(weak_ptr<T> desired) noexcept;
     atomic(const atomic&) = delete;
     void operator=(const atomic&) = delete;
 
-    weak_ptr<T> load(memory_order order = memory_order::seq_cst) const noexcept;
-    operator weak_ptr<T>() const noexcept;
-    void store(weak_ptr<T> desired, memory_order order = memory_order::seq_cst) noexcept;
-    void operator=(weak_ptr<T> desired) noexcept;
-
-    weak_ptr<T> exchange(weak_ptr<T> desired,
+    constexpr weak_ptr<T> load(memory_order order = memory_order::seq_cst) const noexcept;
+    constexpr operator weak_ptr<T>() const noexcept;
+    constexpr void store(weak_ptr<T> desired,
                          memory_order order = memory_order::seq_cst) noexcept;
-    bool compare_exchange_weak(weak_ptr<T>& expected, weak_ptr<T> desired,
-                               memory_order success, memory_order failure) noexcept;
-    bool compare_exchange_strong(weak_ptr<T>& expected, weak_ptr<T> desired,
-                                 memory_order success, memory_order failure) noexcept;
-    bool compare_exchange_weak(weak_ptr<T>& expected, weak_ptr<T> desired,
-                               memory_order order = memory_order::seq_cst) noexcept;
-    bool compare_exchange_strong(weak_ptr<T>& expected, weak_ptr<T> desired,
-                                 memory_order order = memory_order::seq_cst) noexcept;
+    constexpr void operator=(weak_ptr<T> desired) noexcept;
 
-    void wait(weak_ptr<T> old, memory_order order = memory_order::seq_cst) const noexcept;
-    void notify_one() noexcept;
-    void notify_all() noexcept;
+    constexpr weak_ptr<T> exchange(weak_ptr<T> desired,
+                                   memory_order order = memory_order::seq_cst) noexcept;
+    constexpr bool compare_exchange_weak(weak_ptr<T>& expected, weak_ptr<T> desired,
+                                         memory_order success, memory_order failure) noexcept;
+    constexpr bool compare_exchange_strong(weak_ptr<T>& expected, weak_ptr<T> desired,
+                                           memory_order success, memory_order failure) noexcept;
+    constexpr bool compare_exchange_weak(weak_ptr<T>& expected, weak_ptr<T> desired,
+                                         memory_order order = memory_order::seq_cst) noexcept;
+    constexpr bool compare_exchange_strong(weak_ptr<T>& expected, weak_ptr<T> desired,
+                                           memory_order order = memory_order::seq_cst) noexcept;
+
+    constexpr void wait(weak_ptr<T> old,
+                        memory_order order = memory_order::seq_cst) const noexcept;
+    constexpr void notify_one() noexcept;
+    constexpr void notify_all() noexcept;
 
   private:
     weak_ptr<T> p;              // \expos
@@ -5776,7 +5781,7 @@ Value-initializes \tcode{p}.
 
 \indexlibraryctor{atomic<weak_ptr<T>>}%
 \begin{itemdecl}
-atomic(weak_ptr<T> desired) noexcept;
+constexpr atomic(weak_ptr<T> desired) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5798,7 +5803,7 @@ This results in undefined behavior.
 
 \indexlibrarymember{store}{atomic<weak_ptr<T>>}%
 \begin{itemdecl}
-void store(weak_ptr<T> desired, memory_order order = memory_order::seq_cst) noexcept;
+constexpr void store(weak_ptr<T> desired, memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5818,7 +5823,7 @@ Memory is affected according to the value of \tcode{order}.
 
 \indexlibrarymember{operator=}{atomic<weak_ptr<T>>}%
 \begin{itemdecl}
-void operator=(weak_ptr<T> desired) noexcept;
+constexpr void operator=(weak_ptr<T> desired) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5829,7 +5834,7 @@ Equivalent to \tcode{store(desired)}.
 
 \indexlibrarymember{load}{atomic<weak_ptr<T>>}%
 \begin{itemdecl}
-weak_ptr<T> load(memory_order order = memory_order::seq_cst) const noexcept;
+constexpr weak_ptr<T> load(memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5851,7 +5856,7 @@ Atomically returns \tcode{p}.
 
 \indexlibrarymember{operator weak_ptr<T>}{atomic<weak_ptr<T>>}%
 \begin{itemdecl}
-operator weak_ptr<T>() const noexcept;
+constexpr operator weak_ptr<T>() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5862,7 +5867,8 @@ Equivalent to: \tcode{return load();}
 
 \indexlibrarymember{exchange}{atomic<weak_ptr<T>>}%
 \begin{itemdecl}
-weak_ptr<T> exchange(weak_ptr<T> desired, memory_order order = memory_order::seq_cst) noexcept;
+constexpr weak_ptr<T> exchange(weak_ptr<T> desired,
+                               memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5880,10 +5886,10 @@ Atomically returns the value of \tcode{p} immediately before the effects.
 
 \indexlibrarymember{compare_exchange_weak}{atomic<weak_ptr<T>>}%
 \begin{itemdecl}
-bool compare_exchange_weak(weak_ptr<T>& expected, weak_ptr<T> desired,
-                           memory_order success, memory_order failure) noexcept;
-bool compare_exchange_strong(weak_ptr<T>& expected, weak_ptr<T> desired,
-                             memory_order success, memory_order failure) noexcept;
+constexpr bool compare_exchange_weak(weak_ptr<T>& expected, weak_ptr<T> desired,
+                                     memory_order success, memory_order failure) noexcept;
+constexpr bool compare_exchange_strong(weak_ptr<T>& expected, weak_ptr<T> desired,
+                                       memory_order success, memory_order failure) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5930,8 +5936,8 @@ is not required to be part of the atomic operation.
 
 \indexlibrarymember{compare_exchange_weak}{atomic<weak_ptr<T>>}%
 \begin{itemdecl}
-bool compare_exchange_weak(weak_ptr<T>& expected, weak_ptr<T> desired,
-                           memory_order order = memory_order::seq_cst) noexcept;
+constexpr bool compare_exchange_weak(weak_ptr<T>& expected, weak_ptr<T> desired,
+                                     memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5950,8 +5956,8 @@ shall be replaced by the value \tcode{memory_order::relaxed}.
 
 \indexlibrarymember{compare_exchange_strong}{atomic<weak_ptr<T>>}%
 \begin{itemdecl}
-bool compare_exchange_strong(weak_ptr<T>& expected, weak_ptr<T> desired,
-                             memory_order order = memory_order::seq_cst) noexcept;
+constexpr bool compare_exchange_strong(weak_ptr<T>& expected, weak_ptr<T> desired,
+                                       memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5970,7 +5976,7 @@ shall be replaced by the value \tcode{memory_order::relaxed}.
 
 \indexlibrarymember{wait}{atomic<weak_ptr<T>>}%
 \begin{itemdecl}
-void wait(weak_ptr<T> old, memory_order order = memory_order::seq_cst) const noexcept;
+constexpr void wait(weak_ptr<T> old, memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6004,7 +6010,7 @@ This function is an atomic waiting operation\iref{atomics.wait}.
 
 \indexlibrarymember{notify_one}{atomic<weak_ptr<T>>}%
 \begin{itemdecl}
-void notify_one() noexcept;
+constexpr void notify_one() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6021,7 +6027,7 @@ This function is an atomic notifying operation\iref{atomics.wait}.
 
 \indexlibrarymember{notify_all}{atomic<weak_ptr<T>>}%
 \begin{itemdecl}
-void notify_all() noexcept;
+constexpr void notify_all() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Fixes #7941
Fixes cplusplus/papers#1713

Did not apply `constexpr` to deleted functions. The application in the paper was inconsistent, and I deemed the active uses as errors.

Made minor whitespace and line-breaking adjustments to avoid line-wrapping and overfull hboxes.

Fixed odd use of return type on the same line as the template head for an `allocate_shared` overload, where it belonged on the same line as the function name, before applying the `constexpr` keyword.