### PR TITLE
correct formatting in `connect-awaitable`

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -2816,13 +2816,13 @@ namespace std::execution {
     auto fn = [&, fun]() noexcept { fun(std::forward<Ts>(as)...); };
 
     struct awaiter {
-      decltype(@\exposid{fn}@) @\exposid{fn}@;                                     // \expos
+      decltype(fn) @\exposid{fn}@;                                     // \expos
 
       static constexpr bool await_ready() noexcept { return false; }
       void await_suspend(coroutine_handle<>) noexcept { @\exposid{fn}@(); }
       [[noreturn]] void await_resume() noexcept { unreachable(); }
     };
-    return awaiter{@\exposid{fn}@};
+    return awaiter{fn};
   }
 
   @\exposid{operation-state-task}@ @\exposid{connect-awaitable}@(DS sndr, DR rcvr) requires @\libconcept{receiver_of}@<DR, Sigs> {


### PR DESCRIPTION
some references to a local variable are in italics, where they should be in normal code font.

The first _`fn`_ on line 2819 is actually referring to the local `fn` on line 2816, and should therefore be in code font.

The _`fn`_ on line 2825 also refers to the local on 2816 and should be in code font also.