### PR TITLE
[simd.overview] Remove spurious noexcept

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -20065,7 +20065,7 @@ namespace std::simd {
     template<size_t UBytes, class UAbi>
       constexpr explicit basic_mask(const basic_mask<UBytes, UAbi>&) noexcept;
     template<class G>
-      constexpr explicit basic_mask(G&& gen) noexcept;
+      constexpr explicit basic_mask(G&& gen);
     constexpr basic_mask(const bitset<size()>& b) noexcept;
     constexpr explicit basic_mask(@\libconcept{unsigned_integral}@ auto val) noexcept;
 


### PR DESCRIPTION
This function is _defined_ without `noexcept`, which is reasonable since `gen` can throw.
Is this the editorial or the LWG?