### PR TITLE
[new.delete][c.malloc] Properly index `operator new` and its friends

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -2153,7 +2153,6 @@ These functions have the semantics specified in the C standard library.
 \remarks
 These functions do not attempt to allocate
 storage by calling \tcode{::operator new()}\iref{new.delete}.
-\indexlibrarymember{new}{operator}%
 
 \pnum
 These functions implicitly create objects\iref{intro.object}
@@ -2204,7 +2203,7 @@ This function has the semantics specified in the C standard library.
 \remarks
 This function does not attempt to
 deallocate storage by calling
-\tcode{::operator delete()}\indexlibrarymember{delete}{operator}.
+\tcode{::operator delete()}\iref{new.delete}.
 \end{itemdescr}
 
 \xrefc{7.22.3}

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -2107,7 +2107,6 @@ These functions have the semantics specified in the C standard library.
 \remarks
 These functions do not attempt to allocate
 storage by calling \tcode{::operator new()}\iref{new.delete}.
-\indexlibrarymember{new}{operator}%
 
 \pnum
 These functions implicitly create objects\iref{intro.object}
@@ -2158,7 +2157,7 @@ This function has the semantics specified in the C standard library.
 \remarks
 This function does not attempt to
 deallocate storage by calling
-\tcode{::operator delete()}\indexlibrarymember{delete}{operator}.
+\tcode{::operator delete()}\iref{new.delete}.
 \end{itemdescr}
 
 \xrefc{7.24.4}

--- a/source/support.tex
+++ b/source/support.tex
@@ -2699,7 +2699,7 @@ This function is replaceable\iref{term.replaceable.function}.
 
 \rSec3[new.delete.array]{Array forms}
 
-\indexlibrarymember{new}{operator}%
+\indexlibraryglobal{operator new[]}%
 \begin{itemdecl}
 void* operator new[](std::size_t size);
 void* operator new[](std::size_t size, std::align_val_t alignment);
@@ -2753,7 +2753,7 @@ respectively.
 This function is replaceable\iref{term.replaceable.function}.
 \end{itemdescr}
 
-\indexlibrarymember{new}{operator}%
+\indexlibraryglobal{operator new[]}%
 \begin{itemdecl}
 void* operator new[](std::size_t size, const std::nothrow_t&) noexcept;
 void* operator new[](std::size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept;
@@ -2794,7 +2794,7 @@ Otherwise, returns a null pointer.
 This function is replaceable\iref{term.replaceable.function}.
 \end{itemdescr}
 
-\indexlibrarymember{delete}{operator}%
+\indexlibraryglobal{operator delete[]}%
 \begin{itemdecl}
 void operator delete[](void* ptr) noexcept;
 void operator delete[](void* ptr, std::size_t size) noexcept;
@@ -2877,7 +2877,7 @@ when replacing the allocation function.
 \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{delete}{operator}%
+\indexlibraryglobal{operator delete[]}%
 \begin{itemdecl}
 void operator delete[](void* ptr, const std::nothrow_t&) noexcept;
 void operator delete[](void* ptr, std::align_val_t alignment, const std::nothrow_t&) noexcept;

--- a/source/support.tex
+++ b/source/support.tex
@@ -2441,7 +2441,7 @@ meet the requirements of a hosted implementation, they all should.
 
 \rSec3[new.delete.single]{Single-object forms}
 
-\indexlibrarymember{new}{operator}%
+\indexlibraryglobal{operator new}%
 \begin{itemdecl}
 void* operator new(std::size_t size);
 void* operator new(std::size_t size, std::align_val_t alignment);
@@ -2501,7 +2501,7 @@ function does not return.
 This function is replaceable\iref{term.replaceable.function}.
 \end{itemdescr}
 
-\indexlibrarymember{new}{operator}%
+\indexlibraryglobal{operator new}%
 \begin{itemdecl}
 void* operator new(std::size_t size, const std::nothrow_t&) noexcept;
 void* operator new(std::size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept;
@@ -2550,7 +2550,7 @@ T* p2 = new(nothrow) T;         // returns \keyword{nullptr} if it fails
 This function is replaceable\iref{term.replaceable.function}.
 \end{itemdescr}
 
-\indexlibrarymember{delete}{operator}%
+\indexlibraryglobal{operator delete}%
 \begin{itemdecl}
 void operator delete(void* ptr) noexcept;
 void operator delete(void* ptr, std::size_t size) noexcept;
@@ -2650,7 +2650,7 @@ when replacing the allocation function.
 \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{delete}{operator}%
+\indexlibraryglobal{operator delete}%
 \begin{itemdecl}
 void operator delete(void* ptr, const std::nothrow_t&) noexcept;
 void operator delete(void* ptr, std::align_val_t alignment, const std::nothrow_t&) noexcept;

--- a/source/support.tex
+++ b/source/support.tex
@@ -2932,7 +2932,7 @@ the versions in the \Cpp{} standard library\iref{constraints}.
 The provisions of~\ref{basic.stc.dynamic} do not apply to these reserved
 placement forms of \tcode{operator new} and \tcode{operator delete}.
 
-\indexlibrarymember{new}{operator}%
+\indexlibraryglobal{operator new}%
 \begin{itemdecl}
 constexpr void* operator new(std::size_t size, void* ptr) noexcept;
 \end{itemdecl}
@@ -2957,7 +2957,7 @@ Something* p = new (place) Something();
 \end{example}
 \end{itemdescr}
 
-\indexlibrarymember{new}{operator}%
+\indexlibraryglobal{operator new[]}%
 \begin{itemdecl}
 constexpr void* operator new[](std::size_t size, void* ptr) noexcept;
 \end{itemdecl}
@@ -2972,7 +2972,7 @@ constexpr void* operator new[](std::size_t size, void* ptr) noexcept;
 Intentionally performs no other action.
 \end{itemdescr}
 
-\indexlibrarymember{delete}{operator}%
+\indexlibraryglobal{operator delete}%
 \begin{itemdecl}
 void operator delete(void* ptr, void*) noexcept;
 \end{itemdecl}
@@ -2990,7 +2990,7 @@ non-array placement operator new
 terminates by throwing an exception\iref{expr.new}.
 \end{itemdescr}
 
-\indexlibrarymember{delete}{operator}%
+\indexlibraryglobal{operator delete[]}%
 \begin{itemdecl}
 void operator delete[](void* ptr, void*) noexcept;
 \end{itemdecl}

--- a/source/support.tex
+++ b/source/support.tex
@@ -2925,7 +2925,7 @@ the versions in the \Cpp{} standard library\iref{constraints}.
 The provisions of~\ref{basic.stc.dynamic} do not apply to these reserved
 placement forms of \tcode{operator new} and \tcode{operator delete}.
 
-\indexlibrarymember{new}{operator}%
+\indexlibraryglobal{operator new}%
 \begin{itemdecl}
 constexpr void* operator new(std::size_t size, void* ptr) noexcept;
 \end{itemdecl}
@@ -2950,7 +2950,7 @@ Something* p = new (place) Something();
 \end{example}
 \end{itemdescr}
 
-\indexlibrarymember{new}{operator}%
+\indexlibraryglobal{operator new[]}%
 \begin{itemdecl}
 constexpr void* operator new[](std::size_t size, void* ptr) noexcept;
 \end{itemdecl}
@@ -2965,7 +2965,7 @@ constexpr void* operator new[](std::size_t size, void* ptr) noexcept;
 Intentionally performs no other action.
 \end{itemdescr}
 
-\indexlibrarymember{delete}{operator}%
+\indexlibraryglobal{operator delete}%
 \begin{itemdecl}
 constexpr void operator delete(void* ptr, void*) noexcept;
 \end{itemdecl}
@@ -2983,7 +2983,7 @@ non-array placement operator new
 terminates by throwing an exception\iref{expr.new}.
 \end{itemdescr}
 
-\indexlibrarymember{delete}{operator}%
+\indexlibraryglobal{operator delete[]}%
 \begin{itemdecl}
 constexpr void operator delete[](void* ptr, void*) noexcept;
 \end{itemdecl}

--- a/source/support.tex
+++ b/source/support.tex
@@ -2692,7 +2692,7 @@ This function is replaceable\iref{term.replaceable.function}.
 
 \rSec3[new.delete.array]{Array forms}
 
-\indexlibrarymember{new}{operator}%
+\indexlibraryglobal{operator new[]}%
 \begin{itemdecl}
 void* operator new[](std::size_t size);
 void* operator new[](std::size_t size, std::align_val_t alignment);
@@ -2746,7 +2746,7 @@ respectively.
 This function is replaceable\iref{term.replaceable.function}.
 \end{itemdescr}
 
-\indexlibrarymember{new}{operator}%
+\indexlibraryglobal{operator new[]}%
 \begin{itemdecl}
 void* operator new[](std::size_t size, const std::nothrow_t&) noexcept;
 void* operator new[](std::size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept;
@@ -2787,7 +2787,7 @@ Otherwise, returns a null pointer.
 This function is replaceable\iref{term.replaceable.function}.
 \end{itemdescr}
 
-\indexlibrarymember{delete}{operator}%
+\indexlibraryglobal{operator delete[]}%
 \begin{itemdecl}
 void operator delete[](void* ptr) noexcept;
 void operator delete[](void* ptr, std::size_t size) noexcept;
@@ -2870,7 +2870,7 @@ when replacing the allocation function.
 \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{delete}{operator}%
+\indexlibraryglobal{operator delete[]}%
 \begin{itemdecl}
 void operator delete[](void* ptr, const std::nothrow_t&) noexcept;
 void operator delete[](void* ptr, std::align_val_t alignment, const std::nothrow_t&) noexcept;

--- a/source/support.tex
+++ b/source/support.tex
@@ -2434,7 +2434,7 @@ meet the requirements of a hosted implementation, they all should.
 
 \rSec3[new.delete.single]{Single-object forms}
 
-\indexlibrarymember{new}{operator}%
+\indexlibraryglobal{operator new}%
 \begin{itemdecl}
 void* operator new(std::size_t size);
 void* operator new(std::size_t size, std::align_val_t alignment);
@@ -2494,7 +2494,7 @@ function does not return.
 This function is replaceable\iref{term.replaceable.function}.
 \end{itemdescr}
 
-\indexlibrarymember{new}{operator}%
+\indexlibraryglobal{operator new}%
 \begin{itemdecl}
 void* operator new(std::size_t size, const std::nothrow_t&) noexcept;
 void* operator new(std::size_t size, std::align_val_t alignment, const std::nothrow_t&) noexcept;
@@ -2543,7 +2543,7 @@ T* p2 = new(nothrow) T;         // returns \keyword{nullptr} if it fails
 This function is replaceable\iref{term.replaceable.function}.
 \end{itemdescr}
 
-\indexlibrarymember{delete}{operator}%
+\indexlibraryglobal{operator delete}%
 \begin{itemdecl}
 void operator delete(void* ptr) noexcept;
 void operator delete(void* ptr, std::size_t size) noexcept;
@@ -2643,7 +2643,7 @@ when replacing the allocation function.
 \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{delete}{operator}%
+\indexlibraryglobal{operator delete}%
 \begin{itemdecl}
 void operator delete(void* ptr, const std::nothrow_t&) noexcept;
 void operator delete(void* ptr, std::align_val_t alignment, const std::nothrow_t&) noexcept;


### PR DESCRIPTION
These operator functions should be indexed as `\indexlibraryglobal{operator new}` etc., like other operator functions. The indices in [new.delete.single] and [new.delete.array] are still imperfect, as there're multiple entries but a single index can only points to one.

I believe `operator new`/`operator delete` shouldn't be indexed in [c.malloc]. So this PR removes the probably improper indices and adds one `\iref` for consistency.

Fixes #8133.