### PR TITLE
Typo layout_left::mapping::mapping precondition.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -22117,7 +22117,7 @@ then \tcode{Extents::static_extent(0)} equals
 \begin{itemize}
 \item
 If \tcode{extents_type::rank() > 1} is \tcode{true},
-then \tcode{other.stride(1)} equals \tcode{other.extents(0)}.
+then \tcode{other.stride(1)} equals \tcode{other.extents().extent(0)}.
 \item
 \tcode{other.required_span_size()} is representable as
 a value of type \tcode{index_type}.


### PR DESCRIPTION
Here `other` is a layout mapping and layout mappings don't have this API to access the `i`th extent. They only have `extents()` to get the std::extents object. See, https://github.com/cplusplus/draft/blob/fbd1a707daf2381067fa070a902e1743a12fa55f/source/containers.tex#L22446

for the analogous statement in layout_right.