### PR TITLE
[meta.reflection.substitute] Add 'in order'

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -6007,7 +6007,8 @@ template<@\libconcept{reflection_range}@ R = initializer_list<info>>
 \pnum
 Let \tcode{Z} be the template represented by \tcode{templ}
 and let \tcode{Args...} be a sequence of prvalue constant expressions
-that compute the reflections held by the elements of \tcode{arguments}.
+that compute the reflections held by the elements of \tcode{arguments},
+in order.
 
 \pnum
 \returns
@@ -6041,7 +6042,8 @@ template<@\libconcept{reflection_range}@ R = initializer_list<info>>
 \pnum
 Let \tcode{Z} be the template represented by \tcode{templ}
 and let \tcode{Args...} be a sequence of prvalue constant expressions
-that compute the reflections held by the elements of \tcode{arguments}.
+that compute the reflections held by the elements of \tcode{arguments},
+in order.
 
 \pnum
 \returns


### PR DESCRIPTION
A misapplication of P2996R13.

Fixes NB US 115-176 (C++26 CD).

Fixes cplusplus/nbballot#994