### PR TITLE
[exec.run.loop] Remove code font formatting for count and state

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -6487,7 +6487,7 @@ run_loop() noexcept;
 \begin{itemdescr}
 \pnum
 \ensures
-\exposid{count} is \tcode{0} and \exposid{state} is \exposid{starting}.
+Count is \tcode{0} and state is starting.
 \end{itemdescr}
 
 \indexlibrarydtor{run_loop}%
@@ -6498,7 +6498,7 @@ run_loop() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-If \exposid{count} is not \tcode{0} or if \exposid{state} is \exposid{running},
+If count is not \tcode{0} or if state is running,
 invokes \tcode{terminate}\iref{except.terminate}.
 Otherwise, has no effects.
 \end{itemdescr}
@@ -6515,13 +6515,13 @@ Otherwise, has no effects.
 Blocks\iref{defns.block} until one of the following conditions is \tcode{true}:
 \begin{itemize}
 \item
-\exposid{count} is \tcode{0} and \exposid{state} is \exposid{finishing},
-in which case \exposid{pop-front} sets \exposid{state} to \exposid{finished}
+Count is \tcode{0} and state is finishing,
+in which case \exposid{pop-front} sets state to finished
 and returns \tcode{nullptr}; or
 \item
-\exposid{count} is greater than \tcode{0},
+count is greater than \tcode{0},
 in which case an item is removed from the front of the queue,
-\exposid{count} is decremented by \tcode{1}, and
+count is decremented by \tcode{1}, and
 the removed item is returned.
 \end{itemize}
 \end{itemdescr}
@@ -6534,7 +6534,7 @@ void @\exposid{push-back}@(@\exposid{run-loop-opstate-base}@* item);
 \pnum
 \effects
 Adds \tcode{item} to the back of the queue and
-increments \exposid{count} by \tcode{1}.
+increments count by \tcode{1}.
 
 \pnum
 \sync
@@ -6562,13 +6562,13 @@ void run();
 \begin{itemdescr}
 \pnum
 \expects
-\exposid{state} is either \exposid{starting} or \exposid{finishing}.
+State is either starting or finishing.
 
 \pnum
 \effects
-If \exposid{state} is \exposid{starting},
-sets the \exposid{state} to \exposid{running},
-otherwise leaves \exposid{state} unchanged.
+If state is starting,
+sets the state to running,
+otherwise leaves state unchanged.
 Then, equivalent to:
 \begin{codeblock}
 while (auto* op = @\exposid{pop-front}@()) {
@@ -6578,7 +6578,7 @@ while (auto* op = @\exposid{pop-front}@()) {
 
 \pnum
 \remarks
-When \exposid{state} changes, it does so without introducing data races.
+When state changes, it does so without introducing data races.
 \end{itemdescr}
 
 \indexlibrarymember{finish}{run_loop}%
@@ -6589,11 +6589,11 @@ void finish();
 \begin{itemdescr}
 \pnum
 \expects
-\exposid{state} is either \exposid{starting} or \exposid{running}.
+state is either starting or running.
 
 \pnum
 \effects
-Changes \exposid{state} to \exposid{finishing}.
+Changes state to finishing.
 
 \pnum
 \sync


### PR DESCRIPTION
Fixes NB US 231-361 (C++26 CD).

Fixes cplusplus/nbballot#936