### PR TITLE
[exec.par.scheduler] Use 'has the value' for an expression

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -8286,8 +8286,8 @@ let \tcode{\exposid{BACKEND-OF}(sch)} be \tcode{*ptr},
 where \tcode{sch} is associated with \tcode{ptr}.
 
 \pnum
-The expression \tcode{get_forward_progress_guarantee(sch)} returns
-\tcode{forward_progress_guarantee::paral\-lel}.
+The expression \tcode{get_forward_progress_guarantee(sch)} has the value
+\tcode{forward_progress_guarantee::\brk{}parallel}.
 
 \pnum
 Let \tcode{sch2} be an object of type \tcode{parallel_scheduler}.


### PR DESCRIPTION
Fixes NB US 262-394 (C++26 CD).

Fixes cplusplus/nbballot#969