### PR TITLE
[cmath.syn] Enclose `\placeholder{floating-point-type}` in `\tcode`

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -9819,19 +9819,19 @@ but they have the same behavior as in the C standard library\iref{library.c}.
 
 \pnum
 For each function
-with at least one parameter of type \placeholder{floating-point-type},
+with at least one parameter of type \tcode{\placeholder{floating-point-type}},
 the implementation provides
 an overload for each cv-unqualified floating-point type\iref{basic.fundamental}
-where all uses of \placeholder{floating-point-type} in the function signature
+where all uses of \tcode{\placeholder{floating-point-type}} in the function signature
 are replaced with that floating-point type.
 
 \pnum
 For each function
-with at least one parameter of type \placeholder{floating-point-type}
+with at least one parameter of type \tcode{\placeholder{floating-point-type}}
 other than \tcode{abs},
 the implementation also provides additional overloads sufficient to ensure that,
 if every argument corresponding to
-a \placeholder{floating-point-type} parameter has arithmetic type,
+a \tcode{\placeholder{floating-point-type}} parameter has arithmetic type,
 then every such argument is effectively cast to the floating-point type
 with the greatest floating-point conversion rank and
 greatest floating-point conversion subrank
@@ -9845,7 +9845,7 @@ from the overloads provided by the implementation.
 
 \pnum
 An invocation of \tcode{nexttoward} is ill-formed if
-the argument corresponding to the \placeholder{floating-point-type} parameter
+the argument corresponding to the \tcode{\placeholder{floating-point-type}} parameter
 has extended floating-point type.
 
 \xrefc{7.12}


### PR DESCRIPTION
Fixes #8023.