### PR TITLE
[atomics.ref.float] Apply missing changes from P3323R1

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -3751,32 +3751,32 @@ namespace std {
     constexpr atomic_ref(const atomic_ref&) noexcept;
     atomic_ref& operator=(const atomic_ref&) = delete;
 
-    constexpr void store(@\placeholdernc{floating-point-type}@,
+    constexpr void store(value_type,
                          memory_order = memory_order::seq_cst) const noexcept;
     constexpr value_type operator=(value_type) const noexcept;
     constexpr value_type load(memory_order = memory_order::seq_cst) const noexcept;
-    constexpr operator @\placeholdernc{floating-point-type}@() const noexcept;
+    constexpr operator value_type() const noexcept;
 
-    constexpr value_type exchange(@\placeholdernc{floating-point-type}@,
+    constexpr value_type exchange(value_type,
                                  memory_order = memory_order::seq_cst) const noexcept;
-    constexpr bool compare_exchange_weak(value_type&, @\placeholdernc{floating-point-type}@,
+    constexpr bool compare_exchange_weak(value_type&, value_type,
                                memory_order, memory_order) const noexcept;
-    constexpr bool compare_exchange_strong(value_type&, @\placeholdernc{floating-point-type}@,
+    constexpr bool compare_exchange_strong(value_type&, value_type,
                                  memory_order, memory_order) const noexcept;
-    constexpr bool compare_exchange_weak(value_type&, @\placeholdernc{floating-point-type}@,
+    constexpr bool compare_exchange_weak(value_type&, value_type,
                                memory_order = memory_order::seq_cst) const noexcept;
-    constexpr bool compare_exchange_strong(value_type&, @\placeholdernc{floating-point-type}@,
+    constexpr bool compare_exchange_strong(value_type&, value_type,
                                  memory_order = memory_order::seq_cst) const noexcept;
 
-    constexpr value_type fetch_add(@\placeholdernc{floating-point-type}@,
+    constexpr value_type fetch_add(value_type,
                                   memory_order = memory_order::seq_cst) const noexcept;
-    constexpr value_type fetch_sub(@\placeholdernc{floating-point-type}@,
+    constexpr value_type fetch_sub(value_type,
                                   memory_order = memory_order::seq_cst) const noexcept;
 
     constexpr value_type operator+=(value_type) const noexcept;
     constexpr value_type operator-=(value_type) const noexcept;
 
-    constexpr void wait(@\placeholdernc{floating-point-type}@,
+    constexpr void wait(value_type,
                         memory_order = memory_order::seq_cst) const noexcept;
     constexpr void notify_one() const noexcept;
     constexpr void notify_all() const noexcept;


### PR DESCRIPTION
Paper P3323R1 cv-qualified types in atomic and atomic_ref was incompletely applied in commit cd4dbcf2aa6df895a25dbf8c0773dd0fa67ef45d.