### PR TITLE
[simd.complex.access] Move into [simd.class]

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -17614,6 +17614,14 @@ namespace std::simd {
     template<@\exposconcept{simd-integral}@ I>
       constexpr resize_t<I::size(), basic_vec> operator[](const I& indices) const;
 
+    // \ref{simd.complex.access}, \tcode{basic_vec} complex accessors
+    constexpr auto real() const noexcept;
+    constexpr auto imag() const noexcept;
+    template<@\exposconcept{simd-floating-point}@ V>
+      constexpr void real(const V& v) noexcept;
+    template<@\exposconcept{simd-floating-point}@ V>
+      constexpr void imag(const V& v) noexcept;
+
     // \ref{simd.unary}, \tcode{basic_vec} unary operators
     constexpr basic_vec& operator++() noexcept;
     constexpr basic_vec operator++(int) noexcept;
@@ -17659,14 +17667,6 @@ namespace std::simd {
     friend constexpr mask_type operator<=(const basic_vec&, const basic_vec&) noexcept;
     friend constexpr mask_type operator>(const basic_vec&, const basic_vec&) noexcept;
     friend constexpr mask_type operator<(const basic_vec&, const basic_vec&) noexcept;
-
-    // \ref{simd.complex.access}, \tcode{basic_vec} complex-value accessors
-    constexpr auto real() const noexcept;
-    constexpr auto imag() const noexcept;
-    template<@\exposconcept{simd-floating-point}@ V>
-      constexpr void real(const V& v) noexcept;
-    template<@\exposconcept{simd-floating-point}@ V>
-      constexpr void imag(const V& v) noexcept;
 
     // \ref{simd.cond}, \tcode{basic_vec} exposition only conditional operators
     friend constexpr basic_vec @\exposid{simd-select-impl}@( // \expos
@@ -17949,6 +17949,59 @@ template<@\exposconcept{simd-integral}@ I>
 \pnum
 \effects
 Equivalent to: \tcode{return permute(*this, indices);}
+\end{itemdescr}
+
+\rSec3[simd.complex.access]{\tcode{basic_vec} complex accessors}
+
+\indexlibrarymember{real}{basic_vec}
+\indexlibrarymember{imag}{basic_vec}
+\begin{itemdecl}
+constexpr auto real() const noexcept;
+constexpr auto imag() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{\exposconcept{simd-complex}<basic_vec>} is modeled.
+
+\pnum
+\returns
+An object of type \tcode{rebind_t<typename T::value_type, basic_vec>}
+where the $i^\text{th}$ element is initialized to the result of
+\tcode{\placeholder{cmplx-func}(operator[]($i$))} for all $i$ in the range
+\range{0}{size()}, where \placeholder{cmplx-func} is the corresponding function
+from \libheader{complex}.
+\end{itemdescr}
+
+\indexlibrarymember{real}{basic_vec}
+\indexlibrarymember{imag}{basic_vec}
+\begin{itemdecl}
+template<@\exposconcept{simd-floating-point}@ V>
+  constexpr void real(const V& v) noexcept;
+template<@\exposconcept{simd-floating-point}@ V>
+  constexpr void imag(const V& v) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\begin{itemize}
+ \item
+   \tcode{\exposconcept{simd-complex}<basic_vec>} is modeled,
+ \item
+   \tcode{\libconcept{same_as}<typename V::value_type, typename T::value_type>}
+   is modeled, and
+ \item
+   \tcode{V::size() == size()} is \tcode{true}.
+\end{itemize}
+
+\pnum
+\effects
+Replaces each element of the \tcode{basic_vec} object such that the
+$i^\text{th}$ element is replaced with \tcode{value_type(v[$i$],
+operator[]($i$).imag())} or \tcode{value_type(operator[]($i$).real(), v[$i$])}
+for \tcode{real} and \tcode{imag} respectively, for all $i$ in the range \range{0}{size()}.
 \end{itemdescr}
 
 \rSec3[simd.unary]{\tcode{basic_vec} unary operators}
@@ -18257,59 +18310,6 @@ Let \placeholder{op} be the operator.
 A \tcode{basic_mask} object initialized with the results of applying
 \placeholder{op} to \tcode{lhs} and \tcode{rhs} as a binary element-wise
 operation.
-\end{itemdescr}
-
-\rSec3[simd.complex.access]{\tcode{vec} complex accessors}
-
-\indexlibrarymember{real}{basic_vec}
-\indexlibrarymember{imag}{basic_vec}
-\begin{itemdecl}
-constexpr auto real() const noexcept;
-constexpr auto imag() const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\constraints
-\tcode{\exposconcept{simd-complex}<basic_vec>} is modeled.
-
-\pnum
-\returns
-An object of type \tcode{rebind_t<typename T::value_type, basic_vec>}
-where the $i^\text{th}$ element is initialized to the result of
-\tcode{\placeholder{cmplx-func}(operator[]($i$))} for all $i$ in the range
-\range{0}{size()}, where \placeholder{cmplx-func} is the corresponding function
-from \libheader{complex}.
-\end{itemdescr}
-
-\indexlibrarymember{real}{basic_vec}
-\indexlibrarymember{imag}{basic_vec}
-\begin{itemdecl}
-template<@\exposconcept{simd-floating-point}@ V>
-  constexpr void real(const V& v) noexcept;
-template<@\exposconcept{simd-floating-point}@ V>
-  constexpr void imag(const V& v) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\constraints
-\begin{itemize}
- \item
-   \tcode{\exposconcept{simd-complex}<basic_vec>} is modeled,
- \item
-   \tcode{\libconcept{same_as}<typename V::value_type, typename T::value_type>}
-   is modeled, and
- \item
-   \tcode{V::size() == size()} is \tcode{true}.
-\end{itemize}
-
-\pnum
-\effects
-Replaces each element of the \tcode{basic_vec} object such that the
-$i^\text{th}$ element is replaced with \tcode{value_type(v[$i$],
-operator[]($i$).imag())} or \tcode{value_type(operator[]($i$).real(), v[$i$])}
-for \tcode{real} and \tcode{imag} respectively, for all $i$ in the range \range{0}{size()}.
 \end{itemdescr}
 
 \rSec3[simd.cond]{\tcode{basic_vec} exposition only conditional operators}


### PR DESCRIPTION
The complex accessors are member functions.

Fixes NB US 179-293 (C++26 CD).

Fixes cplusplus/nbballot#868