### PR TITLE
[range.join.iterator] Remove spurious return

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -7091,7 +7091,7 @@ friend constexpr void iter_swap(const @\exposid{iterator}@& x, const @\exposid{i
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return ranges::iter_swap(*x.\exposid{inner_}, *y.\exposid{inner_});}
+Equivalent to: \tcode{ranges::iter_swap(*x.\exposid{inner_}, *y.\exposid{inner_});}
 \end{itemdescr}
 
 \rSec3[range.join.sentinel]{Class template \tcode{join_view::\exposid{sentinel}}}


### PR DESCRIPTION
I suspect this is editorial rather than LWG, since the return type of `ranges::iter_swap` is explicitly defined as `void`.