### PR TITLE
[basic.def] Turn list of examples into a note

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -173,7 +173,9 @@ A declaration of an entity $X$ is
 a redeclaration of $X$
 if another declaration of $X$ is reachable from it\iref{module.reach};
 otherwise, it is a \defnadj{first}{declaration}.
-A declaration may also have effects including:
+
+\begin{note}
+A declaration can also have effects including:
 \begin{itemize}
 \item a static assertion\iref{dcl.pre},
 \item controlling template instantiation\iref{temp.explicit},
@@ -181,6 +183,7 @@ A declaration may also have effects including:
 \item use of attributes\iref{dcl.attr}, and
 \item nothing (in the case of an \grammarterm{empty-declaration}).
 \end{itemize}
+\end{note}
 
 \pnum
 \indextext{declaration!function}%


### PR DESCRIPTION
The list of example side effects should neither be deemed normtaive nor exhaustive (although we will try).  It should be demoted to a note.