### PR TITLE
[lex.separate] No more instantiation units

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -43,10 +43,8 @@ A \Cpp{} program need not all be translated at the same time.
 
 \pnum
 \begin{note}
-Previously translated translation units and instantiation
-units can be preserved individually or in libraries. The separate
-translation units of a program communicate\iref{basic.link} by (for
-example)
+Previously translated translation units can be preserved individually or in libraries.
+The separate translation units of a program communicate\iref{basic.link} by (for example)
 calls to functions whose identifiers have external or module linkage,
 manipulation of objects whose identifiers have external or module linkage, or
 manipulation of data files. Translation units can be separately


### PR DESCRIPTION
The term "instantiation unit" was removed by the application of P2996 for reflection, #7930.  This PR removes the last remaining reference from a note.