### PR TITLE
[mem] Exposition-only formatting for private members

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -5386,9 +5386,9 @@ namespace std {
     operator void**() const noexcept;
 
   private:
-    Smart& s;                   // \expos
-    tuple<Args...> a;           // \expos
-    Pointer p;                  // \expos
+    Smart& @\exposid{s}@;                   // \expos
+    tuple<Args...> @\exposid{a}@;           // \expos
+    Pointer @\exposid{p}@;                  // \expos
   };
 }
 \end{codeblock}
@@ -5422,23 +5422,23 @@ constexpr explicit out_ptr_t(Smart& smart, Args... args);
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{s} with \tcode{smart},
-\tcode{a} with \tcode{std::forward<Args>(args)...}, and
-value-initializes \tcode{p}.
+Initializes \exposid{s} with \tcode{smart},
+\exposid{a} with \tcode{std::forward<Args>(args)...}, and
+value-initializes \exposid{p}.
 Then, equivalent to:
 \begin{itemize}
 \item
 % pretend to \item that there is real text here, but undo the vertical spacing
 \mbox{}\vspace{-\baselineskip}\vspace{-\parskip}
 \begin{codeblock}
-s.reset();
+@\exposid{s}@.reset();
 \end{codeblock}
-if the expression \tcode{s.reset()} is well-formed;
+if the expression \tcode{\exposid{s}.reset()} is well-formed;
 
 \item
 otherwise,
 \begin{codeblock}
-s = Smart();
+@\exposid{s}@ = Smart();
 \end{codeblock}
 if \tcode{is_constructible_v<Smart>} is \tcode{true};
 
@@ -5476,20 +5476,20 @@ Equivalent to:
 % pretend to \item that there is real text here, but undo the vertical spacing
 \mbox{}\vspace{-\baselineskip}\vspace{-\parskip}
 \begin{codeblock}
-if (p) {
+if (@\exposid{p}@) {
   apply([&](auto&&... args) {
-    s.reset(static_cast<SP>(p), std::forward<Args>(args)...); }, std::move(a));
+    @\exposid{s}@.reset(static_cast<SP>(@\exposid{p}@), std::forward<Args>(args)...); }, std::move(@\exposid{a}@));
 }
 \end{codeblock}
 if the expression
-\tcode{s.reset(static_cast<SP>(p), std::forward<Args>(args)...)}
+\tcode{\exposid{s}.reset(static_cast<SP>(\exposid{p}), std::forward<Args>(args)...)}
 is well-\linebreak formed;
 \item
 otherwise,
 \begin{codeblock}
-if (p) {
+if (@\exposid{p}@) {
   apply([&](auto&&... args) {
-    s = Smart(static_cast<SP>(p), std::forward<Args>(args)...); }, std::move(a));
+    @\exposid{s}@ = Smart(static_cast<SP>(@\exposid{p}@), std::forward<Args>(args)...); }, std::move(@\exposid{a}@));
 }
 \end{codeblock}
 if \tcode{is_constructible_v<Smart, SP, Args...>} is \tcode{true};
@@ -5509,7 +5509,7 @@ constexpr operator Pointer*() const noexcept;
 
 \pnum
 \returns
-\tcode{addressof(const_cast<Pointer\&>(p))}.
+\tcode{addressof(const_cast<Pointer\&>(\exposid{p}))}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -5534,12 +5534,12 @@ operator void**() const noexcept;
 A pointer value \tcode{v} such that:
 \begin{itemize}
 \item
-the initial value \tcode{*v} is equivalent to \tcode{static_cast<void*>(p)} and
+the initial value \tcode{*v} is equivalent to \tcode{static_cast<void*>(\exposid{p})} and
 \item
 any modification of \tcode{*v}
 that is not followed by a subsequent modification of \tcode{*this}
-affects the value of \tcode{p} during the destruction of \tcode{*this},
-such that \tcode{static_cast<void*>(p) == *v}.
+affects the value of \exposid{p} during the destruction of \tcode{*this},
+such that \tcode{static_cast<void*>(\exposid{p}) == *v}.
 \end{itemize}
 
 \pnum
@@ -5626,9 +5626,9 @@ namespace std {
     operator void**() const noexcept;
 
   private:
-    Smart& s;                   // \expos
-    tuple<Args...> a;           // \expos
-    Pointer p;                  // \expos
+    Smart& @\exposid{s}@;                   // \expos
+    tuple<Args...> @\exposid{a}@;           // \expos
+    Pointer @\exposid{p}@;                  // \expos
   };
 }
 \end{codeblock}
@@ -5659,9 +5659,9 @@ constexpr explicit inout_ptr_t(Smart& smart, Args... args);
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{s} with \tcode{smart},
-\tcode{a} with \tcode{std::forward<Args>(args)...}, and
-\tcode{p} to either
+Initializes \exposid{s} with \tcode{smart},
+\exposid{a} with \tcode{std::forward<Args>(args)...}, and
+\exposid{p} to either
 \begin{itemize}
 \item \tcode{smart} if \tcode{is_pointer_v<Smart>} is \tcode{true},
 \item otherwise, \tcode{smart.get()}.
@@ -5669,7 +5669,7 @@ Initializes \tcode{s} with \tcode{smart},
 
 \pnum
 \remarks
-An implementation can call \tcode{s.release()}.
+An implementation can call \tcode{\exposid{s}.release()}.
 
 \pnum
 \begin{note}
@@ -5691,8 +5691,8 @@ Let \tcode{SP} be
 \tcode{\exposid{POINTER_OF_OR}(Smart, Pointer)}\iref{memory.general}.
 
 \pnum
-Let \exposid{release-statement} be \tcode{s.release();}
-if an implementation does not call \tcode{s.release()} in the constructor.
+Let \exposid{release-statement} be \tcode{\exposid{s}.release();}
+if an implementation does not call \tcode{\exposid{s}.release()} in the constructor.
 Otherwise, it is empty.
 
 \pnum
@@ -5704,28 +5704,28 @@ Equivalent to:
 \mbox{}\vspace{-\baselineskip}\vspace{-\parskip}
 \begin{codeblock}
 apply([&](auto&&... args) {
-  s = Smart(static_cast<SP>(p), std::forward<Args>(args)...); }, std::move(a));
+  @\exposid{s}@ = Smart(static_cast<SP>(@\exposid{p}@), std::forward<Args>(args)...); }, std::move(@\exposid{a}@));
 \end{codeblock}
 if \tcode{is_pointer_v<Smart>} is \tcode{true};
 \item
 otherwise,
 \begin{codeblock}
 @\exposid{release-statement}@;
-if (p) {
+if (@\exposid{p}@) {
   apply([&](auto&&... args) {
-    s.reset(static_cast<SP>(p), std::forward<Args>(args)...); }, std::move(a));
+    @\exposid{s}@.reset(static_cast<SP>(@\exposid{p}@), std::forward<Args>(args)...); }, std::move(@\exposid{a}@));
 }
 \end{codeblock}
 if the expression
-\tcode{s.reset(static_cast<SP>(p), std::forward<Args>(args)...)}
+\tcode{\exposid{s}.reset(static_cast<SP>(\exposid{p}), std::forward<Args>(args)...)}
 is well-\newline formed;
 \item
 otherwise,
 \begin{codeblock}
 @\exposid{release-statement}@;
-if (p) {
+if (@\exposid{p}@) {
   apply([&](auto&&... args) {
-    s = Smart(static_cast<SP>(p), std::forward<Args>(args)...); }, std::move(a));
+    @\exposid{s}@ = Smart(static_cast<SP>(@\exposid{p}@), std::forward<Args>(args)...); }, std::move(@\exposid{a}@));
 }
 \end{codeblock}
 if \tcode{is_constructible_v<Smart, SP, Args...>} is \tcode{true};
@@ -5745,7 +5745,7 @@ constexpr operator Pointer*() const noexcept;
 
 \pnum
 \returns
-\tcode{addressof(const_cast<Pointer\&>(p))}.
+\tcode{addressof(const_cast<Pointer\&>(\exposid{p}))}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -5770,12 +5770,12 @@ operator void**() const noexcept;
 A pointer value \tcode{v} such that:
 \begin{itemize}
 \item
-the initial value \tcode{*v} is equivalent to \tcode{static_cast<void*>(p)} and
+the initial value \tcode{*v} is equivalent to \tcode{static_cast<void*>(\exposid{p})} and
 \item
 any modification of \tcode{*v}
 that is not followed by subsequent modification of \tcode{*this}
-affects the value of \tcode{p} during the destruction of \tcode{*this},
-such that \tcode{static_cast<void*>(p) == *v}.
+affects the value of \exposid{p} during the destruction of \tcode{*this},
+such that \tcode{static_cast<void*>(\exposid{p}) == *v}.
 \end{itemize}
 
 \pnum
@@ -7410,7 +7410,7 @@ The \tcode{memory_resource} class is an abstract interface to an unbounded set o
 \begin{codeblock}
 namespace std::pmr {
   class memory_resource {
-    static constexpr size_t max_align = alignof(max_align_t);   // \expos
+    static constexpr size_t @\exposid{max-align}@ = alignof(max_align_t);   // \expos
 
   public:
     memory_resource() = default;
@@ -7419,8 +7419,8 @@ namespace std::pmr {
 
     memory_resource& operator=(const memory_resource&) = default;
 
-    void* allocate(size_t bytes, size_t alignment = max_align);
-    void deallocate(void* p, size_t bytes, size_t alignment = max_align);
+    void* allocate(size_t bytes, size_t alignment = @\exposid{max-align}@);
+    void deallocate(void* p, size_t bytes, size_t alignment = @\exposid{max-align}@);
 
     bool is_equal(const memory_resource& other) const noexcept;
 
@@ -7449,7 +7449,7 @@ Destroys this \tcode{memory_resource}.
 
 \indexlibrarymember{allocate}{memory_resource}%
 \begin{itemdecl}
-void* allocate(size_t bytes, size_t alignment = max_align);
+void* allocate(size_t bytes, size_t alignment = @\exposid{max-align}@);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7470,7 +7470,7 @@ What and when the call to \tcode{do_allocate} throws.
 
 \indexlibrarymember{deallocate}{memory_resource}%
 \begin{itemdecl}
-void deallocate(void* p, size_t bytes, size_t alignment = max_align);
+void deallocate(void* p, size_t bytes, size_t alignment = @\exposid{max-align}@);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7592,7 +7592,7 @@ if its template argument is a \cv-unqualified object type.
 \begin{codeblock}
 namespace std::pmr {
   template<class Tp = byte> class polymorphic_allocator {
-    memory_resource* memory_rsrc;       // \expos
+    memory_resource* @\exposid{memory-rsrc}@;       // \expos
 
   public:
     using value_type = Tp;
@@ -7648,7 +7648,7 @@ polymorphic_allocator() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Sets \tcode{memory_rsrc} to \tcode{get_default_resource()}.
+Sets \exposid{memory-rsrc} to \tcode{get_default_resource()}.
 \end{itemdescr}
 
 \indexlibraryctor{polymorphic_allocator}%
@@ -7663,7 +7663,7 @@ polymorphic_allocator(memory_resource* r);
 
 \pnum
 \effects
-Sets \tcode{memory_rsrc} to \tcode{r}.
+Sets \exposid{memory-rsrc} to \tcode{r}.
 
 \pnum
 \throws
@@ -7683,7 +7683,7 @@ template<class U> polymorphic_allocator(const polymorphic_allocator<U>& other) n
 \begin{itemdescr}
 \pnum
 \effects
-Sets \tcode{memory_rsrc} to \tcode{other.resource()}.
+Sets \exposid{memory-rsrc} to \tcode{other.resource()}.
 \end{itemdescr}
 
 
@@ -7701,7 +7701,7 @@ If \tcode{numeric_limits<size_t>::max() / sizeof(Tp) < n},
 throws \tcode{bad_array_new_length}.
 Otherwise equivalent to:
 \begin{codeblock}
-return static_cast<Tp*>(memory_rsrc->allocate(n * sizeof(Tp), alignof(Tp)));
+return static_cast<Tp*>(\exposid{memory-rsrc}->allocate(n * sizeof(Tp), alignof(Tp)));
 \end{codeblock}
 \end{itemdescr}
 
@@ -7714,12 +7714,12 @@ void deallocate(Tp* p, size_t n);
 \pnum
 \expects
 \tcode{p} was allocated from a memory resource \tcode{x},
-equal to \tcode{*memory_rsrc},
+equal to \tcode{*\exposid{memory-rsrc}},
 using \tcode{x.allocate(n * sizeof(Tp), alignof(Tp))}.
 
 \pnum
 \effects
-Equivalent to \tcode{memory_rsrc->deallocate(p, n * sizeof(Tp), alignof(Tp))}.
+Equivalent to \tcode{\exposid{memory-rsrc}->deallocate(p, n * sizeof(Tp), alignof(Tp))}.
 
 \pnum
 \throws
@@ -7734,7 +7734,7 @@ void* allocate_bytes(size_t nbytes, size_t alignment = alignof(max_align_t));
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return memory_rsrc->allocate(nbytes, alignment);}
+Equivalent to: \tcode{return \exposid{memory-rsrc}->allocate(nbytes, alignment);}
 
 \pnum
 \begin{note}
@@ -7753,7 +7753,7 @@ void deallocate_bytes(void* p, size_t nbytes, size_t alignment = alignof(max_ali
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to \tcode{memory_rsrc->deallocate(p, nbytes, alignment)}.
+Equivalent to \tcode{\exposid{memory-rsrc}->deallocate(p, nbytes, alignment)}.
 \end{itemdescr}
 
 \indexlibrarymember{allocate_object}{polymorphic_allocator}%
@@ -7901,7 +7901,7 @@ memory_resource* resource() const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{memory_rsrc}.
+\exposid{memory-rsrc}.
 \end{itemdescr}
 
 \rSec3[mem.poly.allocator.eq]{Equality}
@@ -8323,9 +8323,9 @@ and then is released all at once when the memory resource object is destroyed.
 \begin{codeblock}
 namespace std::pmr {
   class monotonic_buffer_resource : public memory_resource {
-    memory_resource* upstream_rsrc;     // \expos
-    void* current_buffer;               // \expos
-    size_t next_buffer_size;            // \expos
+    memory_resource* @\exposid{upstream-rsrc}@;     // \expos
+    void* @\exposid{current-buffer}@;               // \expos
+    size_t @\exposid{next-buffer-size}@;            // \expos
 
   public:
     explicit monotonic_buffer_resource(memory_resource* upstream);
@@ -8373,12 +8373,12 @@ monotonic_buffer_resource(size_t initial_size, memory_resource* upstream);
 
 \pnum
 \effects
-Sets \tcode{upstream_rsrc} to \tcode{upstream} and
-\tcode{current_buffer} to \keyword{nullptr}.
+Sets \exposid{upstream-rsrc} to \tcode{upstream} and
+\exposid{current-buffer} to \keyword{nullptr}.
 If \tcode{initial_size} is specified,
-sets \tcode{next_buffer_size} to at least \tcode{initial_size};
-otherwise sets \tcode{next_buffer_size} to an
-\impldef{default \tcode{next_buffer_size} for a \tcode{monotonic_buffer_resource}} size.
+sets \exposid{next-buffer-size} to at least \tcode{initial_size};
+otherwise sets \exposid{next-buffer-size} to an
+\impldef{default \exposid{next-buffer-size} for a \tcode{monotonic_buffer_resource}} size.
 \end{itemdescr}
 
 \indexlibraryctor{monotonic_buffer_resource}%
@@ -8394,10 +8394,10 @@ monotonic_buffer_resource(void* buffer, size_t buffer_size, memory_resource* ups
 
 \pnum
 \effects
-Sets \tcode{upstream_rsrc} to \tcode{upstream},
-\tcode{current_buffer} to \tcode{buffer}, and
-\tcode{next_buffer_size} to \tcode{buffer_size} (but not less than 1),
-then increases \tcode{next_buffer_size}
+Sets \exposid{upstream-rsrc} to \tcode{upstream},
+\exposid{current-buffer} to \tcode{buffer}, and
+\exposid{next-buffer-size} to \tcode{buffer_size} (but not less than 1),
+then increases \exposid{next-buffer-size}
 by an \impldef{growth factor for \tcode{monotonic_buffer_resource}} growth factor (which need not be integral).
 \end{itemdescr}
 
@@ -8423,14 +8423,14 @@ void release();
 \begin{itemdescr}
 \pnum
 \effects
-Calls \tcode{upstream_rsrc->deallocate()} as necessary
+Calls \tcode{\exposid{upstream-rsrc}->deallocate()} as necessary
 to release all allocated memory.
-Resets \tcode{current_buffer} and \tcode{next_buffer_size}
+Resets \exposid{current-buffer} and \exposid{next-buffer-size}
 to their initial values at construction.
 
 \pnum
 \begin{note}
-The memory is released back to \tcode{upstream_rsrc}
+The memory is released back to \exposid{upstream-rsrc}
 even if some blocks that were allocated from \tcode{*this}
 have not been deallocated from \tcode{*this}.
 \end{note}
@@ -8444,7 +8444,7 @@ memory_resource* upstream_resource() const;
 \begin{itemdescr}
 \pnum
 \returns
-The value of \tcode{upstream_rsrc}.
+The value of \exposid{upstream-rsrc}.
 \end{itemdescr}
 
 \indexlibrarymember{do_allocate}{monotonic_buffer_resource}%
@@ -8455,15 +8455,15 @@ void* do_allocate(size_t bytes, size_t alignment) override;
 \begin{itemdescr}
 \pnum
 \effects
-If the unused space in \tcode{current_buffer}
+If the unused space in \exposid{current-buffer}
 can fit a block with the specified \tcode{bytes} and \tcode{alignment},
-then allocate the return block from \tcode{current_buffer};
-otherwise set \tcode{current_buffer} to \tcode{upstream_rsrc->allocate(n, m)},
-where \tcode{n} is not less than \tcode{max(bytes, next_buffer_size)} and
+then allocate the return block from \exposid{current-buffer};
+otherwise set \exposid{current-buffer} to \tcode{\exposid{upstream-rsrc}->allocate(n, m)},
+where \tcode{n} is not less than \tcode{max(bytes, \exposid{next-buffer-size})} and
 \tcode{m} is not less than \tcode{alignment},
-and increase \tcode{next_buffer_size}
+and increase \exposid{next-buffer-size}
 by an \impldef{growth factor for \tcode{monotonic_buffer_resource}} growth factor (which need not be integral),
-then allocate the return block from the newly-allocated \tcode{current_buffer}.
+then allocate the return block from the newly-allocated \exposid{current-buffer}.
 
 \pnum
 \returns
@@ -8474,7 +8474,7 @@ for a class derived from \tcode{memory_resource}\iref{mem.res.class}.
 
 \pnum
 \throws
-Nothing unless \tcode{upstream_rsrc->allocate()} throws.
+Nothing unless \tcode{\exposid{upstream-rsrc}->allocate()} throws.
 \end{itemdescr}
 
 \indexlibrarymember{do_deallocate}{monotonic_buffer_resource}%
@@ -8562,20 +8562,20 @@ namespace std {
   template<class OuterAlloc, class... InnerAllocs>
   class scoped_allocator_adaptor : public OuterAlloc {
   private:
-    using OuterTraits = allocator_traits<OuterAlloc>;   // \expos
-    scoped_allocator_adaptor<InnerAllocs...> inner;     // \expos
+    using @\exposid{outer-traits}@ = allocator_traits<OuterAlloc>;  // \expos
+    scoped_allocator_adaptor<InnerAllocs...> @\exposid{inner}@;     // \expos
 
   public:
     using outer_allocator_type = OuterAlloc;
     using inner_allocator_type = @\seebelow@;
 
-    using value_type           = OuterTraits::value_type;
-    using size_type            = OuterTraits::size_type;
-    using difference_type      = OuterTraits::difference_type;
-    using pointer              = OuterTraits::pointer;
-    using const_pointer        = OuterTraits::const_pointer;
-    using void_pointer         = OuterTraits::void_pointer;
-    using const_void_pointer   = OuterTraits::const_void_pointer;
+    using value_type           = @\exposid{outer-traits}@::value_type;
+    using size_type            = @\exposid{outer-traits}@::size_type;
+    using difference_type      = @\exposid{outer-traits}@::difference_type;
+    using pointer              = @\exposid{outer-traits}@::pointer;
+    using const_pointer        = @\exposid{outer-traits}@::const_pointer;
+    using void_pointer         = @\exposid{outer-traits}@::void_pointer;
+    using const_void_pointer   = @\exposid{outer-traits}@::const_void_pointer;
 
     using propagate_on_container_copy_assignment = @\seebelow@;
     using propagate_on_container_move_assignment = @\seebelow@;
@@ -8584,7 +8584,7 @@ namespace std {
 
     template<class Tp> struct rebind {
       using other = scoped_allocator_adaptor<
-        OuterTraits::template rebind_alloc<Tp>, InnerAllocs...>;
+        @\exposid{outer-traits}@::template rebind_alloc<Tp>, InnerAllocs...>;
     };
 
     scoped_allocator_adaptor();
@@ -8707,7 +8707,7 @@ scoped_allocator_adaptor();
 \begin{itemdescr}
 \pnum
 \effects
-Value-initializes the \tcode{OuterAlloc} base class and the \tcode{inner} allocator
+Value-initializes the \tcode{OuterAlloc} base class and the \exposid{inner} allocator
 object.
 \end{itemdescr}
 
@@ -8725,7 +8725,7 @@ template<class OuterA2>
 \pnum
 \effects
 Initializes the \tcode{OuterAlloc} base class with
-\tcode{std::forward<OuterA2>(outerAlloc)} and \tcode{inner} with \tcode{innerAllocs...}
+\tcode{std::forward<OuterA2>(outerAlloc)} and \exposid{inner} with \tcode{innerAllocs...}
 (hence recursively initializing each allocator within the adaptor with the corresponding
 allocator from the argument list).
 \end{itemdescr}
@@ -8818,7 +8818,7 @@ const inner_allocator_type& inner_allocator() const noexcept;
 \pnum
 \returns
 \tcode{*this} if \tcode{sizeof...(InnerAllocs)} is zero; otherwise,
-\tcode{inner}.
+\exposid{inner}.
 \end{itemdescr}
 
 \indexlibrarymember{outer_allocator}{scoped_allocator_adaptor}%

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -5853,9 +5853,9 @@ namespace std {
     operator void**() const noexcept;
 
   private:
-    Smart& s;                   // \expos
-    tuple<Args...> a;           // \expos
-    Pointer p;                  // \expos
+    Smart& @\exposid{s}@;                   // \expos
+    tuple<Args...> @\exposid{a}@;           // \expos
+    Pointer @\exposid{p}@;                  // \expos
   };
 }
 \end{codeblock}
@@ -5889,23 +5889,23 @@ constexpr explicit out_ptr_t(Smart& smart, Args... args);
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{s} with \tcode{smart},
-\tcode{a} with \tcode{std::forward<Args>(args)...}, and
-value-initializes \tcode{p}.
+Initializes \exposid{s} with \tcode{smart},
+\exposid{a} with \tcode{std::forward<Args>(args)...}, and
+value-initializes \exposid{p}.
 Then, equivalent to:
 \begin{itemize}
 \item
 % pretend to \item that there is real text here, but undo the vertical spacing
 \mbox{}\vspace{-\baselineskip}\vspace{-\parskip}
 \begin{codeblock}
-s.reset();
+@\exposid{s}@.reset();
 \end{codeblock}
-if the expression \tcode{s.reset()} is well-formed;
+if the expression \tcode{\exposid{s}.reset()} is well-formed;
 
 \item
 otherwise,
 \begin{codeblock}
-s = Smart();
+@\exposid{s}@ = Smart();
 \end{codeblock}
 if \tcode{is_constructible_v<Smart>} is \tcode{true};
 
@@ -5943,20 +5943,20 @@ Equivalent to:
 % pretend to \item that there is real text here, but undo the vertical spacing
 \mbox{}\vspace{-\baselineskip}\vspace{-\parskip}
 \begin{codeblock}
-if (p) {
+if (@\exposid{p}@) {
   apply([&](auto&&... args) {
-    s.reset(static_cast<SP>(p), std::forward<Args>(args)...); }, std::move(a));
+    @\exposid{s}@.reset(static_cast<SP>(@\exposid{p}@), std::forward<Args>(args)...); }, std::move(@\exposid{a}@));
 }
 \end{codeblock}
 if the expression
-\tcode{s.reset(static_cast<SP>(p), std::forward<Args>(args)...)}
+\tcode{\exposid{s}.reset(static_cast<SP>(\exposid{p}), std::forward<Args>(args)...)}
 is well-\linebreak formed;
 \item
 otherwise,
 \begin{codeblock}
-if (p) {
+if (@\exposid{p}@) {
   apply([&](auto&&... args) {
-    s = Smart(static_cast<SP>(p), std::forward<Args>(args)...); }, std::move(a));
+    @\exposid{s}@ = Smart(static_cast<SP>(@\exposid{p}@), std::forward<Args>(args)...); }, std::move(@\exposid{a}@));
 }
 \end{codeblock}
 if \tcode{is_constructible_v<Smart, SP, Args...>} is \tcode{true};
@@ -5976,7 +5976,7 @@ constexpr operator Pointer*() const noexcept;
 
 \pnum
 \returns
-\tcode{addressof(const_cast<Pointer\&>(p))}.
+\tcode{addressof(const_cast<Pointer\&>(\exposid{p}))}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -6001,12 +6001,12 @@ operator void**() const noexcept;
 A pointer value \tcode{v} such that:
 \begin{itemize}
 \item
-the initial value \tcode{*v} is equivalent to \tcode{static_cast<void*>(p)} and
+the initial value \tcode{*v} is equivalent to \tcode{static_cast<void*>(\exposid{p})} and
 \item
 any modification of \tcode{*v}
 that is not followed by a subsequent modification of \tcode{*this}
-affects the value of \tcode{p} during the destruction of \tcode{*this},
-such that \tcode{static_cast<void*>(p) == *v}.
+affects the value of \exposid{p} during the destruction of \tcode{*this},
+such that \tcode{static_cast<void*>(\exposid{p}) == *v}.
 \end{itemize}
 
 \pnum
@@ -6093,9 +6093,9 @@ namespace std {
     operator void**() const noexcept;
 
   private:
-    Smart& s;                   // \expos
-    tuple<Args...> a;           // \expos
-    Pointer p;                  // \expos
+    Smart& @\exposid{s}@;                   // \expos
+    tuple<Args...> @\exposid{a}@;           // \expos
+    Pointer @\exposid{p}@;                  // \expos
   };
 }
 \end{codeblock}
@@ -6126,9 +6126,9 @@ constexpr explicit inout_ptr_t(Smart& smart, Args... args);
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{s} with \tcode{smart},
-\tcode{a} with \tcode{std::forward<Args>(args)...}, and
-\tcode{p} to either
+Initializes \exposid{s} with \tcode{smart},
+\exposid{a} with \tcode{std::forward<Args>(args)...}, and
+\exposid{p} to either
 \begin{itemize}
 \item \tcode{smart} if \tcode{is_pointer_v<Smart>} is \tcode{true},
 \item otherwise, \tcode{smart.get()}.
@@ -6136,7 +6136,7 @@ Initializes \tcode{s} with \tcode{smart},
 
 \pnum
 \remarks
-An implementation can call \tcode{s.release()}.
+An implementation can call \tcode{\exposid{s}.release()}.
 
 \pnum
 \begin{note}
@@ -6158,8 +6158,8 @@ Let \tcode{SP} be
 \tcode{\exposid{POINTER_OF_OR}(Smart, Pointer)}\iref{memory.general}.
 
 \pnum
-Let \exposid{release-statement} be \tcode{s.release();}
-if an implementation does not call \tcode{s.release()} in the constructor.
+Let \exposid{release-statement} be \tcode{\exposid{s}.release();}
+if an implementation does not call \tcode{\exposid{s}.release()} in the constructor.
 Otherwise, it is empty.
 
 \pnum
@@ -6171,28 +6171,28 @@ Equivalent to:
 \mbox{}\vspace{-\baselineskip}\vspace{-\parskip}
 \begin{codeblock}
 apply([&](auto&&... args) {
-  s = Smart(static_cast<SP>(p), std::forward<Args>(args)...); }, std::move(a));
+  @\exposid{s}@ = Smart(static_cast<SP>(@\exposid{p}@), std::forward<Args>(args)...); }, std::move(@\exposid{a}@));
 \end{codeblock}
 if \tcode{is_pointer_v<Smart>} is \tcode{true};
 \item
 otherwise,
 \begin{codeblock}
 @\exposid{release-statement}@;
-if (p) {
+if (@\exposid{p}@) {
   apply([&](auto&&... args) {
-    s.reset(static_cast<SP>(p), std::forward<Args>(args)...); }, std::move(a));
+    @\exposid{s}@.reset(static_cast<SP>(@\exposid{p}@), std::forward<Args>(args)...); }, std::move(@\exposid{a}@));
 }
 \end{codeblock}
 if the expression
-\tcode{s.reset(static_cast<SP>(p), std::forward<Args>(args)...)}
+\tcode{\exposid{s}.reset(static_cast<SP>(\exposid{p}), std::forward<Args>(args)...)}
 is well-\newline formed;
 \item
 otherwise,
 \begin{codeblock}
 @\exposid{release-statement}@;
-if (p) {
+if (@\exposid{p}@) {
   apply([&](auto&&... args) {
-    s = Smart(static_cast<SP>(p), std::forward<Args>(args)...); }, std::move(a));
+    @\exposid{s}@ = Smart(static_cast<SP>(@\exposid{p}@), std::forward<Args>(args)...); }, std::move(@\exposid{a}@));
 }
 \end{codeblock}
 if \tcode{is_constructible_v<Smart, SP, Args...>} is \tcode{true};
@@ -6212,7 +6212,7 @@ constexpr operator Pointer*() const noexcept;
 
 \pnum
 \returns
-\tcode{addressof(const_cast<Pointer\&>(p))}.
+\tcode{addressof(const_cast<Pointer\&>(\exposid{p}))}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -6237,12 +6237,12 @@ operator void**() const noexcept;
 A pointer value \tcode{v} such that:
 \begin{itemize}
 \item
-the initial value \tcode{*v} is equivalent to \tcode{static_cast<void*>(p)} and
+the initial value \tcode{*v} is equivalent to \tcode{static_cast<void*>(\exposid{p})} and
 \item
 any modification of \tcode{*v}
 that is not followed by subsequent modification of \tcode{*this}
-affects the value of \tcode{p} during the destruction of \tcode{*this},
-such that \tcode{static_cast<void*>(p) == *v}.
+affects the value of \exposid{p} during the destruction of \tcode{*this},
+such that \tcode{static_cast<void*>(\exposid{p}) == *v}.
 \end{itemize}
 
 \pnum
@@ -7877,7 +7877,7 @@ The \tcode{memory_resource} class is an abstract interface to an unbounded set o
 \begin{codeblock}
 namespace std::pmr {
   class memory_resource {
-    static constexpr size_t max_align = alignof(max_align_t);   // \expos
+    static constexpr size_t @\exposid{max-align}@ = alignof(max_align_t);   // \expos
 
   public:
     memory_resource() = default;
@@ -7886,8 +7886,8 @@ namespace std::pmr {
 
     memory_resource& operator=(const memory_resource&) = default;
 
-    void* allocate(size_t bytes, size_t alignment = max_align);
-    void deallocate(void* p, size_t bytes, size_t alignment = max_align);
+    void* allocate(size_t bytes, size_t alignment = @\exposid{max-align}@);
+    void deallocate(void* p, size_t bytes, size_t alignment = @\exposid{max-align}@);
 
     bool is_equal(const memory_resource& other) const noexcept;
 
@@ -7916,7 +7916,7 @@ Destroys this \tcode{memory_resource}.
 
 \indexlibrarymember{allocate}{memory_resource}%
 \begin{itemdecl}
-void* allocate(size_t bytes, size_t alignment = max_align);
+void* allocate(size_t bytes, size_t alignment = @\exposid{max-align}@);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7937,7 +7937,7 @@ What and when the call to \tcode{do_allocate} throws.
 
 \indexlibrarymember{deallocate}{memory_resource}%
 \begin{itemdecl}
-void deallocate(void* p, size_t bytes, size_t alignment = max_align);
+void deallocate(void* p, size_t bytes, size_t alignment = @\exposid{max-align}@);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8059,7 +8059,7 @@ if its template argument is a \cv-unqualified object type.
 \begin{codeblock}
 namespace std::pmr {
   template<class Tp = byte> class polymorphic_allocator {
-    memory_resource* memory_rsrc;       // \expos
+    memory_resource* @\exposid{memory-rsrc}@;       // \expos
 
   public:
     using value_type = Tp;
@@ -8115,7 +8115,7 @@ polymorphic_allocator() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Sets \tcode{memory_rsrc} to \tcode{get_default_resource()}.
+Sets \exposid{memory-rsrc} to \tcode{get_default_resource()}.
 \end{itemdescr}
 
 \indexlibraryctor{polymorphic_allocator}%
@@ -8130,7 +8130,7 @@ polymorphic_allocator(memory_resource* r);
 
 \pnum
 \effects
-Sets \tcode{memory_rsrc} to \tcode{r}.
+Sets \exposid{memory-rsrc} to \tcode{r}.
 
 \pnum
 \throws
@@ -8150,7 +8150,7 @@ template<class U> polymorphic_allocator(const polymorphic_allocator<U>& other) n
 \begin{itemdescr}
 \pnum
 \effects
-Sets \tcode{memory_rsrc} to \tcode{other.resource()}.
+Sets \exposid{memory-rsrc} to \tcode{other.resource()}.
 \end{itemdescr}
 
 
@@ -8168,7 +8168,7 @@ If \tcode{numeric_limits<size_t>::max() / sizeof(Tp) < n},
 throws \tcode{bad_array_new_length}.
 Otherwise equivalent to:
 \begin{codeblock}
-return static_cast<Tp*>(memory_rsrc->allocate(n * sizeof(Tp), alignof(Tp)));
+return static_cast<Tp*>(\exposid{memory-rsrc}->allocate(n * sizeof(Tp), alignof(Tp)));
 \end{codeblock}
 \end{itemdescr}
 
@@ -8181,12 +8181,12 @@ void deallocate(Tp* p, size_t n);
 \pnum
 \expects
 \tcode{p} was allocated from a memory resource \tcode{x},
-equal to \tcode{*memory_rsrc},
+equal to \tcode{*\exposid{memory-rsrc}},
 using \tcode{x.allocate(n * sizeof(Tp), alignof(Tp))}.
 
 \pnum
 \effects
-Equivalent to \tcode{memory_rsrc->deallocate(p, n * sizeof(Tp), alignof(Tp))}.
+Equivalent to \tcode{\exposid{memory-rsrc}->deallocate(p, n * sizeof(Tp), alignof(Tp))}.
 
 \pnum
 \throws
@@ -8201,7 +8201,7 @@ void* allocate_bytes(size_t nbytes, size_t alignment = alignof(max_align_t));
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return memory_rsrc->allocate(nbytes, alignment);}
+Equivalent to: \tcode{return \exposid{memory-rsrc}->allocate(nbytes, alignment);}
 
 \pnum
 \begin{note}
@@ -8220,7 +8220,7 @@ void deallocate_bytes(void* p, size_t nbytes, size_t alignment = alignof(max_ali
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to \tcode{memory_rsrc->deallocate(p, nbytes, alignment)}.
+Equivalent to \tcode{\exposid{memory-rsrc}->deallocate(p, nbytes, alignment)}.
 \end{itemdescr}
 
 \indexlibrarymember{allocate_object}{polymorphic_allocator}%
@@ -8368,7 +8368,7 @@ memory_resource* resource() const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{memory_rsrc}.
+\exposid{memory-rsrc}.
 \end{itemdescr}
 
 \rSec3[mem.poly.allocator.eq]{Equality}
@@ -8789,9 +8789,9 @@ and then is released all at once when the memory resource object is destroyed.
 \begin{codeblock}
 namespace std::pmr {
   class monotonic_buffer_resource : public memory_resource {
-    memory_resource* upstream_rsrc;     // \expos
-    void* current_buffer;               // \expos
-    size_t next_buffer_size;            // \expos
+    memory_resource* @\exposid{upstream-rsrc}@;     // \expos
+    void* @\exposid{current-buffer}@;               // \expos
+    size_t @\exposid{next-buffer-size}@;            // \expos
 
   public:
     explicit monotonic_buffer_resource(memory_resource* upstream);
@@ -8839,12 +8839,12 @@ monotonic_buffer_resource(size_t initial_size, memory_resource* upstream);
 
 \pnum
 \effects
-Sets \tcode{upstream_rsrc} to \tcode{upstream} and
-\tcode{current_buffer} to \keyword{nullptr}.
+Sets \exposid{upstream-rsrc} to \tcode{upstream} and
+\exposid{current-buffer} to \keyword{nullptr}.
 If \tcode{initial_size} is specified,
-sets \tcode{next_buffer_size} to at least \tcode{initial_size};
-otherwise sets \tcode{next_buffer_size} to an
-\impldef{default \tcode{next_buffer_size} for a \tcode{monotonic_buffer_resource}} size.
+sets \exposid{next-buffer-size} to at least \tcode{initial_size};
+otherwise sets \exposid{next-buffer-size} to an
+\impldef{default \exposid{next-buffer-size} for a \tcode{monotonic_buffer_resource}} size.
 \end{itemdescr}
 
 \indexlibraryctor{monotonic_buffer_resource}%
@@ -8860,10 +8860,10 @@ monotonic_buffer_resource(void* buffer, size_t buffer_size, memory_resource* ups
 
 \pnum
 \effects
-Sets \tcode{upstream_rsrc} to \tcode{upstream},
-\tcode{current_buffer} to \tcode{buffer}, and
-\tcode{next_buffer_size} to \tcode{buffer_size} (but not less than 1),
-then increases \tcode{next_buffer_size}
+Sets \exposid{upstream-rsrc} to \tcode{upstream},
+\exposid{current-buffer} to \tcode{buffer}, and
+\exposid{next-buffer-size} to \tcode{buffer_size} (but not less than 1),
+then increases \exposid{next-buffer-size}
 by an \impldef{growth factor for \tcode{monotonic_buffer_resource}} growth factor (which need not be integral).
 \end{itemdescr}
 
@@ -8889,14 +8889,14 @@ void release();
 \begin{itemdescr}
 \pnum
 \effects
-Calls \tcode{upstream_rsrc->deallocate()} as necessary
+Calls \tcode{\exposid{upstream-rsrc}->deallocate()} as necessary
 to release all allocated memory.
-Resets \tcode{current_buffer} and \tcode{next_buffer_size}
+Resets \exposid{current-buffer} and \exposid{next-buffer-size}
 to their initial values at construction.
 
 \pnum
 \begin{note}
-The memory is released back to \tcode{upstream_rsrc}
+The memory is released back to \exposid{upstream-rsrc}
 even if some blocks that were allocated from \tcode{*this}
 have not been deallocated from \tcode{*this}.
 \end{note}
@@ -8910,7 +8910,7 @@ memory_resource* upstream_resource() const;
 \begin{itemdescr}
 \pnum
 \returns
-The value of \tcode{upstream_rsrc}.
+The value of \exposid{upstream-rsrc}.
 \end{itemdescr}
 
 \indexlibrarymember{do_allocate}{monotonic_buffer_resource}%
@@ -8921,15 +8921,15 @@ void* do_allocate(size_t bytes, size_t alignment) override;
 \begin{itemdescr}
 \pnum
 \effects
-If the unused space in \tcode{current_buffer}
+If the unused space in \exposid{current-buffer}
 can fit a block with the specified \tcode{bytes} and \tcode{alignment},
-then allocate the return block from \tcode{current_buffer};
-otherwise set \tcode{current_buffer} to \tcode{upstream_rsrc->allocate(n, m)},
-where \tcode{n} is not less than \tcode{max(bytes, next_buffer_size)} and
+then allocate the return block from \exposid{current-buffer};
+otherwise set \exposid{current-buffer} to \tcode{\exposid{upstream-rsrc}->allocate(n, m)},
+where \tcode{n} is not less than \tcode{max(bytes, \exposid{next-buffer-size})} and
 \tcode{m} is not less than \tcode{alignment},
-and increase \tcode{next_buffer_size}
+and increase \exposid{next-buffer-size}
 by an \impldef{growth factor for \tcode{monotonic_buffer_resource}} growth factor (which need not be integral),
-then allocate the return block from the newly-allocated \tcode{current_buffer}.
+then allocate the return block from the newly-allocated \exposid{current-buffer}.
 
 \pnum
 \returns
@@ -8940,7 +8940,7 @@ for a class derived from \tcode{memory_resource}\iref{mem.res.class}.
 
 \pnum
 \throws
-Nothing unless \tcode{upstream_rsrc->allocate()} throws.
+Nothing unless \tcode{\exposid{upstream-rsrc}->allocate()} throws.
 \end{itemdescr}
 
 \indexlibrarymember{do_deallocate}{monotonic_buffer_resource}%
@@ -9028,20 +9028,20 @@ namespace std {
   template<class OuterAlloc, class... InnerAllocs>
   class scoped_allocator_adaptor : public OuterAlloc {
   private:
-    using OuterTraits = allocator_traits<OuterAlloc>;   // \expos
-    scoped_allocator_adaptor<InnerAllocs...> inner;     // \expos
+    using @\exposid{outer-traits}@ = allocator_traits<OuterAlloc>;  // \expos
+    scoped_allocator_adaptor<InnerAllocs...> @\exposid{inner}@;     // \expos
 
   public:
     using outer_allocator_type = OuterAlloc;
     using inner_allocator_type = @\seebelow@;
 
-    using value_type           = OuterTraits::value_type;
-    using size_type            = OuterTraits::size_type;
-    using difference_type      = OuterTraits::difference_type;
-    using pointer              = OuterTraits::pointer;
-    using const_pointer        = OuterTraits::const_pointer;
-    using void_pointer         = OuterTraits::void_pointer;
-    using const_void_pointer   = OuterTraits::const_void_pointer;
+    using value_type           = @\exposid{outer-traits}@::value_type;
+    using size_type            = @\exposid{outer-traits}@::size_type;
+    using difference_type      = @\exposid{outer-traits}@::difference_type;
+    using pointer              = @\exposid{outer-traits}@::pointer;
+    using const_pointer        = @\exposid{outer-traits}@::const_pointer;
+    using void_pointer         = @\exposid{outer-traits}@::void_pointer;
+    using const_void_pointer   = @\exposid{outer-traits}@::const_void_pointer;
 
     using propagate_on_container_copy_assignment = @\seebelow@;
     using propagate_on_container_move_assignment = @\seebelow@;
@@ -9050,7 +9050,7 @@ namespace std {
 
     template<class Tp> struct rebind {
       using other = scoped_allocator_adaptor<
-        OuterTraits::template rebind_alloc<Tp>, InnerAllocs...>;
+        @\exposid{outer-traits}@::template rebind_alloc<Tp>, InnerAllocs...>;
     };
 
     scoped_allocator_adaptor();
@@ -9173,7 +9173,7 @@ scoped_allocator_adaptor();
 \begin{itemdescr}
 \pnum
 \effects
-Value-initializes the \tcode{OuterAlloc} base class and the \tcode{inner} allocator
+Value-initializes the \tcode{OuterAlloc} base class and the \exposid{inner} allocator
 object.
 \end{itemdescr}
 
@@ -9191,7 +9191,7 @@ template<class OuterA2>
 \pnum
 \effects
 Initializes the \tcode{OuterAlloc} base class with
-\tcode{std::forward<OuterA2>(outerAlloc)} and \tcode{inner} with \tcode{innerAllocs...}
+\tcode{std::forward<OuterA2>(outerAlloc)} and \exposid{inner} with \tcode{innerAllocs...}
 (hence recursively initializing each allocator within the adaptor with the corresponding
 allocator from the argument list).
 \end{itemdescr}
@@ -9284,7 +9284,7 @@ const inner_allocator_type& inner_allocator() const noexcept;
 \pnum
 \returns
 \tcode{*this} if \tcode{sizeof...(InnerAllocs)} is zero; otherwise,
-\tcode{inner}.
+\exposid{inner}.
 \end{itemdescr}
 
 \indexlibrarymember{outer_allocator}{scoped_allocator_adaptor}%


### PR DESCRIPTION
Towards #4702.

Also rename some exposition-only names into kebab-case:
- _`max_align`_ to _`max-align`_,
- _`memory_rsrc`_ to _`memory-rsrc`_,
- _`upstream_rsrc`_ to _`upstream-rsrc`_,
- _`current_buffer`_ to _`current-buffer`_,
- _`next_buffer_size`_ to _`next-buffer-size`_, and
- _`OuterTraits`_ to _`outer-traits`_.