### PR TITLE
[optional.optional.ref.general] Fix reference to [optional.ref.iterators]

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -4485,7 +4485,7 @@ namespace std {
       // \ref{optional.ref.swap}, swap
       constexpr void swap(optional& rhs) noexcept;
 
-      // \ref{optional.iterators}, iterator support
+      // \ref{optional.ref.iterators}, iterator support
       constexpr iterator begin() const noexcept;
       constexpr iterator end() const noexcept;
 


### PR DESCRIPTION
Currently the comment mistakenly refer to [optional.iterators], while [optional.ref.iterators] should be referred to instead.

Fixes #8155.