### PR TITLE
[stringstream.members] Add missing param

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -9992,7 +9992,7 @@ Equivalent to: \tcode{rdbuf()->str(std::move(s));}
 \indexlibrarymember{str}{basic_stringstream}%
 \begin{itemdecl}
 template<class T>
-  void str(const T&);
+  void str(const T& t);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
We say "Effects: Equivalent to: `rdbuf()->str(t);`" but there is no `t`.