### PR TITLE
[dcl.attr.grammar] Delete redundant "and no alignment-specifier".

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -9480,7 +9480,6 @@ In an \grammarterm{attribute-list}, an ellipsis may appear only if that
 by an ellipsis is a pack expansion\iref{temp.variadic}.
 An \grammarterm{attribute-specifier} that contains
 an \grammarterm{attribute-list} with no \grammarterm{attribute}s
-and no \grammarterm{alignment-specifier}
 has no effect.
 The order in which the \grammarterm{attribute-token}{s} appear in an
 \grammarterm{attribute-list} is not significant. If a


### PR DESCRIPTION
Now that we say "an attribute-list with no attributes", the additional "and no alignment-specifier" is redundant.

Suggested by @timsong-cpp.

@katzdm FYI.