### PR TITLE
[alg.partitions] Replace hallucinated "copy_assignable" concept with "copyable"

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -8004,7 +8004,7 @@ if the value type of \tcode{ForwardIterator1} does not meet both the
 \oldconcept{CopyConstructible} and \oldconcept{CopyAssignable} requirements.
 For the parallel algorithm overloads in namespace \tcode{ranges},
 there can be a performance cost if \tcode{iter_value_t<I>}
-does not model both \libconcept{copy_constructible} and \tcode{copy_assignable}.
+does not model \libconcept{copyable}.
 \end{note}
 
 \pnum


### PR DESCRIPTION
When reviewing [P3179R9.html](https://wiki.edg.com/pub/Wg21sofia2025/StrawPolls/P3179R9.html), it was discovered that a note mentions a hallucinated `copy_assignable` concept.

https://lists.isocpp.org/lib/2025/07/32289.php reflector discussion here suggested to use `copyable`. This makes sense: `copy_constructible` and the hallucinated `copy_assignable` combined should be `copyable`.