### PR TITLE
[expr.call] Itemize to clarify sequencing ambiguity

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3903,10 +3903,13 @@ is not considered.
 The \grammarterm{postfix-expression} is sequenced before
 each \grammarterm{expression} in the \grammarterm{expression-list}
 and any default argument.
-The initialization of a parameter or,
-if the implementation introduces any temporary objects
+The
+\begin{itemize}
+\item initialization of a parameter or,
+\item if the implementation introduces any temporary objects
 to hold the values of function parameters\iref{class.temporary},
 the initialization of those temporaries,
+\end{itemize}
 including every associated value computation and side effect,
 is indeterminately sequenced with respect to that of any other parameter.
 These evaluations are


### PR DESCRIPTION
The current wording is ambiguous and can be read in two ways:

> The
> - initialization of a parameter or,
> - if the implementation introduces any temporary objects to hold the values of function parameters ([class.temporary]), the initialization of those temporaries,
>
> including every associated value computation and side effect,
> is indeterminately sequenced with respect to that of any other parameter.

OR

> The
> - initialization of a parameter or,
> - if the implementation introduces any temporary objects to hold the values of function parameters ([class.temporary]), the initialization of those temporaries,
> including every associated value computation and side effect,
> 
> is indeterminately sequenced with respect to that of any other parameter.

I think it's fairly clear that we want "including every associated value computation and side effect" to apply to either case, and this also matches the original wording in https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0145r3.pdf

Besides the ambiguity, the wording is mentally demanding from the reader, and bullets help tidy it up.