### PR TITLE
[class], [utility], [time] remove redundant `constexpr-suitable` references to determine constexpr-ness of constructors/destructors

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1440,8 +1440,7 @@ constructor for that class with no
 \grammarterm{compound-statement}.
 If that user-written default constructor would be ill-formed,
 the program is ill-formed.
-If that user-written default constructor would be constexpr-suitable\iref{dcl.constexpr},
-the implicitly-defined
+The implicitly-defined
 default constructor is \keyword{constexpr}.
 Before the defaulted default constructor for a class is
 implicitly defined,
@@ -1726,8 +1725,7 @@ otherwise the copy/move constructor is
 The copy/move constructor is implicitly defined even if the implementation elided
 its odr-use\iref{term.odr.use,class.temporary}.
 \end{note}
-If an implicitly-defined\iref{dcl.fct.def.default} constructor would be constexpr-suitable\iref{dcl.constexpr},
-the implicitly-defined
+The implicitly-defined\iref{dcl.fct.def.default}
 constructor is \keyword{constexpr}.
 
 \pnum
@@ -2223,8 +2221,7 @@ Otherwise, the destructor is
 \defnx{non-trivial}{destructor!non-trivial}.
 
 \pnum
-A defaulted destructor is a constexpr destructor
-if it is constexpr-suitable\iref{dcl.constexpr}.
+A defaulted destructor is a constexpr destructor.
 
 \pnum
 Before a

--- a/source/time.tex
+++ b/source/time.tex
@@ -1255,7 +1255,7 @@ namespace std::chrono {
 
   public:
     // \ref{time.duration.cons}, construct/copy/destroy
-    constexpr duration() = default;
+    duration() = default;
     template<class Rep2>
       constexpr explicit duration(const Rep2& r);
     template<class Rep2, class Period2>
@@ -1303,12 +1303,6 @@ If \tcode{Period::num} is not positive, the program is ill-formed.
 \pnum
 Members of \tcode{duration} do not throw exceptions other than
 those thrown by the indicated operations on their representations.
-
-\pnum
-The defaulted copy constructor of \tcode{duration} shall be a
-constexpr function if and only if the required initialization
-of the member \tcode{rep_} for copy and move, respectively, would
-be constexpr-suitable\iref{dcl.constexpr}.
 
 \pnum
 \begin{example}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -810,12 +810,6 @@ the element-wise operations specified to be called for that operation
 throws an exception.
 
 \pnum
-The defaulted move and copy constructor, respectively, of \tcode{pair}
-is a constexpr function if and only if all required element-wise
-initializations for move and copy, respectively,
-would be constexpr-suitable\iref{dcl.constexpr}.
-
-\pnum
 If \tcode{(is_trivially_destructible_v<T1> \&\& is_trivially_destructible_v<T2>)}
 is \tcode{true}, then the destructor of \tcode{pair} is trivial.
 
@@ -1796,14 +1790,6 @@ is zero-based.
 \pnum
 For each \tcode{tuple} constructor, an exception is thrown only if the construction of
 one of the types in \tcode{Types} throws an exception.
-
-\pnum
-The defaulted move and copy constructor, respectively, of
-\tcode{tuple} is a constexpr function if and only if all
-required element-wise initializations for move and copy, respectively,
-would be constexpr-suitable\iref{dcl.constexpr}.
-The defaulted move and copy constructor of \tcode{tuple<>} are
-constexpr functions.
 
 \pnum
 If \tcode{is_trivially_destructible_v<$\tcode{T}_i$>} is \tcode{true} for all $\tcode{T}_i$,
@@ -5773,9 +5759,6 @@ Any exception thrown by the value-initialization of $\tcode{T}_0$.
 
 \pnum
 \remarks
-This function is \keyword{constexpr} if and only if the
-value-initialization of the alternative type $\tcode{T}_0$
-would be constexpr-suitable\iref{dcl.constexpr}.
 The exception specification is equivalent to
 \tcode{is_nothrow_default_constructible_v<$\tcode{T}_0$>}.
 \begin{note}


### PR DESCRIPTION
It occurred to me constructors/destructors can't be coroutines. Currently only remaining things which makes a function NOT `constexpr-suitable` is function being a coroutine. Hence constructors and destructors can always be constexpr. Removed wording is redundant and no longer has any meaning.

Question: I can go further and remove `constexpr-suitable` completely by removing its definition in [dcl.constexpr], and replacing its uses with `function is not a coroutine`.