### PR TITLE
removing hyphenation from ly adverbs

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -256,7 +256,7 @@ that takes separate iterator and sentinel arguments.
 
 \pnum
 The well-formedness and behavior of a call to an algorithm with
-an explicitly-specified template argument list
+an explicitly specified template argument list
 is unspecified, except where explicitly stated otherwise.
 \begin{note}
 Consequently, an implementation can declare an algorithm with
@@ -9566,7 +9566,7 @@ The next permutation is found by assuming that the set of all permutations
 is lexicographically sorted with respect to \tcode{comp} and \tcode{proj}.
 If no such permutation exists,
 transforms the sequence into the first permutation;
-that is, the ascendingly-sorted one.
+that is, the ascendingly sorted one.
 
 \pnum
 \returns
@@ -9625,7 +9625,7 @@ The previous permutation is found by assuming that the set of all permutations
 is lexicographically sorted with respect to \tcode{comp} and \tcode{proj}.
 If no such permutation exists,
 transforms the sequence into the last permutation;
-that is, the descendingly-sorted one.
+that is, the descendingly sorted one.
 
 \pnum
 \returns
@@ -11148,7 +11148,7 @@ before allowing the exception to propagate.
 When new objects are created by
 the algorithms specified in \ref{specialized.algorithms},
 the lifetime ends for any existing objects
-(including potentially-overlapping subobjects \ref{intro.object})
+(including potentially overlapping subobjects \ref{intro.object})
 in storage that is reused \ref{basic.life}.
 \end{note}
 

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -395,7 +395,7 @@ contains the potential results of the right operand.
 \item Otherwise, the set is empty.
 \end{itemize}
 \begin{note}
-This set is a (possibly-empty) set of \grammarterm{id-expression}{s},
+This set is a (possibly empty) set of \grammarterm{id-expression}{s},
 each of which is either $E$ or a subexpression of $E$.
 \begin{example}
 In the following example, the set of potential results of the initializer
@@ -455,7 +455,7 @@ This covers
 A variable is named by an expression
 if the expression is an \grammarterm{id-expression} that denotes it.
 A variable \tcode{x} that is named by a
-potentially-evaluated expression $N$
+potentially evaluated expression $N$
 that appears at a point $P$
 is \defnx{odr-used}{odr-use} by $N$ unless
 \begin{itemize}
@@ -510,10 +510,10 @@ int h(bool cond) {
 \end{example}
 
 \pnum
-A structured binding is odr-used if it appears as a potentially-evaluated expression.
+A structured binding is odr-used if it appears as a potentially evaluated expression.
 
 \pnum
-\tcode{*\keyword{this}} is odr-used if \keyword{this} appears as a potentially-evaluated expression
+\tcode{*\keyword{this}} is odr-used if \keyword{this} appears as a potentially evaluated expression
 (including as the result of any implicit transformation to
 a class member access expression\iref{expr.prim.id.general}).
 
@@ -521,7 +521,7 @@ a class member access expression\iref{expr.prim.id.general}).
 A virtual member
 function is odr-used if it is not pure.
 A function is odr-used if it is named by
-a potentially-evaluated expression or conversion.
+a potentially evaluated expression or conversion.
 A non-placement allocation or deallocation
 function for a class is odr-used by the definition of a constructor of that
 class. A non-placement deallocation function for a class is odr-used by the
@@ -537,7 +537,7 @@ is a permissible implementation technique.
 
 \pnum
 An assignment operator function in a class is odr-used by an
-implicitly-defined
+implicitly defined
 copy assignment or move assignment function for another class as specified
 in~\ref{class.copy.assign}.
 A constructor for a class is odr-used as specified
@@ -778,7 +778,7 @@ is subject to the requirements described in this paragraph (recursively).
 For the purposes of the preceding requirements:
 
 \begin{itemize}
-\item If \tcode{D} is a class with an implicitly-declared
+\item If \tcode{D} is a class with an implicitly declared
 constructor\iref{class.default.ctor,class.copy.ctor},
 it is as if the constructor was
 implicitly defined in every translation unit where it is odr-used, and the
@@ -1411,7 +1411,7 @@ within the \grammarterm{parameter-declaration-clause}\iref{dcl.fct.default}.
 \begin{itemize}
 \item
 If $P$ is associated with a \grammarterm{declarator} and
-is preceded by a (possibly-parenthesized) \grammarterm{noptr-declarator} of
+is preceded by a (possibly parenthesized) \grammarterm{noptr-declarator} of
 the form
 \grammarterm{declarator-id} \opt{\grammarterm{attribute-specifier-seq}},
 its scope extends to the end of the nearest enclosing
@@ -3395,7 +3395,7 @@ an object of a most derived class type or of a non-class type is called a
 \defn{most derived object}.
 
 \pnum
-A \defn{potentially-overlapping subobject} is either:
+A \defn{potentially overlapping subobject} is either:
 \begin{itemize}
 \item a base class subobject, or
 \item a non-static data member
@@ -3407,7 +3407,7 @@ declared with the \tcode{no_unique_address} attribute\iref{dcl.attr.nouniqueaddr
 \indextext{object!nonzero size}%
 An object has nonzero size if it
 \begin{itemize}
-\item is not a potentially-overlapping subobject, or
+\item is not a potentially overlapping subobject, or
 \item is not of class type, or
 \item is of a class type with virtual member functions or virtual base classes, or
 \item has subobjects of nonzero size or unnamed bit-fields of nonzero length.
@@ -3499,7 +3499,7 @@ that are not themselves of implicit-lifetime types.
 Further, after implicitly creating objects within a specified region of storage,
 some operations are described as producing a pointer to a
 \defnadj{suitable created}{object}.
-These operations select one of the implicitly-created objects
+These operations select one of the implicitly created objects
 whose address is the address of the start of the region of storage,
 and produce a pointer value that points to that object,
 if that value would result in the program having defined behavior.
@@ -3839,7 +3839,7 @@ the storage that $o_1$ occupied, and
 \item $o_1$ is not a const, complete object, and
 
 \item neither $o_1$ nor $o_2$
-is a potentially-overlapping subobject\iref{intro.object}, and
+is a potentially overlapping subobject\iref{intro.object}, and
 
 \item either $o_1$ and $o_2$ are both complete objects, or
 $o_1$ and $o_2$ are direct subobjects of objects $p_1$ and $p_2$, respectively,
@@ -4530,7 +4530,7 @@ of \tcode{X::operator=(const X\&)} can bind to it.
 
 \pnum
 When an object of class type \tcode{X}
-is passed to or returned from a potentially-evaluated function call,
+is passed to or returned from a potentially evaluated function call,
 if \tcode{X} is
 \begin{itemize}
 \item
@@ -4855,7 +4855,7 @@ or functions\iref{dcl.fct}.
 \pnum
 \indextext{object!byte copying and|(}%
 \indextext{type!trivially copyable}%
-For any object (other than a potentially-overlapping subobject) of trivially copyable type
+For any object (other than a potentially overlapping subobject) of trivially copyable type
 \tcode{T}, whether or not the object holds a valid value of type
 \tcode{T}, the underlying bytes\iref{intro.memory} making up the
 object can be copied into an array of
@@ -4882,7 +4882,7 @@ std::memcpy(&obj, buf, N);      // at this point, each subobject of \tcode{obj} 
 \pnum
 For two distinct objects \tcode{obj1} and \tcode{obj2}
 of trivially copyable type \tcode{T},
-where neither \tcode{obj1} nor \tcode{obj2} is a potentially-overlapping subobject,
+where neither \tcode{obj1} nor \tcode{obj2} is a potentially overlapping subobject,
 if the underlying bytes\iref{intro.memory} making up
 \tcode{obj1} are copied into \tcode{obj2},
 \begin{footnote}
@@ -4939,17 +4939,17 @@ with that of the C programming language.
 \end{footnote}
 
 \pnum
-\indextext{type!incompletely-defined object}%
+\indextext{type!incompletely defined object}%
 A class that has been declared but not defined, an enumeration type in certain
 contexts\iref{dcl.enum}, or an array of unknown
 bound or of incomplete element type, is an
-\defnadj{incompletely-defined}{object type}.
+\defnadj{incompletely defined}{object type}.
 \begin{footnote}
-The size and layout of an instance of an incompletely-defined
+The size and layout of an instance of an incompletely defined
 object type is unknown.
 \end{footnote}
 \label{term.incomplete.type}%
-Incompletely-defined object types and \cv{}~\keyword{void} are
+Incompletely defined object types and \cv{}~\keyword{void} are
 \defnadjx{incomplete}{types}{type}\iref{basic.fundamental}.
 \begin{note}
 Objects cannot be defined to have an incomplete type\iref{basic.def}.
@@ -5681,7 +5681,7 @@ a pointer value that points to an object \placeholder{x}
 if there is an object \placeholder{y},
 pointer-interconvertible with \placeholder{x},
 such that \placeholder{b} is within the storage occupied by
-\placeholder{y}, or the immediately-enclosing array object
+\placeholder{y}, or the immediately enclosing array object
 if \placeholder{y} is an array element.
 
 \pnum
@@ -5995,7 +5995,7 @@ a subexpression of an immediate subexpression of $E$.
 Expressions appearing in the \grammarterm{compound-statement} of a \grammarterm{lambda-expression}
 are not subexpressions of the \grammarterm{lambda-expression}.
 \end{note}
-The \defnadjx{potentially-evaluated}{subexpressions}{subexpression} of
+The \defnadjx{potentially evaluated}{subexpressions}{subexpression} of
 an expression, conversion, or \grammarterm{initializer} $E$ are
 \begin{itemize}
 \item
@@ -7002,7 +7002,7 @@ double d1 = fd();   // either initialized statically or dynamically to \tcode{1.
 \indextext{initialization!order of}%
 Dynamic initialization of a non-block variable with static storage duration is
 unordered if the variable is an implicitly or explicitly instantiated
-specialization, is partially-ordered if the variable
+specialization, is partially ordered if the variable
 is an inline variable that is not an implicitly or explicitly instantiated
 specialization, and otherwise is ordered.
 \begin{note}
@@ -7028,7 +7028,7 @@ with static storage duration are ordered as follows:
 If \tcode{V} and \tcode{W} have ordered initialization and
 the definition of \tcode{V}
 is appearance-ordered before the definition of \tcode{W}, or
-if \tcode{V} has partially-ordered initialization,
+if \tcode{V} has partially ordered initialization,
 \tcode{W} does not have unordered initialization, and
 for every definition \tcode{E} of \tcode{W}
 there exists a definition \tcode{D} of \tcode{V}

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -791,7 +791,7 @@ shall not directly or indirectly cause the implicit definition of a
 defaulted default constructor for the enclosing class or the
 exception specification of that constructor.
 An immediate invocation\iref{expr.const} that
-is a potentially-evaluated subexpression\iref{intro.execution}
+is a potentially evaluated subexpression\iref{intro.execution}
 of a default member initializer
 is neither evaluated nor checked for whether it
 is a constant expression at the point where the subexpression appears.
@@ -1095,7 +1095,7 @@ virtual\iref{class.virtual} or pure virtual\iref{class.abstract}.
 \indextext{~@\tcode{\~}|see{destructor}}%
 \indextext{assignment!copy|see{assignment operator, copy}}%
 \indextext{assignment!move|see{assignment operator, move}}%
-\indextext{implicitly-declared default constructor|see{constructor, default}}
+\indextext{implicitly declared default constructor|see{constructor, default}}
 
 \pnum
 \indextext{constructor!default}%
@@ -1114,15 +1114,15 @@ types when the program does not explicitly declare them.
 The implementation will implicitly define them
 as needed\iref{dcl.fct.def.default}.
 \end{note}
-An implicitly-declared special member function is declared at the closing
+An implicitly declared special member function is declared at the closing
 \tcode{\}} of the \grammarterm{class-specifier}.
-Programs shall not define implicitly-declared special member functions.
+Programs shall not define implicitly declared special member functions.
 
 \pnum
-Programs may explicitly refer to implicitly-declared special member functions.
+Programs may explicitly refer to implicitly declared special member functions.
 \begin{example}
 A program may explicitly call or form a pointer to member
-to an implicitly-declared special member function.
+to an implicitly declared special member function.
 
 \begin{codeblock}
 struct A { };                   // implicitly declared \tcode{A::operator=}
@@ -1202,7 +1202,7 @@ that names a constructor\iref{class.qual};
 otherwise, in a \grammarterm{member-declaration} that belongs to the
 \grammarterm{member-specification} of a class or class template,
 the \grammarterm{id-expression} is the
-injected-class-name\iref{class.pre} of the immediately-enclosing entity;
+injected-class-name\iref{class.pre} of the immediately enclosing entity;
 
 \item
 otherwise, the
@@ -1309,12 +1309,12 @@ for which each parameter
 that is not a function parameter pack
 has a default argument
 (including the case of a constructor with no parameters).
-\indextext{implicitly-declared default constructor}%
+\indextext{implicitly declared default constructor}%
 If there is no user-declared constructor or constructor template for class
 \tcode{X},
 a non-explicit constructor having no parameters is implicitly declared
 as defaulted\iref{dcl.fct.def}.
-An implicitly-declared default constructor is an
+An implicitly declared default constructor is an
 inline public member of its class.
 
 \pnum
@@ -1380,7 +1380,7 @@ if it is not the active member of its union.
 It is already the active member if \tcode{U} was value-initialized.
 \end{note}
 Otherwise,
-an implicitly-defined\iref{dcl.fct.def.default} default constructor performs the set of
+an implicitly defined\iref{dcl.fct.def.default} default constructor performs the set of
 initializations of the class that would be performed by a user-written default
 constructor for that class with no
 \grammarterm{ctor-initializer}\iref{class.base.init} and an empty
@@ -1388,16 +1388,16 @@ constructor for that class with no
 If that user-written default constructor would be ill-formed,
 the program is ill-formed.
 If that user-written default constructor would be constexpr-suitable\iref{dcl.constexpr},
-the implicitly-defined
+the implicitly defined
 default constructor is \keyword{constexpr}.
 Before the defaulted default constructor for a class is
 implicitly defined,
 all the non-user-provided default constructors for its base classes and
 its non-static data members are implicitly defined.
 \begin{note}
-An implicitly-declared default constructor has an
+An implicitly declared default constructor has an
 exception specification\iref{except.spec}.
-An explicitly-defaulted definition might have an
+An explicitly defaulted definition might have an
 implicit exception specification, see~\ref{dcl.fct.def}.
 \end{note}
 
@@ -1551,7 +1551,7 @@ The latter case is deprecated if the class has a user-declared copy assignment
 operator or a user-declared destructor\iref{depr.impldec}.
 
 \pnum
-The implicitly-declared copy constructor for a class
+The implicitly declared copy constructor for a class
 \tcode{X}
 will have the form
 \begin{codeblock}
@@ -1569,12 +1569,12 @@ or
 \tcode{M\&}.
 \begin{footnote}
 This implies that the reference parameter of the
-implicitly-declared copy constructor
+implicitly declared copy constructor
 cannot bind to a
 \tcode{volatile}
 lvalue; see~\ref{diff.class}.
 \end{footnote}
-Otherwise, the implicitly-declared copy constructor will have the form
+Otherwise, the implicitly declared copy constructor will have the form
 \begin{codeblock}
 X::X(X&)
 \end{codeblock}
@@ -1605,13 +1605,13 @@ a copy constructor.
 \end{note}
 
 \pnum
-The implicitly-declared move constructor for class \tcode{X} will have the form
+The implicitly declared move constructor for class \tcode{X} will have the form
 \begin{codeblock}
 X::X(X&&)
 \end{codeblock}
 
 \pnum
-An implicitly-declared copy/move constructor is an
+An implicitly declared copy/move constructor is an
 inline public member of its class.
 A defaulted copy/\brk{}move constructor for a class
   \tcode{X} is defined as deleted\iref{dcl.fct.def.delete} if \tcode{X} has:
@@ -1673,8 +1673,8 @@ otherwise the copy/move constructor is
 The copy/move constructor is implicitly defined even if the implementation elided
 its odr-use\iref{term.odr.use,class.temporary}.
 \end{note}
-If an implicitly-defined\iref{dcl.fct.def.default} constructor would be constexpr-suitable\iref{dcl.constexpr},
-the implicitly-defined
+If an implicitly defined\iref{dcl.fct.def.default} constructor would be constexpr-suitable\iref{dcl.constexpr},
+the implicitly defined
 constructor is \keyword{constexpr}.
 
 \pnum
@@ -1684,12 +1684,12 @@ all non-user-provided copy/move constructors for its
 potentially constructed subobjects
 are implicitly defined.
 \begin{note}
-An implicitly-declared copy/move constructor has an
+An implicitly declared copy/move constructor has an
 implied exception specification\iref{except.spec}.
 \end{note}
 
 \pnum
-The implicitly-defined copy/move constructor for a non-union class
+The implicitly defined copy/move constructor for a non-union class
 \tcode{X}
 performs a memberwise copy/move of its bases and members.
 \begin{note}
@@ -1716,10 +1716,10 @@ otherwise, the base or member is direct-initialized with the corresponding base 
 
 \indextext{initialization!virtual base class}%
 Virtual base class subobjects shall be initialized only once by
-the implicitly-defined copy/move constructor (see~\ref{class.base.init}).
+the implicitly defined copy/move constructor (see~\ref{class.base.init}).
 
 \pnum
-The implicitly-defined copy/move constructor for a union
+The implicitly defined copy/move constructor for a union
 \tcode{X} copies the object representation\iref{term.object.representation} of \tcode{X}.
 For each object nested within\iref{intro.object}
 the object that is the source of the copy,
@@ -1787,8 +1787,8 @@ constructor or move assignment operator, the implicitly declared copy
 assignment operator is defined as deleted; otherwise, it is
 defaulted\iref{dcl.fct.def}.
 The latter case is deprecated if the class has a user-declared copy constructor
-or a user-declared destructor\iref{depr.impldec}.
-The implicitly-declared copy assignment operator for a class
+or a user-declared destructor \iref{depr.impldec}.
+The implicitly declared copy assignment operator for a class
 \tcode{X}
 will have the form
 \begin{codeblock}
@@ -1808,12 +1808,12 @@ each such class type has a copy assignment operator whose non-object parameter i
 or \tcode{M}.
 \begin{footnote}
 This implies that the reference parameter of the
-implicitly-declared copy assignment operator cannot bind to a
+implicitly declared copy assignment operator cannot bind to a
 \tcode{volatile} lvalue; see~\ref{diff.class}.
 \end{footnote}
 \end{itemize}
 
-Otherwise, the implicitly-declared copy assignment operator
+Otherwise, the implicitly declared copy assignment operator
 will have the form
 \begin{codeblock}
 X& X::operator=(X&)
@@ -1869,17 +1869,17 @@ struct S {
 \end{example}
 
 \pnum
-The implicitly-declared move assignment operator for a class \tcode{X} will have the form
+The implicitly declared move assignment operator for a class \tcode{X} will have the form
 \begin{codeblock}
 X& X::operator=(X&&)
 \end{codeblock}
 
 \pnum
-The implicitly-declared copy/move assignment operator for class
+The implicitly declared copy/move assignment operator for class
 \tcode{X}
 has the return type
 \tcode{X\&}.
-An implicitly-declared copy/move assignment operator is an
+An implicitly declared copy/move assignment operator is an
 inline public member of its class.
 
 \pnum
@@ -1951,7 +1951,7 @@ otherwise the copy/move assignment operator is
 \defnx{non-trivial}{assignment operator!copy!non-trivial}.
 
 \pnum
-An implicitly-defined\iref{dcl.fct.def.default} copy/move assignment operator is \keyword{constexpr}.
+An implicitly defined\iref{dcl.fct.def.default} copy/move assignment operator is \keyword{constexpr}.
 
 \pnum
 Before the defaulted copy/move assignment operator for a class is
@@ -1960,12 +1960,12 @@ all non-user-provided copy/move assignment operators for
 its direct base classes and
 its non-static data members are implicitly defined.
 \begin{note}
-An implicitly-declared copy/move assignment operator has an
+An implicitly declared copy/move assignment operator has an
 implied exception specification\iref{except.spec}.
 \end{note}
 
 \pnum
-The implicitly-defined copy/move assignment operator for a
+The implicitly defined copy/move assignment operator for a
 non-union class \tcode{X} performs memberwise copy/move assignment of its subobjects. The direct
 base classes of \tcode{X} are assigned first, in the order of their declaration in the
 \grammarterm{base-specifier-list}, and then the immediate non-static data members of
@@ -1991,7 +1991,7 @@ the built-in assignment operator is used.
 
 \indextext{assignment operator!copy!virtual bases and}%
 It is unspecified whether subobjects representing virtual base classes
-are assigned more than once by the implicitly-defined copy/move assignment
+are assigned more than once by the implicitly defined copy/move assignment
 operator.
 \begin{example}
 \begin{codeblock}
@@ -2003,12 +2003,12 @@ struct C : B, A { };
 
 It is unspecified whether the virtual base class subobject
 \tcode{V}
-is assigned twice by the implicitly-defined copy/move assignment operator for
+is assigned twice by the implicitly defined copy/move assignment operator for
 \tcode{C}.
 \end{example}
 
 \pnum
-The implicitly-defined copy/move assignment operator for a
+The implicitly defined copy/move assignment operator for a
 union \tcode{X} copies the object representation\iref{term.object.representation} of \tcode{X}.
 If the source and destination of the assignment are not the same object, then
 for each object nested within\iref{intro.object}
@@ -2017,7 +2017,7 @@ a corresponding object $o$ nested within the destination is created,
 and the lifetime of $o$ begins before the copy is performed.
 
 \pnum
-The implicitly-defined copy/move assignment operator for a class
+The implicitly defined copy/move assignment operator for a class
 returns the object for which the assignment operator is invoked,
 that is, the object assigned to.
 \indextext{assignment operator!move|)}
@@ -2045,7 +2045,7 @@ in a \grammarterm{member-declaration} that belongs to the
 but is not a friend
 declaration\iref{class.friend}, the \grammarterm{id-expression} is
 \tcode{\~}\grammarterm{class-name} and the \grammarterm{class-name} is the
-injected-class-name\iref{class.pre} of the immediately-enclosing entity or
+injected-class-name\iref{class.pre} of the immediately enclosing entity or
 
 \item
 otherwise, the
@@ -2071,11 +2071,11 @@ If a class has no user-declared
 prospective destructor,
 a prospective destructor is implicitly
 declared as defaulted\iref{dcl.fct.def}.
-An implicitly-declared prospective destructor is an
+An implicitly declared prospective destructor is an
 inline public member of its class.
 
 \pnum
-An implicitly-declared prospective destructor for a class \tcode{X} will have the form
+An implicitly declared prospective destructor for a class \tcode{X} will have the form
 \begin{codeblock}
 ~X()
 \end{codeblock}
@@ -2856,7 +2856,7 @@ members and cannot be initialized.
 An unnamed bit-field shall not be declared with a cv-qualified type.
 \begin{note}
 An unnamed bit-field is useful for padding to conform to
-externally-imposed layouts.
+externally imposed layouts.
 \end{note}
 \indextext{bit-field!zero width of}%
 \indextext{bit-field!alignment of}%
@@ -3244,7 +3244,7 @@ the beginning of its lifetime is sequenced after
 the value computation of the left and right operands
 and before the assignment.
 \begin{note}
-This ends the lifetime of the previously-active
+This ends the lifetime of the previously active
 member of the union, if any\iref{basic.life}.
 \end{note}
 \begin{example}
@@ -5586,7 +5586,7 @@ struct A {
 
 \pnum
 In a non-delegating constructor
-other than an implicitly-defined copy/move constructor\iref{class.copy.ctor},
+other than an implicitly defined copy/move constructor\iref{class.copy.ctor},
 if a given potentially constructed subobject is not designated by a
 \grammarterm{mem-initializer-id}
 (including the case where there is no
@@ -5698,7 +5698,7 @@ A a2(1);                // OK, unfortunately
 In a non-delegating constructor, the destructor for each potentially constructed
 subobject of class type is potentially invoked\iref{class.dtor}.
 \begin{note}
-This provision ensures that destructors can be called for fully-constructed
+This provision ensures that destructors can be called for fully constructed
 subobjects in case an exception is thrown\iref{except.ctor}.
 \end{note}
 
@@ -6573,7 +6573,7 @@ the respective three-way comparison operator function,
 except that the return type is replaced with \tcode{bool} and
 the \grammarterm{declarator-id} is replaced with \tcode{operator==}.
 \begin{note}
-Such an implicitly-declared \tcode{==} operator for a class \tcode{X}
+Such an implicitly declared \tcode{==} operator for a class \tcode{X}
 is defined as defaulted
 in the definition of \tcode{X} and
 has the same \grammarterm{parameter-declaration-clause} and
@@ -6584,7 +6584,7 @@ or \keyword{consteval} if
 the three-way comparison operator function is so declared.
 If the three-way comparison operator function
 has no \grammarterm{noexcept-specifier},
-the implicitly-declared \tcode{==} operator function
+the implicitly declared \tcode{==} operator function
 has an implicit exception specification\iref{except.spec} that
 can differ from the implicit exception specification of
 the three-way comparison operator function.
@@ -6766,7 +6766,7 @@ if such an index exists and
 
 \pnum
 The \defn{common comparison type} \tcode{U}
-of a possibly-empty list of $n$ comparison category types
+of a possibly empty list of $n$ comparison category types
 $\tcode{T}_0$, $\tcode{T}_1$, $\dotsc$, $\tcode{T}_{n-1}$
 is defined as follows:
 

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -418,14 +418,14 @@ Some identifiers are no longer well-formed.
 Concatenated \grammarterm{string-literal}s can no longer have
 conflicting \grammarterm{encoding-prefix}es.
 \rationale
-Removal of unimplemented conditionally-supported feature.
+Removal of unimplemented conditionally supported feature.
 \effect
 Concatenation of \grammarterm{string-literal}s
 with different \grammarterm{encoding-prefix}es
 is now ill-formed.
 \begin{example}
 \begin{codeblock}
-auto c = L"a" U"b";             // was conditionally-supported; now ill-formed
+auto c = L"a" U"b";             // was conditionally supported; now ill-formed
 \end{codeblock}
 \end{example}
 
@@ -1476,7 +1476,7 @@ A valid \CppXVII{} program that directly makes use of the \tcode{pointer},
 \change
 Remove \tcode{raw_storage_iterator}.
 \rationale
-The iterator encouraged use of potentially-throwing algorithms, but did
+The iterator encouraged use of potentially throwing algorithms, but did
 not return the number of elements successfully constructed,
 as would be necessary to destroy them.
 \effect
@@ -2277,7 +2277,7 @@ in this revision of \Cpp{}, violating the one-definition rule.
 
 \diffref{class.default.ctor,class.dtor,class.copy.ctor,class.copy.assign}
 \change
-Implicitly-declared special member functions are defined as deleted
+Implicitly declared special member functions are defined as deleted
 when the implicit definition would have been ill-formed.
 \rationale
 Improves template argument deduction failure.
@@ -2814,7 +2814,7 @@ Deletion of semantically well-defined feature.
 \difficulty
 Semantic transformation.
 In \Cpp{}, the initializer for one of a set of
-mutually-referential file-local objects with static storage
+mutually referential file-local objects with static storage
 duration must invoke a function
 call to achieve the initialization.
 \howwide
@@ -3459,8 +3459,8 @@ Seldom.
 \change
 Copying volatile objects.
 
-The implicitly-declared copy constructor and
-implicitly-declared copy assignment operator
+The implicitly declared copy constructor and
+implicitly declared copy assignment operator
 cannot make a copy of a volatile lvalue.
 \begin{example}
 The following is valid in C:
@@ -3483,7 +3483,7 @@ would greatly complicate the generation of
 efficient code for class objects.
 Discussion of
 providing two alternative signatures for these
-implicitly-defined operations raised
+implicitly defined operations raised
 unanswered concerns about creating
 ambiguities and complicating
 the rules that specify the formation of

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -6225,11 +6225,11 @@ namespace std {
 \pnum
 \indextext{\idxcode{array}!initialization}%
 \indextext{requirements!container}%
-An \tcode{array} relies on the implicitly-declared special
+An \tcode{array} relies on the implicitly declared special
 member functions\iref{class.default.ctor,class.dtor,class.copy.ctor} to
 conform to the container requirements table in~\ref{container.requirements}.
 In addition to the requirements specified in the container requirements table,
-the implicitly-declared move constructor and move assignment operator for \tcode{array}
+the implicitly declared move constructor and move assignment operator for \tcode{array}
 require that \tcode{T} be \oldconcept{MoveConstructible} or \oldconcept{MoveAssignable},
 respectively.
 
@@ -6996,7 +6996,7 @@ Modifying any list requires access to the element preceding the first element
 of interest, but in a \tcode{forward_list} there is no constant-time way to access a
 preceding element.
 For this reason, \tcode{erase_after} and \tcode{splice_after}
-take fully-open ranges, not semi-open ranges.
+take fully open ranges, not semi-open ranges.
 \end{note}
 
 \pnum

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1434,7 +1434,7 @@ in contexts where class template argument deduction would be performed\iref{temp
 \end{note}
 The other
 \grammarterm{simple-type-specifier}{s}
-specify either a previously-declared type, a type determined from an
+specify either a previously declared type, a type determined from an
 expression, or one of the
 fundamental types\iref{basic.fundamental}.
 \tref{dcl.type.simple}
@@ -2204,7 +2204,7 @@ auto f2(int x) -> decltype(auto) { return (x); }        // return type is \tcode
 \pnum
 For a \grammarterm{placeholder-type-specifier}
 with a \grammarterm{type-constraint},
-the immediately-declared constraint\iref{temp.param}
+the immediately declared constraint\iref{temp.param}
 of the \grammarterm{type-constraint} for the type deduced for the placeholder
 shall be satisfied.
 
@@ -4283,7 +4283,7 @@ The names in the
 default argument are looked up, and the semantic constraints are checked,
 at the point where the default argument appears, except that
 an immediate invocation\iref{expr.const} that
-is a potentially-evaluated subexpression\iref{intro.execution} of
+is a potentially evaluated subexpression\iref{intro.execution} of
 the \grammarterm{initializer-clause} in a \grammarterm{parameter-declaration} is
 neither evaluated
 nor checked for whether it is a constant expression at that point.
@@ -4377,7 +4377,7 @@ class A {
 A default argument is evaluated each time the function is called
 with no argument for the corresponding parameter.
 \indextext{argument!scope of default}%
-A parameter shall not appear as a potentially-evaluated expression
+A parameter shall not appear as a potentially evaluated expression
 in a default argument.
 \indextext{argument and name hiding!default}%
 \begin{note}
@@ -5587,7 +5587,7 @@ is potentially invoked\iref{class.dtor}
 from the context where the aggregate initialization occurs.
 \begin{note}
 This provision ensures that destructors can be called
-for fully-constructed subobjects
+for fully constructed subobjects
 in case an exception is thrown\iref{except.ctor}.
 \end{note}
 
@@ -5662,7 +5662,7 @@ and not the unnamed bit-field before it.
 
 \pnum
 If a member has a default member initializer
-and a potentially-evaluated subexpression thereof is an aggregate
+and a potentially evaluated subexpression thereof is an aggregate
 initialization that would use that default member initializer,
 the program is ill-formed.
 \begin{example}
@@ -5791,7 +5791,7 @@ float y[4][3] = {
   { 3, 5, 7 },
 };
 \end{codeblock}
-is a completely-braced initialization:
+is a completely braced initialization:
 1, 3, and 5 initialize the first row of the array
 \tcode{y[0]},
 namely
@@ -5815,7 +5815,7 @@ In the following example, braces in the
 are elided;
 however the
 \grammarterm{initializer-list}
-has the same effect as the completely-braced
+has the same effect as the completely braced
 \grammarterm{initializer-list}
 of the above example,
 \begin{codeblock}
@@ -5949,7 +5949,7 @@ UTF-8 string literal,
 UTF-16 string literal,
 UTF-32 string literal, or
 wide string literal,
-respectively, or by an appropriately-typed \grammarterm{string-literal} enclosed in
+respectively, or by an appropriately typed \grammarterm{string-literal} enclosed in
 braces\iref{lex.string}.
 Additionally, an array of \keyword{char} or
 \tcode{\keyword{unsigned} \keyword{char}}
@@ -6348,7 +6348,7 @@ copy-list-initialization, or by direct-initialization for
 direct-list-initialization).
 
 \item Otherwise, if \tcode{T} is a character array and the initializer list has a
-single element that is an appropriately-typed \grammarterm{string-literal}\iref{dcl.init.string},
+single element that is an appropriately typed \grammarterm{string-literal}\iref{dcl.init.string},
 initialization is performed as described in that subclause.
 
 \item Otherwise, if \tcode{T} is an aggregate, aggregate initialization is
@@ -6850,14 +6850,14 @@ void f(const char* s = __func__);   // error: \mname{func} is undeclared
 \end{codeblock}
 \end{example}
 
-\rSec2[dcl.fct.def.default]{Explicitly-defaulted functions}%
+\rSec2[dcl.fct.def.default]{Explicitly defaulted functions}%
 
 \pnum
 A function definition whose
 \grammarterm{function-body}
 is of the form
 \tcode{= default ;}
-is called an \defnx{explicitly-defaulted}{definition!function!explicitly-defaulted} definition.
+is called an \defnx{explicitly defaulted}{definition!function!explicitly defaulted} definition.
 A function that is explicitly defaulted shall
 \begin{itemize}
 \item be a special member function\iref{special} or
@@ -6940,7 +6940,7 @@ U u2 = static_cast<U&&>(u1);            // OK, calls \tcode{std::terminate} if \
 \end{example}
 
 \pnum
-Explicitly-defaulted functions and implicitly-declared functions are collectively
+Explicitly defaulted functions and implicitly declared functions are collectively
 called \defn{defaulted} functions, and the implementation
 shall provide implicit definitions
 for them\iref{class.ctor,class.dtor,class.copy.ctor,class.copy.assign} as described below,
@@ -6953,7 +6953,7 @@ an eligible special member function\iref{special}
 is defined as deleted.
 A function is
 \defn{user-provided} if it is user-declared and not explicitly
-defaulted or deleted on its first declaration. A user-provided explicitly-defaulted function
+defaulted or deleted on its first declaration. A user-provided explicitly defaulted function
 (i.e., explicitly defaulted after its first declaration)
 is implicitly defined at the point where it is explicitly defaulted; if such a function is implicitly
 defined as deleted, the program is ill-formed.
@@ -6996,7 +6996,7 @@ nontrivial1::nontrivial1() = default;   // not first declaration
 \pnum
 A \defnadj{deleted}{definition} of a function is a function definition
 whose \grammarterm{function-body} is a \grammarterm{deleted-function-body}
-or an explicitly-defaulted definition of the function where the function is
+or an explicitly defaulted definition of the function where the function is
 defined as deleted.
 A \defnadj{deleted}{function} is
 a function with a
@@ -7015,7 +7015,7 @@ if one is supplied.
 This includes calling the function
 implicitly or explicitly and forming a pointer or pointer-to-member to the
 function. It applies even for references in expressions that are not
-potentially-evaluated. For an overload set, only the
+potentially evaluated. For an overload set, only the
 function selected by overload resolution is referenced. The implicit
 odr-use\iref{term.odr.use} of a virtual function does not, by itself,
 constitute a reference.
@@ -7414,7 +7414,7 @@ and the exception propagates to the caller or resumer.
 
 \pnum
 The expression \keyword{co_await} \tcode{\exposid{promise}.final_suspend()}
-shall not be potentially-throwing\iref{except.spec}.
+shall not be potentially throwing\iref{except.spec}.
 
 \rSec2[dcl.fct.def.replace]{Replaceable function definitions}
 
@@ -8065,7 +8065,7 @@ void f() {
 \indextext{namespaces|(}
 
 \pnum
-A namespace is an optionally-named entity
+A namespace is an optionally named entity
 whose scope can contain declarations of any kind of entity.
 The name of a
 namespace can be used to access entities that belong to that namespace;
@@ -8653,7 +8653,7 @@ for the derived class\iref{class.copy.ctor,class.copy.assign},
 the \grammarterm{using-declaration} does not by itself
 suppress the implicit declaration of the derived class member;
 the member from the base class is hidden or overridden
-by the implicitly-declared copy/move constructor or assignment operator
+by the implicitly declared copy/move constructor or assignment operator
 of the derived class, as described below.
 
 \pnum
@@ -8971,7 +8971,7 @@ An \tcode{asm} declaration has the form
     \opt{attribute-specifier-seq} \keyword{asm} \terminal{(} balanced-token-seq \terminal{)} \terminal{;}
 \end{bnf}
 
-The \tcode{asm} declaration is conditionally-supported;
+The \tcode{asm} declaration is conditionally supported;
 any restrictions on the \grammarterm{balanced-token-seq} and
 its meaning are \impldef{meaning of \tcode{asm} declaration}.
 The optional \grammarterm{attribute-specifier-seq} in
@@ -9021,7 +9021,7 @@ have been replaced\iref{lex.string.uneval}.
 This document specifies the semantics for the
 \grammarterm{unevaluated-string}{s} \tcode{"C"} and \tcode{"C++"}.
 Use of an \grammarterm{unevaluated-string}
-other than \tcode{"C"} or \tcode{"C++"} is conditionally-supported,
+other than \tcode{"C"} or \tcode{"C++"} is conditionally supported,
 with \impldef{semantics of linkage specifiers} semantics.
 \begin{note}
 Therefore, a \grammarterm{linkage-specification} with a language linkage
@@ -9051,7 +9051,7 @@ extern "C" {
 \pnum
 A \grammarterm{module-import-declaration} appearing in
 a linkage specification with other than \Cpp{} language linkage
-is conditionally-supported with
+is conditionally supported with
 \impldef{support for \grammarterm{module-import-declaration}s
 with non-\Cpp{} language linkage} semantics.
 
@@ -9894,7 +9894,7 @@ A \defnadj{nodiscard}{call} is either
 \pnum
 \recommended
 Appearance of a nodiscard call as
-a potentially-evaluated discarded-value expression\iref{expr.prop}
+a potentially evaluated discarded-value expression\iref{expr.prop}
 of non-void type
 is discouraged unless explicitly cast to \keyword{void}.
 Implementations should issue a warning in such cases.
@@ -9988,7 +9988,7 @@ should be \tcode{0} unless the implementation can issue such warnings.
 \pnum
 The \grammarterm{attribute-token} \tcode{no_unique_address}
 specifies that a non-static data member
-is a potentially-overlapping subobject\iref{intro.object}.
+is a potentially overlapping subobject\iref{intro.object}.
 No \grammarterm{attribute-argument-clause} shall be present.
 The attribute may appertain to a non-static data member
 other than a bit-field.
@@ -10006,7 +10006,7 @@ can be reused as storage for other members.
 The value of a \grammarterm{has-attribute-expression}
 for the \tcode{no_unique_address} attribute
 should be \tcode{0} for a given implementation
-unless this attribute can cause a potentially-overlapping subobject
+unless this attribute can cause a potentially overlapping subobject
 to have zero size.
 
 \begin{example}
@@ -10030,3 +10030,4 @@ if their respective types are all empty.
 
 \indextext{attribute|)}%
 \indextext{declaration|)}
+

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -649,7 +649,7 @@ throw an exception from a function with a non-throwing exception specification.
 \end{note}
 \begin{example}
 \begin{codeblock}
-extern void f();                // potentially-throwing
+extern void f();                // potentially throwing
 
 void g() noexcept {
   f();                          // valid, even if \tcode{f} throws
@@ -757,9 +757,9 @@ The predicate indicating whether a function cannot exit via an exception
 is called the \defn{exception specification} of the function.
 If the predicate is false,
 the function has a
-\indextext{exception specification!potentially-throwing}%
-\defnx{potentially-throwing exception specification}%
-{potentially-throwing!exception specification},
+\indextext{exception specification!potentially throwing}%
+\defnx{potentially throwing exception specification}%
+{potentially throwing!exception specification},
 otherwise it has a
 \indextext{exception specification!non-throwing}%
 \defn{non-throwing exception specification}.
@@ -844,7 +844,7 @@ struct D: B {
 The declaration of
 \tcode{D::f}
 is ill-formed because it
-has a potentially-throwing exception specification,
+has a potentially throwing exception specification,
 whereas
 \tcode{B::f}
 has a non-throwing exception specification.
@@ -852,14 +852,14 @@ has a non-throwing exception specification.
 
 \pnum
 An expression $E$ is
-\defnx{potentially-throwing}{potentially-throwing!expression} if
+\defnx{potentially throwing}{potentially throwing!expression} if
 \begin{itemize}
 \item
 $E$ is a function call\iref{expr.call}
 whose \grammarterm{postfix-expression}
 has a function type,
 or a pointer-to-function type,
-with a potentially-throwing exception specification,
+with a potentially throwing exception specification,
 or
 \item
 $E$ implicitly invokes a function
@@ -867,7 +867,7 @@ $E$ implicitly invokes a function
 an allocation function in a \grammarterm{new-expression},
 a constructor for a function argument,
 or a destructor)
-that has a potentially-throwing exception specification,
+that has a potentially throwing exception specification,
 or
 \item
 $E$ is a \grammarterm{throw-expression}\iref{expr.throw},
@@ -884,16 +884,16 @@ polymorphic class type\iref{expr.typeid},
 or
 \item
 any of the immediate subexpressions\iref{intro.execution}
-of $E$ is potentially-throwing.
+of $E$ is potentially throwing.
 \end{itemize}
 
 \pnum
-An implicitly-declared constructor for a class \tcode{X},
+An implicitly declared constructor for a class \tcode{X},
 or a constructor without a \grammarterm{noexcept-specifier}
 that is defaulted on its first declaration,
-has a potentially-throwing exception specification
+has a potentially throwing exception specification
 if and only if
-any of the following constructs is potentially-throwing:
+any of the following constructs is potentially throwing:
 \begin{itemize}
 \item
 the invocation of a constructor selected by overload resolution
@@ -907,7 +907,7 @@ such as a default argument expression, or,
 for a default constructor, a default member initializer.
 \end{itemize}
 \begin{note}
-Even though destructors for fully-constructed subobjects
+Even though destructors for fully constructed subobjects
 are invoked when an exception is thrown
 during the execution of a constructor\iref{except.ctor},
 their exception specifications do not contribute
@@ -918,22 +918,22 @@ rather than escape the constructor\iref{except.throw,except.terminate}.
 \end{note}
 
 \pnum
-The exception specification for an implicitly-declared destructor,
+The exception specification for an implicitly declared destructor,
 or a destructor without a \grammarterm{noexcept-specifier},
-is potentially-throwing if and only if
+is potentially throwing if and only if
 any of the destructors
 for any of its potentially constructed subobjects
-has a potentially-throwing exception specification or
+has a potentially throwing exception specification or
 the destructor is virtual and the destructor of any virtual base class
-has a potentially-throwing exception specification.
+has a potentially throwing exception specification.
 
 \pnum
-The exception specification for an implicitly-declared assignment operator,
+The exception specification for an implicitly declared assignment operator,
 or an assignment-operator without a \grammarterm{noexcept-specifier}
 that is defaulted on its first declaration,
-is potentially-throwing if and only if
+is potentially throwing if and only if
 the invocation of any assignment operator
-in the implicit definition is potentially-throwing.
+in the implicit definition is potentially throwing.
 
 \pnum
 A deallocation function\iref{basic.stc.dynamic.deallocation}
@@ -944,9 +944,9 @@ has a non-throwing exception specification.
 The exception specification for a comparison operator function\iref{over.binary}
 without a \grammarterm{noexcept-specifier}
 that is defaulted on its first declaration
-is potentially-throwing if and only if
+is potentially throwing if and only if
 any expression
-in the implicit definition is potentially-throwing.
+in the implicit definition is potentially throwing.
 
 \pnum
 \begin{example}
@@ -966,10 +966,10 @@ struct B {
 int n = 7;
 struct D : public A, public B {
     int * p = new int[n];
-    // \tcode{D::D()} potentially-throwing, as the \keyword{new} operator may throw \tcode{bad_alloc} or \tcode{bad_array_new_length}
+    // \tcode{D::D()} potentially throwing, as the \keyword{new} operator may throw \tcode{bad_alloc} or \tcode{bad_array_new_length}
     // \tcode{D::D(const D\&)} non-throwing
-    // \tcode{D::D(D\&\&)} potentially-throwing, as the default argument for \tcode{B}'s constructor may throw
-    // \tcode{D::\~D()} potentially-throwing
+    // \tcode{D::D(D\&\&)} potentially throwing, as the default argument for \tcode{B}'s constructor may throw
+    // \tcode{D::\~D()} potentially throwing
 };
 \end{codeblock}
 Furthermore, if
@@ -977,7 +977,7 @@ Furthermore, if
 were virtual,
 the program would be ill-formed since a function that overrides a virtual
 function from a base class
-shall not have a potentially-throwing exception specification
+shall not have a potentially throwing exception specification
 if the base class function has a non-throwing exception specification.
 \end{example}
 

--- a/source/exec.tex
+++ b/source/exec.tex
@@ -1343,7 +1343,7 @@ try {
   set_error(std::move(rcvr), current_exception());
 }
 \end{codeblock}
-if \tcode{expr} is potentially-throwing; otherwise, \tcode{expr}.
+if \tcode{expr} is potentially throwing; otherwise, \tcode{expr}.
 \tcode{\exposid{TRY-SET-VALUE}(rcvr, expr)} is
 \begin{codeblock}
 @\exposid{TRY-EVAL}@(rcvr, @\exposid{SET-VALUE}@(rcvr, expr))
@@ -5218,7 +5218,7 @@ if and only if they were obtained from the same \tcode{run_loop} instance.
 Let \exposid{sch} be an expression of type \exposid{run-loop-scheduler}.
 The expression \tcode{schedule(\exposid{sch})}
 has type \exposid{run-loop-\newline sender} and
-is not potentially-throwing if \exposid{sch} is not potentially-throwing.
+is not potentially throwing if \exposid{sch} is not potentially throwing.
 
 \begin{itemdecl}
 class @\exposid{run-loop-sender}@;
@@ -5248,11 +5248,11 @@ Then:
 \item
 The expression \tcode{connect(\exposid{sndr}, \exposid{rcvr})}
 has type \tcode{\exposid{run-loop-opstate}<decay_t<decltype((\exposid{rcvr}))>>}
-and is potentially-throwing if and only if
-\tcode{(void(\exposid{sndr}), auto(\exposid{rcvr}))} is potentially-throwing.
+and is potentially throwing if and only if
+\tcode{(void(\exposid{sndr}), auto(\exposid{rcvr}))} is potentially throwing.
 \item
 The expression \tcode{get_completion_scheduler<C>(get_env(\exposid{sndr}))}
-is potentially-throwing if and only if \exposid{sndr} is potentially-throwing,
+is potentially throwing if and only if \exposid{sndr} is potentially throwing,
 has type \exposid{run-loop-scheduler}, and
 compares equal to the \exposid{run-loop-\newline scheduler} instance
 from which \exposid{sndr} was obtained.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2544,7 +2544,7 @@ usual, which can result in them being defined as deleted.
 
 \pnum
 The closure type associated with a \grammarterm{lambda-expression} has an
-implicitly-declared destructor\iref{class.dtor}.
+implicitly declared destructor\iref{class.dtor}.
 
 \pnum
 A member of a closure type shall not be
@@ -3328,7 +3328,7 @@ into the \grammarterm{expression} is performed.
 
 \item
 If the \keyword{noexcept} specifier is present,
-$E$ shall not be a potentially-throwing expression\iref{except.spec}.
+$E$ shall not be a potentially throwing expression\iref{except.spec}.
 
 \item
 If the \grammarterm{return-type-requirement} is present, then:
@@ -3339,7 +3339,7 @@ Substitution of template arguments (if any)
 into the \grammarterm{return-type-requirement} is performed.
 
 \item
-The immediately-declared constraint\iref{temp.param}
+The immediately declared constraint\iref{temp.param}
 of the \grammarterm{type-constraint} for \tcode{\keyword{decltype}((E))}
 shall be satisfied.
 \end{itemize}
@@ -3501,7 +3501,7 @@ One of the expressions shall be a glvalue of type ``array of
 to \tcode{T}'' and the other shall be a prvalue of unscoped enumeration or integral type.
 The result is of type ``\tcode{T}''.
 \indextext{type!incomplete}%
-The type ``\tcode{T}'' shall be a completely-defined object type.%
+The type ``\tcode{T}'' shall be a completely defined object type.%
 \begin{footnote}
 This
 is true even if the subscript operator is used in the following common idiom:
@@ -3576,7 +3576,7 @@ even if the type of the function actually called is different.
 \indextext{type!incomplete}%
 If the \grammarterm{postfix-expression} names a pseudo-destructor
 (in which case the \grammarterm{postfix-expression}
-is a possibly-parenthesized class member access),
+is a possibly parenthesized class member access),
 the function call destroys
 the object of scalar type
 denoted by the object expression
@@ -3597,7 +3597,7 @@ definition results in undefined behavior.
 \begin{note}
 This requirement allows the case
 when the expression has the type of a
-potentially-throwing function, but the called function has
+potentially throwing function, but the called function has
 a non-throwing exception specification,
 and the function types are otherwise the same.
 \end{note}
@@ -3722,7 +3722,7 @@ but it is unspecified whether the value of \tcode{j} is 1 or 2.
 \end{example}
 
 \pnum
-The result of a function call is the result of the possibly-converted operand
+The result of a function call is the result of the possibly converted operand
 of the \keyword{return} statement\iref{stmt.return}
 that transferred control out of the called function (if any),
 except in a virtual function call if the return type of the
@@ -3794,13 +3794,13 @@ to type \tcode{\keyword{void}*}\iref{conv.ptr}.
 After these conversions, if the
 argument does not have arithmetic, enumeration, pointer, pointer-to-member,
 or class type, the program is ill-formed.
-Passing a potentially-evaluated argument
+Passing a potentially evaluated argument
 of a scoped enumeration type\iref{dcl.enum} or
 of a class type\iref{class} having
 an eligible non-trivial copy constructor\iref{special,class.copy.ctor},
 an eligible non-trivial move constructor, or
 a non-trivial destructor\iref{class.dtor},
-with no corresponding parameter, is conditionally-supported with
+with no corresponding parameter, is conditionally supported with
 \impldef{passing argument of class type through ellipsis} semantics. If the argument has
 integral or enumeration type that is subject to the integral
 promotions\iref{conv.prom}, or a floating-point type that is subject to the
@@ -4022,7 +4022,7 @@ is ``\cvqual{vq12} \tcode{T}''. If \tcode{E2} is not declared to be a
 ``\cvqual{cq12} \cvqual{vq12} \tcode{T}''.
 
 \item If \tcode{E2} is an overload set,
-the expression shall be the (possibly-parenthesized) left-hand operand of
+the expression shall be the (possibly parenthesized) left-hand operand of
 a member function call\iref{expr.call}, and
 function overload resolution\iref{over.match}
 is used to select the function to which \tcode{E2} refers.
@@ -4100,7 +4100,7 @@ The
 \indextext{value computation}%
 value computation of the \tcode{++} expression is sequenced before the
 modification of the operand object. With respect to an
-indeterminately-sequenced function call, the operation of postfix
+indeterminately sequenced function call, the operation of postfix
 \tcode{++} is
 a single evaluation.
 \begin{note}
@@ -4298,7 +4298,7 @@ that class shall be completely defined.
 
 \pnum
 If an \grammarterm{expression} operand of \keyword{typeid} is
-a possibly-parenthesized \grammarterm{unary-expression}
+a possibly parenthesized \grammarterm{unary-expression}
 whose \grammarterm{unary-operator} is \tcode{*} and
 whose operand evaluates to a null pointer value\iref{basic.compound},
 the \keyword{typeid} expression throws an exception\iref{except.throw}
@@ -4696,7 +4696,7 @@ and back to its original type yields the original pointer value.
 \pnum
 Converting a function pointer to an object pointer
 type or vice versa is
-conditionally-supported. The meaning of such a conversion is
+conditionally supported. The meaning of such a conversion is
 \impldef{converting function pointer to object pointer and vice versa},
 except that if an implementation
 supports conversions in both directions, converting a prvalue of one type to the other
@@ -5124,7 +5124,7 @@ transfers control to its caller or resumer.
 \end{bnf}
 
 \pnum
-An \grammarterm{await-expression} shall appear only as a potentially-evaluated
+An \grammarterm{await-expression} shall appear only as a potentially evaluated
 expression within the \grammarterm{compound-statement} of a
 \grammarterm{function-body} or \grammarterm{lambda-expression},
 in either case
@@ -5139,7 +5139,7 @@ default argument\iref{dcl.fct.default}.
 An \grammarterm{await-expression} shall not appear in the initializer of
 a block variable with static or thread storage duration.
 An \grammarterm{await-expression} shall not be
-a potentially-evaluated subexpression
+a potentially evaluated subexpression
 of the predicate of a contract assertion\iref{basic.contract}.
 A context within a function where an \grammarterm{await-expression} can appear
 is called a \term{suspension context} of the function.
@@ -5181,7 +5181,7 @@ the temporary materialization conversion\iref{conv.rval} is applied.
 \item
 \placeholder{e} is an lvalue
 referring to the result of evaluating
-the (possibly-converted) \placeholder{o}.
+the (possibly converted) \placeholder{o}.
 
 \item
 % FIXME: h needs to be an expression so we can use it as an argument
@@ -5214,7 +5214,7 @@ as the \placeholder{await-resume} expression.
 
 \pnum
 The \grammarterm{await-expression} evaluates
-the (possibly-converted) \placeholder{o} expression and
+the (possibly converted) \placeholder{o} expression and
 the \placeholder{await-ready} expression, then:
 \begin{itemize}
 \item
@@ -5313,7 +5313,7 @@ int a[] = { co_await h() };     // error: \grammarterm{await-expression} outside
 \indextext{operator!\idxcode{sizeof}}%
 \indextext{byte}%
 The \keyword{sizeof} operator yields the number of bytes
-occupied by a non-potentially-overlapping object of the type
+occupied by a non-potentially overlapping object of the type
 of its operand. The operand is either an expression,
 which is an unevaluated operand\iref{term.unevaluated.operand}, or a parenthesized
 \grammarterm{type-id}.
@@ -5351,13 +5351,13 @@ When applied to a class, the result is the number of bytes in an object
 of that class including any padding required for placing objects of that
 type in an array.
 The result of applying \keyword{sizeof} to a
-potentially-overlapping subobject is
+potentially overlapping subobject is
 the size of the type, not the size of the subobject.
 \begin{footnote}
-The actual size of a potentially-overlapping subobject
+The actual size of a potentially overlapping subobject
 can be less than the result of
 applying \keyword{sizeof} to the subobject, due to virtual base classes
-and less strict padding requirements on potentially-overlapping subobjects.
+and less strict padding requirements on potentially overlapping subobjects.
 \end{footnote}
 \indextext{array!\idxcode{sizeof}}%
 When applied to an array, the result is the total number of bytes in the
@@ -5443,7 +5443,7 @@ the temporary materialization conversion\iref{conv.rval} is applied.
 \pnum
 The result of the \keyword{noexcept} operator is a prvalue of type \keyword{bool}.
 The result is \tcode{false} if
-the full-expression of the operand is potentially-throwing\iref{except.spec}, and
+the full-expression of the operand is potentially throwing\iref{except.spec}, and
 \tcode{true} otherwise.
 \begin{note}
 A \grammarterm{noexcept-expression}
@@ -5655,7 +5655,7 @@ number of elements to initialize.
 If the value of the \grammarterm{expression} is invalid after converting to \tcode{std::size_t}:
 \begin{itemize}
 \item
-if the \grammarterm{expression} is a potentially-evaluated core constant expression,
+if the \grammarterm{expression} is a potentially evaluated core constant expression,
 the program is ill-formed;
 \item
 otherwise, an allocation function is not called; instead
@@ -5678,7 +5678,7 @@ function is called to allocate an array with no elements.
 If the allocated type is an array,
 the \grammarterm{new-initializer} is a \grammarterm{braced-init-list}, and
 the \grammarterm{expression}
-is potentially-evaluated and not a core constant expression,
+is potentially evaluated and not a core constant expression,
 the semantic constraints of copy-initializing a hypothetical element of
 the array from an empty initializer list
 are checked\iref{dcl.init.list}.
@@ -6614,7 +6614,7 @@ the corresponding original operand for the remainder of this section.
 
 \indextext{incomplete}%
 For addition, either both operands shall have arithmetic
-type, or one operand shall be a pointer to a completely-defined object
+type, or one operand shall be a pointer to a completely defined object
 type and the other shall have integral type.
 
 \pnum
@@ -6625,9 +6625,9 @@ For subtraction, one of the following shall hold:
 \item
 \indextext{arithmetic!pointer}%
 both operands are pointers to cv-qualified or cv-unqualified
-versions of the same completely-defined object type; or
+versions of the same completely defined object type; or
 
-\item the left operand is a pointer to a completely-defined object type
+\item the left operand is a pointer to a completely defined object type
 and the right operand has integral type.
 \end{itemize}
 
@@ -6644,7 +6644,7 @@ the result has the type of \tcode{P}.
 \begin{itemize}
 \item If \tcode{P} evaluates to a null pointer value and
 \tcode{J} evaluates to 0, the result is a null pointer value.
-\item Otherwise, if \tcode{P} points to a (possibly-hypothetical) array element $i$
+\item Otherwise, if \tcode{P} points to a (possibly hypothetical) array element $i$
 of an array object \tcode{x} with $n$ elements\iref{dcl.array},
 \begin{footnote}
 As specified in \ref{basic.compound},
@@ -6656,10 +6656,10 @@ $n$ for this purpose.
 \end{footnote}
 the expressions \tcode{P + J} and \tcode{J + P}
 (where \tcode{J} has the value $j$)
-point to the (possibly-hypothetical) array element
+point to the (possibly hypothetical) array element
 $i + j$ of \tcode{x} if $0 \le i + j \le n$
 and the expression \tcode{P - J}
-points to the (possibly-hypothetical) array element
+points to the (possibly hypothetical) array element
 $i - j$ of \tcode{x} if $0 \le i - j \le n$.
 \item Otherwise, the behavior is undefined.
 \end{itemize}
@@ -7567,7 +7567,7 @@ and before the
 value computation of the assignment expression.
 The right operand is sequenced before the left operand.
 With
-respect to an indeterminately-sequenced function call, the operation of
+respect to an indeterminately sequenced function call, the operation of
 a compound assignment is a single evaluation.
 \begin{note}
 Therefore, a function call cannot intervene between the
@@ -7625,7 +7625,7 @@ The object designated by \tcode{E1} is accessed twice.
 \end{note}
 For \tcode{+=} and \tcode{-=},
 \tcode{E1} shall either have arithmetic type or be a pointer to a
-possibly cv-qualified completely-defined object type. In all other
+possibly cv-qualified completely defined object type. In all other
 cases, \tcode{E1} shall have arithmetic type.
 
 \pnum
@@ -7879,12 +7879,12 @@ void f() {
 \end{example}
 
 \pnum
-A variable is \defn{potentially-constant} if
+A variable is \defn{potentially constant} if
 it is constexpr or
 it has reference or non-volatile const-qualified integral or enumeration type.
 
 \pnum
-A constant-initialized potentially-constant variable $V$ is
+A constant-initialized potentially constant variable $V$ is
 \defn{usable in constant expressions} at a point $P$ if
 $V$'s initializing declaration $D$ is reachable from $P$ and
 \begin{itemize}
@@ -8021,7 +8021,7 @@ an lvalue-to-rvalue conversion that is applied to
 an object with an indeterminate value\iref{basic.indet};
 
 \item
-an invocation of an implicitly-defined copy/move constructor or
+an invocation of an implicitly defined copy/move constructor or
 copy/move assignment operator
 for a union whose active member (if any) is mutable,
 unless the lifetime of the union object began within the evaluation of $E$;
@@ -8525,7 +8525,7 @@ its enclosing statement is enclosed\iref{stmt.pre} by
 the \grammarterm{compound-statement} of a consteval if statement\iref{stmt.if}.
 \end{itemize}
 An invocation is an \defn{immediate invocation}
-if it is a potentially-evaluated explicit or implicit invocation of
+if it is a potentially evaluated explicit or implicit invocation of
 an immediate function and
 is not in an immediate function context.
 An aggregate initialization is an immediate invocation
@@ -8542,7 +8542,7 @@ if it is not initially in an immediate function context
 and it is either
 \begin{itemize}
 \item
-a potentially-evaluated \grammarterm{id-expression}
+a potentially evaluated \grammarterm{id-expression}
 that denotes an immediate function
 that is not a subexpression of an immediate invocation, or
 \item
@@ -8706,7 +8706,7 @@ if it is:
 a manifestly constant-evaluated expression,
 
 \item
-a potentially-evaluated expression\iref{basic.def.odr},
+a potentially evaluated expression\iref{basic.def.odr},
 
 \item
 an immediate subexpression of a \grammarterm{braced-init-list},
@@ -8723,7 +8723,7 @@ In some cases, constant evaluation is needed to determine whether such an expres
 or
 
 \item
-a potentially-evaluated subexpression\iref{intro.execution} of one of the above.
+a potentially evaluated subexpression\iref{intro.execution} of one of the above.
 \end{itemize}
 
 \indextext{function!needed for constant evaluation}%
@@ -8737,7 +8737,7 @@ a constexpr function that is named by an expression\iref{basic.def.odr}
 that is potentially constant evaluated, or
 
 \item
-a potentially-constant variable named by a potentially constant evaluated expression.
+a potentially constant variable named by a potentially constant evaluated expression.
 \end{itemize}
 
 \indextext{expression|)}

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -209,12 +209,12 @@ and the non-member function templates
 that operate on strings are referred to as the string component.
 \end{defnote}
 
-\indexdefn{behavior!conditionally-supported}%
-\definition{conditionally-supported}{defns.cond.supp}
+\indexdefn{behavior!conditionally supported}%
+\definition{conditionally supported}{defns.cond.supp}
 program construct that an implementation is not required to support
 
 \begin{defnote}
-Each implementation documents all conditionally-supported
+Each implementation documents all conditionally supported
 constructs that it does not support.
 \end{defnote}
 
@@ -282,8 +282,8 @@ never exhibits behavior specified as erroneous in \ref{intro} through \ref{\last
 \indexdefn{expression-equivalent}%
 expressions that all have the same effects,
 either
-are all potentially-throwing or
-are all not potentially-throwing,
+are all potentially throwing or
+are all not potentially throwing,
 and
 either
 are all \termref{defns.const.subexpr}{constant subexpression}{s} or
@@ -715,7 +715,7 @@ and \tcode{x.front()} can be called only if \tcode{x.empty()} returns
 
 \rSec1[intro.compliance]{Implementation compliance}%
 \indextext{diagnostic message|see{message, diagnostic}}%
-\indexdefn{conditionally-supported behavior|see{behavior, con\-ditionally-supported}}%
+\indexdefn{conditionally supported behavior|see{behavior, con\-ditionally supported}}%
 \indextext{dynamic type|see{type, dynamic}}%
 \indextext{static type|see{type, static}}%
 \indextext{ill-formed program|see{program, ill-formed}}%
@@ -785,7 +785,7 @@ a preprocessing translation unit with
 a \tcode{\#warning} preprocessing directive\iref{cpp.error},
 \item
 an occurrence
-of a construct described in this document as ``conditionally-supported'' when
+of a construct described in this document as ``conditionally supported'' when
 the implementation does not support that construct, or
 \item
 a contract assertion\iref{basic.contract.eval}
@@ -889,7 +889,7 @@ Having done so, however, they can compile and execute such programs.
 
 \pnum
 Each implementation shall include documentation that identifies all
-conditionally-supported constructs\indextext{behavior!conditionally-supported}
+conditionally supported constructs\indextext{behavior!conditionally supported}
 that it does not support and defines all locale-specific characteristics.
 \begin{footnote}
 This documentation also defines implementation-defined behavior;
@@ -934,7 +934,7 @@ Each implementation shall include documentation describing its characteristics
 and behavior in these respects.
 \begin{footnote}
 This documentation also includes
-conditionally-supported constructs and locale-specific behavior.
+conditionally supported constructs and locale-specific behavior.
 See~\ref{intro.compliance.general}.
 \end{footnote}
 Such documentation shall define the instance of the

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -34,7 +34,7 @@ and source files included\iref{cpp.include} via the preprocessing
 directive \tcode{\#include}, less any source lines skipped by any of the
 conditional inclusion\iref{cpp.cond} preprocessing directives,
 as modified by the implementation-defined behavior of any
-conditionally-supported-directives\iref{cpp.pre} and pragmas\iref{cpp.pragma},
+conditionally supported-directives\iref{cpp.pre} and pragmas\iref{cpp.pragma},
 if any, is
 called a \defnadj{preprocessing}{translation unit}.
 \begin{note}
@@ -684,7 +684,7 @@ after certain occurrences of an \tcode{import} token
 The appearance of either of the characters \tcode{'} or \tcode{\textbackslash} or of
 either of the character sequences \tcode{/*} or \tcode{//} in a
 \grammarterm{q-char-sequence} or an \grammarterm{h-char-sequence}
-is conditionally-supported with \impldef{meaning of \tcode{'}, \tcode{\textbackslash},
+is conditionally supported with \impldef{meaning of \tcode{'}, \tcode{\textbackslash},
 \tcode{/*}, or \tcode{//} in a \grammarterm{q-char-sequence} or an
 \grammarterm{h-char-sequence}} semantics, as is the appearance of the character
 \tcode{"} in an \grammarterm{h-char-sequence}.
@@ -1475,7 +1475,7 @@ A multicharacter literal shall not have an \grammarterm{encoding-prefix}.
 If a multicharacter literal contains a \grammarterm{c-char}
 that is not encodable as a single code unit in the ordinary literal encoding,
 the program is ill-formed.
-Multicharacter literals are conditionally-supported.
+Multicharacter literals are conditionally supported.
 
 \pnum
 The kind of a \grammarterm{character-literal},
@@ -1577,7 +1577,7 @@ Otherwise, the program is ill-formed.
 A \grammarterm{character-literal} with
 a \grammarterm{c-char-sequence} consisting of
 a single \grammarterm{conditional-escape-sequence}
-is conditionally-supported and
+is conditionally supported and
 has an \impldef{value of \grammarterm{conditional-escape-sequence}} value.
 \end{itemize}
 
@@ -1686,7 +1686,7 @@ its \grammarterm{floating-point-suffix} as specified in \tref{lex.fcon.type}.
 The floating-point suffixes
 \tcode{f16}, \tcode{f32}, \tcode{f64}, \tcode{f128}, \tcode{bf16},
 \tcode{F16}, \tcode{F32}, \tcode{F64}, \tcode{F128}, and \tcode{BF16}
-are conditionally-supported. See \ref{basic.extended.fp}.
+are conditionally supported. See \ref{basic.extended.fp}.
 \end{note}
 \begin{simpletypetable}
 {Types of \grammarterm{floating-point-literal}{s}}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2878,7 +2878,7 @@ is \tcode{true}.
 Let \tcode{x1} and \tcode{x2} denote objects of (possibly different) types
 \tcode{XX::void_pointer}, \tcode{XX::const_void_pointer}, \tcode{XX::pointer},
 or \tcode{XX::const_pointer}. Then, \tcode{x1} and \tcode{x2} are
-\defn{equivalently-valued} pointer values, if and only if both \tcode{x1} and \tcode{x2}
+\defn{equivalently valued} pointer values, if and only if both \tcode{x1} and \tcode{x2}
 can be explicitly converted to the two corresponding objects \tcode{px1} and \tcode{px2}
 of type \tcode{XX::const_pointer}, using a sequence of \keyword{static_cast}s
 using only these four types, and the expression \tcode{px1 == px2}
@@ -2891,7 +2891,7 @@ Then for the expressions
 w1 == w2
 w1 != w2
 \end{codeblock}
-either or both objects may be replaced by an equivalently-valued object of type
+either or both objects may be replaced by an equivalently valued object of type
 \tcode{XX::const_void_pointer} with no change in semantics.
 
 \pnum
@@ -2906,7 +2906,7 @@ p1 >= p2
 p1 > p2
 p1 - p2
 \end{codeblock}
-either or both objects may be replaced by an equivalently-valued object of type
+either or both objects may be replaced by an equivalently valued object of type
 \tcode{XX::const_pointer} with no change in semantics.
 
 \pnum
@@ -3932,9 +3932,9 @@ Functions defined in the
 \Cpp{} standard library
 \indextext{specifications!\Cpp{}}%
 that do not have a \throws paragraph
-but do have a potentially-throwing exception specification
+but do have a potentially throwing exception specification
 may throw \impldef{exceptions thrown by standard library functions that have a
-potentially-throwing exception specification} exceptions.
+potentially throwing exception specification} exceptions.
 \begin{footnote}
 In particular, they
 can report a failure to allocate storage by throwing an exception of type

--- a/source/limits.tex
+++ b/source/limits.tex
@@ -122,6 +122,6 @@ Handlers per try block\iref{except.handle} [256].
 \item%
 Number of placeholders\iref{func.bind.place} [10].
 \item%
-Number of hazard-protectable possibly-reclaimable objects\iref{saferecl.hp.general} [256].
+Number of hazard-protectable possibly reclaimable objects\iref{saferecl.hp.general} [256].
 
 \end{itemize}

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -1041,7 +1041,7 @@ template<class T>
   is a subset of the region reachable through \tcode{result}\iref{basic.compound}
   and suitably aligned for the type \tcode{T}.
 \item
-  No element in the range \range{first}{last} is a potentially-overlapping subobject.
+  No element in the range \range{first}{last} is a potentially overlapping subobject.
 \end{itemize}
 
 \pnum
@@ -1103,7 +1103,7 @@ template<class T>
   a subset of the region reachable through \tcode{result}\iref{basic.compound}
   and suitably aligned for the type \tcode{T}.
 \item
-  No element in the range \range{first}{last} is a potentially-overlapping
+  No element in the range \range{first}{last} is a potentially overlapping
   subobject.
 \end{itemize}
 
@@ -8400,7 +8400,7 @@ where \tcode{n} is not less than \tcode{max(bytes, next_buffer_size)} and
 \tcode{m} is not less than \tcode{alignment},
 and increase \tcode{next_buffer_size}
 by an \impldef{growth factor for \tcode{monotonic_buffer_resource}} growth factor (which need not be integral),
-then allocate the return block from the newly-allocated \tcode{current_buffer}.
+then allocate the return block from the newly allocated \tcode{current_buffer}.
 
 \pnum
 \returns

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -143,7 +143,7 @@ The behavior of a program is undefined if
 \item
   an instantiation of a template specified in \ref{type.traits}
   directly or indirectly depends on
-  an incompletely-defined object type \tcode{T}, and
+  an incompletely defined object type \tcode{T}, and
 \item
   that instantiation could yield a different result
   were \tcode{T} hypothetically completed.
@@ -983,7 +983,7 @@ A union is a class type that
 The compilation of the
   expression can result in side effects such as the instantiation of class template
   specializations and function template specializations, the generation of
-  implicitly-defined functions, and so on. Such side effects are not in the ``immediate
+  implicitly defined functions, and so on. Such side effects are not in the ``immediate
   context'' and can result in the program being ill-formed.
 \end{tailnote}
 &
@@ -1022,7 +1022,7 @@ The compilation of the
   The compilation of the expressions can result in side effects
   such as the instantiation of class template specializations and
   function template specializations,
-  the generation of implicitly-defined functions, and so on.
+  the generation of implicitly defined functions, and so on.
   Such side effects are not in the ``immediate context'' and
   can result in the program being ill-formed.
   \end{tailnote}
@@ -1268,7 +1268,7 @@ The compilation of the
   The initialization can result in effects such as
   the instantiation of class template specializations and
   function template specializations,
-  the generation of implicitly-defined functions, and so on.
+  the generation of implicitly defined functions, and so on.
   Such effects are not in the ``immediate context'' and
   can result in the program being ill-formed.
   \end{tailnote}
@@ -1291,7 +1291,7 @@ The compilation of the
   The initialization can result in effects such as
   the instantiation of class template specializations and
   function template specializations,
-  the generation of implicitly-defined functions, and so on.
+  the generation of implicitly defined functions, and so on.
   Such effects are not in the ``immediate context'' and
   can result in the program being ill-formed.
   \end{tailnote}
@@ -1358,7 +1358,7 @@ variable initialization is considered.
 The evaluation of the
 initialization can result in side effects such as the instantiation of class
 template specializations and function template specializations, the generation
-of implicitly-defined functions, and so on. Such side effects are not in the
+of implicitly defined functions, and so on. Such side effects are not in the
 ``immediate context'' and can result in the program being ill-formed.
 \end{note}
 
@@ -1642,7 +1642,7 @@ the immediate context of the \grammarterm{expression} of the \tcode{return} stat
 The
 initialization can result in side effects such as the
 instantiation of class template specializations and function template
-specializations, the generation of implicitly-defined functions, and so on. Such
+specializations, the generation of implicitly defined functions, and so on. Such
 side effects are not in the ``immediate context'' and can result in the program
 being ill-formed.
 \end{note}
@@ -2021,7 +2021,7 @@ argument passing.
  \begin{note}
  The compilation of the expression can result in side effects such as
  the instantiation of class template specializations and function
- template specializations, the generation of implicitly-defined
+ template specializations, the generation of implicitly defined
  functions, and so on. Such side effects are not in the ``immediate
  context'' and can result in the program being ill-formed.
  \end{note}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -2277,7 +2277,7 @@ $p(z)$ or $P(z_i)$.
 
 \pnum
 An associated probability function is typically expressed
-using certain externally-supplied quantities
+using certain externally supplied quantities
 known as the \term{parameters of the distribution}.
 Such distribution parameters are identified
 in this context by writing, for example,
@@ -2796,7 +2796,7 @@ A \tcode{mersenne_twister_engine} random number
 engine
 \begin{footnote}
 The name of this engine refers, in part, to a property of its period:
- For properly-selected values of the parameters,
+ For properly selected values of the parameters,
  the period is closely related to a large Mersenne prime number.
 \end{footnote}
 produces unsigned integer random numbers

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -2477,7 +2477,7 @@ Otherwise, if the parameter type is a character array
 Since there are no parameters of array type,
 this will only occur as the referenced type of a reference parameter.
 \end{footnote}
-and the initializer list has a single element that is an appropriately-typed
+and the initializer list has a single element that is an appropriately typed
 \grammarterm{string-literal}\iref{dcl.init.string}, the implicit conversion
 sequence is the identity conversion.
 
@@ -3556,7 +3556,7 @@ void f() {
   *bptr = 99;                   // ditto
   bptr->operator=(dobj2);       // calls \tcode{D::\keyword{operator}=(const B\&)}
   *bptr = dobj2;                // ditto
-  dobj1 = dobj2;                // calls implicitly-declared \tcode{D::\keyword{operator}=(const D\&)}
+  dobj1 = dobj2;                // calls implicitly declared \tcode{D::\keyword{operator}=(const D\&)}
 }
 \end{codeblock}
 \end{example}

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -270,7 +270,7 @@ A sequence of preprocessing tokens is only a \grammarterm{conditionally-supporte
 if it does not begin with any of the directive names
 appearing after a \tcode{\#} in the syntax.
 A \grammarterm{conditionally-supported-directive} is
-conditionally-supported with
+conditionally supported with
 \impldef{additional supported forms of preprocessing directive}
 semantics.
 
@@ -280,7 +280,7 @@ If one of the \grammarterm{pp-tokens} of a \tcode{\#embed} directive
 \tcode{limit}, \tcode{prefix}, \tcode{suffix}, or \tcode{if_empty}
 and that \grammarterm{identifier} is defined
 as a macro\iref{cpp.replace.general}, the program is ill-formed.
-Any \grammarterm{embed-prefixed-parameter} is conditionally-supported,
+Any \grammarterm{embed-prefixed-parameter} is conditionally supported,
 with \impldef{supported forms of \#embed prefix parameters} semantics.
 
 \pnum
@@ -925,7 +925,7 @@ Every resource also has a \defn{resource-count}, which is
 
 \begin{itemize}
 \item
-  the value as computed from the optionally-provided \tcode{limit}
+  the value as computed from the optionally provided \tcode{limit}
   \grammarterm{embed-parameter}\iref{cpp.embed.param.limit}, if present;
 \item
   otherwise, the implementation-resource-count.

--- a/source/support.tex
+++ b/source/support.tex
@@ -299,7 +299,7 @@ accepts a restricted set of \tcode{\placeholder{type}}
 arguments in this document.
 Use of the \tcode{offsetof} macro with a \tcode{\placeholder{type}}
 other than a standard-layout class\iref{class.prop}
-is conditionally-supported.
+is conditionally supported.
 \begin{footnote}
 Note that \tcode{offsetof}
 is required to work as specified even if unary
@@ -3220,7 +3220,7 @@ inline constexpr size_t hardware_destructive_interference_size = @\impdef{}@;
 
 \pnum
 This number is the minimum recommended offset
-between two concurrently-accessed objects
+between two concurrently accessed objects
 to avoid additional performance degradation due to contention
 introduced by the implementation.
 It shall be at least \tcode{alignof(max_align_t)}.

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -427,7 +427,7 @@ in the scope of the template declaration.
 \pnum
 A \grammarterm{type-constraint} \tcode{Q} that designates a concept \tcode{C}
 can be used to constrain a
-contextually-determined type or template type parameter pack \tcode{T}
+contextually determined type or template type parameter pack \tcode{T}
 with a \grammarterm{constraint-expression} \tcode{E} defined as follows.
 If \tcode{Q} is of the form \tcode{C<A$_1$, $\dotsc$, A$_n$>},
 then let \tcode{E$'$} be \tcode{C<T, A$_1$, $\dotsc$, A$_n$>}.
@@ -436,14 +436,14 @@ If \tcode{T} is not a pack,
 then \tcode{E} is \tcode{E$'$},
 otherwise \tcode{E} is \tcode{(E$'$ \&\& ...)}.
 This \grammarterm{constraint-expression} \tcode{E} is called the
-\defnx{immediately-declared constraint}{constraint!immediately-declared}
+\defnx{immediately declared constraint}{constraint!immediately declared}
 of \tcode{Q} for \tcode{T}.
 The concept designated by a \grammarterm{type-constraint}
 shall be a type concept\iref{temp.concept}.
 
 \pnum
 A \grammarterm{type-parameter} that starts with a \grammarterm{type-constraint}
-introduces the immediately-declared constraint
+introduces the immediately declared constraint
 of the \grammarterm{type-constraint} for the parameter.
 \begin{example}
 \begin{codeblock}
@@ -558,7 +558,7 @@ S<v> z;                         // OK due to both adjustment and conversion
 \pnum
 A constant template parameter declared with a type that
 contains a placeholder type with a \grammarterm{type-constraint}
-introduces the immediately-declared constraint
+introduces the immediately declared constraint
 of the \grammarterm{type-constraint}
 for the invented type corresponding to the placeholder\iref{dcl.fct}.
 
@@ -4165,7 +4165,7 @@ template <class T> void spam(decltype([]{}) (*s)[sizeof(T)]);
 \end{codeblock}
 \end{example}
 \indextext{expression!functionally equivalent|see{functionally equivalent, expressions}}%
-Two potentially-evaluated expressions involving template parameters that are not equivalent are
+Two potentially evaluated expressions involving template parameters that are not equivalent are
 \defnx{functionally equivalent}{functionally equivalent!expressions}
 if, for any given set of template arguments, the evaluation of the
 expression results in the same value.
@@ -4346,7 +4346,7 @@ The type $X(M)$ is ``rvalue reference to \cv{}~$A$''
 if the optional \grammarterm{ref-qualifier} of
 $M$ is \tcode{\&\&} or
 if $M$ has no \grammarterm{ref-qualifier} and
-the positionally-corresponding parameter of the other transformed template
+the positionally corresponding parameter of the other transformed template
 has rvalue reference type;
 if this determination depends recursively upon
 whether $X(M)$ is an rvalue reference type,
@@ -5775,7 +5775,7 @@ instantiation and is not initialized in a \grammarterm{member-declarator},
 it names a static member function that is a dependent member of the current
 instantiation, or
 \item
-it names a potentially-constant variable\iref{expr.const}
+it names a potentially constant variable\iref{expr.const}
 that is initialized with an expression that is value-dependent.
 \end{itemize}
 
@@ -6304,7 +6304,7 @@ an inline function,
 declared with a type deduced
 from its initializer or return value\iref{dcl.spec.auto},
 \item
-a potentially-constant variable\iref{expr.const}, or
+a potentially constant variable\iref{expr.const}, or
 \item
 a specialization of a templated class.
 \end{itemize}
@@ -6318,7 +6318,7 @@ from an imported translation unit\iref{basic.link}.
 \indextext{instantiation!template implicit}%
 Unless a class template specialization is a declared specialization,
 the class template specialization is implicitly instantiated when the
-specialization is referenced in a context that requires a completely-defined
+specialization is referenced in a context that requires a completely defined
 object type or when the completeness of the class type affects the semantics
 of the program.
 \begin{note}
@@ -6787,7 +6787,7 @@ of that entity unless an explicit
 specialization of the entity with the same template arguments
 is reachable therefrom.
 If the \grammarterm{declaration}
-of the explicit instantiation names an implicitly-declared special member
+of the explicit instantiation names an implicitly declared special member
 function\iref{special}, the program is ill-formed.
 
 \pnum
@@ -7004,7 +7004,7 @@ in this case, the definition of the class template shall
 be reachable from the explicit specialization for the member of the class
 template.
 If such an explicit specialization for the member of a class template names an
-implicitly-declared special member function\iref{special},
+implicitly declared special member function\iref{special},
 the program is ill-formed.
 
 \pnum
@@ -7137,7 +7137,7 @@ or to make it compile will be such a trial as to kindle its self-immolation.
 A
 \grammarterm{simple-template-id}
 that names a class template explicit specialization that has been declared but
-not defined can be used exactly like the names of other incompletely-defined
+not defined can be used exactly like the names of other incompletely defined
 classes\iref{basic.types}.
 \begin{example}
 \begin{codeblock}
@@ -7651,7 +7651,7 @@ If the constraints are not satisfied, type deduction fails.
 In the context of a function call, if type deduction has not yet failed, then
 for those function parameters for which the function call has arguments,
 each function parameter with a type that was non-dependent
-before substitution of any explicitly-specified template arguments
+before substitution of any explicitly specified template arguments
 is checked against its corresponding argument;
 if the corresponding argument cannot be implicitly converted
 to the parameter type, type deduction fails.
@@ -7660,7 +7660,7 @@ Overload resolution will check the other parameters, including
 parameters with dependent types in which
 no template parameters participate in template argument deduction and
 parameters that became non-dependent due to substitution of
-explicitly-specified template arguments.
+explicitly specified template arguments.
 \end{note}
 If type deduction has not yet failed, then
 all uses of template parameters in the function type are
@@ -7760,7 +7760,7 @@ only in the immediate context of the deduction substitution loci.
 \begin{note}
 The substitution into types and expressions can result
 in effects such as the instantiation of class template specializations and/or
-function template specializations, the generation of implicitly-defined functions,
+function template specializations, the generation of implicitly defined functions,
 etc. Such effects are not in the ``immediate context'' and can result in the
 program being ill-formed.
 \end{note}
@@ -8377,7 +8377,7 @@ any cv-qualifiers of \tcode{A}
 \item
 If the original \tcode{A} is
 a function pointer or pointer-to-member-function type
-with a potentially-throwing exception specification\iref{except.spec},
+with a potentially throwing exception specification\iref{except.spec},
 the exception specification.
 \item
 Any cv-qualifiers in \tcode{A}
@@ -8908,7 +8908,7 @@ a template template parameter, and
 \item
 \tcode{\keyword{noexcept}(\opt{i})} represents an
 exception specification\iref{except.spec}
-in which the (possibly-implicit, see~\ref{dcl.fct})
+in which the (possibly implicit, see~\ref{dcl.fct})
 \grammarterm{noexcept-specifier}'s operand
 satisfies the rules for an \tcode{\opt{i}} above.
 \end{itemize}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -10784,7 +10784,7 @@ promise(promise&& rhs) noexcept;
 \pnum
 \effects
 Transfers ownership of the shared state
-of \tcode{rhs} (if any) to the newly-constructed object.
+of \tcode{rhs} (if any) to the newly constructed object.
 
 \pnum
 \ensures
@@ -12580,7 +12580,7 @@ by invoking its deleter with a pointer to \tcode{x};
 the behavior is undefined if that invocation exits via an exception.
 
 \pnum
-A hazard-protectable object \tcode{x} is \defn{possibly-reclaimable}
+A hazard-protectable object \tcode{x} is \defn{possibly reclaimable}
 with respect to an evaluation $A$ if
 \begin{itemize}
 \item
@@ -12617,7 +12617,7 @@ delays the reclamation of \tcode{x}.
 \end{itemize}
 
 \pnum
-The number of possibly-reclaimable objects has an unspecified bound.
+The number of possibly reclaimable objects has an unspecified bound.
 \begin{note}
 The bound can be a function of the number of hazard pointers,
 the number of threads that retire objects, and
@@ -12727,7 +12727,7 @@ Move-assigning \tcode{d} to \tcode{deleter} does not exit via an exception.
 Move-assigns \tcode{d} to \tcode{deleter},
 thereby setting it as the deleter of \tcode{x},
 then retires \tcode{x}.
-May reclaim possibly-reclaimable objects.
+May reclaim possibly reclaimable objects.
 \end{itemdescr}
 
 \rSec3[saferecl.hp.holder]{Class \tcode{hazard_pointer}}
@@ -12969,7 +12969,7 @@ Constructs a hazard pointer.
 
 \pnum
 \returns
-A \tcode{hazard_pointer} object that owns the newly-constructed hazard pointer.
+A \tcode{hazard_pointer} object that owns the newly constructed hazard pointer.
 
 \pnum
 \throws

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2825,7 +2825,7 @@ Only the validity of the immediate context of the expression is considered.
 \begin{note}
 The compilation of the expression can result in side effects
 such as the instantiation of class template specializations and
-function template specializations, the generation of implicitly-defined functions, and so on.
+function template specializations, the generation of implicitly defined functions, and so on.
 Such side effects are not in the ``immediate context'' and
 can result in the program being ill-formed.
 \end{note}
@@ -6596,7 +6596,7 @@ However, any such small-object optimization shall only be applied to types \tcod
 \tcode{is_nothrow_move_constructible_v<T>} is \tcode{true}.
 \begin{example}
 A contained value of type \tcode{int} could be stored in an internal buffer,
-not in separately-allocated memory.
+not in separately allocated memory.
 \end{example}
 
 \rSec3[any.cons]{Construction and destruction}


### PR DESCRIPTION
Change: remove hyphenation on -ly adverbs in the text (_only_ the text) of the Standard. 

Reason: Most common writing style guides omit hyphenation for -ly adverbs; i.e., an -ly adverb + adjective combination does not create a compound adjective. 

Chicago Manual of Style, 17th ed., 5.93: "(3) A two-word phrasal adjective that begins with an adverb ending in -ly is not hyphenated {a sharply worded reprimand}" 
Chicago Manual of Style, 17th ed., 7.85: "With the exception of proper nouns (such as United States) and compounds formed by an adverb ending in ly plus an adjective, it is never incorrect to hyphenate adjectival compounds before a noun." 

New Oxford Style Manual [Oxford Univ Press, 2016], 3.3.3: "Do not hyphenate adjectival compounds where the first element is an adverb ending in -ly"

New York Times Manual of Style and Usage, 5th ed., hyphen: "Never use a hyphen after an adverb ending in ly"

AP Stylebook, 55th ed., hyphen: "No hyphen is needed to link a two-word phrase that includes the adverb very and all adverbs ending in -ly"