### PR TITLE
[macros] Fix sentence spacing after `\tcode`

### DIFF
--- a/source/macros.tex
+++ b/source/macros.tex
@@ -242,7 +242,7 @@
 \newcommand{\GrammarStylex}[1]{\textcolor{grammar-gray}{\textsf{\textit{#1}}}}
 
 % Code and definitions embedded in text.
-\newcommand{\tcode}[1]{\CodeStylex{#1}}
+\newcommand{\tcode}[1]{\ifmmode\CodeStylex{#1}\else\CodeStylex{#1}\@\fi}
 \newcommand{\term}[1]{\textit{#1}}
 \newcommand{\gterm}[1]{\GrammarStylex{#1}}
 \newcommand{\fakegrammarterm}[1]{\gterm{#1}}


### PR DESCRIPTION
TeX treats a word ending with an uppercase letter as an abbreviation. This makes the space after `\tcode{T}.` result in regular interword spacing. To restore proper (wider) sentence spacing, this commit appends `\@` to the `\tcode` macro.

There are dozens of intances of `\tcode{...UPPERCASE}. `