### PR TITLE
[range.adaptor.object][range.adaptor.object] Index special kinds of function objects and their related `operator|`

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -3098,6 +3098,7 @@ the \tcode{exception_ptr} error completion signature from the set.
 
 \rSec3[exec.adapt.obj]{Closure objects}
 
+\indexlibrarymisc{\idxcode{operator|}}{pipeable sender adaptor closure objects}%
 \pnum
 A \defnadj{pipeable}{sender adaptor closure object} is a function object
 that accepts one or more \libconcept{sender} arguments and returns a \libconcept{sender}.

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -860,7 +860,7 @@ is an \ntmbs{} with static storage duration.
 \rSec4[customization.point.object]{Customization Point Object types}
 
 \pnum
-A \term{customization point object} is a function object\iref{function.objects}
+A \defn{customization point object} is a function object\iref{function.objects}
 with a literal class type that interacts with program-defined types while
 enforcing semantic requirements on that interaction.
 

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -4211,6 +4211,7 @@ assert(ranges::equal(ints | views::filter(even), views::filter(ints, even)));
 
 \rSec2[range.adaptor.object]{Range adaptor objects}
 
+\indexlibrarymisc{\idxcode{operator|}}{range adaptor closure objects}%
 \pnum
 A \defn{range adaptor closure object} is a unary function object that accepts
 a range argument. For

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -4212,7 +4212,7 @@ assert(ranges::equal(ints | views::filter(even), views::filter(ints, even)));
 \rSec2[range.adaptor.object]{Range adaptor objects}
 
 \pnum
-A \term{range adaptor closure object} is a unary function object that accepts
+A \defn{range adaptor closure object} is a unary function object that accepts
 a range argument. For
 a range adaptor closure object \tcode{C} and an expression \tcode{R} such that
 \tcode{decltype((R))} models \libconcept{range}, the following
@@ -4279,7 +4279,7 @@ The behavior of a program
 that adds a specialization for \tcode{range_adaptor_closure} is undefined.
 
 \pnum
-A \term{range adaptor object} is a
+A \defn{range adaptor object} is a
 customization point object\iref{customization.point.object}
 that accepts a \libconcept{viewable_range} as its first argument and returns a view.
 


### PR DESCRIPTION
As drive-by, also change `\term` to `\defn` in [customization.point.object] to index "customization point object".

Fixes #8052.