### PR TITLE
[class.copy.ctor][class.copy.assign] Tweak style and indexing for copy/move constructors and assignment operators, remove "user-declared"

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1782,14 +1782,10 @@ and the lifetime of $o$ begins before the copy is performed.
 \rSec2[class.copy.assign]{Copy/move assignment operator}%
 
 \pnum
-\indextext{assignment operator!copy|(}%
-\indextext{assignment operator!move|(}%
 \indextext{special member function|see{assignment operator}}%
 \indextext{copy!class object|see{assignment operator, copy}}%
-\indextext{move!class object|see{assignment operator, move}}%
 \indextext{operator!copy assignment|see{assignment operator, copy}}%
-\indextext{operator!move assignment|see{assignment operator, move}}%
-A user-declared \term{copy} assignment operator \tcode{X::operator=} is a
+A \defnadj{copy}{assignment operator} \tcode{X::operator=} is a
 non-static non-template member function of class \tcode{X} with exactly one
 non-object parameter of type \tcode{X}, \tcode{X\&}, \tcode{const X\&},
 \tcode{volatile X\&}, or \tcode{const volatile X\&}.
@@ -1870,7 +1866,9 @@ X& X::operator=(X&)
 \end{codeblock}
 
 \pnum
-A user-declared move assignment operator \tcode{X::operator=} is
+\indextext{move!class object|see{assignment operator, move}}%
+\indextext{operator!move assignment|see{assignment operator, move}}%
+A \defnadj{move}{assignment operator} \tcode{X::operator=} is
 a non-static non-template member function of class \tcode{X} with exactly
 one non-object parameter of type \tcode{X\&\&}, \tcode{const X\&\&}, \tcode{volatile X\&\&}, or
 \tcode{const volatile X\&\&}.

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1474,16 +1474,12 @@ describes how arguments can be specified for the calls to these constructors.
 \rSec3[class.copy.ctor]{Copy/move constructors}%
 
 \pnum
-\indextext{constructor!copy|(}%
-\indextext{constructor!move|(}%
 \indextext{copy!class object|see{constructor, copy}}%
-\indextext{move!class object|see{constructor, move}}%
 A non-template constructor for class
 \tcode{X}
 is
 a
-copy
-constructor if its first parameter is of type
+\defnadj{copy}{constructor} if its first parameter is of type
 \tcode{X\&},
 \tcode{const X\&},
 \tcode{volatile X\&}
@@ -1509,7 +1505,8 @@ X c = b;            // calls \tcode{X(const X\&, int);}
 \end{example}
 
 \pnum
-A non-template constructor for class \tcode{X} is a move constructor if its
+\indextext{move!class object|see{constructor, move}}%
+A non-template constructor for class \tcode{X} is a \defnadj{move}{constructor} if its
 first parameter is of type \tcode{X\&\&}, \tcode{const X\&\&},
 \tcode{volatile X\&\&}, or \tcode{const volatile X\&\&}, and either there are
 no other parameters or else all other parameters have default

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1382,16 +1382,12 @@ describes how arguments can be specified for the calls to these constructors.
 \rSec3[class.copy.ctor]{Copy/move constructors}%
 
 \pnum
-\indextext{constructor!copy|(}%
-\indextext{constructor!move|(}%
 \indextext{copy!class object|see{constructor, copy}}%
-\indextext{move!class object|see{constructor, move}}%
 A non-template constructor for class
 \tcode{X}
 is
 a
-copy
-constructor if its first parameter is of type
+\defnadj{copy}{constructor} if its first parameter is of type
 \tcode{X\&},
 \tcode{const X\&},
 \tcode{volatile X\&}
@@ -1417,7 +1413,8 @@ X c = b;            // calls \tcode{X(const X\&, int);}
 \end{example}
 
 \pnum
-A non-template constructor for class \tcode{X} is a move constructor if its
+\indextext{move!class object|see{constructor, move}}%
+A non-template constructor for class \tcode{X} is a \defnadj{move}{constructor} if its
 first parameter is of type \tcode{X\&\&}, \tcode{const X\&\&},
 \tcode{volatile X\&\&}, or \tcode{const volatile X\&\&}, and either there are
 no other parameters or else all other parameters have default

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1704,14 +1704,10 @@ and the lifetime of $o$ begins before the copy is performed.
 \rSec2[class.copy.assign]{Copy/move assignment operator}%
 
 \pnum
-\indextext{assignment operator!copy|(}%
-\indextext{assignment operator!move|(}%
 \indextext{special member function|see{assignment operator}}%
 \indextext{copy!class object|see{assignment operator, copy}}%
-\indextext{move!class object|see{assignment operator, move}}%
 \indextext{operator!copy assignment|see{assignment operator, copy}}%
-\indextext{operator!move assignment|see{assignment operator, move}}%
-A user-declared \term{copy} assignment operator \tcode{X::operator=} is a
+A \defnadj{copy}{assignment operator} \tcode{X::operator=} is a
 non-static non-template member function of class \tcode{X} with exactly one
 non-object parameter of type \tcode{X}, \tcode{X\&}, \tcode{const X\&},
 \tcode{volatile X\&}, or \tcode{const volatile X\&}.
@@ -1793,7 +1789,9 @@ X& X::operator=(X&)
 \end{codeblock}
 
 \pnum
-A user-declared move assignment operator \tcode{X::operator=} is
+\indextext{move!class object|see{assignment operator, move}}%
+\indextext{operator!move assignment|see{assignment operator, move}}%
+A \defnadj{move}{assignment operator} \tcode{X::operator=} is
 a non-static non-template member function of class \tcode{X} with exactly
 one non-object parameter of type \tcode{X\&\&}, \tcode{const X\&\&}, \tcode{volatile X\&\&}, or
 \tcode{const volatile X\&\&}.


### PR DESCRIPTION
Terms _copy constructor_, _move constructor_, _copy assignment operator_, and _move assignment operator_ should be italicized as a whole. `\defnadj` seems appropriate for this.

Some `\indextext` seem attached to wrong paragraphs, so this PR moves them.

It's probably superfluous to say "user-declared" as the implicitly declared ones are arguably left uncovered.

Fixes #556.