### PR TITLE
[checks] Add check for "constexpr friend"

### DIFF
--- a/tools/check-source.sh
+++ b/tools/check-source.sh
@@ -139,6 +139,10 @@ grep -ne '\bexplicit\b.*\bconstexpr\b' $texlib |
 grep -ne '\bconstexpr\b.*\sstatic\s' $texlib |
     fail 'constexpr static' || failed=1
 
+# In library declarations, friend should not follow constexpr
+grep -ne '\bconstexpr\b.*\sfriend\s' $texlib |
+    fail 'constexpr friend' || failed=1
+
 # "Class" heading without namespace
 for f in $texlib; do
     sed -n '/rSec[0-9].*{Class/,/\\end{codeblock}/{/\\begin{example}/,/\\end{example}/b;/\\begin{codeblock}/,/\(^namespace\)\|\(\\end{codeblock}\)/{s/template<[^>]*>//;/\(class\|struct\)[A-Za-z0-9_: ]*{/{=;p;};};}' $f |


### PR DESCRIPTION
After merging #8053, it seems like there are no more occurrences of `constexpr friend`; the correct order is `friend constexpr`.

We can add a check to ensure this mistake it won't be reintroduced.