### PR TITLE
alx-0014 - Refactor syntax of preprocessing directives

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -60,40 +60,6 @@
 \end{bnf}
 
 \begin{bnf}
-\nontermdef{if-section}\br
-    if-group \opt{elif-groups} \opt{else-group} endif-line
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{if-group}\br
-    \terminal{\# if \ \ \ \ } constant-expression new-line \opt{group}\br
-    \terminal{\# ifdef \ } identifier new-line \opt{group}\br
-    \terminal{\# ifndef } identifier new-line \opt{group}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{elif-groups}\br
-    elif-group \opt{elif-groups}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{elif-group}\br
-    \terminal{\# elif \ \ \ } constant-expression new-line \opt{group}\br
-    \terminal{\# elifdef } identifier new-line \opt{group}\br
-    \terminal{\# elifndef} identifier new-line \opt{group}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{else-group}\br
-    \terminal{\# else \ \ } new-line \opt{group}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{endif-line}\br
-    \terminal{\# endif \ } new-line
-\end{bnf}
-
-\begin{bnf}
 \nontermdef{text-line}\br
     \opt{pp-tokens} new-line
 \end{bnf}
@@ -274,6 +240,40 @@ has been replaced.
 \rSec1[cpp.cond]{Conditional inclusion}%
 \indextext{preprocessing directive!conditional inclusion}%
 \indextext{inclusion!conditional|see{preprocessing directive, conditional inclusion}}
+
+\begin{bnf}
+\nontermdef{if-section}\br
+    if-group \opt{elif-groups} \opt{else-group} endif-line
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{if-group}\br
+    \terminal{\# if \ \ \ \ } constant-expression new-line \opt{group}\br
+    \terminal{\# ifdef \ } identifier new-line \opt{group}\br
+    \terminal{\# ifndef } identifier new-line \opt{group}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{elif-groups}\br
+    elif-group \opt{elif-groups}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{elif-group}\br
+    \terminal{\# elif \ \ \ } constant-expression new-line \opt{group}\br
+    \terminal{\# elifdef } identifier new-line \opt{group}\br
+    \terminal{\# elifndef} identifier new-line \opt{group}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{else-group}\br
+    \terminal{\# else \ \ } new-line \opt{group}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{endif-line}\br
+    \terminal{\# endif \ } new-line
+\end{bnf}
 
 \indextext{\idxcode{defined}}%
 \begin{bnf}

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -52,7 +52,7 @@
     embed-directive\br
     define-directive\br
     undef-directive\br
-    \terminal{\# line \ \ } pp-tokens new-line\br
+    line-directive\br
     \terminal{\# error \ } \opt{pp-tokens} new-line\br
     \terminal{\# warning} \opt{pp-tokens} new-line\br
     \terminal{\# pragma } \opt{pp-tokens} new-line\br
@@ -2089,6 +2089,11 @@ a macro name.
 \rSec1[cpp.line]{Line control}%
 \indextext{preprocessing directive!line control}%
 \indextext{\idxcode{\#line}|see{preprocessing directive, line control}}
+
+\begin{bnf}
+\nontermdef{line-directive}\br
+    \terminal{\# line \ \ } pp-tokens new-line\br
+\end{bnf}
 
 \pnum
 The \grammarterm{string-literal} of a

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -55,7 +55,7 @@
     line-directive\br
     diagnostic-directive\br
     pragma-directive\br
-    \terminal{\# }new-line
+    null-directive
 \end{bnf}
 
 \begin{bnf}
@@ -2200,6 +2200,11 @@ Any pragma that is not recognized by the implementation is ignored.
 
 \rSec1[cpp.null]{Null directive}%
 \indextext{preprocessing directive!null}
+
+\begin{bnf}
+\nontermdef{null-directive}\br
+    \terminal{\# }new-line
+\end{bnf}
 
 \pnum
 A preprocessing directive of the form

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -53,8 +53,7 @@
     define-directive\br
     undef-directive\br
     line-directive\br
-    \terminal{\# error \ } \opt{pp-tokens} new-line\br
-    \terminal{\# warning} \opt{pp-tokens} new-line\br
+    diagnostic-directive\br
     \terminal{\# pragma } \opt{pp-tokens} new-line\br
     \terminal{\# }new-line
 \end{bnf}
@@ -2154,6 +2153,12 @@ otherwise, the result is processed as appropriate.
 \indextext{preprocessing directive!diagnostic}%
 \indextext{preprocessing directive!warning}%
 \indextext{\idxcode{\#error}|see{preprocessing directive, error}}
+
+\begin{bnf}
+\nontermdef{diagnostic-directive}\br
+    \terminal{\# error \ } \opt{pp-tokens} new-line\br
+    \terminal{\# warning} \opt{pp-tokens} new-line\br
+\end{bnf}
 
 \pnum
 A preprocessing directive of the form

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -54,7 +54,7 @@
     undef-directive\br
     line-directive\br
     diagnostic-directive\br
-    \terminal{\# pragma } \opt{pp-tokens} new-line\br
+    pragma-directive\br
     \terminal{\# }new-line
 \end{bnf}
 
@@ -2181,6 +2181,11 @@ should include the specified sequence of preprocessing tokens.
 \rSec1[cpp.pragma]{Pragma directive}%
 \indextext{preprocessing directive!pragma}%
 \indextext{\idxcode{\#pragma}|see{preprocessing directive, pragma}}
+
+\begin{bnf}
+\nontermdef{pragma-directive}\br
+    \terminal{\# pragma } \opt{pp-tokens} new-line\br
+\end{bnf}
 
 \pnum
 A preprocessing directive of the form

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -50,11 +50,8 @@
     include-directive\br
     pp-import\br
     embed-directive\br
-    \terminal{\# define } identifier replacement-list new-line\br
-    \terminal{\# define } identifier lparen \opt{identifier-list} \terminal{)} replacement-list new-line\br
-    \terminal{\# define } identifier lparen \terminal{... )} replacement-list new-line\br
-    \terminal{\# define } identifier lparen identifier-list \terminal{, ... )} replacement-list new-line\br
-    \terminal{\# undef \ } identifier new-line\br
+    define-directive\br
+    undef-directive\br
     \terminal{\# line \ \ } pp-tokens new-line\br
     \terminal{\# error \ } \opt{pp-tokens} new-line\br
     \terminal{\# warning} \opt{pp-tokens} new-line\br
@@ -104,22 +101,6 @@
 \begin{bnf}
 \nontermdef{conditionally-supported-directive}\br
     pp-tokens new-line
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{lparen}\br
-    \descr{a \terminal{(} character not immediately preceded by whitespace}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{identifier-list}\br
-    identifier\br
-    identifier-list \terminal{,} identifier
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{replacement-list}\br
-    \opt{pp-tokens}
 \end{bnf}
 
 \begin{bnf}
@@ -1454,6 +1435,35 @@ int x = Y;      // error: \tcode{Y} is neither a defined macro nor a declared na
 \indextext{macro!replacement|(}%
 \indextext{replacement!macro|see{macro, replacement}}%
 \indextext{preprocessing directive!macro replacement|see{macro, replacement}}
+
+\begin{bnf}
+\nontermdef{define-directive}\br
+    \terminal{\# define } identifier replacement-list new-line\br
+    \terminal{\# define } identifier lparen \opt{identifier-list} \terminal{)} replacement-list new-line\br
+    \terminal{\# define } identifier lparen \terminal{... )} replacement-list new-line\br
+    \terminal{\# define } identifier lparen identifier-list \terminal{, ... )} replacement-list new-line\br
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{undef-directive}\br
+    \terminal{\# undef \ } identifier new-line\br
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{lparen}\br
+    \descr{a \terminal{(} character not immediately preceded by whitespace}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{identifier-list}\br
+    identifier\br
+    identifier-list \terminal{,} identifier
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{replacement-list}\br
+    \opt{pp-tokens}
+\end{bnf}
 
 \pnum
 \indextext{macro!replacement list}%

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -49,7 +49,7 @@
 \nontermdef{control-line}\br
     include-directive\br
     pp-import\br
-    \terminal{\# embed \ } pp-tokens new-line\br
+    embed-directive\br
     \terminal{\# define } identifier replacement-list new-line\br
     \terminal{\# define } identifier lparen \opt{identifier-list} \terminal{)} replacement-list new-line\br
     \terminal{\# define } identifier lparen \terminal{... )} replacement-list new-line\br
@@ -125,47 +125,6 @@
 \begin{bnf}
 \nontermdef{pp-tokens}\br
     preprocessing-token \opt{pp-tokens}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{embed-parameter-seq}\br
-    embed-parameter \opt{embed-parameter-seq}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{embed-parameter}\br
-    embed-standard-parameter\br
-    embed-prefixed-parameter
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{embed-standard-parameter}\br
-    \terminal{limit} \terminal{(} pp-balanced-token-seq \terminal{)}\br
-    \terminal{prefix} \terminal{(} \opt{pp-balanced-token-seq} \terminal{)}\br
-    \terminal{suffix} \terminal{(} \opt{pp-balanced-token-seq} \terminal{)}\br
-    \terminal{if_empty} \terminal{(} \opt{pp-balanced-token-seq} \terminal{)}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{embed-prefixed-parameter}\br
-    identifier :: identifier\br
-    identifier :: identifier \terminal{(} \opt{pp-balanced-token-seq} \terminal{)}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{pp-balanced-token-seq}\br
-    pp-balanced-token \opt{pp-balanced-token-seq}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{pp-balanced-token}\br
-    \terminal{(} \opt{pp-balanced-token-seq} \terminal{)}\br
-    \terminal{[} \opt{pp-balanced-token-seq} \terminal{]}\br
-    \terminal{\{} \opt{pp-balanced-token-seq} \terminal{\}}\br
-    \textnormal{any} pp-token \textnormal{except:}\br
-    \bnfindent\textnormal{parenthesis (\unicode{0028}{left parenthesis} and \unicode{0029}{right parenthesis}),}\br
-    \bnfindent\textnormal{bracket (\unicode{005b}{left square bracket} and \unicode{005d}{right square bracket}), or}\br
-    \bnfindent\textnormal{brace (\unicode{007b}{left curly bracket} and \unicode{007d}{right curly bracket}).}
 \end{bnf}
 
 \begin{bnf}
@@ -849,6 +808,52 @@ directives:
 \rSec1[cpp.embed]{Resource inclusion}
 \indextext{preprocessing directive!embed a resource}
 \indextext{\idxcode{\#embed}}%
+
+\begin{bnf}
+\nontermdef{embed-directive}\br
+    \terminal{\# embed \ } pp-tokens new-line\br
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{embed-parameter-seq}\br
+    embed-parameter \opt{embed-parameter-seq}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{embed-parameter}\br
+    embed-standard-parameter\br
+    embed-prefixed-parameter
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{embed-standard-parameter}\br
+    \terminal{limit} \terminal{(} pp-balanced-token-seq \terminal{)}\br
+    \terminal{prefix} \terminal{(} \opt{pp-balanced-token-seq} \terminal{)}\br
+    \terminal{suffix} \terminal{(} \opt{pp-balanced-token-seq} \terminal{)}\br
+    \terminal{if_empty} \terminal{(} \opt{pp-balanced-token-seq} \terminal{)}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{embed-prefixed-parameter}\br
+    identifier :: identifier\br
+    identifier :: identifier \terminal{(} \opt{pp-balanced-token-seq} \terminal{)}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{pp-balanced-token-seq}\br
+    pp-balanced-token \opt{pp-balanced-token-seq}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{pp-balanced-token}\br
+    \terminal{(} \opt{pp-balanced-token-seq} \terminal{)}\br
+    \terminal{[} \opt{pp-balanced-token-seq} \terminal{]}\br
+    \terminal{\{} \opt{pp-balanced-token-seq} \terminal{\}}\br
+    \textnormal{any} pp-token \textnormal{except:}\br
+    \bnfindent\textnormal{parenthesis (\unicode{0028}{left parenthesis} and \unicode{0029}{right parenthesis}),}\br
+    \bnfindent\textnormal{bracket (\unicode{005b}{left square bracket} and \unicode{005d}{right square bracket}), or}\br
+    \bnfindent\textnormal{brace (\unicode{007b}{left curly bracket} and \unicode{007d}{right curly bracket}).}
+\end{bnf}
 
 \rSec2[cpp.embed.gen]{General}
 

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -47,7 +47,7 @@
 
 \begin{bnf}
 \nontermdef{control-line}\br
-    \terminal{\# include} pp-tokens new-line\br
+    include-directive\br
     pp-import\br
     \terminal{\# embed \ } pp-tokens new-line\br
     \terminal{\# define } identifier replacement-list new-line\br
@@ -695,6 +695,11 @@ ATTR_DEPRECATED("This function is deprecated") void anvil();
 \indextext{preprocessing directive!source-file inclusion}
 \indextext{inclusion!source file|see{preprocessing directive, source-file inclusion}}%
 \indextext{\idxcode{\#include}}%
+
+\begin{bnf}
+\nontermdef{include-directive}\br
+    \terminal{\# include} pp-tokens new-line\br
+\end{bnf}
 
 \pnum
 A \defnadj{header}{search} for a sequence of characters

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -55,7 +55,7 @@
     line-directive\br
     diagnostic-directive\br
     pragma-directive\br
-    \terminal{\# }new-line
+    null-directive
 \end{bnf}
 
 \begin{bnf}
@@ -2237,6 +2237,11 @@ Any pragma that is not recognized by the implementation is ignored.
 
 \rSec1[cpp.null]{Null directive}%
 \indextext{preprocessing directive!null}
+
+\begin{bnf}
+\nontermdef{null-directive}\br
+    \terminal{\# }new-line
+\end{bnf}
 
 \pnum
 A preprocessing directive of the form

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -53,8 +53,7 @@
     define-directive\br
     undef-directive\br
     line-directive\br
-    \terminal{\# error \ } \opt{pp-tokens} new-line\br
-    \terminal{\# warning} \opt{pp-tokens} new-line\br
+    diagnostic-directive\br
     \terminal{\# pragma } \opt{pp-tokens} new-line\br
     \terminal{\# }new-line
 \end{bnf}
@@ -2191,6 +2190,12 @@ otherwise, the result is processed as appropriate.
 \indextext{preprocessing directive!diagnostic}%
 \indextext{preprocessing directive!warning}%
 \indextext{\idxcode{\#error}|see{preprocessing directive, error}}
+
+\begin{bnf}
+\nontermdef{diagnostic-directive}\br
+    \terminal{\# error \ } \opt{pp-tokens} new-line\br
+    \terminal{\# warning} \opt{pp-tokens} new-line\br
+\end{bnf}
 
 \pnum
 A preprocessing directive of the form

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -49,7 +49,7 @@
 \nontermdef{control-line}\br
     include-directive\br
     pp-import\br
-    \terminal{\# embed \ } pp-tokens new-line\br
+    embed-directive\br
     \terminal{\# define } identifier replacement-list new-line\br
     \terminal{\# define } identifier lparen \opt{identifier-list} \terminal{)} replacement-list new-line\br
     \terminal{\# define } identifier lparen \terminal{... )} replacement-list new-line\br
@@ -130,47 +130,6 @@
 \begin{bnf}
 \nontermdef{pp-tokens}\br
     preprocessing-token \opt{pp-tokens}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{embed-parameter-seq}\br
-    embed-parameter \opt{embed-parameter-seq}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{embed-parameter}\br
-    embed-standard-parameter\br
-    embed-prefixed-parameter
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{embed-standard-parameter}\br
-    \terminal{limit} \terminal{(} pp-balanced-token-seq \terminal{)}\br
-    \terminal{prefix} \terminal{(} \opt{pp-balanced-token-seq} \terminal{)}\br
-    \terminal{suffix} \terminal{(} \opt{pp-balanced-token-seq} \terminal{)}\br
-    \terminal{if_empty} \terminal{(} \opt{pp-balanced-token-seq} \terminal{)}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{embed-prefixed-parameter}\br
-    identifier :: identifier\br
-    identifier :: identifier \terminal{(} \opt{pp-balanced-token-seq} \terminal{)}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{pp-balanced-token-seq}\br
-    pp-balanced-token \opt{pp-balanced-token-seq}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{pp-balanced-token}\br
-    \terminal{(} \opt{pp-balanced-token-seq} \terminal{)}\br
-    \terminal{[} \opt{pp-balanced-token-seq} \terminal{]}\br
-    \terminal{\{} \opt{pp-balanced-token-seq} \terminal{\}}\br
-    \textnormal{any} pp-token \textnormal{except:}\br
-    \bnfindent\textnormal{parenthesis (\unicode{0028}{left parenthesis} and \unicode{0029}{right parenthesis}),}\br
-    \bnfindent\textnormal{bracket (\unicode{005b}{left square bracket} and \unicode{005d}{right square bracket}), or}\br
-    \bnfindent\textnormal{brace (\unicode{007b}{left curly bracket} and \unicode{007d}{right curly bracket}).}
 \end{bnf}
 
 \begin{bnf}
@@ -842,6 +801,52 @@ directives:
 \rSec1[cpp.embed]{Resource inclusion}
 \indextext{preprocessing directive!embed a resource}
 \indextext{\idxcode{\#embed}}%
+
+\begin{bnf}
+\nontermdef{embed-directive}\br
+    \terminal{\# embed \ } pp-tokens new-line\br
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{embed-parameter-seq}\br
+    embed-parameter \opt{embed-parameter-seq}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{embed-parameter}\br
+    embed-standard-parameter\br
+    embed-prefixed-parameter
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{embed-standard-parameter}\br
+    \terminal{limit} \terminal{(} pp-balanced-token-seq \terminal{)}\br
+    \terminal{prefix} \terminal{(} \opt{pp-balanced-token-seq} \terminal{)}\br
+    \terminal{suffix} \terminal{(} \opt{pp-balanced-token-seq} \terminal{)}\br
+    \terminal{if_empty} \terminal{(} \opt{pp-balanced-token-seq} \terminal{)}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{embed-prefixed-parameter}\br
+    identifier :: identifier\br
+    identifier :: identifier \terminal{(} \opt{pp-balanced-token-seq} \terminal{)}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{pp-balanced-token-seq}\br
+    pp-balanced-token \opt{pp-balanced-token-seq}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{pp-balanced-token}\br
+    \terminal{(} \opt{pp-balanced-token-seq} \terminal{)}\br
+    \terminal{[} \opt{pp-balanced-token-seq} \terminal{]}\br
+    \terminal{\{} \opt{pp-balanced-token-seq} \terminal{\}}\br
+    \textnormal{any} pp-token \textnormal{except:}\br
+    \bnfindent\textnormal{parenthesis (\unicode{0028}{left parenthesis} and \unicode{0029}{right parenthesis}),}\br
+    \bnfindent\textnormal{bracket (\unicode{005b}{left square bracket} and \unicode{005d}{right square bracket}), or}\br
+    \bnfindent\textnormal{brace (\unicode{007b}{left curly bracket} and \unicode{007d}{right curly bracket}).}
+\end{bnf}
 
 \rSec2[cpp.embed.gen]{General}
 

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -65,40 +65,6 @@
 \end{bnf}
 
 \begin{bnf}
-\nontermdef{if-section}\br
-    if-group \opt{elif-groups} \opt{else-group} endif-line
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{if-group}\br
-    \terminal{\# if \ \ \ \ } constant-expression new-line \opt{group}\br
-    \terminal{\# ifdef \ } identifier new-line \opt{group}\br
-    \terminal{\# ifndef } identifier new-line \opt{group}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{elif-groups}\br
-    elif-group \opt{elif-groups}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{elif-group}\br
-    \terminal{\# elif \ \ \ } constant-expression new-line \opt{group}\br
-    \terminal{\# elifdef } identifier new-line \opt{group}\br
-    \terminal{\# elifndef} identifier new-line \opt{group}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{else-group}\br
-    \terminal{\# else \ \ } new-line \opt{group}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{endif-line}\br
-    \terminal{\# endif \ } new-line
-\end{bnf}
-
-\begin{bnf}
 \nontermdef{text-line}\br
     \opt{pp-tokens} new-line
 \end{bnf}
@@ -269,6 +235,40 @@ has been replaced.
 \rSec1[cpp.cond]{Conditional inclusion}%
 \indextext{preprocessing directive!conditional inclusion}%
 \indextext{inclusion!conditional|see{preprocessing directive, conditional inclusion}}
+
+\begin{bnf}
+\nontermdef{if-section}\br
+    if-group \opt{elif-groups} \opt{else-group} endif-line
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{if-group}\br
+    \terminal{\# if \ \ \ \ } constant-expression new-line \opt{group}\br
+    \terminal{\# ifdef \ } identifier new-line \opt{group}\br
+    \terminal{\# ifndef } identifier new-line \opt{group}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{elif-groups}\br
+    elif-group \opt{elif-groups}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{elif-group}\br
+    \terminal{\# elif \ \ \ } constant-expression new-line \opt{group}\br
+    \terminal{\# elifdef } identifier new-line \opt{group}\br
+    \terminal{\# elifndef} identifier new-line \opt{group}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{else-group}\br
+    \terminal{\# else \ \ } new-line \opt{group}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{endif-line}\br
+    \terminal{\# endif \ } new-line
+\end{bnf}
 
 \indextext{\idxcode{defined}}%
 \begin{bnf}

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -54,7 +54,7 @@
     undef-directive\br
     line-directive\br
     diagnostic-directive\br
-    \terminal{\# pragma } \opt{pp-tokens} new-line\br
+    pragma-directive\br
     \terminal{\# }new-line
 \end{bnf}
 
@@ -2218,6 +2218,11 @@ should include the specified sequence of preprocessing tokens.
 \rSec1[cpp.pragma]{Pragma directive}%
 \indextext{preprocessing directive!pragma}%
 \indextext{\idxcode{\#pragma}|see{preprocessing directive, pragma}}
+
+\begin{bnf}
+\nontermdef{pragma-directive}\br
+    \terminal{\# pragma } \opt{pp-tokens} new-line\br
+\end{bnf}
 
 \pnum
 A preprocessing directive of the form

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -50,11 +50,8 @@
     include-directive\br
     pp-import\br
     embed-directive\br
-    \terminal{\# define } identifier replacement-list new-line\br
-    \terminal{\# define } identifier lparen \opt{identifier-list} \terminal{)} replacement-list new-line\br
-    \terminal{\# define } identifier lparen \terminal{... )} replacement-list new-line\br
-    \terminal{\# define } identifier lparen identifier-list \terminal{, ... )} replacement-list new-line\br
-    \terminal{\# undef \ } identifier new-line\br
+    define-directive\br
+    undef-directive\br
     line-directive\br
     \terminal{\# error \ } \opt{pp-tokens} new-line\br
     \terminal{\# warning} \opt{pp-tokens} new-line\br
@@ -109,22 +106,6 @@
 \begin{bnf}
 \nontermdef{conditionally-supported-directive}\br
     pp-tokens new-line
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{lparen}\br
-    \descr{a \terminal{(} character not immediately preceded by whitespace}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{identifier-list}\br
-    identifier\br
-    identifier-list \terminal{,} identifier
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{replacement-list}\br
-    \opt{pp-tokens}
 \end{bnf}
 
 \begin{bnf}
@@ -1492,6 +1473,35 @@ int x = Y;      // error: \tcode{Y} is neither a defined macro nor a declared na
 \indextext{macro!replacement|(}%
 \indextext{replacement!macro|see{macro, replacement}}%
 \indextext{preprocessing directive!macro replacement|see{macro, replacement}}
+
+\begin{bnf}
+\nontermdef{define-directive}\br
+    \terminal{\# define } identifier replacement-list new-line\br
+    \terminal{\# define } identifier lparen \opt{identifier-list} \terminal{)} replacement-list new-line\br
+    \terminal{\# define } identifier lparen \terminal{... )} replacement-list new-line\br
+    \terminal{\# define } identifier lparen identifier-list \terminal{, ... )} replacement-list new-line\br
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{undef-directive}\br
+    \terminal{\# undef \ } identifier new-line\br
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{lparen}\br
+    \descr{a \terminal{(} character not immediately preceded by whitespace}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{identifier-list}\br
+    identifier\br
+    identifier-list \terminal{,} identifier
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{replacement-list}\br
+    \opt{pp-tokens}
+\end{bnf}
 
 \pnum
 \indextext{macro!replacement list}%

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -47,7 +47,7 @@
 
 \begin{bnf}
 \nontermdef{control-line}\br
-    \terminal{\# include} pp-tokens new-line\br
+    include-directive\br
     pp-import\br
     \terminal{\# embed \ } pp-tokens new-line\br
     \terminal{\# define } identifier replacement-list new-line\br
@@ -684,6 +684,11 @@ ATTR_DEPRECATED("This function is deprecated") void anvil();
 \indextext{preprocessing directive!source-file inclusion}
 \indextext{inclusion!source file|see{preprocessing directive, source-file inclusion}}%
 \indextext{\idxcode{\#include}}%
+
+\begin{bnf}
+\nontermdef{include-directive}\br
+    \terminal{\# include} pp-tokens new-line\br
+\end{bnf}
 
 \pnum
 A \defnadj{header}{search} for a sequence of characters


### PR DESCRIPTION
Closes: #8249 

Cc: @jwakely , @jensmaurer 

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase after CWG Motion 3b (p3920).

```
$ git range-diff main..origin/alx-0014 d8bd209c..alx-0014 
1:  ed2683a4 = 1:  19c52494 (alx-0014r6-A) Refactor syntax of include directives
2:  c6ce3de1 = 2:  f99709f8 (alx-0014r6-B) Refactor syntax of embed directives
3:  600fa4c2 = 3:  47b7a580 (alx-0014r6-C) Refactor syntax of macros
4:  22509106 = 4:  1d405f7f (alx-0014r6-D) Refactor syntax of conditional directives
5:  61fd02e7 = 5:  823c6a4d (alx-0014r6-E) Refactor syntax of line directives
6:  fb1efad7 = 6:  c117fa30 (alx-0014r6-F) Refactor syntax of diagnostic directives
7:  2f2dee42 = 7:  4425d456 (alx-0014r6-G) Refactor syntax of pragma directives
8:  9b4bf160 = 8:  5f136b8b (alx-0014r6-H) Refactor syntax of null directives
```
</details>

<details>
<summary>v1c</summary>

-  Rebase after CWG Motion 4 (p3868r3).  Motion 4 did apply the change from alx-0014r6-E, so that patch has been dropped.

```
$ git range-diff 19c52494^..origin/alx-0014 6cdd68b3..alx-0014 
1:  19c52494 = 1:  f32fe47f (alx-0014r6-A) Refactor syntax of include directives
2:  f99709f8 = 2:  4900dba2 (alx-0014r6-B) Refactor syntax of embed directives
3:  47b7a580 ! 3:  0e7d29b1 (alx-0014r6-C) Refactor syntax of macros
    @@ source/preprocessor.tex
     -    \terminal{\# undef \ } identifier new-line\br
     +    define-directive\br
     +    undef-directive\br
    -     \terminal{\# line \ \ } pp-tokens new-line\br
    +     line-directive\br
          \terminal{\# error \ } \opt{pp-tokens} new-line\br
          \terminal{\# warning} \opt{pp-tokens} new-line\br
     @@
4:  1d405f7f ! 4:  88c8cdaa (alx-0014r6-D) Refactor syntax of conditional directives
    @@ Commit message
     
      ## source/preprocessor.tex ##
     @@
    -     \terminal{\# }new-line
    +     line-directive \opt{line-directives}
      \end{bnf}
      
     -\begin{bnf}
    @@ source/preprocessor.tex
     -    \terminal{\# endif \ } new-line
     -\end{bnf}
     -
    - \begin{bnf}
    +-\begin{bnf}
      \nontermdef{text-line}\br
          \opt{pp-tokens} new-line
    + \end{bnf}
     @@ source/preprocessor.tex: has been replaced.
      \indextext{preprocessing directive!conditional inclusion}%
      \indextext{inclusion!conditional|see{preprocessing directive, conditional inclusion}}
5:  823c6a4d < -:  -------- (alx-0014r6-E) Refactor syntax of line directives
6:  c117fa30 = 5:  7ac593dc (alx-0014r6-F) Refactor syntax of diagnostic directives
7:  4425d456 = 6:  a2dc93b6 (alx-0014r6-G) Refactor syntax of pragma directives
8:  5f136b8b = 7:  e2ebd3bf (alx-0014r6-H) Refactor syntax of null directives
```
</details>

<details>
<summary>v1d</summary>

-  Rebase.

```
$ git range-diff f32fe47f^..origin/alx-0014 wg21/main..alx-0014 
1:  f32fe47f = 1:  8a7862f5 (alx-0014r6-A) Refactor syntax of include directives
2:  4900dba2 = 2:  90e5fd46 (alx-0014r6-B) Refactor syntax of embed directives
3:  0e7d29b1 = 3:  cf3a68ab (alx-0014r6-C) Refactor syntax of macros
4:  88c8cdaa = 4:  9b795749 (alx-0014r6-D) Refactor syntax of conditional directives
5:  7ac593dc = 5:  59c1c171 (alx-0014r6-F) Refactor syntax of diagnostic directives
6:  a2dc93b6 = 6:  1b3c1d67 (alx-0014r6-G) Refactor syntax of pragma directives
7:  e2ebd3bf = 7:  609580fe (alx-0014r6-H) Refactor syntax of null directives
```
</details>

<details>
<summary>v1e</summary>

-  Fix rebasing accident from v1c.

```
$ git range-diff 8a7862f5^ origin/alx-0014 alx-0014 
1:  8a7862f5 = 1:  8a7862f5 (alx-0014r6-A) Refactor syntax of include directives
2:  90e5fd46 = 2:  90e5fd46 (alx-0014r6-B) Refactor syntax of embed directives
3:  cf3a68ab = 3:  cf3a68ab (alx-0014r6-C) Refactor syntax of macros
4:  9b795749 ! 4:  acbd537d (alx-0014r6-D) Refactor syntax of conditional directives
    @@ source/preprocessor.tex
     -    \terminal{\# endif \ } new-line
     -\end{bnf}
     -
    --\begin{bnf}
    + \begin{bnf}
      \nontermdef{text-line}\br
          \opt{pp-tokens} new-line
    - \end{bnf}
     @@ source/preprocessor.tex: has been replaced.
      \indextext{preprocessing directive!conditional inclusion}%
      \indextext{inclusion!conditional|see{preprocessing directive, conditional inclusion}}
5:  59c1c171 = 5:  ebc741a1 (alx-0014r6-F) Refactor syntax of diagnostic directives
6:  1b3c1d67 = 6:  8441d23b (alx-0014r6-G) Refactor syntax of pragma directives
7:  609580fe = 7:  3a31df2b (alx-0014r6-H) Refactor syntax of null directives
```
</details>