### PR TITLE
[locale.moneypunct.virtuals] latex: remove redundant backslash-space

### DIFF
--- a/source/text.tex
+++ b/source/text.tex
@@ -4673,7 +4673,7 @@ int do_frac_digits() const;
 \returns
 The number of digits after the decimal radix separator, if any.
 \begin{footnote}
-In common U.S.\ locales, this is 2.
+In common U.S. locales, this is 2.
 \end{footnote}
 \end{itemdescr}
 


### PR DESCRIPTION
The backslash-space in "U.S.\ locales" can be replaced with a plain space, because TeX treats a period after uppercase as an acronym (which yields normal spacing). L4595, L4610 already use a plain space in "U.S. locales", so this change improves consistency.