### PR TITLE
[task.promise] Refer to parameter types of the completion signatures

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -7477,7 +7477,7 @@ for some receiver \tcode{Rcvr}.
 \pnum
 \exposid{error-variant} is a \tcode{variant<monostate,
 remove_cvref_t<E>...>}, with duplicate types removed, where \tcode{E...}
-are template arguments of the specialization of
+are the parameter types of the template arguments of the specialization of
 \tcode{execution::completion_signatures} denoted by
 \tcode{error_types}.
 


### PR DESCRIPTION
Fixes NB US 260-390 (C++26 CD).

Fixes cplusplus/nbballot#965