### PR TITLE
[hive.cons]/15 Add noexcept to move constructor

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -8281,7 +8281,7 @@ Linear in \tcode{x.size()}.
 
 \indexlibraryctor{hive}%
 \begin{itemdecl}
-hive(hive&& x);
+hive(hive&& x) noexcept;
 hive(hive&& x, const type_identity_t<Allocator>& alloc);
 \end{itemdecl}
 


### PR DESCRIPTION
The synopsis specifies noexcept for this constructor and the effects don't invoke behavior that could throw, so the missing noexcept looks like an oversight. However, the originating paper P0447R28 is also missing noexcept here.