### PR TITLE
[lib] Use `\exposid(nc)` for `decay-copy`, `synth-three-way`, and `synth-three-way-result`

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -6076,7 +6076,7 @@ namespace std {
   template<class T, size_t N>
     constexpr bool operator==(const array<T, N>& x, const array<T, N>& y);
   template<class T, size_t N>
-    constexpr @\placeholder{synth-three-way-result}@<T>
+    constexpr @\exposid{synth-three-way-result}@<T>
       operator<=>(const array<T, N>& x, const array<T, N>& y);
 
   // \ref{array.special}, specialized algorithms
@@ -6444,7 +6444,7 @@ namespace std {
   template<class T, class Allocator>
     constexpr bool operator==(const deque<T, Allocator>& x, const deque<T, Allocator>& y);
   template<class T, class Allocator>
-    constexpr @\placeholder{synth-three-way-result}@<T>
+    constexpr @\exposid{synth-three-way-result}@<T>
       operator<=>(const deque<T, Allocator>& x, const deque<T, Allocator>& y);
 
   template<class T, class Allocator>
@@ -6940,7 +6940,7 @@ namespace std {
     constexpr bool operator==(const forward_list<T, Allocator>& x,
                               const forward_list<T, Allocator>& y);
   template<class T, class Allocator>
-    constexpr @\placeholder{synth-three-way-result}@<T>
+    constexpr @\exposid{synth-three-way-result}@<T>
       operator<=>(const forward_list<T, Allocator>& x,
                   const forward_list<T, Allocator>& y);
 
@@ -8995,7 +8995,7 @@ namespace std {
   template<class T, class Allocator>
     constexpr bool operator==(const list<T, Allocator>& x, const list<T, Allocator>& y);
   template<class T, class Allocator>
-    constexpr @\placeholder{synth-three-way-result}@<T>
+    constexpr @\exposid{synth-three-way-result}@<T>
       operator<=>(const list<T, Allocator>& x, const list<T, Allocator>& y);
 
   template<class T, class Allocator>
@@ -9788,7 +9788,7 @@ namespace std {
   template<class T, class Allocator>
     constexpr bool operator==(const vector<T, Allocator>& x, const vector<T, Allocator>& y);
   template<class T, class Allocator>
-    constexpr @\placeholder{synth-three-way-result}@<T>
+    constexpr @\exposid{synth-three-way-result}@<T>
       operator<=>(const vector<T, Allocator>& x, const vector<T, Allocator>& y);
 
   template<class T, class Allocator>
@@ -11420,7 +11420,7 @@ namespace std {
     constexpr bool operator==(const map<Key, T, Compare, Allocator>& x,
                               const map<Key, T, Compare, Allocator>& y);
   template<class Key, class T, class Compare, class Allocator>
-    constexpr @\placeholder{synth-three-way-result}@<pair<const Key, T>>
+    constexpr @\exposid{synth-three-way-result}@<pair<const Key, T>>
       operator<=>(const map<Key, T, Compare, Allocator>& x,
                   const map<Key, T, Compare, Allocator>& y);
 
@@ -11443,7 +11443,7 @@ namespace std {
     constexpr bool operator==(const multimap<Key, T, Compare, Allocator>& x,
                               const multimap<Key, T, Compare, Allocator>& y);
   template<class Key, class T, class Compare, class Allocator>
-    constexpr @\placeholder{synth-three-way-result}@<pair<const Key, T>>
+    constexpr @\exposid{synth-three-way-result}@<pair<const Key, T>>
       operator<=>(const multimap<Key, T, Compare, Allocator>& x,
                   const multimap<Key, T, Compare, Allocator>& y);
 
@@ -12585,7 +12585,7 @@ namespace std {
     constexpr bool operator==(const set<Key, Compare, Allocator>& x,
                               const set<Key, Compare, Allocator>& y);
   template<class Key, class Compare, class Allocator>
-    constexpr @\placeholder{synth-three-way-result}@<Key>
+    constexpr @\exposid{synth-three-way-result}@<Key>
       operator<=>(const set<Key, Compare, Allocator>& x,
                   const set<Key, Compare, Allocator>& y);
 
@@ -12607,7 +12607,7 @@ namespace std {
     constexpr bool operator==(const multiset<Key, Compare, Allocator>& x,
                               const multiset<Key, Compare, Allocator>& y);
   template<class Key, class Compare, class Allocator>
-    constexpr @\placeholder{synth-three-way-result}@<Key>
+    constexpr @\exposid{synth-three-way-result}@<Key>
       operator<=>(const multiset<Key, Compare, Allocator>& x,
                   const multiset<Key, Compare, Allocator>& y);
 
@@ -19079,7 +19079,7 @@ namespace std {
 
     friend constexpr bool operator==(const flat_set& x, const flat_set& y);
 
-    friend constexpr @\placeholder{synth-three-way-result}@<value_type>
+    friend constexpr @\exposid{synth-three-way-result}@<value_type>
       operator<=>(const flat_set& x, const flat_set& y);
 
     friend constexpr void swap(flat_set& x, flat_set& y) noexcept { x.swap(y); }
@@ -19750,7 +19750,7 @@ namespace std {
 
     friend constexpr bool operator==(const flat_multiset& x, const flat_multiset& y);
 
-    friend constexpr @\placeholder{synth-three-way-result}@<value_type>
+    friend constexpr @\exposid{synth-three-way-result}@<value_type>
       operator<=>(const flat_multiset& x, const flat_multiset& y);
 
     friend constexpr void swap(flat_multiset& x, flat_multiset& y) noexcept

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -539,16 +539,16 @@ is followed by a comment ending in \expos.
 \pnum
 The following are defined for exposition only
 to aid in the specification of the library:
-\indexlibrary{decay-copy@\tcode{\placeholder{decay-copy}}}%
+\indexlibrary{decay-copy@\exposid{decay-copy}}%
 \begin{codeblock}
 namespace std {
   template<class T>
     requires @\libconcept{convertible_to}@<T, decay_t<T>>
-      constexpr decay_t<T> @\placeholdernc{decay-copy}@(T&& v)       // \expos
+      constexpr decay_t<T> @\exposidnc{decay-copy}@(T&& v)       // \expos
         noexcept(is_nothrow_convertible_v<T, decay_t<T>>)
       { return std::forward<T>(v); }
 
-  constexpr auto @\placeholdernc{synth-three-way}@ =                 // \expos
+  constexpr auto @\exposidnc{synth-three-way}@ =                 // \expos
     []<class T, class U>(const T& t, const U& u)
       requires requires {
         { t < u } -> @\exposconcept{boolean-testable}@;
@@ -565,8 +565,8 @@ namespace std {
     };
 
   template<class T, class U = T>
-  using @\placeholdernc{synth-three-way-result}@ =                  // \expos
-    decltype(@\placeholdernc{synth-three-way}@(declval<T&>(), declval<U&>()));
+  using @\exposidnc{synth-three-way-result}@ =                  // \expos
+    decltype(@\exposidnc{synth-three-way}@(declval<T&>(), declval<U&>()));
 }
 \end{codeblock}
 

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -4513,7 +4513,7 @@ range adaptor object\iref{range.adaptor.object}.
 Given a subexpression \tcode{E}, the expression
 \tcode{views::all(E)} is expression-equivalent to:
 \begin{itemize}
-\item \tcode{\placeholdernc{decay-copy}(E)} if the decayed type of \tcode{E}
+\item \tcode{\exposidnc{decay-copy}(E)} if the decayed type of \tcode{E}
 models \libconcept{view}.
 
 \item Otherwise, \tcode{ref_view\{E\}} if that expression is well-formed.
@@ -5894,7 +5894,7 @@ is expression-equivalent to:
 \item
 If \tcode{T} is a specialization
 of \tcode{empty_view}\iref{range.empty.view},
-then \tcode{((void)F, \placeholdernc{decay-copy}(E))},
+then \tcode{((void)F, \exposidnc{decay-copy}(E))},
 except that the evaluations of \tcode{E} and \tcode{F}
 are indeterminately sequenced.
 
@@ -6377,7 +6377,7 @@ is expression-equivalent to:
 \item
 If \tcode{T} is a specialization of
 \tcode{empty_view}\iref{range.empty.view},
-then \tcode{((void)F, \placeholdernc{decay-copy}(E))},
+then \tcode{((void)F, \exposidnc{decay-copy}(E))},
 except that the evaluations of \tcode{E} and \tcode{F}
 are indeterminately sequenced.
 
@@ -6420,7 +6420,7 @@ views::repeat(*E.@\exposid{value_}@, ranges::distance(E) - std::min<D>(ranges::d
 \end{codeblock}
 except that \tcode{E} is evaluated only once;
 \item
-otherwise, \tcode{((void)F, \placeholdernc{decay-copy}(E))},
+otherwise, \tcode{((void)F, \exposidnc{decay-copy}(E))},
 except that the evaluations of \tcode{E} and \tcode{F} are indeterminately sequenced.
 \end{itemize}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -137,8 +137,8 @@ namespace std {
   template<class T1, class T2, class U1, class U2>
     constexpr bool operator==(const pair<T1, T2>&, const pair<U1, U2>&);
   template<class T1, class T2, class U1, class U2>
-    constexpr common_comparison_category_t<@\placeholder{synth-three-way-result}@<T1, U1>,
-                                           @\placeholder{synth-three-way-result}@<T2, U2>>
+    constexpr common_comparison_category_t<@\exposid{synth-three-way-result}@<T1, U1>,
+                                           @\exposid{synth-three-way-result}@<T2, U2>>
       operator<=>(const pair<T1, T2>&, const pair<U1, U2>&);
 
   template<class T1, class T2>
@@ -1318,8 +1318,8 @@ each of \tcode{decltype(x.first == y.first)} and
 \indexlibrarymember{operator<=>}{pair}%
 \begin{itemdecl}
 template<class T1, class T2, class U1, class U2>
-  constexpr common_comparison_category_t<@\placeholder{synth-three-way-result}@<T1, U1>,
-                                         @\placeholder{synth-three-way-result}@<T2, U2>>
+  constexpr common_comparison_category_t<@\exposid{synth-three-way-result}@<T1, U1>,
+                                         @\exposid{synth-three-way-result}@<T2, U2>>
     operator<=>(const pair<T1, T2>& x, const pair<U1, U2>& y);
 \end{itemdecl}
 
@@ -1328,8 +1328,8 @@ template<class T1, class T2, class U1, class U2>
 \effects
 Equivalent to:
 \begin{codeblock}
-if (auto c = @\placeholdernc{synth-three-way}@(x.first, y.first); c != 0) return c;
-return @\placeholdernc{synth-three-way}@(x.second, y.second);
+if (auto c = @\exposidnc{synth-three-way}@(x.first, y.first); c != 0) return c;
+return @\exposidnc{synth-three-way}@(x.second, y.second);
 \end{codeblock}
 \end{itemdescr}
 
@@ -1614,7 +1614,7 @@ namespace std {
   template<class... TTypes, @\exposconceptnc{tuple-like}@ UTuple>
     constexpr bool operator==(const tuple<TTypes...>&, const UTuple&);
   template<class... TTypes, class... UTypes>
-    constexpr common_comparison_category_t<@\placeholdernc{synth-three-way-result}@<TTypes, UTypes>...>
+    constexpr common_comparison_category_t<@\exposidnc{synth-three-way-result}@<TTypes, UTypes>...>
       operator<=>(const tuple<TTypes...>&, const tuple<UTypes...>&);
   template<class... TTypes, @\exposconceptnc{tuple-like}@ UTuple>
     constexpr @\seebelownc@ operator<=>(const tuple<TTypes...>&, const UTuple&);
@@ -2992,10 +2992,10 @@ The second overload is to be found via argument-dependent lookup\iref{basic.look
 \indexlibrarymember{operator<=>}{tuple}%
 \begin{itemdecl}
 template<class... TTypes, class... UTypes>
-  constexpr common_comparison_category_t<@\placeholder{synth-three-way-result}@<TTypes, UTypes>...>
+  constexpr common_comparison_category_t<@\exposid{synth-three-way-result}@<TTypes, UTypes>...>
     operator<=>(const tuple<TTypes...>& t, const tuple<UTypes...>& u);
 template<class... TTypes, @\exposconcept{tuple-like}@ UTuple>
-  constexpr common_comparison_category_t<@\placeholder{synth-three-way-result}@<TTypes, Elems>...>
+  constexpr common_comparison_category_t<@\exposid{synth-three-way-result}@<TTypes, Elems>...>
     operator<=>(const tuple<TTypes...>& t, const UTuple& u);
 \end{itemdecl}
 
@@ -3013,7 +3013,7 @@ If \tcode{sizeof...(TTypes)} equals zero,
 returns \tcode{strong_ordering::equal}.
 Otherwise, equivalent to:
 \begin{codeblock}
-if (auto c = @\placeholder{synth-three-way}@(get<0>(t), get<0>(u)); c != 0) return c;
+if (auto c = @\exposid{synth-three-way}@(get<0>(t), get<0>(u)); c != 0) return c;
 return @$\tcode{t}_\mathrm{tail}$@ <=> @$\tcode{u}_\mathrm{tail}$@;
 \end{codeblock}
 where $\tcode{r}_\mathrm{tail}$ for some \tcode{r}


### PR DESCRIPTION
This PR only addresses those in [expos.only.entity], and there're still some other exposition-only names that should be enclosed by `\exposid(nc)`.

Affected sections:
- [expos.only.entity]
- [utility.syn]
- [pairs.spec]
- [tuple.syn]
- [tuple.rel]
- [array.syn]
- [deque.syn]
- [forward.list.syn]
- [list.syn]
- [vector.syn]
- [associative.map.syn]
- [associative.set.syn]
- [flat.set.defn]
- [flat.multiset.defn]
- [range.all.general]
- [range.take.overview]
- [range.drop.overview]

Fixes #7126.