### PR TITLE
[istream.sentry] Minor tweaks

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4585,13 +4585,11 @@ the function calls
 \tcode{setstate(failbit | eofbit)}
 (which may throw
 \tcode{ios_base::failure}).
+After any preparation is completed, \exposid{ok_} is set to the value of \tcode{is.good()}.
 
 \pnum
 \remarks
-The constructor
-\begin{codeblock}
-explicit sentry(basic_istream& is, bool noskipws = false)
-\end{codeblock}
+This constructor
 uses the currently imbued locale in \tcode{is},
 to determine whether the next input character is
 whitespace or not.
@@ -4606,13 +4604,6 @@ if (ct.is(ct.space, c))
 \end{codeblock}
 
 \pnum
-If, after any preparation is completed,
-\tcode{is.good()}
-is
-\tcode{true},
-\tcode{\exposid{ok_} != false};
-otherwise,
-\tcode{\exposid{ok_} == false}.
 During preparation, the constructor may call
 \tcode{setstate(failbit)}
 (which may throw

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4588,8 +4588,8 @@ the function calls
 
 \pnum
 The currently imbued locale in \tcode{is} is used
-to determine whether or not the next input character is whitespace.
-The character \tcode{c} is a whitespace character if
+to determine whether the next input character is whitespace:
+The character \tcode{c} is a whitespace character if and only if
 \tcode{ct.is(ct.space, c)} is \tcode{true},
 where \tcode{ct} is \tcode{use_facet<ctype<charT>>(is.getloc())}.
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4571,7 +4571,7 @@ This will be possible only in functions
 that are part of the library.
 The semantics of the constructor used in user code is as specified.
 \end{footnote}
-If \tcode{noskipws} is zero and
+If \tcode{noskipws} is \tcode{false} and
 \tcode{is.flags() \& ios_base::skipws}
 is nonzero, the function extracts and discards each character as long as
 the next available input character \tcode{c} is a whitespace character.
@@ -4600,8 +4600,8 @@ whitespace or not.
 To decide if the character \tcode{c} is a whitespace character,
 the constructor performs as if it executes the following code fragment:
 \begin{codeblock}
-const ctype<charT>& ctype = use_facet<ctype<charT>>(is.getloc());
-if (ctype.is(ctype.space, c) != 0)
+const ctype<charT>& ct = use_facet<ctype<charT>>(is.getloc());
+if (ct.is(ct.space, c))
   // \tcode{c} is a whitespace character.
 \end{codeblock}
 
@@ -4610,7 +4610,7 @@ If, after any preparation is completed,
 \tcode{is.good()}
 is
 \tcode{true},
-\tcode{\exposid{ok_} != false}
+\tcode{\exposid{ok_} != false};
 otherwise,
 \tcode{\exposid{ok_} == false}.
 During preparation, the constructor may call

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4585,23 +4585,13 @@ the function calls
 \tcode{setstate(failbit | eofbit)}
 (which may throw
 \tcode{ios_base::failure}).
-After any preparation is completed, \exposid{ok_} is set to the value of \tcode{is.good()}.
 
 \pnum
-\remarks
-This constructor
-uses the currently imbued locale in \tcode{is},
-to determine whether the next input character is
-whitespace or not.
-
-\pnum
-To decide if the character \tcode{c} is a whitespace character,
-the constructor performs as if it executes the following code fragment:
-\begin{codeblock}
-const ctype<charT>& ct = use_facet<ctype<charT>>(is.getloc());
-if (ct.is(ct.space, c))
-  // \tcode{c} is a whitespace character.
-\end{codeblock}
+The currently imbued locale in \tcode{is} is used
+to determine whether or not the next input character is whitespace.
+The character \tcode{c} is a whitespace character if
+\tcode{ct.is(ct.space, c)} is \tcode{true},
+where \tcode{ct} is \tcode{use_facet<ctype<charT>>(is.getloc())}.
 
 \pnum
 During preparation, the constructor may call
@@ -4616,6 +4606,9 @@ can also perform additional
 \indextext{implementation-dependent}%
 implementation-dependent operations.
 \end{footnote}
+
+\pnum
+After any preparation is completed, \exposid{ok_} is set to the value of \tcode{is.good()}.
 \end{itemdescr}
 
 \indexlibrarydtor{sentry}%


### PR DESCRIPTION
1. Change "`noskipws` is zero" to "`noskipws` is `false`". The latter is more conventional since `noskipws` is a `bool`.
2. Rename the variable `ctype` to `ct`. This prevents it from shadowing the class template `std::ctype`.
3. Remove redundant comparison between the result of `ct.is(…)` (which has type `bool`) and `0`.
4. Add a semicolon to make the sentence structure more clear.