### PR TITLE
[lib.intro, iterator.concept.inc, concept.regularinvocable] Avoid "annotation"; hyphenate "freestanding-deleted"

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -74,8 +74,8 @@ be valid for that object.
 
 \pnum
 Expressions declared in a \grammarterm{requires-expression} in the library clauses are
-required to be equality-preserving, except for those annotated with the comment
-``not required to be equality-preserving.'' An expression so annotated
+required to be equality-preserving, except for those marked with the comment
+``not required to be equality-preserving.'' An expression marked with such a comment
 may be equality-preserving, but is not required to be so.
 
 \pnum
@@ -1261,7 +1261,7 @@ The \tcode{invoke} function call expression shall be
 equality-preserving\iref{concepts.equality} and
 shall not modify the function object or the arguments.
 \begin{note}
-This requirement supersedes the annotation in the definition of
+This requirement supersedes the comment in the definition of
 \libconcept{invocable}.
 \end{note}
 

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1588,7 +1588,7 @@ The \libconcept{incrementable} concept specifies requirements on types that can 
 and post-increment operators. The increment operations are required to be equality-preserving,
 and the type is required to be \libconcept{equality_comparable}.
 \begin{note}
-This supersedes the annotations on the increment expressions
+These requirements supersede the comments on the increment expressions
 in the definition of \libconcept{weakly_incrementable}.
 \end{note}
 

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -991,10 +991,10 @@ except that not all of the members of those items are required to be present.
 \pnum
 Function declarations and function template declarations
 followed by a comment that include \textit{freestanding-deleted} are
-\defnadjx{freestanding deleted}{functions}{function}.
+\defnadjx{freestanding-deleted}{functions}{function}.
 On freestanding implementations,
-it is \impldef{whether a freestanding deleted function is a deleted function}
-whether each entity introduced by a freestanding deleted function
+it is \impldef{whether a freestanding-deleted function is a deleted function}
+whether each entity introduced by a freestanding-deleted function
 is a deleted function\iref{dcl.fct.def.delete} or
 whether the requirements are the same as
 the corresponding requirements for a hosted implementation.
@@ -1067,15 +1067,15 @@ the definition is not followed by a comment that includes \textit{hosted}.
 
 \pnum
 \begin{note}
-Freestanding annotations follow some additional exposition conventions
+Such comments follow some additional exposition conventions
 that do not impose any additional normative requirements.
-Header synopses that begin with a comment containing "all freestanding"
-contain no hosted items and no freestanding deleted functions.
-Header synopses that begin with a comment containing "mostly freestanding"
-contain at least one hosted item or freestanding deleted function.
+Header synopses that begin with a comment containing ``all freestanding''
+contain no hosted items and no freestanding-deleted functions.
+Header synopses that begin with a comment containing ``mostly freestanding''
+contain at least one hosted item or freestanding-deleted function.
 Classes and class templates followed by a comment
-containing "partially freestanding"
-contain at least one hosted item or freestanding deleted function.
+containing ``partially freestanding''
+contain at least one hosted item or freestanding-deleted function.
 \end{note}
 \begin{example}
 \begin{codeblock}

--- a/source/preface.tex
+++ b/source/preface.tex
@@ -6,7 +6,7 @@
 
 \chapter{Introduction}
 
-Clauses and subclauses in this document are annotated
+Clauses and subclauses in this document are marked
 with a so-called stable name,
 presented in square brackets next to the (sub)clause heading
 (such as ``[lex.token]'' for \ref{lex.token}, ``Tokens'').


### PR DESCRIPTION
Now that many sections use "annotation" to mean a specific core-language construct, we should avoid using "annotation" to mean anything but that construct, i.e. stop using it to mean "code comment." (There will be an NB comment to this effect.)

Drive-by hyphenate "freestanding-deleted function". Not all freestanding-deleted functions are freestanding functions, and not all freestanding-deleted functions are deleted functions; hyphenating helps the reader understand that this is a term of art that cannot meaningfully be broken down into its component notions.