### PR TITLE
[linalg.conj.conjugatedaccessor] Fix constructor missing from synopsis, typos

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -12793,8 +12793,9 @@ namespace std::linalg {
     using offset_policy = conjugated_accessor<NestedAccessor::offset_policy>;
 
     constexpr conjugated_accessor() = default;
+    constexpr conjugated_accessor(const NestedAccessor& acc);
     template<class OtherNestedAccessor>
-      explicit(!is_convertible_v<OtherNestedAccessor, NestedAccessor>>)
+      explicit(!is_convertible_v<OtherNestedAccessor, NestedAccessor>)
       constexpr conjugated_accessor(const conjugated_accessor<OtherNestedAccessor>& other);
 
     constexpr reference access(data_handle_type p, size_t i) const;
@@ -12838,7 +12839,7 @@ Direct-non-list-initializes
 \indexlibraryctor{conjugated_accessor}%
 \begin{itemdecl}
 template<class OtherNestedAccessor>
-  explicit(!is_convertible_v<OtherNestedAccessor, NestedAccessor>>)
+  explicit(!is_convertible_v<OtherNestedAccessor, NestedAccessor>)
     constexpr conjugated_accessor(const conjugated_accessor<OtherNestedAccessor>& other);
 \end{itemdecl}
 


### PR DESCRIPTION
Part of #7214.

- `constexpr conjugated_accessor(const NestedAccessor& acc);` is defined below, but is missing from the synopsis
- there is a typo in two places: `is_convertible_v<...>>`