### PR TITLE
[thread] Exposition-only formatting for private members

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -1980,7 +1980,7 @@ namespace std {
     static unsigned int hardware_concurrency() noexcept;
 
   private:
-    stop_source ssource;        // \expos
+    stop_source @\exposid{ssource}@;        // \expos
   };
 }
 \end{codeblock}
@@ -2001,7 +2001,7 @@ a thread of execution.
 \pnum
 \ensures
 \tcode{get_id() == id()} is \tcode{true}
-and \tcode{ssource.stop_possible()} is \tcode{false}.
+and \tcode{\exposid{ssource}.stop_possible()} is \tcode{false}.
 \end{itemdescr}
 
 \indexlibraryctor{jthread}%
@@ -2025,7 +2025,7 @@ The following are all \tcode{true}:
 
 \pnum
 \effects
-Initializes \tcode{ssource}.
+Initializes \exposid{ssource}.
 The new thread of execution executes
 \begin{codeblock}
 invoke(auto(std::forward<F>(f)), get_stop_token(),  // for \tcode{invoke}, see \ref{func.invoke}
@@ -2054,7 +2054,7 @@ synchronizes with the beginning of the invocation of the copy of \tcode{f}.
 \pnum
 \ensures
 \tcode{get_id() != id()} is \tcode{true}
-and \tcode{ssource.stop_possible()} is \tcode{true}
+and \tcode{\exposid{ssource}.stop_possible()} is \tcode{true}
 and \tcode{*this} represents the newly started thread.
 \begin{note}
 The calling thread can make a stop request only once,
@@ -2086,9 +2086,9 @@ jthread(jthread&& x) noexcept;
 \tcode{x.get_id() == id()}
 and \tcode{get_id()} returns the value of \tcode{x.get_id()}
 prior to the start of construction.
-\tcode{ssource} has the value of \tcode{x.ssource}
+\exposid{ssource} has the value of \tcode{x.\exposid{ssource}}
 prior to the start of construction
-and \tcode{x.ssource.stop_possible()} is \tcode{false}.
+and \tcode{x.\exposid{ssource}.stop_possible()} is \tcode{false}.
 \end{itemdescr}
 
 \indexlibrarydtor{jthread}%
@@ -2124,7 +2124,7 @@ and sets \tcode{x} to a default constructed state.
 \ensures
 \tcode{get_id()} returns the value of \tcode{x.get_id()}
 prior to the assignment.
-\tcode{ssource} has the value of \tcode{x.ssource}
+\exposid{ssource} has the value of \tcode{x.\exposid{ssource}}
 prior to the assignment.
 
 \pnum
@@ -2252,7 +2252,7 @@ stop_source get_stop_source() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return ssource;}
+Equivalent to: \tcode{return \exposid{ssource};}
 \end{itemdescr}
 
 \indexlibrarymember{get_stop_token}{jthread}%
@@ -2263,7 +2263,7 @@ stop_token get_stop_token() const noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return ssource.get_token();}
+Equivalent to: \tcode{return \exposid{ssource}.get_token();}
 \end{itemdescr}
 
 \indexlibrarymember{request_stop}{jthread}%
@@ -2274,7 +2274,7 @@ bool request_stop() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return ssource.request_stop();}
+Equivalent to: \tcode{return \exposid{ssource}.request_stop();}
 \end{itemdescr}
 
 
@@ -3153,7 +3153,7 @@ if there exist side effects \tcode{X} and \tcode{Y} on \tcode{M} such that:
 namespace std {
   template<class T> struct atomic_ref {
   private:
-    T* ptr;             // \expos
+    T* @\exposid{ptr}@;             // \expos
 
   public:
     using value_type = remove_cv_t<T>;
@@ -3196,18 +3196,18 @@ namespace std {
 
 \pnum
 An \tcode{atomic_ref} object applies atomic operations\iref{atomics.general} to
-the object referenced by \tcode{*ptr} such that,
+the object referenced by \tcode{*\exposid{ptr}} such that,
 for the lifetime\iref{basic.life} of the \tcode{atomic_ref} object,
-the object referenced by \tcode{*ptr} is an atomic object\iref{intro.races}.
+the object referenced by \tcode{*\exposid{ptr}} is an atomic object\iref{intro.races}.
 
 \pnum
 The program is ill-formed if \tcode{is_trivially_copyable_v<T>} is \tcode{false}.
 
 \pnum
-The lifetime\iref{basic.life} of an object referenced by \tcode{*ptr}
+The lifetime\iref{basic.life} of an object referenced by \tcode{*\exposid{ptr}}
 shall exceed the lifetime of all \tcode{atomic_ref}s that reference the object.
 While any \tcode{atomic_ref} instances exist
-that reference the \tcode{*ptr} object,
+that reference the \tcode{*\exposid{ptr}} object,
 all accesses to that object shall exclusively occur
 through those \tcode{atomic_ref} instances.
 No subobject of the object referenced by \tcode{atomic_ref}
@@ -3367,7 +3367,7 @@ constexpr void store(value_type desired,
 
 \pnum
 \effects
-Atomically replaces the value referenced by \tcode{*ptr}
+Atomically replaces the value referenced by \tcode{*\exposid{ptr}}
 with the value of \tcode{desired}.
 Memory is affected according to the value of \tcode{order}.
 \end{itemdescr}
@@ -3416,7 +3416,7 @@ Memory is affected according to the value of \tcode{order}.
 
 \pnum
 \returns
-Atomically returns the value referenced by \tcode{*ptr}.
+Atomically returns the value referenced by \tcode{*\exposid{ptr}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator \placeholder{type}}{atomic_ref}%
@@ -3449,14 +3449,14 @@ constexpr value_type exchange(value_type desired,
 
 \pnum
 \effects
-Atomically replaces the value referenced by \tcode{*ptr}
+Atomically replaces the value referenced by \tcode{*\exposid{ptr}}
 with \tcode{desired}.
 Memory is affected according to the value of \tcode{order}.
 This operation is an atomic read-modify-write operation\iref{intro.multithread}.
 
 \pnum
 \returns
-Atomically returns the value referenced by \tcode{*ptr}
+Atomically returns the value referenced by \tcode{*\exposid{ptr}}
 immediately before the effects.
 \end{itemdescr}
 
@@ -3498,9 +3498,9 @@ constexpr bool compare_exchange_strong(value_type& expected, value_type desired,
 \effects
 Retrieves the value in \tcode{expected}.
 It then atomically compares the value representation of
-the value referenced by \tcode{*ptr} for equality
+the value referenced by \tcode{*\exposid{ptr}} for equality
 with that previously retrieved from \tcode{expected},
-and if \tcode{true}, replaces the value referenced by \tcode{*ptr}
+and if \tcode{true}, replaces the value referenced by \tcode{*\exposid{ptr}}
 with that in \tcode{desired}.
 If and only if the comparison is \tcode{true},
 memory is affected according to the value of \tcode{success}, and
@@ -3516,11 +3516,11 @@ the value \tcode{memory_order::relaxed}.
 If and only if the comparison is \tcode{false} then,
 after the atomic operation,
 the value in \tcode{expected} is replaced by
-the value read from the value referenced by \tcode{*ptr}
+the value read from the value referenced by \tcode{*\exposid{ptr}}
 during the atomic comparison.
 If the operation returns \tcode{true},
 these operations are atomic read-modify-write operations\iref{intro.races}
-on the value referenced by \tcode{*ptr}.
+on the value referenced by \tcode{*\exposid{ptr}}.
 Otherwise, these operations are atomic load operations on that memory.
 
 \pnum
@@ -3531,7 +3531,7 @@ The result of the comparison.
 \remarks
 A weak compare-and-exchange operation may fail spuriously.
 That is, even when the value representations referred to
-by \tcode{expected} and \tcode{ptr} compare equal,
+by \tcode{expected} and \exposid{ptr} compare equal,
 it may return \tcode{false} and
 store back to \tcode{expected}
 the same value representation that was originally there.
@@ -3577,7 +3577,7 @@ Repeatedly performs the following steps, in order:
 \pnum
 \remarks
 This function is an atomic waiting operation\iref{atomics.wait}
-on atomic object \tcode{*ptr}.
+on atomic object \tcode{*\exposid{ptr}}.
 \end{itemdescr}
 
 \indexlibrarymember{notify_one}{atomic_ref<T>}%
@@ -3592,14 +3592,14 @@ constexpr void notify_one() const noexcept;
 
 \pnum
 \effects
-Unblocks the execution of at least one atomic waiting operation on \tcode{*ptr}
+Unblocks the execution of at least one atomic waiting operation on \tcode{*\exposid{ptr}}
 that is eligible to be unblocked\iref{atomics.wait} by this call,
 if any such atomic waiting operations exist.
 
 \pnum
 \remarks
 This function is an atomic notifying operation\iref{atomics.wait}
-on atomic object \tcode{*ptr}.
+on atomic object \tcode{*\exposid{ptr}}.
 \end{itemdescr}
 
 \indexlibrarymember{notify_all}{atomic_ref<T>}%
@@ -3614,13 +3614,13 @@ constexpr void notify_all() const noexcept;
 
 \pnum
 \effects
-Unblocks the execution of all atomic waiting operations on \tcode{*ptr}
+Unblocks the execution of all atomic waiting operations on \tcode{*\exposid{ptr}}
 that are eligible to be unblocked\iref{atomics.wait} by this call.
 
 \pnum
 \remarks
 This function is an atomic notifying operation\iref{atomics.wait}
-on atomic object \tcode{*ptr}.
+on atomic object \tcode{*\exposid{ptr}}.
 \end{itemdescr}
 
 \indexlibrarymember{address}{atomic_ref<T>}%
@@ -3631,7 +3631,7 @@ constexpr @\exposid{address-return-type}@ address() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{ptr}.
+\exposid{ptr}.
 \end{itemdescr}
 
 \rSec3[atomics.ref.int]{Specializations for integral types}
@@ -3657,7 +3657,7 @@ if \tcode{is_always_lock_free} is \tcode{false} and
 namespace std {
   template<> struct atomic_ref<@\placeholder{integral-type}@> {
   private:
-    @\placeholder{integral-type}@* ptr;         // \expos
+    @\placeholder{integral-type}@* @\exposid{ptr}@;         // \expos
 
   public:
     using value_type = remove_cv_t<@\placeholder{integral-type}@>;
@@ -3767,15 +3767,15 @@ constexpr value_type fetch_@\placeholdernc{key}@(value_type operand,
 
 \pnum
 \effects
-Atomically replaces the value referenced by \tcode{*ptr} with
-the result of the computation applied to the value referenced by \tcode{*ptr}
+Atomically replaces the value referenced by \tcode{*\exposid{ptr}} with
+the result of the computation applied to the value referenced by \tcode{*\exposid{ptr}}
 and the given operand.
 Memory is affected according to the value of \tcode{order}.
 These operations are atomic read-modify-write operations\iref{intro.races}.
 
 \pnum
 \returns
-Atomically, the value referenced by \tcode{*ptr}
+Atomically, the value referenced by \tcode{*\exposid{ptr}}
 immediately before the effects.
 
 \pnum
@@ -3821,9 +3821,9 @@ constexpr void store_@\placeholdernc{key}@(value_type operand,
 
 \pnum
 \effects
-Atomically replaces the value referenced by \tcode{*ptr}
+Atomically replaces the value referenced by \tcode{*\exposid{ptr}}
 with the result of the computation applied to
-the value referenced by \tcode{*ptr} and the given \tcode{operand}.
+the value referenced by \tcode{*\exposid{ptr}} and the given \tcode{operand}.
 Memory is affected according to the value of \tcode{order}.
 These operations are atomic modify-write operations\iref{atomics.order}.
 
@@ -3831,7 +3831,7 @@ These operations are atomic modify-write operations\iref{atomics.order}.
 \remarks
 Except for \tcode{store_max} and \tcode{store_min},
 for signed integer types,
-the result is as if \tcode{*ptr} and parameters
+the result is as if \tcode{*\exposid{ptr}} and parameters
 were converted to their corresponding unsigned types,
 the computation performed on those types, and
 the result converted back to the signed type.
@@ -3841,7 +3841,7 @@ There are no undefined results arising from the computation.
 For \tcode{store_max} and \tcode{store_min},
 the maximum and minimum computation is performed
 as if by \tcode{max} and \tcode{min} algorithms\iref{alg.min.max}, respectively,
-with \tcode{*ptr} and the first parameter as the arguments.
+with \tcode{*\exposid{ptr}} and the first parameter as the arguments.
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{atomic_ref<\placeholder{integral-type}>}%
@@ -3883,7 +3883,7 @@ if \tcode{is_always_lock_free} is \tcode{false} and
 namespace std {
   template<> struct atomic_ref<@\placeholder{floating-point-type}@> {
   private:
-    @\placeholder{floating-point-type}@* ptr;   // \expos
+    @\placeholder{floating-point-type}@* @\exposid{ptr}@;   // \expos
 
   public:
     using value_type = remove_cv_t<@\placeholder{floating-point-type}@>;
@@ -3994,19 +3994,19 @@ constexpr value_type fetch_@\placeholdernc{key}@(value_type operand,
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{is_const_v<\exposid{floating-point-type}>} is \tcode{false}.
+\tcode{is_const_v<\placeholder{floating-point-type}>} is \tcode{false}.
 
 \pnum
 \effects
-Atomically replaces the value referenced by \tcode{*ptr} with
-the result of the computation applied to the value referenced by \tcode{*ptr}
+Atomically replaces the value referenced by \tcode{*\exposid{ptr}} with
+the result of the computation applied to the value referenced by \tcode{*\exposid{ptr}}
 and the given operand.
 Memory is affected according to the value of \tcode{order}.
 These operations are atomic read-modify-write operations\iref{intro.races}.
 
 \pnum
 \returns
-Atomically, the value referenced by \tcode{*ptr}
+Atomically, the value referenced by \tcode{*\exposid{ptr}}
 immediately before the effects.
 
 \pnum
@@ -4027,27 +4027,27 @@ may be different than the calling thread's floating-point environment.
 For \tcode{fetch_fmaximum} and \tcode{fetch_fminimum},
 the maximum and minimum computation is performed
 as if by \tcode{fmaximum} and \tcode{fminimum}, respectively,
-with \tcode{*ptr} and the first parameter as the arguments.
+with \tcode{*\exposid{ptr}} and the first parameter as the arguments.
 \item
 For \tcode{fetch_fmaximum_num} and \tcode{fetch_fminimum_num},
 the maximum and minimum computation is performed
 as if by \tcode{fmaximum_num} and \tcode{fminimum_num}, respectively,
-with \tcode{*ptr} and the first parameter as the arguments.
+with \tcode{*\exposid{ptr}} and the first parameter as the arguments.
 \item
 For \tcode{fetch_max} and \tcode{fetch_min},
 the maximum and minimum computation is performed
 as if by \tcode{fmaximum_num} and \tcode{fminimum_num}, respectively,
-with \tcode{*ptr} and the first parameter as the arguments, except that:
+with \tcode{*\exposid{ptr}} and the first parameter as the arguments, except that:
 \begin{itemize}
 \item
-If both arguments are NaN, an unspecified NaN value is stored at \tcode{*ptr}.
+If both arguments are NaN, an unspecified NaN value is stored at \tcode{*\exposid{ptr}}.
 \item
 If exactly one argument is a NaN,
-either the other argument or an unspecified NaN value is stored at \tcode{*ptr};
+either the other argument or an unspecified NaN value is stored at \tcode{*\exposid{ptr}};
 it is unspecified which.
 \item
 If the arguments are differently signed zeros,
-which of these values is stored at \tcode{*ptr} is unspecified.
+which of these values is stored at \tcode{*\exposid{ptr}} is unspecified.
 \end{itemize}
 \end{itemize}
 
@@ -4083,9 +4083,9 @@ constexpr void store_@\placeholdernc{key}@(value_type operand,
 
 \pnum
 \effects
-Atomically replaces the value referenced by \tcode{*ptr}
+Atomically replaces the value referenced by \tcode{*\exposid{ptr}}
 with the result of the computation applied to
-the value referenced by \tcode{*ptr} and the given \tcode{operand}.
+the value referenced by \tcode{*\exposid{ptr}} and the given \tcode{operand}.
 Memory is affected according to the value of \tcode{order}.
 These operations are atomic modify-write operations\iref{atomics.order}.
 
@@ -4113,23 +4113,23 @@ Tree reductions are permitted for atomic modify-write operations.
 For \tcode{store_fmaximum} and \tcode{store_fminimum},
 the maximum and minimum computation is performed
 as if by \tcode{fmaximum} and \tcode{fminimum}, respectively,
-with \tcode{*ptr} and the first parameter as the arguments.
+with \tcode{*\exposid{ptr}} and the first parameter as the arguments.
 \item
 For \tcode{store_fmaximum_num} and \tcode{store_fminimum_num},
 the maximum and minimum computation is performed
 as if by \tcode{fmaximum_num }and \tcode{fminimum_num}, respectively,
-with \tcode{*ptr} and the first parameter as the arguments.
+with \tcode{*\exposid{ptr}} and the first parameter as the arguments.
 \item
 For \tcode{store_max} and \tcode{store_min},
 the maximum and minimum computation is performed
 as if by \tcode{fmaximum_num} and \tcode{fminimum_num}, respectively,
-with \tcode{*ptr} and the first parameter as the arguments, except that:
+with \tcode{*\exposid{ptr}} and the first parameter as the arguments, except that:
 \begin{itemize}
 \item
-If both arguments are NaN, an unspecified NaN value is stored at \tcode{*ptr}.
+If both arguments are NaN, an unspecified NaN value is stored at \tcode{*\exposid{ptr}}.
 \item
 If exactly one argument is a NaN,
-either the other argument or an unspecified NaN value is stored at \tcode{*ptr},
+either the other argument or an unspecified NaN value is stored at \tcode{*\exposid{ptr}},
 it is unspecified which.
 \item
 If the arguments are differently signed zeros,
@@ -4152,7 +4152,7 @@ constexpr value_type operator @\placeholder{op}@=(value_type operand) const noex
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{is_const_v<\exposid{floating-point-type}>} is \tcode{false}.
+\tcode{is_const_v<\placeholder{floating-point-type}>} is \tcode{false}.
 
 \pnum
 \effects
@@ -4179,7 +4179,7 @@ if \tcode{is_always_lock_free} is \tcode{false} and
 namespace std {
   template<> struct atomic_ref<@\placeholder{pointer-type}@> {
   private:
-    @\placeholder{pointer-type}@* ptr;        // \expos
+    @\placeholder{pointer-type}@* @\exposid{ptr}@;        // \expos
 
   public:
     using value_type = remove_cv_t<@\placeholder{pointer-type}@>;
@@ -4275,15 +4275,15 @@ constexpr value_type fetch_@\placeholdernc{key}@(@\seeabovenc@ operand,
 
 \pnum
 \effects
-Atomically replaces the value referenced by \tcode{*ptr} with
-the result of the computation applied to the value referenced by \tcode{*ptr}
+Atomically replaces the value referenced by \tcode{*\exposid{ptr}} with
+the result of the computation applied to the value referenced by \tcode{*\exposid{ptr}}
 and the given operand.
 Memory is affected according to the value of \tcode{order}.
 These operations are atomic read-modify-write operations\iref{intro.races}.
 
 \pnum
 \returns
-Atomically, the value referenced by \tcode{*ptr}
+Atomically, the value referenced by \tcode{*\exposid{ptr}}
 immediately before the effects.
 
 \pnum
@@ -4330,9 +4330,9 @@ constexpr void store_@\placeholdernc{key}@(@\seeabovenc@ operand,
 
 \pnum
 \effects
-Atomically replaces the value referenced by \tcode{*ptr}
+Atomically replaces the value referenced by \tcode{*\exposid{ptr}}
 with the result of the computation applied to
-the value referenced by \tcode{*ptr} and the given \tcode{operand}.
+the value referenced by \tcode{*\exposid{ptr}} and the given \tcode{operand}.
 Memory is affected according to the value of \tcode{order}.
 These operations are atomic modify-write operations\iref{atomics.order}.
 
@@ -4343,7 +4343,7 @@ but the operations otherwise have no undefined behavior.
 For \tcode{store_max} and \tcode{store_min},
 the \tcode{maximum} and \tcode{minimum} computation is performed
 as if by \tcode{max} and \tcode{min} algorithms\iref{alg.min.max}, respectively,
-with \tcode{*ptr} and the first parameter as the arguments.
+with \tcode{*\exposid{ptr}} and the first parameter as the arguments.
 \begin{note}
 If the pointers point to different complete objects (or subobjects thereof),
 the \tcode{<} operator does not establish
@@ -6158,7 +6158,7 @@ namespace std {
     constexpr void notify_all() noexcept;
 
   private:
-    shared_ptr<T> p;            // \expos
+    shared_ptr<T> @\exposid{p}@;            // \expos
   };
 }
 \end{codeblock}
@@ -6171,7 +6171,7 @@ constexpr atomic() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Value-initializes \tcode{p}.
+Value-initializes \exposid{p}.
 \end{itemdescr}
 
 \indexlibraryctor{atomic<shared_ptr<T>>}%
@@ -6212,7 +6212,7 @@ constexpr void store(shared_ptr<T> desired, memory_order order = memory_order::s
 \pnum
 \effects
 Atomically replaces the value pointed to by \keyword{this} with
-the value of \tcode{desired} as if by \tcode{p.swap(desired)}.
+the value of \tcode{desired} as if by \tcode{\exposid{p}.swap(desired)}.
 Memory is affected according to the value of \tcode{order}.
 \end{itemdescr}
 
@@ -6257,7 +6257,7 @@ Memory is affected according to the value of \tcode{order}.
 
 \pnum
 \returns
-Atomically returns \tcode{p}.
+Atomically returns \exposid{p}.
 \end{itemdescr}
 
 \indexlibrarymember{operator shared_ptr<T>}{atomic<shared_ptr<T>>}%
@@ -6280,14 +6280,14 @@ constexpr shared_ptr<T> exchange(shared_ptr<T> desired,
 \begin{itemdescr}
 \pnum
 \effects
-Atomically replaces \tcode{p} with \tcode{desired}
-as if by \tcode{p.swap(desired)}.
+Atomically replaces \exposid{p} with \tcode{desired}
+as if by \tcode{\exposid{p}.swap(desired)}.
 Memory is affected according to the value of \tcode{order}.
 This is an atomic read-modify-write operation\iref{intro.races}.
 
 \pnum
 \returns
-Atomically returns the value of \tcode{p} immediately before the effects.
+Atomically returns the value of \exposid{p} immediately before the effects.
 \end{itemdescr}
 
 \indexlibrarymember{compare_exchange_weak}{atomic<shared_ptr<T>>}%
@@ -6309,15 +6309,15 @@ constexpr bool compare_exchange_strong(shared_ptr<T>& expected, shared_ptr<T> de
 
 \pnum
 \effects
-If \tcode{p} is equivalent to \tcode{expected},
-assigns \tcode{desired} to \tcode{p} and
+If \exposid{p} is equivalent to \tcode{expected},
+assigns \tcode{desired} to \exposid{p} and
 has synchronization semantics corresponding to the value of \tcode{success},
-otherwise assigns \tcode{p} to \tcode{expected} and
+otherwise assigns \exposid{p} to \tcode{expected} and
 has synchronization semantics corresponding to the value of \tcode{failure}.
 
 \pnum
 \returns
-\tcode{true} if \tcode{p} was equivalent to \tcode{expected},
+\tcode{true} if \exposid{p} was equivalent to \tcode{expected},
 \tcode{false} otherwise.
 
 \pnum
@@ -6486,7 +6486,7 @@ namespace std {
     constexpr void notify_all() noexcept;
 
   private:
-    weak_ptr<T> p;              // \expos
+    weak_ptr<T> @\exposid{p}@;              // \expos
   };
 }
 \end{codeblock}
@@ -6499,7 +6499,7 @@ constexpr atomic() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Value-initializes \tcode{p}.
+Value-initializes \exposid{p}.
 \end{itemdescr}
 
 \indexlibraryctor{atomic<weak_ptr<T>>}%
@@ -6540,7 +6540,7 @@ constexpr void store(weak_ptr<T> desired, memory_order order = memory_order::seq
 \pnum
 \effects
 Atomically replaces the value pointed to by \keyword{this} with
-the value of \tcode{desired} as if by \tcode{p.swap(desired)}.
+the value of \tcode{desired} as if by \tcode{\exposid{p}.swap(desired)}.
 Memory is affected according to the value of \tcode{order}.
 \end{itemdescr}
 
@@ -6574,7 +6574,7 @@ Memory is affected according to the value of \tcode{order}.
 
 \pnum
 \returns
-Atomically returns \tcode{p}.
+Atomically returns \exposid{p}.
 \end{itemdescr}
 
 \indexlibrarymember{operator weak_ptr<T>}{atomic<weak_ptr<T>>}%
@@ -6597,14 +6597,14 @@ constexpr weak_ptr<T> exchange(weak_ptr<T> desired,
 \begin{itemdescr}
 \pnum
 \effects
-Atomically replaces \tcode{p} with \tcode{desired}
-as if by \tcode{p.swap(desired)}.
+Atomically replaces \exposid{p} with \tcode{desired}
+as if by \tcode{\exposid{p}.swap(desired)}.
 Memory is affected according to the value of \tcode{order}.
 This is an atomic read-modify-write operation\iref{intro.races}.
 
 \pnum
 \returns
-Atomically returns the value of \tcode{p} immediately before the effects.
+Atomically returns the value of \exposid{p} immediately before the effects.
 \end{itemdescr}
 
 \indexlibrarymember{compare_exchange_weak}{atomic<weak_ptr<T>>}%
@@ -6625,15 +6625,15 @@ constexpr bool compare_exchange_strong(weak_ptr<T>& expected, weak_ptr<T> desire
 
 \pnum
 \effects
-If \tcode{p} is equivalent to \tcode{expected},
-assigns \tcode{desired} to \tcode{p} and
+If \exposid{p} is equivalent to \tcode{expected},
+assigns \tcode{desired} to \exposid{p} and
 has synchronization semantics corresponding to the value of \tcode{success},
-otherwise assigns \tcode{p} to \tcode{expected} and
+otherwise assigns \exposid{p} to \tcode{expected} and
 has synchronization semantics corresponding to the value of \tcode{failure}.
 
 \pnum
 \returns
-\tcode{true} if \tcode{p} was equivalent to \tcode{expected},
+\tcode{true} if \exposid{p} was equivalent to \tcode{expected},
 \tcode{false} otherwise.
 
 \pnum
@@ -8197,7 +8197,7 @@ namespace std {
     lock_guard& operator=(const lock_guard&) = delete;
 
   private:
-    mutex_type& pm;             // \expos
+    mutex_type& @\exposid{pm}@;             // \expos
   };
 }
 \end{codeblock}
@@ -8207,7 +8207,7 @@ An object of type \tcode{lock_guard} controls the ownership of a lockable object
 within a scope. A \tcode{lock_guard} object maintains ownership of a lockable
 object throughout the \tcode{lock_guard} object's lifetime\iref{basic.life}.
 The behavior of a program is undefined if the lockable object referenced by
-\tcode{pm} does not exist for the entire lifetime of the \tcode{lock_guard}
+\exposid{pm} does not exist for the entire lifetime of the \tcode{lock_guard}
 object. The supplied \tcode{Mutex} type shall meet the \oldconcept{BasicLockable}
 requirements\iref{thread.req.lockable.basic}.
 
@@ -8219,7 +8219,7 @@ explicit lock_guard(mutex_type& m);
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{pm} with \tcode{m}. Calls \tcode{m.lock()}.
+Initializes \exposid{pm} with \tcode{m}. Calls \tcode{m.lock()}.
 \end{itemdescr}
 
 \indexlibraryctor{lock_guard}%
@@ -8234,7 +8234,7 @@ The calling thread holds a non-shared lock on \tcode{m}.
 
 \pnum
 \effects
-Initializes \tcode{pm} with \tcode{m}.
+Initializes \exposid{pm} with \tcode{m}.
 
 \pnum
 \throws
@@ -8249,7 +8249,7 @@ Nothing.
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{pm.unlock()}
+Equivalent to: \tcode{\exposid{pm}.unlock()}
 \end{itemdescr}
 
 \rSec3[thread.lock.scoped]{Class template \tcode{scoped_lock}}
@@ -8270,7 +8270,7 @@ namespace std {
     scoped_lock& operator=(const scoped_lock&) = delete;
 
   private:
-    tuple<MutexTypes&...> pm;   // \expos
+    tuple<MutexTypes&...> @\exposid{pm}@;   // \expos
   };
 }
 \end{codeblock}
@@ -8280,7 +8280,7 @@ An object of type \tcode{scoped_lock} controls the ownership of lockable objects
 within a scope. A \tcode{scoped_lock} object maintains ownership of lockable
 objects throughout the \tcode{scoped_lock} object's lifetime\iref{basic.life}.
 The behavior of a program is undefined if the lockable objects referenced by
-\tcode{pm} do not exist for the entire lifetime of the \tcode{scoped_lock}
+\exposid{pm} do not exist for the entire lifetime of the \tcode{scoped_lock}
 object.
 \begin{itemize}
 \item
@@ -8304,7 +8304,7 @@ explicit scoped_lock(MutexTypes&... m);
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{pm} with \tcode{tie(m...)}.
+Initializes \exposid{pm} with \tcode{tie(m...)}.
 Then if \tcode{sizeof...(MutexTypes)} is \tcode{0}, no effects.
 Otherwise if \tcode{sizeof...(MutexTypes)} is \tcode{1}, then \tcode{m.lock()}.
 Otherwise, \tcode{lock(m...)}.
@@ -8322,7 +8322,7 @@ The calling thread holds a non-shared lock on each element of \tcode{m}.
 
 \pnum
 \effects
-Initializes \tcode{pm} with \tcode{tie(m...)}.
+Initializes \exposid{pm} with \tcode{tie(m...)}.
 
 \pnum
 \throws
@@ -8338,7 +8338,7 @@ Nothing.
 \pnum
 \effects
 For all \tcode{i} in \range{0}{sizeof...(MutexTypes)},
-\tcode{get<i>(pm).unlock()}.
+\tcode{get<i>(\exposid{pm}).unlock()}.
 \end{itemdescr}
 
 \rSec3[thread.lock.unique]{Class template \tcode{unique_lock}}
@@ -8392,8 +8392,8 @@ namespace std {
     mutex_type* mutex() const noexcept;
 
   private:
-    mutex_type* pm;             // \expos
-    bool owns;                  // \expos
+    mutex_type* @\exposid{pm}@;             // \expos
+    bool @\exposid{owns}@;                  // \expos
   };
 }
 \end{codeblock}
@@ -8404,8 +8404,8 @@ object within a scope. Ownership of the lockable object may be acquired at
 construction or after construction, and may be transferred, after
 acquisition, to another \tcode{unique_lock} object. Objects of type \tcode{unique_lock} are not
 copyable but are movable. The behavior of a program is undefined if the contained pointer
-\tcode{pm} is not null and the lockable object pointed
-to by \tcode{pm} does not exist for the entire remaining
+\exposid{pm} is not null and the lockable object pointed
+to by \exposid{pm} does not exist for the entire remaining
 lifetime\iref{basic.life} of the \tcode{unique_lock} object. The supplied
 \tcode{Mutex} type shall meet the \oldconcept{BasicLockable}
 requirements\iref{thread.req.lockable.basic}.
@@ -8430,7 +8430,7 @@ unique_lock() noexcept;
 \begin{itemdescr}
 \pnum
 \ensures
-\tcode{pm == nullptr} and \tcode{owns == false}.
+\tcode{\exposid{pm} == nullptr} and \tcode{\exposid{owns} == false}.
 \end{itemdescr}
 
 \indexlibraryctor{unique_lock}%
@@ -8445,7 +8445,7 @@ Calls \tcode{m.lock()}.
 
 \pnum
 \ensures
-\tcode{pm == addressof(m)} and \tcode{owns == true}.
+\tcode{\exposid{pm} == addressof(m)} and \tcode{\exposid{owns} == true}.
 \end{itemdescr}
 
 \indexlibraryctor{unique_lock}%
@@ -8456,7 +8456,7 @@ unique_lock(mutex_type& m, defer_lock_t) noexcept;
 \begin{itemdescr}
 \pnum
 \ensures
-\tcode{pm == addressof(m)} and \tcode{owns == false}.
+\tcode{\exposid{pm} == addressof(m)} and \tcode{\exposid{owns} == false}.
 \end{itemdescr}
 
 \indexlibraryctor{unique_lock}%
@@ -8476,7 +8476,7 @@ Calls \tcode{m.try_lock()}.
 
 \pnum
 \ensures
-\tcode{pm == addressof(m)} and \tcode{owns == res},
+\tcode{\exposid{pm} == addressof(m)} and \tcode{o\exposid{owns}wns == res},
 where \tcode{res} is the value returned by the call to \tcode{m.try_lock()}.
 \end{itemdescr}
 
@@ -8492,7 +8492,7 @@ The calling thread holds a non-shared lock on \tcode{m}.
 
 \pnum
 \ensures
-\tcode{pm == addressof(m)} and \tcode{owns == true}.
+\tcode{\exposid{pm} == addressof(m)} and \tcode{\exposid{owns} == true}.
 
 \pnum
 \throws
@@ -8517,7 +8517,7 @@ Calls \tcode{m.try_lock_until(abs_time)}.
 
 \pnum
 \ensures
-\tcode{pm == addressof(m)} and \tcode{owns == res},
+\tcode{\exposid{pm} == addressof(m)} and \tcode{\exposid{owns} == res},
 where \tcode{res} is
 the value returned by the call to \tcode{m.try_lock_until(abs_time)}.
 \end{itemdescr}
@@ -8539,7 +8539,7 @@ Calls \tcode{m.try_lock_for(rel_time)}.
 
 \pnum
 \ensures
-\tcode{pm == addressof(m)} and \tcode{owns == res},
+\tcode{\exposid{pm} == addressof(m)} and \tcode{\exposid{owns} == res},
 where \tcode{res} is the value returned by the call to \tcode{m.try_lock_for(rel_time)}.
 \end{itemdescr}
 
@@ -8551,7 +8551,7 @@ unique_lock(unique_lock&& u) noexcept;
 \begin{itemdescr}
 \pnum
 \ensures
-\tcode{pm == u_p.pm} and \tcode{owns == u_p.owns} (where \tcode{u_p} is the state of \tcode{u} just prior to this construction),  \tcode{u.pm == 0} and \tcode{u.owns == false}.
+\tcode{\exposid{pm} == u_p.\exposid{pm}} and \tcode{\exposid{owns} == u_p.\exposid{owns}} (where \tcode{u_p} is the state of \tcode{u} just prior to this construction),  \tcode{u.\exposid{pm} == 0} and \tcode{u.\exposid{owns} == false}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{unique_lock}%
@@ -8577,7 +8577,7 @@ Equivalent to: \tcode{unique_lock(std::move(u)).swap(*this)}
 \begin{itemdescr}
 \pnum
 \effects
-If \tcode{owns} calls \tcode{pm->unlock()}.
+If \exposid{owns} calls \tcode{\exposid{pm}->unlock()}.
 \end{itemdescr}
 
 \rSec4[thread.lock.unique.locking]{Locking}
@@ -8590,22 +8590,22 @@ void lock();
 \begin{itemdescr}
 \pnum
 \effects
-As if by \tcode{pm->lock()}.
+As if by \tcode{\exposid{pm}->lock()}.
 
 \pnum
 \ensures
-\tcode{owns == true}.
+\tcode{\exposid{owns} == true}.
 
 \pnum
 \throws
-Any exception thrown by \tcode{pm->lock()}. \tcode{system_error} when an exception
+Any exception thrown by \tcode{\exposid{pm}->lock()}. \tcode{system_error} when an exception
 is required\iref{thread.req.exception}.
 
 \pnum
 \errors
 \begin{itemize}
-\item \tcode{operation_not_permitted} --- if \tcode{pm} is \keyword{nullptr}.
-\item \tcode{resource_deadlock_would_occur} --- if on entry \tcode{owns}
+\item \tcode{operation_not_permitted} --- if \exposid{pm} is \keyword{nullptr}.
+\item \tcode{resource_deadlock_would_occur} --- if on entry \exposid{owns}
 is \tcode{true}.
 \end{itemize}
 \end{itemdescr}
@@ -8623,27 +8623,27 @@ requirements\iref{thread.req.lockable.req}.
 
 \pnum
 \effects
-As if by \tcode{pm->try_lock()}.
+As if by \tcode{\exposid{pm}->try_lock()}.
 
 \pnum
 \ensures
-\tcode{owns == res}, where \tcode{res} is the value returned by
-\tcode{pm->try_lock()}.
+\tcode{\exposid{owns} == res}, where \tcode{res} is the value returned by
+\tcode{\exposid{pm}->try_lock()}.
 
 \pnum
 \returns
-The value returned by \tcode{pm->try_lock()}.
+The value returned by \tcode{\exposid{pm}->try_lock()}.
 
 \pnum
 \throws
-Any exception thrown by \tcode{pm->try_lock()}. \tcode{system_error} when an exception
+Any exception thrown by \tcode{\exposid{pm}->try_lock()}. \tcode{system_error} when an exception
 is required\iref{thread.req.exception}.
 
 \pnum
 \errors
 \begin{itemize}
-\item \tcode{operation_not_permitted} --- if \tcode{pm} is \keyword{nullptr}.
-\item \tcode{resource_deadlock_would_occur} --- if on entry \tcode{owns}
+\item \tcode{operation_not_permitted} --- if \exposid{pm} is \keyword{nullptr}.
+\item \tcode{resource_deadlock_would_occur} --- if on entry \exposid{owns}
 is \tcode{true}.
 \end{itemize}
 \end{itemdescr}
@@ -8662,27 +8662,27 @@ requirements\iref{thread.req.lockable.timed}.
 
 \pnum
 \effects
-As if by \tcode{pm->try_lock_until(abs_time)}.
+As if by \tcode{\exposid{pm}->try_lock_until(abs_time)}.
 
 \pnum
 \ensures
-\tcode{owns == res}, where \tcode{res} is the value returned by
-\tcode{pm->try_lock_until(abs_time)}.
+\tcode{\exposid{owns} == res}, where \tcode{res} is the value returned by
+\tcode{\exposid{pm}->try_lock_until(abs_time)}.
 
 \pnum
 \returns
-The value returned by \tcode{pm->try_lock_until(abs_time)}.
+The value returned by \tcode{\exposid{pm}->try_lock_until(abs_time)}.
 
 \pnum
 \throws
-Any exception thrown by \tcode{pm->try_lock_until(abstime)}. \tcode{system_error} when an
+Any exception thrown by \tcode{\exposid{pm}->try_lock_until(abstime)}. \tcode{system_error} when an
 exception is required\iref{thread.req.exception}.
 
 \pnum
 \errors
 \begin{itemize}
-\item \tcode{operation_not_permitted} --- if \tcode{pm} is \keyword{nullptr}.
-\item \tcode{resource_deadlock_would_occur} --- if on entry \tcode{owns} is
+\item \tcode{operation_not_permitted} --- if \exposid{pm} is \keyword{nullptr}.
+\item \tcode{resource_deadlock_would_occur} --- if on entry \exposid{owns} is
 \tcode{true}.
 \end{itemize}
 \end{itemdescr}
@@ -8700,26 +8700,26 @@ The supplied \tcode{Mutex} type meets the \oldconcept{TimedLockable} requirement
 
 \pnum
 \effects
-As if by \tcode{pm->try_lock_for(rel_time)}.
+As if by \tcode{\exposid{pm}->try_lock_for(rel_time)}.
 
 \pnum
 \ensures
-\tcode{owns == res}, where \tcode{res} is the value returned by \tcode{pm->try_lock_for(rel_time)}.
+\tcode{\exposid{owns} == res}, where \tcode{res} is the value returned by \tcode{\exposid{pm}->try_lock_for(rel_time)}.
 
 \pnum
 \returns
-The value returned by \tcode{pm->try_lock_for(rel_time)}.
+The value returned by \tcode{\exposid{pm}->try_lock_for(rel_time)}.
 
 \pnum
 \throws
-Any exception thrown by \tcode{pm->try_lock_for(rel_time)}. \tcode{system_error} when an
+Any exception thrown by \tcode{\exposid{pm}->try_lock_for(rel_time)}. \tcode{system_error} when an
 exception is required\iref{thread.req.exception}.
 
 \pnum
 \errors
 \begin{itemize}
-\item \tcode{operation_not_permitted} --- if \tcode{pm} is \keyword{nullptr}.
-\item \tcode{resource_deadlock_would_occur} --- if on entry \tcode{owns} is
+\item \tcode{operation_not_permitted} --- if \exposid{pm} is \keyword{nullptr}.
+\item \tcode{resource_deadlock_would_occur} --- if on entry \exposid{owns} is
 \tcode{true}.
 \end{itemize}
 \end{itemdescr}
@@ -8732,11 +8732,11 @@ void unlock();
 \begin{itemdescr}
 \pnum
 \effects
-As if by \tcode{pm->unlock()}.
+As if by \tcode{\exposid{pm}->unlock()}.
 
 \pnum
 \ensures
-\tcode{owns == false}.
+\tcode{\exposid{owns} == false}.
 
 \pnum
 \throws
@@ -8746,7 +8746,7 @@ an exception is required\iref{thread.req.exception}.
 \pnum
 \errors
 \begin{itemize}
-\item \tcode{operation_not_permitted} --- if on entry \tcode{owns} is \tcode{false}.
+\item \tcode{operation_not_permitted} --- if on entry \exposid{owns} is \tcode{false}.
 \end{itemize}
 \end{itemdescr}
 
@@ -8771,11 +8771,11 @@ mutex_type* release() noexcept;
 \begin{itemdescr}
 \pnum
 \ensures
-\tcode{pm == 0} and \tcode{owns == false}.
+\tcode{\exposid{pm} == 0} and \tcode{\exposid{owns} == false}.
 
 \pnum
 \returns
-The previous value of \tcode{pm}.
+The previous value of \exposid{pm}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{unique_lock}%
@@ -8800,7 +8800,7 @@ bool owns_lock() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{owns}.
+\exposid{owns}.
 \end{itemdescr}
 
 \indexlibrarymember{operator bool}{unique_lock}%
@@ -8822,7 +8822,7 @@ mutex_type *mutex() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{pm}.
+\exposid{pm}.
 \end{itemdescr}
 
 \rSec3[thread.lock.shared]{Class template \tcode{shared_lock}}
@@ -8874,8 +8874,8 @@ namespace std {
     mutex_type* mutex() const noexcept;
 
   private:
-    mutex_type* pm;                             // \expos
-    bool owns;                                  // \expos
+    mutex_type* @\exposid{pm}@;                             // \expos
+    bool @\exposid{owns}@;                                  // \expos
   };
 }
 \end{codeblock}
@@ -8886,8 +8886,8 @@ lockable object within a scope. Shared ownership of the lockable object may be
 acquired at construction or after construction, and may be transferred, after
 acquisition, to another \tcode{shared_lock} object. Objects of type
 \tcode{shared_lock} are not copyable but are movable. The behavior of a program
-is undefined if the contained pointer \tcode{pm} is not null and the lockable
-object pointed to by \tcode{pm} does not exist for the entire remaining
+is undefined if the contained pointer \exposid{pm} is not null and the lockable
+object pointed to by \exposid{pm} does not exist for the entire remaining
 lifetime\iref{basic.life} of the \tcode{shared_lock} object. The supplied
 \tcode{Mutex} type shall meet the \oldconcept{SharedLockable}
 requirements\iref{thread.req.lockable.shared}.
@@ -8912,7 +8912,7 @@ shared_lock() noexcept;
 \begin{itemdescr}
 \pnum
 \ensures
-\tcode{pm == nullptr} and \tcode{owns == false}.
+\tcode{\exposid{pm} == nullptr} and \tcode{\exposid{owns} == false}.
 \end{itemdescr}
 
 \indexlibraryctor{shared_lock}%
@@ -8927,7 +8927,7 @@ Calls \tcode{m.lock_shared()}.
 
 \pnum
 \ensures
-\tcode{pm == addressof(m)} and \tcode{owns == true}.
+\tcode{\exposid{pm} == addressof(m)} and \tcode{\exposid{owns} == true}.
 \end{itemdescr}
 
 \indexlibraryctor{shared_lock}%
@@ -8938,7 +8938,7 @@ shared_lock(mutex_type& m, defer_lock_t) noexcept;
 \begin{itemdescr}
 \pnum
 \ensures
-\tcode{pm == addressof(m)} and \tcode{owns == false}.
+\tcode{pm == addressof(m)} and \tcode{\exposid{owns} == false}.
 \end{itemdescr}
 
 \indexlibraryctor{shared_lock}%
@@ -8953,7 +8953,7 @@ Calls \tcode{m.try_lock_shared()}.
 
 \pnum
 \ensures
-\tcode{pm == addressof(m)} and \tcode{owns == res}
+\tcode{\exposid{pm} == addressof(m)} and \tcode{\exposid{owns} == res}
 where \tcode{res} is the
 value returned by the call to \tcode{m.try_lock_shared()}.
 \end{itemdescr}
@@ -8970,7 +8970,7 @@ The calling thread holds a shared lock on \tcode{m}.
 
 \pnum
 \ensures
-\tcode{pm == addressof(m)} and \tcode{owns == true}.
+\tcode{\exposid{pm} == addressof(m)} and \tcode{\exposid{owns} == true}.
 \end{itemdescr}
 
 \indexlibraryctor{shared_lock}%
@@ -8992,7 +8992,7 @@ Calls \tcode{m.try_lock_shared_until(abs_time)}.
 
 \pnum
 \ensures
-\tcode{pm == addressof(m)} and \tcode{owns == res}
+\tcode{\exposid{pm} == addressof(m)} and \tcode{\exposid{owns} == res}
 where \tcode{res}
 is the value returned by the call to \tcode{m.try_lock_shared_until(abs_time)}.
 \end{itemdescr}
@@ -9016,7 +9016,7 @@ Calls \tcode{m.try_lock_shared_for(rel_time)}.
 
 \pnum
 \ensures
-\tcode{pm == addressof(m)} and \tcode{owns == res}
+\tcode{\exposid{pm} == addressof(m)} and \tcode{\exposid{owns} == res}
 where \tcode{res} is
 the value returned by the call to \tcode{m.try_lock_shared_for(rel_time)}.
 \end{itemdescr}
@@ -9029,7 +9029,7 @@ the value returned by the call to \tcode{m.try_lock_shared_for(rel_time)}.
 \begin{itemdescr}
 \pnum
 \effects
-If \tcode{owns} calls \tcode{pm->unlock_shared()}.
+If \exposid{owns} calls \tcode{\exposid{pm}->unlock_shared()}.
 \end{itemdescr}
 
 \indexlibraryctor{shared_lock}%
@@ -9040,9 +9040,9 @@ shared_lock(shared_lock&& sl) noexcept;
 \begin{itemdescr}
 \pnum
 \ensures
-\tcode{pm == sl_p.pm} and \tcode{owns == sl_p.owns} (where
+\tcode{\exposid{pm} == sl_p.\exposid{pm}} and \tcode{\exposid{owns} == sl_p.\exposid{owns}} (where
 \tcode{sl_p} is the state of \tcode{sl} just prior to this construction),
-\tcode{sl.pm == nullptr} and \tcode{sl.owns == false}.
+\tcode{sl.\exposid{pm} == nullptr} and \tcode{sl.\exposid{owns} == false}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{shared_lock}%
@@ -9070,22 +9070,22 @@ void lock();
 \begin{itemdescr}
 \pnum
 \effects
-As if by \tcode{pm->lock_shared()}.
+As if by \tcode{\exposid{pm}->lock_shared()}.
 
 \pnum
 \ensures
-\tcode{owns == true}.
+\tcode{\exposid{owns} == true}.
 
 \pnum
 \throws
-Any exception thrown by \tcode{pm->lock_shared()}.
+Any exception thrown by \tcode{\exposid{pm}->lock_shared()}.
 \tcode{system_error} when an exception is required\iref{thread.req.exception}.
 
 \pnum
 \errors
 \begin{itemize}
-\item \tcode{operation_not_permitted} --- if \tcode{pm} is \keyword{nullptr}.
-\item \tcode{resource_deadlock_would_occur} --- if on entry \tcode{owns} is
+\item \tcode{operation_not_permitted} --- if \exposid{pm} is \keyword{nullptr}.
+\item \tcode{resource_deadlock_would_occur} --- if on entry \exposid{owns} is
 \tcode{true}.
 \end{itemize}
 \end{itemdescr}
@@ -9098,27 +9098,27 @@ bool try_lock();
 \begin{itemdescr}
 \pnum
 \effects
-As if by \tcode{pm->try_lock_shared()}.
+As if by \tcode{\exposid{pm}->try_lock_shared()}.
 
 \pnum
 \ensures
-\tcode{owns == res}, where \tcode{res} is the value returned by
-the call to \tcode{pm->try_lock_shared()}.
+\tcode{\exposid{owns} == res}, where \tcode{res} is the value returned by
+the call to \tcode{\exposid{pm}->try_lock_shared()}.
 
 \pnum
 \returns
-The value returned by the call to \tcode{pm->try_lock_shared()}.
+The value returned by the call to \tcode{\exposid{pm}->try_lock_shared()}.
 
 \pnum
 \throws
-Any exception thrown by \tcode{pm->try_lock_shared()}.
+Any exception thrown by \tcode{\exposid{pm}->try_lock_shared()}.
 \tcode{system_error} when an exception is required\iref{thread.req.exception}.
 
 \pnum
 \errors
 \begin{itemize}
-\item \tcode{operation_not_permitted} --- if \tcode{pm} is \keyword{nullptr}.
-\item \tcode{resource_deadlock_would_occur} --- if on entry \tcode{owns} is
+\item \tcode{operation_not_permitted} --- if \exposid{pm} is \keyword{nullptr}.
+\item \tcode{resource_deadlock_would_occur} --- if on entry \exposid{owns} is
 \tcode{true}.
 \end{itemize}
 \end{itemdescr}
@@ -9137,28 +9137,28 @@ requirements\iref{thread.req.lockable.shared.timed}.
 
 \pnum
 \effects
-As if by \tcode{pm->try_lock_shared_until(abs_time)}.
+As if by \tcode{\exposid{pm}->try_lock_shared_until(abs_time)}.
 
 \pnum
 \ensures
-\tcode{owns == res}, where \tcode{res} is the value returned by
-the call to \tcode{pm->try_lock_shared_until(abs_time)}.
+\tcode{\exposid{owns} == res}, where \tcode{res} is the value returned by
+the call to \tcode{\exposid{pm}->try_lock_shared_until(abs_time)}.
 
 \pnum
 \returns
 The value returned by the call to
-\tcode{pm->try_lock_shared_until(abs_time)}.
+\tcode{\exposid{pm}->try_lock_shared_until(abs_time)}.
 
 \pnum
 \throws
-Any exception thrown by \tcode{pm->try_lock_shared_until(abs_time)}.
+Any exception thrown by \tcode{\exposid{pm}->try_lock_shared_until(abs_time)}.
 \tcode{system_error} when an exception is required\iref{thread.req.exception}.
 
 \pnum
 \errors
 \begin{itemize}
-\item \tcode{operation_not_permitted} --- if \tcode{pm} is \keyword{nullptr}.
-\item \tcode{resource_deadlock_would_occur} --- if on entry \tcode{owns} is
+\item \tcode{operation_not_permitted} --- if \exposid{pm} is \keyword{nullptr}.
+\item \tcode{resource_deadlock_would_occur} --- if on entry \exposid{owns} is
 \tcode{true}.
 \end{itemize}
 \end{itemdescr}
@@ -9177,25 +9177,25 @@ requirements\iref{thread.req.lockable.shared.timed}.
 
 \pnum
 \effects
-As if by \tcode{pm->try_lock_shared_for(rel_time)}.
+As if by \tcode{\exposid{pm}->try_lock_shared_for(rel_time)}.
 
 \pnum
 \ensures
-\tcode{owns == res}, where \tcode{res} is the value returned by the call to \tcode{pm->try_lock_shared_for(rel_time)}.
+\tcode{\exposid{owns} == res}, where \tcode{res} is the value returned by the call to \tcode{\exposid{pm}->try_lock_shared_for(rel_time)}.
 
 \pnum
 \returns
-The value returned by the call to \tcode{pm->try_lock_shared_for(rel_time)}.
+The value returned by the call to \tcode{\exposid{pm}->try_lock_shared_for(rel_time)}.
 
 \pnum
 \throws
-Any exception thrown by \tcode{pm->try_lock_shared_for(rel_time)}. \tcode{system_error} when an exception is required\iref{thread.req.exception}.
+Any exception thrown by \tcode{\exposid{pm}->try_lock_shared_for(rel_time)}. \tcode{system_error} when an exception is required\iref{thread.req.exception}.
 
 \pnum
 \errors
 \begin{itemize}
-\item \tcode{operation_not_permitted} --- if \tcode{pm} is \keyword{nullptr}.
-\item \tcode{resource_deadlock_would_occur} --- if on entry \tcode{owns} is
+\item \tcode{operation_not_permitted} --- if \exposid{pm} is \keyword{nullptr}.
+\item \tcode{resource_deadlock_would_occur} --- if on entry \exposid{owns} is
 \tcode{true}.
 \end{itemize}
 \end{itemdescr}
@@ -9208,11 +9208,11 @@ void unlock();
 \begin{itemdescr}
 \pnum
 \effects
-As if by \tcode{pm->unlock_shared()}.
+As if by \tcode{\exposid{pm}->unlock_shared()}.
 
 \pnum
 \ensures
-\tcode{owns == false}.
+\tcode{\exposid{owns} == false}.
 
 \pnum
 \throws
@@ -9221,7 +9221,7 @@ As if by \tcode{pm->unlock_shared()}.
 \pnum
 \errors
 \begin{itemize}
-\item \tcode{operation_not_permitted} --- if on entry \tcode{owns} is
+\item \tcode{operation_not_permitted} --- if on entry \exposid{owns} is
 \tcode{false}.
 \end{itemize}
 \end{itemdescr}
@@ -9247,11 +9247,11 @@ mutex_type* release() noexcept;
 \begin{itemdescr}
 \pnum
 \ensures
-\tcode{pm == nullptr} and \tcode{owns == false}.
+\tcode{\exposid{pm} == nullptr} and \tcode{\exposid{owns} == false}.
 
 \pnum
 \returns
-The previous value of \tcode{pm}.
+The previous value of \exposid{pm}.
 \end{itemdescr}
 
 \indexlibrarymember{swap}{shared_lock}%
@@ -9276,7 +9276,7 @@ bool owns_lock() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{owns}.
+\exposid{owns}.
 \end{itemdescr}
 
 \indexlibrarymember{operator bool}{shared_lock}%
@@ -9287,7 +9287,7 @@ explicit operator bool() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{owns}.
+\exposid{owns}.
 \end{itemdescr}
 
 \indexlibrarymember{mutex}{shared_lock}%
@@ -9298,7 +9298,7 @@ mutex_type* mutex() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{pm}.
+\exposid{pm}.
 \end{itemdescr}
 
 \rSec2[thread.lock.algorithm]{Generic locking algorithms}
@@ -10497,7 +10497,7 @@ namespace std {
       bool try_acquire_until(const chrono::time_point<Clock, Duration>& abs_time);
 
   private:
-    ptrdiff_t counter;          // \expos
+    ptrdiff_t @\exposid{counter}@;          // \expos
   };
 }
 \end{codeblock}
@@ -10527,7 +10527,7 @@ static constexpr ptrdiff_t max() noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-The maximum value of \tcode{counter}.
+The maximum value of \exposid{counter}.
 This value is greater than or equal to \tcode{least_max_value}.
 \end{itemdescr}
 
@@ -10544,7 +10544,7 @@ constexpr explicit counting_semaphore(ptrdiff_t desired);
 
 \pnum
 \effects
-Initializes \tcode{counter} with \tcode{desired}.
+Initializes \exposid{counter} with \tcode{desired}.
 
 \pnum
 \throws
@@ -10560,13 +10560,13 @@ void release(ptrdiff_t update = 1);
 \pnum
 \expects
 \tcode{update >= 0} is \tcode{true}, and
-\tcode{update <= max() - counter} is \tcode{true}.
+\tcode{update <= max() - \exposid{counter}} is \tcode{true}.
 
 \pnum
 \effects
-Atomically execute \tcode{counter += update}.
+Atomically execute \tcode{\exposid{counter} += update}.
 Then, unblocks any threads
-that are waiting for \tcode{counter} to be greater than zero.
+that are waiting for \exposid{counter} to be greater than zero.
 
 \pnum
 \sync
@@ -10591,11 +10591,11 @@ bool try_acquire() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Attempts to atomically decrement \tcode{counter} if it is positive,
+Attempts to atomically decrement \exposid{counter} if it is positive,
 without blocking.
-If \tcode{counter} is not decremented, there is no effect and
+If \exposid{counter} is not decremented, there is no effect and
 \tcode{try_acquire} immediately returns.
-An implementation may fail to decrement \tcode{counter}
+An implementation may fail to decrement \exposid{counter}
 even if it is positive.
 \begin{note}
 This spurious failure is normally uncommon, but
@@ -10608,7 +10608,7 @@ in the absence of contending semaphore operations.
 
 \pnum
 \returns
-\tcode{true} if \tcode{counter} was decremented, otherwise \tcode{false}.
+\tcode{true} if \exposid{counter} was decremented, otherwise \tcode{false}.
 \end{itemdescr}
 
 \indexlibrarymember{acquire}{counting_semaphore}%
@@ -10624,7 +10624,7 @@ Repeatedly performs the following steps, in order:
 \item Evaluates \tcode{try_acquire()}. If the result is \tcode{true}, returns.
 \item
 \indextext{block (execution)}%
-Blocks on \tcode{*this} until \tcode{counter} is greater than zero.
+Blocks on \tcode{*this} until \exposid{counter} is greater than zero.
 \end{itemize}
 
 \pnum
@@ -10657,7 +10657,7 @@ Repeatedly performs the following steps, in order:
 \item
   \indextext{block (execution)}%
   Blocks on \tcode{*this}
-  until \tcode{counter} is greater than zero or until the timeout expires.
+  until \exposid{counter} is greater than zero or until the timeout expires.
   If it is unblocked by the timeout expiring, returns \tcode{false}.
 \end{itemize}
 The timeout expires\iref{thread.req.timing}
@@ -10727,7 +10727,7 @@ namespace std {
     void arrive_and_wait(ptrdiff_t update = 1);
 
   private:
-    ptrdiff_t counter;  // \expos
+    ptrdiff_t @\exposid{counter}@;  // \expos
   };
 }
 \end{codeblock}
@@ -10750,7 +10750,7 @@ static constexpr ptrdiff_t max() noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-The maximum value of \tcode{counter} that the implementation supports.
+The maximum value of \exposid{counter} that the implementation supports.
 \end{itemdescr}
 
 \indexlibraryctor{latch}%
@@ -10766,7 +10766,7 @@ constexpr explicit latch(ptrdiff_t expected);
 
 \pnum
 \effects
-Initializes \tcode{counter} with \tcode{expected}.
+Initializes \exposid{counter} with \tcode{expected}.
 
 \pnum
 \throws
@@ -10782,12 +10782,12 @@ void count_down(ptrdiff_t update = 1);
 \pnum
 \expects
 \tcode{update >= 0} is \tcode{true}, and
-\tcode{update <= counter} is \tcode{true}.
+\tcode{update <= \exposid{counter}} is \tcode{true}.
 
 \pnum
 \effects
-Atomically decrements \tcode{counter} by \tcode{update}.
-If \tcode{counter} is equal to zero,
+Atomically decrements \exposid{counter} by \tcode{update}.
+If \exposid{counter} is equal to zero,
 unblocks all threads blocked on \tcode{*this}.
 
 \pnum
@@ -10812,7 +10812,7 @@ bool try_wait() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-With very low probability \tcode{false}. Otherwise \tcode{counter == 0}.
+With very low probability \tcode{false}. Otherwise \tcode{\exposid{counter} == 0}.
 \end{itemdescr}
 
 \indexlibrarymember{wait}{latch}%
@@ -10824,9 +10824,9 @@ void wait() const;
 \pnum
 \indextext{block (execution)}%
 \effects
-If \tcode{counter} equals zero, returns immediately.
+If \exposid{counter} equals zero, returns immediately.
 Otherwise, blocks on \tcode{*this}
-until a call to \tcode{count_down} that decrements \tcode{counter} to zero.
+until a call to \tcode{count_down} that decrements \exposid{counter} to zero.
 
 \pnum
 \throws
@@ -10902,7 +10902,7 @@ namespace std {
     void arrive_and_drop();
 
   private:
-    CompletionFunction completion;      // \expos
+    CompletionFunction @\exposid{completion}@;      // \expos
   };
 }
 \end{codeblock}
@@ -10939,7 +10939,7 @@ will remain blocked until the phase completion step is run.
 The \defn{phase completion step}
 that is executed at the end of each phase has the following effects:
 \begin{itemize}
-\item Invokes the completion function, equivalent to \tcode{completion()}.
+\item Invokes the completion function, equivalent to \tcode{\exposid{completion}()}.
 \item Unblocks all threads that are blocked on the phase synchronization point.
 \end{itemize}
 The end of the completion step strongly happens before
@@ -10967,7 +10967,7 @@ an unspecified type, such that,
 in addition to satisfying the requirements of \tcode{CompletionFunction},
 it meets the \oldconcept{DefaultConstructible}
 requirements (\tref{cpp17.defaultconstructible}) and
-\tcode{completion()} has no effects.
+\tcode{\exposid{completion}()} has no effects.
 
 \pnum
 \tcode{barrier::arrival_token} is an unspecified type,
@@ -11003,7 +11003,7 @@ constexpr explicit barrier(ptrdiff_t expected,
 \effects
 Sets both the initial expected count for each barrier phase and
 the current expected count for the first phase to \tcode{expected}.
-Initializes \tcode{completion} with \tcode{std::move(f)}.
+Initializes \exposid{completion} with \tcode{std::move(f)}.
 Starts the first phase.
 \begin{note}
 If \tcode{expected} is 0 this object can only be destroyed.
@@ -11283,7 +11283,7 @@ namespace std {
     const char*       what() const noexcept;
 
   private:
-    error_code ec_;             // \expos
+    error_code @\exposid{ec_}@;             // \expos
   };
 }
 \end{codeblock}
@@ -11296,7 +11296,7 @@ explicit future_error(future_errc e);
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{ec_} with \tcode{make_error_code(e)}.
+Initializes \exposid{ec_} with \tcode{make_error_code(e)}.
 \end{itemdescr}
 
 \indexlibrarymember{code}{future_error}%
@@ -11307,7 +11307,7 @@ const error_code& code() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{ec_}.
+\exposid{ec_}.
 \end{itemdescr}
 
 \indexlibrarymember{what}{future_error}%


### PR DESCRIPTION
Towards #4702, #5940.

Affected sections and exposition-only identifiers:

[thread.jthread.class]
- _`ssource`_

[atomics.ref.generic]
- _`ptr`_

[util.smartptr.atomic.shared]
- _`p`_

[util.smartptr.atomic.weak]
- _`p`_

[thread.lock.guard]
- _`pm`_

[thread.lock.scoped]
- _`pm`_

[thread.lock.unique]
- _`pm`_
- _`owns`_

[thread.lock.shared]
- _`pm`_
- _`owns`_

[thread.sema.cnt]
- _`counter`_

[thread.latch.class]
- _`counter`_

[thread.barrier.class]
- _`completion`_

[futures.future.error]
- _`ec_`_

Drive-by changes:

[atomics.ref.float]
- Use `\placeholder` for _`floating-point-type`_