### PR TITLE
[meta.reflection.queries]/1 Use info return type

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -3906,7 +3906,7 @@ Otherwise, \tcode{false}.
 
 \indexlibraryglobal{type_of}%
 \begin{itemdecl}
-consteval bool type_of(info r);
+consteval info type_of(info r);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Bring the return type of type_of in line with the synopsis and with the intention of the function and with the wording in P2996R13 from where this wording originates.