### PR TITLE
[cpp.pragma.op] Colocate the two pragma specifications

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -2161,6 +2161,43 @@ The behavior may cause translation to fail or cause the translator or
 the resulting program to behave in a non-conforming manner.
 Any pragma that is not recognized by the implementation is ignored.
 
+\rSec1[cpp.pragma.op]{Pragma operator}%
+\indextext{macro!pragma operator}%
+\indextext{operator!pragma|see{macro, pragma operator}}
+
+\pnum
+A unary operator expression of the form:
+\begin{ncbnf}
+\terminal{_Pragma} \terminal{(} string-literal \terminal{)}
+\end{ncbnf}
+is processed as follows: The \grammarterm{string-literal} is \defnx{destringized}{destringization}
+by deleting the \tcode{L} prefix, if present, deleting the leading and trailing
+double-quotes, replacing each escape sequence \tcode{\textbackslash"} by a double-quote, and
+replacing each escape sequence \tcode{\textbackslash\textbackslash} by a single
+backslash. The resulting sequence of characters is processed through translation phase 3
+to produce preprocessing tokens that are executed as if they were the
+\grammarterm{pp-tokens} in a pragma directive. The original four preprocessing
+tokens in the unary operator expression are removed.
+
+\pnum
+\begin{example}
+\begin{codeblock}
+#pragma listing on "..\listing.dir"
+\end{codeblock}
+can also be expressed as:
+\begin{codeblock}
+_Pragma ( "listing on \"..\\listing.dir\"" )
+\end{codeblock}
+The latter form is processed in the same way whether it appears literally
+as shown, or results from macro replacement, as in:
+\begin{codeblock}
+#define LISTING(x) PRAGMA(listing on #x)
+#define PRAGMA(x) _Pragma(#x)
+
+LISTING( ..\listing.dir )
+\end{codeblock}
+\end{example}
+
 \rSec1[cpp.null]{Null directive}%
 \indextext{preprocessing directive!null}
 
@@ -2469,41 +2506,4 @@ the program is ill-formed.
 Any other predefined macro names shall begin with a
 leading underscore followed by an uppercase letter or a second
 underscore.
-
-\rSec1[cpp.pragma.op]{Pragma operator}%
-\indextext{macro!pragma operator}%
-\indextext{operator!pragma|see{macro, pragma operator}}
-
-\pnum
-A unary operator expression of the form:
-\begin{ncbnf}
-\terminal{_Pragma} \terminal{(} string-literal \terminal{)}
-\end{ncbnf}
-is processed as follows: The \grammarterm{string-literal} is \defnx{destringized}{destringization}
-by deleting the \tcode{L} prefix, if present, deleting the leading and trailing
-double-quotes, replacing each escape sequence \tcode{\textbackslash"} by a double-quote, and
-replacing each escape sequence \tcode{\textbackslash\textbackslash} by a single
-backslash. The resulting sequence of characters is processed through translation phase 3
-to produce preprocessing tokens that are executed as if they were the
-\grammarterm{pp-tokens} in a pragma directive. The original four preprocessing
-tokens in the unary operator expression are removed.
-
-\pnum
-\begin{example}
-\begin{codeblock}
-#pragma listing on "..\listing.dir"
-\end{codeblock}
-can also be expressed as:
-\begin{codeblock}
-_Pragma ( "listing on \"..\\listing.dir\"" )
-\end{codeblock}
-The latter form is processed in the same way whether it appears literally
-as shown, or results from macro replacement, as in:
-\begin{codeblock}
-#define LISTING(x) PRAGMA(listing on #x)
-#define PRAGMA(x) _Pragma(#x)
-
-LISTING( ..\listing.dir )
-\end{codeblock}
-\end{example}
 \indextext{preprocessing directive|)}


### PR DESCRIPTION
Moves the specification for the `_Pragma` operator to follow the specification for the `pragma` directive, to provide clearer context.