### PR TITLE
[simd.alg, simd.reductions] Use libconcept for `totally_ordered`

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -18420,7 +18420,7 @@ template<class T, class Abi> constexpr T reduce_min(const basic_vec<T, Abi>& x) 
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{T} models \tcode{totally_ordered}.
+\tcode{T} models \libconcept{totally_ordered}.
 
 \pnum
 \returns
@@ -18438,7 +18438,7 @@ template<class T, class Abi>
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{T} models \tcode{totally_ordered}.
+\tcode{T} models \libconcept{totally_ordered}.
 
 \pnum
 \returns
@@ -18457,7 +18457,7 @@ template<class T, class Abi> constexpr T reduce_max(const basic_vec<T, Abi>& x) 
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{T} models \tcode{totally_ordered}.
+\tcode{T} models \libconcept{totally_ordered}.
 
 \pnum
 \returns
@@ -18475,7 +18475,7 @@ template<class T, class Abi>
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{T} models \tcode{totally_ordered}.
+\tcode{T} models \libconcept{totally_ordered}.
 
 \pnum
 \returns

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -19262,7 +19262,7 @@ template<class T, class Abi>
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{T} models \tcode{totally_ordered}.
+\tcode{T} models \libconcept{totally_ordered}.
 
 \pnum
 \returns
@@ -19280,7 +19280,7 @@ template<class T, class Abi>
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{T} models \tcode{totally_ordered}.
+\tcode{T} models \libconcept{totally_ordered}.
 
 \pnum
 \returns
@@ -19311,7 +19311,7 @@ template<class T, class Abi>
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{T} models \tcode{totally_ordered}.
+\tcode{T} models \libconcept{totally_ordered}.
 
 \pnum
 \expects


### PR DESCRIPTION
...Because they are concepts.