### PR TITLE
[lex.pptoken] Reoder list items to avoid "or" and "and" at same level

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -637,6 +637,9 @@ would cause further lexical analysis to fail,
 except that
 \begin{itemize}
 \item
+a \grammarterm{string-literal} token is never formed
+when a \grammarterm{header-name} token can be formed, and
+\item
 a \grammarterm{header-name}\iref{lex.header} is only formed
 \begin{itemize}
 \item
@@ -646,11 +649,8 @@ immediately after the \tcode{include}, \tcode{embed}, or \tcode{import} preproce
 \item
 immediately after a preprocessing token sequence of \xname{has_include}
 or \xname{has_embed} immediately followed by \tcode{(}
-in a \tcode{\#if}, \tcode{\#elif}, or \tcode{\#embed} directive\iref{cpp.cond,cpp.embed} and
+in a \tcode{\#if}, \tcode{\#elif}, or \tcode{\#embed} directive\iref{cpp.cond,cpp.embed}.
 \end{itemize}
-\item
-a \grammarterm{string-literal} token is never formed
-when a \grammarterm{header-name} token can be formed.
 \end{itemize}
 \end{itemize}
 


### PR DESCRIPTION
Suggested by editorial review committee.