### PR TITLE
[meta.reflection.access.context] Remove stray `static` in declaration of `via`

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -5222,7 +5222,7 @@ are both the null reflection.
 \end{itemdescr}
 
 \begin{itemdecl}
-static consteval access_context @\libmember{via}{access_context}@(info cls) const;
+consteval access_context @\libmember{via}{access_context}@(info cls) const;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
This is a misapplication of P2996R13 https://github.com/cplusplus/papers/issues/1668.

Fixes https://github.com/cplusplus/nbballot/issues/777.

The synopsis has no `static` (which is correct).