### PR TITLE
[dcl.ptr] Move "See also" from normative paragraph to example

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3119,10 +3119,8 @@ or allow it to be changed through a cv-unqualified pointer later, for example:
 *ppc = &ci;         // OK, but would make \tcode{p} point to \tcode{ci} because of previous error
 *p = 5;             // clobber \tcode{ci}
 \end{codeblock}
-\end{example}
-
-\pnum
 See also~\ref{expr.assign} and~\ref{dcl.init}.
+\end{example}
 
 \pnum
 \begin{note}


### PR DESCRIPTION
Fixes #6449.