### PR TITLE
[task.promise] Remove trailing semicolons in comments in examples

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -7431,9 +7431,9 @@ namespace std::execution {
     void uncaught_exception();
     coroutine_handle<> unhandled_stopped();
 
-    void return_void();                 // present only if \tcode{is_void_v<T>} is \tcode{true};
+    void return_void();                 // present only if \tcode{is_void_v<T>} is \tcode{true}
     template<class V>
-      void return_value(V&& value);     // present only if \tcode{is_void_v<T>} is \tcode{false};
+      void return_value(V&& value);     // present only if \tcode{is_void_v<T>} is \tcode{false}
 
     template<class E>
       @\unspec@ yield_value(with_error<E> error);
@@ -7456,7 +7456,7 @@ namespace std::execution {
     allocator_type    @\exposidnc{alloc}@;            // \expos
     stop_source_type  @\exposidnc{source}@;           // \expos
     stop_token_type   @\exposidnc{token}@;            // \expos
-    optional<T>       @\exposidnc{result}@;           // \expos; present only if \tcode{is_void_v<T>} is \tcode{false};
+    optional<T>       @\exposidnc{result}@;           // \expos; present only if \tcode{is_void_v<T>} is \tcode{false}
     @\exposidnc{error-variant}@     @\exposidnc{errors}@;           // \expos
   };
 }


### PR DESCRIPTION
Fixes NB US 259-380 (C++26 CD).

Fixes cplusplus/nbballot#955