### PR TITLE
[exec.when.all] Fix spelling of 'get_stop_token_t'

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -4444,8 +4444,8 @@ Returns an object \tcode{e} such that
 \tcode{state.\exposid{stop-src}.get_token()}, and
 \item
 given a query object \tcode{q}
-with type other than \cv{} \tcode{stop_token_t} and
-whose type satisfies \exposconceptx{forwarding-que\-ry}{forwarding-query},
+with type other than \cv{} \tcode{get_stop_token_t} and
+whose type satisfies \exposconceptx{forwarding-\brk{}query}{forwarding-query},
 \tcode{e.query(q)} is expression-equivalent to \tcode{get_env(rcvr).query(q)}.
 \end{itemize}
 


### PR DESCRIPTION
Fixes NB US 223-343 (C++26 CD).

Fixes cplusplus/nbballot#918