### PR TITLE
[exec.write.env] De-bulletize specification of check-types

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -3175,6 +3175,8 @@ struct @\exposid{impls-for}@<@\exposid{write-env-t}@> : @\exposid{default-impls}
     static consteval void @\exposid{check-types}@();
 };
 \end{codeblock}
+
+\pnum
 Invocation of
 \tcode{\exposid{impls-for}<\exposid{write-env-t}>::\exposid{join-env}}
 returns an object \tcode{e} such that
@@ -3187,15 +3189,16 @@ the expression \tcode{e.query(q)} is expression-equivalent
 to \tcode{state.query(q)} if that expression is valid,
 otherwise, \tcode{e.query(q)} is expression-equivalent
 to \tcode{env.query(q)}.
-\item
+\end{itemize}
+
+\pnum
 For a type \tcode{Sndr} and a pack of types \tcode{Env},
 let \tcode{State} be \tcode{\exposid{data-type}<Sndr>} and
 let \tcode{JoinEnv} be the pack
 \tcode{decltype(\exposid{join-env}(declval<State>(), \exposid{FWD-ENV}(declval<Env>())))}.
-Then \tcode{\exposid{impls-for}<\exposid{write-\linebreak{}env-t}>::\exposid{check-types}<Sndr, Env...>()}
+Then \tcode{\exposid{impls-for}<\exposid{write-env-\brk{}t}>::\exposid{check-types}<Sndr, Env...>()}
 is expression-equivalent to
-\tcode{get_completion_signatures<\linebreak{}\exposid{child-type}<Sndr>, JoinEnv...>()}.
-\end{itemize}
+\tcode{get_completion_signatures<\exposid{child-\linebreak{}type}<Sndr>, JoinEnv...>()}.
 
 \rSec3[exec.unstoppable]{\tcode{execution::unstoppable}}
 


### PR DESCRIPTION
Fixes NB US 218-349 (C++26 CD).

Fixes cplusplus/nbballot#924