### PR TITLE
[exec.snd] Harmonize subclause titles

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -4884,7 +4884,7 @@ return let_stopped(
   });
 \end{codeblock}
 
-\rSec3[exec.associate]{\tcode{std::execution::associate}}
+\rSec3[exec.associate]{\tcode{execution::associate}}
 
 \pnum
 \tcode{associate} tries to associate
@@ -5141,7 +5141,7 @@ The evaluation of \tcode{associate(sndr, token)}
 may cause side effects observable
 via \tcode{token}{'s} associated async scope object.
 
-\rSec3[exec.stop.when]{Exposition-only \tcode{std::execution::\exposid{stop-when}}}
+\rSec3[exec.stop.when]{Exposition-only \tcode{execution::\exposid{stop-when}}}
 
 \pnum
 %%FIXME: Should stop-when be declared somewhere as \expos?
@@ -5217,7 +5217,7 @@ an exposition-only type \exposid{stoken-t} such that:
 \end{itemize}
 \end{itemize}
 
-\rSec3[exec.spawn.future]{\tcode{std::execution::spawn_future}}
+\rSec3[exec.spawn.future]{\tcode{execution::spawn_future}}
 
 \pnum
 \tcode{spawn_future} attempts to associate the given input sender
@@ -5830,7 +5830,7 @@ For a stopped completion, a disengaged \tcode{optional} object is returned.
 \end{itemize}
 \end{itemize}
 
-\rSec3[exec.spawn]{\tcode{std::execution::spawn}}
+\rSec3[exec.spawn]{\tcode{execution::spawn}}
 
 \pnum
 \tcode{spawn} attempts to associate the given input sender with


### PR DESCRIPTION
Drop unnecessary 'std::' prefix

Fixes NB FR-033-335 (C++26 CD).

Fixes cplusplus/nbballot#910