### PR TITLE
[task.promise] Clarifications and disambiguations

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -7648,19 +7648,19 @@ template<class... Args>
 \begin{itemdescr}
 \pnum
 If there is no parameter with type \tcode{allocator_arg_t} then let
-\tcode{\placeholder{alloc}} be \tcode{Allocator()}.
-Let \tcode{\placeholder{arg_next}} be the parameter following the first
-\tcode{allocator_arg_t} parameter (if any) and let \tcode{\placeholder{alloc}}
-be \tcode{Allocator(\placeholder{arg_next})}.
-Then \tcode{PAlloc} is \tcode{allocator_traits<Allocator>::template
-re\-bind_alloc\brk{}<U>} where \tcode{U} is an unspecified type
-whose size and alignment are both \tcode{__STDCPP_DEFAULT_NEW_ALIGNMENT__}.
+\tcode{alloc} be \tcode{allocator_type()}.
+Otherwise, let \tcode{arg_next} be the parameter
+following the first \tcode{allocator_arg_t} parameter,
+and let \tcode{alloc} be \tcode{allocator_type(arg_next)}.
+Let \tcode{PAlloc} be \tcode{allocator_traits<allocator_type>::template
+rebind_alloc<U>}, where \tcode{U} is an unspecified type
+whose size and alignment are both \mname{STDCPP_DEFAULT_NEW_ALIGNMENT}.
 
 \pnum
 \mandates
 \begin{itemize}
 \item The first parameter of type \tcode{allocator_arg_t} (if any) is not the last parameter.
-\item \tcode{Allocator(\placeholder{arg_next})} is a valid expression if there is a parameter
+\item \tcode{allocator_type(arg_next)} is a valid expression if there is a parameter
 of type \tcode{allocator_arg_t}.
 \item \tcode{allocator_traits<PAlloc>::pointer} is a pointer type.
 \end{itemize}
@@ -7668,7 +7668,7 @@ of type \tcode{allocator_arg_t}.
 \pnum
 \effects
 Initializes an allocator \tcode{palloc} of type \tcode{PAlloc} with
-\tcode{\placeholder{alloc}}.
+\tcode{alloc}.
 Uses \tcode{palloc} to allocate storage for the
 smallest array of \tcode{U} sufficient to provide storage for a
 coroutine state of size \tcode{size}, and unspecified additional


### PR DESCRIPTION
Cleans up multiple issues in p16:

* The name "alloc" was confusingly used both for an exposition-only member and for a locally defined variable. The latter is renamed to "alc".
* Locally defined variables are just typeset as normal code, not as placeholders.
* Some commas inserted to separate coordinate subclauses.
* Replaced "(if any)" with leading "Oherwise", which seems better in order to avoid seemingly providing two conflicting definitions of `alc`.

**Open question:** What is "`Allocator`"?