### PR TITLE
[exec.sysctxrepl.psb] Make 'one of the expressions below' more explicit

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -8553,7 +8553,9 @@ the lifetimes of \tcode{*this},
 the object referred to by \tcode{r}, and
 any storage referenced by \tcode{s}
 all happen after
-the beginning of the evaluation of one of the expressions below.
+the beginning of the evaluation of
+the call to \tcode{set_value}, \tcode{set_error}, or \tcode{set_done}
+on \tcode{r} (see below).
 
 \pnum
 \effects


### PR DESCRIPTION
Fixes NB US 266-399 (C++26 CD).

Fixes cplusplus/nbballot#974