### PR TITLE
Fix the entry for [re.def] in xrefdelta.tex

### DIFF
--- a/source/xrefdelta.tex
+++ b/source/xrefdelta.tex
@@ -300,7 +300,7 @@
 \movedxref{depr.iterator.primitives}{depr.iterator}
 \movedxref{depr.iterator.basic}{depr.iterator}
 
-\movedxref{re.def}{intro.refs}
+\movedxref{re.def}{intro.defs}
 \movedxref{basic.scope.declarative}{basic.scope.scope}
 \movedxref{basic.funscope}{stmt.label}
 \movedxref{basic.scope.hiding}{basic.lookup}


### PR DESCRIPTION
The contents were moved to [intro.defs] but not [intro.refs] by #4288. But the PR mistakenly added the corresponding entry in xrefdelta.tex.

Fixes #8110.