### PR TITLE
[checks] Check for missing hyphen in "floating point"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -6163,7 +6163,7 @@ Every floating-point type has a \defnadj{floating-point}{conversion rank}
 defined as follows:
 \begin{itemize}
 \item
-The rank of a floating point type \tcode{T} is greater than
+The rank of a floating-point type \tcode{T} is greater than
 the rank of any floating-point type
 whose set of values is a proper subset of the set of values of \tcode{T}.
 \item

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2674,7 +2674,7 @@ binary representation of the required template specializations of
 
 \diffref{facet.num.get.virtuals}
 \change
-The \tcode{num_get} facet recognizes hexadecimal floating point values.
+The \tcode{num_get} facet recognizes hexadecimal floating-point values.
 \rationale
 Required by new feature.
 \effect

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -11902,7 +11902,7 @@ In particular, if for all input and output arguments
 the \tcode{value_type} is a floating-point type,
 implementers are free to leverage approximations,
 use arithmetic operations not explicitly listed above, and
-compute floating point sums in any way that improves their accuracy.
+compute floating-point sums in any way that improves their accuracy.
 \end{note}
 
 \pnum

--- a/tools/check-source.sh
+++ b/tools/check-source.sh
@@ -8,6 +8,7 @@ failed=0
 texfiles=$(ls *.tex | grep -v macros.tex | grep -v layout.tex | grep -v tables.tex)
 texlibdesc="support.tex concepts.tex diagnostics.tex memory.tex meta.tex utilities.tex containers.tex iterators.tex ranges.tex algorithms.tex strings.tex text.tex numerics.tex time.tex iostreams.tex threads.tex exec.tex"
 texlib="lib-intro.tex $texlibdesc"
+texnoback=$(ls *.tex | grep -v back.tex)
 
 # Filter that reformats the error message as a "workflow command",
 # for native handling by github actions.
@@ -38,6 +39,10 @@ for f in *.tex; do
     [ $(tail -c 2 $f | wc -l) -eq 1 ] ||
 	echo "$f" | fail 'trailing empty lines' || failed=1
 done
+
+# "floating point" instead of "floating-point"
+grep -in 'floating point' $texnoback |
+    fail '"floating point" should be hyphenated like "floating-point"' || failed=1
 
 # indented \begin{codeblock} / \end{codeblock} (causes unwanted empty space)
 grep -ne '^.\+\\\(begin\|end\){codeblock}' $texfiles |


### PR DESCRIPTION
Closes #8123.

Based on #8122, which adds those hyphens in a few places.