### PR TITLE
[cmp.common] Remove unnecessary "std::" before strong_ordering

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -5323,7 +5323,7 @@ the expanded parameter pack, or
 \keyword{void} if any element of \tcode{Ts}
 is not a comparison category type.
 \begin{note}
-This is \tcode{std::strong_ordering} if the expansion is empty.
+This is \tcode{strong_ordering} if the expansion is empty.
 \end{note}
 \end{itemdescr}
 


### PR DESCRIPTION
Based on my search, this is the only occurrence of `std::` before `strong_ordering`, `partial_ordering`, or `weak_ordering` in library wording.