### PR TITLE
[simd.mask.overview] Fix markup; add two missing closing @

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -20045,8 +20045,8 @@ It is unspecified whether \tcode{errno}\iref{errno} is accessed.
 namespace std::simd {
   template<size_t Bytes, class Abi> class basic_mask {
   public:
-    using @\libmember{value_type}{basic_mask} = bool;
-    using @\libmember{abi_type}{basic_mask} = Abi;
+    using @\libmember{value_type}{basic_mask}@ = bool;
+    using @\libmember{abi_type}{basic_mask}@ = Abi;
     using @\libmember{iterator}{basic_mask}@ = @\exposid{simd-iterator}@<basic_mask>;
     using @\libmember{const_iterator}{basic_mask}@ = @\exposid{simd-iterator}@<const basic_mask>;
 


### PR DESCRIPTION
Resolves the following markup issue:
<img width="602" height="56" alt="Screenshot_20250725_164318" src="https://github.com/user-attachments/assets/16f212bd-d1be-4b11-9160-1ec92e0563f1" />
