### PR TITLE
[simd.mask.nonmembers] Add 'basic_mask' to subclause heading

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -20365,7 +20365,7 @@ The integral value corresponding to the bits in \tcode{*this}.
 Nothing.
 \end{itemdescr}
 
-\rSec2[simd.mask.nonmembers]{Non-member operations}
+\rSec2[simd.mask.nonmembers]{\tcode{basic_mask} non-member operations}
 
 \rSec3[simd.mask.binary]{\tcode{basic_mask} binary operators}
 


### PR DESCRIPTION
Fixes NB US 186-300 (C++26 CD).

Fixes cplusplus/nbballot#875