### PR TITLE
P3348R4 C++26 should refer to C23 not C17

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -12006,10 +12006,14 @@ declares the functions described in this subclause.
 \indexlibraryglobal{bsearch}%
 \indexlibraryglobal{qsort}%
 \begin{itemdecl}
-void* bsearch(const void* key, const void* base, size_t nmemb, size_t size,
+void* bsearch(const void* key, void* base, size_t nmemb, size_t size,
               @\placeholder{c-compare-pred}@* compar);
-void* bsearch(const void* key, const void* base, size_t nmemb, size_t size,
+void* bsearch(const void* key, void* base, size_t nmemb, size_t size,
               @\placeholder{compare-pred}@* compar);
+const void* bsearch(const void* key, const void* base, size_t nmemb, size_t size,
+                    @\placeholder{c-compare-pred}@* compar);
+const void* bsearch(const void* key, const void* base, size_t nmemb, size_t size,
+                    @\placeholder{compare-pred}@* compar);
 void qsort(void* base, size_t nmemb, size_t size, @\placeholder{c-compare-pred}@* compar);
 void qsort(void* base, size_t nmemb, size_t size, @\placeholder{compare-pred}@* compar);
 \end{itemdecl}
@@ -12029,4 +12033,4 @@ These functions have the semantics specified in the C standard library.
 Any exception thrown by \tcode{compar}\iref{res.on.exception.handling}.
 \end{itemdescr}
 
-\xrefc{7.22.5}
+\xrefc{7.24.5}

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -273,6 +273,18 @@ Valid \CppXXIII{} code that defines \tcode{replaceable_if_eligible} or
 \tcode{trivially_relocatable_if_eligible} as macros is invalid
 in this revision of \Cpp{}.
 
+\rSec2[diff.cpp23.mem]{\ref{mem}: memory management library}
+
+\diffref{c.malloc}
+\change
+Calling \tcode{realloc} with a non-null pointer and zero size
+has erroneous behavior.
+\rationale
+The C standard library does not define this behavior.
+\effect
+Valid \CppXXIII{} code that calls \tcode{realloc}
+with a non-null pointer and a size of zero is erroneous and may change behavior.
+
 \rSec2[diff.cpp23.containers]{\ref{containers}: containers library}
 
 \diffref{span.overview}
@@ -3674,12 +3686,12 @@ standard library.
 
 \rSec2[diff.mods.to.definitions]{Modifications to definitions}
 
-\rSec3[diff.char16]{Types \tcode{char16_t} and \tcode{char32_t}}
+\rSec3[diff.char16]{Types \tcode{char8_t}, \tcode{char16_t}, and \tcode{char32_t}}
 
 \pnum
-The types \keyword{char16_t} and \keyword{char32_t}
+The types \keyword{char8_t}, \keyword{char16_t}, and \keyword{char32_t}
 are distinct types rather than typedefs to existing integral types.
-The tokens \keyword{char16_t} and \keyword{char32_t}
+The tokens \keyword{char8_t}, \keyword{char16_t}, and \keyword{char32_t}
 are keywords in \Cpp{}\iref{lex.key}.
 They do not appear as macro or type names defined in
 \libheaderref{cuchar}.
@@ -3695,14 +3707,6 @@ It does not appear as a macro or type name defined in any of
 \libheaderref{cstddef},
 \libheaderref{cstdlib},
 or \libheaderref{cwchar}.
-
-\rSec3[diff.header.assert.h]{Header \tcode{<assert.h>}}
-\indexhdr{assert.h}%
-
-\pnum
-The token \keyword{static_assert} is a keyword in \Cpp{}.
-It does not appear as a macro name defined
-in \libheaderref{cassert}.
 
 \rSec3[diff.header.iso646.h]{Header \tcode{<iso646.h>}}
 
@@ -3723,21 +3727,6 @@ and
 are keywords in \Cpp{}\iref{lex.key},
 and are not introduced as macros
 by \libheaderref{iso646.h}.
-
-\rSec3[diff.header.stdalign.h]{Header \tcode{<stdalign.h>}}
-
-\pnum
-The token \keyword{alignas} is a keyword in \Cpp{}\iref{lex.key},
-and is not introduced as a macro
-by \libheaderref{stdalign.h}.
-
-\rSec3[diff.header.stdbool.h]{Header \tcode{<stdbool.h>}}
-
-\pnum
-The tokens \keyword{bool}, \keyword{true}, and \keyword{false}
-are keywords in \Cpp{}\iref{lex.key},
-and are not introduced as macros
-by \libheaderref{stdbool.h}.
 
 \rSec3[diff.null]{Macro \tcode{NULL}}
 

--- a/source/future.tex
+++ b/source/future.tex
@@ -220,17 +220,32 @@ static constexpr bool has_denorm_loss = false;
 \rSec1[depr.c.macros]{Deprecated C macros}
 
 \pnum
-The header \libheaderref{stdalign.h} has the following macros:
+The header \libheaderref{cfloat} has the following macros:
 \begin{codeblock}
-#define @\libxmacro{alignas_is_defined}@ 1
-#define @\libxmacro{alignof_is_defined}@ 1
+#define @\libmacro{FLT_HAS_SUBNORM}@ @\seebelow@
+#define @\libmacro{DBL_HAS_SUBNORM}@ @\seebelow@
+#define @\libmacro{LDBL_HAS_SUBNORM}@ @\seebelow@
+#define @\libmacro{DECIMAL_DIG}@ @\seebelow@
 \end{codeblock}
+The header defines these macros the same as
+the C standard library header \libheader{float.h}.
+
+\xrefc{5.2.4.2.2, 7.33.5}
+
+\pnum
+In addition to being available via inclusion of the \libheader{cfloat} header,
+the macros \tcode{INFINITY} and \tcode{NAN} are
+available when \libheaderref{cmath} is included.
+
+\xrefc{7.12}
 
 \pnum
 The header \libheaderref{stdbool.h} has the following macro:
 \begin{codeblock}
 #define @\libxmacro{bool_true_false_are_defined}@ 1
 \end{codeblock}
+
+\xrefc{7.19}
 
 \rSec1[depr.cerrno]{Deprecated error numbers}
 
@@ -761,6 +776,21 @@ template<class Visitor, class Context>
 \effects
 Equivalent to: \tcode{return visit(std::forward<Visitor>(vis), arg.value);}
 \end{itemdescr}
+
+\rSec1[depr.ctime]{Deprecated time formatting}
+
+\pnum
+The header \libheaderref{ctime} has the following additions:
+\begin{codeblock}
+char* asctime(const tm* timeptr);
+char* ctime(const time_t* timer);
+\end{codeblock}
+
+\pnum
+The functions \tcode{asctime} and \tcode{ctime}
+are not required to avoid data races\iref{res.on.data.races}.
+
+\xrefc{7.29}
 
 \rSec1[depr.fs.path.factory]{Deprecated filesystem path factory functions}
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -18875,6 +18875,8 @@ As specified in~\ref{fs.err.report}.
 \indexlibraryglobal{ferror}%
 \indexlibraryglobal{perror}%
 \begin{codeblock}
+#define __STDC_VERSION_STDIO_H__ 202311L
+
 namespace std {
   using size_t = @\textit{see \ref{support.types.layout}}@;
   using FILE = @\seebelow@;
@@ -18889,6 +18891,7 @@ namespace std {
 #define @\libmacro{EOF}@ @\seebelow@
 #define @\libmacro{FOPEN_MAX}@ @\seebelow@
 #define @\libmacro{FILENAME_MAX}@ @\seebelow@
+#define @\libmacro{_PRINTF_NAN_LEN_MAX}@ @\seebelow@
 #define @\libmacro{L_tmpnam}@ @\seebelow@
 #define @\libmacro{SEEK_CUR}@ @\seebelow@
 #define @\libmacro{SEEK_END}@ @\seebelow@
@@ -18983,33 +18986,42 @@ an argument that is a null pointer value.
 \indexlibraryglobal{PRIuN}%
 \indexlibraryglobal{PRIxN}%
 \indexlibraryglobal{PRIXN}%
+\indexlibraryglobal{PRIbN}%
+\indexlibraryglobal{PRIBN}%
 \indexlibraryglobal{SCNdN}%
 \indexlibraryglobal{SCNiN}%
 \indexlibraryglobal{SCNoN}%
 \indexlibraryglobal{SCNuN}%
 \indexlibraryglobal{SCNxN}%
+\indexlibraryglobal{SCNbN}%
 \indexlibraryglobal{PRIdLEASTN}%
 \indexlibraryglobal{PRIiLEASTN}%
 \indexlibraryglobal{PRIoLEASTN}%
 \indexlibraryglobal{PRIuLEASTN}%
 \indexlibraryglobal{PRIxLEASTN}%
 \indexlibraryglobal{PRIXLEASTN}%
+\indexlibraryglobal{PRIbLEASTN}%
+\indexlibraryglobal{PRIBLEASTN}%
 \indexlibraryglobal{SCNdLEASTN}%
 \indexlibraryglobal{SCNiLEASTN}%
 \indexlibraryglobal{SCNoLEASTN}%
 \indexlibraryglobal{SCNuLEASTN}%
 \indexlibraryglobal{SCNxLEASTN}%
+\indexlibraryglobal{SCNbLEASTN}%
 \indexlibraryglobal{PRIdFASTN}%
 \indexlibraryglobal{PRIiFASTN}%
 \indexlibraryglobal{PRIoFASTN}%
 \indexlibraryglobal{PRIuFASTN}%
 \indexlibraryglobal{PRIxFASTN}%
 \indexlibraryglobal{PRIXFASTN}%
+\indexlibraryglobal{PRIbFASTN}%
+\indexlibraryglobal{PRIBFASTN}%
 \indexlibraryglobal{SCNdFASTN}%
 \indexlibraryglobal{SCNiFASTN}%
 \indexlibraryglobal{SCNoFASTN}%
 \indexlibraryglobal{SCNuFASTN}%
 \indexlibraryglobal{SCNxFASTN}%
+\indexlibraryglobal{SCNbFASTN}%
 \begin{codeblock}
 #include <cstdint>  // see \ref{cstdint.syn}
 
@@ -19027,61 +19039,78 @@ namespace std {
   constexpr imaxdiv_t div(intmax_t, intmax_t);  // optional, see below
 }
 
+#define __STDC_VERSION_INTTYPES_H__ 202311L
+
 #define PRId@\placeholdernc{N}@ @\seebelow@
 #define PRIi@\placeholdernc{N}@ @\seebelow@
 #define PRIo@\placeholdernc{N}@ @\seebelow@
 #define PRIu@\placeholdernc{N}@ @\seebelow@
 #define PRIx@\placeholdernc{N}@ @\seebelow@
 #define PRIX@\placeholdernc{N}@ @\seebelow@
+#define PRIb@\placeholdernc{N}@ @\seebelow@
+#define PRIB@\placeholdernc{N}@ @\seebelow@
 #define SCNd@\placeholdernc{N}@ @\seebelow@
 #define SCNi@\placeholdernc{N}@ @\seebelow@
 #define SCNo@\placeholdernc{N}@ @\seebelow@
 #define SCNu@\placeholdernc{N}@ @\seebelow@
 #define SCNx@\placeholdernc{N}@ @\seebelow@
+#define SCNb@\placeholdernc{N}@ @\seebelow@
 #define PRIdLEAST@\placeholdernc{N}@ @\seebelow@
 #define PRIiLEAST@\placeholdernc{N}@ @\seebelow@
 #define PRIoLEAST@\placeholdernc{N}@ @\seebelow@
 #define PRIuLEAST@\placeholdernc{N}@ @\seebelow@
 #define PRIxLEAST@\placeholdernc{N}@ @\seebelow@
 #define PRIXLEAST@\placeholdernc{N}@ @\seebelow@
+#define PRIbLEAST@\placeholdernc{N}@ @\seebelow@
+#define PRIBLEAST@\placeholdernc{N}@ @\seebelow@
 #define SCNdLEAST@\placeholdernc{N}@ @\seebelow@
 #define SCNiLEAST@\placeholdernc{N}@ @\seebelow@
 #define SCNoLEAST@\placeholdernc{N}@ @\seebelow@
 #define SCNuLEAST@\placeholdernc{N}@ @\seebelow@
 #define SCNxLEAST@\placeholdernc{N}@ @\seebelow@
+#define SCNbLEAST@\placeholdernc{N}@ @\seebelow@
 #define PRIdFAST@\placeholdernc{N}@ @\seebelow@
 #define PRIiFAST@\placeholdernc{N}@ @\seebelow@
 #define PRIoFAST@\placeholdernc{N}@ @\seebelow@
 #define PRIuFAST@\placeholdernc{N}@ @\seebelow@
 #define PRIxFAST@\placeholdernc{N}@ @\seebelow@
 #define PRIXFAST@\placeholdernc{N}@ @\seebelow@
+#define PRIbFAST@\placeholdernc{N}@ @\seebelow@
+#define PRIBFAST@\placeholdernc{N}@ @\seebelow@
 #define SCNdFAST@\placeholdernc{N}@ @\seebelow@
 #define SCNiFAST@\placeholdernc{N}@ @\seebelow@
 #define SCNoFAST@\placeholdernc{N}@ @\seebelow@
 #define SCNuFAST@\placeholdernc{N}@ @\seebelow@
 #define SCNxFAST@\placeholdernc{N}@ @\seebelow@
+#define SCNbFAST@\placeholdernc{N}@ @\seebelow@
 #define @\libmacro{PRIdMAX}@ @\seebelow@
 #define @\libmacro{PRIiMAX}@ @\seebelow@
 #define @\libmacro{PRIoMAX}@ @\seebelow@
 #define @\libmacro{PRIuMAX}@ @\seebelow@
 #define @\libmacro{PRIxMAX}@ @\seebelow@
 #define @\libmacro{PRIXMAX}@ @\seebelow@
+#define @\libmacro{PRIbMAX}@ @\seebelow@
+#define @\libmacro{PRIBMAX}@ @\seebelow@
 #define @\libmacro{SCNdMAX}@ @\seebelow@
 #define @\libmacro{SCNiMAX}@ @\seebelow@
 #define @\libmacro{SCNoMAX}@ @\seebelow@
 #define @\libmacro{SCNuMAX}@ @\seebelow@
 #define @\libmacro{SCNxMAX}@ @\seebelow@
+#define @\libmacro{SCNbMAX}@ @\seebelow@
 #define @\libmacro{PRIdPTR}@ @\seebelow@
 #define @\libmacro{PRIiPTR}@ @\seebelow@
 #define @\libmacro{PRIoPTR}@ @\seebelow@
 #define @\libmacro{PRIuPTR}@ @\seebelow@
 #define @\libmacro{PRIxPTR}@ @\seebelow@
 #define @\libmacro{PRIXPTR}@ @\seebelow@
+#define @\libmacro{PRIbPTR}@ @\seebelow@
+#define @\libmacro{PRIBPTR}@ @\seebelow@
 #define @\libmacro{SCNdPTR}@ @\seebelow@
 #define @\libmacro{SCNiPTR}@ @\seebelow@
 #define @\libmacro{SCNoPTR}@ @\seebelow@
 #define @\libmacro{SCNuPTR}@ @\seebelow@
 #define @\libmacro{SCNxPTR}@ @\seebelow@
+#define @\libmacro{SCNbPTR}@ @\seebelow@
 \end{codeblock}
 
 \pnum
@@ -19092,10 +19121,6 @@ with the following changes:
 \item
 The header \libheader{cinttypes} includes the header \libheaderref{cstdint} instead
 of \libheader{stdint.h}, and
-\item
-\tcode{intmax_t} and \tcode{uintmax_t} are not required
-to be able to represent all values of extended integer types
-wider than \tcode{long long} and \tcode{unsigned long long}, respectively, and
 \item
 if and only if the type \tcode{intmax_t} designates an extended integer
 type\iref{basic.fundamental}, the following function signatures are added:
@@ -19118,3 +19143,6 @@ Each of the \tcode{SCN} macros listed in this subclause
 is defined if and only if the implementation
 defines the corresponding \grammarterm{typedef-name} in~\ref{cstdint.syn} and
 has a suitable \tcode{fscanf} length modifier for the type.
+Each of the \tcode{PRIB} macros listed in this subclause
+is defined if and only if \tcode{fprintf} supports
+the \tcode{B} conversion specifier.

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -292,7 +292,7 @@
 \newcommand{\CppXXIII}{\Cpp{} 2023}
 \newcommand{\CppXXVI}{\Cpp{} 2026}
 \newcommand{\IsoCUndated}{ISO/IEC 9899}
-\newcommand{\IsoC}{\IsoCUndated{}:2018}
+\newcommand{\IsoC}{\IsoCUndated{}:2024}
 \newcommand{\IsoFloatUndated}{ISO/IEC 60559}
 \newcommand{\IsoPosixUndated}{ISO/IEC/IEEE 9945}
 \newcommand{\IsoPosix}{\IsoPosixUndated{}:2009}

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -2022,12 +2022,10 @@ declares the functions described in this subclause.
 \indexlibraryglobal{aligned_alloc}%
 \indexlibraryglobal{calloc}%
 \indexlibraryglobal{malloc}%
-\indexlibraryglobal{realloc}%
 \begin{itemdecl}
 void* aligned_alloc(size_t alignment, size_t size);
 void* calloc(size_t nmemb, size_t size);
 void* malloc(size_t size);
-void* realloc(void* ptr, size_t size);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2045,8 +2043,35 @@ storage by calling \tcode{::operator new()}\iref{new.delete}.
 These functions implicitly create objects\iref{intro.object}
 in the returned region of storage and
 return a pointer to a suitable created object.
-In the case of \tcode{calloc} and \tcode{realloc},
-the objects are created before the storage is zeroed or copied, respectively.
+In the case of \tcode{calloc},
+the objects are created before the storage is zeroed.
+\end{itemdescr}
+
+\indexlibraryglobal{realloc}%
+\begin{itemdecl}
+void* realloc(void* ptr, size_t size);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{free(ptr)} has well-defined behavior.
+
+\pnum
+\effects
+If \tcode{ptr} is not null and \tcode{size} is zero,
+the behavior is erroneous and the effects are implementation-defined.
+Otherwise, this function has the semantics specified in the C standard library.
+
+\pnum
+\remarks
+This function does not attempt to allocate storage
+by calling \tcode{::operator new()}\iref{new.delete}.
+When a non-null pointer is returned,
+this function implicitly creates objects\iref{intro.object}
+in the returned region of storage and
+returns a pointer to a suitable created object.
+The objects are created before the storage is copied.
 \end{itemdescr}
 
 \indexlibraryglobal{free}%

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -137,7 +137,8 @@ namespace std {
 
 \pnum
 The contents and meaning of the header \libheader{cfenv}
-are the same as the C standard library header \libheader{fenv.h}.
+are a subset of the C standard library header \libheader{fenv.h} and
+only the declarations shown in the synopsis above are present.
 \begin{note}
 This document does not require an implementation to support the
 \tcode{FENV_ACCESS} pragma;
@@ -9347,6 +9348,12 @@ An iterator referencing one past the last value in the array.
 \indexlibraryglobal{nexttoward}%
 \indexlibraryglobal{nexttowardf}%
 \indexlibraryglobal{nexttowardl}%
+\indexlibraryglobal{nextup}%
+\indexlibraryglobal{nextupf}%
+\indexlibraryglobal{nextupl}%
+\indexlibraryglobal{nextdown}%
+\indexlibraryglobal{nextdownf}%
+\indexlibraryglobal{nextdownl}%
 \indexlibraryglobal{pow}%
 \indexlibraryglobal{powf}%
 \indexlibraryglobal{powl}%
@@ -9637,6 +9644,14 @@ namespace std {
   constexpr float               nexttowardf(float x, long double y);
   constexpr long double         nexttowardl(long double x, long double y);
 
+  constexpr @\placeholdernc{floating-point-type}@ nextup(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               nextupf(float x);
+  constexpr long double         nextupl(long double x);
+
+  constexpr @\placeholdernc{floating-point-type}@ nextdown(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               nextdownf(float x);
+  constexpr long double         nextdownl(long double x);
+
   constexpr @\placeholdernc{floating-point-type}@ fdim(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
   constexpr float               fdimf(float x, float y);
   constexpr long double         fdiml(long double x, long double y);
@@ -9786,7 +9801,8 @@ namespace std {
 
 \pnum
 The contents and meaning of the header \libheader{cmath}
-are the same as the C standard library header \libheader{math.h},
+are a subset of the C standard library header \libheader{math.h} and
+only the declarations shown in the synopsis above are present,
 with the addition of
 a three-dimensional hypotenuse function\iref{c.math.hypot3},
 a linear interpolation function\iref{c.math.lerp}, and

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -5465,13 +5465,18 @@ The same suffix \tcode{s} is used for \tcode{chrono::duration} literals denoting
 \indexlibraryglobal{strtok}%
 \indexlibraryglobal{strxfrm}%
 \begin{codeblock}
+#define __STDC_VERSION_STRING_H__ 202311L
+
 namespace std {
   using size_t = @\textit{see \ref{support.types.layout}}@;                                            // freestanding
 
   void* memcpy(void* s1, const void* s2, size_t n);                     // freestanding
+  void* memccpy(void* s1, const void* s2, int c, size_t n);             // freestanding
   void* memmove(void* s1, const void* s2, size_t n);                    // freestanding
   char* strcpy(char* s1, const char* s2);                               // freestanding
   char* strncpy(char* s1, const char* s2, size_t n);                    // freestanding
+  char* strdup(const char* s);
+  char* strndup(const char* s, size_t size);
   char* strcat(char* s1, const char* s2);                               // freestanding
   char* strncat(char* s1, const char* s2, size_t n);                    // freestanding
   int memcmp(const void* s1, const void* s2, size_t n);                 // freestanding
@@ -5493,6 +5498,7 @@ namespace std {
   char* strstr(char* s1, const char* s2);                               // freestanding; see \ref{library.c}
   char* strtok(char* s1, const char* s2);
   void* memset(void* s, int c, size_t n);                               // freestanding
+  void* memset_explicit(void* s, int c, size_t n);                      // freestanding
   char* strerror(int errnum);
   size_t strlen(const char* s);                                         // freestanding
 }
@@ -5526,4 +5532,4 @@ have different signatures in this document,
 but they have the same behavior as in the C standard library\iref{library.c}.
 \end{note}
 
-\xrefc{7.24}
+\xrefc{7.26}

--- a/source/support.tex
+++ b/source/support.tex
@@ -90,13 +90,14 @@ namespace std {
 The contents and meaning of the header \libheaderdef{cstddef} are the same as
 the C standard library header \libheader{stddef.h},
 except that it does not declare the type \keyword{wchar_t},
+that it does not define the macro \tcode{unreachable},
 that it also declares the type \tcode{byte}
 and its associated operations\iref{support.types.byteops},
 and as noted in
 \ref{support.types.nullptr} and
 \ref{support.types.layout}.
 
-\xrefc{7.19}
+\xrefc{7.22}
 
 \rSec2[cstdlib.syn]{Header \tcode{<cstdlib>} synopsis}
 
@@ -187,14 +188,20 @@ namespace std {
   void* aligned_alloc(size_t alignment, size_t size);
   void* calloc(size_t nmemb, size_t size);
   void free(void* ptr);
+  void free_sized(void* ptr, size_t size);
+  void free_aligned_sized(void* ptr, size_t alignment, size_t size);
   void* malloc(size_t size);
   void* realloc(void* ptr, size_t size);
+  size_t memalignment(const void* p);                                   // freestanding
 
   double atof(const char* nptr);
   int atoi(const char* nptr);
   long int atol(const char* nptr);
   long long int atoll(const char* nptr);
   double strtod(const char* nptr, char** endptr);
+  int strfromd(char* s, size_t n, const char* format, double fp);
+  int strfromf(char* s, size_t n, const char* format, float fp);
+  int strfroml(char* s, size_t n, const char* format, long double fp);
   float strtof(const char* nptr, char** endptr);
   long double strtold(const char* nptr, char** endptr);
   long int strtol(const char* nptr, char** endptr, int base);
@@ -210,10 +217,14 @@ namespace std {
   size_t wcstombs(char* s, const wchar_t* pwcs, size_t n);
 
   // \ref{alg.c.library}, C standard library algorithms
-  void* bsearch(const void* key, const void* base, size_t nmemb, size_t size,   // freestanding
+  void* bsearch(const void* key, void* base, size_t nmemb, size_t size,         // freestanding
                 @\placeholder{c-compare-pred}@*@\itcorr[-1]@ compar);
-  void* bsearch(const void* key, const void* base, size_t nmemb, size_t size,   // freestanding
+  void* bsearch(const void* key, void* base, size_t nmemb, size_t size,         // freestanding
                 @\placeholder{compare-pred}@*@\itcorr[-1]@ compar);
+  const void* bsearch(const void* key, const void* base, size_t nmemb,          // freestanding
+                      size_t size, @\placeholder{c-compare-pred}@*@\itcorr[-1]@ compar);
+  const void* bsearch(const void* key, const void* base, size_t nmemb,          // freestanding
+                      size_t size, @\placeholder{compare-pred}@*@\itcorr[-1]@ compar);
   void qsort(void* base, size_t nmemb, size_t size, @\placeholder{c-compare-pred}@*@\itcorr[-1]@ compar);    // freestanding
   void qsort(void* base, size_t nmemb, size_t size, @\placeholder{compare-pred}@*@\itcorr[-1]@ compar);      // freestanding
 
@@ -241,7 +252,8 @@ namespace std {
 \pnum
 The contents and meaning of the header \libheader{cstdlib} are the same as
 the C standard library header \libheader{stdlib.h},
-except that it does not declare the type \keyword{wchar_t},
+except that it does not declare the types \keyword{wchar_t} or \tcode{once_flag},
+and does not declare the function \tcode{call_once},
 and except as noted in
 \ref{support.types.nullptr},
 \ref{support.types.layout},
@@ -256,7 +268,7 @@ Several functions have additional overloads in this document,
 but they have the same behavior as in the C standard library\iref{library.c}.
 \end{note}
 
-\xrefc{7.22}
+\xrefc{7.24}
 
 \rSec2[support.types.nullptr]{Null pointers}
 
@@ -285,7 +297,7 @@ but not
 \tcode{(void*)0}.
 \end{footnote}
 
-\xrefc{7.19}
+\xrefc{7.22}
 
 \rSec2[support.types.layout]{Sizes, alignments, and offsets}
 
@@ -340,7 +352,7 @@ is at least as great as that of every scalar type, and whose alignment
 requirement is supported in every context\iref{basic.align}.
 \tcode{std::is_trivially_default_constructible_v<max_align_t>} is \tcode{true}.
 
-\xrefc{7.19}
+\xrefc{7.22}
 
 \rSec2[support.types.byteops]{\tcode{byte} type operations}
 
@@ -1753,53 +1765,48 @@ namespace std {
 \rSec2[climits.syn]{Header \tcode{<climits>} synopsis}
 
 \indexheader{climits}%
-\indexlibraryglobal{CHAR_BIT}%
-\indexlibraryglobal{SCHAR_MIN}%
-\indexlibraryglobal{SCHAR_MAX}%
-\indexlibraryglobal{UCHAR_MAX}%
-\indexlibraryglobal{CHAR_MIN}%
-\indexlibraryglobal{CHAR_MAX}%
-\indexlibraryglobal{MB_LEN_MAX}%
-\indexlibraryglobal{SHRT_MIN}%
-\indexlibraryglobal{SHRT_MAX}%
-\indexlibraryglobal{USHRT_MAX}%
-\indexlibraryglobal{INT_MIN}%
-\indexlibraryglobal{INT_MAX}%
-\indexlibraryglobal{UINT_MAX}%
-\indexlibraryglobal{LONG_MIN}%
-\indexlibraryglobal{LONG_MAX}%
-\indexlibraryglobal{ULONG_MAX}%
-\indexlibraryglobal{LLONG_MIN}%
-\indexlibraryglobal{LLONG_MAX}%
-\indexlibraryglobal{ULLONG_MAX}%
 \begin{codeblock}
 // all freestanding
-#define CHAR_BIT @\seebelow@
-#define SCHAR_MIN @\seebelow@
-#define SCHAR_MAX @\seebelow@
-#define UCHAR_MAX @\seebelow@
-#define CHAR_MIN @\seebelow@
-#define CHAR_MAX @\seebelow@
-#define MB_LEN_MAX @\seebelow@
-#define SHRT_MIN @\seebelow@
-#define SHRT_MAX @\seebelow@
-#define USHRT_MAX @\seebelow@
-#define INT_MIN @\seebelow@
-#define INT_MAX @\seebelow@
-#define UINT_MAX @\seebelow@
-#define LONG_MIN @\seebelow@
-#define LONG_MAX @\seebelow@
-#define ULONG_MAX @\seebelow@
-#define LLONG_MIN @\seebelow@
-#define LLONG_MAX @\seebelow@
-#define ULLONG_MAX @\seebelow@
+#define @\libmacro{BOOL_WIDTH}@ @\seebelow@
+#define @\libmacro{CHAR_BIT}@ @\seebelow@
+#define @\libmacro{CHAR_WIDTH}@ @\seebelow@
+#define @\libmacro{SCHAR_WIDTH}@ @\seebelow@
+#define @\libmacro{UCHAR_WIDTH}@ @\seebelow@
+#define @\libmacro{USHRT_WIDTH}@ @\seebelow@
+#define @\libmacro{SHRT_WIDTH}@ @\seebelow@
+#define @\libmacro{UINT_WIDTH}@ @\seebelow@
+#define @\libmacro{INT_WIDTH}@ @\seebelow@
+#define @\libmacro{ULONG_WIDTH}@ @\seebelow@
+#define @\libmacro{LONG_WIDTH}@ @\seebelow@
+#define @\libmacro{ULLONG_WIDTH}@ @\seebelow@
+#define @\libmacro{LLONG_WIDTH}@ @\seebelow@
+#define @\libmacro{SCHAR_MIN}@ @\seebelow@
+#define @\libmacro{SCHAR_MAX}@ @\seebelow@
+#define @\libmacro{UCHAR_MAX}@ @\seebelow@
+#define @\libmacro{CHAR_MIN}@ @\seebelow@
+#define @\libmacro{CHAR_MAX}@ @\seebelow@
+#define @\libmacro{MB_LEN_MAX}@ @\seebelow@
+#define @\libmacro{SHRT_MIN}@ @\seebelow@
+#define @\libmacro{SHRT_MAX}@ @\seebelow@
+#define @\libmacro{USHRT_MAX}@ @\seebelow@
+#define @\libmacro{INT_MIN}@ @\seebelow@
+#define @\libmacro{INT_MAX}@ @\seebelow@
+#define @\libmacro{UINT_MAX}@ @\seebelow@
+#define @\libmacro{LONG_MIN}@ @\seebelow@
+#define @\libmacro{LONG_MAX}@ @\seebelow@
+#define @\libmacro{ULONG_MAX}@ @\seebelow@
+#define @\libmacro{LLONG_MIN}@ @\seebelow@
+#define @\libmacro{LLONG_MAX}@ @\seebelow@
+#define @\libmacro{ULLONG_MAX}@ @\seebelow@
 \end{codeblock}
 
 \pnum
 The header \libheader{climits} defines all macros the same as
-the C standard library header \libheader{limits.h}.
+the C standard library header \libheader{limits.h},
+except that it does not define the macro \tcode{BITINT_MAXWIDTH}.
 \begin{note}
-Except for \tcode{CHAR_BIT} and \tcode{MB_LEN_MAX}, a macro referring to
+Except for the \tcode{WIDTH} macros, \tcode{CHAR_BIT}, and \tcode{MB_LEN_MAX},
+a macro referring to
 an integer type \tcode{T} defines a constant whose type is the promoted
 type of \tcode{T}\iref{conv.prom}.
 \end{note}
@@ -1809,88 +1816,51 @@ type of \tcode{T}\iref{conv.prom}.
 \rSec2[cfloat.syn]{Header \tcode{<cfloat>} synopsis}
 
 \indexheader{cfloat}%
-\indexlibraryglobal{DBL_DECIMAL_DIG}%
-\indexlibraryglobal{DBL_DIG}%
-\indexlibraryglobal{DBL_EPSILON}%
-\indexlibraryglobal{DBL_HAS_SUBNORM}%
-\indexlibraryglobal{DBL_MANT_DIG}%
-\indexlibraryglobal{DBL_MAX}%
-\indexlibraryglobal{DBL_MAX_10_EXP}%
-\indexlibraryglobal{DBL_MAX_EXP}%
-\indexlibraryglobal{DBL_MIN}%
-\indexlibraryglobal{DBL_MIN_10_EXP}%
-\indexlibraryglobal{DBL_MIN_EXP}%
-\indexlibraryglobal{DBL_TRUE_MIN}%
-\indexlibraryglobal{DECIMAL_DIG}%
-\indexlibraryglobal{FLT_DECIMAL_DIG}%
-\indexlibraryglobal{FLT_DIG}%
-\indexlibraryglobal{FLT_EPSILON}%
-\indexlibraryglobal{FLT_EVAL_METHOD}%
-\indexlibraryglobal{FLT_HAS_SUBNORM}%
-\indexlibraryglobal{FLT_MANT_DIG}%
-\indexlibraryglobal{FLT_MAX}%
-\indexlibraryglobal{FLT_MAX_10_EXP}%
-\indexlibraryglobal{FLT_MAX_EXP}%
-\indexlibraryglobal{FLT_MIN}%
-\indexlibraryglobal{FLT_MIN_10_EXP}%
-\indexlibraryglobal{FLT_MIN_EXP}%
-\indexlibraryglobal{FLT_RADIX}%
-\indexlibraryglobal{FLT_ROUNDS}%
-\indexlibraryglobal{FLT_TRUE_MIN}%
-\indexlibraryglobal{LDBL_DECIMAL_DIG}%
-\indexlibraryglobal{LDBL_DIG}%
-\indexlibraryglobal{LDBL_EPSILON}%
-\indexlibraryglobal{LDBL_HAS_SUBNORM}%
-\indexlibraryglobal{LDBL_MANT_DIG}%
-\indexlibraryglobal{LDBL_MAX}%
-\indexlibraryglobal{LDBL_MAX_10_EXP}%
-\indexlibraryglobal{LDBL_MAX_EXP}%
-\indexlibraryglobal{LDBL_MIN}%
-\indexlibraryglobal{LDBL_MIN_10_EXP}%
-\indexlibraryglobal{LDBL_MIN_EXP}%
-\indexlibraryglobal{LDBL_TRUE_MIN}%
 \begin{codeblock}
 // all freestanding
-#define FLT_ROUNDS @\seebelow@
-#define FLT_EVAL_METHOD @\seebelow@
-#define FLT_HAS_SUBNORM @\seebelow@
-#define DBL_HAS_SUBNORM @\seebelow@
-#define LDBL_HAS_SUBNORM @\seebelow@
-#define FLT_RADIX @\seebelow@
-#define FLT_MANT_DIG @\seebelow@
-#define DBL_MANT_DIG @\seebelow@
-#define LDBL_MANT_DIG @\seebelow@
-#define FLT_DECIMAL_DIG @\seebelow@
-#define DBL_DECIMAL_DIG @\seebelow@
-#define LDBL_DECIMAL_DIG @\seebelow@
-#define DECIMAL_DIG @\seebelow@
-#define FLT_DIG @\seebelow@
-#define DBL_DIG @\seebelow@
-#define LDBL_DIG @\seebelow@
-#define FLT_MIN_EXP @\seebelow@
-#define DBL_MIN_EXP @\seebelow@
-#define LDBL_MIN_EXP @\seebelow@
-#define FLT_MIN_10_EXP @\seebelow@
-#define DBL_MIN_10_EXP @\seebelow@
-#define LDBL_MIN_10_EXP @\seebelow@
-#define FLT_MAX_EXP @\seebelow@
-#define DBL_MAX_EXP @\seebelow@
-#define LDBL_MAX_EXP @\seebelow@
-#define FLT_MAX_10_EXP @\seebelow@
-#define DBL_MAX_10_EXP @\seebelow@
-#define LDBL_MAX_10_EXP @\seebelow@
-#define FLT_MAX @\seebelow@
-#define DBL_MAX @\seebelow@
-#define LDBL_MAX @\seebelow@
-#define FLT_EPSILON @\seebelow@
-#define DBL_EPSILON @\seebelow@
-#define LDBL_EPSILON @\seebelow@
-#define FLT_MIN @\seebelow@
-#define DBL_MIN @\seebelow@
-#define LDBL_MIN @\seebelow@
-#define FLT_TRUE_MIN @\seebelow@
-#define DBL_TRUE_MIN @\seebelow@
-#define LDBL_TRUE_MIN @\seebelow@
+#define __STDC_VERSION_FLOAT_H__ 202311
+
+#define @\libmacro{FLT_ROUNDS}@ @\seebelow@
+#define @\libmacro{FLT_EVAL_METHOD}@ @\seebelow@
+#define @\libmacro{FLT_RADIX}@ @\seebelow@
+#define @\libmacro{INFINITY}@ @\seebelow@
+#define @\libmacro{NAN}@ @\seebelow@
+#define @\libmacro{FLT_SNAN}@ @\seebelow@
+#define @\libmacro{DBL_SNAN}@ @\seebelow@
+#define @\libmacro{LDBL_SNAN}@ @\seebelow@
+#define @\libmacro{FLT_MANT_DIG}@ @\seebelow@
+#define @\libmacro{DBL_MANT_DIG}@ @\seebelow@
+#define @\libmacro{LDBL_MANT_DIG}@ @\seebelow@
+#define @\libmacro{FLT_DECIMAL_DIG}@ @\seebelow@
+#define @\libmacro{DBL_DECIMAL_DIG}@ @\seebelow@
+#define @\libmacro{LDBL_DECIMAL_DIG}@ @\seebelow@
+#define @\libmacro{FLT_DIG}@ @\seebelow@
+#define @\libmacro{DBL_DIG}@ @\seebelow@
+#define @\libmacro{LDBL_DIG}@ @\seebelow@
+#define @\libmacro{FLT_MIN_EXP}@ @\seebelow@
+#define @\libmacro{DBL_MIN_EXP}@ @\seebelow@
+#define @\libmacro{LDBL_MIN_EXP}@ @\seebelow@
+#define @\libmacro{FLT_MIN_10_EXP}@ @\seebelow@
+#define @\libmacro{DBL_MIN_10_EXP}@ @\seebelow@
+#define @\libmacro{LDBL_MIN_10_EXP}@ @\seebelow@
+#define @\libmacro{FLT_MAX_EXP}@ @\seebelow@
+#define @\libmacro{DBL_MAX_EXP}@ @\seebelow@
+#define @\libmacro{LDBL_MAX_EXP}@ @\seebelow@
+#define @\libmacro{FLT_MAX_10_EXP}@ @\seebelow@
+#define @\libmacro{DBL_MAX_10_EXP}@ @\seebelow@
+#define @\libmacro{LDBL_MAX_10_EXP}@ @\seebelow@
+#define @\libmacro{FLT_MAX}@ @\seebelow@
+#define @\libmacro{DBL_MAX}@ @\seebelow@
+#define @\libmacro{LDBL_MAX}@ @\seebelow@
+#define @\libmacro{FLT_EPSILON}@ @\seebelow@
+#define @\libmacro{DBL_EPSILON}@ @\seebelow@
+#define @\libmacro{LDBL_EPSILON}@ @\seebelow@
+#define @\libmacro{FLT_MIN}@ @\seebelow@
+#define @\libmacro{DBL_MIN}@ @\seebelow@
+#define @\libmacro{LDBL_MIN}@ @\seebelow@
+#define @\libmacro{FLT_TRUE_MIN}@ @\seebelow@
+#define @\libmacro{DBL_TRUE_MIN}@ @\seebelow@
+#define @\libmacro{LDBL_TRUE_MIN}@ @\seebelow@
 \end{codeblock}
 
 \pnum
@@ -1967,6 +1937,8 @@ macros that specify limits of integer types.
 \indexlibraryglobal{UINTMAX_C}%
 \begin{codeblock}
 // all freestanding
+#define __STDC_VERSION_STDINT_H__ 202311L
+
 namespace std {
   using int8_t         = @\textit{signed integer type}@;   // optional
   using int16_t        = @\textit{signed integer type}@;   // optional
@@ -2011,50 +1983,68 @@ namespace std {
   using uintptr_t      = @\textit{unsigned integer type}@; // optional
 }
 
-#define INT@\placeholdernc{N}@_MIN         @\seebelow@
-#define INT@\placeholdernc{N}@_MAX         @\seebelow@
-#define UINT@\placeholdernc{N}@_MAX        @\seebelow@
+#define INT@\placeholdernc{N}@_MIN          @\seebelow@
+#define INT@\placeholdernc{N}@_MAX          @\seebelow@
+#define UINT@\placeholdernc{N}@_MAX         @\seebelow@
+#define INT@\placeholdernc{N}@_WIDTH        @\seebelow@
+#define UINT@\placeholdernc{N}@_WIDTH       @\seebelow@
 
-#define INT_FAST@\placeholdernc{N}@_MIN    @\seebelow@
-#define INT_FAST@\placeholdernc{N}@_MAX    @\seebelow@
-#define UINT_FAST@\placeholdernc{N}@_MAX   @\seebelow@
+#define INT_FAST@\placeholdernc{N}@_MIN     @\seebelow@
+#define INT_FAST@\placeholdernc{N}@_MAX     @\seebelow@
+#define UINT_FAST@\placeholdernc{N}@_MAX    @\seebelow@
+#define INT_FAST@\placeholdernc{N}@_WIDTH   @\seebelow@
+#define UINT_FAST@\placeholdernc{N}@_WIDTH  @\seebelow@
 
-#define INT_LEAST@\placeholdernc{N}@_MIN   @\seebelow@
-#define INT_LEAST@\placeholdernc{N}@_MAX   @\seebelow@
-#define UINT_LEAST@\placeholdernc{N}@_MAX  @\seebelow@
+#define INT_LEAST@\placeholdernc{N}@_MIN    @\seebelow@
+#define INT_LEAST@\placeholdernc{N}@_MAX    @\seebelow@
+#define UINT_LEAST@\placeholdernc{N}@_MAX   @\seebelow@
+#define INT_LEAST@\placeholdernc{N}@_WIDTH  @\seebelow@
+#define UINT_LEAST@\placeholdernc{N}@_WIDTH @\seebelow@
 
-#define INTMAX_MIN       @\seebelow@
-#define INTMAX_MAX       @\seebelow@
-#define UINTMAX_MAX      @\seebelow@
+#define INTMAX_MIN        @\seebelow@
+#define INTMAX_MAX        @\seebelow@
+#define UINTMAX_MAX       @\seebelow@
+#define INTMAX_WIDTH      @\seebelow@
+#define UINTMAX_WIDTH     @\seebelow@
 
-#define INTPTR_MIN       @\seebelow@              // optional
-#define INTPTR_MAX       @\seebelow@              // optional
-#define UINTPTR_MAX      @\seebelow@              // optional
+#define INTPTR_MIN        @\seebelow@              // optional
+#define INTPTR_MAX        @\seebelow@              // optional
+#define UINTPTR_MAX       @\seebelow@              // optional
+#define INTPTR_WIDTH      @\seebelow@              // optional
+#define UINTPTR_WIDTH     @\seebelow@              // optional
 
-#define PTRDIFF_MIN      @\seebelow@
-#define PTRDIFF_MAX      @\seebelow@
-#define SIZE_MAX         @\seebelow@
+#define PTRDIFF_MIN       @\seebelow@
+#define PTRDIFF_MAX       @\seebelow@
+#define PTRDIFF_WIDTH     @\seebelow@
+#define SIZE_MAX          @\seebelow@
+#define SIZE_WIDTH        @\seebelow@
 
-#define SIG_ATOMIC_MIN   @\seebelow@
-#define SIG_ATOMIC_MAX   @\seebelow@
+#define SIG_ATOMIC_MIN    @\seebelow@
+#define SIG_ATOMIC_MAX    @\seebelow@
+#define SIG_ATOMIC_WIDTH  @\seebelow@
 
-#define WCHAR_MIN        @\seebelow@
-#define WCHAR_MAX        @\seebelow@
+#define WCHAR_MIN         @\seebelow@
+#define WCHAR_MAX         @\seebelow@
+#define WCHAR_WIDTH       @\seebelow@
 
-#define WINT_MIN         @\seebelow@
-#define WINT_MAX         @\seebelow@
+#define WINT_MIN          @\seebelow@
+#define WINT_MAX          @\seebelow@
+#define WINT_WIDTH        @\seebelow@
 
-#define INT@\placeholdernc{N}@_C(value)    @\seebelow@
-#define UINT@\placeholdernc{N}@_C(value)   @\seebelow@
-#define INTMAX_C(value)  @\seebelow@
-#define UINTMAX_C(value) @\seebelow@
+#define INT@\placeholdernc{N}@_C(value)     @\seebelow@
+#define UINT@\placeholdernc{N}@_C(value)    @\seebelow@
+#define INTMAX_C(value)   @\seebelow@
+#define UINTMAX_C(value)  @\seebelow@
 \end{codeblock}
 
 \pnum
 The header defines all types and macros the same as
 the C standard library header \libheader{stdint.h}.
+The types denoted by \tcode{intmax_t} and \tcode{uintmax_t}
+are not required to be able to represent all values of extended integer types
+wider than \tcode{long long} and \tcode{unsigned long long}, respectively.
 
-\xrefc{7.20}
+\xrefc{7.22}
 
 \pnum
 All types that use the placeholder \placeholder{N}
@@ -2321,7 +2311,7 @@ The function \tcode{quick_exit} is signal-safe\iref{support.signal}
 when the functions registered with \tcode{at_quick_exit} are.
 \end{itemdescr}
 
-\xrefc{7.22.4}
+\xrefc{7.24.4}
 
 \rSec1[support.dynamic]{Dynamic memory management}
 
@@ -6310,6 +6300,8 @@ function.
 \indexheader{cstdarg}%
 \begin{codeblock}
 // all freestanding
+#define __STDC_VERSION_STDARG_H__ 202311L
+
 namespace std {
   using @\libglobal{va_list}@ = @\seebelow@;
 }
@@ -6317,7 +6309,7 @@ namespace std {
 #define @\libmacro{va_arg}@(V, P) @\seebelow@
 #define @\libmacro{va_copy}@(VDST, VSRC) @\seebelow@
 #define @\libmacro{va_end}@(V) @\seebelow@
-#define @\libmacro{va_start}@(V, P) @\seebelow@
+#define @\libmacro{va_start}@(V, ...) @\seebelow@
 \end{codeblock}
 
 \pnum
@@ -6328,33 +6320,16 @@ standard library header \libheader{stdarg.h}, with the following changes:
 In lieu of the default argument promotions specified in \IsoC{} 6.5.2.2,
 the definition in~\ref{expr.call} applies.
 \item
-The restrictions that C places on the second parameter to the
-\libmacro{va_start} macro in header \libheader{stdarg.h}
-are different in this document.
-The parameter
-\tcode{parmN}
-is the rightmost parameter in the variable parameter list
-of the function definition (the one just before the
-\tcode{...}).
-\begin{footnote}
-Note that
-\tcode{va_start}
-is required to work as specified even if unary
-\tcode{operator\&}
-is overloaded for the type of
-\tcode{parmN}.
-\end{footnote}
-If the parameter \tcode{parmN} is a pack expansion\iref{temp.variadic} or
-an entity resulting from a lambda capture\iref{expr.prim.lambda},
-the program is ill-formed, no diagnostic required.
-If the parameter
-\tcode{parmN}
-is of a reference type, or of a type that is not compatible with the
-type that results when passing an argument for which there is no
-parameter, the behavior is undefined.
+The preprocessing tokens
+comprising the second and subsequent arguments to \tcode{va_start} (if any)
+are discarded.
+\begin{note}
+\tcode{va_start} accepts a second argument
+for compatibility with prior revisions of \Cpp{}.
+\end{note}
 \end{itemize}
 
-\xrefc{7.16.1.1}
+\xrefc{7.16}
 
 \rSec2[csetjmp.syn]{Header \tcode{<csetjmp>} synopsis}
 
@@ -6362,6 +6337,8 @@ parameter, the behavior is undefined.
 \indexlibraryglobal{longjmp}%
 \indexlibraryglobal{setjmp}%
 \begin{codeblock}
+#define __STDC_VERSION_SETJMP_H__ 202311L
+
 namespace std {
   using jmp_buf = @\seebelow@;
   [[noreturn]] void longjmp(jmp_buf env, int val);
@@ -6537,13 +6514,13 @@ The following source file is both valid \Cpp{} and valid C.
 Viewed as \Cpp{}, it declares a function with C language linkage;
 viewed as C it simply declares a function (and provides a prototype).
 \begin{codeblock}
-#include <stdbool.h>    // for \tcode{bool} in C, no effect in \Cpp{}
+#include <uchar.h>      // for \tcode{char8_t} in C, not necessary in \Cpp{}
 #include <stddef.h>     // for \tcode{size_t}
 
 #ifdef __cplusplus      // see \ref{cpp.predefined}
 extern "C"              // see \ref{dcl.link}
 #endif
-void f(bool b[], size_t n);
+void f(char8_t s[], size_t n);
 \end{codeblock}
 \end{example}
 
@@ -6627,9 +6604,7 @@ are keywords in \Cpp{}\iref{lex.key}.
 \indexheader{stdalign.h}%
 \pnum
 The contents of the \Cpp{} header \libheader{stdalign.h} are the same as the C
-standard library header \libheader{stdalign.h}, with the following changes:
-The header \libheader{stdalign.h} does not
-define a macro named \tcode{alignas}.
+standard library header \libheader{stdalign.h}.
 
 \xrefc{7.15}
 
@@ -6638,11 +6613,9 @@ define a macro named \tcode{alignas}.
 \indexheader{stdbool.h}%
 \pnum
 The contents of the \Cpp{} header \libheader{stdbool.h} are the same as the C
-standard library header \libheader{stdbool.h}, with the following changes:
-The header \libheader{stdbool.h} does not
-define macros named \tcode{bool}, \tcode{true}, or \tcode{false}.
+standard library header \libheader{stdbool.h}.
 
-\xrefc{7.18}
+\xrefc{7.19}
 
 \rSec2[tgmath.h.syn]{Header \tcode{<tgmath.h>} synopsis}
 

--- a/source/text.tex
+++ b/source/text.tex
@@ -13157,6 +13157,8 @@ are the same as the C standard library header \libheader{wctype.h}.
 \indexlibraryglobal{wprintf}%
 \indexlibraryglobal{wscanf}%
 \begin{codeblock}
+#define __STDC_VERSION_WCHAR_H__ 202311L
+
 namespace std {
   using size_t = @\textit{see \ref{support.types.layout}}@;                                             // freestanding
   using mbstate_t = @\seebelow@;                                          // freestanding
@@ -13236,6 +13238,7 @@ namespace std {
 #define @\libmacro{WCHAR_MAX}@ @\seebelow@                                             // freestanding
 #define @\libmacro{WCHAR_MIN}@ @\seebelow@                                             // freestanding
 #define @\libmacro{WEOF}@ @\seebelow@                                                  // freestanding
+#define @\libmacro{WCHAR_WIDTH}@ @\seebelow@                                           // freestanding
 \end{codeblock}
 
 \pnum
@@ -13251,7 +13254,7 @@ have different signatures in this document,
 but they have the same behavior as in the C standard library\iref{library.c}.
 \end{note}
 
-\xrefc{7.29}
+\xrefc{7.31}
 
 \rSec2[cuchar.syn]{Header \tcode{<cuchar>} synopsis}
 
@@ -13264,6 +13267,8 @@ but they have the same behavior as in the C standard library\iref{library.c}.
 \indexlibraryglobal{mbrtoc32}%
 \indexlibraryglobal{c32rtomb}%
 \begin{codeblock}
+#define __STDC_VERSION_UCHAR_H__ 202311L
+
 namespace std {
   using mbstate_t = @\seebelow@;
   using size_t = @\textit{see \ref{support.types.layout}}@;
@@ -13279,12 +13284,11 @@ namespace std {
 
 \pnum
 The contents and meaning of the header \libheaderdef{cuchar}
-are the same as the C standard library header
-\libheader{uchar.h}, except that it
-declares the additional \tcode{mbrtoc8} and \tcode{c8rtomb} functions
-and does not declare types \keyword{char16_t} nor \keyword{char32_t}.
+are the same as the C standard library header \libheader{uchar.h},
+except that it does not declare types
+\keyword{char8_t}, \keyword{char16_t}, or \keyword{char32_t}.
 
-\xrefc{7.28}
+\xrefc{7.30}
 
 \rSec2[c.mb.wcs]{Multibyte / wide string and character conversion functions}
 
@@ -13336,17 +13340,18 @@ with other calls to the same function.
 
 \xrefc{7.22.7}
 
-\indexlibraryglobal{mbrlen}%
-\indexlibraryglobal{mbrstowcs}%
-\indexlibraryglobal{wcrstombs}%
-\indexlibraryglobal{mbrtowc}%
-\indexlibraryglobal{wcrtomb}%
 \begin{itemdecl}
-size_t mbrlen(const char* s, size_t n, mbstate_t* ps);
-size_t mbrtowc(wchar_t* pwc, const char* s, size_t n, mbstate_t* ps);
-size_t wcrtomb(char* s, wchar_t wc, mbstate_t* ps);
-size_t mbsrtowcs(wchar_t* dst, const char** src, size_t len, mbstate_t* ps);
-size_t wcsrtombs(char* dst, const wchar_t** src, size_t len, mbstate_t* ps);
+size_t @\libglobal{mbrlen}@(const char* s, size_t n, mbstate_t* ps);
+size_t @\libglobal{mbrtowc}@(wchar_t* pwc, const char* s, size_t n, mbstate_t* ps);
+size_t @\libglobal{wcrtomb}@(char* s, wchar_t wc, mbstate_t* ps);
+size_t @\libglobal{mbrtoc8}@(char8_t* pc8, const char* s, size_t n, mbstate_t* ps);
+size_t @\libglobal{c8rtomb}@(char* s, char8_t c8, mbstate_t* ps);
+size_t @\libglobal{mbrtoc16}@(char16_t* pc16, const char* s, size_t n, mbstate_t* ps);
+size_t @\libglobal{c16rtomb}@(char* s, char16_t c16, mbstate_t* ps);
+size_t @\libglobal{mbrtoc32}@(char32_t* pc32, const char* s, size_t n, mbstate_t* ps);
+size_t @\libglobal{c32rtomb}@(char* s, char32_t c32, mbstate_t* ps);
+size_t @\libglobal{mbsrtowcs}@(wchar_t* dst, const char** src, size_t len, mbstate_t* ps);
+size_t @\libglobal{wcsrtombs}@(char* dst, const wchar_t** src, size_t len, mbstate_t* ps);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -13363,95 +13368,4 @@ with other calls to the same function
 with an \tcode{mbstate_t*} argument that is a null pointer value.
 \end{itemdescr}
 
-\xrefc{7.29.6.3}
-
-\indexlibraryglobal{mbrtoc8}%
-\begin{itemdecl}
-size_t mbrtoc8(char8_t* pc8, const char* s, size_t n, mbstate_t* ps);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-If \tcode{s} is a null pointer,
-equivalent to \tcode{mbrtoc8(nullptr, "", 1, ps)}.
-Otherwise, the function inspects at most \tcode{n} bytes
-beginning with the byte pointed to by \tcode{s}
-to determine the number of bytes needed to complete
-the next multibyte character (including any shift sequences).
-If the function determines
-that the next multibyte character is complete and valid,
-\indextext{UTF-8}%
-it determines the values of the corresponding UTF-8 code units and then,
-if \tcode{pc8} is not a null pointer,
-stores the value of the first (or only) such code unit
-in the object pointed to by \tcode{pc8}.
-Subsequent calls will store successive UTF-8 code units
-without consuming any additional input
-until all the code units have been stored.
-If the corresponding Unicode character is \unicode{0000}{null},
-the resulting state described is the initial conversion state.
-
-\pnum
-\returns
-The first of the following that applies (given the current conversion state):
-\begin{itemize}
-\item \tcode{0}, if the next \tcode{n} or fewer bytes complete
-the multibyte character
-that corresponds to the \unicode{0000}{null} Unicode character
-(which is the value stored).
-\item between \tcode{1} and \tcode{n} (inclusive),
-if the next \tcode{n} or fewer bytes complete a valid multibyte character
-(whose first (or only) code unit is stored);
-the value returned is the number of bytes that complete the multibyte character.
-\item \tcode{(size_t)(-3)}, if the next code unit
-resulting from a previous call has been stored
-(no bytes from the input have been consumed by this call).
-\item \tcode{(size_t)(-2)}, if the next \tcode{n} bytes
-contribute to an incomplete (but potentially valid) multibyte character, and
-all \tcode{n} bytes have been processed (no value is stored).
-\item \tcode{(size_t)(-1)}, if an encoding error occurs,
-in which case the next \tcode{n} or fewer bytes do not contribute to
-a complete and valid multibyte character (no value is stored);
-the value of the macro \tcode{EILSEQ} is stored in \tcode{errno}, and
-the conversion state is unspecified.
-\end{itemize}
-\end{itemdescr}
-
-\indexlibraryglobal{c8rtomb}%
-\begin{itemdecl}
-size_t c8rtomb(char* s, char8_t c8, mbstate_t* ps);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-If \tcode{s} is a null pointer, equivalent to
-\tcode{c8rtomb(buf, u8'$\backslash$0', ps)}
-where \tcode{buf} is an internal buffer.
-\indextext{UTF-8}%
-Otherwise, if \tcode{c8} completes a sequence of valid UTF-8 code units,
-determines the number of bytes needed
-to represent the multibyte character (including any shift sequences),
-and stores the multibyte character representation in the array
-whose first element is pointed to by \tcode{s}.
-At most \tcode{MB_CUR_MAX} bytes are stored.
-If the multibyte character is a null character, a null byte is stored,
-preceded by any shift sequence needed to restore the initial shift state;
-the resulting state described is the initial conversion state.
-
-\pnum
-\returns
-The number of bytes stored in the array object (including any shift sequences).
-If \tcode{c8} does not contribute to a sequence of \keyword{char8_t}
-corresponding to a valid multibyte character,
-the value of the macro \tcode{EILSEQ} is stored in \tcode{errno},
-\tcode{(size_t) (-1)} is returned, and the conversion state is unspecified.
-
-\pnum
-\remarks
-Calls to \tcode{c8rtomb} with a null pointer argument for \tcode{s}
-may introduce a data race\iref{res.on.data.races}
-with other calls to \tcode{c8rtomb}
-with a null pointer argument for \tcode{s}.
-\end{itemdescr}
+\xrefc{7.30.1, 7.31.6.3, 7.31.6.4}

--- a/source/time.tex
+++ b/source/time.tex
@@ -11607,25 +11607,32 @@ The specialization is enabled\iref{unord.hash}.
 \rSec1[ctime.syn]{Header \tcode{<ctime>} synopsis}
 
 \indexheader{ctime}%
-\indexlibraryglobal{asctime}%
 \indexlibraryglobal{clock_t}%
 \indexlibraryglobal{clock}%
-\indexlibraryglobal{ctime}%
 \indexlibraryglobal{difftime}%
 \indexlibraryglobal{gmtime}%
+\indexlibraryglobal{gmtime_r}%
 \indexlibraryglobal{localtime}%
+\indexlibraryglobal{localtime_r}%
 \indexlibraryglobal{mktime}%
 \indexlibraryglobal{size_t}%
 \indexlibraryglobal{strftime}%
 \indexlibraryglobal{time_t}%
 \indexlibraryglobal{timespec_get}%
+\indexlibraryglobal{timespec_getres}%
 \indexlibraryglobal{timespec}%
 \indexlibraryglobal{time}%
+\indexlibraryglobal{timegm}%
 \indexlibraryglobal{tm}%
 \begin{codeblock}
+#define __STDC_VERSION_TIME_H__ 202311L
+
 #define @\libmacro{NULL}@ @\textit{see \ref{support.types.nullptr}}@
 #define @\libmacro{CLOCKS_PER_SEC}@ @\seebelow@
 #define @\libmacro{TIME_UTC}@ @\seebelow@
+#define @\libmacro{TIME_MONOTONIC}@ @\seebelow@     // optional
+#define @\libmacro{TIME_ACTIVE}@ @\seebelow@        // optional
+#define @\libmacro{TIME_THREAD_ACTIVE}@ @\seebelow@ // optional
 
 namespace std {
   using size_t = @\textit{see \ref{support.types.layout}}@;
@@ -11638,12 +11645,14 @@ namespace std {
   clock_t clock();
   double difftime(time_t time1, time_t time0);
   time_t mktime(tm* timeptr);
+  time_t timegm(tm* timeptr);
   time_t time(time_t* timer);
   int timespec_get(timespec* ts, int base);
-  char* asctime(const tm* timeptr);
-  char* ctime(const time_t* timer);
+  int timespec_getres(timespec* ts, int base);
   tm* gmtime(const time_t* timer);
+  tm* gmtime_r(const time_t* timer, tm* buf);
   tm* localtime(const time_t* timer);
+  tm* localtime_r(const time_t* timer, tm* buf);
   size_t strftime(char* s, size_t maxsize, const char* format, const tm* timeptr);
 }
 \end{codeblock}
@@ -11658,8 +11667,8 @@ The contents of the header \libheader{ctime} are the same as the C standard libr
 \end{footnote}
 
 \pnum
-The functions \tcode{asctime}, \tcode{ctime}, \tcode{gmtime}, and
+The functions \tcode{gmtime} and
 \tcode{localtime} are not required to avoid data
 races\iref{res.on.data.races}.
 
-\xrefc{7.27}
+\xrefc{7.29}

--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -505,3 +505,8 @@
 
 % P3475R2 Defang and deprecate memory_order::consume
 \removedxref{dcl.attr.depend}
+
+% P3348R3 C++26 should refer to C23 not C17
+\removedxref{diff.header.assert.h}
+\removedxref{diff.header.stdalign.h}
+\removedxref{diff.header.stdbool.h}


### PR DESCRIPTION
Avoid lone subclause [depr.ctime] in Annex D.

Fixes #7940.
Fixes cplusplus/papers#2020