### PR TITLE
Fix typo in submdspan_extents.

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -21080,7 +21080,7 @@ namespace std {
   struct full_extent_t { explicit full_extent_t() = default; };
   inline constexpr full_extent_t full_extent{};
 
-  template<class IndexType, class... Extents, class... SliceSpecifiers>
+  template<class IndexType, size_t... Extents, class... SliceSpecifiers>
     constexpr auto submdspan_extents(const extents<IndexType, Extents...>&, SliceSpecifiers...);
 
   // \ref{mdspan.sub.sub}, \tcode{submdspan} function template
@@ -25500,7 +25500,7 @@ otherwise,
 
 \indexlibraryglobal{submdspan_extents}%
 \begin{itemdecl}
-template<class IndexType, class... Extents, class... SliceSpecifiers>
+template<class IndexType, size_t... Extents, class... SliceSpecifiers>
   constexpr auto submdspan_extents(const extents<IndexType, Extents...>& src,
                                    SliceSpecifiers... slices);
 \end{itemdecl}
@@ -25508,7 +25508,7 @@ template<class IndexType, class... Extents, class... SliceSpecifiers>
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{sizeof...(slices)} equals \tcode{Extents::rank()}.
+\tcode{sizeof...(slices)} equals \tcode{sizeof...(Extents)}.
 
 \pnum
 \mandates


### PR DESCRIPTION
The pack `Extents` must be a pack of `size_t` integers.