### PR TITLE
italicize exposition-only `product-type::apply` in [exec.when.all]

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -4515,7 +4515,7 @@ equivalent to the following lambda expression:
 \end{codeblock}
 where $e$ is the expression
 \begin{codeblock}
-std::forward<Sndr>(sndr).apply(@\exposid{make-state}@<Rcvr>())
+std::forward<Sndr>(sndr).@\exposid{apply}@(@\exposid{make-state}@<Rcvr>())
 \end{codeblock}
 and where \exposid{make-state} is the following exposition-only class template:
 \begin{codeblock}


### PR DESCRIPTION
the "`apply`" that appears in [[exec.when.all]/12](https://eel.is/c++draft/exec#when.all-12) actually refers to the exposition-only _`apply`_ member of _`product-type`_ struct defined here:

https://eel.is/c++draft/exec#snd.expos-17

since it is exposition-only, it should be italicized.
