### PR TITLE
[flat.multiset.defn] Fix format

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -19770,8 +19770,8 @@ namespace std {
 
     friend constexpr bool operator==(const flat_multiset& x, const flat_multiset& y);
 
-    friend @\placeholder{synth-three-way-result}@<value_type>
-      constexpr operator<=>(const flat_multiset& x, const flat_multiset& y);
+    friend constexpr @\placeholder{synth-three-way-result}@<value_type>
+      operator<=>(const flat_multiset& x, const flat_multiset& y);
 
     friend constexpr void swap(flat_multiset& x, flat_multiset& y) noexcept
       { x.swap(y); }


### PR DESCRIPTION
It's weird to put `constexpr` after the return type, and it's also inconsistent with other places.