### PR TITLE
[func.wrap.move.class, func.wrap.copy.class] Fix singular and plural

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -14123,7 +14123,7 @@ namespace std {
   public:
     using result_type = R;
 
-    // \ref{func.wrap.move.ctor}, constructors, assignment, and destructor
+    // \ref{func.wrap.move.ctor}, constructors, assignments, and destructor
     move_only_function() noexcept;
     move_only_function(nullptr_t) noexcept;
     move_only_function(move_only_function&&) noexcept;
@@ -14170,7 +14170,7 @@ Such small-object optimization can only be applied to a type \tcode{T}
 for which \tcode{is_nothrow_move_constructible_v<T>} is \tcode{true}.
 \end{note}
 
-\rSec4[func.wrap.move.ctor]{Constructors, assignment, and destructor}
+\rSec4[func.wrap.move.ctor]{Constructors, assignments, and destructor}
 
 \indextext{move_only_function::is-callable-from@\tcode{move_only_function::\exposid{is-callable-from}}}%
 \begin{itemdecl}
@@ -14516,7 +14516,7 @@ namespace std {
   public:
     using result_type = R;
 
-    // \ref{func.wrap.copy.ctor}, constructors, assignments, and destructors
+    // \ref{func.wrap.copy.ctor}, constructors, assignments, and destructor
     copyable_function() noexcept;
     copyable_function(nullptr_t) noexcept;
     copyable_function(const copyable_function&);
@@ -14565,7 +14565,7 @@ Such small-object optimization can only be applied to a type \tcode{T}
 for which \tcode{is_nothrow_move_constructible_v<T>} is \tcode{true}.
 \end{note}
 
-\rSec4[func.wrap.copy.ctor]{Constructors, assignments, and destructors}
+\rSec4[func.wrap.copy.ctor]{Constructors, assignments, and destructor}
 
 \indextext{copyable_function::is-callable-from@\tcode{copyable_function::\exposid{is-callable-from}}}%
 \begin{itemdecl}


### PR DESCRIPTION
Constructor and assignment should be plural because there are multiple ones. 
Destructor should be singular because there is only one.