### PR TITLE
[stringbuf.members] Remove `// exposition only` from `{itemdecl}`

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -8416,7 +8416,7 @@ are now considered uninitialized
 (except for those characters re-initialized by the new \tcode{basic_string}).
 
 \begin{itemdecl}
-void @\exposid{init-buf-ptrs}@(); // \expos
+void @\exposid{init-buf-ptrs}@();
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Fixes #5941.