### PR TITLE
[exec.snd.expos] Move specification of default template argument for 'Data'

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -1716,6 +1716,12 @@ that has been direct-list-initialized with the forwarded arguments,
 where \exposid{basic-sender} is the following exposition-only class template except as noted below.
 \end{itemdescr}
 
+\pnum
+\remarks
+The default template argument for the \tcode{Data} template parameter
+denotes an unspecified empty trivially copyable class type
+that models \libconcept{semiregular}.
+
 \begin{codeblock}
 namespace std::execution {
   template<class Tag>
@@ -1844,11 +1850,6 @@ namespace std::execution {
   };
 }
 \end{codeblock}
-
-\pnum
-The default template argument for the \tcode{Data} template parameter
-denotes an unspecified empty trivially copyable class type
-that models \libconcept{semiregular}.
 
 \pnum
 It is unspecified whether a specialization of \exposid{basic-sender}


### PR DESCRIPTION
Fixes NB US 212-352 (C++26 CD).

Fixes cplusplus/nbballot#927