### PR TITLE
[linalg.conj.conjugatedaccessor] Fix incorrect return type of `nested_accessor`

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -12802,7 +12802,7 @@ namespace std::linalg {
     constexpr typename offset_policy::data_handle_type
       offset(data_handle_type p, size_t i) const;
 
-    constexpr const Accessor& nested_accessor() const noexcept { return @\exposid{nested-accessor_}@; }
+    constexpr const NestedAccessor& nested_accessor() const noexcept { return @\exposid{nested-accessor_}@; }
 
   private:
     NestedAccessor @\exposid{nested-accessor_}@{};                           // \expos


### PR DESCRIPTION
One part of #7214.

As @mhoemmen explains:

> ## Fix return type of nested_accessor member function
> 
> The `nested_accessor` member function of `conjugated_accessor` (which is defined inline in the class' synopsis) currently returns `const Accessor&`. This is incorrect, because there is no `Accessor` type in scope.
> 
> The intent is for the function to return `const NestedAccessor&`. As main author of this proposal, this is the intent. At some point in revisions, the template parameter was renamed from `Accessor` to `NestedAccessor`. It's likely that we missed changing the return type of `nested_accessor`.

@jwakely does this need an LWG issue or can we "just fix this"?