### PR TITLE
[filesystems] Replace "encoded character type" with "character type" from the core wording

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -14092,13 +14092,13 @@ shall be one of:
   argument \tcode{const Source\&} \tcode{source} shall have an
   effective range \range{source.begin()}{source.end()}.
 \item A type meeting the \oldconcept{InputIterator} requirements that iterates over an NTCTS\@.
-  The value type shall be an encoded character type. A function argument
+  The value type shall be a character type\iref{basic.fundamental}. A function argument
   \tcode{const Source\&} \tcode{source} shall have an effective range
   \range{source}{end} where \tcode{end} is the first
   iterator value with an element value equal to
   \tcode{iterator_traits<Source>::value_type()}.
 \item A character array that after array-to-pointer decay results in a
-  pointer to the start of an NTCTS\@. The value type shall be an encoded character type. A
+  pointer to the start of an NTCTS\@. The value type shall be a character type. A
   function argument \tcode{const Source\&} \tcode{source} shall
   have an effective range \range{source}{end} where
   \tcode{end} is the first iterator value with an element value equal to
@@ -14116,7 +14116,7 @@ either
 \tcode{basic_string} or \tcode{basic_string_view}, or
 \item
 the \grammarterm{qualified-id} \tcode{iterator_traits<decay_t<Source>>::value_type} is valid and
-denotes a possibly const encoded character type\iref{temp.deduct}.
+denotes a possibly const character type\iref{temp.deduct}.
 \end{itemize}
 
 \pnum

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -13782,7 +13782,7 @@ namespace std::filesystem {
 \indexlibrarymember{value_type}{path}%
 \pnum
 \tcode{value_type} is a \keyword{typedef} for the
-operating system dependent encoded character type used to represent pathnames.
+operating system dependent character type\iref{basic.fundamental} used to represent pathnames.
 
 \indexlibrarymember{preferred_separator}{path}%
 \pnum

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -13252,23 +13252,18 @@ is unreasonable for a program to detect them prior to calling the function.
 \rSec2[fs.req]{Requirements}
 
 \pnum
-Throughout subclause~\ref{filesystems}, \tcode{char}, \keyword{wchar_t}, \keyword{char8_t},
-\keyword{char16_t}, and \keyword{char32_t} are collectively called
-\defnx{encoded character types}{encoded character type}.
-
-\pnum
 Functions with template parameters named \tcode{EcharT}
 shall not participate in overload resolution
-unless \tcode{EcharT} is one of the encoded character types.
+unless \tcode{EcharT} is a character type\iref{basic.fundamental}.
 
 \pnum
 Template parameters named \tcode{InputIterator} shall meet the
 \oldconcept{InputIterator} requirements\iref{input.iterators} and shall
-have a value type that is one of the encoded character types.
+have a value type that is a character type.
 
 \pnum
 \begin{note}
-Use of an encoded character type implies an associated
+Use of a character type implies an associated
 character set and encoding.
 Since \tcode{signed char} and \tcode{unsigned char} have no
 implied character set and encoding,

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -13216,23 +13216,18 @@ is unreasonable for a program to detect them prior to calling the function.
 \rSec2[fs.req]{Requirements}
 
 \pnum
-Throughout subclause~\ref{filesystems}, \tcode{char}, \keyword{wchar_t}, \keyword{char8_t},
-\keyword{char16_t}, and \keyword{char32_t} are collectively called
-\defnx{encoded character types}{encoded character type}.
-
-\pnum
 Functions with template parameters named \tcode{EcharT}
 shall not participate in overload resolution
-unless \tcode{EcharT} is one of the encoded character types.
+unless \tcode{EcharT} is a character type\iref{basic.fundamental}.
 
 \pnum
 Template parameters named \tcode{InputIterator} shall meet the
 \oldconcept{InputIterator} requirements\iref{input.iterators} and shall
-have a value type that is one of the encoded character types.
+have a value type that is a character type.
 
 \pnum
 \begin{note}
-Use of an encoded character type implies an associated
+Use of a character type implies an associated
 character set and encoding.
 Since \tcode{signed char} and \tcode{unsigned char} have no
 implied character set and encoding,

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -14057,13 +14057,13 @@ shall be one of:
   argument \tcode{const Source\&} \tcode{source} shall have an
   effective range \range{source.begin()}{source.end()}.
 \item A type meeting the \oldconcept{InputIterator} requirements that iterates over an NTCTS\@.
-  The value type shall be an encoded character type. A function argument
+  The value type shall be a character type\iref{basic.fundamental}. A function argument
   \tcode{const Source\&} \tcode{source} shall have an effective range
   \range{source}{end} where \tcode{end} is the first
   iterator value with an element value equal to
   \tcode{iterator_traits<Source>::value_type()}.
 \item A character array that after array-to-pointer decay results in a
-  pointer to the start of an NTCTS\@. The value type shall be an encoded character type. A
+  pointer to the start of an NTCTS\@. The value type shall be a character type. A
   function argument \tcode{const Source\&} \tcode{source} shall
   have an effective range \range{source}{end} where
   \tcode{end} is the first iterator value with an element value equal to
@@ -14081,7 +14081,7 @@ either
 \tcode{basic_string} or \tcode{basic_string_view}, or
 \item
 the \grammarterm{qualified-id} \tcode{iterator_traits<decay_t<Source>>::value_type} is valid and
-denotes a possibly const encoded character type\iref{temp.deduct}.
+denotes a possibly const character type\iref{temp.deduct}.
 \end{itemize}
 
 \pnum

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -13746,7 +13746,7 @@ namespace std::filesystem {
 \indexlibrarymember{value_type}{path}%
 \pnum
 \tcode{value_type} is a \grammarterm{typedef-name} for the
-operating system dependent encoded character type used to represent pathnames.
+operating system dependent character type\iref{basic.fundamental} used to represent pathnames.
 
 \indexlibrarymember{preferred_separator}{path}%
 \pnum


### PR DESCRIPTION
The terms "_encoded character type(s)_" (introduced in [fs.req]) and "_character type(s)_" (introduced in [basic.fundamental]) mean exactly the same set of types. It's probably better to avoid such duplicate. And the current preference seems to be using "character type" throughout the library wording, rather than renaming the term in the core wording.

Closes #5638.