### PR TITLE
[exec.snd] Fix cross-references for 'impls-for'

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -2925,7 +2925,7 @@ Otherwise, it is expression-equivalent to
 For \tcode{just}, \tcode{just_error}, and \tcode{just_stopped},
 let \exposid{set-cpo} be
 \tcode{set_value}, \tcode{set_error}, and \tcode{set_stopped}, respectively.
-The exposition-only class template \exposid{impls-for}\iref{exec.snd.general}
+The exposition-only class template \exposid{impls-for}\iref{exec.snd.expos}
 is specialized for \exposid{just-cpo} as follows:
 \begin{codeblock}
 namespace std::execution {
@@ -2955,7 +2955,7 @@ the expression \tcode{read_env(q)} is expression-equivalent to
 \tcode{\exposid{make-sender}(read_env, q)}.
 
 \pnum
-The exposition-only class template \exposid{impls-for}\iref{exec.snd.general}
+The exposition-only class template \exposid{impls-for}\iref{exec.snd.expos}
 is specialized for \tcode{read_env} as follows:
 \indexlibraryglobal{\exposid{impls-for}<\exposid{decayed-typeof}<read_env>>}
 \begin{codeblock}
@@ -3156,7 +3156,7 @@ Otherwise, it is expression-equivalent to
 
 \pnum
 Let \exposid{write-env-t} denote the type \tcode{decltype(auto(write_env))}.
-The exposition-only class template \exposid{impls-for}\iref{exec.snd.general}
+The exposition-only class template \exposid{impls-for}\iref{exec.snd.expos}
 is specialized for \exposid{write-env-t} as follows:
 \indexlibraryglobal{\exposid{impls-for}<\exposid{write-env-t}>}
 \begin{codeblock}
@@ -3298,7 +3298,7 @@ transform_sender(@\exposid{get-domain-early}@(sndr), @\exposid{make-sender}@(con
 except that \tcode{sndr} is evaluated only once.
 
 \pnum
-The exposition-only class template \exposid{impls-for}
+The exposition-only class template \exposid{impls-for}\iref{exec.snd.expos}
 is specialized for \tcode{continues_on_t} as follows:
 \begin{codeblock}
 namespace std::execution {
@@ -3376,7 +3376,7 @@ transform_sender(
 except that \tcode{sch} is evaluated only once.
 
 \pnum
-The exposition-only class template \exposid{impls-for}\iref{exec.snd.general}
+The exposition-only class template \exposid{impls-for}\iref{exec.snd.expos}
 is specialized for \tcode{schedule_from_t} as follows:
 \indexlibraryglobal{\exposid{impls-for}<schedule_from_t>}%
 \begin{codeblock}
@@ -3775,7 +3775,7 @@ except that \tcode{sndr} is evaluated only once.
 For \tcode{then}, \tcode{upon_error}, and \tcode{upon_stopped},
 let \exposid{set-cpo} be
 \tcode{set_value}, \tcode{set_error}, and \tcode{set_stopped}, respectively.
-The exposition-only class template \exposid{impls-for}\iref{exec.snd.general}
+The exposition-only class template \exposid{impls-for}\iref{exec.snd.expos}
 is specialized for \exposid{then-cpo} as follows:
 \indexlibraryglobal{\exposid{impls-for}<\exposid{decayed-typeof}<\exposid{then-cpo}>>}
 \begin{codeblock}
@@ -3881,7 +3881,7 @@ transform_sender(@\exposid{get-domain-early}@(sndr), @\exposid{make-sender}@(@\e
 except that \tcode{sndr} is evaluated only once.
 
 \pnum
-The exposition-only class template \exposid{impls-for}\iref{exec.snd.general}
+The exposition-only class template \exposid{impls-for}\iref{exec.snd.expos}
 is specialized for \exposid{let-cpo} as follows:
 \indexlibraryglobal{\exposid{impls-for}<\exposid{decayed-typeof}<\exposid{let-cpo}>>}
 \begin{codeblock}
@@ -4162,7 +4162,7 @@ execution domain does not customize \tcode{bulk}.
 \end{note}
 
 \pnum
-The exposition-only class template \exposid{impls-for}\iref{exec.snd.general}
+The exposition-only class template \exposid{impls-for}\iref{exec.snd.expos}
 is specialized for \tcode{bulk_chunked_t} as follows:
 \indexlibraryglobal{\exposid{impls-for}<bulk_chunked_t>}
 \begin{codeblock}
@@ -4200,7 +4200,7 @@ if \tcode{Tag} denotes a type other than \tcode{set_value_t} or
 if the expression \tcode{f(auto(shape), auto(shape), args...)} is well-formed.
 
 \pnum
-The exposition-only class template \exposid{impls-for}\iref{exec.snd.general}
+The exposition-only class template \exposid{impls-for}\iref{exec.snd.expos}
 is specialized for \tcode{bulk_unchunked_t} as follows:
 \begin{codeblock}
 namespace std::execution {
@@ -4396,7 +4396,7 @@ transform_sender(CD2(), @\exposid{make-sender}@(when_all, {}, sndrs...))
 \end{codeblock}
 
 \pnum
-The exposition-only class template \exposid{impls-for}\iref{exec.snd.general}
+The exposition-only class template \exposid{impls-for}\iref{exec.snd.expos}
 is specialized for \tcode{when_all_t} as follows:
 \indexlibraryglobal{\exposid{impls-for}<when_all_t>}
 \begin{codeblock}
@@ -4731,7 +4731,7 @@ transform_sender(@\exposid{get-domain-early}@(sndr), @\exposid{make-sender}@(int
 except that \tcode{sndr} is only evaluated once.
 
 \pnum
-The exposition-only class template \exposid{impls-for}\iref{exec.snd.general}
+The exposition-only class template \exposid{impls-for}\iref{exec.snd.expos}
 is specialized for \tcode{into_variant} as follows:
 \indexlibraryglobal{\exposid{impls-for}<into_variant_t>}
 \indexlibrarymember{\exposid{check-types}}{\exposid{impls-for}<into_variant_t>}
@@ -4796,7 +4796,7 @@ transform_sender(@\exposid{get-domain-early}@(sndr), @\exposid{make-sender}@(sto
 except that \tcode{sndr} is only evaluated once.
 
 \pnum
-The exposition-only class template \exposid{impls-for}\iref{exec.snd.general}
+The exposition-only class template \exposid{impls-for}\iref{exec.snd.expos}
 is specialized for \tcode{stopped_as_optional_t} as follows:
 \indexlibraryglobal{\exposid{impls-for}<stopped_as_optional_t>}
 \indexlibrarymember{\exposid{check-types}}{\exposid{impls-for}<stopped_as_optional_t>}
@@ -5035,7 +5035,7 @@ except that \tcode{sndr} is evaluated only once.
 \end{itemize}
 
 \pnum
-The exposition-only class template \exposid{impls-for}\iref{exec.snd.general}
+The exposition-only class template \exposid{impls-for}\iref{exec.snd.expos}
 is specialized for \tcode{associate_t} as follows:
 \indexlibraryglobal{execution::\exposid{impls-for}<associate_t>}%
 \begin{codeblock}
@@ -5505,7 +5505,7 @@ if (associated)
 \end{itemdescr}
 
 \pnum
-The exposition-only class template \exposid{impls-for}\iref{exec.snd.general}
+The exposition-only class template \exposid{impls-for}\iref{exec.snd.expos}
 is specialized for \tcode{spawn_future_t} as follows:
 
 \indexlibraryglobal{execution::\exposid{impls-for}<spawn_future_t>}%
@@ -6889,7 +6889,7 @@ transform_sender(@\exposid{get-domain-early}@(sndr), @\exposid{make-sender}@(aff
 except that \tcode{sndr} is evaluated only once.
 
 \pnum
-The exposition-only class template \exposid{impls-for}
+The exposition-only class template \exposid{impls-for}\iref{exec.snd.expos}
 is specialized for \tcode{affine_on_t} as follows:
 
 \begin{codeblock}
@@ -7850,7 +7850,7 @@ enum @\exposid{scope-state-type}@ {     // \expos
 \end{codeblock}
 
 \pnum
-The exposition-only class template \exposid{impls-for}\iref{exec.snd.general}
+The exposition-only class template \exposid{impls-for}\iref{exec.snd.expos}
 is specialized for \exposid{scope-join-t} as follows:
 
 \indexlibraryglobal{execution::\exposid{impls-for}<\exposid{scope-join-t}>}%


### PR DESCRIPTION
Fixes NB US 208-333 (C++26 CD).

Fixes cplusplus/nbballot#908