### PR TITLE
Fix typo in [meta.reflection.access.context]/5.5.2

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -5097,7 +5097,7 @@ let \tcode{\exposid{eval-point}($P$)} be the following program point:
     \item
       a block scope or
     \item
-      a function parameter scope or lambda or lambda scope
+      a function parameter scope or lambda scope
       introduced by a \grammarterm{consteval-block-declaration}.
     \end{itemize}
   \item


### PR DESCRIPTION
Typo was introduced during transcription to Latex (see draft approved in Sofia [here](https://wiki.edg.com/pub/Wg21sofia2025/CoreWorkingGroup/p2996r13.html#pnum_629)).