### PR TITLE
[simd.syn] Fix various formatting issues, improve aesthetics

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -16515,7 +16515,7 @@ namespace std::simd {
   template<@\exposid{simd-size-type}@ N, class V> struct resize { using type = @\seebelow@; };
   template<@\exposid{simd-size-type}@ N, class V> using @\libmember{resize_t}{simd}@ = typename resize<N, V>::type;
 
-  // \ref{simd.flags}, Load and store flags
+  // \ref{simd.flags}, load and store flags
   template<class... Flags> struct flags;
   inline constexpr flags<> @\libmember{flag_default}{simd}@{};
   inline constexpr flags<@\exposid{convert-flag}@> @\libmember{flag_convert}{simd}@{};
@@ -16523,16 +16523,16 @@ namespace std::simd {
   template<size_t N> requires (has_single_bit(N))
     constexpr flags<@\exposid{overaligned-flag}<N>@> @\libmember{flag_overaligned}{simd}@{};
 
-  // \ref{simd.iterator}, Class template \exposid{simd-iterator}
+  // \ref{simd.iterator}, class template \exposid{simd-iterator}
   template<class V>
     class @\exposidnc{simd-iterator}@;                // \expos
 
-  // \ref{simd.class}, Class template \tcode{basic_vec}
+  // \ref{simd.class}, class template \tcode{basic_vec}
   template<class T, class Abi = @\exposid{native-abi}@<T>> class basic_vec;
   template<class T, @\exposid{simd-size-type}@ N = @\exposid{simd-size-v}@<T, @\exposid{native-abi}@<T>>>
     using @\libmember{vec}{simd}@ = basic_vec<T, @\exposid{deduce-abi-t}@<T, N>>;
 
-  // \ref{simd.mask.class}, Class template \tcode{basic_mask}
+  // \ref{simd.mask.class}, class template \tcode{basic_mask}
   template<size_t Bytes, class Abi = @\exposid{native-abi}@<@\exposid{integer-from}@<Bytes>>> class basic_mask;
   template<class T, @\exposid{simd-size-type}@ N = @\exposid{simd-size-v}@<T, @\exposid{native-abi}@<T>>>
     using @\libmember{mask}{simd}@ = basic_mask<sizeof(T), @\exposid{deduce-abi-t}@<T, N>>;
@@ -16627,7 +16627,7 @@ namespace std::simd {
     constexpr void partial_store(const basic_vec<T, Abi>& v, I first, S last,
       const typename basic_vec<T, Abi>::mask_type& mask, flags<Flags...> f = {});
 
-  // \ref{simd.permute.static}, Permute by static index generator
+  // \ref{simd.permute.static}, permute by static index generator
   static constexpr @\exposid{simd-size-type}@ @\libmember{zero_element}{simd}@   = @\impdefx{value of \tcode{simd::zero_element}}@;
   static constexpr @\exposid{simd-size-type}@ @\libmember{uninit_element}{simd}@ = @\impdefx{value of \tcode{simd::uninit_element}}@;
 
@@ -16636,13 +16636,13 @@ namespace std::simd {
   template<@\exposid{simd-size-type}@ N = @\seebelow@, @\exposconcept{simd-mask-type}@ M, class IdxMap>
     constexpr resize_t<N, M> permute(const M& v, IdxMap&& idxmap);
 
-  // \ref{simd.permute.dynamic}, Permute by dynamic index
+  // \ref{simd.permute.dynamic}, permute by dynamic index
   template<@\exposconcept{simd-vec-type}@ V, @\exposconcept{simd-integral}@ I>
     constexpr resize_t<I::size(), V> permute(const V& v, const I& indices);
   template<@\exposconcept{simd-mask-type}@ M, @\exposconcept{simd-integral}@ I>
     constexpr resize_t<I::size(), M> permute(const M& v, const I& indices);
 
-  // \ref{simd.permute.mask}, Permute by active mask bits
+  // \ref{simd.permute.mask}, permute by active mask bits
   template<@\exposconcept{simd-vec-type}@ V>
     constexpr V compress(const V& v, const typename V::mask_type& selector);
   template<@\exposconcept{simd-mask-type}@ M>
@@ -16661,7 +16661,7 @@ namespace std::simd {
     constexpr M expand(const M& v, const type_identity_t<M>& selector,
                        const M& original = {});
 
-  // \ref{simd.permute.memory}, Permute to and from memory
+  // \ref{simd.permute.memory}, permute to and from memory
   template<class V = @\seebelow@,
            ranges::@\libconcept{contiguous_range}@ R, @\exposconcept{simd-integral}@ I, class... Flags>
     requires ranges::@\libconcept{sized_range}@<R>
@@ -16769,7 +16769,7 @@ namespace std::simd {
     constexpr T reduce_max(const basic_vec<T, Abi>&,
                            const typename basic_vec<T, Abi>::mask_type&) noexcept;
 
-  // \ref{simd.alg}, Algorithms
+  // \ref{simd.alg}, algorithms
   template<class T, class Abi>
     constexpr basic_vec<T, Abi>
       min(const basic_vec<T, Abi>& a, const basic_vec<T, Abi>& b) noexcept;
@@ -16791,7 +16791,7 @@ namespace std::simd {
     constexpr auto select(const basic_mask<Bytes, Abi>& c, const T& a, const U& b)
     noexcept -> decltype(@\exposid{simd-select-impl}@(c, a, b));
 
-  // \ref{simd.math}, Mathematical functions
+  // \ref{simd.math}, mathematical functions
   template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> acos(const V& x);
   template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> asin(const V& x);
   template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> atan(const V& x);
@@ -16814,18 +16814,18 @@ namespace std::simd {
       frexp(const V& value, rebind_t<int, @\exposid{deduced-vec-t}@<V>>* exp);
   template<@\exposconcept{math-floating-point}@ V>
     constexpr rebind_t<int, @\exposid{deduced-vec-t}@<V>> ilogb(const V& x);
-  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> ldexp(const V& x, const
-  rebind_t<int, @\exposid{deduced-vec-t}@<V>>& exp);
+  template<@\exposconcept{math-floating-point}@ V>
+    constexpr @\exposid{deduced-vec-t}@<V> ldexp(const V& x, const rebind_t<int, @\exposid{deduced-vec-t}@<V>>& exp);
   template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> log(const V& x);
   template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> log10(const V& x);
   template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> log1p(const V& x);
   template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> log2(const V& x);
   template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> logb(const V& x);
   template<class T, class Abi>
-    constexpr basic_vec<T, Abi> modf(const type_identity_t<basic_vec<T, Abi>>& value,
-                                      basic_vec<T, Abi>* iptr);
-  template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> scalbn(const V& x, const
-  rebind_t<int, @\exposid{deduced-vec-t}@<V>>& n);
+    constexpr basic_vec<T, Abi>
+      modf(const type_identity_t<basic_vec<T, Abi>>& value, basic_vec<T, Abi>* iptr);
+  template<@\exposconcept{math-floating-point}@ V>
+    constexpr @\exposid{deduced-vec-t}@<V> scalbn(const V& x, const rebind_t<int, @\exposid{deduced-vec-t}@<V>>& n);
   template<@\exposconcept{math-floating-point}@ V>
     constexpr @\exposid{deduced-vec-t}@<V> scalbln(
       const V& x, const rebind_t<long int, @\exposid{deduced-vec-t}@<V>>& n);
@@ -16882,7 +16882,7 @@ namespace std::simd {
     constexpr @\exposid{math-common-simd-t}@<V0, V1, V2> fma(const V0& x, const V1& y, const V2& z);
   template<class V0, class V1, class V2>
     constexpr @\exposid{math-common-simd-t}@<V0, V1, V2>
-    lerp(const V0& a, const V1& b, const V2& t) noexcept;
+      lerp(const V0& a, const V1& b, const V2& t) noexcept;
   template<@\exposconcept{math-floating-point}@ V>
     constexpr rebind_t<int, @\exposid{deduced-vec-t}@<V>> fpclassify(const V& x);
   template<@\exposconcept{math-floating-point}@ V>
@@ -16914,13 +16914,11 @@ namespace std::simd {
     constexpr typename @\exposid{math-common-simd-t}@<V0, V1>::mask_type
       isunordered(const V0& x, const V1& y);
   template<@\exposconcept{math-floating-point}@ V>
-    @\exposid{deduced-vec-t}@<V> assoc_laguerre(const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& n, const
-      rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& m,
-                     const V& x);
+    @\exposid{deduced-vec-t}@<V> assoc_laguerre(const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& n,
+                                    const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& m, const V& x);
   template<@\exposconcept{math-floating-point}@ V>
-    @\exposid{deduced-vec-t}@<V> assoc_legendre(const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& l, const
-      rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& m,
-                     const V& x);
+    @\exposid{deduced-vec-t}@<V> assoc_legendre(const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& l,
+                                    const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& m, const V& x);
   template<class V0, class V1>
     @\exposid{math-common-simd-t}@<V0, V1> beta(const V0& x, const V1& y);
   template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-vec-t}@<V> comp_ellint_1(const V& k);
@@ -16960,7 +16958,7 @@ namespace std::simd {
     @\exposid{deduced-vec-t}@<V>
       sph_neumann(const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& n, const V& x);
 
-  // \ref{simd.bit}, Bit manipulation
+  // \ref{simd.bit}, bit manipulation
   template<@\exposconcept{simd-vec-type}@ V> constexpr V byteswap(const V& v) noexcept;
   template<@\exposconcept{simd-vec-type}@ V> constexpr V bit_ceil(const V& v) noexcept;
   template<@\exposconcept{simd-vec-type}@ V> constexpr V bit_floor(const V& v) noexcept;
@@ -16979,21 +16977,25 @@ namespace std::simd {
     constexpr V  rotr(const V& v, int s) noexcept;
 
   template<@\exposconcept{simd-vec-type}@ V>
-    constexpr rebind_t<make_signed_t<typename V::value_type>, V> bit_width(const V& v) noexcept;
+    constexpr rebind_t<make_signed_t<typename V::value_type>, V>
+      bit_width(const V& v) noexcept;
   template<@\exposconcept{simd-vec-type}@ V>
     constexpr rebind_t<make_signed_t<typename V::value_type>, V>
-    countl_zero(const V& v) noexcept;
-  template<@\exposconcept{simd-vec-type}@ V>
-    constexpr rebind_t<make_signed_t<typename V::value_type>, V> countl_one(const V& v) noexcept;
+      countl_zero(const V& v) noexcept;
   template<@\exposconcept{simd-vec-type}@ V>
     constexpr rebind_t<make_signed_t<typename V::value_type>, V>
-    countr_zero(const V& v) noexcept;
+      countl_one(const V& v) noexcept;
   template<@\exposconcept{simd-vec-type}@ V>
-    constexpr rebind_t<make_signed_t<typename V::value_type>, V> countr_one(const V& v) noexcept;
+    constexpr rebind_t<make_signed_t<typename V::value_type>, V>
+      countr_zero(const V& v) noexcept;
   template<@\exposconcept{simd-vec-type}@ V>
-    constexpr rebind_t<make_signed_t<typename V::value_type>, V> popcount(const V& v) noexcept;
+    constexpr rebind_t<make_signed_t<typename V::value_type>, V>
+      countr_one(const V& v) noexcept;
+  template<@\exposconcept{simd-vec-type}@ V>
+    constexpr rebind_t<make_signed_t<typename V::value_type>, V>
+      popcount(const V& v) noexcept;
 
-  // \ref{simd.complex.math}, vec complex math
+  // \ref{simd.complex.math}, \tcode{vec} complex math
   template<@\exposconcept{simd-complex}@ V>
     constexpr rebind_t<@\exposid{simd-complex-value-type<V>}@, V> real(const V&) noexcept;
 
@@ -17036,13 +17038,13 @@ namespace std::simd {
 }
 
 namespace std {
-  // See \ref{simd.alg}, Algorithms
+  // See \ref{simd.alg}, algorithms
   using simd::min;
   using simd::max;
   using simd::minmax;
   using simd::clamp;
 
-  // See \ref{simd.math}, Mathematical functions
+  // See \ref{simd.math}, mathematical functions
   using simd::acos;
   using simd::asin;
   using simd::atan;
@@ -17135,7 +17137,7 @@ namespace std {
   using simd::sph_legendre;
   using simd::sph_neumann;
 
-  // See \ref{simd.bit}, Bit manipulation
+  // See \ref{simd.bit}, bit manipulation
   using simd::byteswap;
   using simd::bit_ceil;
   using simd::bit_floor;
@@ -17149,7 +17151,7 @@ namespace std {
   using simd::countr_one;
   using simd::popcount;
 
-  // See \ref{simd.complex.math}, vec complex math
+  // See \ref{simd.complex.math}, \tcode{vec} complex math
   using simd::real;
   using simd::imag;
   using simd::arg;


### PR DESCRIPTION
Closes #8031.

This PR fixes a number of problems (some objective, some aesthetic) in [simd.syn]:
- Comments with references to subsequent sections should not capitalize the section name
- `vec` should be `\tcode{vec}`
- The two-space indentation in some places was missing
- Some code just needs to be reflown because parameters are misaligned and other things are broken

Aesthetics are also improved a bit. While it's not objectively wrong to do so, putting `countl_one` on one line and `countl_zero` onto two because of a single-character difference is ugly. It substantially improves aesthetics if we make it a bit more consistent.