### PR TITLE
[algorithms][memory.syn] Index result types of existing `ranges` algorithms, their members, and aliases

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -961,7 +961,7 @@ namespace std {
 
   namespace ranges {
     template<class I, class F>
-      using for_each_result = in_fun_result<I, F>;
+      using @\libglobal{for_each_result}@ = in_fun_result<I, F>;
 
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
              @\libconcept{indirectly_unary_invocable}@<projected<I, Proj>> Fun>
@@ -990,7 +990,7 @@ namespace std {
 
   namespace ranges {
     template<class I, class F>
-      using for_each_n_result = in_fun_result<I, F>;
+      using @\libglobal{for_each_n_result}@ = in_fun_result<I, F>;
 
     template<@\libconcept{input_iterator}@ I, class Proj = identity,
              @\libconcept{indirectly_unary_invocable}@<projected<I, Proj>> Fun>
@@ -1395,7 +1395,7 @@ namespace std {
 
   namespace ranges {
     template<class I1, class I2>
-      using mismatch_result = in_in_result<I1, I2>;
+      using @\libglobal{mismatch_result}@ = in_in_result<I1, I2>;
 
     template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
              class Pred = ranges::equal_to, class Proj1 = identity, class Proj2 = identity>
@@ -1748,9 +1748,9 @@ namespace std {
       constexpr auto fold_right_last(R&& r, F f);
 
     template<class I, class T>
-      using fold_left_with_iter_result = in_value_result<I, T>;
+      using @\libglobal{fold_left_with_iter_result}@ = in_value_result<I, T>;
     template<class I, class T>
-      using fold_left_first_with_iter_result = in_value_result<I, T>;
+      using @\libglobal{fold_left_first_with_iter_result}@ = in_value_result<I, T>;
 
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class T = iter_value_t<I>,
              @\exposconcept{indirectly-binary-left-foldable}@<T, I> F>
@@ -1783,7 +1783,7 @@ namespace std {
 
   namespace ranges {
     template<class I, class O>
-      using copy_result = in_out_result<I, O>;
+      using @\libglobal{copy_result}@ = in_out_result<I, O>;
 
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O>
       requires @\libconcept{indirectly_copyable}@<I, O>
@@ -1816,7 +1816,7 @@ namespace std {
 
   namespace ranges {
     template<class I, class O>
-      using copy_n_result = in_out_result<I, O>;
+      using @\libglobal{copy_n_result}@ = in_out_result<I, O>;
 
     template<@\libconcept{input_iterator}@ I, @\libconcept{weakly_incrementable}@ O>
       requires @\libconcept{indirectly_copyable}@<I, O>
@@ -1842,7 +1842,7 @@ namespace std {
 
   namespace ranges {
     template<class I, class O>
-      using copy_if_result = in_out_result<I, O>;
+      using @\libglobal{copy_if_result}@ = in_out_result<I, O>;
 
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O, class Proj = identity,
              @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
@@ -1878,7 +1878,7 @@ namespace std {
 
   namespace ranges {
     template<class I1, class I2>
-      using copy_backward_result = in_out_result<I1, I2>;
+      using @\libglobal{copy_backward_result}@ = in_out_result<I1, I2>;
 
     template<@\libconcept{bidirectional_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{bidirectional_iterator}@ I2>
       requires @\libconcept{indirectly_copyable}@<I1, I2>
@@ -1902,7 +1902,7 @@ namespace std {
 
   namespace ranges {
     template<class I, class O>
-      using move_result = in_out_result<I, O>;
+      using @\libglobal{move_result}@ = in_out_result<I, O>;
 
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O>
       requires @\libconcept{indirectly_movable}@<I, O>
@@ -1931,7 +1931,7 @@ namespace std {
 
   namespace ranges {
     template<class I1, class I2>
-      using move_backward_result = in_out_result<I1, I2>;
+      using @\libglobal{move_backward_result}@ = in_out_result<I1, I2>;
 
     template<@\libconcept{bidirectional_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{bidirectional_iterator}@ I2>
       requires @\libconcept{indirectly_movable}@<I1, I2>
@@ -1954,7 +1954,7 @@ namespace std {
 
   namespace ranges {
     template<class I1, class I2>
-      using swap_ranges_result = in_in_result<I1, I2>;
+      using @\libglobal{swap_ranges_result}@ = in_in_result<I1, I2>;
 
     template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2>
       requires @\libconcept{indirectly_swappable}@<I1, I2>
@@ -2006,7 +2006,7 @@ namespace std {
 
   namespace ranges {
     template<class I, class O>
-      using unary_transform_result = in_out_result<I, O>;
+      using @\libglobal{unary_transform_result}@ = in_out_result<I, O>;
 
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O,
              @\libconcept{copy_constructible}@ F, class Proj = identity>
@@ -2034,7 +2034,7 @@ namespace std {
         transform(Ep&& exec, R&& r, OutR&& result_r, F op, Proj proj = {}); // freestanding-deleted
 
     template<class I1, class I2, class O>
-      using binary_transform_result = in_in_out_result<I1, I2, O>;
+      using @\libglobal{binary_transform_result}@ = in_in_out_result<I1, I2, O>;
 
     template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
              @\libconcept{weakly_incrementable}@ O, @\libconcept{copy_constructible}@ F, class Proj1 = identity,
@@ -2172,7 +2172,7 @@ namespace std {
 
   namespace ranges {
     template<class I, class O>
-      using replace_copy_result = in_out_result<I, O>;
+      using @\libglobal{replace_copy_result}@ = in_out_result<I, O>;
 
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class O,
              class Proj = identity,
@@ -2215,7 +2215,7 @@ namespace std {
                      Proj proj = {});                           // freestanding-deleted
 
     template<class I, class O>
-      using replace_copy_if_result = in_out_result<I, O>;
+      using @\libglobal{replace_copy_if_result}@ = in_out_result<I, O>;
 
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class O, class T = iter_value_t<O>
              class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
@@ -2408,7 +2408,7 @@ namespace std {
 
   namespace ranges {
     template<class I, class O>
-      using remove_copy_result = in_out_result<I, O>;
+      using @\libglobal{remove_copy_result}@ = in_out_result<I, O>;
 
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O,
              class Proj = identity, class T = projected_value_t<I, Proj>>
@@ -2442,7 +2442,7 @@ namespace std {
                     Proj proj = {});                                        // freestanding-deleted
 
     template<class I, class O>
-      using remove_copy_if_result = in_out_result<I, O>;
+      using @\libglobal{remove_copy_if_result}@ = in_out_result<I, O>;
 
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O,
              class Proj = identity, @\libconcept{indirect_unary_predicate}@<projected<I, Proj>> Pred>
@@ -2530,7 +2530,7 @@ namespace std {
 
   namespace ranges {
     template<class I, class O>
-      using unique_copy_result = in_out_result<I, O>;
+      using @\libglobal{unique_copy_result}@ = in_out_result<I, O>;
 
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S, @\libconcept{weakly_incrementable}@ O, class Proj = identity,
              @\libconcept{indirect_equivalence_relation}@<projected<I, Proj>> C = ranges::equal_to>
@@ -2924,7 +2924,7 @@ namespace std {
 
   namespace ranges {
     template<class I, class O>
-      using partial_sort_copy_result = in_out_result<I, O>;
+      using @\libglobal{partial_sort_copy_result}@ = in_out_result<I, O>;
 
     template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1,
              @\libconcept{random_access_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
@@ -3275,7 +3275,7 @@ namespace std {
 
   namespace ranges {
     template<class I, class O1, class O2>
-      using partition_copy_result = in_out_out_result<I, O1, O2>;
+      using @\libglobal{partition_copy_result}@ = in_out_out_result<I, O1, O2>;
 
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S,
              @\libconcept{weakly_incrementable}@ O1, @\libconcept{weakly_incrementable}@ O2,
@@ -3357,7 +3357,7 @@ namespace std {
 
   namespace ranges {
     template<class I1, class I2, class O>
-      using merge_result = in_in_out_result<I1, I2, O>;
+      using @\libglobal{merge_result}@ = in_in_out_result<I1, I2, O>;
 
     template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
              @\libconcept{weakly_incrementable}@ O, class Comp = ranges::less, class Proj1 = identity,
@@ -3508,7 +3508,7 @@ namespace std {
 
   namespace ranges {
     template<class I1, class I2, class O>
-      using set_union_result = in_in_out_result<I1, I2, O>;
+      using @\libglobal{set_union_result}@ = in_in_out_result<I1, I2, O>;
 
     template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
              @\libconcept{weakly_incrementable}@ O, class Comp = ranges::less,
@@ -3571,7 +3571,7 @@ namespace std {
 
   namespace ranges {
     template<class I1, class I2, class O>
-      using set_intersection_result = in_in_out_result<I1, I2, O>;
+      using @\libglobal{set_intersection_result}@ = in_in_out_result<I1, I2, O>;
 
     template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
              @\libconcept{weakly_incrementable}@ O, class Comp = ranges::less,
@@ -3634,7 +3634,7 @@ namespace std {
 
   namespace ranges {
     template<class I, class O>
-      using set_difference_result = in_out_result<I, O>;
+      using @\libglobal{set_difference_result}@ = in_out_result<I, O>;
 
     template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
              @\libconcept{weakly_incrementable}@ O, class Comp = ranges::less,
@@ -3697,7 +3697,7 @@ namespace std {
 
   namespace ranges {
     template<class I1, class I2, class O>
-      using set_symmetric_difference_result = in_in_out_result<I1, I2, O>;
+      using @\libglobal{set_symmetric_difference_result}@ = in_in_out_result<I1, I2, O>;
 
     template<@\libconcept{input_iterator}@ I1, @\libconcept{sentinel_for}@<I1> S1, @\libconcept{input_iterator}@ I2, @\libconcept{sentinel_for}@<I2> S2,
              @\libconcept{weakly_incrementable}@ O, class Comp = ranges::less,
@@ -3941,7 +3941,7 @@ namespace std {
 
   namespace ranges {
     template<class T>
-      using minmax_result = min_max_result<T>;
+      using @\libglobal{minmax_result}@ = min_max_result<T>;
 
     template<class T, class Proj = identity,
              @\libconcept{indirect_strict_weak_order}@<projected<const T*, Proj>> Comp = ranges::less>
@@ -4048,7 +4048,7 @@ namespace std {
 
   namespace ranges {
     template<class I>
-      using minmax_element_result = min_max_result<I>;
+      using @\libglobal{minmax_element_result}@ = min_max_result<I>;
 
     template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
              @\libconcept{indirect_strict_weak_order}@<projected<I, Proj>> Comp = ranges::less>
@@ -4161,7 +4161,7 @@ namespace std {
 
   namespace ranges {
     template<class I>
-      using next_permutation_result = in_found_result<I>;
+      using @\libglobal{next_permutation_result}@ = in_found_result<I>;
 
     template<@\libconcept{bidirectional_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
              class Proj = identity>
@@ -4184,7 +4184,7 @@ namespace std {
 
   namespace ranges {
     template<class I>
-      using prev_permutation_result = in_found_result<I>;
+      using @\libglobal{prev_permutation_result}@ = in_found_result<I>;
 
     template<@\libconcept{bidirectional_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Comp = ranges::less,
              class Proj = identity>
@@ -4210,9 +4210,9 @@ and has no base classes or members other than those specified.
 \begin{codeblock}
 namespace std::ranges {
   template<class I, class F>
-  struct in_fun_result {
-    [[no_unique_address]] I in;
-    [[no_unique_address]] F fun;
+  struct @\libglobal{in_fun_result}@ {
+    [[no_unique_address]] I @\libmember{in}{in_fun_result}@;
+    [[no_unique_address]] F @\libmember{fun}{in_fun_result}@;
 
     template<class I2, class F2>
       requires @\libconcept{convertible_to}@<const I&, I2> && @\libconcept{convertible_to}@<const F&, F2>
@@ -4228,9 +4228,9 @@ namespace std::ranges {
   };
 
   template<class I1, class I2>
-  struct in_in_result {
-    [[no_unique_address]] I1 in1;
-    [[no_unique_address]] I2 in2;
+  struct @\libglobal{in_in_result}@ {
+    [[no_unique_address]] I1 @\libmember{in1}{in_in_result}@;
+    [[no_unique_address]] I2 @\libmember{in2}{in_in_result}@;
 
     template<class II1, class II2>
       requires @\libconcept{convertible_to}@<const I1&, II1> && @\libconcept{convertible_to}@<const I2&, II2>
@@ -4246,9 +4246,9 @@ namespace std::ranges {
   };
 
   template<class I, class O>
-  struct in_out_result {
-    [[no_unique_address]] I in;
-    [[no_unique_address]] O out;
+  struct @\libglobal{in_out_result}@ {
+    [[no_unique_address]] I @\libmember{in}{in_out_result}@;
+    [[no_unique_address]] O @\libmember{out}{in_out_result}@;
 
     template<class I2, class O2>
       requires @\libconcept{convertible_to}@<const I&, I2> && @\libconcept{convertible_to}@<const O&, O2>
@@ -4264,10 +4264,10 @@ namespace std::ranges {
   };
 
   template<class I1, class I2, class O>
-  struct in_in_out_result {
-    [[no_unique_address]] I1 in1;
-    [[no_unique_address]] I2 in2;
-    [[no_unique_address]] O  out;
+  struct @\libglobal{in_in_out_result}@ {
+    [[no_unique_address]] I1 @\libmember{in1}{in_in_out_result}@;
+    [[no_unique_address]] I2 @\libmember{in2}{in_in_out_result}@;
+    [[no_unique_address]] O  @\libmember{out}{in_in_out_result}@;
 
     template<class II1, class II2, class OO>
       requires @\libconcept{convertible_to}@<const I1&, II1> &&
@@ -4287,10 +4287,10 @@ namespace std::ranges {
   };
 
   template<class I, class O1, class O2>
-  struct in_out_out_result {
-    [[no_unique_address]] I  in;
-    [[no_unique_address]] O1 out1;
-    [[no_unique_address]] O2 out2;
+  struct @\libglobal{in_out_out_result}@ {
+    [[no_unique_address]] I  @\libmember{in}{in_out_out_result}@;
+    [[no_unique_address]] O1 @\libmember{out1}{in_out_out_result}@;
+    [[no_unique_address]] O2 @\libmember{out2}{in_out_out_result}@;
 
     template<class II, class OO1, class OO2>
       requires @\libconcept{convertible_to}@<const I&, II> &&
@@ -4310,9 +4310,9 @@ namespace std::ranges {
   };
 
   template<class T>
-  struct min_max_result {
-    [[no_unique_address]] T min;
-    [[no_unique_address]] T max;
+  struct @\libglobal{min_max_result}@ {
+    [[no_unique_address]] T @\libmember{min}{min_max_result}@;
+    [[no_unique_address]] T @\libmember{max}{min_max_result}@;
 
     template<class T2>
       requires @\libconcept{convertible_to}@<const T&, T2>
@@ -4328,9 +4328,9 @@ namespace std::ranges {
   };
 
   template<class I>
-  struct in_found_result {
-    [[no_unique_address]] I in;
-    bool found;
+  struct @\libglobal{in_found_result}@ {
+    [[no_unique_address]] I @\libmember{in}{in_found_result}@;
+    bool @\libmember{found}{in_found_result}@;
 
     template<class I2>
       requires @\libconcept{convertible_to}@<const I&, I2>
@@ -4345,9 +4345,9 @@ namespace std::ranges {
   };
 
   template<class I, class T>
-  struct in_value_result {
-    [[no_unique_address]] I in;
-    [[no_unique_address]] T value;
+  struct @\libglobal{in_value_result}@ {
+    [[no_unique_address]] I @\libmember{in}{in_value_result}@;
+    [[no_unique_address]] T @\libmember{value}{in_value_result}@;
 
     template<class I2, class T2>
       requires @\libconcept{convertible_to}@<const I&, I2> && @\libconcept{convertible_to}@<const T&, T2>
@@ -4363,9 +4363,9 @@ namespace std::ranges {
   };
 
   template<class O, class T>
-  struct out_value_result {
-    [[no_unique_address]] O out;
-    [[no_unique_address]] T value;
+  struct @\libglobal{out_value_result}@ {
+    [[no_unique_address]] O @\libmember{out}{out_value_result}@;
+    [[no_unique_address]] T @\libmember{value}{out_value_result}@;
 
     template<class O2, class T2>
       requires @\libconcept{convertible_to}@<const O&, O2> && @\libconcept{convertible_to}@<const T&, T2>
@@ -12230,7 +12230,7 @@ namespace std {
 
   namespace ranges {
     template<class O, class T>
-      using iota_result = out_value_result<O, T>;
+      using @\libglobal{iota_result}@ = out_value_result<O, T>;
 
     template<@\libconcept{input_or_output_iterator}@ O, @\libconcept{sentinel_for}@<O> S, @\libconcept{weakly_incrementable}@ T>
       requires @\libconcept{indirectly_writable}@<O, const T&>

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -313,7 +313,7 @@ namespace std {
 
   namespace ranges {
     template<class I, class O>
-      using uninitialized_copy_result = in_out_result<I, O>;                        // freestanding
+      using @\libglobal{uninitialized_copy_result}@ = in_out_result<I, O>;                        // freestanding
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S1,
              @\exposconcept{nothrow-forward-iterator}@ O, @\exposconcept{nothrow-sentinel-for}@<O> S2>
       requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_reference_t<I>>
@@ -325,7 +325,7 @@ namespace std {
           uninitialized_copy(IR&& in_range, OR&& out_range);                        // freestanding
 
     template<class I, class O>
-      using uninitialized_copy_n_result = in_out_result<I, O>;                      // freestanding
+      using @\libglobal{uninitialized_copy_n_result}@ = in_out_result<I, O>;                      // freestanding
     template<@\libconcept{input_iterator}@ I, @\exposconcept{nothrow-forward-iterator}@ O, @\exposconcept{nothrow-sentinel-for}@<O> S>
       requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_reference_t<I>>
         constexpr uninitialized_copy_n_result<I, O>
@@ -374,7 +374,7 @@ namespace std {
 
   namespace ranges {
     template<class I, class O>
-      using uninitialized_move_result = in_out_result<I, O>;                        // freestanding
+      using @\libglobal{uninitialized_move_result}@ = in_out_result<I, O>;                        // freestanding
     template<@\libconcept{input_iterator}@ I, @\libconcept{sentinel_for}@<I> S1,
              @\exposconcept{nothrow-forward-iterator}@ O, @\exposconcept{nothrow-sentinel-for}@<O> S2>
       requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_rvalue_reference_t<I>>
@@ -386,7 +386,7 @@ namespace std {
           uninitialized_move(IR&& in_range, OR&& out_range);                        // freestanding
 
     template<class I, class O>
-      using uninitialized_move_n_result = in_out_result<I, O>;                      // freestanding
+      using @\libglobal{uninitialized_move_n_result}@ = in_out_result<I, O>;                      // freestanding
     template<@\libconcept{input_iterator}@ I,
              @\exposconcept{nothrow-forward-iterator}@ O, @\exposconcept{nothrow-sentinel-for}@<O> S>
       requires @\libconcept{constructible_from}@<iter_value_t<O>, iter_rvalue_reference_t<I>>


### PR DESCRIPTION
Fixes #8047.

It's not clear to me whether we should index conversion functions. Perhaps we can do that later.