### PR TITLE
[meta.member] Properly introduce intended implicit conversion

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -2800,15 +2800,15 @@ struct C: public A, public B { };       // not a standard-layout class
 static_assert( is_pointer_interconvertible_with_class( &C::b ) );
   // Succeeds because, despite its appearance, \tcode{\&C::b} has type
   // ``pointer to member of \tcode{B} of type \tcode{int}''.
-static_assert( is_pointer_interconvertible_with_class<C>( &C::b ) );
-  // Forces the use of class \tcode{C}, and fails.
+static_assert( !is_pointer_interconvertible_with_class<C, int>( &C::b ) );
+  // Forces the use of class \tcode{C}, and the result is \tcode{false}.
 
 static_assert( is_corresponding_member( &C::a, &C::b ) );
   // Succeeds because, despite its appearance, \tcode{\&C::a} and \tcode{\&C::b} have types
   // ``pointer to member of \tcode{A} of type \tcode{int}'' and
   // ``pointer to member of \tcode{B} of type \tcode{int}'', respectively.
-static_assert( is_corresponding_member<C, C>( &C::a, &C::b ) );
-  // Forces the use of class \tcode{C}, and fails.
+static_assert( !is_corresponding_member<C, C, int, int>( &C::a, &C::b ) );
+  // Forces the use of class \tcode{C}, and the result is \tcode{false}.
 \end{codeblock}
 \end{example}
 \end{note}


### PR DESCRIPTION
Previously, the `static_assert` the example failed due to deduction failure but not `false` results. This PR makes the template arguments fully specified, which allows intended implicit conversion.

Fixes #8240.