### PR TITLE
[meta.type.synop] Remove redundant cast in constant_wrapper declaration

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -169,7 +169,7 @@ namespace std {
   template<class T>
     struct @\exposidnc{cw-fixed-value}@;                                      // \expos
 
-  template<@\exposidnc{cw-fixed-value}@ X, class = typename decltype(@\exposid{cw-fixed-value}@(X))::@\exposid{type}@>
+  template<@\exposidnc{cw-fixed-value}@ X, class = typename decltype(X)::@\exposid{type}@>
     struct constant_wrapper;
 
   template<class T>


### PR DESCRIPTION
The use of `decltype(cw-fixed-value(X))` instead of just `decltype(X)` is a workaround for a GCC bug: https://gcc.gnu.org/PR117392

There's no need for the standard to specify it this way.

The `typename` is redundant too, but that's a separate topic.