### PR TITLE
[expr.unary.op] Add a note about dereferencing a dangling pointer

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5238,6 +5238,11 @@ If the operand points to an object or function,
 the result denotes that object or function;
 otherwise, the behavior is undefined except as specified in \ref{expr.typeid}.
 \begin{note}
+Indirection through a pointer to an object outside that object's
+lifetime is valid. The lvalue thus obtained can be used in limited
+ways, see~\ref{basic.life}.
+\end{note}
+\begin{note}
 \indextext{type!incomplete}%
 Indirection through a pointer to an incomplete type (other than
 \cv{} \keyword{void}) is valid. The lvalue thus obtained can be


### PR DESCRIPTION
Dereferencing a dangling pointer to an object is valid; the resulting lvalue can be used in limited ways as per [basic.life] p8.

Add a non-normative note linking the two sections together.

The original wording ("If the operand points to an object...") misled me; I assumed the object would have been within its lifetime, and therefore dereferencing a dangling pointer would be UB, but the kind folks at CWG explained the correct interpretation to me -- a pointer can "point to an object" even outside that object's lifetime.