### PR TITLE
Remove notes about shared memory from the lock free recommendation

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -3135,11 +3135,6 @@ atomic operations on the same memory location via two different addresses will
 communicate atomically.
 \end{footnote}
 The implementation of these operations should not depend on any per-process state.
-\begin{note}
-This restriction enables communication by memory that is
-mapped into a process more than once and by memory that is shared between two
-processes.
-\end{note}
 
 \rSec2[atomics.wait]{Waiting and notifying}
 


### PR DESCRIPTION
Following long discussion in SG1 about P3255R1
https://lists.isocpp.org/parallel/2025/09/4624.php

We agreed that the notes about "shared memory" is vague and cannot be relied on. The standard does not mention anywhere about two processes with shared memory. This note will have conflicts with the meaning of lock free that is proposed in P3255R1. Since this note is not useful, let's remove it editorially.

Can  Olivier Giroux verify the change?

