### PR TITLE
[atomics.syn,atomics.ref.pointer] Remove partial specialization atomic_ref<T*>

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -2419,8 +2419,6 @@ namespace std {
 namespace std {
   // \ref{atomics.ref.generic}, class template \tcode{atomic_ref}
   template<class T> struct atomic_ref;                                              // freestanding
-  // \ref{atomics.ref.pointer}, partial specialization for pointers
-  template<class T> struct atomic_ref<T*>;                                          // freestanding
 
   // \ref{atomics.types.generic}, class template \tcode{atomic}
   template<class T> struct atomic;                                                  // freestanding
@@ -3277,7 +3275,7 @@ if \tcode{is_always_lock_free} is \tcode{false} and
 \rSec3[atomics.ref.ops]{Operations}
 
 \indexlibrarymember{required_alignment}{atomic_ref}%
-\indexlibrarymember{required_alignment}{atomic_ref<T*>}%
+\indexlibrarymember{required_alignment}{atomic_ref<\placeholder{pointer-type}>}%
 \indexlibrarymember{required_alignment}{atomic_ref<\placeholder{integral-type}>}%
 \indexlibrarymember{required_alignment}{atomic_ref<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
@@ -3303,7 +3301,7 @@ could be supported only if aligned to \tcode{2*alignof(double)}.
 \end{itemdescr}
 
 \indexlibrarymember{is_always_lock_free}{atomic_ref}%
-\indexlibrarymember{is_always_lock_free}{atomic_ref<T*>}%
+\indexlibrarymember{is_always_lock_free}{atomic_ref<\placeholder{pointer-type}>}%
 \indexlibrarymember{is_always_lock_free}{atomic_ref<\placeholder{integral-type}>}%
 \indexlibrarymember{is_always_lock_free}{atomic_ref<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
@@ -3318,7 +3316,7 @@ and \tcode{false} otherwise.
 \end{itemdescr}
 
 \indexlibrarymember{is_lock_free}{atomic_ref}%
-\indexlibrarymember{is_lock_free}{atomic_ref<T*>}%
+\indexlibrarymember{is_lock_free}{atomic_ref<\placeholder{pointer-type}>}%
 \indexlibrarymember{is_lock_free}{atomic_ref<\placeholder{integral-type}>}%
 \indexlibrarymember{is_lock_free}{atomic_ref<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
@@ -3334,7 +3332,7 @@ are lock-free,
 \end{itemdescr}
 
 \indexlibraryctor{atomic_ref}%
-\indexlibraryctor{atomic_ref<T*>}%
+\indexlibraryctor{atomic_ref<\placeholder{pointer-type}>}%
 \indexlibrary{\idxcode{atomic_ref<\placeholder{integral-type}>}!constructor}%
 \indexlibrary{\idxcode{atomic_ref<\placeholder{floating-point-type}>}!constructor}%
 \begin{itemdecl}
@@ -3356,7 +3354,7 @@ Nothing.
 \end{itemdescr}
 
 \indexlibraryctor{atomic_ref}%
-\indexlibraryctor{atomic_ref<T*>}%
+\indexlibraryctor{atomic_ref<\placeholder{pointer-type}>}%
 \indexlibrary{\idxcode{atomic_ref<\placeholder{integral-type}>}!constructor}%
 \indexlibrary{\idxcode{atomic_ref<\placeholder{floating-point-type}>}!constructor}%
 \begin{itemdecl}
@@ -3370,7 +3368,7 @@ constexpr atomic_ref(const atomic_ref& ref) noexcept;
 \end{itemdescr}
 
 \indexlibrarymember{store}{atomic_ref}%
-\indexlibrarymember{store}{atomic_ref<T*>}%
+\indexlibrarymember{store}{atomic_ref<\placeholder{pointer-type}>}%
 \indexlibrarymember{store}{atomic_ref<\placeholder{integral-type}>}%
 \indexlibrarymember{store}{atomic_ref<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
@@ -3398,7 +3396,7 @@ Memory is affected according to the value of \tcode{order}.
 \end{itemdescr}
 
 \indexlibrarymember{operator=}{atomic_ref}%
-\indexlibrarymember{operator=}{atomic_ref<T*>}%
+\indexlibrarymember{operator=}{atomic_ref<\placeholder{pointer-type}>}%
 \indexlibrarymember{operator=}{atomic_ref<\placeholder{integral-type}>}%
 \indexlibrarymember{operator=}{atomic_ref<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
@@ -3420,7 +3418,7 @@ return desired;
 \end{itemdescr}
 
 \indexlibrarymember{load}{atomic_ref}%
-\indexlibrarymember{load}{atomic_ref<T*>}%
+\indexlibrarymember{load}{atomic_ref<\placeholder{pointer-type}>}%
 \indexlibrarymember{load}{atomic_ref<\placeholder{integral-type}>}%
 \indexlibrarymember{load}{atomic_ref<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
@@ -3445,7 +3443,7 @@ Atomically returns the value referenced by \tcode{*ptr}.
 \end{itemdescr}
 
 \indexlibrarymember{operator \placeholder{type}}{atomic_ref}%
-\indexlibrarymember{operator T*}{atomic_ref<T*>}%
+\indexlibrarymember{operator \placeholder{pointer-type}}{atomic_ref<\placeholder{pointer-type}>}%
 \indexlibrarymember{operator \placeholder{integral-type}}{atomic_ref<\placeholder{integral-type}>}%
 \indexlibrarymember{operator \placeholder{floating-point-type}}{atomic_ref<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
@@ -3459,7 +3457,7 @@ Equivalent to: \tcode{return load();}
 \end{itemdescr}
 
 \indexlibrarymember{exchange}{atomic_ref}%
-\indexlibrarymember{exchange}{atomic_ref<T*>}%
+\indexlibrarymember{exchange}{atomic_ref<\placeholder{pointer-type}>}%
 \indexlibrarymember{exchange}{atomic_ref<\placeholder{integral-type}>}%
 \indexlibrarymember{exchange}{atomic_ref<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
@@ -3486,11 +3484,11 @@ immediately before the effects.
 \end{itemdescr}
 
 \indexlibrarymember{compare_exchange_weak}{atomic_ref}%
-\indexlibrarymember{compare_exchange_weak}{atomic_ref<T*>}%
+\indexlibrarymember{compare_exchange_weak}{atomic_ref<\placeholder{pointer-type}>}%
 \indexlibrarymember{compare_exchange_weak}{atomic_ref<\placeholder{integral-type}>}%
 \indexlibrarymember{compare_exchange_weak}{atomic_ref<\placeholder{floating-point-type}>}%
 \indexlibrarymember{compare_exchange_strong}{atomic_ref}%
-\indexlibrarymember{compare_exchange_strong}{atomic_ref<T*>}%
+\indexlibrarymember{compare_exchange_strong}{atomic_ref<\placeholder{pointer-type}>}%
 \indexlibrarymember{compare_exchange_strong}{atomic_ref<\placeholder{integral-type}>}%
 \indexlibrarymember{compare_exchange_strong}{atomic_ref<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
@@ -4169,8 +4167,8 @@ Equivalent to:
 \tcode{return fetch_\placeholder{key}(operand) \placeholdernc{op} operand;}
 \end{itemdescr}
 
-\rSec3[atomics.ref.pointer]{Partial specialization for pointers}
-\indexlibraryglobal{atomic_ref<T*>}%
+\rSec3[atomics.ref.pointer]{Specialization for pointers}
+\indexlibraryglobal{atomic_ref<\placeholder{pointer-type}>}%
 
 \pnum
 There are specializations of the \tcode{atomic_ref} class template
@@ -4186,7 +4184,7 @@ if \tcode{is_always_lock_free} is \tcode{false} and
 
 \begin{codeblock}
 namespace std {
-  template<class T> struct atomic_ref<@\placeholder{pointer-type}@> {
+  template<> struct atomic_ref<@\placeholder{pointer-type}@> {
   private:
     @\placeholder{pointer-type}@* ptr;        // \expos
 
@@ -4260,10 +4258,10 @@ The following operations perform arithmetic computations.
 The correspondence among key, operator, and computation is specified
 in \tref{atomic.types.pointer.comp}.
 
-\indexlibrarymember{fetch_add}{atomic_ref<T*>}%
-\indexlibrarymember{fetch_sub}{atomic_ref<T*>}%
-\indexlibrarymember{fetch_max}{atomic_ref<T*>}%
-\indexlibrarymember{fetch_min}{atomic_ref<T*>}%
+\indexlibrarymember{fetch_add}{atomic_ref<\placeholder{pointer-type}>}%
+\indexlibrarymember{fetch_sub}{atomic_ref<\placeholder{pointer-type}>}%
+\indexlibrarymember{fetch_max}{atomic_ref<\placeholder{pointer-type}>}%
+\indexlibrarymember{fetch_min}{atomic_ref<\placeholder{pointer-type}>}%
 \begin{itemdecl}
 constexpr value_type fetch_@\placeholdernc{key}@(difference_type operand,
                      memory_order order = memory_order::seq_cst) const noexcept;
@@ -4309,10 +4307,10 @@ the \tcode{<} operator does not establish a strict weak ordering
 \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{store_add}{atomic_ref<T*>}%
-\indexlibrarymember{store_sub}{atomic_ref<T*>}%
-\indexlibrarymember{store_max}{atomic_ref<T*>}%
-\indexlibrarymember{store_min}{atomic_ref<T*>}%
+\indexlibrarymember{store_add}{atomic_ref<\placeholder{pointer-type}>}%
+\indexlibrarymember{store_sub}{atomic_ref<\placeholder{pointer-type}>}%
+\indexlibrarymember{store_max}{atomic_ref<\placeholder{pointer-type}>}%
+\indexlibrarymember{store_min}{atomic_ref<\placeholder{pointer-type}>}%
 \begin{itemdecl}
 constexpr void store_@\placeholdernc{key}@(@\UNSP{see above}@ operand,
                      memory_order order = memory_order::seq_cst) const noexcept;
@@ -4352,8 +4350,8 @@ a strict weak ordering~(\tref{cpp17.lessthancomparable}, \ref{expr.rel}).
 \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{operator+=}{atomic_ref<T*>}%
-\indexlibrarymember{operator-=}{atomic_ref<T*>}%
+\indexlibrarymember{operator+=}{atomic_ref<\placeholder{pointer-type}>}%
+\indexlibrarymember{operator-=}{atomic_ref<\placeholder{pointer-type}>}%
 \begin{itemdecl}
 constexpr value_type operator @\placeholder{op}@=(difference_type operand) const noexcept;
 \end{itemdecl}
@@ -4380,7 +4378,7 @@ be \tcode{\placeholder{integral-type}}
 for the specializations in \ref{atomics.ref.int}.
 
 
-\indexlibrarymember{operator++}{atomic_ref<T*>}%
+\indexlibrarymember{operator++}{atomic_ref<\placeholder{pointer-type}>}%
 \indexlibrarymember{operator++}{atomic_ref<\placeholder{integral-type}>}%
 \begin{itemdecl}
 constexpr value_type operator++(int) const noexcept;
@@ -4396,7 +4394,7 @@ constexpr value_type operator++(int) const noexcept;
 Equivalent to: \tcode{return fetch_add(1);}
 \end{itemdescr}
 
-\indexlibrarymember{operator--}{atomic_ref<T*>}%
+\indexlibrarymember{operator--}{atomic_ref<\placeholder{pointer-type}>}%
 \indexlibrarymember{operator--}{atomic_ref<\placeholder{integral-type}>}%
 \begin{itemdecl}
 constexpr value_type operator--(int) const noexcept;
@@ -4412,7 +4410,7 @@ constexpr value_type operator--(int) const noexcept;
 Equivalent to: \tcode{return fetch_sub(1);}
 \end{itemdescr}
 
-\indexlibrarymember{operator++}{atomic_ref<T*>}%
+\indexlibrarymember{operator++}{atomic_ref<\placeholder{pointer-type}>}%
 \indexlibrarymember{operator++}{atomic_ref<\placeholder{integral-type}>}%
 \begin{itemdecl}
 constexpr value_type operator++() const noexcept;
@@ -4428,7 +4426,7 @@ constexpr value_type operator++() const noexcept;
 Equivalent to: \tcode{return fetch_add(1) + 1;}
 \end{itemdescr}
 
-\indexlibrarymember{operator--}{atomic_ref<T*>}%
+\indexlibrarymember{operator--}{atomic_ref<\placeholder{pointer-type}>}%
 \indexlibrarymember{operator--}{atomic_ref<\placeholder{integral-type}>}%
 \begin{itemdecl}
 constexpr value_type operator--() const noexcept;


### PR DESCRIPTION
A misapplication of paper P3323R1.

Fixes NB US 194-314 (C++26 CD).

Fixes cplusplus/nbballot#889