### PR TITLE
[optional.optional.general], [optional.optional.ref.general] Use "object of type optional<T&>" correctly

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -3365,8 +3365,10 @@ namespace std {
 \end{codeblock}
 
 \pnum
-Any instance of \tcode{optional<T>} at any given time either contains a value or does not contain a value.
-When an instance of \tcode{optional<T>} \defnx{contains a value}{contains a value!\idxcode{optional}},
+An object of type \tcode{optional<T>} at any given time
+either contains a value or does not contain a value.
+When an object of type \tcode{optional<T>}
+\defnx{contains a value}{contains a value!\idxcode{optional}},
 it means that an object of type \tcode{T}, referred to as the optional object's \defnx{contained value}{contained value!\idxcode{optional}},
 is nested within\iref{intro.object} the optional object.
 When an object of type \tcode{optional<T>} is contextually converted to \tcode{bool},
@@ -3374,7 +3376,7 @@ the conversion returns \tcode{true} if the object contains a value;
 otherwise the conversion returns \tcode{false}.
 
 \pnum
-When an \tcode{optional<T>} object contains a value,
+When an object of type \tcode{optional<T>} contains a value,
 member \tcode{val} points to the contained value.
 
 \pnum
@@ -4517,7 +4519,7 @@ namespace std {
 \end{codeblock}
 
 \pnum
-An object of \tcode{optional<T\&>}
+An object of type \tcode{optional<T\&>}
 \defnx{contains a value}{contains a value!\idxcode{optional.ref}}
 if and only if \tcode{\exposidnc{val} != nullptr} is \tcode{true}.
 When an \tcode{optional<T\&>} contains a value,


### PR DESCRIPTION
The current wording in p1 makes no sense to me. Firstly, it says

> An object of `optional<T&>` ...

https://github.com/cplusplus/papers/issues/1661 says

> An instance of `optional<T&>`

https://github.com/cplusplus/draft/pull/7979 editorially replaced "instance" with "object" (accidentally? I could not find discussion on this), and now this is grammatically wrong. The wording idiom is

> An object of <u>type</u>

The second sentence is also inconsistent with the paper. The paper once again uses the term "instance", but the draft wording just says

> When an `optional<T&>`

This is also incorrect because it's a category error. We use this idiom like "an `array`" or "a `vector`" when referring to types, not to objects.