### PR TITLE
Fix sections numbers in existing `\xrefc` and `\IsoC`

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -14486,4 +14486,4 @@ These functions have the semantics specified in the C standard library.
 Any exception thrown by \tcode{compar}\iref{res.on.exception.handling}.
 \end{itemdescr}
 
-\xrefc{7.24.5}
+\xrefc{7.24.6}

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5396,7 +5396,7 @@ In contrast, see \IsoC{} 6.2.6.2.
 \end{note}
 \begin{note}
 The signed and unsigned integer types satisfy
-the constraints given in \IsoC{} 5.2.4.2.1.
+the constraints given in \IsoC{} 5.3.5.3.2.
 \end{note}
 Except as specified above,
 the width of a signed or unsigned integer type is

--- a/source/future.tex
+++ b/source/future.tex
@@ -230,7 +230,7 @@ The header \libheaderref{cfloat} has the following macros:
 The header defines these macros the same as
 the C standard library header \libheader{float.h}.
 
-\xrefc{5.2.4.2.2, 7.33.5}
+\xrefc{5.3.5.3.3, 7.33.6}
 
 \pnum
 In addition to being available via inclusion of the \libheader{cfloat} header,

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -1019,7 +1019,7 @@ of the program:
 Accesses through volatile glvalues are evaluated strictly according to the
 rules of the abstract machine.
 \item
-Data is delivered to the host environment to be written into files (\xrefc{7.21.3}).
+Data is delivered to the host environment to be written into files (\xrefc{7.23.3}).
 
 \begin{note}
 Delivering such data

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -532,7 +532,7 @@ Unsynchronized concurrent use of these objects and streams by multiple threads
 can result in interleaved characters.
 \end{note}
 
-\xrefc{7.21.2}
+\xrefc{7.23.2}
 
 \rSec2[narrow.stream.objects]{Narrow stream objects}
 
@@ -7876,7 +7876,7 @@ Otherwise writes \tcode{out} to \tcode{stream} unchanged.
 \end{itemize}
 Unconditionally unlocks \tcode{stream} on function exit.
 
-\xrefc{7.21.2}.
+\xrefc{7.23.2}.
 
 \begin{note}
 On Windows the native Unicode API is \tcode{WriteConsoleW} and
@@ -18990,7 +18990,7 @@ are the same as the C standard library header \libheader{stdio.h}.
 The return from each function call
 that delivers data
 to the host environment
-to be written to a file (\xrefc{7.21.3})
+to be written to a file (\xrefc{7.23.3})
 is an observable checkpoint\iref{intro.abstract}.
 
 \pnum

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -2204,7 +2204,7 @@ deallocate storage by calling
 \tcode{::operator delete()}\indexlibrarymember{delete}{operator}.
 \end{itemdescr}
 
-\xrefc{7.22.3}
+\xrefc{7.24.4}
 
 \rSec1[smartptr]{Smart pointers}
 

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -6966,7 +6966,7 @@ and oft-questionable quality and performance.
 \end{note}
 \end{itemdescr}
 
-\xrefc{7.22.2}
+\xrefc{7.24.3}
 
 \indextext{random number generation|)}
 
@@ -9895,7 +9895,7 @@ constexpr @\placeholder{floating-point-type}@ abs(@\placeholder{floating-point-t
 The absolute value of \tcode{x}.
 \end{itemdescr}
 
-\xrefc{7.12.7.2, 7.22.6.1}
+\xrefc{7.12.8.3, 7.24.7.1}
 
 \rSec2[c.math.hypot3]{Three-dimensional hypotenuse}
 
@@ -9949,7 +9949,7 @@ is non-negative.
 The classification / comparison functions behave the same as the C macros with the
 corresponding names defined in the C standard library.
 
-\xrefc{7.12.3, 7.12.4}
+\xrefc{7.12.4, 7.12.18}
 
 \rSec2[sf.cmath]{Mathematical special functions}%
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -97,7 +97,7 @@ and as noted in
 \ref{support.types.nullptr} and
 \ref{support.types.layout}.
 
-\xrefc{7.22}
+\xrefc{7.21}
 
 \rSec2[cstdlib.syn]{Header \tcode{<cstdlib>} synopsis}
 
@@ -297,7 +297,7 @@ but not
 \tcode{(void*)0}.
 \end{footnote}
 
-\xrefc{7.22}
+\xrefc{7.21}
 
 \rSec2[support.types.layout]{Sizes, alignments, and offsets}
 
@@ -352,7 +352,7 @@ is at least as great as that of every scalar type, and whose alignment
 requirement is supported in every context\iref{basic.align}.
 \tcode{std::is_trivially_default_constructible_v<max_align_t>} is \tcode{true}.
 
-\xrefc{7.22}
+\xrefc{7.21}
 
 \rSec2[support.types.byteops]{\tcode{byte} type operations}
 
@@ -1828,7 +1828,7 @@ an integer type \tcode{T} defines a constant whose type is the promoted
 type of \tcode{T}\iref{conv.prom}.
 \end{note}
 
-\xrefc{5.2.4.2.1}
+\xrefc{5.3.5.3.2}
 
 \rSec2[cfloat.syn]{Header \tcode{<cfloat>} synopsis}
 
@@ -1884,7 +1884,7 @@ type of \tcode{T}\iref{conv.prom}.
 The header \libheader{cfloat} defines all macros the same as
 the C standard library header \libheader{float.h}.
 
-\xrefc{5.2.4.2.2}
+\xrefc{5.3.5.3.3}
 
 \rSec1[support.arith.types]{Arithmetic types}
 
@@ -2328,7 +2328,7 @@ The function \tcode{quick_exit} is signal-safe\iref{support.signal}
 when the functions registered with \tcode{at_quick_exit} are.
 \end{itemdescr}
 
-\xrefc{7.24.4}
+\xrefc{7.24.5}
 
 \rSec1[support.dynamic]{Dynamic memory management}
 
@@ -6410,7 +6410,7 @@ The contents of the header \libheaderdef{cstdarg} are the same as the C
 standard library header \libheader{stdarg.h}, with the following changes:
 \begin{itemize}
 \item
-In lieu of the default argument promotions specified in \IsoC{} 6.5.2.2,
+In lieu of the default argument promotions specified in \IsoC{} 6.5.3.3,
 the definition in~\ref{expr.call} applies.
 \item
 The preprocessing tokens

--- a/source/text.tex
+++ b/source/text.tex
@@ -233,7 +233,7 @@ with the given precision.
 Nothing.
 \end{itemdescr}
 
-\xrefc{7.21.6.1}
+\xrefc{7.23.6.2}
 
 \rSec2[charconv.from.chars]{Primitive numeric input conversion}
 
@@ -348,7 +348,7 @@ closest to the value of the string matching the pattern.
 Nothing.
 \end{itemdescr}
 
-\xrefc{7.22.1.3, 7.22.1.4}
+\xrefc{7.24.2.6, 7.24.2.8}
 
 \rSec1[localization]{Localization library}
 
@@ -13317,7 +13317,7 @@ size_t wcstombs(char* s, const wchar_t* pwcs, size_t n);
 These functions have the semantics specified in the C standard library.
 \end{itemdescr}
 
-\xrefc{7.22.7.1, 7.22.8, 7.29.6.2.1}
+\xrefc{7.24.8.2, 7.24.9, 7.31.6.3.1}
 
 \indexlibraryglobal{mbtowc}%
 \indexlibraryglobal{wctomb}%
@@ -13338,7 +13338,7 @@ may introduce a data race\iref{res.on.data.races}
 with other calls to the same function.
 \end{itemdescr}
 
-\xrefc{7.22.7}
+\xrefc{7.24.8}
 
 \begin{itemdecl}
 size_t @\libglobal{mbrlen}@(const char* s, size_t n, mbstate_t* ps);
@@ -13368,4 +13368,4 @@ with other calls to the same function
 with an \tcode{mbstate_t*} argument that is a null pointer value.
 \end{itemdescr}
 
-\xrefc{7.30.1, 7.31.6.3, 7.31.6.4}
+\xrefc{7.30.2, 7.31.6.4, 7.31.6.5}


### PR DESCRIPTION
Currently, there are many mistakes in the section numbers in `\xrefc` and after `\IsoC{}`.
- Some are still section numbers in C17.
- Some are section numbers in WG14 [N3220](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3220.pdf). Unfortunately, there're many "General" sections added to C23 after N3220.
  - I'm now using section numbers in WG14 [N3299](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3299.pdf) as the new changes didn't seem to alternate any section number from C23.
- Some seem to be overly updated to match WG14 [N3550](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3550.pdf). These sections are for components in `<stddef.h>`, while in C2y a new header `<stdcountof.h>` is added.
- Some are typo.

Fixes #8109. Fixes #8228.