### PR TITLE
[expr.prim.lambda.closure] Use "incomplete" instead of "not complete".

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2208,7 +2208,7 @@ called the \defn{closure type},
 whose properties are described below.
 
 \pnum
-The closure type is not complete
+The closure type is incomplete
 until the end of its corresponding \grammarterm{compound-statement}.
 
 \pnum


### PR DESCRIPTION
The former is a defined term.