### PR TITLE
[dcl.fct.def.replace] Add 'replaceable function' to index

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4384,7 +4384,7 @@ do not perform allocation or deallocation.
 \pnum
 The library provides default definitions for the global allocation and
 deallocation functions. Some global allocation and deallocation
-functions are replaceable\iref{dcl.fct.def.replace}.
+functions are replaceable\iref{term.replaceable.function}.
 The following allocation and deallocation functions\iref{support.dynamic}
 are implicitly declared in global scope in each translation unit of a
 program.
@@ -5224,9 +5224,10 @@ Scalar types, trivially relocatable class types\iref{class.prop},
 arrays of such types, and cv-qualified versions of these
 types are collectively called \defnadjx{trivially relocatable}{types}{type}.
 \label{term.replaceable.type}%
+\indextext{replaceable!type|see{type, replaceable}}%
 Cv-unqualified scalar types, replaceable class types\iref{class.prop}, and
 arrays of such types are collectively called
-\defnadjx{replaceable}{types}{type}.
+\defnx{replaceable types}{type!replaceable}.
 \label{term.standard.layout.type}%
 Scalar types, standard-layout class
 types\iref{class.prop}, arrays of such types, and
@@ -7993,7 +7994,7 @@ and then return normally.
 It is
 \impldef{replaceability of the contract-violation handler}
 whether the contract-violation handler
-is replaceable\iref{dcl.fct.def.replace}.
+is replaceable\iref{term.replaceable.function}.
 If the contract-violation handler
 is not replaceable,
 a declaration of a replacement function for the contract-violation handler

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -248,8 +248,9 @@ function when assigning to an lvalue of type \tcode{C} from an xvalue of type
 \item it has a deleted destructor.
 \end{itemize}
 
+\indextext{replaceable!class|see{class, replaceable}}%
 \pnum
-A class \tcode{C} is a \defnadj{replaceable}{class} if it is
+A class \tcode{C} is a \defnx{replaceable class}{class!replaceable} if it is
 eligible for replacement and
 \begin{itemize}
 \item has the \tcode{replaceable_if_eligible} \grammarterm{class-property-specifier},

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -7540,10 +7540,14 @@ shall not be potentially-throwing\iref{except.spec}.
 
 \rSec2[dcl.fct.def.replace]{Replaceable function definitions}
 
+\indextext{function!replaceable|(}%
+\indextext{replaceable!function|see{function, replaceable}}%
+
 \pnum
+\label{term.replaceable.function}%
 Certain functions
 for which a definition is supplied by the implementation
-are \defn{replaceable}.
+are \defnx{replaceable}{function!replaceable}.
 A \Cpp{} program may
 provide a definition with the signature of a replaceable function,
 called a \defnadj{replacement}{function}.
@@ -7575,7 +7579,7 @@ provided by the program.
 The implementation-supplied function definition
 is an otherwise-unnamed function with no linkage.
 \end{note}
-
+\indextext{function!replaceable|)}%
 
 \rSec1[dcl.struct.bind]{Structured binding declarations}%
 \indextext{structured binding declaration}%

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -2500,6 +2500,6 @@ a best-effort determination that such a tracing process is a debugger.
 
 \pnum
 \remarks
-This function is replaceable\iref{dcl.fct.def.replace}.
+This function is replaceable\iref{term.replaceable.function}.
 
 \end{itemdescr}

--- a/source/exec.tex
+++ b/source/exec.tex
@@ -8450,7 +8450,7 @@ that implements the \tcode{parallel_scheduler_backend} interface.
 
 \pnum
 \remarks
-This function is replaceable\iref{dcl.fct.def.replace}.
+This function is replaceable\iref{term.replaceable.function}.
 \end{itemdescr}
 
 \begin{codeblock}

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -3416,7 +3416,7 @@ library may be overridden in a derived class defined in the program\iref{class.v
 \pnum
 If a function defined in
 \ref{\firstlibchapter} through \ref{\lastlibchapter} and \ref{depr}
-is specified as replaceable\iref{dcl.fct.def.replace},
+is specified as replaceable\iref{term.replaceable.function},
 the description of function semantics apply
 to both the default version defined by the \Cpp{} standard library and
 the replacement function defined by the program.

--- a/source/support.tex
+++ b/source/support.tex
@@ -2498,7 +2498,7 @@ function does not return.
 
 \pnum
 \remarks
-This function is replaceable\iref{dcl.fct.def.replace}.
+This function is replaceable\iref{term.replaceable.function}.
 \end{itemdescr}
 
 \indexlibrarymember{new}{operator}%
@@ -2547,7 +2547,7 @@ T* p2 = new(nothrow) T;         // returns \keyword{nullptr} if it fails
 
 \pnum
 \remarks
-This function is replaceable\iref{dcl.fct.def.replace}.
+This function is replaceable\iref{term.replaceable.function}.
 \end{itemdescr}
 
 \indexlibrarymember{delete}{operator}%
@@ -2632,7 +2632,7 @@ or any of
 or
 \tcode{realloc},
 declared in \libheaderref{cstdlib}.
-This function is replaceable\iref{dcl.fct.def.replace}.
+This function is replaceable\iref{term.replaceable.function}.
 If a replacement function
 without a \tcode{size} parameter
 is defined by the program,
@@ -2694,7 +2694,7 @@ respectively.
 
 \pnum
 \remarks
-This function is replaceable\iref{dcl.fct.def.replace}.
+This function is replaceable\iref{term.replaceable.function}.
 \end{itemdescr}
 
 \rSec3[new.delete.array]{Array forms}
@@ -2750,7 +2750,7 @@ respectively.
 
 \pnum
 \remarks
-This function is replaceable\iref{dcl.fct.def.replace}.
+This function is replaceable\iref{term.replaceable.function}.
 \end{itemdescr}
 
 \indexlibrarymember{new}{operator}%
@@ -2791,7 +2791,7 @@ Otherwise, returns a null pointer.
 
 \pnum
 \remarks
-This function is replaceable\iref{dcl.fct.def.replace}.
+This function is replaceable\iref{term.replaceable.function}.
 \end{itemdescr}
 
 \indexlibrarymember{delete}{operator}%
@@ -2859,7 +2859,7 @@ to the corresponding \tcode{operator delete} (single-object) function.
 
 \pnum
 \remarks
-This function is replaceable\iref{dcl.fct.def.replace}.
+This function is replaceable\iref{term.replaceable.function}.
 If a replacement function
 without a \tcode{size} parameter
 is defined by the program,
@@ -2921,7 +2921,7 @@ respectively.
 
 \pnum
 \remarks
-This function is replaceable\iref{dcl.fct.def.replace}.
+This function is replaceable\iref{term.replaceable.function}.
 \end{itemdescr}
 
 \rSec3[new.delete.placement]{Non-allocating forms}


### PR DESCRIPTION
Also add a label 'term.replaceable.function' for subclause-agnostic cross-referencing.

Fixes NB US 269-406 (C++26 CD).

Fixes cplusplus/nbballot#978