### PR TITLE
[concepts.callable.general] Replace "function objects" with "callable types"

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -1222,8 +1222,8 @@ fundamental types like \tcode{int} and that are comparable with
 \rSec2[concepts.callable.general]{General}
 
 \pnum
-The concepts in \ref{concepts.callable} describe the requirements on function
-objects\iref{function.objects} and their arguments.
+The concepts in \ref{concepts.callable} describe the requirements on
+callable types\iref{func.def} and their arguments.
 
 \rSec2[concept.invocable]{Concept \cname{invocable}}
 


### PR DESCRIPTION
Fixes #8241.

The introductory paragraph is misleading: we claim that the subsequent concepts are for [function objects](https://eel.is/c++draft/function.objects#def:function_object,type), but the very next concept is `invocable`, which also accepts member function pointers and data member pointers, which are [callable types](https://eel.is/c++draft/func.def#def:type,callable) but not function objects.

This seems like an editorial issue, since it's just about some intro fluff, nothing of normative consequence.