### PR TITLE
[meta.reflection.define.aggregate] Replace "is_enumeration_type" with "is_enum_type"

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -6443,7 +6443,7 @@ it can also be queried by certain other functions in \tcode{std::meta}
   if \tcode{options.bit_width} contains a value $V$, then
   \begin{itemize}
   \item
-    \tcode{is_integral_type(type) || is_enumeration_type(type)} is \tcode{true},
+    \tcode{is_integral_type(type) || is_enum_type(type)} is \tcode{true},
   \item
     \tcode{options.alignment} does not contain a value,
   \item


### PR DESCRIPTION
Fixes #8239.

This fixes a wording bug in P2996R13; `is_enumeration_type` is a hallucination.