### PR TITLE
[containers] fix operator<=> format

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -12587,7 +12587,7 @@ namespace std {
                               const set<Key, Compare, Allocator>& y);
   template<class Key, class Compare, class Allocator>
     constexpr @\placeholder{synth-three-way-result}@<Key>
-      operator<=>(const set<Key, Compare, Allocator>& x, 
+      operator<=>(const set<Key, Compare, Allocator>& x,
                   const set<Key, Compare, Allocator>& y);
 
   template<class Key, class Compare, class Allocator>


### PR DESCRIPTION
They are currently not aligned:
<img width="812" height="267" alt="截圖 2025-09-29 凌晨12 58 25" src="https://github.com/user-attachments/assets/1a2a88d3-6e82-4378-bc7b-bdd4409a1f20" />
This fix puts `operator<=>` on a new line to align with the style used elsewhere.

