### PR TITLE
[unique.ptr.runtime.general] Replace "see below" with "see above" for "using pointer"

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -2905,7 +2905,7 @@ deleters of \tcode{*this} and \tcode{u}.
 namespace std {
   template<class T, class D> class unique_ptr<T[], D> {
   public:
-    using pointer      = @\seebelow@;
+    using pointer      = @\UNSP{see above}@;
     using element_type = T;
     using deleter_type = D;
 


### PR DESCRIPTION
Fixes #585.