### PR TITLE
[simd.permute.memory] Rename 'simd' to 'vec' in subclause title

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -18954,7 +18954,7 @@ element is initialized to the result of \tcode{\exposidnc{select-value}($i$)}
 for all $i$ in the range \range{0}{V::size()}.
 \end{itemdescr}
 
-\rSec3[simd.permute.memory]{\tcode{simd} memory permute}
+\rSec3[simd.permute.memory]{\tcode{vec} memory permute}
 
 \indexlibrarymember{unchecked_gather_from}{simd}
 \begin{itemdecl}


### PR DESCRIPTION
Fixes NB US 184-291 (C++26 CD).

Fixes cplusplus/nbballot#866