### PR TITLE
[mdspan.layout.leftpad.cons] Add \expected.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -23354,6 +23354,7 @@ padding_value == LayoutLeftPaddedMapping::padding_value
 is \tcode{true}.
 
 \pnum
+\expects
 \begin{itemize}
 \item
 If \exposid{rank_} is greater than 1 and


### PR DESCRIPTION
The description of

    template<class LayoutLeftPaddedMapping>
      constexpr explicit(see below )
        mapping(const LayoutLeftPaddedMapping& other);

didn't separate Mandates and Preconditions. This commit adds an \expects to separate the two.

One can compare with the analogous section in [mdspan.layout.rightpad.cons]. I've uploaded the affected page [std-p1079.pdf](https://github.com/user-attachments/files/20896844/std-p1079.pdf).