### PR TITLE
[expected.object.monadic][expected.void.monadic] Add missing necessary `typename`

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -10085,7 +10085,7 @@ Let \tcode{U} be \tcode{remove_cvref_t<invoke_result_t<F>>}.
 \pnum
 \mandates
 \tcode{U} is a specialization of \tcode{expected} and
-\tcode{is_same_v<U::error_type, E>} is \tcode{true}.
+\tcode{is_same_v<typename U::error_type, E>} is \tcode{true}.
 
 \pnum
 \effects
@@ -10115,7 +10115,7 @@ Let \tcode{U} be \tcode{remove_cvref_t<invoke_result_t<F>>}.
 \pnum
 \mandates
 \tcode{U} is a specialization of \tcode{expected} and
-\tcode{is_same_v<U::error_type, E>} is \tcode{true}.
+\tcode{is_same_v<typename U::error_type, E>} is \tcode{true}.
 
 \pnum
 \effects
@@ -10141,7 +10141,7 @@ Let \tcode{G} be \tcode{remove_cvref_t<invoke_result_t<F, decltype(error())>>}.
 \pnum
 \mandates
 \tcode{G} is a specialization of \tcode{expected} and
-\tcode{is_same_v<G::value_type, T>} is \tcode{true}.
+\tcode{is_same_v<typename G::value_type, T>} is \tcode{true}.
 
 \pnum
 \effects
@@ -10168,7 +10168,7 @@ Let \tcode{G} be
 \pnum
 \mandates
 \tcode{G} is a specialization of \tcode{expected} and
-\tcode{is_same_v<G::value_type, T>} is \tcode{true}.
+\tcode{is_same_v<typename G::value_type, T>} is \tcode{true}.
 
 \pnum
 \effects


### PR DESCRIPTION
Although it's unambiguous to implementors and users that `T::value_type` and `T::error_type` must be types, `typename` is still necessary to make the condition well-formed.

Fixes #8177.