### PR TITLE
[const.wrap.class] Add exposition only for exposition only ctor

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -654,14 +654,14 @@ the interface for various type traits.
 template<class T>
 struct @\exposidnc{cw-fixed-value}@ {                                                         // \expos
   using @\exposidnc{type}@ = T;                                                               // \expos
-  constexpr @\exposidnc{cw-fixed-value}@(@\exposidnc{type}@ v) noexcept : @\exposidnc{data}@(v) {}
+  constexpr @\exposidnc{cw-fixed-value}@(@\exposidnc{type}@ v) noexcept : @\exposidnc{data}@(v) {}  // \expos
   T @\exposidnc{data}@;                                                                       // \expos
 };
 
 template<class T, size_t Extent>
 struct @\exposidnc{cw-fixed-value}@<T[Extent]> {                                              // \expos
   using @\exposidnc{type}@ = T[Extent];                                                       // \expos
-  constexpr @\exposidnc{cw-fixed-value}@(T (&arr)[Extent]) noexcept;
+  constexpr @\exposidnc{cw-fixed-value}@(T (&arr)[Extent]) noexcept;                          // \expos
   T @\exposidnc{data}@[Extent];                                                               // \expos
 };
 


### PR DESCRIPTION
These two constructors should also be exposition-only, so it makes sense to add exposition-only for them?