### PR TITLE
[simd.traits] Rename subclause heading to 'Type traits'

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -16505,7 +16505,7 @@ for
 \indexheader{simd}%
 \begin{codeblock}
 namespace std::simd {
-  // \ref{simd.traits}, \tcode{simd} type traits
+  // \ref{simd.traits}, type traits
   template<class T, class U = typename T::value_type> struct alignment;
   template<class T, class U = typename T::value_type>
     constexpr size_t @\libmember{alignment_v}{simd}@ = alignment<T, U>::value;
@@ -17161,7 +17161,7 @@ namespace std {
 }
 \end{codeblock}
 
-\rSec2[simd.traits]{\tcode{vec} type traits}
+\rSec2[simd.traits]{Type traits}
 
 \indexlibrarymember{alignment}{simd}
 \begin{itemdecl}


### PR DESCRIPTION
The subclause applies to both vecs and masks.

Fixes NB US 177-284 (C++26 CD).

Fixes cplusplus/nbballot#859