### PR TITLE
[task.state] Fix formatting of subclause heading

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -7305,7 +7305,7 @@ return @\exposid{state}@<Rcvr>(exchange(@\exposid{handle}@, {}), std::forward<Rc
 \end{codeblock}
 \end{itemdescr}
 
-\rSec3[task.state]{\tcode{Class template \tcode{task::state}}}
+\rSec3[task.state]{Class template \tcode{task::\exposid{state}}}
 
 \begin{codeblock}
 namespace std::execution {


### PR DESCRIPTION
Fixes NB US 248-378 (C++26 CD).

Fixes cplusplus/nbballot#953