### PR TITLE
[mdspan.accessor.aligned.overview] Remove `std::` in example

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -24525,19 +24525,18 @@ possibly less optimized function \tcode{compute_without_requiring_overalignment}
 that has no over-alignment requirement.
 \begin{codeblock}
 void compute_using_fourfold_overalignment(
-  std::mdspan<float, std::dims<1>, std::layout_right,
-    std::aligned_accessor<float, 4 * alignof(float)>> x);
+  mdspan<float, dims<1>, layout_right, aligned_accessor<float, 4 * alignof(float)>> x);
 
 void compute_without_requiring_overalignment(
-  std::mdspan<float, std::dims<1>, std::layout_right> x);
+  mdspan<float, dims<1>, layout_right> x);
 
-void compute(std::mdspan<float, std::dims<1>> x) {
+void compute(mdspan<float, dims<1>> x) {
   constexpr auto byte_alignment = 4 * sizeof(float);
-  auto accessor = std::aligned_accessor<float, byte_alignment>{};
+  auto accessor = aligned_accessor<float, byte_alignment>{};
   auto x_handle = x.data_handle();
 
-  if (std::is_sufficiently_aligned<byte_alignment>(x_handle)) {
-    compute_using_fourfold_overalignment(std::mdspan{x_handle, x.mapping(), accessor});
+  if (is_sufficiently_aligned<byte_alignment>(x_handle)) {
+    compute_using_fourfold_overalignment(mdspan{x_handle, x.mapping(), accessor});
   } else {
     compute_without_requiring_overalignment(x);
   }


### PR DESCRIPTION
We usually don't explicitly spell `std::` in examples unless it's really intentional.