### PR TITLE
[lex.phases] Fix typo of "instantiation"

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -222,7 +222,7 @@ are determined by their respective points of instantiation\iref{temp.point}.
 Other requirements in this document can further constrain
 the context from which an instantiation can be performed.
 For example, a constexpr function template specialization
-might have a point of instantation at the end of a translation unit,
+might have a point of instantiation at the end of a translation unit,
 but its use in certain constant expressions could require
 that it be instantiated at an earlier point\iref{temp.inst}.
 \end{note}


### PR DESCRIPTION
The word should be "instantiation" but not "instantation".