### PR TITLE
[memory.syn] Index `allocation_result` and its members

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -162,9 +162,9 @@ namespace std {
   template<class Alloc> struct allocator_traits;                                    // freestanding
 
   template<class Pointer, class SizeType = size_t>
-  struct allocation_result {                                                        // freestanding
-    Pointer ptr;
-    SizeType count;
+  struct @\libglobal{allocation_result}@ {                                                        // freestanding
+    Pointer @\libmember{ptr}{allocation_result}@;
+    SizeType @\libmember{count}{allocation_result}@;
   };
 
   // \ref{default.allocator}, the default allocator


### PR DESCRIPTION
Follows up #8049.