### PR TITLE
Add missing 'typename' to [basic.scope.class] Example 1

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1544,7 +1544,7 @@ will find no bindings in the class scope.
 \begin{codeblock}
 template<class D>
 struct B {
-  D::type x;            // \#1
+  typename D::type x;   // \#1
 };
 
 struct A { using type = int; };


### PR DESCRIPTION
The example in [basic.scope.class] is missing a `typename` for a dependent type.