### PR TITLE
P3709R2 Reconsider parallel `ranges::rotate_copy` and `ranges::reverse_copy`

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -2608,7 +2608,9 @@ namespace std {
 
   namespace ranges {
     template<class I, class O>
-      using reverse_copy_result = in_out_result<I, O>;
+      using @\libglobal{reverse_copy_result}@ = in_out_result<I, O>;
+    template<class I, class O>
+      using @\libglobal{reverse_copy_truncated_result}@ = in_in_out_result<I, I, O>;
 
     template<@\libconcept{bidirectional_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O>
       requires @\libconcept{indirectly_copyable}@<I, O>
@@ -2622,12 +2624,12 @@ namespace std {
     template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
              @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS>
       requires @\libconcept{indirectly_copyable}@<I, O>
-      reverse_copy_result<I, O>
+      reverse_copy_truncated_result<I, O>
         reverse_copy(Ep&& exec, I first, S last, O result,
                      OutS result_last);                         // freestanding-deleted
     template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR>
       requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR>>
-      reverse_copy_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+      reverse_copy_truncated_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
         reverse_copy(Ep&& exec, R&& r, OutR&& result_r);        // freestanding-deleted
   }
 
@@ -2671,7 +2673,9 @@ namespace std {
 
   namespace ranges {
     template<class I, class O>
-      using rotate_copy_result = in_out_result<I, O>;
+      using @\libglobal{rotate_copy_result}@ = in_out_result<I, O>;
+    template<class I, class O>
+      using @\libglobal{rotate_copy_truncated_result}@ = in_in_out_result<I, I, O>;
 
     template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O>
       requires @\libconcept{indirectly_copyable}@<I, O>
@@ -2686,12 +2690,12 @@ namespace std {
     template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
              @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS>
       requires @\libconcept{indirectly_copyable}@<I, O>
-      ranges::rotate_copy_result<I, O>
+      ranges::rotate_copy_truncated_result<I, O>
         ranges::rotate_copy(Ep&& exec, I first, I middle, S last, O result,
                             OutS result_last);                  // freestanding-deleted
     template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR>
       requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR>>
-      ranges::rotate_copy_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+      ranges::rotate_copy_truncated_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
         ranges::rotate_copy(Ep&& exec, R&& r, iterator_t<R> middle,
                             OutR&& result_r);                   // freestanding-deleted
     // FIXME: once ranges:: is removed, reflow the previous two lines into one
@@ -8163,12 +8167,12 @@ Exactly $N$ assignments.
 template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
          @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS>
   requires @\libconcept{indirectly_copyable}@<I, O>
-  ranges::reverse_copy_result<I, O>
+  ranges::reverse_copy_truncated_result<I, O>
     ranges::reverse_copy(Ep&& exec, I first, S last, O result,
                          OutS result_last);
 template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR>
   requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR>>
-  ranges::reverse_copy_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+  ranges::reverse_copy_truncated_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
     ranges::reverse_copy(Ep&& exec, R&& r, OutR&& result_r);
 \end{itemdecl}
 
@@ -8194,16 +8198,7 @@ the following assignment takes place:
 
 \pnum
 \returns
-\tcode{\{\exposid{NEW_FIRST}, result + $N$\}}.
-\begin{note}
-While the return type for the parallel and non-parallel algorithm overloads
-in the namespace \tcode{ranges} is the same,
-the semantics is different
-because for the parallel range algorithm overloads
-%FIXME: Comma.
-\tcode{result_last - result} can be insufficient
-to copy all data from the input.
-\end{note}
+\tcode{\{last, \exposid{NEW_FIRST}, result + $N$\}}.
 
 \pnum
 \complexity
@@ -8346,7 +8341,7 @@ Exactly $N$ assignments.
 template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
          @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS>
   requires @\libconcept{indirectly_copyable}@<I, O>
-  ranges::rotate_copy_result<I, O>
+  ranges::rotate_copy_truncated_result<I, O>
     ranges::rotate_copy(Ep&& exec, I first, I middle, S last, O result, OutS result_last);
 \end{itemdecl}
 
@@ -8374,16 +8369,14 @@ the following assignment takes place:
 
 \pnum
 \returns
-\tcode{\{first + ($N$ + (middle - first)) \% $M$, result + $N$\}}.
-\begin{note}
-While the return type for the parallel and non-parallel algorithm overloads
-in the namespace \tcode{ranges} is the same,
-the semantics is different
-because for the parallel range algorithm overloads
-%FIXME: Comma.
-\tcode{result_last - result} can be insufficient
-to copy all data from the input.
-\end{note}
+\begin{itemize}
+\item
+  \tcode{\{middle + $N$, first, result + $N$\}}
+  if $N$ is less than \tcode{last - middle}.
+\item
+  Otherwise,
+  \tcode{\{last, first + ($N$ + (middle - first)) \% $M$, result + $N$\}}.
+\end{itemize}
 
 \pnum
 \complexity
@@ -8409,7 +8402,7 @@ return ranges::rotate_copy(ranges::begin(r), middle, ranges::end(r), std::move(r
 \begin{itemdecl}
 template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR>
   requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR>>
-  ranges::rotate_copy_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+  ranges::rotate_copy_truncated_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
     ranges::rotate_copy(Ep&& exec, R&& r, iterator_t<R> middle, OutR&& result_r);
 \end{itemdecl}
 

--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -231,6 +231,15 @@ iter_difference_t<decltype(b)> n = 0;
 for (auto tmp = b; tmp != a; ++tmp) --n;
 return n;
 \end{codeblock}
+For each iterator \tcode{i} and sentinel \tcode{s}
+produced from a range \tcode{r},
+the semantics of \tcode{s - i} has the same type, value, and value category
+as \tcode{ranges::distance(i, s)}.
+\begin{note}
+The implementation can use \tcode{ranges::distance(r)}
+when that produces the same value as \tcode{ranges::\-distance(i, s)}.
+This can be more efficient for sized ranges.
+\end{note}
 
 \pnum
 In the description of the algorithms,
@@ -249,10 +258,25 @@ the semantics are as if the sentinel is converted into an iterator using
 
 \pnum
 Overloads of algorithms that take \libconcept{range} arguments\iref{range.range}
-behave as if they are implemented by calling \tcode{ranges::begin} and
-\tcode{ranges::end} on the \libconcept{range}(s) and
+behave as if they are implemented by
 dispatching to the overload in namespace \tcode{ranges}
-that takes separate iterator and sentinel arguments.
+that takes separate iterator and sentinel arguments,
+where for each range argument \tcode{r}
+\begin{itemize}
+\item
+  a corresponding iterator argument is initialized with \tcode{ranges::begin(r)} and
+\item
+  a corresponding sentinel argument is initialized with \tcode{ranges::end(r)},
+  or \tcode{ranges::\-next(ranges::\-begin(r), ranges::\-end(r))}
+  if the type of \tcode{r} models \libconcept{forward_range}
+  %TODO: this may be a wording bug;
+  %computing the expression ranges::next in itself is always O(1)
+  %because it is merely designating some function object,
+  %so the complexity requirement is vacuously satisfied.
+  %We probably want to say \tcode{ranges::next(r)} here,
+  %which is the intent, of course.
+  and computing \tcode{ranges::next} meets the specified complexity requirements.
+\end{itemize}
 
 \pnum
 The well-formedness and behavior of a call to an algorithm with
@@ -272,23 +296,30 @@ to perform operations on containers and other sequences in parallel.
 
 \pnum
 A \defn{parallel algorithm} is a function template listed in this document
-with a template parameter named \tcode{ExecutionPolicy}.
+with a template parameter named \tcode{ExecutionPolicy}
+or constrained by the following exposition-only concept:
+\begin{codeblock}
+template<class Ep>
+concept @\defexposconcept{execution-policy}@ = // \expos
+  is_execution_policy_v<remove_cvref_t<Ep>>;
+\end{codeblock}
+Such a template parameter is termed an \defnadj{execution policy}{template parameter}.
 
 \pnum
-Parallel algorithms access objects indirectly accessible via their arguments
+A parallel algorithm accesses objects indirectly accessible via its arguments
 by invoking the following functions:
 \begin{itemize}
 \item
-  All operations of the categories of the iterators or \tcode{mdspan} types
+  All operations of the categories of the iterators, sentinels, or \tcode{mdspan} types
   that the algorithm is instantiated with.
 \item
   Operations on those sequence elements that are required by its specification.
 \item
-  User-provided function objects
+  User-provided invocable objects
   to be applied during the execution of the algorithm,
   if required by the specification.
 \item
-  Operations on those function objects required by the specification.
+  Operations on those invocable objects required by the specification.
 \begin{note}
 See~\ref{algorithms.requirements}.
 \end{note}
@@ -344,7 +375,8 @@ to run on different threads of execution.
 
 \pnum
 Unless otherwise specified,
-function objects passed into parallel algorithms as objects of type
+invocable objects passed into parallel algorithms as objects of a type
+denoted by a template parameter named
 \tcode{Predicate},
 \tcode{BinaryPredicate},
 \tcode{Compare},
@@ -352,8 +384,10 @@ function objects passed into parallel algorithms as objects of type
 \tcode{BinaryOperation},
 \tcode{BinaryOperation1},
 \tcode{BinaryOperation2},
-\tcode{BinaryDivideOp}, and
-the operators used by the analogous overloads to these parallel algorithms
+\tcode{BinaryDivideOp}, or
+constrained by a concept that subsumes \libconcept{regular_invocable}
+%TODO: Comma here.
+and the operators used by the analogous overloads to these parallel algorithms
 that are formed by an invocation
 with the specified default predicate or operation (where applicable)
 shall not directly or indirectly modify objects via their arguments,
@@ -565,31 +599,31 @@ and none are available, the algorithm throws a \tcode{bad_alloc} exception.
 \pnum
 During the execution of a parallel algorithm,
 if the invocation of an element access function exits via an uncaught exception,
-the behavior is determined by the \tcode{ExecutionPolicy}.
+the behavior is determined by the execution policy.
 
 \rSec2[algorithms.parallel.overloads]{\tcode{ExecutionPolicy} algorithm overloads}
 
 \pnum
 Parallel algorithms are algorithm overloads.
 Each parallel algorithm overload
-has an additional template type parameter named \tcode{ExecutionPolicy},
-which is the first template parameter.
-Additionally, each parallel algorithm overload
-has an additional function parameter of type \tcode{ExecutionPolicy\&\&},
-which is the first function parameter.
+has an additional function parameter $P$ of type \tcode{ExecutionPolicy\&\&},
+as the first function parameter,
+where \tcode{T} is the execution policy template parameter.
 \begin{note}
 Not all algorithms have parallel algorithm overloads.
 \end{note}
 
 \pnum
 Unless otherwise specified,
-the semantics of \tcode{ExecutionPolicy} algorithm overloads
-are identical to their overloads without.
+the semantics of calling a parallel algorithm overload are identical to
+calling the corresponding algorithm overload without the parameter $P$,
+using all but the first argument.
 
 \pnum
 Unless otherwise specified,
-the complexity requirements of \tcode{ExecutionPolicy} algorithm overloads
-are relaxed from the complexity requirements of the overloads without
+the complexity requirements of a parallel algorithm overload
+are relaxed from the complexity requirements of the corresponding overload
+without the parameter $P$
 as follows:
 when the guarantee says ``at most \placeholder{expr}'' or
 ``exactly \placeholder{expr}''
@@ -598,8 +632,10 @@ and does not specify the number of assignments or swaps, and
 the complexity of the algorithm shall be \bigoh{\placeholder{expr}}.
 
 \pnum
-Parallel algorithms shall not participate in overload resolution unless
-\tcode{is_execution_policy_v<remove_cvref_t<ExecutionPolicy>>} is \tcode{true}.
+A parallel algorithm
+with a template parameter named \tcode{ExecutionPolicy}
+shall not participate in overload resolution unless
+that template parameter satisfies \exposconcept{execution-policy}.
 
 \rSec2[execpol]{Execution policies}
 
@@ -821,6 +857,13 @@ namespace std {
     template<@\libconcept{input_range}@ R, class Proj = identity,
              @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
       constexpr bool all_of(R&& r, Pred pred, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      bool all_of(Ep&& exec, I first, S last, Pred pred, Proj proj = {});   // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      bool all_of(Ep&& exec, R&& r, Pred pred, Proj proj = {});             // freestanding-deleted
   }
 
   // \ref{alg.any.of}, any of
@@ -837,6 +880,13 @@ namespace std {
     template<@\libconcept{input_range}@ R, class Proj = identity,
              @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
       constexpr bool any_of(R&& r, Pred pred, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      bool any_of(Ep&& exec, I first, S last, Pred pred, Proj proj = {});   // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      bool any_of(Ep&& exec, R&& r, Pred pred, Proj proj = {});             // freestanding-deleted
   }
 
   // \ref{alg.none.of}, none of
@@ -853,6 +903,13 @@ namespace std {
     template<@\libconcept{input_range}@ R, class Proj = identity,
              @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
       constexpr bool none_of(R&& r, Pred pred, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      bool none_of(Ep&& exec, I first, S last, Pred pred, Proj proj = {});  // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      bool none_of(Ep&& exec, R&& r, Pred pred, Proj proj = {});            // freestanding-deleted
   }
 
   // \ref{alg.contains}, contains
@@ -867,6 +924,17 @@ namespace std {
         @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
       constexpr bool contains(R&& r, const T& value, Proj proj = {});
 
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity, class T = projected_value_t<I, Proj>>
+      requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T*>
+      bool contains(Ep&& exec, I first, S last, const T& value,
+                    Proj proj = {});                                        // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             class T = projected_value_t<iterator_t<R>, Proj>>
+      requires
+        @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
+      bool contains(Ep&& exec, R&& r, const T& value, Proj proj = {});      // freestanding-deleted
+
     template<@\libconcept{forward_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1,
              @\libconcept{forward_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
              class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
@@ -878,6 +946,18 @@ namespace std {
       requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
       constexpr bool contains_subrange(R1&& r1, R2&& r2,
                                        Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+             @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+             class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
+      bool contains_subrange(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = {},
+                             Proj1 proj1 = {}, Proj2 proj2 = {});           // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+             class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+      bool contains_subrange(Ep&& exec, R1&& r1, R2&& r2, Pred pred = {}, Proj1 proj1 = {},
+                             Proj2 proj2 = {});                             // freestanding-deleted
   }
 
   // \ref{alg.foreach}, for each
@@ -899,6 +979,15 @@ namespace std {
              @\libconcept{indirectly_unary_invocable}@<projected<iterator_t<R>, Proj>> Fun>
       constexpr for_each_result<borrowed_iterator_t<R>, Fun>
         for_each(R&& r, Fun f, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity,
+             @\libconcept{indirectly_unary_invocable}@<projected<I, Proj>> Fun>
+      I for_each(Ep&& exec, I first, S last, Fun f, Proj proj = {});        // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             @\libconcept{indirectly_unary_invocable}@<projected<iterator_t<R>, Proj>> Fun>
+      borrowed_iterator_t<R>
+        for_each(Ep&& exec, R&& r, Fun f, Proj proj = {});                  // freestanding-deleted
   }
 
   template<class InputIterator, class Size, class Function>
@@ -915,6 +1004,11 @@ namespace std {
              @\libconcept{indirectly_unary_invocable}@<projected<I, Proj>> Fun>
       constexpr for_each_n_result<I, Fun>
         for_each_n(I first, iter_difference_t<I> n, Fun f, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, class Proj = identity,
+             @\libconcept{indirectly_unary_invocable}@<projected<I, Proj>> Fun>
+      I for_each_n(Ep&& exec, I first, iter_difference_t<I> n, Fun f,
+                   Proj proj = {});                             // freestanding-deleted
   }
 
   // \ref{alg.find}, find
@@ -952,6 +1046,18 @@ namespace std {
                                          projected<iterator_t<R>, Proj>, const T*>
       constexpr borrowed_iterator_t<R>
         find(R&& r, const T& value, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity, class T = projected_value_t<I, Proj>>
+      requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T*>
+      I find(Ep&& exec, I first, S last, const T& value, Proj proj = {});   // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             class T = projected_value_t<iterator_t<R>, Proj>>
+      requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to,
+                                         projected<iterator_t<R>, Proj>, const T*>
+      borrowed_iterator_t<R>
+        find(Ep&& exec, R&& r, const T& value, Proj proj = {});             // freestanding-deleted
+
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
              @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
       constexpr I find_if(I first, S last, Pred pred, Proj proj = {});
@@ -959,6 +1065,15 @@ namespace std {
              @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
       constexpr borrowed_iterator_t<R>
         find_if(R&& r, Pred pred, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      I find_if(Ep&& exec, I first, S last, Pred pred, Proj proj = {});     // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      borrowed_iterator_t<R>
+        find_if(Ep&& exec, R&& r, Pred pred, Proj proj = {});               // freestanding-deleted
+
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
              @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
       constexpr I find_if_not(I first, S last, Pred pred, Proj proj = {});
@@ -966,6 +1081,14 @@ namespace std {
              @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
       constexpr borrowed_iterator_t<R>
         find_if_not(R&& r, Pred pred, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      I find_if_not(Ep&& exec, I first, S last, Pred pred, Proj proj = {}); // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      borrowed_iterator_t<R>
+        find_if_not(Ep&& exec, R&& r, Pred pred, Proj proj = {});           // freestanding-deleted
   }
 
   // \ref{alg.find.last}, find last
@@ -979,18 +1102,55 @@ namespace std {
       requires
         @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
       constexpr borrowed_subrange_t<R> find_last(R&& r, const T& value, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity, class T = projected_value_t<I, Proj>>
+      requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T*>
+      subrange<I>
+        find_last(Ep&& exec, I first, S last, const T& value,
+                  Proj proj = {});                                          // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             class T = projected_value_t<iterator_t<R>, Proj>>
+      requires
+        @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
+      borrowed_subrange_t<R>
+        find_last(Ep&& exec, R&& r, const T& value, Proj proj = {});        // freestanding-deleted
+
     template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
              @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
       constexpr subrange<I> find_last_if(I first, S last, Pred pred, Proj proj = {});
     template<@\libconcept{forward_range}@ R, class Proj = identity,
              @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
       constexpr borrowed_subrange_t<R> find_last_if(R&& r, Pred pred, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      subrange<I>
+        find_last_if(Ep&& exec, I first, S last, Pred pred,
+                     Proj proj = {});                                       // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R,
+             class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      borrowed_subrange_t<R>
+        find_last_if(Ep&& exec, R&& r, Pred pred, Proj proj = {});          // freestanding-deleted
+
     template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
              @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
       constexpr subrange<I> find_last_if_not(I first, S last, Pred pred, Proj proj = {});
     template<@\libconcept{forward_range}@ R, class Proj = identity,
              @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
       constexpr borrowed_subrange_t<R> find_last_if_not(R&& r, Pred pred, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      subrange<I>
+        find_last_if_not(Ep&& exec, I first, S last, Pred pred,
+                         Proj proj = {});                                   // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      borrowed_subrange_t<R>
+        find_last_if_not(Ep&& exec, R&& r, Pred pred, Proj proj = {});      // freestanding-deleted
   }
 
   // \ref{alg.find.end}, find end
@@ -1029,6 +1189,20 @@ namespace std {
       constexpr borrowed_subrange_t<R1>
         find_end(R1&& r1, R2&& r2, Pred pred = {},
                  Proj1 proj1 = {}, Proj2 proj2 = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+             @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+             class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
+      subrange<I1>
+        find_end(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = {},
+                 Proj1 proj1 = {}, Proj2 proj2 = {});           // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+             class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+      borrowed_subrange_t<R1>
+        find_end(Ep&& exec, R1&& r1, R2&& r2, Pred pred = {},
+                 Proj1 proj1 = {}, Proj2 proj2 = {});           // freestanding-deleted
   }
 
   // \ref{alg.find.first.of}, find first
@@ -1066,6 +1240,19 @@ namespace std {
       constexpr borrowed_iterator_t<R1>
         find_first_of(R1&& r1, R2&& r2, Pred pred = {},
                       Proj1 proj1 = {}, Proj2 proj2 = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+             @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+             class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
+      I1 find_first_of(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = {},
+                       Proj1 proj1 = {}, Proj2 proj2 = {});     // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+             class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+      borrowed_iterator_t<R1>
+        find_first_of(Ep&& exec, R1&& r1, R2&& r2, Pred pred = {},
+                      Proj1 proj1 = {}, Proj2 proj2 = {});      // freestanding-deleted
   }
 
   // \ref{alg.adjacent.find}, adjacent find
@@ -1097,6 +1284,18 @@ namespace std {
                                        projected<iterator_t<R>, Proj>> Pred = ranges::equal_to>
       constexpr borrowed_iterator_t<R>
         adjacent_find(R&& r, Pred pred = {}, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity,
+             @\libconcept{indirect_binary_predicate}@<projected<I, Proj>,
+                                       projected<I, Proj>> Pred = ranges::equal_to>
+      I adjacent_find(Ep&& exec, I first, S last, Pred pred = {},
+                                Proj proj = {});                            // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             @\libconcept{indirect_binary_predicate}@<projected<iterator_t<R>, Proj>,
+                                       projected<iterator_t<R>, Proj>> Pred = ranges::equal_to>
+      borrowed_iterator_t<R>
+        adjacent_find(Ep&& exec, R&& r, Pred pred = {}, Proj proj = {});    // freestanding-deleted
   }
 
   // \ref{alg.count}, count
@@ -1128,6 +1327,19 @@ namespace std {
                                          projected<iterator_t<R>, Proj>, const T*>
       constexpr range_difference_t<R>
         count(R&& r, const T& value, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity, class T = projected_value_t<I, Proj>>
+      requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T*>
+      iter_difference_t<I>
+        count(Ep&& exec, I first, S last, const T& value, Proj proj = {});  // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             class T = projected_value_t<iterator_t<R>, Proj>>
+      requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to,
+                                         projected<iterator_t<R>, Proj>, const T*>
+      range_difference_t<R>
+        count(Ep&& exec, R&& r, const T& value, Proj proj = {});            // freestanding-deleted
+
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
              @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
       constexpr iter_difference_t<I>
@@ -1136,6 +1348,15 @@ namespace std {
              @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
       constexpr range_difference_t<R>
         count_if(R&& r, Pred pred, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      iter_difference_t<I>
+        count_if(Ep&& exec, I first, S last, Pred pred, Proj proj = {});    // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      range_difference_t<R>
+        count_if(Ep&& exec, R&& r, Pred pred, Proj proj = {});              // freestanding-deleted
   }
 
   // \ref{alg.mismatch}, mismatch
@@ -1196,6 +1417,20 @@ namespace std {
       constexpr mismatch_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
         mismatch(R1&& r1, R2&& r2, Pred pred = {},
                  Proj1 proj1 = {}, Proj2 proj2 = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+             @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+             class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
+      mismatch_result<I1, I2>
+        mismatch(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = {},
+                 Proj1 proj1 = {}, Proj2 proj2 = {});           // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+             class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+      mismatch_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
+        mismatch(Ep&& exec, R1&& r1, R2&& r2, Pred pred = {},
+                 Proj1 proj1 = {}, Proj2 proj2 = {});           // freestanding-deleted
   }
 
   // \ref{alg.equal}, equal
@@ -1244,6 +1479,18 @@ namespace std {
       requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
       constexpr bool equal(R1&& r1, R2&& r2, Pred pred = {},
                            Proj1 proj1 = {}, Proj2 proj2 = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+             @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+             class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
+      bool equal(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2,
+                 Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {});       // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+             class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+      bool equal(Ep&& exec, R1&& r1, R2&& r2,
+                 Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {});       // freestanding-deleted
   }
 
   // \ref{alg.is.permutation}, is permutation
@@ -1315,6 +1562,20 @@ namespace std {
       constexpr borrowed_subrange_t<R1>
         search(R1&& r1, R2&& r2, Pred pred = {},
                Proj1 proj1 = {}, Proj2 proj2 = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+             @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+             class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
+      subrange<I1>
+        search(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2,
+               Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {});         // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+             class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+      borrowed_subrange_t<R1>
+        search(Ep&& exec, R1&& r1, R2&& r2,
+               Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {});         // freestanding-deleted
   }
 
   template<class ForwardIterator, class Size,
@@ -1355,6 +1616,20 @@ namespace std {
       constexpr borrowed_subrange_t<R>
         search_n(R&& r, range_difference_t<R> count,
                  const T& value, Pred pred = {}, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Pred = ranges::equal_to, class Proj = identity,
+             class T = projected_value_t<I, Proj>>
+      requires @\libconcept{indirectly_comparable}@<I, const T*, Pred, Proj>
+      subrange<I>
+        search_n(Ep&& exec, I first, S last, iter_difference_t<I> count,
+                 const T& value, Pred pred = {}, Proj proj = {});           // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Pred = ranges::equal_to,
+             class Proj = identity, class T = projected_value_t<I, Proj>>
+      requires @\libconcept{indirectly_comparable}@<iterator_t<R>, const T*, Pred, Proj>
+      borrowed_subrange_t<R>
+        search_n(Ep&& exec, R&& r, range_difference_t<R> count,
+                 const T& value, Pred pred = {}, Proj proj = {});           // freestanding-deleted
   }
 
   template<class ForwardIterator, class Searcher>
@@ -1374,6 +1649,19 @@ namespace std {
       constexpr bool starts_with(R1&& r1, R2&& r2, Pred pred = {},
                                  Proj1 proj1 = {}, Proj2 proj2 = {});
 
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+             @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+             class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
+      bool starts_with(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2,
+                       Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {}); // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1,
+             @\exposconcept{sized-random-access-range}@ R2, class Pred = ranges::equal_to,
+             class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+      bool starts_with(Ep&& exec, R1&& r1, R2&& r2,
+                       Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {}); // freestanding-deleted
+
     // \ref{alg.ends.with}, ends with
     template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
              class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
@@ -1389,6 +1677,19 @@ namespace std {
                @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
       constexpr bool ends_with(R1&& r1, R2&& r2, Pred pred = {},
                                Proj1 proj1 = {}, Proj2 proj2 = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+             @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+             class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
+      bool ends_with(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2,
+                     Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {});   // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1,
+             @\exposconcept{sized-random-access-range}@ R2, class Pred = ranges::equal_to,
+             class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+      bool ends_with(Ep&& exec, R1&& r1, R2&& r2,
+                     Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {});   // freestanding-deleted
 
     // \ref{alg.fold}, fold
     template<class F>
@@ -1500,6 +1801,16 @@ namespace std {
       requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O>
       constexpr copy_result<borrowed_iterator_t<R>, O>
         copy(R&& r, O result);
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS>
+      requires @\libconcept{indirectly_copyable}@<I, O>
+      copy_result<I, O>
+        copy(Ep&& exec, I first, S last, O result, OutS result_last);       // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR>
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR>>
+      copy_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+        copy(Ep&& exec, R&& r, OutR&& result_r);                            // freestanding-deleted
   }
 
   template<class InputIterator, class Size, class OutputIterator>
@@ -1519,6 +1830,13 @@ namespace std {
       requires @\libconcept{indirectly_copyable}@<I, O>
       constexpr copy_n_result<I, O>
         copy_n(I first, iter_difference_t<I> n, O result);
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{random_access_iterator}@ O,
+             @\libconcept{sized_sentinel_for}@<O> OutS>
+      requires @\libconcept{indirectly_copyable}@<I, O>
+      copy_n_result<I, O>
+        copy_n(Ep&& exec, I first, iter_difference_t<I> n, O result,
+               OutS result_last);                               // freestanding-deleted
   }
 
   template<class InputIterator, class OutputIterator, class Predicate>
@@ -1544,6 +1862,21 @@ namespace std {
       requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O>
       constexpr copy_if_result<borrowed_iterator_t<R>, O>
         copy_if(R&& r, O result, Pred pred, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS,
+             class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      requires @\libconcept{indirectly_copyable}@<I, O>
+      copy_if_result<I, O>
+        copy_if(Ep&& exec, I first, S last, O result, OutS result_last,
+                Pred pred, Proj proj = {});                     // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR,
+             class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR>>
+      copy_if_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+        copy_if(Ep&& exec, R&& r, OutR&& result_r, Pred pred,
+                Proj proj = {});                                // freestanding-deleted
   }
 
   template<class BidirectionalIterator1, class BidirectionalIterator2>
@@ -1587,6 +1920,16 @@ namespace std {
       requires @\libconcept{indirectly_movable}@<iterator_t<R>, O>
       constexpr move_result<borrowed_iterator_t<R>, O>
         move(R&& r, O result);
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS>
+      requires @\libconcept{indirectly_movable}@<I, O>
+      move_result<I, O>
+        move(Ep&& exec, I first, S last, O result, OutS result_last);       // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR>
+      requires @\libconcept{indirectly_movable}@<iterator_t<R>, iterator_t<OutR>>
+      move_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+        move(Ep&& exec, R&& r, OutR&& result_r);                            // freestanding-deleted
   }
 
   template<class BidirectionalIterator1, class BidirectionalIterator2>
@@ -1629,6 +1972,16 @@ namespace std {
       requires @\libconcept{indirectly_swappable}@<iterator_t<R1>, iterator_t<R2>>
       constexpr swap_ranges_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
         swap_ranges(R1&& r1, R2&& r2);
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+             @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2>
+      requires @\libconcept{indirectly_swappable}@<I1, I2>
+      swap_ranges_result<I1, I2>
+        swap_ranges(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2);   // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2>
+      requires @\libconcept{indirectly_swappable}@<iterator_t<R1>, iterator_t<R2>>
+      swap_ranges_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
+        swap_ranges(Ep&& exec, R1&& r1, R2&& r2);                           // freestanding-deleted
   }
 
   template<class ForwardIterator1, class ForwardIterator2>
@@ -1674,6 +2027,20 @@ namespace std {
       constexpr unary_transform_result<borrowed_iterator_t<R>, O>
         transform(R&& r, O result, F op, Proj proj = {});
 
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS,
+             @\libconcept{copy_constructible}@ F, class Proj = identity>
+      requires @\libconcept{indirectly_writable}@<O, indirect_result_t<F&, projected<I, Proj>>>
+      unary_transform_result<I, O>
+        transform(Ep&& exec, I first1, S last1, O result, OutS result_last,
+                  F op, Proj proj = {});                                    // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR,
+             @\libconcept{copy_constructible}@ F, class Proj = identity>
+      requires @\libconcept{indirectly_writable}@<iterator_t<OutR>,
+                                   indirect_result_t<F&, projected<iterator_t<R>, Proj>>>
+      unary_transform_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+        transform(Ep&& exec, R&& r, OutR&& result_r, F op, Proj proj = {}); // freestanding-deleted
+
     template<class I1, class I2, class O>
       using binary_transform_result = in_in_out_result<I1, I2, O>;
 
@@ -1692,6 +2059,27 @@ namespace std {
       constexpr binary_transform_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
         transform(R1&& r1, R2&& r2, O result,
                   F binary_op, Proj1 proj1 = {}, Proj2 proj2 = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+             @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+             @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS,
+             @\libconcept{copy_constructible}@ F, class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{indirectly_writable}@<O, indirect_result_t<F&, projected<I1, Proj1>,
+                                   projected<I2, Proj2>>>
+      binary_transform_result<I1, I2, O>
+        transform(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2,
+                  O result, OutS result_last,
+                  F binary_op, Proj1 proj1 = {}, Proj2 proj2 = {});         // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+             @\exposconcept{sized-random-access-range}@ OutR, @\libconcept{copy_constructible}@ F,
+             class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{indirectly_writable}@<iterator_t<OutR>,
+                                   indirect_result_t<F&, projected<iterator_t<R1>, Proj1>,
+                                   projected<iterator_t<R2>, Proj2>>>
+      binary_transform_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>,
+                              borrowed_iterator_t<OutR>>
+        transform(Ep&& exec, R1&& r1, R2&& r2, OutR&& result_r,
+                  F binary_op, Proj1 proj1 = {}, Proj2 proj2 = {});         // freestanding-deleted
   }
 
   // \ref{alg.replace}, replace
@@ -1727,6 +2115,22 @@ namespace std {
                                          projected<iterator_t<R>, Proj>, const T1*>
       constexpr borrowed_iterator_t<R>
         replace(R&& r, const T1& old_value, const T2& new_value, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity, class T1 = projected_value_t<I, Proj>, class T2 = T1>
+      requires @\libconcept{indirectly_writable}@<I, const T2&> &&
+               @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T1*>
+      I replace(Ep&& exec, I first, S last,
+                const T1& old_value, const T2& new_value, Proj proj = {});  // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             class T1 = projected_value_t<iterator_t<R>, Proj>, class T2 = T1>
+      requires @\libconcept{indirectly_writable}@<iterator_t<R>, const T2&> &&
+               @\libconcept{indirect_binary_predicate}@<ranges::equal_to,
+                                         projected<iterator_t<R>, Proj>, const T1*>
+      borrowed_iterator_t<R>
+        replace(Ep&& exec, R&& r, const T1& old_value, const T2& new_value,
+                Proj proj = {});                                            // freestanding-deleted
+
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
              class T = projected_value_t<I, Proj>,
              @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
@@ -1737,6 +2141,20 @@ namespace std {
       requires @\libconcept{indirectly_writable}@<iterator_t<R>, const T&>
       constexpr borrowed_iterator_t<R>
         replace_if(R&& r, Pred pred, const T& new_value, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity, class T = projected_value_t<I, Proj>,
+             @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      requires @\libconcept{indirectly_writable}@<I, const T&>
+      I replace_if(Ep&& exec, I first, S last, Pred pred,
+                   const T& new_value, Proj proj = {});         // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             class T = projected_value_t<I, Proj>,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      requires @\libconcept{indirectly_writable}@<iterator_t<R>, const T&>
+      borrowed_iterator_t<R>
+        replace_if(Ep&& exec, R&& r, Pred pred, const T& new_value,
+                   Proj proj = {});                             // freestanding-deleted
   }
 
   template<class InputIterator, class OutputIterator, class T>
@@ -1783,6 +2201,27 @@ namespace std {
         replace_copy(R&& r, O result, const T1& old_value, const T2& new_value,
                      Proj proj = {});
 
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS,
+             class Proj = identity,
+             class T1 = projected_value_t<I, Proj>, class T2 = iter_value_t<O>>
+      requires @\libconcept{indirectly_copyable}@<I, O> &&
+               @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T1*> &&
+               @\libconcept{indirectly_writable}@<O, const T2&>
+      replace_copy_result<I, O>
+        replace_copy(Ep&& exec, I first, S last, O result, OutS result_last, const T1& old_value,
+                     const T2& new_value, Proj proj = {});      // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR,
+             class Proj = identity, class T1 = projected_value_t<iterator_t<R>, Proj>,
+             class T2 = range_value_t<OutR>>
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR>> &&
+               @\libconcept{indirect_binary_predicate}@<ranges::equal_to,
+                                         projected<iterator_t<R>, Proj>, const T1*> &&
+               @\libconcept{indirectly_writable}@<iterator_t<OutR>, const T2&>
+      replace_copy_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+        replace_copy(Ep&& exec, R&& r, OutR&& result_r, const T1& old_value, const T2& new_value,
+                     Proj proj = {});                           // freestanding-deleted
+
     template<class I, class O>
       using replace_copy_if_result = in_out_result<I, O>;
 
@@ -1798,6 +2237,22 @@ namespace std {
       constexpr replace_copy_if_result<borrowed_iterator_t<R>, O>
         replace_copy_if(R&& r, O result, Pred pred, const T& new_value,
                         Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS, class T = iter_value_t<O>,
+             class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      requires @\libconcept{indirectly_copyable}@<I, O> && @\libconcept{indirectly_writable}@<O, const T&>
+      replace_copy_if_result<I, O>
+        replace_copy_if(Ep&& exec, I first, S last, O result, OutS result_last,
+                        Pred pred, const T& new_value, Proj proj = {});     // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR,
+             class T = range_value_t<OutR>, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR>> &&
+               @\libconcept{indirectly_writable}@<OutR, const T&>
+      replace_copy_if_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+        replace_copy_if(Ep&& exec, R&& r, OutR&& result_r, Pred pred, const T& new_value,
+                        Proj proj = {});                                    // freestanding-deleted
   }
 
   // \ref{alg.fill}, fill
@@ -1825,6 +2280,17 @@ namespace std {
     template<class O, class T = iter_value_t<O>>
       requires @\libconcept{output_iterator}@<O, const T&>
       constexpr O fill_n(O first, iter_difference_t<O> n, const T& value);
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> S,
+             class T = iter_value_t<O>>
+      requires @\libconcept{indirectly_writable}@<O, const T&>
+      O fill(Ep&& exec, O first, S last, const T& value);                   // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class T = range_value_t<R>>
+      requires @\libconcept{indirectly_writable}@<iterator_t<R>, const T&>
+      borrowed_iterator_t<R> fill(Ep&& exec, R&& r, const T& value);        // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ O, class T = iter_value_t<O>>
+      requires @\libconcept{indirectly_writable}@<O, const T&>
+      O fill_n(Ep&& exec, O first, iter_difference_t<O> n, const T& value); // freestanding-deleted
   }
 
   // \ref{alg.generate}, generate
@@ -1841,7 +2307,7 @@ namespace std {
     ForwardIterator generate_n(ExecutionPolicy&& exec,          // freestanding-deleted, see \ref{algorithms.parallel.overloads}
                                ForwardIterator first, Size n, Generator gen);
 
-  namespace ranges {
+  namespace ranges {    // FIXME: missing gap between declaration bundles
     template<@\libconcept{input_or_output_iterator}@ O, @\libconcept{sentinel_for}@<O> S, @\libconcept{copy_constructible}@ F>
       requires @\libconcept{invocable}@<F&> && @\libconcept{indirectly_writable}@<O, invoke_result_t<F&>>
       constexpr O generate(O first, S last, F gen);
@@ -1851,6 +2317,16 @@ namespace std {
     template<@\libconcept{input_or_output_iterator}@ O, @\libconcept{copy_constructible}@ F>
       requires @\libconcept{invocable}@<F&> && @\libconcept{indirectly_writable}@<O, invoke_result_t<F&>>
       constexpr O generate_n(O first, iter_difference_t<O> n, F gen);
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> S,
+             @\libconcept{copy_constructible}@ F>
+      requires @\libconcept{invocable}@<F&> && @\libconcept{indirectly_writable}@<O, invoke_result_t<F&>>
+      O generate(Ep&& exec, O first, S last, F gen);                        // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\libconcept{copy_constructible}@ F>
+      requires @\libconcept{invocable}@<F&> && @\libconcept{indirectly_writable}@<iterator_t<R>, invoke_result_t<F&>>
+      borrowed_iterator_t<R> generate(Ep&& exec, R&& r, F gen);             // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ O, @\libconcept{copy_constructible}@ F>
+      requires @\libconcept{invocable}@<F&> && @\libconcept{indirectly_writable}@<O, invoke_result_t<F&>>
+      O generate_n(Ep&& exec, O first, iter_difference_t<O> n, F gen);      // freestanding-deleted
   }
 
   // \ref{alg.remove}, remove
@@ -1882,6 +2358,20 @@ namespace std {
                                          projected<iterator_t<R>, Proj>, const T*>
       constexpr borrowed_subrange_t<R>
         remove(R&& r, const T& value, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity, class T = projected_value_t<I, Proj>>
+      requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T*>
+      subrange<I> remove(Ep&& exec, I first, S last, const T& value,
+                         Proj proj = {});                                   // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             class T = projected_value_t<iterator_t<R>, Proj>>
+      requires @\libconcept{permutable}@<iterator_t<R>> &&
+               @\libconcept{indirect_binary_predicate}@<ranges::equal_to,
+                                         projected<iterator_t<R>, Proj>, const T*>
+      borrowed_subrange_t<R>
+        remove(Ep&& exec, R&& r, const T& value, Proj proj = {});           // freestanding-deleted
+
     template<@\libconcept{permutable}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
              @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
       constexpr subrange<I> remove_if(I first, S last, Pred pred, Proj proj = {});
@@ -1890,6 +2380,16 @@ namespace std {
       requires @\libconcept{permutable}@<iterator_t<R>>
       constexpr borrowed_subrange_t<R>
         remove_if(R&& r, Pred pred, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      subrange<I>
+        remove_if(Ep&& exec, I first, S last, Pred pred, Proj proj = {});   // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      requires @\libconcept{permutable}@<iterator_t<R>>
+      borrowed_subrange_t<R>
+        remove_if(Ep&& exec, R&& r, Pred pred, Proj proj = {});             // freestanding-deleted
   }
 
   template<class InputIterator, class OutputIterator,
@@ -1932,6 +2432,23 @@ namespace std {
       constexpr remove_copy_result<borrowed_iterator_t<R>, O>
         remove_copy(R&& r, O result, const T& value, Proj proj = {});
 
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS,
+             class Proj = identity, class T = projected_value_t<I, Proj>>
+      requires @\libconcept{indirectly_copyable}@<I, O> &&
+               @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T*>
+      remove_copy_result<I, O>
+        remove_copy(Ep&& exec, I first, S last, O result, OutS result_last, const T& value,
+                    Proj proj = {});                                        // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR,
+             class Proj = identity, class T = projected_value_t<iterator_t<R>, Proj>>
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR>> &&
+               @\libconcept{indirect_binary_predicate}@<ranges::equal_to,
+                                         projected<iterator_t<R>, Proj>, const T*>
+      remove_copy_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+        remove_copy(Ep&& exec, R&& r, OutR&& result_r, const T& value,
+                    Proj proj = {});                                        // freestanding-deleted
+
     template<class I, class O>
       using remove_copy_if_result = in_out_result<I, O>;
 
@@ -1945,6 +2462,21 @@ namespace std {
       requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O>
       constexpr remove_copy_if_result<borrowed_iterator_t<R>, O>
         remove_copy_if(R&& r, O result, Pred pred, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS,
+             class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      requires @\libconcept{indirectly_copyable}@<I, O>
+      remove_copy_if_result<I, O>
+        remove_copy_if(Ep&& exec, I first, S last, O result, OutS result_last, Pred pred,
+                       Proj proj = {});                         // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR,
+             class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR>>
+      remove_copy_if_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+        remove_copy_if(Ep&& exec, R&& r, OutR&& result_r, Pred pred,
+                       Proj proj = {});                         // freestanding-deleted
   }
 
   // \ref{alg.unique}, unique
@@ -1970,6 +2502,18 @@ namespace std {
       requires @\libconcept{permutable}@<iterator_t<R>>
       constexpr borrowed_subrange_t<R>
         unique(R&& r, C comp = {}, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity,
+             @\libconcept{indirect_equivalence_relation}@<projected<I, Proj>> C = ranges::equal_to>
+      requires @\libconcept{permutable}@<I>
+      subrange<I> unique(Ep&& exec, I first, S last, C comp = {},
+                         Proj proj = {});                       // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             @\libconcept{indirect_equivalence_relation}@<projected<iterator_t<R>, Proj>> C = ranges::equal_to>
+      requires @\libconcept{permutable}@<iterator_t<R>>
+      borrowed_subrange_t<R>
+        unique(Ep&& exec, R&& r, C comp = {}, Proj proj = {});  // freestanding-deleted
   }
 
   template<class InputIterator, class OutputIterator>
@@ -2012,6 +2556,21 @@ namespace std {
                 @\libconcept{indirectly_copyable_storable}@<iterator_t<R>, O>)
       constexpr unique_copy_result<borrowed_iterator_t<R>, O>
         unique_copy(R&& r, O result, C comp = {}, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS, class Proj = identity,
+             @\libconcept{indirect_equivalence_relation}@<projected<I, Proj>> C = ranges::equal_to>
+      requires @\libconcept{indirectly_copyable}@<I, O>
+      unique_copy_result<I, O>
+        unique_copy(Ep&& exec, I first, S last, O result, OutS result_last, C comp = {},
+                    Proj proj = {});                            // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR,
+             class Proj = identity,
+             @\libconcept{indirect_equivalence_relation}@<projected<iterator_t<R>, Proj>> C = ranges::equal_to>
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR>>
+      unique_copy_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+        unique_copy(Ep&& exec, R&& r, OutR&& result_r, C comp = {},
+                    Proj proj = {});                            // freestanding-deleted
   }
 
   // \ref{alg.reverse}, reverse
@@ -2028,6 +2587,13 @@ namespace std {
     template<@\libconcept{bidirectional_range}@ R>
       requires @\libconcept{permutable}@<iterator_t<R>>
       constexpr borrowed_iterator_t<R> reverse(R&& r);
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S>
+      requires @\libconcept{permutable}@<I>
+      I reverse(Ep&& exec, I first, S last);                    // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R>
+      requires @\libconcept{permutable}@<iterator_t<R>>
+      borrowed_iterator_t<R> reverse(Ep&& exec, R&& r);         // freestanding-deleted
   }
 
   template<class BidirectionalIterator, class OutputIterator>
@@ -2052,6 +2618,17 @@ namespace std {
       requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O>
       constexpr reverse_copy_result<borrowed_iterator_t<R>, O>
         reverse_copy(R&& r, O result);
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS>
+      requires @\libconcept{indirectly_copyable}@<I, O>
+      reverse_copy_result<I, O>
+        reverse_copy(Ep&& exec, I first, S last, O result,
+                     OutS result_last);                         // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR>
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR>>
+      reverse_copy_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+        reverse_copy(Ep&& exec, R&& r, OutR&& result_r);        // freestanding-deleted
   }
 
   // \ref{alg.rotate}, rotate
@@ -2071,6 +2648,15 @@ namespace std {
     template<@\libconcept{forward_range}@ R>
       requires @\libconcept{permutable}@<iterator_t<R>>
       constexpr borrowed_subrange_t<R> rotate(R&& r, iterator_t<R> middle);
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S>
+      requires @\libconcept{permutable}@<I>
+      subrange<I>
+        rotate(Ep&& exec, I first, I middle, S last);           // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R>
+      requires @\libconcept{permutable}@<iterator_t<R>>
+      borrowed_subrange_t<R>
+        rotate(Ep&& exec, R&& r, iterator_t<R> middle);         // freestanding-deleted
   }
 
   template<class ForwardIterator, class OutputIterator>
@@ -2095,6 +2681,20 @@ namespace std {
       requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O>
       constexpr rotate_copy_result<borrowed_iterator_t<R>, O>
         rotate_copy(R&& r, iterator_t<R> middle, O result);
+
+    // FIXME: remove ranges:: namespace
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS>
+      requires @\libconcept{indirectly_copyable}@<I, O>
+      ranges::rotate_copy_result<I, O>
+        ranges::rotate_copy(Ep&& exec, I first, I middle, S last, O result,
+                            OutS result_last);                  // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR>
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR>>
+      ranges::rotate_copy_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+        ranges::rotate_copy(Ep&& exec, R&& r, iterator_t<R> middle,
+                            OutR&& result_r);                   // freestanding-deleted
+    // FIXME: once ranges:: is removed, reflow the previous two lines into one
   }
 
   // \ref{alg.random.sample}, sample
@@ -2152,6 +2752,15 @@ namespace std {
     template<@\libconcept{forward_range}@ R>
       requires @\libconcept{permutable}@<iterator_t<R>>
       constexpr borrowed_subrange_t<R> shift_left(R&& r, range_difference_t<R> n);
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S>
+      requires @\libconcept{permutable}@<I>
+      subrange<I>
+        shift_left(Ep&& exec, I first, S last, iter_difference_t<I> n);     // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R>
+      requires @\libconcept{permutable}@<iterator_t<R>>
+      borrowed_subrange_t<R>
+        shift_left(Ep&& exec, R&& r, range_difference_t<R> n);              // freestanding-deleted
   }
 
   template<class ForwardIterator>
@@ -2170,6 +2779,15 @@ namespace std {
     template<@\libconcept{forward_range}@ R>
       requires @\libconcept{permutable}@<iterator_t<R>>
       constexpr borrowed_subrange_t<R> shift_right(R&& r, range_difference_t<R> n);
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S>
+      requires @\libconcept{permutable}@<I>
+      subrange<I>
+        shift_right(Ep&& exec, I first, S last, iter_difference_t<I> n);    // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R>
+      requires @\libconcept{permutable}@<iterator_t<R>>
+      borrowed_subrange_t<R>
+        shift_right(Ep&& exec, R&& r, range_difference_t<R> n);             // freestanding-deleted
   }
 
   // \ref{alg.sorting}, sorting and related operations
@@ -2197,6 +2815,16 @@ namespace std {
       requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
       constexpr borrowed_iterator_t<R>
         sort(R&& r, Comp comp = {}, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Comp = ranges::less, class Proj = identity>
+      requires @\libconcept{sortable}@<I, Comp, Proj>
+      I sort(Ep&& exec, I first, S last, Comp comp = {}, Proj proj = {});   // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Comp = ranges::less,
+             class Proj = identity>
+      requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
+      borrowed_iterator_t<R>
+        sort(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});             // freestanding-deleted
   }
 
   template<class RandomAccessIterator>
@@ -2221,6 +2849,17 @@ namespace std {
       requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
       constexpr borrowed_iterator_t<R>
         stable_sort(R&& r, Comp comp = {}, Proj proj = {});                             // hosted
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Comp = ranges::less, class Proj = identity>
+      requires @\libconcept{sortable}@<I, Comp, Proj>
+      I stable_sort(Ep&& exec, I first, S last, Comp comp = {},
+                    Proj proj = {});                                        // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Comp = ranges::less,
+             class Proj = identity>
+      requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
+      borrowed_iterator_t<R>
+        stable_sort(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});      // freestanding-deleted
   }
 
   template<class RandomAccessIterator>
@@ -2249,6 +2888,18 @@ namespace std {
       constexpr borrowed_iterator_t<R>
         partial_sort(R&& r, iterator_t<R> middle, Comp comp = {},
                      Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Comp = ranges::less, class Proj = identity>
+      requires @\libconcept{sortable}@<I, Comp, Proj>
+      I partial_sort(Ep&& exec, I first, I middle, S last, Comp comp = {},
+                     Proj proj = {});                           // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R,
+             class Comp = ranges::less, class Proj = identity>
+      requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
+      borrowed_iterator_t<R>
+        partial_sort(Ep&& exec, R&& r, iterator_t<R> middle, Comp comp = {},
+                     Proj proj = {});                           // freestanding-deleted
   }
 
   template<class InputIterator, class RandomAccessIterator>
@@ -2298,6 +2949,25 @@ namespace std {
       constexpr partial_sort_copy_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
         partial_sort_copy(R1&& r, R2&& result_r, Comp comp = {},
                           Proj1 proj1 = {}, Proj2 proj2 = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+             @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+             class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{indirectly_copyable}@<I1, I2> && @\libconcept{sortable}@<I2, Comp, Proj2> &&
+               @\libconcept{indirect_strict_weak_order}@<Comp, projected<I1, Proj1>, projected<I2, Proj2>>
+      partial_sort_copy_result<I1, I2>
+        partial_sort_copy(Ep&& exec, I1 first, S1 last, I2 result_first, S2 result_last,
+                          Comp comp = {}, Proj1 proj1 = {},
+                          Proj2 proj2 = {});                    // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+             class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R1>, iterator_t<R2>> &&
+               @\libconcept{sortable}@<iterator_t<R2>, Comp, Proj2> &&
+               @\libconcept{indirect_strict_weak_order}@<Comp, projected<iterator_t<R1>, Proj1>,
+                                          projected<iterator_t<R2>, Proj2>>
+      partial_sort_copy_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
+        partial_sort_copy(Ep&& exec, R1&& r, R2&& result_r, Comp comp = {},
+                          Proj1 proj1 = {}, Proj2 proj2 = {});  // freestanding-deleted
   }
 
   template<class ForwardIterator>
@@ -2320,6 +2990,15 @@ namespace std {
     template<@\libconcept{forward_range}@ R, class Proj = identity,
              @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
       constexpr bool is_sorted(R&& r, Comp comp = {}, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
+      bool is_sorted(Ep&& exec, I first, S last, Comp comp = {},
+                     Proj proj = {});                                       // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+      bool is_sorted(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});     // freestanding-deleted
   }
 
   template<class ForwardIterator>
@@ -2347,6 +3026,16 @@ namespace std {
              @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
       constexpr borrowed_iterator_t<R>
         is_sorted_until(R&& r, Comp comp = {}, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
+      I is_sorted_until(Ep&& exec, I first, S last, Comp comp = {},
+                        Proj proj = {});                                    // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+      borrowed_iterator_t<R>
+        is_sorted_until(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});  // freestanding-deleted
   }
 
   // \ref{alg.nth.element}, Nth element
@@ -2375,6 +3064,18 @@ namespace std {
       requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
       constexpr borrowed_iterator_t<R>
         nth_element(R&& r, iterator_t<R> nth, Comp comp = {}, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Comp = ranges::less, class Proj = identity>
+      requires @\libconcept{sortable}@<I, Comp, Proj>
+      I nth_element(Ep&& exec, I first, I nth, S last, Comp comp = {},
+                    Proj proj = {});                            // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Comp = ranges::less,
+             class Proj = identity>
+      requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
+      borrowed_iterator_t<R>
+        nth_element(Ep&& exec, R&& r, iterator_t<R> nth, Comp comp = {},
+                    Proj proj = {});                            // freestanding-deleted
   }
 
   // \ref{alg.binary.search}, binary search
@@ -2487,6 +3188,14 @@ namespace std {
     template<@\libconcept{input_range}@ R, class Proj = identity,
              @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
       constexpr bool is_partitioned(R&& r, Pred pred, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      bool is_partitioned(Ep&& exec, I first, S last, Pred pred,
+                          Proj proj = {});                                  // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      bool is_partitioned(Ep&& exec, R&& r, Pred pred, Proj proj = {});     // freestanding-deleted
   }
 
   template<class ForwardIterator, class Predicate>
@@ -2509,6 +3218,17 @@ namespace std {
       requires @\libconcept{permutable}@<iterator_t<R>>
       constexpr borrowed_subrange_t<R>
         partition(R&& r, Pred pred, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      subrange<I>
+        // FIXME: LWG issue, I'm pretty sure there should be requires permutable<I> here.
+        partition(Ep&& exec, I first, S last, Pred pred, Proj proj = {});   // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      requires @\libconcept{permutable}@<iterator_t<R>>
+      borrowed_subrange_t<R>
+        partition(Ep&& exec, R&& r, Pred pred, Proj proj = {});             // freestanding-deleted
   }
 
   template<class BidirectionalIterator, class Predicate>
@@ -2532,6 +3252,18 @@ namespace std {
       requires @\libconcept{permutable}@<iterator_t<R>>
       constexpr borrowed_subrange_t<R> stable_partition(R&& r, Pred pred,           // hosted
                                                         Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      requires @\libconcept{permutable}@<I>
+      subrange<I>
+        stable_partition(Ep&& exec, I first, S last, Pred pred,
+                         Proj proj = {});                                   // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      requires @\libconcept{permutable}@<iterator_t<R>>
+      borrowed_subrange_t<R>
+        stable_partition(Ep&& exec, R&& r, Pred pred, Proj proj = {});      // freestanding-deleted
   }
 
   template<class InputIterator, class OutputIterator1,
@@ -2566,6 +3298,26 @@ namespace std {
                @\libconcept{indirectly_copyable}@<iterator_t<R>, O2>
       constexpr partition_copy_result<borrowed_iterator_t<R>, O1, O2>
         partition_copy(R&& r, O1 out_true, O2 out_false, Pred pred, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             @\libconcept{random_access_iterator}@ O1, @\libconcept{sized_sentinel_for}@<O1> OutS1,
+             @\libconcept{random_access_iterator}@ O2, @\libconcept{sized_sentinel_for}@<O2> OutS2,
+             class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+      requires @\libconcept{indirectly_copyable}@<I, O1> && @\libconcept{indirectly_copyable}@<I, O2>
+      partition_copy_result<I, O1, O2>
+        partition_copy(Ep&& exec, I first, S last, O1 out_true, OutS1 last_true,
+                       O2 out_false, OutS2 last_false, Pred pred,
+                       Proj proj = {});                         // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R,
+             @\exposconcept{sized-random-access-range}@ OutR1, @\exposconcept{sized-random-access-range}@ OutR2,
+             class Proj = identity,
+             @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+      requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR1>> &&
+               @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR2>>
+      partition_copy_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR1>,
+                            borrowed_iterator_t<OutR2>>
+        partition_copy(Ep&& exec, R&& r, OutR1&& out_true_r, OutR2&& out_false_r, Pred pred,
+                       Proj proj = {});                         // freestanding-deleted
   }
 
   template<class ForwardIterator, class Predicate>
@@ -2627,6 +3379,22 @@ namespace std {
       constexpr merge_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
         merge(R1&& r1, R2&& r2, O result,
               Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+             @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+             @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS, class Comp = ranges::less,
+             class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{mergeable}@<I1, I2, O, Comp, Proj1, Proj2>
+      merge_result<I1, I2, O>
+        merge(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2, O result, OutS result_last,
+              Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});          // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+             @\exposconcept{sized-random-access-range}@ OutR, class Comp = ranges::less,
+             class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{mergeable}@<iterator_t<R1>, iterator_t<R2>, iterator_t<OutR>, Comp, Proj1, Proj2>
+      merge_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, borrowed_iterator_t<OutR>>
+        merge(Ep&& exec, R1&& r1, R2&& r2, OutR&& result_r,
+              Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});          // freestanding-deleted
   }
 
   template<class BidirectionalIterator>
@@ -2658,6 +3426,18 @@ namespace std {
       requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
       constexpr borrowed_iterator_t<R>
         inplace_merge(R&& r, iterator_t<R> middle, Comp comp = {}, Proj proj = {});     // hosted
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Comp = ranges::less, class Proj = identity>
+      requires @\libconcept{sortable}@<I, Comp, Proj>
+      I inplace_merge(Ep&& exec, I first, I middle, S last, Comp comp = {},
+                      Proj proj = {});                          // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Comp = ranges::less,
+             class Proj = identity>
+      requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
+      borrowed_iterator_t<R>
+        inplace_merge(Ep&& exec, R&& r, iterator_t<R> middle, Comp comp = {},
+                      Proj proj = {});                          // freestanding-deleted
   }
 
   // \ref{alg.set.operations}, set operations
@@ -2692,6 +3472,20 @@ namespace std {
                                         projected<iterator_t<R2>, Proj2>> Comp = ranges::less>
       constexpr bool includes(R1&& r1, R2&& r2, Comp comp = {},
                               Proj1 proj1 = {}, Proj2 proj2 = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+             @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+             class Proj1 = identity, class Proj2 = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<I1, Proj1>, projected<I2, Proj2>> Comp =
+               ranges::less>
+      bool includes(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2,
+                    Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});    // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+             class Proj1 = identity, class Proj2 = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R1>, Proj1>,
+                                        projected<iterator_t<R2>, Proj2>> Comp = ranges::less>
+      bool includes(Ep&& exec, R1&& r1, R2&& r2,
+                    Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});    // freestanding-deleted
   }
 
   template<class InputIterator1, class InputIterator2, class OutputIterator>
@@ -2736,6 +3530,25 @@ namespace std {
       constexpr set_union_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
         set_union(R1&& r1, R2&& r2, O result, Comp comp = {},
                   Proj1 proj1 = {}, Proj2 proj2 = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+             @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+             @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS, class Comp = ranges::less,
+             class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{mergeable}@<I1, I2, O, Comp, Proj1, Proj2>
+      set_union_result<I1, I2, O>
+        set_union(Ep&& exec, I1 first1, S1 last1,
+                  I2 first2, S2 last2, O result, OutS result_last,
+                  Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});      // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+             @\exposconcept{sized-random-access-range}@ OutR, class Comp = ranges::less,
+             class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{mergeable}@<iterator_t<R1>, iterator_t<R2>, iterator_t<OutR>,
+                        Comp, Proj1, Proj2>
+      set_union_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>,
+                       borrowed_iterator_t<OutR>>
+        set_union(Ep&& exec, R1&& r1, R2&& r2, OutR&& result_r, Comp comp = {},
+                  Proj1 proj1 = {}, Proj2 proj2 = {});                      // freestanding-deleted
   }
 
   template<class InputIterator1, class InputIterator2, class OutputIterator>
@@ -2780,6 +3593,25 @@ namespace std {
       constexpr set_intersection_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
         set_intersection(R1&& r1, R2&& r2, O result,
                          Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+             @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+             @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS, class Comp = ranges::less,
+             class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{mergeable}@<I1, I2, O, Comp, Proj1, Proj2>
+      set_intersection_result<I1, I2, O>
+        set_intersection(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2,
+                         O result, OutS result_last, Comp comp = {}, Proj1 proj1 = {},
+                         Proj2 proj2 = {});                     // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+             @\exposconcept{sized-random-access-range}@ OutR, class Comp = ranges::less,
+             class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{mergeable}@<iterator_t<R1>, iterator_t<R2>, iterator_t<OutR>,
+                        Comp, Proj1, Proj2>
+      set_intersection_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>,
+                              borrowed_iterator_t<OutR>>
+        set_intersection(Ep&& exec, R1&& r1, R2&& r2, OutR&& result_r, Comp comp = {},
+                         Proj1 proj1 = {}, Proj2 proj2 = {});   // freestanding-deleted
   }
 
   template<class InputIterator1, class InputIterator2, class OutputIterator>
@@ -2824,6 +3656,25 @@ namespace std {
       constexpr set_difference_result<borrowed_iterator_t<R1>, O>
         set_difference(R1&& r1, R2&& r2, O result,
                        Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+             @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+             @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS, class Comp = ranges::less,
+             class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{mergeable}@<I1, I2, O, Comp, Proj1, Proj2>
+      set_difference_result<I1, I2, O>
+        set_difference(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2,
+                       O result, OutS result_last, Comp comp = {}, Proj1 proj1 = {},
+                       Proj2 proj2 = {});                       // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+             @\exposconcept{sized-random-access-range}@ OutR, class Comp = ranges::less,
+             class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{mergeable}@<iterator_t<R1>, iterator_t<R2>, iterator_t<OutR>,
+                        Comp, Proj1, Proj2>
+      set_difference_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>,
+                            borrowed_iterator_t<OutR>>
+        set_difference(Ep&& exec, R1&& r1, R2&& r2, OutR&& result_r, Comp comp = {},
+                       Proj1 proj1 = {}, Proj2 proj2 = {});     // freestanding-deleted
   }
 
   template<class InputIterator1, class InputIterator2, class OutputIterator>
@@ -2870,6 +3721,25 @@ namespace std {
                                                 borrowed_iterator_t<R2>, O>
         set_symmetric_difference(R1&& r1, R2&& r2, O result, Comp comp = {},
                                  Proj1 proj1 = {}, Proj2 proj2 = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+             @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+             @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS, class Comp = ranges::less,
+             class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{mergeable}@<I1, I2, O, Comp, Proj1, Proj2>
+      set_symmetric_difference_result<I1, I2, O>
+        set_symmetric_difference(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2,
+                                 O result, OutS result_last, Comp comp = {},
+                                 Proj1 proj1 = {}, Proj2 proj2 = {});       // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+             @\exposconcept{sized-random-access-range}@ OutR, class Comp = ranges::less,
+             class Proj1 = identity, class Proj2 = identity>
+      requires @\libconcept{mergeable}@<iterator_t<R1>, iterator_t<R2>, iterator_t<OutR>,
+                        Comp, Proj1, Proj2>
+      set_symmetric_difference_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>,
+                                      borrowed_iterator_t<OutR>>
+        set_symmetric_difference(Ep&& exec, R1&& r1, R2&& r2, OutR&& result_r, Comp comp = {},
+                                 Proj1 proj1 = {}, Proj2 proj2 = {});       // freestanding-deleted
   }
 
   // \ref{alg.heap.operations}, heap operations
@@ -2965,6 +3835,15 @@ namespace std {
     template<@\libconcept{random_access_range}@ R, class Proj = identity,
              @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
       constexpr bool is_heap(R&& r, Comp comp = {}, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
+      bool is_heap(Ep&& exec, I first, S last, Comp comp = {},
+                   Proj proj = {});                                         // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+      bool is_heap(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});       // freestanding-deleted
   }
 
   template<class RandomAccessIterator>
@@ -2992,6 +3871,16 @@ namespace std {
              @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
       constexpr borrowed_iterator_t<R>
         is_heap_until(R&& r, Comp comp = {}, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
+      I is_heap_until(Ep&& exec, I first, S last, Comp comp = {},
+                      Proj proj = {});                                      // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+      borrowed_iterator_t<R>
+        is_heap_until(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});    // freestanding-deleted
   }
 
   // \ref{alg.min.max}, minimum and maximum
@@ -3015,6 +3904,11 @@ namespace std {
       requires @\libconcept{indirectly_copyable_storable}@<iterator_t<R>, range_value_t<R>*>
       constexpr range_value_t<R>
         min(R&& r, Comp comp = {}, Proj proj = {});
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+      requires @\libconcept{indirectly_copyable_storable}@<iterator_t<R>, range_value_t<R>*>
+      range_value_t<R>
+        min(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});              // freestanding-deleted
   }
 
   template<class T> constexpr const T& max(const T& a, const T& b);
@@ -3037,6 +3931,11 @@ namespace std {
       requires @\libconcept{indirectly_copyable_storable}@<iterator_t<R>, range_value_t<R>*>
       constexpr range_value_t<R>
         max(R&& r, Comp comp = {}, Proj proj = {});
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+      requires @\libconcept{indirectly_copyable_storable}@<iterator_t<R>, range_value_t<R>*>
+      range_value_t<R>
+        max(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});              // freestanding-deleted
   }
 
   template<class T> constexpr pair<const T&, const T&> minmax(const T& a, const T& b);
@@ -3064,6 +3963,11 @@ namespace std {
       requires @\libconcept{indirectly_copyable_storable}@<iterator_t<R>, range_value_t<R>*>
       constexpr minmax_result<range_value_t<R>>
         minmax(R&& r, Comp comp = {}, Proj proj = {});
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+      requires @\libconcept{indirectly_copyable_storable}@<iterator_t<R>, range_value_t<R>*>
+      minmax_result<range_value_t<R>>
+        minmax(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});           // freestanding-deleted
   }
 
   template<class ForwardIterator>
@@ -3087,6 +3991,17 @@ namespace std {
              @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
       constexpr borrowed_iterator_t<R>
         min_element(R&& r, Comp comp = {}, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
+      I min_element(Ep&& exec, I first, S last, Comp comp = {},
+                    Proj proj = {});                                        // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R,
+             class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+      borrowed_iterator_t<R>
+        min_element(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});      // freestanding-deleted
   }
 
   template<class ForwardIterator>
@@ -3110,6 +4025,17 @@ namespace std {
              @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
       constexpr borrowed_iterator_t<R>
         max_element(R&& r, Comp comp = {}, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
+      I max_element(Ep&& exec, I first, S last, Comp comp = {},
+                    Proj proj = {});                                        // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R,
+             class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+      borrowed_iterator_t<R>
+        max_element(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});      // freestanding-deleted
   }
 
   template<class ForwardIterator>
@@ -3139,6 +4065,17 @@ namespace std {
              @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
       constexpr minmax_element_result<borrowed_iterator_t<R>>
         minmax_element(R&& r, Comp comp = {}, Proj proj = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+             class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
+      minmax_element_result<I>
+        minmax_element(Ep&& exec, I first, S last, Comp comp = {},
+                       Proj proj = {});                                     // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+      minmax_element_result<borrowed_iterator_t<R>>
+        minmax_element(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});   // freestanding-deleted
   }
 
   // \ref{alg.clamp}, bounded value
@@ -3192,6 +4129,21 @@ namespace std {
       constexpr bool
         lexicographical_compare(R1&& r1, R2&& r2, Comp comp = {},
                                 Proj1 proj1 = {}, Proj2 proj2 = {});
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+             @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+             class Proj1 = identity, class Proj2 = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<I1, Proj1>,
+                                        projected<I2, Proj2>> Comp = ranges::less>
+      bool lexicographical_compare(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2,
+                                   Comp comp = {}, Proj1 proj1 = {},
+                                   Proj2 proj2 = {});                       // freestanding-deleted
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+             class Proj1 = identity, class Proj2 = identity,
+             @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R1>, Proj1>,
+                                        projected<iterator_t<R2>, Proj2>> Comp = ranges::less>
+      bool lexicographical_compare(Ep&& exec, R1&& r1, R2&& r2, Comp comp = {},
+                                   Proj1 proj1 = {}, Proj2 proj2 = {});     // freestanding-deleted
   }
 
   // \ref{alg.three.way}, three-way comparison algorithms
@@ -3455,6 +4407,13 @@ template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, clas
 template<@\libconcept{input_range}@ R, class Proj = identity,
          @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
   constexpr bool ranges::all_of(R&& r, Pred pred, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  bool ranges::all_of(Ep&& exec, I first, S last, Pred pred, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  bool ranges::all_of(Ep&& exec, R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3495,6 +4454,13 @@ template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, clas
 template<@\libconcept{input_range}@ R, class Proj = identity,
          @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
   constexpr bool ranges::any_of(R&& r, Pred pred, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  bool ranges::any_of(Ep&& exec, I first, S last, Pred pred, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  bool ranges::any_of(Ep&& exec, R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3535,6 +4501,13 @@ template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, clas
 template<@\libconcept{input_range}@ R, class Proj = identity,
          @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
   constexpr bool ranges::none_of(R&& r, Pred pred, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  bool ranges::none_of(Ep&& exec, I first, S last, Pred pred, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  bool ranges::none_of(Ep&& exec, R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3578,6 +4551,24 @@ template<@\libconcept{input_range}@ R, class Proj = identity, class T = projecte
 \tcode{ranges::find(std::move(first), last, value, proj) != last}.
 \end{itemdescr}
 
+\begin{itemdecl}
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity, class T = projected_value_t<I, Proj>>
+  requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T*>
+  bool ranges::contains(Ep&& exec, I first, S last, const T& value, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         class T = projected_value_t<iterator_t<R>, Proj>>
+  requires
+    @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
+  bool ranges::contains(Ep&& exec, R&& r, const T& value, Proj proj = {});
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\tcode{ranges::find(std::forward<Ep>(exec), first, last, value, proj) != last}.
+\end{itemdescr}
+
 \indexlibraryglobal{contains_subrange}%
 \begin{itemdecl}
 template<@\libconcept{forward_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1,
@@ -3597,6 +4588,29 @@ template<@\libconcept{forward_range}@ R1, @\libconcept{forward_range}@ R2,
 \pnum
 \returns
 \tcode{first2 == last2 || !ranges::search(first1, last1, first2, last2, pred, proj1, proj2).empty()}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+         @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+         class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
+  bool ranges::contains_subrange(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2,
+                                 Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+         class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+  bool ranges::contains_subrange(Ep&& exec, R1&& r1, R2&& r2, Pred pred = {},
+                                 Proj1 proj1 = {}, Proj2 proj2 = {});
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\begin{codeblock}
+first2 == last2 || !ranges::search(std::forward<Ep>(exec), first1, last1,
+                                   first2, last2, pred, proj1, proj2).empty()
+\end{codeblock}
 \end{itemdescr}
 
 \rSec2[alg.foreach]{For each}
@@ -3722,6 +4736,54 @@ The overloads in namespace \tcode{ranges} require
 \end{note}
 \end{itemdescr}
 
+\begin{itemdecl}
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+          class Proj = identity,
+          @\libconcept{indirectly_unary_invocable}@<projected<I, Proj>> Fun>
+  I ranges::for_each(Ep&& exec, I first, S last, Fun f, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         @\libconcept{indirectly_unary_invocable}@<projected<iterator_t<R>, Proj>> Fun>
+  borrowed_iterator_t<R>
+    ranges::for_each(Ep&& exec, R&& r, Fun f, Proj proj = {});
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Calls \tcode{invoke(f, invoke(proj, *i))}
+for every iterator \tcode{i}
+in the range \range{first}{last}.
+\begin{note}
+If the result of \tcode{invoke(proj, *i)} is a mutable reference,
+\tcode{f} can apply non-constant functions.
+\end{note}
+
+\pnum
+\returns
+\tcode{last}.
+
+\pnum
+\complexity
+Applies \tcode{f} and \tcode{proj} exactly \tcode{last - first} times.
+
+\pnum
+\remarks
+\begin{itemize}
+\item
+  If \tcode{f} returns a result, the result is ignored.
+\item
+  Implementations do not have the freedom granted under \ref{algorithms.parallel.exec}
+  to make arbitrary copies of elements from the input sequence.
+\item
+  \tcode{f} may modify objects via its arguments\iref{algorithms.parallel.user}.
+\end{itemize}
+\begin{note}
+Does not return a copy of its \tcode{Fun} parameter,
+since parallelization often does not permit
+efficient state accumulation.
+\end{note}
+\end{itemdescr}
+
 \indexlibraryglobal{for_each_n}%
 \begin{itemdecl}
 template<class InputIterator, class Size, class Function>
@@ -3838,6 +4900,53 @@ requires \tcode{Fun} to model \libconcept{copy_constructible}.
 \end{note}
 \end{itemdescr}
 
+\begin{itemdecl}
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, class Proj = identity,
+         @\libconcept{indirectly_unary_invocable}@<projected<I, Proj>> Fun>
+  I ranges::for_each_n(Ep&& exec, I first, iter_difference_t<I> n, Fun f, Proj proj = {});
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\expects
+\tcode{n >= 0} is \tcode{true}.
+
+\pnum
+\effects
+Calls \tcode{invoke(f, invoke(proj, *i))}
+for every iterator \tcode{i}
+in the range \range{first}{first + n}.
+\begin{note}
+If the result of \tcode{invoke(proj, *i)} is a mutable reference,
+\tcode{f} can apply non-constant functions.
+\end{note}
+
+\pnum
+\returns
+\tcode{first + n}.
+
+\pnum
+\complexity
+Applies \tcode{f} and \tcode{proj} exactly \tcode{last - first} times.
+
+\pnum
+\remarks
+\begin{itemize}
+\item
+  If \tcode{f} returns a result, the result is ignored.
+\item
+  Implementations do not have the freedom granted under \ref{algorithms.parallel.exec}
+  to make arbitrary copies of elements from the input sequence.
+\item
+  \tcode{f} may modify objects via its arguments\iref{algorithms.parallel.user}.
+\end{itemize}
+\begin{note}
+Does not return a copy of its \tcode{Fun} parameter,
+since parallelization often does not permit
+efficient state accumulation.
+\end{note}
+\end{itemdescr}
+
 \rSec2[alg.find]{Find}
 
 \indexlibraryglobal{find}%
@@ -3875,6 +4984,17 @@ template<@\libconcept{input_range}@ R, class Proj = identity, class T = projecte
   requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
   constexpr borrowed_iterator_t<R>
     ranges::find(R&& r, const T& value, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity, class T = projected_value_t<I, Proj>>
+  requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T*>
+  I ranges::find(Ep&& exec, I first, S last, const T& value, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         class T = projected_value_t<iterator_t<R>, Proj>>
+  requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to,
+                                     projected<iterator_t<R>, Proj>, const T*>
+  borrowed_iterator_t<R> ranges::find(Ep&& exec, R&& r, const T& value, Proj proj = {});
+
 template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
          @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
   constexpr I ranges::find_if(I first, S last, Pred pred, Proj proj = {});
@@ -3882,6 +5002,14 @@ template<@\libconcept{input_range}@ R, class Proj = identity,
          @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
   constexpr borrowed_iterator_t<R>
     ranges::find_if(R&& r, Pred pred, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  I ranges::find_if(Ep&& exec, I first, S last, Pred pred, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  borrowed_iterator_t<R> ranges::find_if(Ep&& exec, R&& r, Pred pred, Proj proj = {});
+
 template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
          @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
   constexpr I ranges::find_if_not(I first, S last, Pred pred, Proj proj = {});
@@ -3889,6 +5017,13 @@ template<@\libconcept{input_range}@ R, class Proj = identity,
          @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
   constexpr borrowed_iterator_t<R>
     ranges::find_if_not(R&& r, Pred pred, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  I ranges::find_if_not(Ep&& exec, I first, S last, Pred pred, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  borrowed_iterator_t<R> ranges::find_if_not(Ep&& exec, R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3927,18 +5062,46 @@ template<@\libconcept{forward_range}@ R, class Proj = identity,
          class T = projected_value_t<iterator_t<R>, Proj>>
   requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
   constexpr borrowed_subrange_t<R> ranges::find_last(R&& r, const T& value, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity, class T = projected_value_t<I, Proj>>
+  requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T*>
+  subrange<I> ranges::find_last(Ep&& exec, I first, S last, const T& value, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+          class T = projected_value_t<iterator_t<R>, Proj>>
+  requires
+    @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
+  borrowed_subrange_t<R> ranges::find_last(Ep&& exec, R&& r, const T& value, Proj proj = {});
+
 template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
          @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
   constexpr subrange<I> ranges::find_last_if(I first, S last, Pred pred, Proj proj = {});
 template<@\libconcept{forward_range}@ R, class Proj = identity,
          @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
   constexpr borrowed_subrange_t<R> ranges::find_last_if(R&& r, Pred pred, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  subrange<I> ranges::find_last_if(Ep&& exec, I first, S last, Pred pred, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R,
+          class Proj = identity,
+          @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  borrowed_subrange_t<R> ranges::find_last_if(Ep&& exec, R&& r, Pred pred, Proj proj = {});
+
 template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
          @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
   constexpr subrange<I> ranges::find_last_if_not(I first, S last, Pred pred, Proj proj = {});
 template<@\libconcept{forward_range}@ R, class Proj = identity,
          @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
   constexpr borrowed_subrange_t<R> ranges::find_last_if_not(R&& r, Pred pred, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  subrange<I> ranges::find_last_if_not(Ep&& exec, I first, S last, Pred pred, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  borrowed_subrange_t<R> ranges::find_last_if_not(Ep&& exec, R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4005,6 +5168,20 @@ template<@\libconcept{forward_range}@ R1, @\libconcept{forward_range}@ R2,
   requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
   constexpr borrowed_subrange_t<R1>
     ranges::find_end(R1&& r1, R2&& r2, Pred pred = {},
+                     Proj1 proj1 = {}, Proj2 proj2 = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+         @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+         class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
+  subrange<I1>
+    ranges::find_end(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = {},
+                     Proj1 proj1 = {}, Proj2 proj2 = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+         class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+  borrowed_subrange_t<R1>
+    ranges::find_end(Ep&& exec, R1&& r1, R2&& r2, Pred pred = {},
                      Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
 
@@ -4092,6 +5269,19 @@ template<@\libconcept{input_range}@ R1, @\libconcept{forward_range}@ R2,
     ranges::find_first_of(R1&& r1, R2&& r2,
                           Pred pred = {},
                           Proj1 proj1 = {}, Proj2 proj2 = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+         @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+         class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
+  I1 ranges::find_first_of(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = {},
+                           Proj1 proj1 = {}, Proj2 proj2 = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+         class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+  borrowed_iterator_t<R1>
+    ranges::find_first_of(Ep&& exec, R1&& r1, R2&& r2, Pred pred = {},
+                          Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4152,6 +5342,17 @@ template<@\libconcept{forward_range}@ R, class Proj = identity,
          @\libconcept{indirect_binary_predicate}@<projected<iterator_t<R>, Proj>,
                                    projected<iterator_t<R>, Proj>> Pred = ranges::equal_to>
   constexpr borrowed_iterator_t<R> ranges::adjacent_find(R&& r, Pred pred = {}, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity,
+         @\libconcept{indirect_binary_predicate}@<projected<I, Proj>,
+                                    projected<I, Proj>> Pred = ranges::equal_to>
+  I ranges::adjacent_find(Ep&& exec, I first, S last, Pred pred = {}, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         @\libconcept{indirect_binary_predicate}@<projected<iterator_t<R>, Proj>,
+                                    projected<iterator_t<R>, Proj>> Pred = ranges::equal_to>
+  borrowed_iterator_t<R>
+    ranges::adjacent_find(Ep&& exec, R&& r, Pred pred = {}, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4173,13 +5374,13 @@ Returns \tcode{last} if no such iterator is found.
 
 \pnum
 \complexity
-For the overloads with no \tcode{ExecutionPolicy},
+For the non-parallel algorithm overloads,
 exactly \[ \min(\tcode{(i - first) + 1}, \ \tcode{(last - first) - 1}) \]
 applications of the corresponding predicate,
 where \tcode{i} is \tcode{adjacent_find}'s return value.
-For the overloads with an \tcode{ExecutionPolicy},
-\bigoh{\tcode{last - first}} applications of the corresponding predicate,
-and no more than twice as many applications of any projection.
+For the parallel algorithm overloads,
+\bigoh{\tcode{last - first}} applications of the corresponding predicate.
+No more than twice as many applications of any projection.
 \end{itemdescr}
 
 \rSec2[alg.count]{Count}
@@ -4213,6 +5414,18 @@ template<@\libconcept{input_range}@ R, class Proj = identity, class T = projecte
   requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
   constexpr range_difference_t<R>
     ranges::count(R&& r, const T& value, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity, class T = projected_value_t<I, Proj>>
+  requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T*>
+  iter_difference_t<I>
+    ranges::count(Ep&& exec, I first, S last, const T& value, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         class T = projected_value_t<iterator_t<R>, Proj>>
+  requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to,
+                                      projected<iterator_t<R>, Proj>, const T*>
+  range_difference_t<R> ranges::count(Ep&& exec, R&& r, const T& value, Proj proj = {});
+
 template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
          @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
   constexpr iter_difference_t<I>
@@ -4221,6 +5434,15 @@ template<@\libconcept{input_range}@ R, class Proj = identity,
          @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
   constexpr range_difference_t<R>
     ranges::count_if(R&& r, Pred pred, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  iter_difference_t<I>
+    ranges::count_if(Ep&& exec, I first, S last, Pred pred, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  range_difference_t<R>
+    ranges::count_if(Ep&& exec, R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4314,12 +5536,26 @@ template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2,
   constexpr ranges::mismatch_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
     ranges::mismatch(R1&& r1, R2&& r2, Pred pred = {},
                      Proj1 proj1 = {}, Proj2 proj2 = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+         @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+         class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
+  ranges::mismatch_result<I1, I2>
+    ranges::mismatch(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = {},
+                     Proj1 proj1 = {}, Proj2 proj2 = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+         class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+  ranges::mismatch_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
+    ranges::mismatch(Ep&& exec, R1&& r1, R2&& r2, Pred pred = {},
+                     Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 Let \tcode{last2} be \tcode{first2 + (last1 - first1)}
-for the overloads with no parameter \tcode{last2} or \tcode{r2}.
+for the overloads in namespace \tcode{std} with no parameter \tcode{last2}.
 
 \pnum
 Let $E$ be:
@@ -4404,6 +5640,18 @@ template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, class Pre
   requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
   constexpr bool ranges::equal(R1&& r1, R2&& r2, Pred pred = {},
                                Proj1 proj1 = {}, Proj2 proj2 = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+         @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+         class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
+  bool ranges::equal(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2,
+                     Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+         class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+  bool ranges::equal(Ep&& exec, R1&& r1, R2&& r2,
+                     Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4412,7 +5660,7 @@ Let:
 \begin{itemize}
 \item
   \tcode{last2} be \tcode{first2 + (last1 - first1)}
-  for the overloads with no parameter \tcode{last2} or \tcode{r2};
+  for the overloads in namespace \tcode{std} with no parameter \tcode{last2};
 \item
   \tcode{pred} be \tcode{equal_to\{\}}
   for the overloads with no parameter \tcode{pred};
@@ -4447,27 +5695,20 @@ If
   and \tcode{last1 - first1 != last2 - first2}
   for the overloads in namespace \tcode{std};
 \item
- the types of \tcode{first1}, \tcode{last1}, \tcode{first2}, and \tcode{last2}
- pairwise model \libconcept{sized_sentinel_for}\iref{iterator.concept.sizedsentinel}
+  the types of \tcode{first1}, \tcode{last1}, \tcode{first2}, and \tcode{last2}
+  pairwise model \libconcept{sized_sentinel_for}\iref{iterator.concept.sizedsentinel}
   and \tcode{last1 - first1 != last2 - first2}
-  for the first overload in namespace \tcode{ranges},
+  for the first and third overloads in namespace \tcode{ranges}, or
 \item
    \tcode{R1} and \tcode{R2} each model \libconcept{sized_range} and
    \tcode{ranges::distance(r1) != ranges::distance(r2)}
-   for the second overload in namespace \tcode{ranges},
+   for the second and fourth overloads in namespace \tcode{ranges},
 \end{itemize}
 then no applications of the corresponding predicate and each projection;
-otherwise,
-\begin{itemize}
-\item
-  For the overloads with no \tcode{ExecutionPolicy},
-  at most $\min(\tcode{last1 - first1}, \ \tcode{last2 - first2})$
-  applications of the corresponding predicate and any projections.
-\item
-  For the overloads with an \tcode{ExecutionPolicy},
-  \bigoh{\min(\tcode{last1 - first1}, \ \tcode{last2 - first2})}
-  applications of the corresponding predicate.
-\end{itemize}
+%FIXME: "At" should be lower because presumably,
+%the intent was to remove bullets here instead of creating a single-bullet list.
+otherwise, At most $\min(\brk{}\tcode{last1 - first1},\brk{} \ \tcode{last2 - first2})$
+applications of the corresponding predicate and any projections.
 \end{itemdescr}
 
 \rSec2[alg.is.permutation]{Is permutation}
@@ -4640,6 +5881,20 @@ template<@\libconcept{forward_range}@ R1, @\libconcept{forward_range}@ R2, class
   constexpr borrowed_subrange_t<R1>
     ranges::search(R1&& r1, R2&& r2, Pred pred = {},
                    Proj1 proj1 = {}, Proj2 proj2 = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+         @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+         class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
+  subrange<I1>
+    ranges::search(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2,
+                   Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+         class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+  borrowed_subrange_t<R1>
+    ranges::search(Ep&& exec, R1&& r1, R2&& r2,
+                   Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4735,6 +5990,20 @@ template<@\libconcept{forward_range}@ R, class Pred = ranges::equal_to,
   constexpr borrowed_subrange_t<R>
     ranges::search_n(R&& r, range_difference_t<R> count,
                      const T& value, Pred pred = {}, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Pred = ranges::equal_to, class Proj = identity,
+         class T = projected_value_t<I, Proj>>
+  requires @\libconcept{indirectly_comparable}@<I, const T*, Pred, Proj>
+  subrange<I>
+    ranges::search_n(Ep&& exec, I first, S last, iter_difference_t<I> count,
+                     const T& value, Pred pred = {}, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Pred = ranges::equal_to,
+         class Proj = identity, class T = projected_value_t<I, Proj>>
+  requires @\libconcept{indirectly_comparable}@<iterator_t<R>, const T*, Pred, Proj>
+  borrowed_subrange_t<R>
+    ranges::search_n(Ep&& exec, R&& r, range_difference_t<R> count,
+                     const T& value, Pred pred = {}, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4795,6 +6064,30 @@ ranges::mismatch(std::move(first1), last1, std::move(first2), last2,
 \end{codeblock}
 \end{itemdescr}
 
+\begin{itemdecl}
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+         @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+         class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
+  bool ranges::starts_with(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2,
+                           Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1,
+         @\exposconcept{sized-random-access-range}@ R2, class Pred = ranges::equal_to,
+         class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+  bool ranges::starts_with(Ep&& exec, R1&& r1, R2&& r2,
+                           Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+\begin{codeblock}
+ranges::mismatch(std::forward<Ep>(exec), std::move(first1), last1, std::move(first2),
+                 last2, pred, proj1, proj2).in2 == last2
+\end{codeblock}
+\end{itemdescr}
+
 \rSec2[alg.ends.with]{Ends with}
 
 \indexlibraryglobal{ends_with}%
@@ -4823,6 +6116,29 @@ ranges::equal(std::move(first1) + (N1 - N2), last1, std::move(first2), last2,
 \end{itemdescr}
 
 \begin{itemdecl}
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+         @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+         class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{indirectly_comparable}@<I1, I2, Pred, Proj1, Proj2>
+  bool ranges::ends_with(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2,
+                         Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{N1} be \tcode{ranges::distance(r1)} and
+\tcode{N2} be \tcode{ranges::distance(r2)}.
+
+\pnum
+\returns
+\tcode{false} if $\tcode{N1} < \tcode{N2}$, otherwise
+\begin{codeblock}
+ranges::equal(std::forward<Ep>(exec), std::move(first1) + (N1 - N2), last1,
+              std::move(first2), last2, pred, proj1, proj2)
+\end{codeblock}
+\end{itemdescr}
+
+\begin{itemdecl}
 template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, class Pred = ranges::equal_to, class Proj1 = identity,
          class Proj2 = identity>
   requires (@\libconcept{forward_range}@<R1> || @\libconcept{sized_range}@<R1>) &&
@@ -4842,6 +6158,30 @@ Let \tcode{N1} be \tcode{ranges::distance(r1)} and
 \tcode{false} if $\tcode{N1} < \tcode{N2}$, otherwise
 \begin{codeblock}
 ranges::equal(views::drop(ranges::ref_view(r1), N1 - static_cast<decltype(N1)>(N2)),
+              r2, pred, proj1, proj2)
+\end{codeblock}
+\end{itemdescr}
+
+\begin{itemdecl}
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1,
+         @\exposconcept{sized-random-access-range}@ R2, class Pred = ranges::equal_to,
+         class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{indirectly_comparable}@<iterator_t<R1>, iterator_t<R2>, Pred, Proj1, Proj2>
+  bool ranges::ends_with(Ep&& exec, R1&& r1, R2&& r2,
+                         Pred pred = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{N1} be \tcode{ranges::distance(r1)} and
+\tcode{N2} be \tcode{ranges::distance(r2)}.
+
+\pnum
+\returns
+\tcode{false} if $\tcode{N1} < \tcode{N2}$, otherwise
+\begin{codeblock}
+ranges::equal(std::forward<Ep>(exec),
+              views::drop(ranges::ref_view(r1), N1 - static_cast<decltype(N1)>(N2)),
               r2, pred, proj1, proj2)
 \end{codeblock}
 \end{itemdescr}
@@ -5067,28 +6407,50 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
   ForwardIterator2 copy(ExecutionPolicy&& exec,
                         ForwardIterator1 first, ForwardIterator1 last,
                         ForwardIterator2 result);
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS>
+  requires @\libconcept{indirectly_copyable}@<I, O>
+  ranges::copy_result<I, O>
+    ranges::copy(Ep&& exec, I first, S last, O result, OutS result_last);
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR>
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR>>
+  ranges::copy_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+    ranges::copy(Ep&& exec, R&& r, OutR&& result_r);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
+Let \tcode{result_last} be \tcode{result + (last - first)}
+for the overload in namespace \tcode{std}.
+
+\pnum
+Let $N$ be $\min(\tcode{last - first}, \ \tcode{result_last - result})$
+
+\pnum
 \expects
-The ranges \range{first}{last} and \range{result}{result + (last - first)}
+The ranges \range{first}{last} and \range{result}{result + $N$}
 do not overlap.
 
 \pnum
 \effects
-Copies elements in the range \range{first}{last}
-into the range \range{result}{result + (last - first)}.
-For each non-negative integer \tcode{n < (last - first)},
-performs \tcode{*(result + n) = *(first + n)}.
+Copies elements in the range \range{first}{first + $N$}
+into the range \range{result}{result + $N$}.
+For each non-negative integer $n < N$,
+performs \tcode{*(result + $n$) = *(first + $n$)}.
 
 \pnum
 \returns
-\tcode{result + (last - first)}.
+\begin{itemize}
+\item
+  \tcode{result + $N$} for the overload in namespace \tcode{std}.
+\item
+  \tcode{\{first + $N$, result + $N$\}} for the overloads in namespace \tcode{ranges}.
+\end{itemize}
 
 \pnum
 \complexity
-Exactly \tcode{last - first} assignments.
+Exactly $N$ assignments.
 \end{itemdescr}
 
 \indexlibraryglobal{copy_n}%
@@ -5105,11 +6467,24 @@ template<@\libconcept{input_iterator}@ I, @\libconcept{weakly_incrementable}@ O>
   requires @\libconcept{indirectly_copyable}@<I, O>
   constexpr ranges::copy_n_result<I, O>
     ranges::copy_n(I first, iter_difference_t<I> n, O result);
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{random_access_iterator}@ O,
+         @\libconcept{sized_sentinel_for}@<O> OutS>
+  requires @\libconcept{indirectly_copyable}@<I, O>
+  ranges::copy_n_result<I, O>
+    ranges::copy_n(Ep&& exec, I first, iter_difference_t<I> n, O result, OutS result_last);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-Let $N$ be $\max(0, \tcode{n})$.
+Let $M$ be $\max(0, \ \tcode{n})$.
+
+\pnum
+Let \tcode{result_last} be \tcode{result + $M$}
+for the overloads with no parameter \tcode{result_last}.
+
+\pnum
+Let $N$ be $\min(\tcode{result_last - result}, M)$.
 
 \pnum
 \mandates
@@ -5158,38 +6533,67 @@ template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O, cl
   requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O>
   constexpr ranges::copy_if_result<borrowed_iterator_t<R>, O>
     ranges::copy_if(R&& r, O result, Pred pred, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+          @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS,
+          class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  requires @\libconcept{indirectly_copyable}@<I, O>
+  ranges::copy_if_result<I, O>
+    ranges::copy_if(Ep&& exec, I first, S last, O result, OutS result_last,
+                    Pred pred, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR,
+          class Proj = identity,
+          @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR>>
+  ranges::copy_if_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+    ranges::copy_if(Ep&& exec, R&& r, OutR&& result_r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-Let $E$ be:
+Let $E(\tcode{i})$ be:
 \begin{itemize}
 \item
   \tcode{bool(pred(*i))}
   for the overloads in namespace \tcode{std};
 \item
   \tcode{bool(invoke(pred, invoke(proj, *i)))}
-  for the overloads in namespace \tcode{ranges},
+  for the overloads in namespace \tcode{ranges}.
 \end{itemize}
-and $N$ be the number of iterators \tcode{i} in the range \range{first}{last}
-for which the condition $E$ holds.
+
+\pnum
+Let:
+\begin{itemize}
+\item
+  $M$ be the number of iterators \tcode{i} in the range \range{first}{last}
+  for which the condition $E(\tcode{i})$ holds;
+\item
+  \tcode{result_last} be \tcode{result + $M$}
+  for the overloads with no parameter \tcode{result_last} or \tcode{result_r};
+\item
+  $N$ be $\min(M, \ \tcode{result_last - result})$.
+\end{itemize}
 
 \pnum
 \expects
-The ranges \range{first}{last} and \range{result}{result + (last - first)}
+The ranges \range{first}{last} and \range{result}{result + $N$}
 do not overlap.
 \begin{note}
-For the overload with an \tcode{ExecutionPolicy},
-there might be a performance cost
+For the parallel algorithm overload in namespace \tcode{std},
+there can be a performance cost
 if \tcode{iterator_traits<For\-ward\-It\-er\-ator1>::value_type}
-is not \oldconcept{\-Move\-Constructible} (\tref{cpp17.moveconstructible}).
+does not meet the \oldconcept{\-Move\-Constructible} (\tref{cpp17.moveconstructible}) requirements.
+For the parallel algorithm overloads in namespace \tcode{ranges},
+there can be a performance cost
+if \tcode{iter_value_t<I>} does not model \libconcept{move_constructible}.
 \end{note}
 
 \pnum
 \effects
-Copies all of the elements referred to
+Copies the first $N$ elements referred to
 by the iterator \tcode{i} in the range \range{first}{last}
-for which $E$ is \tcode{true}.
+for which $E(\tcode{i})$ is \tcode{true}
+into the range \range{result}{result + $N$}.
 
 \pnum
 \returns
@@ -5200,11 +6604,18 @@ for which $E$ is \tcode{true}.
 \item
   \tcode{\{last, result + $N$\}}
   for the overloads in namespace \tcode{ranges}.
+\item
+  Otherwise, \tcode{\{j, result_last\}}
+  for the overloads in namespace \tcode{ranges},
+  where \tcode{j} is the iterator in \range{first}{last}
+  for which $E(\tcode{j})$ holds
+  and there are exactly $N$ iterators \tcode{i}
+  in \range{first}{j} for which $E(\tcode{i})$ holds.
 \end{itemize}
 
 \pnum
 \complexity
-Exactly \tcode{last - first} applications
+At most \tcode{last - first} applications
 of the corresponding predicate and any projection.
 
 \pnum
@@ -5330,11 +6741,40 @@ template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
   ForwardIterator2 move(ExecutionPolicy&& exec,
                         ForwardIterator1 first, ForwardIterator1 last,
                         ForwardIterator2 result);
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS>
+  requires @\libconcept{indirectly_movable}@<I, O>
+  ranges::move_result<I, O>
+    ranges::move(Ep&& exec, I first, S last, O result, OutS result_last);
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR>
+  requires @\libconcept{indirectly_movable}@<iterator_t<R>, iterator_t<OutR>>
+  ranges::move_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+    ranges::move(Ep&& exec, R&& r, OutR&& result_r);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-Let $N$ be \tcode{last - first}.
+Let $E$ be:
+\begin{itemize}
+\item
+  %FIXME: This is extremely confusing to read from top to bottom
+  %       because $n$ is defined multiple paragraphs below.
+  %       Can we make this $E(\tcode{i})$ or something?
+  %       We did that for copy_if.
+  \tcode{std::move(*(first + $n$))}
+  for the overload in namespace \tcode{std};
+\item
+  \tcode{ranges::iter_move(first + $n$)}
+  for the overloads in namespace \tcode{ranges}.
+\end{itemize}
+
+\pnum
+Let \tcode{result_last} be \tcode{result + (last - first)}
+for the overloads in namespace \tcode{std}.
+
+\pnum
+Let $N$ be $\min(\tcode{last - first}, \ \tcode{result_last - result})$.
 
 \pnum
 \expects
@@ -5343,14 +6783,21 @@ do not overlap.
 
 \pnum
 \effects
-Moves elements in the range \range{first}{last}
+Moves elements in the range \range{first}{first + $N$}
 into the range \range{result}{result + $N$}.
 For each non-negative integer $n < N$,
-performs \tcode{*(result + $n$) = std::\brk{}move(*(first + $n$))}.
+performs \tcode{*(result + $n$) = $E$}.
 
 \pnum
 \returns
-\tcode{result + $N$}.
+\begin{itemize}
+\item
+  \tcode{result + $N$}
+  for the overload in namespace \tcode{std}.
+\item
+  \tcode{\{first + $N$, result + $N$\}}
+  for the overloads in namespace \tcode{ranges}.
+\end{itemize}
 
 \pnum
 \complexity
@@ -5441,6 +6888,16 @@ template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2>
   requires @\libconcept{indirectly_swappable}@<iterator_t<R1>, iterator_t<R2>>
   constexpr ranges::swap_ranges_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
     ranges::swap_ranges(R1&& r1, R2&& r2);
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+         @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2>
+  requires @\libconcept{indirectly_swappable}@<I1, I2>
+  ranges::swap_ranges_result<I1, I2>
+    ranges::swap_ranges(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2);
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2>
+  requires @\libconcept{indirectly_swappable}@<iterator_t<R1>, iterator_t<R2>>
+  ranges::swap_ranges_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
+    ranges::swap_ranges(Ep&& exec, R1&& r1, R2&& r2);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5449,7 +6906,8 @@ Let:
 \begin{itemize}
 \item
   \tcode{last2} be \tcode{first2 + (last1 - first1)}
-  for the overloads with no parameter named \tcode{last2};
+  for the overloads in namespace \tcode{std}
+  with no parameter named \tcode{last2};
 \item $M$ be $\min(\tcode{last1 - first1}, \ \tcode{last2 - first2})$.
 \end{itemize}
 
@@ -5546,6 +7004,21 @@ template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O, @\
   requires @\libconcept{indirectly_writable}@<O, indirect_result_t<F&, projected<iterator_t<R>, Proj>>>
   constexpr ranges::unary_transform_result<borrowed_iterator_t<R>, O>
     ranges::transform(R&& r, O result, F op, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS,
+         @\libconcept{copy_constructible}@ F, class Proj = identity>
+  requires @\libconcept{indirectly_writable}@<O, indirect_result_t<F&, projected<I, Proj>>>
+  ranges::unary_transform_result<I, O>
+    ranges::transform(Ep&& exec, I first1, S last1, O result, OutS result_last,
+                      F op, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR,
+          @\libconcept{copy_constructible}@ F, class Proj = identity>
+  requires @\libconcept{indirectly_writable}@<iterator_t<OutR>,
+                                indirect_result_t<F&, projected<iterator_t<R>, Proj>>>
+  ranges::unary_transform_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+    ranges::transform(Ep&& exec, R&& r, OutR&& result_r, F op, Proj proj = {});
+
 template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
          @\libconcept{weakly_incrementable}@ O, @\libconcept{copy_constructible}@ F, class Proj1 = identity,
          class Proj2 = identity>
@@ -5561,6 +7034,27 @@ template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, @\libconc
   constexpr ranges::binary_transform_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
     ranges::transform(R1&& r1, R2&& r2, O result,
                       F binary_op, Proj1 proj1 = {}, Proj2 proj2 = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+         @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+         @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS,
+         @\libconcept{copy_constructible}@ F, class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{indirectly_writable}@<O, indirect_result_t<F&, projected<I1, Proj1>,
+                                projected<I2, Proj2>>>
+  ranges::binary_transform_result<I1, I2, O>
+    ranges::transform(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2,
+                      O result, OutS result_last,
+                      F binary_op, Proj1 proj1 = {}, Proj2 proj2 = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+         @\exposconcept{sized-random-access-range}@ OutR, @\libconcept{copy_constructible}@ F,
+          class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{indirectly_writable}@<iterator_t<OutR>,
+                                indirect_result_t<F&, projected<iterator_t<R1>, Proj1>,
+                                projected<iterator_t<R2>, Proj2>>>
+  ranges::binary_transform_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>,
+                                  borrowed_iterator_t<OutR>>
+    ranges::transform(Ep&& exec, R1&& r1, R2&& r2, OutR&& result_r,
+                      F binary_op, Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5570,11 +7064,17 @@ Let:
 \setlength{\emergencystretch}{1em}
 \item
   \tcode{last2} be \tcode{first2 + (last1 - first1)}
-  for the overloads with parameter \tcode{first2}
+  for the overloads in namespace \tcode{std}
+  with parameter \tcode{first2}
   but no parameter \tcode{last2};
 \item
-  $N$ be \tcode{last1 - first1} for unary transforms, or
+  $M$ be \tcode{last1 - first1} for unary transforms, or
   $\min(\tcode{last1 - first1}, \ \tcode{last2 - first2})$ for binary transforms;
+\item
+  \tcode{result_last} be \tcode{result + $M$}
+  for the overloads with no parameter \tcode{result_last} or \tcode{result_r};
+\item
+  $N$ be $\min(M, \ \tcode{result_last - result})$;
 \item
   $E$ be
   \begin{itemize}
@@ -5595,6 +7095,10 @@ Let:
 
 \pnum
 \expects
+For parallel algorithm overloads
+%FIXME: Comma!
+\tcode{op} and \tcode{binary_op} satisfy the requirements
+specified in \ref{algorithms.parallel.user}.
 \tcode{op} and \tcode{binary_op} do not invalidate iterators or subranges, nor
 modify elements in the ranges
 \begin{itemize}
@@ -5630,7 +7134,7 @@ a new corresponding value equal to $E$.
 \complexity
 Exactly $N$ applications of \tcode{op} or \tcode{binary_op}, and
 any projections.
-This requirement also applies to the overload with an \tcode{ExecutionPolicy}.
+This requirement also applies to the parallel algorithm overloads.
 
 \pnum
 \remarks
@@ -5673,6 +7177,22 @@ template<@\libconcept{input_range}@ R, class Proj = identity,
            @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<iterator_t<R>, Proj>, const T1*>
   constexpr borrowed_iterator_t<R>
     ranges::replace(R&& r, const T1& old_value, const T2& new_value, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity, class T1 = projected_value_t<I, Proj>, class T2 = T1>
+  requires @\libconcept{indirectly_writable}@<I, const T2&> &&
+           @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T1*>
+  I ranges::replace(Ep&& exec, I first, S last,
+                    const T1& old_value, const T2& new_value, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         class T1 = projected_value_t<iterator_t<R>, Proj>, class T2 = T1>
+  requires @\libconcept{indirectly_writable}@<iterator_t<R>, const T2&> &&
+            @\libconcept{indirect_binary_predicate}@<ranges::equal_to,
+                                      projected<iterator_t<R>, Proj>, const T1*>
+  borrowed_iterator_t<R>
+    ranges::replace(Ep&& exec, R&& r, const T1& old_value, const T2& new_value,
+                    Proj proj = {});
+
 template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
          class T = projected_value_t<I, Proj>,
          @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
@@ -5683,6 +7203,19 @@ template<@\libconcept{input_range}@ R, class Proj = identity, class T = projecte
   requires @\libconcept{indirectly_writable}@<iterator_t<R>, const T&>
   constexpr borrowed_iterator_t<R>
     ranges::replace_if(R&& r, Pred pred, const T& new_value, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity, class T = projected_value_t<I, Proj>,
+         @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  requires @\libconcept{indirectly_writable}@<I, const T&>
+  I ranges::replace_if(Ep&& exec, I first, S last, Pred pred,
+                       const T& new_value, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         class T = projected_value_t<I, Proj>,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  requires @\libconcept{indirectly_writable}@<iterator_t<R>, const T&>
+  borrowed_iterator_t<R>
+    ranges::replace_if(Ep&& exec, R&& r, Pred pred, const T& new_value, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5761,6 +7294,27 @@ template<@\libconcept{input_range}@ R, class O, class Proj = identity,
     ranges::replace_copy(R&& r, O result, const T1& old_value, const T2& new_value,
                          Proj proj = {});
 
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS,
+         class Proj = identity,
+         class T1 = projected_value_t<I, Proj>, class T2 = iter_value_t<O>>
+  requires @\libconcept{indirectly_copyable}@<I, O> &&
+           @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T1*> &&
+           @\libconcept{indirectly_writable}@<O, const T2&>
+  ranges::replace_copy_result<I, O>
+    ranges::replace_copy(Ep&& exec, I first, S last, O result, OutS result_last,
+                         const T1& old_value, const T2& new_value, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR,
+         class Proj = identity, class T1 = projected_value_t<iterator_t<R>, Proj>,
+         class T2 = range_value_t<OutR>>
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR>> &&
+           @\libconcept{indirect_binary_predicate}@<ranges::equal_to,
+                                      projected<iterator_t<R>, Proj>, const T1*> &&
+           @\libconcept{indirectly_writable}@<iterator_t<OutR>, const T2&>
+  ranges::replace_copy_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+    ranges::replace_copy(Ep&& exec, R&& r, OutR&& result_r, const T1& old_value,
+                         const T2& new_value, Proj proj = {});
+
 template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S,class O, class T = iter_value_t<O>,
          class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
   requires @\libconcept{indirectly_copyable}@<I, O> && @\libconcept{output_iterator}@<O, const T&>
@@ -5772,6 +7326,22 @@ template<@\libconcept{input_range}@ R, class O, class T = iter_value_t<O>, class
   requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O> && @\libconcept{output_iterator}@<O, const T&>
   constexpr ranges::replace_copy_if_result<borrowed_iterator_t<R>, O>
     ranges::replace_copy_if(R&& r, O result, Pred pred, const T& new_value,
+                            Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS, class T = iter_value_t<O>,
+         class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  requires @\libconcept{indirectly_copyable}@<I, O> && @\libconcept{indirectly_writable}@<O, const T&>
+  ranges::replace_copy_if_result<I, O>
+    ranges::replace_copy_if(Ep&& exec, I first, S last, O result, OutS result_last,
+                            Pred pred, const T& new_value, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR,
+         class T = range_value_t<OutR>, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR>> &&
+           @\libconcept{indirectly_writable}@<OutR, const T&>
+  ranges::replace_copy_if_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+    ranges::replace_copy_if(Ep&& exec, R&& r, OutR&& result_r, Pred pred, const T& new_value,
                             Proj proj = {});
 \end{itemdecl}
 
@@ -5791,19 +7361,29 @@ Let $E$ be
 \end{itemize}
 
 \pnum
+Let %FIXME: missing colon
+\begin{itemize}
+\item
+  \tcode{result_last} be \tcode{result + (last - first)}
+  for the overloads with no parameter \tcode{result_last} or \tcode{result_r};
+\item
+  $N$ be $\min(\tcode{last - first}, \ \tcode{result_last - result})$.
+\end{itemize}
+
+\pnum
 \mandates
 The results of the expressions \tcode{*first} and \tcode{new_value}
 are writable\iref{iterator.requirements.general} to \tcode{result}.
 
 \pnum
 \expects
-The ranges \range{first}{last} and \range{result}{result + (last - first)}
+The ranges \range{first}{last} and \range{result}{result + $N$}
 do not overlap.
 
 \pnum
 \effects
 Assigns through every iterator \tcode{i}
-in the range \range{result}{result + (last - first)}
+in the range \range{result}{result + $N$}
 a new corresponding value
 \begin{itemize}
 \item \tcode{new_value} if $E$ is \tcode{true} or
@@ -5814,16 +7394,16 @@ a new corresponding value
 \returns
 \begin{itemize}
 \item
-  \tcode{result + (last - first)}
+  \tcode{result + $N$}
   for the overloads in namespace \tcode{std}.
 \item
-  \tcode{\{last, result + (last - first)\}}
+  \tcode{\{first + $N$, result + $N$\}}
   for the overloads in namespace \tcode{ranges}.
 \end{itemize}
 
 \pnum
 \complexity
-Exactly \tcode{last - first} applications
+Exactly $N$ applications
 of the corresponding predicate and any projection.
 \end{itemdescr}
 
@@ -5855,6 +7435,17 @@ template<class R, class T = range_value_t<R>>
 template<class O, class T = iter_value_t<O>>
   requires @\libconcept{output_iterator}@<O, const T&>
   constexpr O ranges::fill_n(O first, iter_difference_t<O> n, const T& value);
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> S,
+         class T = iter_value_t<O>>
+  requires @\libconcept{indirectly_writable}@<O, const T&>
+  O ranges::fill(Ep&& exec, O first, S last, const T& value);
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class T = range_value_t<R>>
+  requires @\libconcept{indirectly_writable}@<iterator_t<R>, const T&>
+  borrowed_iterator_t<R> fill(Ep&& exec, R&& r, const T& value);
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ O, class T = iter_value_t<O>>
+  requires @\libconcept{indirectly_writable}@<O, const T&>
+  O ranges::fill_n(Ep&& exec, O first, iter_difference_t<O> n, const T& value);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5911,6 +7502,17 @@ template<class R, @\libconcept{copy_constructible}@ F>
 template<@\libconcept{input_or_output_iterator}@ O, @\libconcept{copy_constructible}@ F>
   requires @\libconcept{invocable}@<F&> && @\libconcept{indirectly_writable}@<O, invoke_result_t<F&>>
   constexpr O ranges::generate_n(O first, iter_difference_t<O> n, F gen);
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> S,
+         @\libconcept{copy_constructible}@ F>
+  requires @\libconcept{invocable}@<F&> && @\libconcept{indirectly_writable}@<O, invoke_result_t<F&>>
+  O ranges::generate(Ep&& exec, O first, S last, F gen);
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\libconcept{copy_constructible}@ F>
+  requires @\libconcept{invocable}@<F&> && @\libconcept{indirectly_writable}@<iterator_t<R>, invoke_result_t<F&>>
+  borrowed_iterator_t<R> ranges::generate(Ep&& exec, R&& r, F gen);
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ O, @\libconcept{copy_constructible}@ F>
+  requires @\libconcept{invocable}@<F&> && @\libconcept{indirectly_writable}@<O, invoke_result_t<F&>>
+  O ranges::generate_n(Ep&& exec, O first, iter_difference_t<O> n, F gen);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5935,6 +7537,11 @@ through each iterator in the range \range{first}{first + $N$}.
 \pnum
 \complexity
 Exactly $N$ evaluations of \tcode{gen()} and assignments.
+
+\pnum
+\remarks
+\tcode{gen} may modify objects via its arguments
+for parallel algorithm overloads\iref{algorithms.parallel.user}.
 \end{itemdescr}
 
 \rSec2[alg.remove]{Remove}
@@ -5969,6 +7576,20 @@ template<@\libconcept{forward_range}@ R, class Proj = identity,
            @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
   constexpr borrowed_subrange_t<R>
     ranges::remove(R&& r, const T& value, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity, class T = projected_value_t<I, Proj>>
+  requires @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T*>
+  subrange<I>
+    ranges::remove(Ep&& exec, I first, S last, const T& value, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         class T = projected_value_t<iterator_t<R>, Proj>>
+  requires @\libconcept{permutable}@<iterator_t<R>> &&
+           @\libconcept{indirect_binary_predicate}@<ranges::equal_to,
+                                      projected<iterator_t<R>, Proj>, const T*>
+  borrowed_subrange_t<R>
+    ranges::remove(Ep&& exec, R&& r, const T& value, Proj proj = {});
+
 template<@\libconcept{permutable}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
          @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
   constexpr subrange<I> ranges::remove_if(I first, S last, Pred pred, Proj proj = {});
@@ -5977,6 +7598,16 @@ template<@\libconcept{forward_range}@ R, class Proj = identity,
   requires @\libconcept{permutable}@<iterator_t<R>>
   constexpr borrowed_subrange_t<R>
     ranges::remove_if(R&& r, Pred pred, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  subrange<I>
+    ranges::remove_if(Ep&& exec, I first, S last, Pred pred, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  requires @\libconcept{permutable}@<iterator_t<R>>
+  borrowed_subrange_t<R>
+    ranges::remove_if(Ep&& exec, R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6065,6 +7696,23 @@ template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O, cl
            @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<iterator_t<R>, Proj>, const T*>
   constexpr ranges::remove_copy_result<borrowed_iterator_t<R>, O>
     ranges::remove_copy(R&& r, O result, const T& value, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS,
+         class Proj = identity, class T = projected_value_t<I, Proj>>
+  requires @\libconcept{indirectly_copyable}@<I, O> &&
+           @\libconcept{indirect_binary_predicate}@<ranges::equal_to, projected<I, Proj>, const T*>
+  ranges::remove_copy_result<I, O>
+    ranges::remove_copy(Ep&& exec, I first, S last, O result, OutS result_last,
+                        const T& value, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR,
+         class Proj = identity, class T = projected_value_t<iterator_t<R>, Proj>>
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR>> &&
+           @\libconcept{indirect_binary_predicate}@<ranges::equal_to,
+                                      projected<iterator_t<R>, Proj>, const T*>
+  ranges::remove_copy_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+    ranges::remove_copy(Ep&& exec, R&& r, OutR&& result_r, const T& value, Proj proj = {});
+
 template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O,
          class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
   requires @\libconcept{indirectly_copyable}@<I, O>
@@ -6075,11 +7723,25 @@ template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O, cl
   requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O>
   constexpr ranges::remove_copy_if_result<borrowed_iterator_t<R>, O>
     ranges::remove_copy_if(R&& r, O result, Pred pred, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS,
+         class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  requires @\libconcept{indirectly_copyable}@<I, O>
+  ranges::remove_copy_if_result<I, O>
+    ranges::remove_copy_if(Ep&& exec, I first, S last, O result, OutS result_last,
+                           Pred pred, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR,
+         class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR>>
+  ranges::remove_copy_if_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+    ranges::remove_copy_if(Ep&& exec, R&& r, OutR&& result_r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-Let $E$ be
+Let $E(\tcode{i})$ be
 \begin{itemize}
 \item \tcode{bool(*i == value)} for \tcode{remove_copy};
 \item \tcode{bool(pred(*i))} for \tcode{remove_copy_if};
@@ -6088,8 +7750,17 @@ Let $E$ be
 \end{itemize}
 
 \pnum
-Let $N$ be the number of elements in \range{first}{last}
-for which $E$ is \tcode{false}.
+Let %FIXME: missing colon
+\begin{itemize}
+\item
+  $M$ be the number of iterators \tcode{i} in \range{first}{last}
+  for which $E(\tcode{i})$ is \tcode{false};
+\item
+  \tcode{result_last} be \tcode{result + $M$}
+  for the overloads with no parameter \tcode{result_last} or \tcode{result_r};
+\item
+  $N$ be $\min(M, \ \tcode{result_last - result})$.
+\end{itemize}
 
 \pnum
 \mandates
@@ -6097,30 +7768,46 @@ for which $E$ is \tcode{false}.
 
 \pnum
 \expects
-The ranges \range{first}{last} and \range{result}{result + (last - first)}
+The ranges \range{first}{last} and \range{result}{result + $N$}
 do not overlap.
 \begin{note}
-For the overloads with an \tcode{ExecutionPolicy},
-there might be a performance cost
+For the parallel algorithm overloads in namespace \tcode{std},
+there can be a performance cost
 if \tcode{iterator_traits<ForwardIterator1>::value_type} does not meet
 the \oldconcept{\-Move\-Constructible} (\tref{cpp17.moveconstructible}) requirements.
+For the parallel algorithm overloads in namespace \tcode{ranges},
+there can be a performance cost
+if \tcode{iter_value_t<I>} does not model \libconcept{move_constructible}.
 \end{note}
 
 \pnum
 \effects
-Copies all the elements referred to by the iterator \tcode{i}
-in the range \range{first}{last} for which $E$ is \tcode{false}.
+Copies the first $N$ elements referred to by the iterator \tcode{i}
+in the range \range{first}{last} for which $E(\tcode{i})$ is \tcode{false}
+into the range \range{result}{result + $N$}.
 
 \pnum
 \returns
 \begin{itemize}
-\item \tcode{result + $N$}, for the algorithms in namespace \tcode{std}.
-\item \tcode{\{last, result + $N$\}}, for the algorithms in namespace \tcode{ranges}.
+\item
+  \tcode{result + $N$},
+  for the algorithms in namespace \tcode{std}.
+\item
+  \tcode{\{last, result + $N$\}},
+  for the algorithms in namespace \tcode{ranges},
+  if $N$ is equal to $M$.
+\item
+  Otherwise, \tcode{\{j, result_last\}},
+  for the algorithms in namespace \tcode{ranges},
+  where \tcode{j} is the iterator in \range{first}{last}
+  for which $E(\tcode{j})$ is \tcode{false}
+  and there are exactly $N$ iterators \tcode{i} in \range{first}{j}
+  for which $E(\tcode{j})$ is \tcode{false}.
 \end{itemize}
 
 \pnum
 \complexity
-Exactly \tcode{last - first} applications
+At most \tcode{last - first} applications
 of the corresponding predicate and any projection.
 
 \pnum
@@ -6154,6 +7841,16 @@ template<@\libconcept{forward_range}@ R, class Proj = identity,
   requires @\libconcept{permutable}@<iterator_t<R>>
   constexpr borrowed_subrange_t<R>
     ranges::unique(R&& r, C comp = {}, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity,
+         @\libconcept{indirect_equivalence_relation}@<projected<I, Proj>> C = ranges::equal_to>
+  requires @\libconcept{permutable}@<I>
+  subrange<I> ranges::unique(Ep&& exec, I first, S last, C comp = {}, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         @\libconcept{indirect_equivalence_relation}@<projected<iterator_t<R>, Proj>> C = ranges::equal_to>
+  requires @\libconcept{permutable}@<iterator_t<R>>
+  borrowed_subrange_t<R> ranges::unique(Ep&& exec, R&& r, C comp = {}, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6240,13 +7937,27 @@ template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O, cl
             @\libconcept{indirectly_copyable_storable}@<iterator_t<R>, O>)
   constexpr ranges::unique_copy_result<borrowed_iterator_t<R>, O>
     ranges::unique_copy(R&& r, O result, C comp = {}, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS, class Proj = identity,
+         @\libconcept{indirect_equivalence_relation}@<projected<I, Proj>> C = ranges::equal_to>
+  requires @\libconcept{indirectly_copyable}@<I, O>
+  ranges::unique_copy_result<I, O>
+    ranges::unique_copy(Ep&& exec, I first, S last, O result, OutS result_last,
+                        C comp = {}, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR,
+         class Proj = identity,
+         @\libconcept{indirect_equivalence_relation}@<projected<iterator_t<R>, Proj>> C = ranges::equal_to>
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR>>
+  ranges::unique_copy_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+    ranges::unique_copy(Ep&& exec, R&& r, OutR&& result_r, C comp = {}, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 Let \tcode{pred} be \tcode{equal_to\{\}} for the overloads
 in namespace \tcode{std} with no parameter \tcode{pred}, and
-let $E$ be
+let $E(\tcode{i})$ be
 \begin{itemize}
 \setlength{\emergencystretch}{1em}
 \item
@@ -6258,6 +7969,19 @@ let $E$ be
 \end{itemize}
 
 \pnum
+Let %FIXME: Colon.
+\begin{itemize}
+\item
+  $M$ be the number of iterators \tcode{i} in the range \range{first + 1}{last}
+  for which $E(\tcode{i})$ is \tcode{false};
+\item
+  \tcode{result_last} be \tcode{result + $M$ + 1}
+  for the overloads with no parameter \tcode{result_last} or \tcode{result_r};
+\item
+  $N$ be $\min(\tcode{$M$ + 1}, \ \tcode{result_last - result})$.
+\end{itemize}
+
+\pnum
 \mandates
 \tcode{*first} is writable\iref{iterator.requirements.general} to \tcode{result}.
 
@@ -6265,7 +7989,7 @@ let $E$ be
 \expects
 \begin{itemize}
 \item
-  The ranges \range{first}{last} and \range{result}{result + (last - first)}
+  The ranges \range{first}{last} and \range{result}{result + $N$}
   do not overlap.
 \item
   For the overloads in namespace \tcode{std}:
@@ -6286,31 +8010,51 @@ let $E$ be
     Otherwise, \tcode{T} meets both
     the \oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible}) and
     \oldconcept{CopyAssignable} requirements.
-    \begin{note}
-    For the overloads with an \tcode{ExecutionPolicy},
-    there might be a performance cost
-    if the value type of \tcode{ForwardIterator1} does not meet both the
-    \oldconcept{CopyConstructible} and \oldconcept{CopyAssignable} requirements.
-    \end{note}
   \end{itemize}
 \end{itemize}
+\begin{note}
+For the parallel algorithm overloads in namespace \tcode{std},
+there can be a performance cost
+if the value type of \tcode{ForwardIterator1} does not meet both the
+\oldconcept{CopyConstructible} and \oldconcept{CopyAssignable} requirements.
+For the parallel algorithm overloads in namespace \tcode{ranges},
+there can be a performance cost if \tcode{iter_value_t<I>}
+does not model both \libconcept{copy_constructible}
+%FIXME: There exists no such concept,
+%but the note refers to it.
+%LWG input needed.
+and \tcode{copy_assignable}.
+\end{note}
 
 \pnum
 \effects
-Copies only the first element from every consecutive group of equal elements
-referred to by the iterator \tcode{i} in the range \range{first}{last}
-for which $E$ holds.
+Copies only the first element from $N$ consecutive groups of equivalent elements
+referred to by the iterator \tcode{i} in the range \range{first + 1}{last}
+for which $E(\tcode{i})$ holds
+into the range \range{result}{result + $N$}.
 
 \pnum
 \returns
 \begin{itemize}
-\item \tcode{result + $N$} for the overloads in namespace \tcode{std}.
-\item \tcode{\{last, result + $N$\}} for the overloads in namespace \tcode{ranges}.
+\item
+  \tcode{result + $N$}
+  for the overloads in namespace \tcode{std}.
+\item
+  \tcode{\{last, result + $N$\}}
+  for the overloads in namespace \tcode{ranges},
+  if $N$ is equal to \tcode{$M$ + 1}.
+\item
+  Otherwise, \tcode{\{j, result_last\}}
+  for the overloads in namespace \tcode{ranges},
+  where \tcode{j} is the iterator in \range{first + 1}{last}
+  for which $E(\tcode{j})$ is \tcode{false}
+  and there are exactly \tcode{$N$ - 1} iterators \tcode{i} in \range{first + 1}{j}
+  for which $E(\tcode{i})$ is \tcode{false}.
 \end{itemize}
 
 \pnum
 \complexity
-Exactly \tcode{last - first - 1} applications
+At most \tcode{last - first - 1} applications
 of the corresponding predicate
 and no more than twice as many applications of any projection.
 \end{itemdescr}
@@ -6331,6 +8075,13 @@ template<@\libconcept{bidirectional_iterator}@ I, @\libconcept{sentinel_for}@<I>
 template<@\libconcept{bidirectional_range}@ R>
   requires @\libconcept{permutable}@<iterator_t<R>>
   constexpr borrowed_iterator_t<R> ranges::reverse(R&& r);
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S>
+  requires @\libconcept{permutable}@<I>
+  I ranges::reverse(Ep&& exec, I first, S last);
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R>
+  requires @\libconcept{permutable}@<iterator_t<R>>
+  borrowed_iterator_t<R> ranges::reverse(Ep&& exec, R&& r);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6408,6 +8159,57 @@ the following assignment takes place:
 Exactly $N$ assignments.
 \end{itemdescr}
 
+\begin{itemdecl}
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS>
+  requires @\libconcept{indirectly_copyable}@<I, O>
+  ranges::reverse_copy_result<I, O>
+    ranges::reverse_copy(Ep&& exec, I first, S last, O result,
+                         OutS result_last);
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR>
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR>>
+  ranges::reverse_copy_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+    ranges::reverse_copy(Ep&& exec, R&& r, OutR&& result_r);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let $N$ be $\min(\tcode{last - first}, \ \tcode{result_last - result})$,
+and let \exposid{NEW_FIRST} be \tcode{first + (last - first) - $N$}.
+
+\pnum
+\expects
+The ranges \range{first}{last} and \range{result}{result + $N$}
+do not overlap.
+
+\pnum
+\effects
+Copies the range \range{\exposid{NEW_FIRST}}{last}
+to the range \range{result}{result + $N$}
+%FIXME: Feels like i should be mathematical instead of code font.
+%Otherwise we run into the "is true" situation here:
+such that for every non-negative integer \tcode{i < $N$}
+the following assignment takes place:
+\tcode{*(result + $N$ - 1 - i) = *(\exposid{NEW_FIRST} + i)}.
+
+\pnum
+\returns
+\tcode{\{\exposid{NEW_FIRST}, result + $N$\}}.
+\begin{note}
+While the return type for the parallel and non-parallel algorithm overloads
+in the namespace \tcode{ranges} is the same,
+the semantics is different
+because for the parallel range algorithm overloads
+%FIXME: Comma.
+\tcode{result_last - result} can be insufficient
+to copy all data from the input.
+\end{note}
+
+\pnum
+\complexity
+Exactly $N$ assignments.
+\end{itemdescr}
+
 \rSec2[alg.rotate]{Rotate}
 
 \indexlibraryglobal{rotate}%
@@ -6473,6 +8275,24 @@ Equivalent to:
 \tcode{return ranges::rotate(ranges::begin(r), middle, ranges::end(r));}
 \end{itemdescr}
 
+\begin{itemdecl}
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S>
+  requires @\libconcept{permutable}@<I>
+  subrange<I> ranges::rotate(Ep&& exec, I first, I middle, S last);
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R>
+  requires @\libconcept{permutable}@<iterator_t<R>>
+  borrowed_subrange_t<R> ranges::rotate(Ep&& exec, R&& r, iterator_t<R> middle);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+return ranges::rotate(std::forward<Ep>(exec), ranges::begin(r), middle, ranges::end(r));
+\end{codeblock}
+\end{itemdescr}
+
 \indexlibraryglobal{rotate_copy}%
 \begin{itemdecl}
 template<class ForwardIterator, class OutputIterator>
@@ -6523,6 +8343,54 @@ Exactly $N$ assignments.
 \end{itemdescr}
 
 \begin{itemdecl}
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS>
+  requires @\libconcept{indirectly_copyable}@<I, O>
+  ranges::rotate_copy_result<I, O>
+    ranges::rotate_copy(Ep&& exec, I first, I middle, S last, O result, OutS result_last);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let $M$ be \tcode{last - first}
+and $N$ be $\min(M, \ \tcode{result_last - result})$.
+
+\pnum
+\expects
+\range{first}{middle} and \range{middle}{last}
+are valid ranges.
+The ranges \range{first}{last} and \range{result}{result + $N$}
+do not overlap.
+
+\pnum
+\effects
+Copies the range \range{first}{last}
+to the range \range{result}{result + $N$}
+%FIXME: i has more mathematical vibes than code font vibes.
+%This feels wrong.
+such that for each non-negative integer \tcode{i < $N$}
+the following assignment takes place:
+\tcode{*(result + i) = *(first + (i + (middle - first)) \% $M$)}.
+
+\pnum
+\returns
+\tcode{\{first + ($N$ + (middle - first)) \% $M$, result + $N$\}}.
+\begin{note}
+While the return type for the parallel and non-parallel algorithm overloads
+in the namespace \tcode{ranges} is the same,
+the semantics is different
+because for the parallel range algorithm overloads
+%FIXME: Comma.
+\tcode{result_last - result} can be insufficient
+to copy all data from the input.
+\end{note}
+
+\pnum
+\complexity
+Exactly $N$ assignments.
+\end{itemdescr}
+
+\begin{itemdecl}
 template<@\libconcept{forward_range}@ R, @\libconcept{weakly_incrementable}@ O>
   requires @\libconcept{indirectly_copyable}@<iterator_t<R>, O>
   constexpr ranges::rotate_copy_result<borrowed_iterator_t<R>, O>
@@ -6535,6 +8403,23 @@ template<@\libconcept{forward_range}@ R, @\libconcept{weakly_incrementable}@ O>
 Equivalent to:
 \begin{codeblock}
 return ranges::rotate_copy(ranges::begin(r), middle, ranges::end(r), std::move(result));
+\end{codeblock}
+\end{itemdescr}
+
+\begin{itemdecl}
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, @\exposconcept{sized-random-access-range}@ OutR>
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR>>
+  ranges::rotate_copy_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR>>
+    ranges::rotate_copy(Ep&& exec, R&& r, iterator_t<R> middle, OutR&& result_r);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+return ranges::rotate_copy(std::forward<Ep>(exec), ranges::begin(r), middle, ranges::end(r),
+                           ranges::begin(result_r), ranges::end(result_r));
 \end{codeblock}
 \end{itemdescr}
 
@@ -6693,6 +8578,16 @@ template<@\libconcept{permutable}@ I, @\libconcept{sentinel_for}@<I> S>
 template<@\libconcept{forward_range}@ R>
   requires @\libconcept{permutable}@<iterator_t<R>>
   constexpr borrowed_subrange_t<R> ranges::shift_left(R&& r, range_difference_t<R> n)
+  // FIXME: semicolon
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S>
+  requires @\libconcept{permutable}@<I>
+  subrange<I>
+    ranges::shift_left(Ep&& exec, I first, S last, iter_difference_t<I> n);
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R>
+  requires @\libconcept{permutable}@<iterator_t<R>>
+  borrowed_subrange_t<R>
+    ranges::shift_left(Ep&& exec, R&& r, range_difference_t<R> n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6709,7 +8604,7 @@ Otherwise, moves the element
 from position \tcode{first + n + i}
 into position \tcode{first + i}
 for each non-negative integer \tcode{i < (last - first) - n}.
-For the overloads without an \tcode{ExecutionPolicy} template parameter,
+For the non-parallel algorithm overloads,
 does so in order starting
 from \tcode{i = 0} and proceeding to \tcode{i = (last - first) - n - 1}.
 
@@ -6718,6 +8613,7 @@ from \tcode{i = 0} and proceeding to \tcode{i = (last - first) - n - 1}.
 Let \exposid{NEW_LAST} be \tcode{first + (last - first - n)}
 if \tcode{n < last - first},
 otherwise \tcode{first}.
+Returns:
 \begin{itemize}
 \item
 \exposid{NEW_LAST} for the overloads in namespace \tcode{std}.
@@ -6747,6 +8643,15 @@ template<@\libconcept{permutable}@ I, @\libconcept{sentinel_for}@<I> S>
 template<@\libconcept{forward_range}@ R>
   requires @\libconcept{permutable}@<iterator_t<R>>
   constexpr borrowed_subrange_t<R> ranges::shift_right(R&& r, range_difference_t<R> n);
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S>
+  requires @\libconcept{permutable}@<I>
+  subrange<I>
+    ranges::shift_right(Ep&& exec, I first, S last, iter_difference_t<I> n);
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R>
+  requires @\libconcept{permutable}@<iterator_t<R>>
+  borrowed_subrange_t<R>
+    ranges::shift_right(Ep&& exec, R&& r, range_difference_t<R> n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6769,11 +8674,10 @@ Does so in order starting
 from \tcode{i = (last - first) - n - 1} and proceeding to \tcode{i = 0} if
 \begin{itemize}
 \item
-for the overload in namespace \tcode{std}
-without an \tcode{ExecutionPolicy} template parameter,
-\tcode{Forward\-Iterator} meets the \oldconcept{BidirectionalIterator} requirements,
+for the non-parallel algorithm overload in namespace \tcode{std},
+\tcode{Forward\-Iterator} meets the \oldconcept{\-Bi\-directional\-Iterator} requirements,
 \item
-for the overloads in namespace \tcode{ranges},
+for the non-parallel algorithm overloads in namespace \tcode{ranges},
 \tcode{I} models \libconcept{bidirectional_iterator}.
 \end{itemize}
 
@@ -6781,6 +8685,7 @@ for the overloads in namespace \tcode{ranges},
 \returns
 Let \exposid{NEW_FIRST} be \tcode{first + n} if \tcode{n < last - first},
 otherwise \tcode{last}.
+Returns:
 \begin{itemize}
 \item
 \exposid{NEW_FIRST} for the overloads in namespace \tcode{std}.
@@ -6916,6 +8821,15 @@ template<@\libconcept{random_access_range}@ R, class Comp = ranges::less, class 
   requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
   constexpr borrowed_iterator_t<R>
     ranges::sort(R&& r, Comp comp = {}, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Comp = ranges::less, class Proj = identity>
+  requires @\libconcept{sortable}@<I, Comp, Proj>
+  I ranges::sort(Ep&& exec, I first, S last, Comp comp = {}, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Comp = ranges::less,
+         class Proj = identity>
+  requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
+  borrowed_iterator_t<R> ranges::sort(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6974,6 +8888,16 @@ template<@\libconcept{random_access_range}@ R, class Comp = ranges::less, class 
   requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
   constexpr borrowed_iterator_t<R>
     ranges::stable_sort(R&& r, Comp comp = {}, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Comp = ranges::less, class Proj = identity>
+  requires @\libconcept{sortable}@<I, Comp, Proj>
+  I ranges::stable_sort(Ep&& exec, I first, S last, Comp comp = {}, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Comp = ranges::less,
+         class Proj = identity>
+  requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
+  borrowed_iterator_t<R>
+    ranges::stable_sort(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7043,6 +8967,10 @@ template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I>
   requires @\libconcept{sortable}@<I, Comp, Proj>
   constexpr I
     ranges::partial_sort(I first, I middle, S last, Comp comp = {}, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Comp = ranges::less, class Proj = identity>
+  requires @\libconcept{sortable}@<I, Comp, Proj>
+  I ranges::partial_sort(Ep&& exec, I first, I middle, S last, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7097,6 +9025,25 @@ return ranges::partial_sort(ranges::begin(r), middle, ranges::end(r), comp, proj
 \end{codeblock}
 \end{itemdescr}
 
+\begin{itemdecl}
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R,
+         class Comp = ranges::less, class Proj = identity>
+  requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
+  borrowed_iterator_t<R>
+    ranges::partial_sort(Ep&& exec, R&& r, iterator_t<R> middle, Comp comp = {},
+                         Proj proj = {});
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+return ranges::partial_sort(std::forward<Ep>(exec), ranges::begin(r), middle,
+                            ranges::end(r), comp, proj);
+\end{codeblock}
+\end{itemdescr}
+
 \rSec3[partial.sort.copy]{\tcode{partial_sort_copy}}
 
 \indexlibraryglobal{partial_sort_copy}%
@@ -7144,6 +9091,25 @@ template<@\libconcept{input_range}@ R1, @\libconcept{random_access_range}@ R2, c
                                       projected<iterator_t<R2>, Proj2>>
   constexpr ranges::partial_sort_copy_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
     ranges::partial_sort_copy(R1&& r, R2&& result_r, Comp comp = {},
+                              Proj1 proj1 = {}, Proj2 proj2 = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+         @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+         class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{indirectly_copyable}@<I1, I2> && @\libconcept{sortable}@<I2, Comp, Proj2> &&
+            @\libconcept{indirect_strict_weak_order}@<Comp, projected<I1, Proj1>, projected<I2, Proj2>>
+  ranges::partial_sort_copy_result<I1, I2>
+    ranges::partial_sort_copy(Ep&& exec, I1 first, S1 last, I2 result_first, S2 result_last,
+                              Comp comp = {}, Proj1 proj1 = {},
+                              Proj2 proj2 = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+         class Comp = ranges::less, class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R1>, iterator_t<R2>> &&
+           @\libconcept{sortable}@<iterator_t<R2>, Comp, Proj2> &&
+           @\libconcept{indirect_strict_weak_order}@<Comp, projected<iterator_t<R1>, Proj1>,
+                                      projected<iterator_t<R2>, Proj2>>
+  ranges::partial_sort_copy_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>>
+    ranges::partial_sort_copy(Ep&& exec, R1&& r, R2&& result_r, Comp comp = {},
                               Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
 
@@ -7285,6 +9251,25 @@ Equivalent to:
 \tcode{return ranges::is_sorted_until(first, last, comp, proj) == last;}
 \end{itemdescr}
 
+\begin{itemdecl}
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
+  bool ranges::is_sorted(Ep&& exec, I first, S last, Comp comp = {}, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+  bool ranges::is_sorted(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+return ranges::is_sorted_until(std::forward<Ep>(exec), first, last, comp, proj) == last;
+\end{codeblock}
+\end{itemdescr}
+
 \indexlibraryglobal{is_sorted_until}%
 \begin{itemdecl}
 template<class ForwardIterator>
@@ -7312,6 +9297,16 @@ template<@\libconcept{forward_range}@ R, class Proj = identity,
          @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
   constexpr borrowed_iterator_t<R>
     ranges::is_sorted_until(R&& r, Comp comp = {}, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
+  I ranges::is_sorted_until(Ep&& exec, I first, S last, Comp comp = {},
+                    Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+  borrowed_iterator_t<R>
+    ranges::is_sorted_until(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7356,6 +9351,10 @@ template<@\libconcept{random_access_iterator}@ I, @\libconcept{sentinel_for}@<I>
   requires @\libconcept{sortable}@<I, Comp, Proj>
   constexpr I
     ranges::nth_element(I first, I nth, S last, Comp comp = {}, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Comp = ranges::less, class Proj = identity>
+  requires @\libconcept{sortable}@<I, Comp, Proj>
+  I ranges::nth_element(Ep&& exec, I first, I nth, S last, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7391,8 +9390,8 @@ it holds that:
 
 \pnum
 \complexity
-For the overloads with no \tcode{ExecutionPolicy}, linear on average.
-For the overloads with an \tcode{ExecutionPolicy}, \bigoh{N} applications of
+For the non-parallel algorithm overloads, linear on average.
+For the parallel algorithm overloads, \bigoh{N} applications of
 the predicate, and \bigoh{N \log N} swaps, where $N = \tcode{last - first}$.
 \end{itemdescr}
 
@@ -7409,6 +9408,24 @@ template<@\libconcept{random_access_range}@ R, class Comp = ranges::less, class 
 Equivalent to:
 \begin{codeblock}
 return ranges::nth_element(ranges::begin(r), nth, ranges::end(r), comp, proj);
+\end{codeblock}
+\end{itemdescr}
+
+\begin{itemdecl}
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Comp = ranges::less,
+         class Proj = identity>
+  requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
+  borrowed_iterator_t<R>
+    ranges::nth_element(Ep&& exec, R&& r, iterator_t<R> nth, Comp comp = {}, Proj proj = {});
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+return ranges::nth_element(std::forward<Ep>(exec), ranges::begin(r), nth, ranges::end(r),
+                           comp, proj);
 \end{codeblock}
 \end{itemdescr}
 
@@ -7670,6 +9687,13 @@ template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, clas
 template<@\libconcept{input_range}@ R, class Proj = identity,
          @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
   constexpr bool ranges::is_partitioned(R&& r, Pred pred, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  bool ranges::is_partitioned(Ep&& exec, I first, S last, Pred pred, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  bool ranges::is_partitioned(Ep&& exec, R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7708,6 +9732,17 @@ template<@\libconcept{forward_range}@ R, class Proj = identity,
   requires @\libconcept{permutable}@<iterator_t<R>>
   constexpr borrowed_subrange_t<R>
     ranges::partition(R&& r, Pred pred, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  subrange<I>
+    // FIXME: LWG issue, I'm pretty sure there should be requires permutable<I> here.
+    ranges::partition(Ep&& exec, I first, S last, Pred pred, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  requires @\libconcept{permutable}@<iterator_t<R>>
+  borrowed_subrange_t<R>
+    ranges::partition(Ep&& exec, R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7744,7 +9779,7 @@ Returns:
 Let $N = \tcode{last - first}$:
 \begin{itemize}
 \item
-  For the overload with no \tcode{ExecutionPolicy},
+  For the non-parallel algorithm overloads,
   exactly $N$ applications of the predicate and projection.
   At most $N / 2$ swaps if the type of \tcode{first} meets
   the \oldconcept{BidirectionalIterator} requirements
@@ -7753,7 +9788,7 @@ Let $N = \tcode{last - first}$:
   for the overloads in namespace \tcode{ranges},
   and at most $N$ swaps otherwise.
 \item
-  For the overload with an \tcode{ExecutionPolicy},
+  For the parallel algorithm overloads,
   \bigoh{N \log N} swaps and \bigoh{N} applications of the predicate.
 \end{itemize}
 
@@ -7778,6 +9813,17 @@ template<@\libconcept{bidirectional_range}@ R, class Proj = identity,
          @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
   requires @\libconcept{permutable}@<iterator_t<R>>
   constexpr borrowed_subrange_t<R> ranges::stable_partition(R&& r, Pred pred, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  requires @\libconcept{permutable}@<I>
+  subrange<I>
+    ranges::stable_partition(Ep&& exec, I first, S last, Pred pred, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  requires @\libconcept{permutable}@<iterator_t<R>>
+  borrowed_subrange_t<R>
+    ranges::stable_partition(Ep&& exec, R&& r, Pred pred, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7819,11 +9865,12 @@ Returns:
 Let $N$ = \tcode{last - first}:
 \begin{itemize}
 \item
-  For the overloads with no \tcode{ExecutionPolicy}, at most $N \log_2 N$ swaps,
+  For the non-parallel algorithm overloads,
+  at most $N \log_2 N$ swaps,
   but only \bigoh{N} swaps if there is enough extra memory.
   Exactly $N$ applications of the predicate and projection.
 \item
-  For the overload with an \tcode{ExecutionPolicy},
+  For the parallel algorithm overloads,
   \bigoh{N \log N} swaps and \bigoh{N} applications of the predicate.
 \end{itemize}
 \end{itemdescr}
@@ -7854,6 +9901,25 @@ template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O1, @
            @\libconcept{indirectly_copyable}@<iterator_t<R>, O2>
   constexpr ranges::partition_copy_result<borrowed_iterator_t<R>, O1, O2>
     ranges::partition_copy(R&& r, O1 out_true, O2 out_false, Pred pred, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         @\libconcept{random_access_iterator}@ O1, @\libconcept{sized_sentinel_for}@<O1> OutS1,
+         @\libconcept{random_access_iterator}@ O2, @\libconcept{sized_sentinel_for}@<O2> OutS2,
+         class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
+  requires @\libconcept{indirectly_copyable}@<I, O1> && @\libconcept{indirectly_copyable}@<I, O2>
+  ranges::partition_copy_result<I, O1, O2>
+    ranges::partition_copy(Ep&& exec, I first, S last, O1 out_true, OutS1 last_true,
+                           O2 out_false, OutS2 last_false, Pred pred, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R,
+         @\exposconcept{sized-random-access-range}@ OutR1, @\exposconcept{sized-random-access-range}@ OutR2,
+         class Proj = identity,
+         @\libconcept{indirect_unary_predicate}@<projected<iterator_t<R>, Proj>> Pred>
+  requires @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR1>> &&
+            @\libconcept{indirectly_copyable}@<iterator_t<R>, iterator_t<OutR2>>
+  ranges::partition_copy_result<borrowed_iterator_t<R>, borrowed_iterator_t<OutR1>,
+                                borrowed_iterator_t<OutR2>>
+    ranges::partition_copy(Ep&& exec, R&& r, OutR1&& out_true_r, OutR2&& out_false_r,
+                           Pred pred, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7861,6 +9927,45 @@ template<@\libconcept{input_range}@ R, @\libconcept{weakly_incrementable}@ O1, @
 Let \tcode{proj} be \tcode{identity\{\}}
 for the overloads with no parameter named \tcode{proj} and
 let $E(x)$ be \tcode{bool(invoke(\brk{}pred, invoke(proj, $x$)))}.
+
+\pnum
+For the overloads with no parameters
+\tcode{last_true}, \tcode{last_false}, \tcode{out_true_r}, or \tcode{out_false_r},
+let
+\begin{itemize}
+\item
+  $M$ be the number of iterators in \range{first}{last}
+  for which $E(\tcode{i})$ is \tcode{true},
+  and $K$ be \tcode{last - first};
+\item
+  \tcode{last_true} be \tcode{out_true + M}, and
+  \tcode{last_false} be \tcode{out_false + $K$}.
+\end{itemize}
+
+\pnum
+For the overloads with parameters
+\tcode{last_true}, \tcode{last_false}, \tcode{out_true_r}, or \tcode{out_false_r},
+let $M$ be \tcode{last_true} \tcode{last_true - out_true}
+and $K$ be \tcode{last_false - out_false}.
+
+\pnum
+Let %FIXME: Colon.
+\begin{itemize}
+\item
+  \exposid{i1} be the iterator in \range{first}{last}
+  for which $E(\tcode{*i1})$ is \tcode{true}
+  and there are exactly $M$ iterators \tcode{j} in \range{first}{\exposid{i1}}
+  for which $E(\tcode{*j})$ is \tcode{true},
+  or \tcode{last} if no such iterator exists;
+\item
+  \exposid{i2} be the iterator in \range{first}{last}
+  for which $E(\tcode{*i2})$ is \tcode{false}
+  and there are exactly $K$ iterators \tcode{j} in \range{first}{\exposid{i2}}
+  for which $E(\tcode{*j})$ is \tcode{true},
+  or \tcode{last} if no such iterator exists;
+\item
+  $N$ be $\min(\tcode{\exposid{i1} - first}, \ \tcode{\exposid{i2} - first})$.
+\end{itemize}
 
 \pnum
 \mandates
@@ -7874,31 +9979,36 @@ to \tcode{out_true} and \tcode{out_false}.
 The input range and output ranges do not overlap.
 
 \begin{note}
-For the overload with an \tcode{ExecutionPolicy},
-there might be a performance cost if \tcode{first}'s value type
+For the parallel algorithm overload in namespace \tcode{std},
+there can be a performance cost if \tcode{first}'s value type
 does not meet the \oldconcept{CopyConstructible} requirements.
+For the parallel algorithm overloads in namespace \tcode{ranges},
+there can be a performance cost if \tcode{first}'s value type
+does not model \libconcept{copy_constructible}.
 \end{note}
 
 \pnum
 \effects
-For each iterator \tcode{i} in \range{first}{last},
-copies \tcode{*i} to the output range beginning with \tcode{out_true}
+For each iterator \tcode{i} in \range{first}{first + $N$},
+copies \tcode{*i} to the output range \range{out_true}{last_true}
 if \tcode{$E(\tcode{*i})$} is \tcode{true}, or
-to the output range beginning with \tcode{out_false} otherwise.
+to the output range \range{out_false}{last_false} otherwise.
 
 \pnum
 \returns
-Let \tcode{o1} be the end of the output range beginning at \tcode{out_true},
-and \tcode{o2} the end of the output range beginning at \tcode{out_false}.
-Returns
+Let \tcode{o1} be the iterator past the last copied element
+in the output range \range{out_true}{last_true},
+and \tcode{o2} be the iterator past the last copied element
+in the output range \range{out_false}{last_false}.
+Returns:
 \begin{itemize}
 \item \tcode{\{o1, o2\}} for the overloads in namespace \tcode{std}.
-\item \tcode{\{last, o1, o2\}} for the overloads in namespace \tcode{ranges}.
+\item \tcode{\{first + $N$, o1, o2\}} for the overloads in namespace \tcode{ranges}.
 \end{itemize}
 
 \pnum
 \complexity
-Exactly \tcode{last - first} applications of \tcode{pred} and \tcode{proj}.
+At most \tcode{last - first} applications of \tcode{pred} and \tcode{proj}.
 \end{itemdescr}
 
 \indexlibraryglobal{partition_point}%
@@ -7985,15 +10095,57 @@ template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, @\libconc
   constexpr ranges::merge_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
     ranges::merge(R1&& r1, R2&& r2, O result,
                   Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+         @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+         @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS, class Comp = ranges::less,
+         class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{mergeable}@<I1, I2, O, Comp, Proj1, Proj2>
+  ranges::merge_result<I1, I2, O>
+    ranges::merge(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2, O result, OutS result_last,
+                  Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+         @\exposconcept{sized-random-access-range}@ OutR, class Comp = ranges::less,
+         class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{mergeable}@<iterator_t<R1>, iterator_t<R2>, iterator_t<OutR>, Comp, Proj1, Proj2>
+  ranges::merge_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, borrowed_iterator_t<OutR>>
+    ranges::merge(Ep&& exec, R1&& r1, R2&& r2, OutR&& result_r,
+                  Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-Let $N$ be \tcode{(last1 - first1) + (last2 - first2)}.
-Let \tcode{comp} be \tcode{less\{\}},
-\tcode{proj1} be \tcode{identity\{\}}, and
-\tcode{proj2} be \tcode{identity\{\}},
-for the overloads with no parameters by those names.
+Let:
+\begin{itemize}
+\item
+  $N$ be:
+  \begin{itemize}
+  \item
+    \tcode{(last1 - first1) + (last2 - first2)}
+    for the overloads with no parameter \tcode{result_last} or \tcode{result_r};
+  \item
+    $\min(\tcode{(last1 - first1) + (last2 - first2)}, \ \tcode{result_last - result})$
+    for the overloads with parameters \tcode{result_last} or \tcode{result_r};
+  \end{itemize}
+\item
+  \tcode{comp} be \tcode{less\{\}},
+  \tcode{proj1} be \tcode{identity\{\}}, and
+  \tcode{proj2} be \tcode{identity\{\}},
+  for the overloads with no parameters by those names;
+\item
+  $E$ be \tcode{bool(invoke(comp, invoke(proj2, e2), invoke(proj1, e1)))};
+\item
+  $K$ be the smallest integer in \range{0}{last1 - first1}
+  such that for every element \tcode{e1} in the position \tcode{first1 + $K$}
+  %FIXME: Comma.
+  there are at least $N - K$ elements \tcode{e2}
+  in \range{first2}{last2} for which $E$ holds,
+  and be equal to \tcode{last1 - first1}
+  if no such integer exists.
+  \begin{note}
+  \tcode{first1 + $K$} points to the position past the last element to be copied.
+  \end{note}
+\end{itemize}
 
 \pnum
 \expects
@@ -8004,25 +10156,24 @@ The resulting range does not overlap with either of the original ranges.
 
 \pnum
 \effects
-Copies all the elements of the two ranges \range{first1}{last1} and
-\range{first2}{last2} into the range \range{result}{result_last},
-where \tcode{result_last} is \tcode{result + $N$}.
+Copies the first $K$ elements of the range \range{first1}{last1}
+and the first $N - K$ elements of the range \range{first2}{last2}
+into the range \range{result}{result + $N$}.
 If an element \tcode{a} precedes \tcode{b} in an input range,
 \tcode{a} is copied into the output range before \tcode{b}.
 If \tcode{e1} is an element of \range{first1}{last1} and
 \tcode{e2} of \range{first2}{last2},
-\tcode{e2} is copied into the output range before \tcode{e1} if and only if
-\tcode{bool(invoke(comp, invoke(proj2, e2), invoke(proj1, e1)))}
-is \tcode{true}.
+\tcode{e2} is copied into the output range before \tcode{e1}
+if and only if $E$ is \tcode{true}.
 
 \pnum
 \returns
 \begin{itemize}
 \item
-  \tcode{result_last}
+  \tcode{result + $N$}
   for the overloads in namespace \tcode{std}.
 \item
-  \tcode{\{last1, last2, result_last\}}
+  \tcode{\{first1 + $K$, first2 + $N$ - $K$, result_last\}}
   for the overloads in namespace \tcode{ranges}.
 \end{itemize}
 
@@ -8030,10 +10181,11 @@ is \tcode{true}.
 \complexity
 \begin{itemize}
 \item
-  For the overloads with no \tcode{ExecutionPolicy},
+  For the non-parallel algorithm overloads,
   at most $N - 1$ comparisons and applications of each projection.
 \item
-  For the overloads with an \tcode{ExecutionPolicy}, \bigoh{N} comparisons.
+  For the parallel algorithm overloads,
+  \bigoh{N} comparisons and applications of each projection.
 \end{itemize}
 
 \pnum
@@ -8067,6 +10219,10 @@ template<@\libconcept{bidirectional_iterator}@ I, @\libconcept{sentinel_for}@<I>
          class Proj = identity>
   requires @\libconcept{sortable}@<I, Comp, Proj>
   constexpr I ranges::inplace_merge(I first, I middle, S last, Comp comp = {}, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Comp = ranges::less, class Proj = identity>
+  requires @\libconcept{sortable}@<I, Comp, Proj>
+  I ranges::inplace_merge(Ep&& exec, I first, I middle, S last, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8102,7 +10258,7 @@ The resulting range is sorted with respect to \tcode{comp} and \tcode{proj}.
 Let $N = \tcode{last - first}$:
 \begin{itemize}
 \item
-  For the overloads with no \tcode{ExecutionPolicy}, and
+  For the non-parallel algorithm overloads, and
   if enough additional memory is available, at most $N - 1$ comparisons.
 \item
   Otherwise, \bigoh{N \log N} comparisons.
@@ -8127,6 +10283,25 @@ template<@\libconcept{bidirectional_range}@ R, class Comp = ranges::less, class 
 Equivalent to:
 \begin{codeblock}
 return ranges::inplace_merge(ranges::begin(r), middle, ranges::end(r), comp, proj);
+\end{codeblock}
+\end{itemdescr}
+
+\begin{itemdecl}
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Comp = ranges::less,
+         class Proj = identity>
+  requires @\libconcept{sortable}@<iterator_t<R>, Comp, Proj>
+  borrowed_iterator_t<R>
+    ranges::inplace_merge(Ep&& exec, R&& r, iterator_t<R> middle, Comp comp = {},
+                          Proj proj = {});
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+return ranges::inplace_merge(std::forward<Ep>(exec), ranges::begin(r), middle,
+                             ranges::end(r), comp, proj);
 \end{codeblock}
 \end{itemdescr}
 
@@ -8177,6 +10352,20 @@ template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, class Pro
                                     projected<iterator_t<R2>, Proj2>> Comp = ranges::less>
   constexpr bool ranges::includes(R1&& r1, R2&& r2, Comp comp = {},
                                   Proj1 proj1 = {}, Proj2 proj2 = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+         @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+         class Proj1 = identity, class Proj2 = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<I1, Proj1>, projected<I2, Proj2>> Comp =
+           ranges::less>
+  bool ranges::includes(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2,
+                        Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+         class Proj1 = identity, class Proj2 = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R1>, Proj1>,
+                                     projected<iterator_t<R2>, Proj2>> Comp = ranges::less>
+  bool ranges::includes(Ep&& exec, R1&& r1, R2&& r2,
+                        Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8250,13 +10439,44 @@ template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, @\libconc
   constexpr ranges::set_union_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
     ranges::set_union(R1&& r1, R2&& r2, O result, Comp comp = {},
                       Proj1 proj1 = {}, Proj2 proj2 = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+         @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+         @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS, class Comp = ranges::less,
+         class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{mergeable}@<I1, I2, O, Comp, Proj1, Proj2>
+  ranges::set_union_result<I1, I2, O>
+    ranges::set_union(Ep&& exec, I1 first1, S1 last1,
+                      I2 first2, S2 last2, O result, OutS result_last,
+                      Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+         @\exposconcept{sized-random-access-range}@ OutR, class Comp = ranges::less,
+         class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{mergeable}@<iterator_t<R1>, iterator_t<R2>, iterator_t<OutR>,
+                    Comp, Proj1, Proj2>
+  ranges::set_union_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>,
+                           borrowed_iterator_t<OutR>>
+    ranges::set_union(Ep&& exec, R1&& r1, R2&& r2, OutR&& result_r, Comp comp = {},
+                      Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-Let \tcode{comp} be \tcode{less\{\}},
-and \tcode{proj1} and \tcode{proj2} be \tcode{identity\{\}}
-for the overloads with no parameters by those names.
+Let:
+\begin{itemize}
+\item
+  \tcode{comp} be \tcode{less\{\}},
+  and \tcode{proj1} and \tcode{proj2} be \tcode{identity\{\}}
+  for the overloads with no parameters by those names;
+\item
+  $M$ be \tcode{(last1 - first1)} plus the number elements in \range{first2}{last2}
+  that are not present in \range{first1}{last1};
+\item
+  \tcode{result_last} be \tcode{result + $M$}
+  for the overloads with no parameter \tcode{result_last} or \tcode{result_r};
+\item
+  $N$ be $\min(M, \ \tcode{result_last - result})$.
+\end{itemize}
 
 \pnum
 \expects
@@ -8266,20 +10486,25 @@ The resulting range does not overlap with either of the original ranges.
 
 \pnum
 \effects
-Constructs a sorted union of the elements from the two ranges;
+Constructs a sorted union of $N$ elements from the two ranges;
 that is, the set of elements that are present in one or both of the ranges.
 
 \pnum
 \returns
-Let \tcode{result_last} be the end of the constructed range.
-Returns
 \begin{itemize}
 \item
   \tcode{result_last}
   for the overloads in namespace \tcode{std}.
 \item
-  \tcode{\{last1, last2, result_last\}}
-  for the overloads in namespace \tcode{ranges}.
+  \tcode{\{last1, last2, result + $N$\}}
+  for the overloads in namespace \tcode{ranges}
+  if $N$ is equal to $M$.
+\item
+  Otherwise, \tcode{\{j1, j2, result_last\}}
+  for the overloads in namespace \tcode{ranges},
+  where the iterators \tcode{j1} and \tcode{j2}
+  point to positions past the last copied or skipped elements
+  in \range{first1}{last1} and \range{first2}{last2}, respectively.
 \end{itemize}
 
 \pnum
@@ -8345,13 +10570,44 @@ template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, @\libconc
   constexpr ranges::set_intersection_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, O>
     ranges::set_intersection(R1&& r1, R2&& r2, O result,
                              Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+         @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+         @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS, class Comp = ranges::less,
+         class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{mergeable}@<I1, I2, O, Comp, Proj1, Proj2>
+  ranges::set_intersection_result<I1, I2, O>
+    ranges::set_intersection(Ep&& exec, I1 first1, S1 last1,
+                      I2 first2, S2 last2, O result, OutS result_last,
+                      Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+         @\exposconcept{sized-random-access-range}@ OutR, class Comp = ranges::less,
+         class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{mergeable}@<iterator_t<R1>, iterator_t<R2>, iterator_t<OutR>,
+                    Comp, Proj1, Proj2>
+  ranges::set_intersection_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>,
+                                  borrowed_iterator_t<OutR>>
+    ranges::set_intersection(Ep&& exec, R1&& r1, R2&& r2, OutR&& result_r, Comp comp = {},
+                             Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-Let \tcode{comp} be \tcode{less\{\}},
-and \tcode{proj1} and \tcode{proj2} be \tcode{identity\{\}}
-for the overloads with no parameters by those names.
+Let:
+\begin{itemize}
+\item
+  \tcode{comp} be \tcode{less\{\}},
+  and \tcode{proj1} and \tcode{proj2} be \tcode{identity\{\}}
+  for the overloads with no parameters by those names;
+\item
+  $M$ be \tcode{(last1 - first1)} plus the number elements in \range{first2}{last2}
+  that are not present in \range{first1}{last1};
+\item
+  \tcode{result_last} be \tcode{result + $M$}
+  for the overloads with no parameter \tcode{result_last} or \tcode{result_r};
+\item
+  $N$ be $\min(M, \ \tcode{result_last - result})$.
+\end{itemize}
 
 \pnum
 \expects
@@ -8361,20 +10617,25 @@ The resulting range does not overlap with either of the original ranges.
 
 \pnum
 \effects
-Constructs a sorted intersection of the elements from the two ranges;
+Constructs a sorted intersection of $N$ elements from the two ranges;
 that is, the set of elements that are present in both of the ranges.
 
 \pnum
 \returns
-Let \tcode{result_last} be the end of the constructed range.
-Returns
 \begin{itemize}
 \item
   \tcode{result_last}
   for the overloads in namespace \tcode{std}.
 \item
-  \tcode{\{last1, last2, result_last\}}
-  for the overloads in namespace \tcode{ranges}.
+  \tcode{\{last1, last2, result + $N$\}}
+  for the overloads in namespace \tcode{ranges}
+  if $N$ is equal to $M$.
+\item
+  Otherwise, \tcode{\{j1, j2, result_last\}}
+  for the overloads in namespace \tcode{ranges},
+  where the iterators \tcode{j1} and \tcode{j2}
+  point to positions past the last copied or skipped elements
+  in \range{first1}{last1} and \range{first2}{last2}, respectively.
 \end{itemize}
 
 \pnum
@@ -8438,13 +10699,44 @@ template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, @\libconc
   constexpr ranges::set_difference_result<borrowed_iterator_t<R1>, O>
     ranges::set_difference(R1&& r1, R2&& r2, O result,
                            Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+         @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+         @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS, class Comp = ranges::less,
+         class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{mergeable}@<I1, I2, O, Comp, Proj1, Proj2>
+  ranges::set_difference_result<I1, I2, O>
+    ranges::set_difference(Ep&& exec, I1 first1, S1 last1,
+                           I2 first2, S2 last2, O result, OutS result_last,
+                           Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+         @\exposconcept{sized-random-access-range}@ OutR, class Comp = ranges::less,
+         class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{mergeable}@<iterator_t<R1>, iterator_t<R2>, iterator_t<OutR>,
+                    Comp, Proj1, Proj2>
+  ranges::set_difference_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>,
+                                borrowed_iterator_t<OutR>>
+    ranges::set_difference(Ep&& exec, R1&& r1, R2&& r2, OutR&& result_r, Comp comp = {},
+                           Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-Let \tcode{comp} be \tcode{less\{\}},
-and \tcode{proj1} and \tcode{proj2} be \tcode{identity\{\}}
-for the overloads with no parameters by those names.
+Let:
+\begin{itemize}
+\item
+  \tcode{comp} be \tcode{less\{\}},
+  and \tcode{proj1} and \tcode{proj2} be \tcode{identity\{\}}
+  for the overloads with no parameters by those names;
+\item
+  $M$ be \tcode{(last1 - first1)} plus the number elements in \range{first2}{last2}
+  that are not present in \range{first1}{last1};
+\item
+  \tcode{result_last} be \tcode{result + $M$}
+  for the overloads with no parameter \tcode{result_last} or \tcode{result_r};
+\item
+  $N$ be $\min(M, \ \tcode{result_last - result})$.
+\end{itemize}
 
 \pnum
 \expects
@@ -8454,22 +10746,27 @@ The resulting range does not overlap with either of the original ranges.
 
 \pnum
 \effects
-Copies the elements of the range \range{first1}{last1}
+Copies $N$ elements of the range \range{first1}{last1}
 which are not present in the range \range{first2}{last2}
-to the range beginning at \tcode{result}.
+to the range \range{result}{result + $N$}.
 The elements in the constructed range are sorted.
 
 \pnum
 \returns
-Let \tcode{result_last} be the end of the constructed range.
-Returns
 \begin{itemize}
 \item
   \tcode{result_last}
   for the overloads in namespace \tcode{std}.
 \item
-  \tcode{\{last1, result_last\}}
-  for the overloads in namespace \tcode{ranges}.
+  \tcode{\{last1, last2, result + $N$\}}
+  for the overloads in namespace \tcode{ranges}
+  if $N$ is equal to $M$.
+\item
+  Otherwise, \tcode{\{j1, j2, result_last\}}
+  for the overloads in namespace \tcode{ranges},
+  where the iterators \tcode{j1} and \tcode{j2}
+  point to positions past the last copied or skipped elements
+  in \range{first1}{last1} and \range{first2}{last2}, respectively.
 \end{itemize}
 
 \pnum
@@ -8534,13 +10831,44 @@ template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, @\libconc
                                                     borrowed_iterator_t<R2>, O>
     ranges::set_symmetric_difference(R1&& r1, R2&& r2, O result, Comp comp = {},
                                      Proj1 proj1 = {}, Proj2 proj2 = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+         @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+         @\libconcept{random_access_iterator}@ O, @\libconcept{sized_sentinel_for}@<O> OutS, class Comp = ranges::less,
+         class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{mergeable}@<I1, I2, O, Comp, Proj1, Proj2>
+  ranges::set_symmetric_difference_result<I1, I2, O>
+    ranges::set_symmetric_difference(Ep&& exec, I1 first1, S1 last1,
+                                     I2 first2, S2 last2, O result, OutS result_last,
+                                     Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+         @\exposconcept{sized-random-access-range}@ OutR, class Comp = ranges::less,
+         class Proj1 = identity, class Proj2 = identity>
+  requires @\libconcept{mergeable}@<iterator_t<R1>, iterator_t<R2>, iterator_t<OutR>,
+                    Comp, Proj1, Proj2>
+  ranges::set_symmetric_difference_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>,
+                                  borrowed_iterator_t<OutR>>
+    ranges::set_symmetric_difference(Ep&& exec, R1&& r1, R2&& r2, OutR&& result_r,
+                                     Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-Let \tcode{comp} be \tcode{less\{\}},
-and \tcode{proj1} and \tcode{proj2} be \tcode{identity\{\}}
-for the overloads with no parameters by those names.
+Let:
+\begin{itemize}
+\item
+  \tcode{comp} be \tcode{less\{\}},
+  and \tcode{proj1} and \tcode{proj2} be \tcode{identity\{\}}
+  for the overloads with no parameters by those names;
+\item
+  $M$ be \tcode{(last1 - first1)} plus the number elements in \range{first2}{last2}
+  that are not present in \range{first1}{last1};
+\item
+  \tcode{result_last} be \tcode{result + $M$}
+  for the overloads with no parameter \tcode{result_last} or \tcode{result_r};
+\item
+  $N$ be $\min(M, \ \tcode{result_last - result})$.
+\end{itemize}
 
 \pnum
 \expects
@@ -8554,20 +10882,25 @@ Copies the elements of the range \range{first1}{last1}
 that are not present in the range \range{first2}{last2},
 and the elements of the range \range{first2}{last2}
 that are not present in the range \range{first1}{last1}
-to the range beginning at \tcode{result}.
+to the range \range{result}{result + $N$}.
 The elements in the constructed range are sorted.
 
 \pnum
 \returns
-Let \tcode{result_last} be the end of the constructed range.
-Returns
 \begin{itemize}
 \item
   \tcode{result_last}
   for the overloads in namespace \tcode{std}.
 \item
-  \tcode{\{last1, last2, result_last\}}
-  for the overloads in namespace \tcode{ranges}.
+  \tcode{\{last1, last2, result + $N$\}}
+  for the overloads in namespace \tcode{ranges}
+  if $N$ is equal to $M$.
+\item
+  Otherwise, \tcode{\{j1, j2, result_last\}}
+  for the overloads in namespace \tcode{ranges},
+  where the iterators \tcode{j1} and \tcode{j2}
+  point to positions past the last copied or skipped elements
+  in \range{first1}{last1} and \range{first2}{last2}, respectively.
 \end{itemize}
 
 \pnum
@@ -8910,6 +11243,25 @@ Equivalent to:
 \tcode{return ranges::is_heap_until(first, last, comp, proj) == last;}
 \end{itemdescr}
 
+\begin{itemdecl}
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
+  bool ranges::is_heap(Ep&& exec, I first, S last, Comp comp = {}, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+  bool ranges::is_heap(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to:
+\begin{codeblock}
+return ranges::is_heap_until(std::forward<Ep>(exec), first, last, comp, proj) == last;
+\end{codeblock}
+\end{itemdescr}
+
 \indexlibraryglobal{is_heap_until}%
 \begin{itemdecl}
 template<class RandomAccessIterator>
@@ -8937,6 +11289,15 @@ template<@\libconcept{random_access_range}@ R, class Proj = identity,
          @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
   constexpr borrowed_iterator_t<R>
     ranges::is_heap_until(R&& r, Comp comp = {}, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
+  I ranges::is_heap_until(Ep&& exec, I first, S last, Comp comp = {}, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+  borrowed_iterator_t<R>
+    ranges::is_heap_until(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9008,6 +11369,11 @@ template<@\libconcept{input_range}@ R, class Proj = identity,
   requires @\libconcept{indirectly_copyable_storable}@<iterator_t<R>, range_value_t<R>*>
   constexpr range_value_t<R>
     ranges::min(R&& r, Comp comp = {}, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+  requires @\libconcept{indirectly_copyable_storable}@<iterator_t<R>, range_value_t<R>*>
+  range_value_t<R>
+    ranges::min(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9086,6 +11452,11 @@ template<@\libconcept{input_range}@ R, class Proj = identity,
   requires @\libconcept{indirectly_copyable_storable}@<iterator_t<R>, range_value_t<R>*>
   constexpr range_value_t<R>
     ranges::max(R&& r, Comp comp = {}, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+  requires @\libconcept{indirectly_copyable_storable}@<iterator_t<R>, range_value_t<R>*>
+  range_value_t<R>
+    ranges::max(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9167,6 +11538,11 @@ template<@\libconcept{input_range}@ R, class Proj = identity,
   requires @\libconcept{indirectly_copyable_storable}@<iterator_t<R>, range_value_t<R>*>
   constexpr ranges::minmax_result<range_value_t<R>>
     ranges::minmax(R&& r, Comp comp = {}, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+  requires @\libconcept{indirectly_copyable_storable}@<iterator_t<R>, range_value_t<R>*>
+  ranges::minmax_result<range_value_t<R>>
+    ranges::minmax(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9222,6 +11598,16 @@ template<@\libconcept{forward_range}@ R, class Proj = identity,
          @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
   constexpr borrowed_iterator_t<R>
     ranges::min_element(R&& r, Comp comp = {}, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
+  I ranges::min_element(Ep&& exec, I first, S last, Comp comp = {}, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R,
+         class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+  borrowed_iterator_t<R>
+    ranges::min_element(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9269,6 +11655,16 @@ template<@\libconcept{forward_range}@ R, class Proj = identity,
          @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
   constexpr borrowed_iterator_t<R>
     ranges::max_element(R&& r, Comp comp = {}, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
+  I ranges::max_element(Ep&& exec, I first, S last, Comp comp = {}, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R,
+         class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+  borrowed_iterator_t<R>
+    ranges::max_element(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -9319,6 +11715,16 @@ template<@\libconcept{forward_range}@ R, class Proj = identity,
          @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
   constexpr ranges::minmax_element_result<borrowed_iterator_t<R>>
     ranges::minmax_element(R&& r, Comp comp = {}, Proj proj = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S,
+         class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
+  ranges::minmax_element_result<I>
+    ranges::minmax_element(Ep&& exec, I first, S last, Comp comp = {}, Proj proj = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R, class Proj = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R>, Proj>> Comp = ranges::less>
+  ranges::minmax_element_result<borrowed_iterator_t<R>>
+    ranges::minmax_element(Ep&& exec, R&& r, Comp comp = {}, Proj proj = {});
 \end{itemdecl}
 
 
@@ -9427,6 +11833,20 @@ template<@\libconcept{input_range}@ R1, @\libconcept{input_range}@ R2, class Pro
   constexpr bool
     ranges::lexicographical_compare(R1&& r1, R2&& r2, Comp comp = {},
                                     Proj1 proj1 = {}, Proj2 proj2 = {});
+
+template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I1, @\libconcept{sized_sentinel_for}@<I1> S1,
+         @\libconcept{random_access_iterator}@ I2, @\libconcept{sized_sentinel_for}@<I2> S2,
+         class Proj1 = identity, class Proj2 = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<I1, Proj1>,
+                                    projected<I2, Proj2>> Comp = ranges::less>
+  bool ranges::lexicographical_compare(Ep&& exec, I1 first1, S1 last1, I2 first2, S2 last2,
+                                       Comp comp = {}, Proj1 proj1 = {}, Proj2 proj2 = {});
+template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ R1, @\exposconcept{sized-random-access-range}@ R2,
+         class Proj1 = identity, class Proj2 = identity,
+         @\libconcept{indirect_strict_weak_order}@<projected<iterator_t<R1>, Proj1>,
+                                    projected<iterator_t<R2>, Proj2>> Comp = ranges::less>
+  bool ranges::lexicographical_compare(Ep&& exec, R1&& r1, R2&& r2, Comp comp = {},
+                                       Proj1 proj1 = {}, Proj2 proj2 = {});
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11219,6 +13639,26 @@ operations to throw exceptions.
 \end{itemdescr}
 
 \begin{itemdecl}
+template<class S, class I>
+concept @\defexposconcept{nothrow-sized-sentinel-for}@ = // \expos
+  @\exposconcept{nothrow-sentinel-for}@<S, I> &&
+  @\libconcept{sentinel_for}@<S, I>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Types \tcode{S} and \tcode{I} model \exposconcept{nothrow-sized-sentinel-for}
+only if no exceptions are thrown from the \tcode{-} operator
+for valid values of type \tcode{I} and \tcode{S}.
+
+\pnum
+\begin{note}
+This concept allows some \libconcept{sized_sentinel_for}\iref{iterator.concept.sizedsentinel}
+operations to throw exceptions.
+\end{note}
+\end{itemdescr}
+
+\begin{itemdecl}
 template<class R>
 concept @\defexposconcept{nothrow-input-range}@ = // \expos
   @\libconcept{range}@<R> &&
@@ -11255,6 +13695,68 @@ concept @\defexposconcept{nothrow-forward-range}@ = // \expos
   @\exposconcept{nothrow-input-range}@<R> &&
   @\exposconcept{nothrow-forward-iterator}@<iterator_t<R>>;
 \end{itemdecl}
+
+\begin{itemdecl}
+template<class I>
+concept @\defexposconcept{nothrow-bidirectional-iterator}@ = // \expos
+  @\exposconcept{nothrow-forward-iterator}@<I> &&
+  @\libconcept{bidirectional_iterator}@<I>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+A type \tcode{I} models \exposconcept{nothrow-bidirectional-iterator}
+only if no exceptions are thrown from decrementing valid iterators.
+\begin{note}
+This concept allows some \libconcept{bidirectional_iterator}\iref{iterator.concept.bidir}
+operations to throw exceptions.
+\end{note}
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class R>
+concept @\defexposconcept{nothrow-bidirectional-range}@ = // \expos
+  @\exposconcept{nothrow-forward-range}@<R> &&
+  @\exposconcept{nothrow-bidirectional-iterator}@<iterator_t<R>>;
+\end{itemdecl}
+
+\begin{itemdecl}
+template<class I>
+concept @\defexposconcept{nothrow-random-access-iterator}@ = // \expos
+  @\exposconcept{nothrow-bidirectional-iterator}@<I> &&
+  @\libconcept{random_access_iterator}@<I> &&
+  @\exposconcept{nothrow-sized-sentinel-for}@<I, I>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+A type \tcode{I} models \exposconcept{nothrow-random-access-iterator}
+only if no exceptions are thrown from comparisons of valid iterators,
+or the \tcode{-}, \tcode{+}, \tcode{-=}, \tcode{+=}, \tcode{[]} operators
+on valid values of type \tcode{I} and \tcode{iter_difference_t<T>}.
+\begin{note}
+This concept allows some \libconcept{random_access_iterator}\iref{iterator.concept.random.access}
+operations to throw exceptions.
+\end{note}
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class R>
+concept @\defexposconcept{nothrow-random-access-range}@ = // \expos
+  @\exposconcept{nothrow-bidirectional-range}@<R> &&
+  @\exposconcept{nothrow-random-access-iterator}@<iterator_t<R>>;
+
+template<class R>
+concept @\defexposconcept{nothrow-sized-random-access-range}@ = // \expos
+  @\exposconcept{nothrow-random-access-range}@<R> && @\libconcept{sized_range}@<R>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+A type \tcode{R} models \exposconcept{nothrow-sized-random-access-range}
+only if no exceptions are thrown from the call to \tcode{ranges::size}
+on an object of type \tcode{R}.
+\end{itemdescr}
 
 \rSec2[uninitialized.construct.default]{\tcode{uninitialized_default_construct}}
 

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -181,15 +181,27 @@ namespace std {
   // \ref{specialized.algorithms}, specialized algorithms
   // \ref{special.mem.concepts}, special memory concepts
   template<class I>
-    concept @\exposconcept{nothrow-input-iterator}@ = @\seebelow@;    // \expos
+    concept @\exposconcept{nothrow-input-iterator}@ = @\seebelow@;                // \expos
   template<class I>
-    concept @\exposconcept{nothrow-forward-iterator}@ = @\seebelow@;  // \expos
+    concept @\exposconcept{nothrow-forward-iterator}@ = @\seebelow@;              // \expos
+  template<class I>
+    concept @\exposconcept{nothrow-bidirectional-iterator}@ = @\seebelow@;        // \expos
+  template<class I>
+    concept @\exposconcept{nothrow-random-access-iterator}@ = @\seebelow@;        // \expos
   template<class S, class I>
-    concept @\exposconcept{nothrow-sentinel-for}@ = @\seebelow@;      // \expos
+    concept @\exposconcept{nothrow-sentinel-for}@ = @\seebelow@;                  // \expos
+  template<class S, class I>
+    concept @\exposconcept{nothrow-sized-sentinel-for}@ = @\seebelow@;            // \expos
   template<class R>
-    concept @\exposconcept{nothrow-input-range}@ = @\seebelow@;       // \expos
+    concept @\exposconcept{nothrow-input-range}@ = @\seebelow@;                   // \expos
   template<class R>
-    concept @\exposconcept{nothrow-forward-range}@ = @\seebelow@;     // \expos
+    concept @\exposconcept{nothrow-forward-range}@ = @\seebelow@;                 // \expos
+  template<class R>
+    concept @\exposconcept{nothrow-bidirectional-range}@ = @\seebelow@;           // \expos
+  template<class R>
+    concept @\exposconcept{nothrow-random-access-range}@ = @\seebelow@;           // \expos
+  template<class R>
+    concept @\exposconcept{nothrow-sized-random-access-range}@ = @\seebelow@;     // \expos
 
   template<class NoThrowForwardIterator>
     constexpr void uninitialized_default_construct(NoThrowForwardIterator first,    // freestanding
@@ -219,6 +231,21 @@ namespace std {
       requires @\libconcept{default_initializable}@<iter_value_t<I>>
         constexpr I uninitialized_default_construct_n(I first,                      // freestanding
                                                       iter_difference_t<I> n);
+
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{nothrow-random-access-iterator}@ I, @\exposconcept{nothrow-sentinel-for}@<I> S>
+      requires @\libconcept{default_initializable}@<iter_value_t<I>>
+        I uninitialized_default_construct(Ep&& exec,                        // freestanding-deleted,
+                                          I first, S last);                 // see \ref{algorithms.parallel.overloads}
+    %FIXME: weird gap, probably unintentional
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{nothrow-sized-random-access-range}@ R>
+      requires @\libconcept{default_initializable}@<range_value_t<R>>
+        borrowed_iterator_t<R> uninitialized_default_construct(Ep&& exec,   // freestanding-deleted,
+                                                               R&& r);      // see \ref{algorithms.parallel.overloads}
+
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{nothrow-random-access-iterator}@ I>
+      requires @\libconcept{default_initializable}@<iter_value_t<I>>
+        I uninitialized_default_construct_n(Ep&& exec, I first,             // freestanding-deleted,
+                                            iter_difference_t<I> n);        // see \ref{algorithms.parallel.overloads}
   }
 
   template<class NoThrowForwardIterator>
@@ -249,6 +276,20 @@ namespace std {
       requires @\libconcept{default_initializable}@<iter_value_t<I>>
         constexpr I uninitialized_value_construct_n(I first,                        // freestanding
                                                     iter_difference_t<I> n);
+
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{nothrow-random-access-iterator}@ I, @\exposconcept{nothrow-sentinel-for}@<I> S>
+      requires @\libconcept{default_initializable}@<iter_value_t<I>>
+        I uninitialized_value_construct(Ep&& exec,                          // freestanding-deleted,
+                                        I first, S last);                   // see \ref{algorithms.parallel.overloads}
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{nothrow-sized-random-access-range}@ R>
+      requires @\libconcept{default_initializable}@<range_value_t<R>>
+        borrowed_iterator_t<R> uninitialized_value_construct(Ep&& exec,     // freestanding-deleted,
+                                                             R&& r);        // see \ref{algorithms.parallel.overloads}
+
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{nothrow-random-access-iterator}@ I>
+      requires @\libconcept{default_initializable}@<iter_value_t<I>>
+        I uninitialized_value_construct_n(Ep&& exec, I first,               // freestanding-deleted,
+                                          iter_difference_t<I> n);          // see \ref{algorithms.parallel.overloads}
   }
 
   template<class InputIterator, class NoThrowForwardIterator>
@@ -291,6 +332,26 @@ namespace std {
         constexpr uninitialized_copy_n_result<I, O>
           uninitialized_copy_n(I ifirst, iter_difference_t<I> n,                    // freestanding
                                O ofirst, S olast);
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S1,
+             @\exposconcept{nothrow-random-access-iterator}@ O, @\exposconcept{nothrow-sentinel-for}@<O> S2>
+      requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_reference_t<I>>
+        uninitialized_copy_result<I, O>
+          uninitialized_copy(Ep&& exec, I ifirst, S1 ilast,                 // freestanding-deleted,
+                             O ofirst, S2 olast);                           // see \ref{algorithms.parallel.overloads}
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ IR,
+             @\exposconcept{nothrow-sized-random-access-range}@ OR>
+      requires @\libconcept{constructible_from}@<range_value_t<OR>, range_reference_t<IR>>
+        uninitialized_copy_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
+          uninitialized_copy(Ep&& exec, IR&& in_range,                      // freestanding-deleted,
+                             OR&& out_range);                               // see \ref{algorithms.parallel.overloads}
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\exposconcept{nothrow-random-access-iterator}@ O,
+             @\exposconcept{nothrow-sentinel-for}@<O> S>
+      requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_reference_t<I>>
+        uninitialized_copy_n_result<I, O>
+          uninitialized_copy_n(Ep&& exec, I ifirst, iter_difference_t<I> n, // freestanding-deleted,
+                               O ofirst, S olast);                          // see \ref{algorithms.parallel.overloads}
   }
 
   template<class InputIterator, class NoThrowForwardIterator>
@@ -334,6 +395,26 @@ namespace std {
         constexpr uninitialized_move_n_result<I, O>
           uninitialized_move_n(I ifirst, iter_difference_t<I> n,                    // freestanding
                                O ofirst, S olast);
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I, @\libconcept{sized_sentinel_for}@<I> S1,
+             @\exposconcept{nothrow-random-access-iterator}@ O, @\exposconcept{nothrow-sentinel-for}@<O> S2>
+      requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_rvalue_reference_t<I>>
+        uninitialized_move_result<I, O>
+          uninitialized_move(Ep&& exec, I ifirst, S1 ilast,                 // freestanding-deleted,
+                             O ofirst, S2 olast);                           // see \ref{algorithms.parallel.overloads}
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-access-range}@ IR,
+             @\exposconcept{nothrow-sized-random-access-range}@ OR>
+      requires @\libconcept{constructible_from}@<range_value_t<OR>, range_rvalue_reference_t<IR>>
+        uninitialized_move_result<borrowed_iterator_t<IR>, borrowed_iterator_t<OR>>
+          uninitialized_move(Ep&& exec, IR&& in_range,                      // freestanding-deleted,
+                             OR&& out_range);                               // see \ref{algorithms.parallel.overloads}
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{random_access_iterator}@ I,
+             @\exposconcept{nothrow-random-access-iterator}@ O, @\exposconcept{nothrow-sentinel-for}@<O> S>
+      requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_rvalue_reference_t<I>>
+        uninitialized_move_n_result<I, O>
+          uninitialized_move_n(Ep&& exec, I ifirst, iter_difference_t<I> n, // freestanding-deleted,
+                               O ofirst, S olast);                          // see \ref{algorithms.parallel.overloads}
   }
 
   template<class NoThrowForwardIterator, class T>
@@ -365,6 +446,21 @@ namespace std {
       requires @\libconcept{constructible_from}@<iter_value_t<I>, const T&>
         constexpr I uninitialized_fill_n(I first,                                   // freestanding
                                          iter_difference_t<I> n, const T& x);
+
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{nothrow-random-access-iterator}@ I, @\exposconcept{nothrow-sentinel-for}@<I> S,
+             class T>
+      requires @\libconcept{constructible_from}@<iter_value_t<I>, const T&>
+        I uninitialized_fill(Ep&& exec, I first, S last,                    // freestanding-deleted,
+                             const T& x);                                   // see \ref{algorithms.parallel.overloads}
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{nothrow-sized-random-access-range}@ R, class T>
+      requires @\libconcept{constructible_from}@<range_value_t<R>, const T&>
+        borrowed_iterator_t<R> uninitialized_fill(Ep&& exec, R&& r,         // freestanding-deleted,
+                                                  const T& x);              // see \ref{algorithms.parallel.overloads}
+
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{nothrow-random-access-iterator}@ I, class T>
+      requires @\libconcept{constructible_from}@<iter_value_t<I>, const T&>
+        I uninitialized_fill_n(Ep&& exec, I first,                          // freestanding-deleted,
+                               iter_difference_t<I> n, const T& x);         // see \ref{algorithms.parallel.overloads}
   }
 
   // \ref{specialized.construct}, \tcode{construct_at}
@@ -407,6 +503,23 @@ namespace std {
     template<@\exposconcept{nothrow-input-iterator}@ I>
       requires @\libconcept{destructible}@<iter_value_t<I>>
         constexpr I destroy_n(I first, iter_difference_t<I> n) noexcept;            // freestanding
+
+    template<@\exposconcept{execution-policy}@ Ep, @\libconcept{destructible}@ T>
+      void destroy_at(Ep&& exec, T* location) noexcept; // freestanding-deleted
+
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{nothrow-random-access-iterator}@ I, @\exposconcept{nothrow-sentinel-for}@<I> S>
+      requires @\libconcept{destructible}@<iter_value_t<I>>
+        I destroy(Ep&& exec,                                                // freestanding-deleted,
+                  I first, S last) noexcept;                                // see \ref{algorithms.parallel.overloads}
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{nothrow-sized-random-access-range}@ R>
+      requires @\libconcept{destructible}@<range_value_t<R>>
+        borrowed_iterator_t<R> destroy(Ep&& exec,                           // freestanding-deleted,
+                                       R&& r) noexcept;                     // see \ref{algorithms.parallel.overloads}
+
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{nothrow-random-access-iterator}@ I>
+      requires @\libconcept{destructible}@<iter_value_t<I>>
+        I destroy_n(Ep&& exec, I first,                                     // freestanding-deleted,
+                    iter_difference_t<I> n) noexcept;                       // see \ref{algorithms.parallel.overloads}
   }
 
   // \ref{unique.ptr}, class template \tcode{unique_ptr}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -132,6 +132,10 @@ namespace std::ranges {
   template<class T>
     concept constant_range = @\seebelow@;
 
+  %FIXME: Shouldn't this be under [range.sized] ?!
+  template<class T>
+    concept @\defexposconcept{sized-random-access-range}@ = @\seebelow@; // \expos
+
   // \ref{view.interface}, class template \tcode{view_interface}
   template<class D>
     requires is_class_v<D> && @\libconcept{same_as}@<D, remove_cv_t<D>>
@@ -1720,6 +1724,21 @@ template<class T>
   concept @\deflibconcept{constant_range}@ =
     @\libconcept{input_range}@<T> && @\exposconcept{constant-iterator}@<iterator_t<T>>;
 \end{itemdecl}
+
+\pnum
+The exposition-only concept \exposconcept{sized-random-access-range}
+specifies the requirements of a \libconcept{range} type
+that is sized and allows random access to its elements.
+
+\begin{itemdecl}
+template<class T>
+  concept @\defexposconcept{sized-random-access-range}@ = // \expos
+    @\libconcept{random_access_range}@<R> && @\libconcept{sized_range}@<R>;
+\end{itemdecl}
+\begin{note}
+This concept constrains some parallel algorithm overloads;
+see \ref{algorithms}.
+\end{note}
 
 \rSec1[range.utility]{Range utilities}
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -755,7 +755,8 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_optional}@                          202110L // also in \libheader{optional}
 #define @\defnlibxname{cpp_lib_optional_range_support}@            202406L // freestanding, also in \libheader{optional}
 #define @\defnlibxname{cpp_lib_out_ptr}@                           202311L // freestanding, also in \libheader{memory}
-#define @\defnlibxname{cpp_lib_parallel_algorithm}@                201603L // also in \libheader{algorithm}, \libheader{numeric}
+#define @\defnlibxname{cpp_lib_parallel_algorithm}@                202506L
+  // also in \libheader{algorithm}, \libheader{numeric}, \libheader{memory}
 #define @\defnlibxname{cpp_lib_philox_engine}@                     202406L // also in \libheader{random}
 #define @\defnlibxname{cpp_lib_polymorphic}@                       202502L // also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_polymorphic_allocator}@             201902L // also in \libheader{memory_resource}


### PR DESCRIPTION
Closes #7944.
Also closes https://github.com/cplusplus/papers/issues/2337.