### PR TITLE
[iterators] Exposition-only formatting for private members

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -832,10 +832,10 @@ be defined as the indirectly readable type's value type.
 
 \indexlibraryglobal{indirectly_readable_traits}%
 \begin{codeblock}
-template<class> struct @\placeholder{cond-value-type}@ { };     // \expos
+template<class> struct @\exposid{cond-value-type}@ { };     // \expos
 template<class T>
   requires is_object_v<T>
-struct @\placeholder{cond-value-type}@<T> {
+struct @\exposid{cond-value-type}@<T> {
   using value_type = remove_cv_t<T>;
 };
 
@@ -849,7 +849,7 @@ template<class> struct indirectly_readable_traits { };
 
 template<class T>
 struct indirectly_readable_traits<T*>
-  : @\placeholder{cond-value-type}@<T> { };
+  : @\exposid{cond-value-type}@<T> { };
 
 template<class I>
   requires is_array_v<I>
@@ -863,11 +863,11 @@ struct indirectly_readable_traits<const I>
 
 template<@\exposconcept{has-member-value-type}@ T>
 struct indirectly_readable_traits<T>
-  : @\placeholder{cond-value-type}@<typename T::value_type> { };
+  : @\exposid{cond-value-type}@<typename T::value_type> { };
 
 template<@\exposconcept{has-member-element-type}@ T>
 struct indirectly_readable_traits<T>
-  : @\placeholder{cond-value-type}@<typename T::element_type> { };
+  : @\exposid{cond-value-type}@<typename T::element_type> { };
 
 template<@\exposconcept{has-member-value-type}@ T>
   requires @\exposconcept{has-member-element-type}@<T>
@@ -877,7 +877,7 @@ template<@\exposconcept{has-member-value-type}@ T>
   requires @\exposconcept{has-member-element-type}@<T> &&
            @\libconcept{same_as}@<remove_cv_t<typename T::element_type>, remove_cv_t<typename T::value_type>>
 struct indirectly_readable_traits<T>
-  : @\placeholder{cond-value-type}@<typename T::value_type> { };
+  : @\exposid{cond-value-type}@<typename T::value_type> { };
 
 template<class T> using iter_value_t = @\seebelow@;
 \end{codeblock}
@@ -4849,14 +4849,14 @@ namespace std {
         operator-(const move_iterator& x, const move_sentinel<S>& y);
     friend constexpr iter_rvalue_reference_t<Iterator>
       iter_move(const move_iterator& i)
-        noexcept(noexcept(ranges::iter_move(i.current)));
+        noexcept(noexcept(ranges::iter_move(i.@\exposid{current}@)));
     template<@\libconcept{indirectly_swappable}@<Iterator> Iterator2>
       friend constexpr void
         iter_swap(const move_iterator& x, const move_iterator<Iterator2>& y)
-          noexcept(noexcept(ranges::iter_swap(x.current, y.current)));
+          noexcept(noexcept(ranges::iter_swap(x.@\exposid{current}@, y.@\exposid{current}@)));
 
   private:
-    Iterator current;   // \expos
+    Iterator @\exposid{current}@;   // \expos
   };
 }
 \end{codeblock}
@@ -4920,7 +4920,7 @@ constexpr move_iterator();
 \begin{itemdescr}
 \pnum
 \effects
-Value-initializes \tcode{current}.
+Value-initializes \exposid{current}.
 \end{itemdescr}
 
 
@@ -4932,7 +4932,7 @@ constexpr explicit move_iterator(Iterator i);
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{current} with \tcode{std::move(i)}.
+Initializes \exposid{current} with \tcode{std::move(i)}.
 \end{itemdescr}
 
 
@@ -4949,7 +4949,7 @@ template<class U> constexpr move_iterator(const move_iterator<U>& u);
 
 \pnum
 \effects
-Initializes \tcode{current} with \tcode{u.current}.
+Initializes \exposid{current} with \tcode{u.\exposid{current}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{move_iterator}%
@@ -4966,8 +4966,8 @@ template<class U> constexpr move_iterator& operator=(const move_iterator<U>& u);
 
 \pnum
 \effects
-Assigns \tcode{u.current} to
-\tcode{current}.
+Assigns \tcode{u.\exposid{current}} to
+\exposid{current}.
 
 \pnum
 \returns
@@ -4984,7 +4984,7 @@ constexpr const Iterator& base() const & noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{current}.
+\exposid{current}.
 \end{itemdescr}
 
 \indexlibrarymember{base}{move_iterator}%
@@ -4995,7 +4995,7 @@ constexpr Iterator base() &&;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{std::move(current)}.
+\tcode{std::move(\exposid{current})}.
 \end{itemdescr}
 
 \rSec3[move.iter.elem]{Element access}
@@ -5008,7 +5008,7 @@ constexpr reference operator*() const;
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return ranges::iter_move(current);}
+Equivalent to: \tcode{return ranges::iter_move(\exposid{current});}
 \end{itemdescr}
 
 \indexlibrarymember{operator[]}{move_iterator}%
@@ -5019,7 +5019,7 @@ constexpr reference operator[](difference_type n) const;
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return ranges::iter_move(current + n);}
+Equivalent to: \tcode{return ranges::iter_move(\exposid{current} + n);}
 \end{itemdescr}
 
 \rSec3[move.iter.nav]{Navigation}
@@ -5032,7 +5032,7 @@ constexpr move_iterator& operator++();
 \begin{itemdescr}
 \pnum
 \effects
-As if by \tcode{++current}.
+As if by \tcode{++\exposid{current}}.
 
 \pnum
 \returns
@@ -5050,10 +5050,10 @@ constexpr auto operator++(int);
 If \tcode{Iterator} models \libconcept{forward_iterator}, equivalent to:
 \begin{codeblock}
 move_iterator tmp = *this;
-++current;
+++@\exposid{current}@;
 return tmp;
 \end{codeblock}
-Otherwise, equivalent to \tcode{++current}.
+Otherwise, equivalent to \tcode{++\exposid{current}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator--}{move_iterator}%
@@ -5064,7 +5064,7 @@ constexpr move_iterator& operator--();
 \begin{itemdescr}
 \pnum
 \effects
-As if by \tcode{--current}.
+As if by \tcode{--\exposid{current}}.
 
 \pnum
 \returns
@@ -5082,7 +5082,7 @@ constexpr move_iterator operator--(int);
 As if by:
 \begin{codeblock}
 move_iterator tmp = *this;
---current;
+--@\exposid{current}@;
 return tmp;
 \end{codeblock}
 \end{itemdescr}
@@ -5095,7 +5095,7 @@ constexpr move_iterator operator+(difference_type n) const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{move_iterator(current + n)}.
+\tcode{move_iterator(\exposid{current} + n)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{move_iterator}%
@@ -5106,7 +5106,7 @@ constexpr move_iterator& operator+=(difference_type n);
 \begin{itemdescr}
 \pnum
 \effects
-As if by: \tcode{current += n;}
+As if by: \tcode{\exposid{current} += n;}
 
 \pnum
 \returns
@@ -5121,7 +5121,7 @@ constexpr move_iterator operator-(difference_type n) const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{move_iterator(current - n)}.
+\tcode{move_iterator(\exposid{current} - n)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-=}{move_iterator}%
@@ -5132,7 +5132,7 @@ constexpr move_iterator& operator-=(difference_type n);
 \begin{itemdescr}
 \pnum
 \effects
-As if by: \tcode{current -= n;}
+As if by: \tcode{\exposid{current} -= n;}
 
 \pnum
 \returns
@@ -5287,13 +5287,13 @@ template<class Iterator>
 \begin{itemdecl}
 friend constexpr iter_rvalue_reference_t<Iterator>
   iter_move(const move_iterator& i)
-    noexcept(noexcept(ranges::iter_move(i.current)));
+    noexcept(noexcept(ranges::iter_move(i.@\exposid{current}@)));
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return ranges::iter_move(i.current);}
+Equivalent to: \tcode{return ranges::iter_move(i.\exposid{current});}
 \end{itemdescr}
 
 \indexlibrarymember{iter_swap}{move_iterator}%
@@ -5301,13 +5301,13 @@ Equivalent to: \tcode{return ranges::iter_move(i.current);}
 template<@\libconcept{indirectly_swappable}@<Iterator> Iterator2>
   friend constexpr void
     iter_swap(const move_iterator& x, const move_iterator<Iterator2>& y)
-      noexcept(noexcept(ranges::iter_swap(x.current, y.current)));
+      noexcept(noexcept(ranges::iter_swap(x.@\exposid{current}@, y.@\exposid{current}@)));
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{ranges::iter_swap(x.current, y.current)}.
+Equivalent to: \tcode{ranges::iter_swap(x.\exposid{current}, y.\exposid{current})}.
 \end{itemdescr}
 
 \indexlibraryglobal{make_move_iterator}%
@@ -5364,7 +5364,7 @@ namespace std {
     constexpr S base() const;
 
   private:
-    S last;     // \expos
+    S @\exposid{last}@;     // \expos
   };
 }
 \end{codeblock}
@@ -5379,7 +5379,7 @@ constexpr move_sentinel();
 \begin{itemdescr}
 \pnum
 \effects
-Value-initializes \tcode{last}.
+Value-initializes \exposid{last}.
 If \tcode{is_trivially_default_constructible_v<S>} is \tcode{true},
 then this constructor is a \keyword{constexpr} constructor.
 \end{itemdescr}
@@ -5392,7 +5392,7 @@ constexpr explicit move_sentinel(S s);
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{last} with \tcode{std::move(s)}.
+Initializes \exposid{last} with \tcode{std::move(s)}.
 \end{itemdescr}
 
 \indexlibraryctor{move_sentinel}%
@@ -5405,7 +5405,7 @@ template<class S2>
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{last} with \tcode{s.last}.
+Initializes \exposid{last} with \tcode{s.\exposid{last}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{move_sentinel}%
@@ -5419,7 +5419,7 @@ template<class S2>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{last = s.last; return *this;}
+Equivalent to: \tcode{\exposid{last} = s.\exposid{last}; return *this;}
 \end{itemdescr}
 
 \indexlibrarymember{base}{move_sentinel}%
@@ -5430,7 +5430,7 @@ constexpr S base() const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{last}.
+\exposid{last}.
 \end{itemdescr}
 
 \rSec2[iterators.common]{Common iterators}
@@ -5514,7 +5514,7 @@ namespace std {
         noexcept(noexcept(ranges::iter_swap(declval<const I&>(), declval<const I2&>())));
 
   private:
-    variant<I, S> v_;   // \expos
+    variant<I, S> @\exposid{v_}@;   // \expos
   };
 
   template<class I, class S>
@@ -5573,7 +5573,7 @@ constexpr common_iterator(I i);
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{v_} as if by \tcode{v_\{in_place_type<I>, std::move(i)\}}.
+Initializes \exposid{v_} as if by \tcode{\exposid{v_}\{in_place_type<I>, std::move(i)\}}.
 \end{itemdescr}
 
 \indexlibraryctor{common_iterator}%
@@ -5584,8 +5584,8 @@ constexpr common_iterator(S s);
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{v_} as if by
-\tcode{v_\{in_place_type<S>, std::move(s)\}}.
+Initializes \exposid{v_} as if by
+\tcode{\exposid{v_}\{in_place_type<S>, std::move(s)\}}.
 \end{itemdescr}
 
 \indexlibraryctor{common_iterator}%
@@ -5598,13 +5598,13 @@ template<class I2, class S2>
 \begin{itemdescr}
 \pnum
 \hardexpects
-\tcode{x.v_.valueless_by_exception()} is \tcode{false}.
+\tcode{x.\exposid{v_}.valueless_by_exception()} is \tcode{false}.
 
 \pnum
 \effects
-Initializes \tcode{v_} as if by
-\tcode{v_\{in_place_index<$i$>, get<$i$>(x.v_)\}},
-where $i$ is \tcode{x.v_.index()}.
+Initializes \exposid{v_} as if by
+\tcode{\exposid{v_}\{in_place_index<$i$>, get<$i$>(x.\exposid{v_})\}},
+where $i$ is \tcode{x.\exposid{v_}.index()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{common_iterator}%
@@ -5618,18 +5618,18 @@ template<class I2, class S2>
 \begin{itemdescr}
 \pnum
 \hardexpects
-\tcode{x.v_.valueless_by_exception()} is \tcode{false}.
+\tcode{x.\exposid{v_}.valueless_by_exception()} is \tcode{false}.
 
 \pnum
 \effects
 Equivalent to:
 \begin{itemize}
-\item If \tcode{v_.index() == x.v_.index()}, then
-\tcode{get<$i$>(v_) = get<$i$>(x.v_)}.
+\item If \tcode{\exposid{v_}.index() == x.\exposid{v_}.index()}, then
+\tcode{get<$i$>(\exposid{v_}) = get<$i$>(x.\exposid{v_})}.
 
-\item Otherwise, \tcode{v_.emplace<$i$>(get<$i$>(x.v_))}.
+\item Otherwise, \tcode{\exposid{v_}.emplace<$i$>(get<$i$>(x.\exposid{v_}))}.
 \end{itemize}
-where $i$ is \tcode{x.v_.index()}.
+where $i$ is \tcode{x.\exposid{v_}.index()}.
 
 \pnum
 \returns
@@ -5648,11 +5648,11 @@ constexpr decltype(auto) operator*() const
 \begin{itemdescr}
 \pnum
 \hardexpects
-\tcode{holds_alternative<I>(v_)} is \tcode{true}.
+\tcode{holds_alternative<I>(\exposid{v_})} is \tcode{true}.
 
 \pnum
 \effects
-Equivalent to: \tcode{return *get<I>(v_);}
+Equivalent to: \tcode{return *get<I>(\exposid{v_});}
 \end{itemdescr}
 
 \indexlibrarymember{operator->}{common_iterator}%
@@ -5673,26 +5673,26 @@ The expression in the \grammarterm{requires-clause} is equivalent to:
 
 \pnum
 \hardexpects
-\tcode{holds_alternative<I>(v_)} is \tcode{true}.
+\tcode{holds_alternative<I>(\exposid{v_})} is \tcode{true}.
 
 \pnum
 \effects
 \begin{itemize}
 \item
 If \tcode{I} is a pointer type or if the expression
-\tcode{get<I>(v_).operator->()} is
-well-formed, equivalent to: \tcode{return get<I>(v_);}
+\tcode{get<I>(\exposid{v_}).operator->()} is
+well-formed, equivalent to: \tcode{return get<I>(\exposid{v_});}
 
 \item
 Otherwise, if \tcode{iter_reference_t<I>} is a reference type, equivalent to:
 \begin{codeblock}
-auto&& tmp = *get<I>(v_);
+auto&& tmp = *get<I>(@\exposid{v_}@);
 return addressof(tmp);
 \end{codeblock}
 
 \item
 Otherwise, equivalent to:
-\tcode{return \exposid{proxy}(*get<I>(v_));} where
+\tcode{return \exposid{proxy}(*get<I>(\exposid{v_}));} where
 \exposid{proxy} is the exposition-only class:
 \begin{codeblock}
 class @\exposid{proxy}@ {
@@ -5718,11 +5718,11 @@ constexpr common_iterator& operator++();
 \begin{itemdescr}
 \pnum
 \hardexpects
-\tcode{holds_alternative<I>(v_)} is \tcode{true}.
+\tcode{holds_alternative<I>(\exposid{v_})} is \tcode{true}.
 
 \pnum
 \effects
-Equivalent to \tcode{++get<I>(v_)}.
+Equivalent to \tcode{++get<I>(\exposid{v_})}.
 
 \pnum
 \returns
@@ -5737,7 +5737,7 @@ constexpr decltype(auto) operator++(int);
 \begin{itemdescr}
 \pnum
 \hardexpects
-\tcode{holds_alternative<I>(v_)} is \tcode{true}.
+\tcode{holds_alternative<I>(\exposid{v_})} is \tcode{true}.
 
 \pnum
 \effects
@@ -5757,7 +5757,7 @@ is \tcode{true} or
 is \tcode{false},
 equivalent to:
 \begin{codeblock}
-return get<I>(v_)++;
+return get<I>(@\exposid{v_}@)++;
 \end{codeblock}
 Otherwise, equivalent to:
 \begin{codeblock}
@@ -5792,14 +5792,14 @@ friend constexpr bool operator==(
 \begin{itemdescr}
 \pnum
 \hardexpects
-\tcode{x.v_.valueless_by_exception()} and \tcode{y.v_.valueless_by_exception()}
+\tcode{x.\exposid{v_}.valueless_by_exception()} and \tcode{y.\exposid{v_}.valueless_by_exception()}
 are each \tcode{false}.
 
 \pnum
 \returns
 \tcode{true} if \tcode{$i$ == $j$},
-and otherwise \tcode{get<$i$>(x.v_) == get<$j$>(y.v_)},
-where $i$ is \tcode{x.v_.index()} and $j$ is \tcode{y.v_.index()}.
+and otherwise \tcode{get<$i$>(x.\exposid{v_}) == get<$j$>(y.\exposid{v_})},
+where $i$ is \tcode{x.\exposid{v_}.index()} and $j$ is \tcode{y.\exposid{v_}.index()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{common_iterator}%
@@ -5813,14 +5813,14 @@ friend constexpr bool operator==(
 \begin{itemdescr}
 \pnum
 \hardexpects
-\tcode{x.v_.valueless_by_exception()} and \tcode{y.v_.valueless_by_exception()}
+\tcode{x.\exposid{v_}.valueless_by_exception()} and \tcode{y.\exposid{v_}.valueless_by_exception()}
 are each \tcode{false}.
 
 \pnum
 \returns
 \tcode{true} if $i$ and $j$ are each \tcode{1}, and otherwise
-\tcode{get<$i$>(x.v_) == get<$j$>(y.v_)}, where
-$i$ is \tcode{x.v_.index()} and $j$ is \tcode{y.v_.index()}.
+\tcode{get<$i$>(x.\exposid{v_}) == get<$j$>(y.\exposid{v_})}, where
+$i$ is \tcode{x.\exposid{v_}.index()} and $j$ is \tcode{y.\exposid{v_}.index()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{common_iterator}%
@@ -5834,14 +5834,14 @@ friend constexpr iter_difference_t<I2> operator-(
 \begin{itemdescr}
 \pnum
 \hardexpects
-\tcode{x.v_.valueless_by_exception()} and \tcode{y.v_.valueless_by_exception()}
+\tcode{x.\exposid{v_}.valueless_by_exception()} and \tcode{y.\exposid{v_}.valueless_by_exception()}
 are each \tcode{false}.
 
 \pnum
 \returns
 \tcode{0} if $i$ and $j$ are each \tcode{1}, and otherwise
-\tcode{get<$i$>(x.v_) - get<$j$>(y.v_)}, where
-$i$ is \tcode{x.v_.index()} and $j$ is \tcode{y.v_.index()}.
+\tcode{get<$i$>(x.\exposid{v_}) - get<$j$>(y.\exposid{v_})}, where
+$i$ is \tcode{x.\exposid{v_}.index()} and $j$ is \tcode{y.\exposid{v_}.index()}.
 \end{itemdescr}
 
 \rSec3[common.iter.cust]{Customizations}
@@ -5856,11 +5856,11 @@ friend constexpr decltype(auto) iter_move(const common_iterator& i)
 \begin{itemdescr}
 \pnum
 \hardexpects
-\tcode{holds_alternative<I>(i.v_)} is \tcode{true}.
+\tcode{holds_alternative<I>(i.\exposid{v_})} is \tcode{true}.
 
 \pnum
 \effects
-Equivalent to: \tcode{return ranges::iter_move(get<I>(i.v_));}
+Equivalent to: \tcode{return ranges::iter_move(get<I>(i.\exposid{v_}));}
 \end{itemdescr}
 
 \indexlibrarymember{iter_swap}{common_iterator}%
@@ -5873,12 +5873,12 @@ template<@\libconcept{indirectly_swappable}@<I> I2, class S2>
 \begin{itemdescr}
 \pnum
 \hardexpects
-\tcode{holds_alternative<I>(x.v_)} and \tcode{holds_alternative<I2>(y.v_)}
+\tcode{holds_alternative<I>(x.\exposid{v_})} and \tcode{holds_alternative<I2>(y.\exposid{v_})}
 are each \tcode{true}.
 
 \pnum
 \effects
-Equivalent to \tcode{ranges::iter_swap(get<I>(x.v_), get<I2>(y.v_))}.
+Equivalent to \tcode{ranges::iter_swap(get<I>(x.\exposid{v_}), get<I2>(y.\exposid{v_}))}.
 \end{itemdescr}
 
 \rSec2[default.sentinel]{Default sentinel}
@@ -6008,15 +6008,15 @@ namespace std {
         const counted_iterator& x, const counted_iterator<I2>& y);
 
     friend constexpr decltype(auto) iter_move(const counted_iterator& i)
-      noexcept(noexcept(ranges::iter_move(i.current)))
+      noexcept(noexcept(ranges::iter_move(i.@\exposid{current}@)))
         requires @\libconcept{input_iterator}@<I>;
     template<@\libconcept{indirectly_swappable}@<I> I2>
       friend constexpr void iter_swap(const counted_iterator& x, const counted_iterator<I2>& y)
-        noexcept(noexcept(ranges::iter_swap(x.current, y.current)));
+        noexcept(noexcept(ranges::iter_swap(x.@\exposid{current}@, y.@\exposid{current}@)));
 
   private:
-    I current = I();                    // \expos
-    iter_difference_t<I> length = 0;    // \expos
+    I @\exposid{current}@ = I();                    // \expos
+    iter_difference_t<I> @\exposid{length}@ = 0;    // \expos
   };
 
   template<@\libconcept{input_iterator}@ I>
@@ -6042,8 +6042,8 @@ constexpr counted_iterator(I i, iter_difference_t<I> n);
 
 \pnum
 \effects
-Initializes \tcode{current} with \tcode{std::move(i)} and
-\tcode{length} with \tcode{n}.
+Initializes \exposid{current} with \tcode{std::move(i)} and
+\exposid{length} with \tcode{n}.
 \end{itemdescr}
 
 \indexlibraryctor{counted_iterator}%
@@ -6056,8 +6056,8 @@ template<class I2>
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{current} with \tcode{x.current} and
-\tcode{length} with \tcode{x.length}.
+Initializes \exposid{current} with \tcode{x.\exposid{current}} and
+\exposid{length} with \tcode{x.\exposid{length}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{counted_iterator}%
@@ -6070,8 +6070,8 @@ template<class I2>
 \begin{itemdescr}
 \pnum
 \effects
-Assigns \tcode{x.current} to \tcode{current} and
-\tcode{x.length} to \tcode{length}.
+Assigns \tcode{x.\exposid{current}} to \exposid{current} and
+\tcode{x.\exposid{length}} to \exposid{length}.
 
 \pnum
 \returns
@@ -6088,7 +6088,7 @@ constexpr const I& base() const & noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return current;}
+Equivalent to: \tcode{return \exposid{current};}
 \end{itemdescr}
 
 \indexlibrarymember{base}{counted_iterator}%
@@ -6099,7 +6099,7 @@ constexpr I base() &&;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{std::move(current)}.
+\tcode{std::move(\exposid{current})}.
 \end{itemdescr}
 
 \indexlibrarymember{count}{counted_iterator}%
@@ -6110,7 +6110,7 @@ constexpr iter_difference_t<I> count() const noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return length;}
+Equivalent to: \tcode{return \exposid{length};}
 \end{itemdescr}
 
 \rSec3[counted.iter.elem]{Element access}
@@ -6125,11 +6125,11 @@ constexpr decltype(auto) operator*() const
 \begin{itemdescr}
 \pnum
 \hardexpects
-\tcode{length > 0} is \tcode{true}.
+\tcode{\exposid{length} > 0} is \tcode{true}.
 
 \pnum
 \effects
-Equivalent to: \tcode{return *current;}
+Equivalent to: \tcode{return *\exposid{current};}
 \end{itemdescr}
 
 \indexlibrarymember{operator->}{counted_iterator}%
@@ -6141,7 +6141,7 @@ constexpr auto operator->() const noexcept
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return to_address(current);}
+Equivalent to: \tcode{return to_address(\exposid{current});}
 \end{itemdescr}
 
 \indexlibrarymember{operator[]}{counted_iterator}%
@@ -6157,7 +6157,7 @@ constexpr decltype(auto) operator[](iter_difference_t<I> n) const
 
 \pnum
 \effects
-Equivalent to: \tcode{return current[n];}
+Equivalent to: \tcode{return \exposid{current}[n];}
 \end{itemdescr}
 
 \rSec3[counted.iter.nav]{Navigation}
@@ -6170,14 +6170,14 @@ constexpr counted_iterator& operator++();
 \begin{itemdescr}
 \pnum
 \hardexpects
-\tcode{length > 0} is \tcode{true}.
+\tcode{\exposid{length} > 0} is \tcode{true}.
 
 \pnum
 \effects
 Equivalent to:
 \begin{codeblock}
-++current;
---length;
+++@\exposid{current}@;
+--@\exposid{length}@;
 return *this;
 \end{codeblock}
 \end{itemdescr}
@@ -6190,15 +6190,15 @@ constexpr decltype(auto) operator++(int);
 \begin{itemdescr}
 \pnum
 \hardexpects
-\tcode{length > 0} is \tcode{true}.
+\tcode{\exposid{length} > 0} is \tcode{true}.
 
 \pnum
 \effects
 Equivalent to:
 \begin{codeblock}
---length;
-try { return current++; }
-catch(...) { ++length; throw; }
+--@\exposid{length}@;
+try { return @\exposid{current}@++; }
+catch(...) { ++@\exposid{length}@; throw; }
 \end{codeblock}
 \end{itemdescr}
 
@@ -6230,8 +6230,8 @@ constexpr counted_iterator& operator--()
 \effects
 Equivalent to:
 \begin{codeblock}
---current;
-++length;
+--@\exposid{current}@;
+++@\exposid{length}@;
 return *this;
 \end{codeblock}
 \end{itemdescr}
@@ -6262,7 +6262,7 @@ constexpr counted_iterator operator+(iter_difference_t<I> n) const
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return counted_iterator(current + n, length - n);}
+Equivalent to: \tcode{return counted_iterator(\exposid{current} + n, \exposid{length} - n);}
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{counted_iterator}%
@@ -6287,14 +6287,14 @@ constexpr counted_iterator& operator+=(iter_difference_t<I> n)
 \begin{itemdescr}
 \pnum
 \hardexpects
-\tcode{n <= length} is \tcode{true}.
+\tcode{n <= \exposid{length} is \tcode{true}}.
 
 \pnum
 \effects
 Equivalent to:
 \begin{codeblock}
-current += n;
-length -= n;
+@\exposid{current}@ += n;
+@\exposid{length}@ -= n;
 return *this;
 \end{codeblock}
 \end{itemdescr}
@@ -6308,7 +6308,7 @@ constexpr counted_iterator operator-(iter_difference_t<I> n) const
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return counted_iterator(current - n, length + n);}
+Equivalent to: \tcode{return counted_iterator(\exposid{current} - n, \exposid{length} + n);}
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{counted_iterator}%
@@ -6326,7 +6326,7 @@ sequence\iref{counted.iterator}.
 
 \pnum
 \effects
-Equivalent to: \tcode{return y.length - x.length;}
+Equivalent to: \tcode{return y.\exposid{length} - x.\exposid{length};}
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{counted_iterator}%
@@ -6339,7 +6339,7 @@ friend constexpr iter_difference_t<I> operator-(
 \pnum
 \effects
 Equivalent to:
-\tcode{return -x.length;}
+\tcode{return -x.\exposid{length};}
 \end{itemdescr}
 
 \indexlibrarymember{operator-}{counted_iterator}%
@@ -6351,7 +6351,7 @@ friend constexpr iter_difference_t<I> operator-(
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return y.length;}
+Equivalent to: \tcode{return y.\exposid{length};}
 \end{itemdescr}
 
 \indexlibrarymember{operator-=}{counted_iterator}%
@@ -6363,14 +6363,14 @@ constexpr counted_iterator& operator-=(iter_difference_t<I> n)
 \begin{itemdescr}
 \pnum
 \hardexpects
-\tcode{-n <= length} is \tcode{true}.
+\tcode{-n <= \exposid{length} is \tcode{true}}.
 
 \pnum
 \effects
 Equivalent to:
 \begin{codeblock}
-current -= n;
-length += n;
+@\exposid{current}@ -= n;
+@\exposid{length}@ += n;
 return *this;
 \end{codeblock}
 \end{itemdescr}
@@ -6392,7 +6392,7 @@ elements of the same sequence\iref{counted.iterator}.
 
 \pnum
 \effects
-Equivalent to: \tcode{return x.length == y.length;}
+Equivalent to: \tcode{return x.\exposid{length} == y.\exposid{length};}
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{counted_iterator}%
@@ -6404,7 +6404,7 @@ friend constexpr bool operator==(
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return x.length == 0;}
+Equivalent to: \tcode{return x.\exposid{length} == 0;}
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{counted_iterator}%
@@ -6422,12 +6422,12 @@ elements of the same sequence\iref{counted.iterator}.
 
 \pnum
 \effects
-Equivalent to: \tcode{return y.length <=> x.length;}
+Equivalent to: \tcode{return y.\exposid{length} <=> x.\exposid{length};}
 
 \pnum
 \begin{note}
 The argument order in the \effects element is reversed
-because \tcode{length} counts down, not up.
+because \exposid{length} counts down, not up.
 \end{note}
 \end{itemdescr}
 
@@ -6437,18 +6437,18 @@ because \tcode{length} counts down, not up.
 \begin{itemdecl}
 friend constexpr decltype(auto)
   iter_move(const counted_iterator& i)
-    noexcept(noexcept(ranges::iter_move(i.current)))
+    noexcept(noexcept(ranges::iter_move(i.@\exposid{current}@)))
     requires @\libconcept{input_iterator}@<I>;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \hardexpects
-\tcode{i.length > 0} is \tcode{true}.
+\tcode{i.\exposid{length} > 0} is \tcode{true}.
 
 \pnum
 \effects
-Equivalent to: \tcode{return ranges::iter_move(i.current);}
+Equivalent to: \tcode{return ranges::iter_move(i.\exposid{current});}
 \end{itemdescr}
 
 \indexlibrarymember{iter_swap}{counted_iterator}%
@@ -6456,17 +6456,17 @@ Equivalent to: \tcode{return ranges::iter_move(i.current);}
 template<@\libconcept{indirectly_swappable}@<I> I2>
   friend constexpr void
     iter_swap(const counted_iterator& x, const counted_iterator<I2>& y)
-      noexcept(noexcept(ranges::iter_swap(x.current, y.current)));
+      noexcept(noexcept(ranges::iter_swap(x.@\exposid{current}@, y.@\exposid{current}@)));
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \hardexpects
-Both \tcode{x.length > 0} and \tcode{y.length > 0} are \tcode{true}.
+Both \tcode{x.\exposid{length} > 0} and \tcode{y.\exposid{length} > 0} are \tcode{true}.
 
 \pnum
 \effects
-Equivalent to \tcode{ranges::iter_swap(x.current, y.current)}.
+Equivalent to \tcode{ranges::iter_swap(x.\exposid{current}, y.\exposid{current})}.
 \end{itemdescr}
 
 \rSec2[unreachable.sentinel]{Unreachable sentinel}
@@ -6565,8 +6565,8 @@ namespace std {
     friend bool operator==(const istream_iterator& i, default_sentinel_t);
 
   private:
-    basic_istream<charT,traits>* in_stream; // \expos
-    T value;                                // \expos
+    basic_istream<charT,traits>* @\exposid{in-stream}@; // \expos
+    T @\exposid{value}@;                                // \expos
   };
 }
 \end{codeblock}
@@ -6586,11 +6586,11 @@ constexpr istream_iterator(default_sentinel_t);
 \begin{itemdescr}
 \pnum
 \effects
-Constructs the end-of-stream iterator, value-initializing \tcode{value}.
+Constructs the end-of-stream iterator, value-initializing \exposid{value}.
 
 \pnum
 \ensures
-\tcode{in_stream == nullptr} is \tcode{true}.
+\tcode{\exposid{in-stream} == nullptr} is \tcode{true}.
 
 \pnum
 \remarks
@@ -6608,9 +6608,9 @@ istream_iterator(istream_type& s);
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{in_stream} with \tcode{addressof(s)},
-value-initializes \tcode{value},
-and then calls \tcode{operator++()}.
+Initializes \exposid{in-stream} with \tcode{addressof(s)},
+value-initializes \exposid{value},
+and then calls\linebreak \tcode{operator++()}.
 \end{itemdescr}
 
 
@@ -6622,13 +6622,13 @@ constexpr istream_iterator(const istream_iterator& x) noexcept(@\seebelow@);
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{in_stream} with \tcode{x.in_stream} and
-initializes \tcode{value} with \tcode{x.value}.
+Initializes \exposid{in-stream} with \tcode{x.\exposid{in-stream}} and
+initializes \exposid{value} with \tcode{x.\exposid{value}}.
 
 \pnum
 \remarks
 An invocation of this constructor may be used in a core constant expression
-if and only if the initialization of \tcode{value} from \tcode{x.value}
+if and only if the initialization of \exposid{value} from \tcode{x.\exposid{value}}
 is a constant subexpression\iref{defns.const.subexpr}.
 The exception specification is equivalent to
 \tcode{is_nothrow_copy_constructible_v<T>}.
@@ -6656,11 +6656,11 @@ const T& operator*() const;
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{in_stream != nullptr} is \tcode{true}.
+\tcode{\exposid{in-stream} != nullptr} is \tcode{true}.
 
 \pnum
 \returns
-\tcode{value}.
+\exposid{value}.
 \end{itemdescr}
 
 \indexlibrarymember{operator->}{istream_iterator}%
@@ -6671,11 +6671,11 @@ const T* operator->() const;
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{in_stream != nullptr} is \tcode{true}.
+\tcode{\exposid{in-stream} != nullptr} is \tcode{true}.
 
 \pnum
 \returns
-\tcode{addressof(value)}.
+\tcode{addressof(\exposid{value})}.
 \end{itemdescr}
 
 \indexlibrarymember{operator++}{istream_iterator}%
@@ -6686,14 +6686,14 @@ istream_iterator& operator++();
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{in_stream != nullptr} is \tcode{true}.
+\tcode{\exposid{in-stream} != nullptr} is \tcode{true}.
 
 \pnum
 \effects
 Equivalent to:
 \begin{codeblock}
-if (!(*in_stream >> value))
-  in_stream = nullptr;
+if (!(*@\exposid{in-stream}@ >> \exposid{value}))
+  @\exposid{in-stream}@ = nullptr;
 \end{codeblock}
 
 \pnum
@@ -6709,7 +6709,7 @@ istream_iterator operator++(int);
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{in_stream != nullptr} is \tcode{true}.
+\tcode{\exposid{in-stream} != nullptr} is \tcode{true}.
 
 \pnum
 \effects
@@ -6731,7 +6731,7 @@ template<class T, class charT, class traits, class Distance>
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{x.in_stream == y.in_stream}.
+\tcode{x.\exposid{in-stream} == y.\exposid{in-stream}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{istream_iterator}%
@@ -6742,7 +6742,7 @@ friend bool operator==(const istream_iterator& i, default_sentinel_t);
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{!i.in_stream}.
+\tcode{!i.\exposid{in-stream}}.
 \end{itemdescr}
 
 \rSec2[ostream.iterator]{Class template \tcode{ostream_iterator}}
@@ -6789,8 +6789,8 @@ namespace std {
     ostream_iterator& operator++(int);
 
   private:
-    basic_ostream<charT,traits>* out_stream;            // \expos
-    const charT* delim;                                 // \expos
+    basic_ostream<charT,traits>* @\exposid{out-stream}@;            // \expos
+    const charT* @\exposid{delim}@;                                 // \expos
   };
 }
 \end{codeblock}
@@ -6805,8 +6805,8 @@ ostream_iterator(ostream_type& s);
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{out_stream} with \tcode{addressof(s)} and
-\tcode{delim} with \keyword{nullptr}.
+Initializes \exposid{out-stream} with \tcode{addressof(s)} and
+\exposid{delim} with \keyword{nullptr}.
 \end{itemdescr}
 
 
@@ -6818,8 +6818,8 @@ ostream_iterator(ostream_type& s, const charT* delimiter);
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{out_stream} with \tcode{addressof(s)} and
-\tcode{delim} with \tcode{delimiter}.
+Initializes \exposid{out-stream} with \tcode{addressof(s)} and
+\exposid{delim} with \tcode{delimiter}.
 \end{itemdescr}
 
 \rSec3[ostream.iterator.ops]{Operations}
@@ -6834,9 +6834,9 @@ ostream_iterator& operator=(const T& value);
 \effects
 As if by:
 \begin{codeblock}
-*out_stream << value;
-if (delim)
-  *out_stream << delim;
+*@\exposid{out-stream}@ << value;
+if (@\exposid{delim}@)
+  *@\exposid{out-stream}@ << @\exposid{delim}@;
 return *this;
 \end{codeblock}
 \end{itemdescr}
@@ -6941,7 +6941,7 @@ namespace std {
     friend bool operator==(const istreambuf_iterator& i, default_sentinel_t s);
 
   private:
-    streambuf_type* sbuf_;              // \expos
+    streambuf_type* @\exposid{sbuf_}@;              // \expos
   };
 }
 \end{codeblock}
@@ -6982,7 +6982,7 @@ namespace std {
 \pnum
 For each \tcode{istreambuf_iterator} constructor in this subclause,
 an end-of-stream iterator is constructed if and only if
-the exposition-only member \tcode{sbuf_} is initialized with a null pointer value.
+the exposition-only member \exposid{sbuf_} is initialized with a null pointer value.
 
 
 \indexlibraryctor{istreambuf_iterator}%
@@ -6994,7 +6994,7 @@ constexpr istreambuf_iterator(default_sentinel_t) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{sbuf_} with \keyword{nullptr}.
+Initializes \exposid{sbuf_} with \keyword{nullptr}.
 \end{itemdescr}
 
 
@@ -7006,7 +7006,7 @@ istreambuf_iterator(istream_type& s) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{sbuf_} with \tcode{s.rdbuf()}.
+Initializes \exposid{sbuf_} with \tcode{s.rdbuf()}.
 \end{itemdescr}
 
 
@@ -7018,7 +7018,7 @@ istreambuf_iterator(streambuf_type* s) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{sbuf_} with \tcode{s}.
+Initializes \exposid{sbuf_} with \tcode{s}.
 \end{itemdescr}
 
 
@@ -7030,7 +7030,7 @@ istreambuf_iterator(const @\placeholder{proxy}@& p) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{sbuf_} with \tcode{p.sbuf_}.
+Initializes \exposid{sbuf_} with \tcode{p.sbuf_}.
 \end{itemdescr}
 
 \rSec3[istreambuf.iterator.ops]{Operations}
@@ -7046,7 +7046,7 @@ charT operator*() const;
 The character obtained via the
 \tcode{streambuf}
 member
-\tcode{sbuf_->sgetc()}.
+\tcode{\exposid{sbuf_}->sgetc()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator++}{istreambuf_iterator}%
@@ -7057,7 +7057,7 @@ istreambuf_iterator& operator++();
 \begin{itemdescr}
 \pnum
 \effects
-As if by \tcode{sbuf_->sbumpc()}.
+As if by \tcode{\exposid{sbuf_}->sbumpc()}.
 
 \pnum
 \returns
@@ -7072,7 +7072,7 @@ As if by \tcode{sbuf_->sbumpc()}.
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{\exposid{proxy}(sbuf_->sbumpc(), sbuf_)}.
+\tcode{\exposid{proxy}(\exposid{sbuf_}->sbumpc(), \exposid{sbuf_})}.
 \end{itemdescr}
 
 \indexlibrarymember{equal}{istreambuf_iterator}%
@@ -7149,7 +7149,7 @@ namespace std {
     bool failed() const noexcept;
 
   private:
-    streambuf_type* sbuf_;              // \expos
+    streambuf_type* @\exposid{sbuf_}@;              // \expos
   };
 }
 \end{codeblock}
@@ -7169,7 +7169,7 @@ is not a null pointer.
 
 \pnum
 \effects
-Initializes \tcode{sbuf_} with \tcode{s.rdbuf()}.
+Initializes \exposid{sbuf_} with \tcode{s.rdbuf()}.
 \end{itemdescr}
 
 
@@ -7186,7 +7186,7 @@ is not a null pointer.
 
 \pnum
 \effects
-Initializes \tcode{sbuf_} with \tcode{s}.
+Initializes \exposid{sbuf_} with \tcode{s}.
 \end{itemdescr}
 
 \rSec3[ostreambuf.iter.ops]{Operations}
@@ -7204,7 +7204,7 @@ If
 yields
 \tcode{false},
 calls
-\tcode{sbuf_->sputc(c)};
+\tcode{\exposid{sbuf_}->sputc(c)};
 otherwise has no effect.
 
 \pnum
@@ -7247,7 +7247,7 @@ bool failed() const noexcept;
 if in any prior use of member
 \tcode{operator=},
 the call to
-\tcode{sbuf_->sputc()}
+\tcode{\exposid{sbuf_}->sputc()}
 returned
 \tcode{traits::eof()};
 or

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -3706,7 +3706,7 @@ the swappable with requirements\iref{swappable.requirements}.
 The exception for overloaded operators allows argument-dependent lookup
 in cases like that of
 \tcode{ostream_iterator::operator=}\iref{ostream.iterator.ops}
-where lookup for the expression \tcode{*out_stream << value}
+where lookup for the expression \tcode{*\exposid{out-stream} << value}
 includes the associated namespaces of \tcode{value}'s type.
 \end{note}
 


### PR DESCRIPTION
Towards #4702 and #5940.

Additional changes:
- Renaming _`in_stream`_ and _`out_stream`_ to kebab-cased _`in-stream`_ and _`out-stream`_ respectively.
- Using `\exposid` instead of `\placeholder` for _`cond-value-type`_.
- Adding one `\linebreak` after style change.
- Consistently use _`out-stream`_ in [global.functions] (in a separated commit).