### PR TITLE
[meta.reflection.array] Use "character type" in Mandates

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -3390,12 +3390,7 @@ Let \tcode{CharT} be \tcode{ranges::range_value_t<R>}.
 
 \pnum
 \mandates
-\tcode{CharT} is one of
-\tcode{char},
-\tcode{wchar_t},
-\tcode{char8_t},
-\tcode{char16_t},
-\tcode{char32_t}.
+\tcode{CharT} is a character type\iref{basic.fundamental}.
 
 \pnum
 Let $V$ be the pack of values of type \tcode{CharT}


### PR DESCRIPTION
Following the discussion in https://github.com/cplusplus/draft/pull/8043#discussion_r2205802486

We already have the defined term "character type", and I find it silly not to use it but to enumerate all of its members.

Jonathan stated that there should be a cross-reference (I assume to [basic.fundamental]), which is a good idea.