### PR TITLE
[exec.par.scheduler] Move class definition from synopsis

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -724,7 +724,7 @@ namespace std::execution {
 
 namespace std::execution {
   // \ref{exec.par.scheduler}, parallel scheduler
-  class @\libglobal{parallel_scheduler}@ { @\unspec@ };
+  class @\libglobal{parallel_scheduler}@;
   parallel_scheduler get_parallel_scheduler();
 }
 
@@ -8277,6 +8277,14 @@ return @\exposid{stop-when}@(std::forward<Sender>(snd), @\exposid{scope}@->@\exp
 \end{itemdescr}
 
 \rSec1[exec.par.scheduler]{Parallel scheduler}
+
+\begin{codeblock}
+namespace std::execution {
+  class @\libglobal{parallel_scheduler}@ {
+    @\unspec@
+  };
+}
+\end{codeblock}
 
 \pnum
 \tcode{parallel_scheduler} models \libconcept{scheduler}.


### PR DESCRIPTION
Fixes NB US 204-321 (C++26 CD).

Fixes cplusplus/nbballot#896