### PR TITLE
[func.wrap.ref.class] Use `ArgTypes` instead of `Args`

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -14960,7 +14960,7 @@ namespace std {
     template<class... T>
       static constexpr bool @\exposidnc{is-invocable-using}@ = @\seebelownc@;     // \expos
 
-    R (*@\exposidnc{thunk-ptr}@)(@\exposidnc{BoundEntityType}@, Args&&...) noexcept(@\placeholdernc{noex}@);  // \expos
+    R (*@\exposidnc{thunk-ptr}@)(@\exposidnc{BoundEntityType}@, ArgTypes&&...) noexcept(@\placeholdernc{noex}@);  // \expos
     @\exposidnc{BoundEntityType}@ @\exposidnc{bound-entity}@;                               // \expos
   };
 
@@ -14976,7 +14976,7 @@ namespace std {
 
 \pnum
 An object of class
-\tcode{function_ref<R(Args...) \cv{} noexcept(\placeholder{noex})>}
+\tcode{function_ref<R(ArgTypes...) \cv{} noexcept(\placeholder{noex})>}
 stores a pointer to function \exposid{thunk-ptr} and
 an object \exposid{bound-entity}.
 \exposid{bound-entity} has
@@ -14984,7 +14984,7 @@ an unspecified trivially copyable type \exposid{BoundEntityType}, that
 models \libconcept{copyable} and
 is capable of storing a pointer to object value or a pointer to function value.
 The type of \exposid{thunk-ptr} is
-\tcode{R(*)(\exposidnc{BoundEntityType}, Args\&\&...) noexcept(\placeholder{noex})}.
+\tcode{R(*)(\exposidnc{BoundEntityType}, ArgTypes\&\&...) noexcept(\placeholder{noex})}.
 
 \pnum
 Each specialization of \tcode{function_ref} is
@@ -14995,7 +14995,7 @@ that models \libconcept{copyable}.
 Within \ref{func.wrap.ref},
 \tcode{\placeholder{call-args}} is an argument pack with elements such that
 \tcode{decltype((\placeholder{call-args}\linebreak{}))...} denote
-\tcode{Args\&\&...} respectively.
+\tcode{ArgTypes\&\&...} respectively.
 
 \rSec4[func.wrap.ref.ctor]{Constructors and assignment operators}
 


### PR DESCRIPTION
Use `ArgTypes` instead of `Args` to match the current class signature.
Also, `R (*thunk-ptr)(BoundEntityType, Args&&...)` should be `ArgTypes...` since there is no `Args...`.