### PR TITLE
[simd.permute.mask] Fix typo

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -16652,7 +16652,7 @@ namespace std::simd {
                          const typename V::value_type& fill_value);
   template<@\exposconcept{simd-mask-type}@ M>
     constexpr M compress(const M& v, const type_identity_t<M>& selector,
-                         const typename V::value_type& fill_value);
+                         const typename M::value_type& fill_value);
 
   template<@\exposconcept{simd-vec-type}@ V>
     constexpr V expand(const V& v, const typename V::mask_type& selector,
@@ -18900,7 +18900,7 @@ template<@\exposconcept{simd-vec-type}@ V>
                        const typename V::value_type& fill_value);
 template<@\exposconcept{simd-mask-type}@ M>
   constexpr M compress(const M& v, const type_identity_t<M>& selector,
-                       const typename V::value_type& fill_value);
+                       const typename M::value_type& fill_value);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
There is no `V` in the function signature.

Fixes cplusplus/nbballot#858