### PR TITLE
[basic.fundamental] Change placeholder to math font

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5318,7 +5318,7 @@ The standard and extended signed integer types are collectively called
 \defnadjx{signed integer}{types}{type}.
 The range of representable values for a signed integer type is
 $-2^{N-1}$ to $2^{N-1}-1$ (inclusive),
-where \placeholder{N} is called the \defn{width} of the type.
+where $N$ is called the \defn{width} of the type.
 \indextext{integral type!implementation-defined \tcode{sizeof}}%
 \begin{note}
 Plain \tcode{int}s are intended to have


### PR DESCRIPTION
You can see that $N$ is used directly above inside of a math expression, so it seems confusing that we would wrap it in `\placeholder{N}` here, rather than clearly referring to the $N$ that appears in math above.