### PR TITLE
[atomics.types.int,atomics.types.float] Excise uses of undeclared 'T'

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -5238,8 +5238,10 @@ in \tref{atomic.types.int.comp}.
 \indexlibrarymember{fetch_sub}{atomic<\placeholder{integral-type}>}%
 \indexlibrarymember{fetch_xor}{atomic<\placeholder{integral-type}>}%
 \begin{itemdecl}
-T fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order::seq_cst) volatile noexcept;
-constexpr T fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order::seq_cst) noexcept;
+@\placeholder{integral-type}@ fetch_@\placeholdernc{key}@(@\placeholder{integral-type}@ operand,
+                         memory_order order = memory_order::seq_cst) volatile noexcept;
+constexpr @\placeholder{integral-type}@ fetch_@\placeholdernc{key}@(@\placeholder{integral-type}@ operand,
+                                   memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5301,7 +5303,7 @@ with the object value and the first parameter as the arguments.
 void store_@\placeholdernc{key}@(@\placeholder{integral-type}@ operand,
                 memory_order order = memory_order::seq_cst) volatile noexcept;
 constexpr void store_@\placeholdernc{key}@(@\placeholder{integral-type}@ operand,
-                         memory_order order = memory_order::seq_cst) noexcept;
+                          memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5342,7 +5344,6 @@ as if by \tcode{max} and \tcode{min} algorithms\iref{alg.min.max}, respectively,
 with the value pointed to by \tcode{this} and the first parameter as the arguments.
 \end{itemdescr}
 
-
 \indexlibrarymember{operator+=}{atomic<T*>}%
 \indexlibrarymember{operator-=}{atomic<T*>}%
 \indexlibrarymember{operator+=}{atomic<\placeholder{integral-type}>}%
@@ -5351,8 +5352,8 @@ with the value pointed to by \tcode{this} and the first parameter as the argumen
 \indexlibrarymember{operator"|=}{atomic<\placeholder{integral-type}>}%
 \indexlibrarymember{operator\caret=}{atomic<\placeholder{integral-type}>}%
 \begin{itemdecl}
-T operator @\placeholder{op}@=(T operand) volatile noexcept;
-constexpr T operator @\placeholder{op}@=(T operand) noexcept;
+@\placeholder{integral-type}@ operator @\placeholder{op}@=(@\placeholder{integral-type}@ operand) volatile noexcept;
+constexpr @\placeholder{integral-type}@ operator @\placeholder{op}@=(@\placeholder{integral-type}@ operand) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5539,8 +5540,10 @@ which are specified below.
 \indexlibrarymember{fetch_max}{atomic<\placeholder{floating-point-type}>}%
 \indexlibrarymember{fetch_min}{atomic<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
-T fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order::seq_cst) volatile noexcept;
-constexpr T fetch_@\placeholdernc{key}@(T operand, memory_order order = memory_order::seq_cst) noexcept;
+@\placeholder{floating-point-type}@ fetch_@\placeholdernc{key}@(@\placeholder{floating-point-type}@ operand,
+                               memory_order order = memory_order::seq_cst) volatile noexcept;
+constexpr @\placeholder{floating-point-type}@ fetch_@\placeholdernc{key}@(@\placeholder{floating-point-type}@ operand,
+                                         memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5710,8 +5713,8 @@ should treat negative zero as smaller than positive zero.
 \indexlibrarymember{operator+=}{atomic<\placeholder{floating-point-type}>}%
 \indexlibrarymember{operator-=}{atomic<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
-T operator @\placeholder{op}@=(T operand) volatile noexcept;
-constexpr T operator @\placeholder{op}@=(T operand) noexcept;
+@\placeholder{floating-point-type}@ operator @\placeholder{op}@=(@\placeholder{floating-point-type}@ operand) volatile noexcept;
+constexpr @\placeholder{floating-point-type}@ operator @\placeholder{op}@=(@\placeholder{floating-point-type}@ operand) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Fixes NB US 196-315 (C++26 CD).

Fixes cplusplus/nbballot#890