### PR TITLE
[meta.reflection.array] Integrate subclause into [meta.define.static]

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3613,7 +3613,7 @@ An object is a \defnadj{potentially non-unique}{object} if it is
   the backing array of an initializer list\iref{dcl.init.ref}, or
 \item
   the object introduced by a call to \tcode{std::meta::reflect_constant_array}
-  or \tcode{std::meta::\brk{}reflect_con\-stant_string}\iref{meta.reflection.array}, or
+  or \tcode{std::meta::reflect_constant_string}\iref{meta.define.static}, or
 \item
   a subobject thereof.
 \end{itemize}

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -2920,7 +2920,13 @@ namespace std {
   consteval bool is_string_literal(const char16_t* p);
   consteval bool is_string_literal(const char32_t* p);
 
-  // \ref{meta.define.static}, promoting to static storage strings
+  // \ref{meta.define.static}, promoting to static storage
+  namespace meta {
+    template<ranges::@\libconcept{input_range}@ R>
+      consteval info reflect_constant_string(R&& r);
+    template<ranges::@\libconcept{input_range}@ R>
+      consteval info reflect_constant_array(R&& r);
+  }
   template<ranges::@\libconcept{input_range}@ R>
     consteval const ranges::range_value_t<R>* define_static_string(R&& r);
   template<ranges::@\libconcept{input_range}@ R>
@@ -3104,13 +3110,6 @@ namespace std::meta {
     consteval info reflect_object(T& object);
   template<class T>
     consteval info reflect_function(T& fn);
-
-  // \ref{meta.reflection.array}, promoting to static storage arrays
-  template<ranges::@\libconcept{input_range}@ R>
-    consteval info reflect_constant_string(R&& r);
-
-  template<ranges::@\libconcept{input_range}@ R>
-    consteval info reflect_constant_array(R&& r);
 
   // \ref{meta.reflection.define.aggregate}, class definition generation
   struct data_member_options;
@@ -3374,10 +3373,102 @@ consteval bool is_string_literal(const char32_t* p);
 \end{itemize}
 \end{itemdescr}
 
-\rSec2[meta.define.static]{Promoting to static storage strings}
+\rSec2[meta.define.static]{Promoting to static storage}
 
 \pnum
 The functions in this subclause promote compile-time storage into static storage.
+
+\indexlibraryglobal{reflect_constant_string}%
+\begin{itemdecl}
+template<ranges::@\libconcept{input_range}@ R>
+  consteval info reflect_constant_string(R&& r);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{CharT} be \tcode{ranges::range_value_t<R>}.
+
+\pnum
+\mandates
+\tcode{CharT} is one of
+\tcode{char},
+\tcode{wchar_t},
+\tcode{char8_t},
+\tcode{char16_t},
+\tcode{char32_t}.
+
+\pnum
+Let $V$ be the pack of values of type \tcode{CharT}
+whose elements are the corresponding elements of \tcode{r},
+except that if \tcode{r} refers to a string literal object,
+then $V$ does not include the trailing null terminator of \tcode{r}.
+
+\pnum
+Let $P$ be the template parameter object\iref{temp.param}
+of type \tcode{const CharT[sizeof...(V) + 1]}
+initialized with \tcode{\{$V$..., CharT()\}}.
+
+\pnum
+\returns
+\tcode{\reflexpr{$P$}}.
+
+\pnum
+\begin{note}
+$P$ is a potentially non-unique object\iref{intro.object}.
+\end{note}
+\end{itemdescr}
+
+\indexlibraryglobal{reflect_constant_array}%
+\begin{itemdecl}
+template<ranges::@\libconcept{input_range}@ R>
+  consteval info reflect_constant_array(R&& r);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{T} be \tcode{ranges::range_value_t<R>}.
+
+\pnum
+\mandates
+\tcode{T} is a structural type\iref{temp.param},
+\tcode{is_constructible_v<T, ranges::range_reference_t<R>>} is \tcode{true}, and
+\tcode{is_copy_constructible_v<T>} is \tcode{true}.
+
+\pnum
+Let $V$ be the pack of values of type \tcode{info}
+of the same size as \tcode{r},
+where the $i^\text{th}$ element is \tcode{reflect_constant($\tcode{e}_i$)},
+where $\tcode{e}_i$ is the $i^\text{th}$ element of \tcode{r}.
+
+\pnum
+Let $P$ be
+\begin{itemize}
+\item
+  If \tcode{sizeof...($V$) > 0} is \tcode{true},
+  then the template parameter object\iref{temp.param}
+  of type \tcode{const T[\brk{}sizeof...(\brk{}$V$)]}
+  initialized with \tcode{\{[:$V$:]...\}}.
+\item
+  Otherwise, the template parameter object
+  of type \tcode{const array<T, 0>}
+  initialized with \tcode{\{\}}.
+\end{itemize}
+
+\pnum
+\returns
+\tcode{\reflexpr{$P$}}.
+
+\pnum
+\throws
+\tcode{meta::exception} unless
+\tcode{reflect_constant(e)} is a constant subexpression
+for every element \tcode{e} of \tcode{r}.
+
+\pnum
+\begin{note}
+$P$ is a potentially non-unique object\iref{intro.object}.
+\end{note}
+\end{itemdescr}
 
 \indexlibraryglobal{define_static_string}%
 \begin{itemdecl}
@@ -6207,103 +6298,6 @@ A reflection of the function designated by \tcode{fn}.
 \tcode{meta::exception} unless
 \tcode{fn} is suitable for use as a constant template argument
 for a constant template parameter of type \tcode{T\&}\iref{temp.arg.nontype}.
-\end{itemdescr}
-
-\rSec2[meta.reflection.array]{Promoting to static storage arrays}
-
-\pnum
-The functions in this subclause promote compile-time storage into static storage.
-
-\indexlibraryglobal{reflect_constant_string}%
-\begin{itemdecl}
-template<ranges::@\libconcept{input_range}@ R>
-  consteval info reflect_constant_string(R&& r);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-Let \tcode{CharT} be \tcode{ranges::range_value_t<R>}.
-
-\pnum
-\mandates
-\tcode{CharT} is one of
-\tcode{char},
-\tcode{wchar_t},
-\tcode{char8_t},
-\tcode{char16_t},
-\tcode{char32_t}.
-
-\pnum
-Let $V$ be the pack of values of type \tcode{CharT}
-whose elements are the corresponding elements of \tcode{r},
-except that if \tcode{r} refers to a string literal object,
-then $V$ does not include the trailing null terminator of \tcode{r}.
-
-\pnum
-Let $P$ be the template parameter object\iref{temp.param}
-of type \tcode{const CharT[sizeof...(V) + 1]}
-initialized with \tcode{\{$V$..., CharT()\}}.
-
-\pnum
-\returns
-\tcode{\reflexpr{$P$}}.
-
-\pnum
-\begin{note}
-$P$ is a potentially non-unique object\iref{intro.object}.
-\end{note}
-\end{itemdescr}
-
-\indexlibraryglobal{reflect_constant_array}%
-\begin{itemdecl}
-template<ranges::@\libconcept{input_range}@ R>
-  consteval info reflect_constant_array(R&& r);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-Let \tcode{T} be \tcode{ranges::range_value_t<R>}.
-
-\pnum
-\mandates
-\tcode{T} is a structural type\iref{temp.param},
-\tcode{is_constructible_v<T, ranges::range_reference_t<R>>} is \tcode{true}, and
-\tcode{is_copy_constructible_v<T>} is \tcode{true}.
-
-\pnum
-Let $V$ be the pack of values of type \tcode{info}
-of the same size as \tcode{r},
-where the $i^\text{th}$ element is \tcode{reflect_constant($\tcode{e}_i$)},
-where $\tcode{e}_i$ is the $i^\text{th}$ element of \tcode{r}.
-
-\pnum
-Let $P$ be
-\begin{itemize}
-\item
-  If \tcode{sizeof...($V$) > 0} is \tcode{true},
-  then the template parameter object\iref{temp.param}
-  of type \tcode{const T[\brk{}sizeof...(\brk{}$V$)]}
-  initialized with \tcode{\{[:$V$:]...\}}.
-\item
-  Otherwise, the template parameter object
-  of type \tcode{const array<T, 0>}
-  initialized with \tcode{\{\}}.
-\end{itemize}
-
-\pnum
-\returns
-\tcode{\reflexpr{$P$}}.
-
-\pnum
-\throws
-\tcode{meta::exception} unless
-\tcode{reflect_constant(e)} is a constant subexpression
-for every element \tcode{e} of \tcode{r}.
-
-\pnum
-\begin{note}
-$P$ is a potentially non-unique object\iref{intro.object}.
-\end{note}
 \end{itemdescr}
 
 \rSec2[meta.reflection.define.aggregate]{Reflection class definition generation}


### PR DESCRIPTION
Fixes NB US 86-157 (C++26 CD).
Fixes NB US 119-180 (C++26 CD).
Fixes NB US 89-196 (C++26 CD).

Fixes cplusplus/nbballot#736
Fixes cplusplus/nbballot#749
Fixes cplusplus/nbballot#765