### PR TITLE
[syntax] Replace plain text with grammar terms where intended

### DIFF
--- a/source/intro.tex
+++ b/source/intro.tex
@@ -1094,9 +1094,9 @@ determines its meaning (e.g., \grammarterm{class-name},
 (e.g., \grammarterm{qualified-id}).
 \item \fakegrammarterm{X-seq} is one or more \fakegrammarterm{X}'s without intervening
 delimiters (e.g., \grammarterm{declaration-seq} is a sequence of
-declarations).
+\grammarterm{declaration}s).
 \item \fakegrammarterm{X-list} is one or more \fakegrammarterm{X}'s separated by
 intervening commas (e.g., \grammarterm{identifier-list} is a sequence of
-identifiers separated by commas).
+\grammarterm{identifier}s separated by commas).
 \end{itemize}%
 \indextext{notation!syntax|)}


### PR DESCRIPTION
For the examples of X-seq and X-list forms of specifiaction, ensure that the thing in the sequence or list is the corresponding grammar element rather than a plain text term, as the two are not always synonyms, notably not the case for the cited *declaration*.