### PR TITLE
[strings] Consistently spell return types and types of data members

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -665,7 +665,7 @@ Because \tcode{basic_string_view} refers to a constant sequence, \tcode{iterator
     constexpr const_reference at(size_type pos) const;                  // freestanding-deleted
     constexpr const_reference front() const;
     constexpr const_reference back() const;
-    constexpr const_pointer data() const noexcept;
+    constexpr const charT* data() const noexcept;
 
     // \ref{string.view.modifiers}, modifiers
     constexpr void remove_prefix(size_type n);
@@ -734,7 +734,7 @@ Because \tcode{basic_string_view} refers to a constant sequence, \tcode{iterator
     constexpr size_type find_last_not_of(const charT* s, size_type pos = npos) const;
 
   private:
-    const_pointer @\exposid{data_}@;        // \expos
+    const charT* @\exposid{data_}@;         // \expos
     size_type @\exposid{size_}@;            // \expos
   };
 
@@ -1110,7 +1110,7 @@ Nothing.
 
 \indexlibrarymember{data}{basic_string_view}%
 \begin{itemdecl}
-constexpr const_pointer data() const noexcept;
+constexpr const charT* data() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2131,10 +2131,10 @@ namespace std {
     constexpr const_reference at(size_type n) const;
     constexpr reference       at(size_type n);
 
-    constexpr const charT& front() const;
-    constexpr charT&       front();
-    constexpr const charT& back() const;
-    constexpr charT&       back();
+    constexpr const_reference front() const;
+    constexpr reference       front();
+    constexpr const_reference back() const;
+    constexpr reference       back();
 
     // \ref{string.modifiers}, modifiers
     constexpr basic_string& operator+=(const basic_string& str);
@@ -2238,7 +2238,7 @@ namespace std {
     // \ref{string.ops}, string operations
     constexpr const charT* c_str() const noexcept;
     constexpr const charT* data() const noexcept;
-    constexpr charT* data() noexcept;
+    constexpr       charT* data() noexcept;
     constexpr operator basic_string_view<charT, traits>() const noexcept;
     constexpr allocator_type get_allocator() const noexcept;
 
@@ -3135,8 +3135,8 @@ if
 
 \indexlibrarymember{front}{basic_string}%
 \begin{itemdecl}
-constexpr const charT& front() const;
-constexpr charT& front();
+constexpr const_reference front() const;
+constexpr reference front();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3151,8 +3151,8 @@ Equivalent to: \tcode{return operator[](0);}
 
 \indexlibrarymember{back}{basic_string}%
 \begin{itemdecl}
-constexpr const charT& back() const;
-constexpr charT& back();
+constexpr const_reference back() const;
+constexpr reference back();
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
For `basic_string::front`/`basic_string::back`, the return types are modified to `(const_)reference` for the consistency with other sequence containers.

For `basic_string_view::data`, the return types is modified to `const charT*` for the consistency with `basic_string`. The same change applies to spelling of the type of closely related exposition-only data member _`data_`_.