### PR TITLE
[flat.{map,multimap,set,multiset}] Harmonize wordings in "The effect of calling..."

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -17053,16 +17053,15 @@ The program is ill-formed if
 
 \pnum
 The effect of calling a constructor
-that takes
-both \tcode{key_container_type} and \tcode{mapped_container_type} arguments with
-containers of different sizes is undefined.
+that takes both \tcode{key_container_type} and \tcode{mapped_container_type} arguments
+with containers of different sizes
+is undefined.
 
 \pnum
 The effect of calling a constructor or member function
-that takes a \tcode{sorted_unique_t} argument with
-a container, containers, or range
-that is not sorted with respect to \tcode{key_comp()}, or
-that contains equal elements,
+that takes a \tcode{sorted_unique_t} argument
+with a container, containers, or range that is not sorted with respect to \tcode{key_comp()},
+or that contains equal elements,
 is undefined.
 
 \pnum
@@ -18250,15 +18249,15 @@ The program is ill-formed if
 
 \pnum
 The effect of calling a constructor
-that takes both \tcode{key_container_type} and
-\tcode{mapped_container_type} arguments
-with containers of different sizes is undefined.
+that takes both \tcode{key_container_type} and \tcode{mapped_container_type} arguments
+with containers of different sizes
+is undefined.
 
 \pnum
 The effect of calling a constructor or member function
 that takes a \tcode{sorted_equivalent_t} argument
-with a container, containers, or range
-that are not sorted with respect to \tcode{key_comp()} is undefined.
+with a container, containers, or range that is not sorted with respect to \tcode{key_comp()}
+is undefined.
 
 \pnum
 The types \tcode{iterator} and \tcode{const_iterator} meet
@@ -18889,8 +18888,9 @@ as \tcode{KeyContainer::value_type}.
 \pnum
 The effect of calling a constructor or member function
 that takes a \tcode{sorted_unique_t} argument
-with a range that is not sorted with respect to \tcode{key_comp()}, or
-that contains equal elements, is undefined.
+with a range or container that is not sorted with respect to \tcode{key_comp()},
+or that contains equal elements,
+is undefined.
 
 \pnum
 The types \tcode{iterator} and \tcode{const_iterator} meet
@@ -19558,8 +19558,9 @@ as \tcode{KeyContainer::value_type}.
 
 \pnum
 The effect of calling a constructor or member function
-that takes a \tcode{sorted_equivalent_t} argument with a range
-that is not sorted with respect to \tcode{key_comp()} is undefined.
+that takes a \tcode{sorted_equivalent_t} argument
+with a range or container that is not sorted with respect to \tcode{key_comp()}
+is undefined.
 
 \pnum
 The types \tcode{iterator} and \tcode{const_iterator} meet


### PR DESCRIPTION
Noticed this in the review of [P3567 "`flat_meow` fixes"](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3567r0.html) today; and this is _not_ one of the things that it's going to fix, so might as well do it editorially first.

The egregious editorial issue here is that one place says "a container, containers, or range that *is* not sorted with respect to `key_comp()`," and another place says "a container, containers, or range that *are* not sorted with respect to `key_comp()`." We should fix the latter. Drive-by harmonize the exact wording and the line-breaks in each similar sentence:

"The effect of calling a _meow_"  
"that _has this property_"  
"with _these arguments_"  
"is undefined".