### PR TITLE
[back] Fix journal article entries in bibliography

### DIFF
--- a/source/back.tex
+++ b/source/back.tex
@@ -61,20 +61,20 @@
   Prentice-Hall, ISBN 0-13-117003-1, copyright \copyright 1995 P.\,J.\ Plauger
 \bibitem{linalg-stable}
   J.\ Demmel, I.\ Dumitriu, and O.\ Holtz,
-  \doccite{Fast linear algebra is stable},
-  Numerische Mathematik 108 (59--91), 2007.
+  Fast linear algebra is stable,
+  \doccite{Numerische Mathematik}, Vol.\ 108, No.\ 1, pp.\ 59--91, 2007.
 \bibitem{blas1}
   C.\,L.\ Lawson, R.\,J.\ Hanson, D.\ Kincaid, and F.\,T.\ Krogh,
-  \doccite{Basic linear algebra subprograms for Fortran usage}.
-  ACM Trans.\ Math.\ Soft., Vol.\ 5, pp.\ 308--323, 1979.
+  Basic linear algebra subprograms for Fortran usage.
+  \doccite{ACM Trans.\ Math.\ Soft.}, Vol.\ 5, No.\ 3, pp.\ 308--323, 1979.
 \bibitem{blas2}
   Jack J.\ Dongarra, Jeremy Du Croz, Sven Hammarling, and Richard J.\ Hanson,
-  \doccite{An Extended Set of FORTRAN Basic Linear Algebra Subprograms}.
-  ACM Trans.\ Math.\ Soft., Vol.\ 14, No.\ 1, pp.\ 1--17, Mar.\ 1988.
+  An extended set of FORTRAN basic linear algebra subprograms.
+  \doccite{ACM Trans.\ Math.\ Soft.}, Vol.\ 14, No.\ 1, pp.\ 1--17, 1988.
 \bibitem{blas3}
   Jack J.\ Dongarra, Jeremy Du Croz, Sven Hammarling, and Iain Duff,
-  \doccite{A Set of Level 3 Basic Linear Algebra Subprograms}.
-  ACM Trans.\ Math.\ Soft., Vol.\ 16, No.\ 1, pp.\ 1--17, Mar.\ 1990.
+  A set of level 3 basic linear algebra subprograms.
+  \doccite{ACM Trans.\ Math.\ Soft.}, Vol.\ 16, No.\ 1, pp.\ 1--17, 1990.
 \bibitem{lapack}
   E.\ Anderson, Z.\ Bai, C.\ Bischof, S.\ Blackford, J.\ Demmel, J.\ Dongarra,
   J.\ Du Croz, A.\ Greenbaum, S.\ Hammarling, A.\ McKenney, and D.\ Sorensen,
@@ -84,12 +84,12 @@
   L.\ Susan Blackford, James Demmel, Jack Dongarra, Iain Duff, Sven Hammarling,
   Greg Henry, Michael Heroux, Linda Kaufman, Andrew Lumbsdaine, Antoine Petitet,
   Roldan Pozo, Karin Remington, and R.\ Clint Whaley,
-  \doccite{An Updated Set of Basic Linear Algebra Subprograms (BLAS)}.
-  ACM Trans.\ Math.\ Soft., Vol.\ 28, Issue 2, pp.\ 135--151, 2002.
+  An updated set of basic linear algebra subprograms (BLAS).
+  \doccite{ACM Trans.\ Math.\ Soft.}, Vol.\ 28, No.\ 2, pp.\ 135--151, 2002.
 \bibitem{flynn-taxonomy}
   Michael J.\ Flynn,
-  \doccite{Very High-Speed Computing Systems}.
-  Proceedings of the IEEE, Vol.\ 54, Issue 12, pp.\ 1901--1909, 1966.
+  Very high-speed computing systems.
+  \doccite{Proceedings of the IEEE}, Vol.\ 54, No.\ 12, pp.\ 1901--1909, 1966.
 \end{thebibliography}
 
 % FIXME: For unknown reasons, hanging paragraphs are not indented within our


### PR DESCRIPTION
This PR applies the following corrections and formatting unifications.
- Fixes author name typo: "R. Client Whaley" should be "R. Clint Whaley". (c.f. https://doi.org/10.1145/567806.567807 )
- Adds missing page numbers.
- Unifies article title format: Roman style with sentence capitalization.
- Unifies journal title format: italicized.
- Unifies journal volume/issue format: "vol. X, no. Y".