### PR TITLE
[expr.typeid][locale.facet] Eliminate bad uses of `\term`

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4569,7 +4569,7 @@ The result of a \keyword{typeid} expression is an lvalue of static type
 \indextext{\idxcode{type_info}}%
 \indexlibraryglobal{type_info}%
 \keyword{const} \tcode{std::type_info}\iref{type.info} and dynamic type \keyword{const}
-\tcode{std::type_info} or \keyword{const} \term{name} where \term{name} is an
+\tcode{std::type_info} or \keyword{const} \tcode{\placeholder{name}} where \tcode{\placeholder{name}} is an
 \impldef{derived type for \tcode{typeid}} class publicly derived from
 \tcode{std::type_info} which preserves the behavior described
 in~\ref{type.info}.

--- a/source/text.tex
+++ b/source/text.tex
@@ -803,7 +803,7 @@ for \tcode{refs == 1}, the implementation never destroys the facet.
 Constructors of all facets defined in this Clause
 take such an argument and pass it along to
 their \tcode{facet} base class constructor.
-All one-argument constructors defined in this Clause are \term{explicit},
+All one-argument constructors defined in this Clause are explicit,
 preventing their participation in implicit conversions.
 
 \pnum


### PR DESCRIPTION
In [expr.typeid], _`name`_ should be a placeholder but not something being defined.

In [locale.facet], it's clear that `explicit` isn't being introduced. According to other occurrences of "explicit" that's an adjective, it seems more consistent to show this occurrence in non-code style.

Addresses https://github.com/cplusplus/draft/issues/329#issuecomment-552850025.