### PR TITLE
[map.overview] Fix typo of constructor of map

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -11575,7 +11575,7 @@ namespace std {
       constexpr map(InputIterator first, InputIterator last, const Allocator& a)
         : map(first, last, Compare(), a) { }
     template<@\exposconcept{container-compatible-range}@<value_type> R>
-      constexpr map(from_range_t, R&& rg, const Allocator& a))
+      constexpr map(from_range_t, R&& rg, const Allocator& a)
         : map(from_range, std::forward<R>(rg), Compare(), a) { }
     constexpr map(initializer_list<value_type> il, const Allocator& a)
       : map(il, Compare(), a) { }


### PR DESCRIPTION
The parameter list of one of the constructors has an redundant `)` at the end.