### PR TITLE
[dcl.fct] Clarify that type adjustment does not make zero-length arrays valid CWG 3121

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3871,6 +3871,8 @@ void g(char[3][3]) {}           // OK, another overload
 
 void h(int x(const int));       // \#3
 void h(int (*)(int)) {}         // defines \#3
+
+void j(int[0]);                 // error: \tcode{int[0]} is not a valid type
 \end{codeblock}
 \end{example}
 


### PR DESCRIPTION
Closes #6575.

Currently non-editorial for triage purposes. Jens wants CWG involvement (see linked issue).