### PR TITLE
[simd.permute.*] Fix wording that referred to V after renaming V to M for some overloads

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -18796,6 +18796,8 @@ template<@\exposid{simd-size-type}@ N = @\seebelow@, @\exposconcept{simd-mask-ty
 Let:
 \begin{itemize}
 \item
+\tcode{V} be \tcode{M} for the overload without template parameter \tcode{V}.
+\item
 \tcode{\exposid{gen-fn}(i)} be \tcode{idxmap(i, V::size())}
 if that expression is well-formed, and \tcode{idxmap(i)} otherwise.
 \item
@@ -18851,7 +18853,7 @@ template<@\exposconcept{simd-mask-type}@ M, @\exposconcept{simd-integral}@ I>
 \begin{itemdescr}
 \pnum
 \expects
-All values in \tcode{indices} are in the range \range{0}{V::size()}.
+All values in \tcode{indices} are in the range \range{0}{v.size()}.
 
 \pnum
 \returns
@@ -18891,7 +18893,7 @@ Different calls to \exposidnc{select-value} can return different unspecified val
 \returns
 A data-parallel object where the $i^\text{th}$
 element is initialized to the result of \tcode{\exposidnc{select-value}($i$)}
-for all $i$ in the range \range{0}{V::size()}.
+for all $i$ in the range \range{0}{v.size()}.
 \end{itemdescr}
 
 \indexlibrarymember{compress}{simd}
@@ -18901,7 +18903,7 @@ template<@\exposconcept{simd-vec-type}@ V>
                        const typename V::value_type& fill_value);
 template<@\exposconcept{simd-mask-type}@ M>
   constexpr M compress(const M& v, const type_identity_t<M>& selector,
-                       const typename V::value_type& fill_value);
+                       const typename M::value_type& fill_value);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -18921,7 +18923,7 @@ of the $i^\text{th}$ element of \tcode{selector} that is \tcode{true}.
 \returns
 A data-parallel object where the $i^\text{th}$
 element is initialized to the result of \tcode{\exposidnc{select-value}($i$)}
-for all $i$ in the range \range{0}{V::size()}.
+for all $i$ in the range \range{0}{v.size()}.
 \end{itemdescr}
 
 \indexlibrarymember{expand}{simd}
@@ -18952,7 +18954,7 @@ where $b$ appears in \tcode{\exposid{set-indices}}.
 \returns
 A data-parallel object where the $i^\text{th}$
 element is initialized to the result of \tcode{\exposidnc{select-value}($i$)}
-for all $i$ in the range \range{0}{V::size()}.
+for all $i$ in the range \range{0}{v.size()}.
 \end{itemdescr}
 
 \rSec3[simd.permute.memory]{\tcode{simd} memory permute}


### PR DESCRIPTION
[simd.permute.static] Now says 'Let `V` be `M` …' which is the shortest solution here. Alternatively, we could introduce `T` to be `V::value_type`/`bool` for the two overloads and instead of `V::size()` write `v.size()`.

Also, maybe we want to rename the function parameter from `v` to `x` for the [simd.permute.*] functions?