### PR TITLE
[pointer.traits.types][allocator.traits.types] Replace undefined "Alias template" element with "Result"

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -379,7 +379,6 @@
 \newcommand{\result}{\Fundesc{Result}}
 \newcommand{\returntype}{\Fundesc{Return type}}
 \newcommand{\ctype}{\Fundesc{Type}}
-\newcommand{\templalias}{\Fundesc{Alias template}}
 
 %% Cross-reference
 \newcommand{\xref}[1]{\textsc{See also:}\space #1}

--- a/source/macros.tex
+++ b/source/macros.tex
@@ -384,7 +384,6 @@
 \newcommand{\result}{\Fundesc{Result}}
 \newcommand{\returntype}{\Fundesc{Return type}}
 \newcommand{\ctype}{\Fundesc{Type}}
-\newcommand{\templalias}{\Fundesc{Alias template}}
 
 %% Cross-reference
 \newcommand{\xref}[1]{\textsc{See also:}\space #1}

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -837,7 +837,7 @@ template<class U> using rebind = @\seebelow@;
 
 \begin{itemdescr}
 \pnum
-\templalias \tcode{Ptr::rebind<U>} if
+\result \tcode{Ptr::rebind<U>} if
 the \grammarterm{qualified-id} \tcode{Ptr::rebind<U>} is valid and denotes a
 type\iref{temp.deduct}; otherwise,
 \tcode{SomePointer<U, Args>} if

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -1833,7 +1833,7 @@ template<class T> using rebind_alloc = @\seebelow@;
 
 \begin{itemdescr}
 \pnum
-\templalias \tcode{Alloc::rebind<T>::other} if
+\result \tcode{Alloc::rebind<T>::other} if
 the \grammarterm{qualified-id} \tcode{Alloc::rebind<T>::other} is valid and denotes a
 type\iref{temp.deduct}; otherwise,
 \tcode{Alloc<T, Args>} if \tcode{Alloc} is a class template instantiation

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -1787,7 +1787,7 @@ template<class T> using rebind_alloc = @\seebelow@;
 
 \begin{itemdescr}
 \pnum
-\templalias \tcode{Alloc::rebind<T>::other} if
+\result \tcode{Alloc::rebind<T>::other} if
 the \grammarterm{qualified-id} \tcode{Alloc::rebind<T>::other} is valid and denotes a
 type\iref{temp.deduct}; otherwise,
 \tcode{Alloc<T, Args>} if \tcode{Alloc} is a class template specialization

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -884,7 +884,7 @@ template<class U> using rebind = @\seebelow@;
 
 \begin{itemdescr}
 \pnum
-\templalias \tcode{Ptr::rebind<U>} if
+\result \tcode{Ptr::rebind<U>} if
 the \grammarterm{qualified-id} \tcode{Ptr::rebind<U>} is valid and denotes a
 type\iref{temp.deduct}; otherwise,
 \tcode{SomePointer<U, Args>} if


### PR DESCRIPTION
The _Alias template_ "element" is used twice in the library wording but not defined in [structure.specifications]. I think the _Result_ element should used instead.

I'm not sure whether this is editorial. If not, this should resolved together with LWG3166.