### PR TITLE
[basic.pre] Clarify that *declaration*s are not declarations

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -97,6 +97,9 @@ that introduces a name\iref{dcl.type.elab},
 implicit declaration of an injected-class-name\iref{class.pre}.
 \end{itemize}
 \begin{note}
+The term declaration is not a synonym for a \grammarterm{declaration}\iref{dcl.pre}.
+\end{note}
+\begin{note}
 The interpretation of a \grammarterm{for-range-declaration} produces
 one or more of the above\iref{stmt.ranged}.
 \end{note}


### PR DESCRIPTION
During our recent review of the standard, much confusion arose from mistaking the grammar term _declaration_ with the textual term "declaration" defined in [basic.pre], so add a note to avoid others spending far too much time to realize the same.