### PR TITLE
[cpp.error] Recommended practice should start it own paragraph

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -2142,6 +2142,8 @@ A preprocessing directive of the form
 \end{ncsimplebnf}
 requires the implementation to produce at least one diagnostic message
 for the preprocessing translation unit\iref{intro.compliance.general}.
+
+\pnum
 \recommended
 Any diagnostic message caused by either of these directives
 should include the specified sequence of preprocessing tokens.


### PR DESCRIPTION
Recommended practices always start a new paragraph.  It is optional whether they have their own paragraph number, but that looks better in this case.