### PR TITLE
[locale.operators] Qualify `collate`

### DIFF
--- a/source/text.tex
+++ b/source/text.tex
@@ -1086,13 +1086,13 @@ template<class charT, class traits, class Allocator>
 \begin{itemdescr}
 \pnum
 \effects
-Compares two strings according to the \tcode{collate<charT>} facet.
+Compares two strings according to the \tcode{std::collate<charT>} facet.
 
 \pnum
 \returns
 \begin{codeblock}
-use_facet<collate<charT>>(*this).compare(s1.data(), s1.data() + s1.size(),
-                                         s2.data(), s2.data() + s2.size()) < 0
+use_facet<std::collate<charT>>(*this).compare(s1.data(), s1.data() + s1.size(),
+                                              s2.data(), s2.data() + s2.size()) < 0
 \end{codeblock}
 
 \pnum


### PR DESCRIPTION
Within `locale::operator()`, unqualified name lookup for `collate` finds `locale::collate`, which is a bit mask. Clearly the intent is to refer to the class template `std::collate`.