### PR TITLE
[basic.link] Fix cross-reference to translation unit

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2876,7 +2876,7 @@ consteval int bad_splice(std::meta::info v) {
 \pnum
 \indextext{program}%
 \indextext{linking}%
-A \defn{program} consists of one or more translation units\iref{lex.separate}
+A \defn{program} consists of one or more translation units\iref{lex.phases}
 linked together. A translation unit consists
 of a sequence of declarations.
 


### PR DESCRIPTION
Tranalation units are defined in phase 7 of translation, [lex.phases] not [lex.separate].