### PR TITLE
[simd.mask.comparison] Add missing param name

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -20436,17 +20436,17 @@ binary element-wise operation.
 \indexlibrarymember{operator>}{basic_mask}
 \begin{itemdecl}
 friend constexpr basic_mask
-  operator==(const basic_mask&, const basic_mask&) noexcept;
+  operator==(const basic_mask& lhs, const basic_mask& rhs) noexcept;
 friend constexpr basic_mask
-  operator!=(const basic_mask&, const basic_mask&) noexcept;
+  operator!=(const basic_mask& lhs, const basic_mask& rhs) noexcept;
 friend constexpr basic_mask
-  operator>=(const basic_mask&, const basic_mask&) noexcept;
+  operator>=(const basic_mask& lhs, const basic_mask& rhs) noexcept;
 friend constexpr basic_mask
-  operator<=(const basic_mask&, const basic_mask&) noexcept;
+  operator<=(const basic_mask& lhs, const basic_mask& rhs) noexcept;
 friend constexpr basic_mask
-  operator>(const basic_mask&, const basic_mask&) noexcept;
+  operator>(const basic_mask& lhs, const basic_mask& rhs) noexcept;
 friend constexpr basic_mask
-  operator<(const basic_mask&, const basic_mask&) noexcept;
+  operator<(const basic_mask& lhs, const basic_mask& rhs) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
The _Returns_ says "A basic_mask object initialized with the results of applying op to `lhs` and `rhs` as a binary element-wise operation)", but there is no `lhs` and `rhs`.