### PR TITLE
[meta.reflection.extract] Remove stray 'T is' and format 'X' in code font

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -5909,11 +5909,11 @@ template<class T>
 \tcode{meta::exception} unless
 \begin{itemize}
 \item
-  \tcode{r} represents a non-static data member with type $X$,
+  \tcode{r} represents a non-static data member with type \tcode{X},
   that is not a bit-field,
   that is a direct member of class \tcode{C},
   \tcode{T} and \tcode{X C::*} are similar types\iref{conv.qual}, and
-  \tcode{T} is \tcode{is_convertible_v<X C::*, T>} is \tcode{true};
+  \tcode{is_convertible_v<X C::*, T>} is \tcode{true};
 \item
   \tcode{r} represents an implicit object member function
   with type \tcode{F} or \tcode{F noexcept}


### PR DESCRIPTION
Fixes NB US 110-171 (C++26 CD).

Fixes cplusplus/nbballot#989