### PR TITLE
[exec.task.scheduler] Fix punctuation and add 'the'

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -7085,8 +7085,8 @@ bool operator==(const task_scheduler& lhs, const Sch& rhs) noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{false} if type of \tcode{\exposid{SCHED}(lhs)} is not \tcode{Sch},
-otherwise \tcode{\exposid{SCHED}(lhs) == rhs;}
+\tcode{false} if the type of \tcode{\exposid{SCHED}(lhs)} is not \tcode{Sch},
+otherwise \tcode{\exposid{SCHED}(lhs) == rhs}.
 \end{itemdescr}
 
 \pnum


### PR DESCRIPTION
Fixes NB US 241-371 (C++26 CD).

Fixes cplusplus/nbballot#946