### PR TITLE
[temp.deduct.general] Replace "nontype template argument" with "constant template argument"

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -7921,7 +7921,7 @@ The \defn{deduction substitution loci} are
 The substitution occurs in all types and expressions that are used
 in the deduction substitution loci.
 The expressions include not only
-constant expressions such as those that appear in array bounds or as nontype
+constant expressions such as those that appear in array bounds or as constant
 template arguments but also general expressions (i.e., non-constant expressions)
 inside \tcode{sizeof}, \keyword{decltype}, and other contexts that allow non-constant
 expressions. The substitution proceeds in lexical order and stops when


### PR DESCRIPTION
I guess this one flew under the radar because it's not spelled "non-type" template argument.