### PR TITLE
[basic.def] Better link do defintion of declaration

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -164,7 +164,7 @@ translation unit.
 \indextext{declaration!definition versus}%
 \indextext{declaration}%
 \indextext{declaration!name}%
-A declaration\iref{dcl} may (re)introduce
+A declaration\iref{basic.pre} may (re)introduce
 one or more names and/or entities into a translation
 unit.
 If so, the


### PR DESCRIPTION
The plain text term  in this sentence refer to the definition in [basic.pre] and not the grammar production defined in [dcl].  The link to the wrong definition is confusing, even though the font choice should carry sufficient information.