### PR TITLE
[basic.link] All names have linkage

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2888,7 +2888,7 @@ of a sequence of declarations.
 
 \pnum
 \indextext{translation unit}%
-A name can have
+A name has
 \defnadj{external}{linkage},
 \defnadj{module}{linkage},
 \defnadj{internal}{linkage}, or


### PR DESCRIPTION
Given that the last option is "no linkage", the list is exhaustive and should not open readers to questioning what other options might be available if a name merely "can have" one of four categories of linkage that otherwise make no claim to be an exhaustive list.