### PR TITLE
[lex.phases] Identifiers do not have linkage, names do

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -201,8 +201,8 @@ only, and does not specify any particular implementation.
 \begin{note}
 Previously translated translation units can be preserved individually or in libraries.
 The separate translation units of a program communicate\iref{basic.link} by (for example)
-calls to functions whose identifiers have external or module linkage,
-manipulation of objects whose identifiers have external or module linkage, or
+calls to functions whose names have external or module linkage,
+manipulation of variables whose names have external or module linkage, or
 manipulation of data files.
 \end{note}
 


### PR DESCRIPTION
Change identifiers to names, so that we use a term with the specified linkage.
Since P2996 it is variables rather than objects that have names, so fix that up to in this informative note --- not normative text, so still editorial.