### PR TITLE
[hive.erasure]/2 Have erase_if reevaluate end() LWG4318

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -8969,7 +8969,7 @@ template<class T, class Allocator, class Predicate>
 Equivalent to:
 \begin{codeblock}
 auto original_size = c.size();
-for (auto i = c.begin(), last = c.end(); i != last; ) {
+for (auto i = c.begin(); i != c.end(); ) {
   if (pred(*i)) {
     i = c.erase(i);
   } else {


### PR DESCRIPTION
The defining code must not cache the end-iterator. In case the last element of the sequence is removed, the past-the-end iterator will be invalidated. This will trigger UB in the loop condition. Instead, re-evaluate end() each time.