### PR TITLE
[range.subrange.general] Rename template parameters

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1938,12 +1938,12 @@ namespace std::ranges {
       @\libconcept{convertible_to}@<From, To> &&
       !@\exposconcept{uses-nonqualification-pointer-conversion}@<decay_t<From>, decay_t<To>>;
 
-  template<class T, class U, class V>
+  template<class P, class I, class S>
     concept @\defexposconceptnc{pair-like-convertible-from}@ =                    // \expos
-      !@\libconcept{range}@<T> && !is_reference_v<T> && @\exposconcept{pair-like}@<T> &&
-      @\libconcept{constructible_from}@<T, U, V> &&
-      @\exposconcept{convertible-to-non-slicing}@<U, tuple_element_t<0, T>> &&
-      @\libconcept{convertible_to}@<V, tuple_element_t<1, T>>;
+      !@\libconcept{range}@<P> && !is_reference_v<P> && @\exposconcept{pair-like}@<P> &&
+      @\libconcept{constructible_from}@<P, I, S> &&
+      @\exposconcept{convertible-to-non-slicing}@<I, tuple_element_t<0, P>> &&
+      @\libconcept{convertible_to}@<S, tuple_element_t<1, P>>;
 
   template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S = I, subrange_kind K =
       @\libconcept{sized_sentinel_for}@<S, I> ? subrange_kind::sized : subrange_kind::unsized>


### PR DESCRIPTION
At first glance, it's hard to understand what the template parameters of `pair-like-convertible-from` represent because `T`, `U`, and `V` are too general.
They actually refer to some pair-like types and iterator and sentinel types, so this fix renames them to increase readability and intention.