### PR TITLE
Fix dangling references to "naming class"

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -5183,7 +5183,7 @@ void f() {
 \pnum
 An additional access check beyond those described earlier in \ref{class.access}
 is applied when a non-static data member or non-static member function is a
-protected member of its naming class\iref{class.access.base}.
+protected member of its designating class\iref{class.access.base}.
 \begin{footnote}
 This
 additional check does not apply to other members,
@@ -5216,10 +5216,10 @@ void fr(B* pb, D1* p1, D2* p2) {
   pb->i = 1;                    // error
   p1->i = 2;                    // error
   p2->i = 3;                    // OK (access through a \tcode{D2})
-  p2->B::i = 4;                 // OK (access through a \tcode{D2}, even though naming class is \tcode{B})
+  p2->B::i = 4;                 // OK (access through a \tcode{D2}, even though designating class is \tcode{B})
   int B::* pmi_B = &B::i;       // error
   int B::* pmi_B2 = &D2::i;     // OK (type of \tcode{\&D2::i} is \tcode{int B::*})
-  B::j = 5;                     // error: not a friend of naming class \tcode{B}
+  B::j = 5;                     // error: not a friend of designating class \tcode{B}
   D2::j = 6;                    // OK (because refers to static member)
 }
 


### PR DESCRIPTION
The term was renamed "designating class" by P2996

https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2996r13.html#pnum_397