### PR TITLE
[flat.map.modifiers] Remove redundancy in 'insert(sorted_unique, i, j)'

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -17792,32 +17792,11 @@ template<class InputIterator>
 \begin{itemdescr}
 \pnum
 \effects
-Adds elements to \exposid{c} as if by:
-\begin{codeblock}
-for (; first != last; ++first) {
-  value_type value = *first;
-  @\exposid{c}@.keys.insert(@\exposid{c}@.keys.end(), std::move(value.first));
-  @\exposid{c}@.values.insert(@\exposid{c}@.values.end(), std::move(value.second));
-}
-\end{codeblock}
-Then, merges the sorted range of newly added elements and
-the sorted range of pre-existing elements into a single sorted range; and
-finally erases the duplicate elements as if by:
-\begin{codeblock}
-auto zv = views::zip(@\exposid{c}@.keys, @\exposid{c}@.values);
-auto it = ranges::unique(zv, @\exposid{key-equiv}@(@\exposid{compare}@)).begin();
-auto dist = distance(zv.begin(), it);
-@\exposid{c}@.keys.erase(@\exposid{c}@.keys.begin() + dist, @\exposid{c}@.keys.end());
-@\exposid{c}@.values.erase(@\exposid{c}@.values.begin() + dist, @\exposid{c}@.values.end());
-\end{codeblock}
+Equivalent to \tcode{insert(first, last)}.
 
 \pnum
 \complexity
 Linear in $N$, where $N$ is \tcode{size()} after the operation.
-
-\pnum
-\remarks
-Since this operation performs an in-place merge, it may allocate memory.
 \end{itemdescr}
 
 \indexlibrarymember{insert_range}{flat_map}%


### PR DESCRIPTION
We can specify this in terms of the overload without the `sorted_unique` tag. That is consistent with how the equivalent functions in `flat_set` and `flat_multiset` are specified.

LWG asked for this in the telecon today.