### PR TITLE
Replace some `\textit`

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -5485,7 +5485,7 @@ The same suffix \tcode{s} is used for \tcode{chrono::duration} literals denoting
 #define __STDC_VERSION_STRING_H__ 202311L
 
 namespace std {
-  using size_t = @\textit{see \ref{support.types.layout}}@;                                            // freestanding
+  using size_t = @\placeholder{see \ref{support.types.layout}}@;                                            // freestanding
 
   void* memcpy(void* s1, const void* s2, size_t n);                     // freestanding
   void* memccpy(void* s1, const void* s2, int c, size_t n);             // freestanding
@@ -5520,7 +5520,7 @@ namespace std {
   size_t strlen(const char* s);                                         // freestanding
 }
 
-#define NULL @\textit{see \ref{support.types.nullptr}}@                                                // freestanding
+#define NULL @\placeholder{see \ref{support.types.nullptr}}@                                                // freestanding
 \end{codeblock}
 
 \pnum

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -5034,14 +5034,14 @@ Characters are extracted and appended until any of the following
 occurs:
 \begin{itemize}
 \item
-\textit{n}
+\tcode{n}
 characters are stored;
 \item
 end-of-file occurs on the input sequence;
 \item
 \tcode{isspace(c, is.getloc())}
 is \tcode{true} for the next available input character
-\textit{c}.
+\tcode{c}.
 \end{itemize}
 
 \pnum
@@ -5109,9 +5109,9 @@ end-of-file occurs on the input sequence;
 \item
 \tcode{traits::eq(c, delim)}
 for the next available input character
-\textit{c}
+\tcode{c}
 (in which case,
-\textit{c}
+\tcode{c}
 is extracted but not appended);
 \item
 \tcode{str.max_size()}

--- a/source/support.tex
+++ b/source/support.tex
@@ -1712,9 +1712,9 @@ namespace std {
     static constexpr bool has_quiet_NaN     = true;
     static constexpr bool has_signaling_NaN = true;
 
-    static constexpr float infinity()      noexcept { return @\textit{value}@; }
-    static constexpr float quiet_NaN()     noexcept { return @\textit{value}@; }
-    static constexpr float signaling_NaN() noexcept { return @\textit{value}@; }
+    static constexpr float infinity()      noexcept { return @\placeholder{value}@; }
+    static constexpr float quiet_NaN()     noexcept { return @\placeholder{value}@; }
+    static constexpr float signaling_NaN() noexcept { return @\placeholder{value}@; }
     static constexpr float denorm_min()    noexcept { return min(); }
 
     static constexpr bool is_iec559  = true;

--- a/source/support.tex
+++ b/source/support.tex
@@ -1956,47 +1956,47 @@ macros that specify limits of integer types.
 #define __STDC_VERSION_STDINT_H__ 202311L
 
 namespace std {
-  using int8_t         = @\textit{signed integer type}@;   // optional
-  using int16_t        = @\textit{signed integer type}@;   // optional
-  using int32_t        = @\textit{signed integer type}@;   // optional
-  using int64_t        = @\textit{signed integer type}@;   // optional
+  using int8_t         = @\placeholdernc{signed integer type}@;   // optional
+  using int16_t        = @\placeholdernc{signed integer type}@;   // optional
+  using int32_t        = @\placeholdernc{signed integer type}@;   // optional
+  using int64_t        = @\placeholdernc{signed integer type}@;   // optional
   using int@\placeholdernc{N}@_t         = @\seebelow@;             // optional
 
-  using int_fast8_t    = @\textit{signed integer type}@;
-  using int_fast16_t   = @\textit{signed integer type}@;
-  using int_fast32_t   = @\textit{signed integer type}@;
-  using int_fast64_t   = @\textit{signed integer type}@;
+  using int_fast8_t    = @\placeholdernc{signed integer type}@;
+  using int_fast16_t   = @\placeholdernc{signed integer type}@;
+  using int_fast32_t   = @\placeholdernc{signed integer type}@;
+  using int_fast64_t   = @\placeholdernc{signed integer type}@;
   using int_fast@\placeholdernc{N}@_t    = @\seebelow@;             // optional
 
-  using int_least8_t   = @\textit{signed integer type}@;
-  using int_least16_t  = @\textit{signed integer type}@;
-  using int_least32_t  = @\textit{signed integer type}@;
-  using int_least64_t  = @\textit{signed integer type}@;
+  using int_least8_t   = @\placeholdernc{signed integer type}@;
+  using int_least16_t  = @\placeholdernc{signed integer type}@;
+  using int_least32_t  = @\placeholdernc{signed integer type}@;
+  using int_least64_t  = @\placeholdernc{signed integer type}@;
   using int_least@\placeholdernc{N}@_t   = @\seebelow@;             // optional
 
-  using intmax_t       = @\textit{signed integer type}@;
-  using intptr_t       = @\textit{signed integer type}@;   // optional
+  using intmax_t       = @\placeholdernc{signed integer type}@;
+  using intptr_t       = @\placeholdernc{signed integer type}@;   // optional
 
-  using uint8_t        = @\textit{unsigned integer type}@; // optional
-  using uint16_t       = @\textit{unsigned integer type}@; // optional
-  using uint32_t       = @\textit{unsigned integer type}@; // optional
-  using uint64_t       = @\textit{unsigned integer type}@; // optional
+  using uint8_t        = @\placeholdernc{unsigned integer type}@; // optional
+  using uint16_t       = @\placeholdernc{unsigned integer type}@; // optional
+  using uint32_t       = @\placeholdernc{unsigned integer type}@; // optional
+  using uint64_t       = @\placeholdernc{unsigned integer type}@; // optional
   using uint@\placeholdernc{N}@_t        = @\seebelow@;             // optional
 
-  using uint_fast8_t   = @\textit{unsigned integer type}@;
-  using uint_fast16_t  = @\textit{unsigned integer type}@;
-  using uint_fast32_t  = @\textit{unsigned integer type}@;
-  using uint_fast64_t  = @\textit{unsigned integer type}@;
+  using uint_fast8_t   = @\placeholdernc{unsigned integer type}@;
+  using uint_fast16_t  = @\placeholdernc{unsigned integer type}@;
+  using uint_fast32_t  = @\placeholdernc{unsigned integer type}@;
+  using uint_fast64_t  = @\placeholdernc{unsigned integer type}@;
   using uint_fast@\placeholdernc{N}@_t   = @\seebelow@;             // optional
 
-  using uint_least8_t  = @\textit{unsigned integer type}@;
-  using uint_least16_t = @\textit{unsigned integer type}@;
-  using uint_least32_t = @\textit{unsigned integer type}@;
-  using uint_least64_t = @\textit{unsigned integer type}@;
+  using uint_least8_t  = @\placeholdernc{unsigned integer type}@;
+  using uint_least16_t = @\placeholdernc{unsigned integer type}@;
+  using uint_least32_t = @\placeholdernc{unsigned integer type}@;
+  using uint_least64_t = @\placeholdernc{unsigned integer type}@;
   using uint_least@\placeholdernc{N}@_t  = @\seebelow@;             // optional
 
-  using uintmax_t      = @\textit{unsigned integer type}@;
-  using uintptr_t      = @\textit{unsigned integer type}@; // optional
+  using uintmax_t      = @\placeholdernc{unsigned integer type}@;
+  using uintptr_t      = @\placeholdernc{unsigned integer type}@; // optional
 }
 
 #define INT@\placeholdernc{N}@_MIN          @\seebelow@

--- a/source/text.tex
+++ b/source/text.tex
@@ -4908,7 +4908,7 @@ namespace std {
   lconv* localeconv();
 }
 
-#define @\libmacro{NULL}@ @\textit{see \ref{support.types.nullptr}}@
+#define @\libmacro{NULL}@ @\placeholder{see \ref{support.types.nullptr}}@
 #define @\libmacro{LC_ALL}@ @\seebelow@
 #define @\libmacro{LC_COLLATE}@ @\seebelow@
 #define @\libmacro{LC_CTYPE}@ @\seebelow@
@@ -13160,7 +13160,7 @@ are the same as the C standard library header \libheader{wctype.h}.
 #define __STDC_VERSION_WCHAR_H__ 202311L
 
 namespace std {
-  using size_t = @\textit{see \ref{support.types.layout}}@;                                             // freestanding
+  using size_t = @\placeholder{see \ref{support.types.layout}}@;                                             // freestanding
   using mbstate_t = @\seebelow@;                                          // freestanding
   using wint_t = @\seebelow@;                                             // freestanding
 
@@ -13234,7 +13234,7 @@ namespace std {
   size_t wcsrtombs(char* dst, const wchar_t** src, size_t len, mbstate_t* ps);
 }
 
-#define @\libmacro{NULL}@ @\textit{see \ref{support.types.nullptr}}@                                                  // freestanding
+#define @\libmacro{NULL}@ @\placeholder{see \ref{support.types.nullptr}}@                                                  // freestanding
 #define @\libmacro{WCHAR_MAX}@ @\seebelow@                                             // freestanding
 #define @\libmacro{WCHAR_MIN}@ @\seebelow@                                             // freestanding
 #define @\libmacro{WEOF}@ @\seebelow@                                                  // freestanding
@@ -13271,7 +13271,7 @@ but they have the same behavior as in the C standard library\iref{library.c}.
 
 namespace std {
   using mbstate_t = @\seebelow@;
-  using size_t = @\textit{see \ref{support.types.layout}}@;
+  using size_t = @\placeholder{see \ref{support.types.layout}}@;
 
   size_t mbrtoc8(char8_t* pc8, const char* s, size_t n, mbstate_t* ps);
   size_t c8rtomb(char* s, char8_t c8, mbstate_t* ps);


### PR DESCRIPTION
Related to https://github.com/cplusplus/draft/issues/2076

I'm not sure if it's worth dismantling all uses of `\textit`. There are ~150 left. This is just picking some low-hanging fruits in wording that might still be visited from time to time.