### PR TITLE
[expr.const]/note-8 Add splice-specifier to list

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -8988,9 +8988,9 @@ and where the reference binding (if any) binds directly.
 Such expressions can be used in \keyword{new}
 expressions\iref{expr.new}, as case expressions\iref{stmt.switch},
 as enumerator initializers if the underlying type is
-fixed\iref{dcl.enum}, as array bounds\iref{dcl.array}, and
-as constant template
-arguments\iref{temp.arg}.
+fixed\iref{dcl.enum}, as array bounds\iref{dcl.array},
+as constant template arguments\iref{temp.arg},
+and as the constant expression of a \grammarterm{splice-specifier}\iref{basic.splice}.
 \end{note}
 \indextext{contextually converted constant expression of type \tcode{bool}|see{conversion, contextual}}%
 \indextext{conversion!contextual to constant expression of type \tcode{bool}}%


### PR DESCRIPTION
This is a back-reference, because [expr.splice] refers to here already.