### PR TITLE
[atomics.ref.generic] Avoid use of undeclared 'T'

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -3676,7 +3676,7 @@ uses the primary template\iref{atomics.ref.generic}.
 \pnum
 The program is ill-formed
 if \tcode{is_always_lock_free} is \tcode{false} and
-\tcode{is_volatile_v<T>} is \tcode{true}.
+\tcode{is_volatile_v<\placeholder{integral-type}>} is \tcode{true}.
 
 \begin{codeblock}
 namespace std {
@@ -3894,7 +3894,7 @@ additional atomic operations appropriate to floating-point types.
 \pnum
 The program is ill-formed
 if \tcode{is_always_lock_free} is \tcode{false} and
-\tcode{is_volatile_v<T>} is \tcode{true}.
+\tcode{is_volatile_v<\placeholder{floating-point-type}>} is \tcode{true}.
 
 \begin{codeblock}
 namespace std {
@@ -4182,7 +4182,7 @@ additional atomic operations appropriate to pointer types.
 \pnum
 The program is ill-formed
 if \tcode{is_always_lock_free} is \tcode{false} and
-\tcode{is_volatile_v<T>} is \tcode{true}.
+\tcode{is_volatile_v<\placeholder{pointer-type}>} is \tcode{true}.
 
 \begin{codeblock}
 namespace std {


### PR DESCRIPTION
Fixes NB US 192-312 (C++26 CD).

Fixes cplusplus/nbballot#887