### PR TITLE
[meta.reflection.operators] Remove superfluous 'the'

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -3640,7 +3640,7 @@ consteval operators operator_of(info r);
 \begin{itemdescr}
 \pnum
 \returns
-The value of the enumerator from the \tcode{operators}
+The value of the enumerator from \tcode{operators}
 whose corresponding \grammarterm{operator-function-id}
 is the unqualified name of the entity represented by \tcode{r}.
 


### PR DESCRIPTION
Fixes NB US 91-198 (C++26 CD).

Fixes cplusplus/nbballot#767