### PR TITLE
[container.insert.return] Fix description of insert-return-type

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2622,7 +2622,7 @@ struct @\placeholder{insert-return-type}@
 \end{codeblock}
 
 \pnum
-The name \exposid{insert-return-type} is exposition only.
+The name \exposid{insert-return-type} is for exposition only.
 \exposid{insert-return-type} has the template parameters,
 data members, and special members specified above.
 It has no base classes or members other than those specified.


### PR DESCRIPTION
Use "for exposition only" for consistency with usage elsewhere in the spec, and for the clarity/grammatical correctness of this sentence.