### PR TITLE
[specialized.algorithms] Fix a typo: T -> I

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -13684,7 +13684,7 @@ concept @\defexposconcept{nothrow-random-access-iterator}@ = // \expos
 A type \tcode{I} models \exposconcept{nothrow-random-access-iterator}
 only if no exceptions are thrown from comparisons of valid iterators,
 or the \tcode{-}, \tcode{+}, \tcode{-=}, \tcode{+=}, \tcode{[]} operators
-on valid values of type \tcode{I} and \tcode{iter_difference_t<T>}.
+on valid values of type \tcode{I} and \tcode{iter_difference_t<I>}.
 \begin{note}
 This concept allows some \libconcept{random_access_iterator}\iref{iterator.concept.random.access}
 operations to throw exceptions.


### PR DESCRIPTION
`iter_diffrence_t<I>` must be used instead of `iter_diffrence_t<T>` according to https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3179r9.html#modify_special_mem_concepts.