### PR TITLE
[atomics.ref.pointer,atomics.types.pointer] Use 'see above' for fetch_key declaration

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -4263,8 +4263,8 @@ in \tref{atomic.types.pointer.comp}.
 \indexlibrarymember{fetch_max}{atomic_ref<\placeholder{pointer-type}>}%
 \indexlibrarymember{fetch_min}{atomic_ref<\placeholder{pointer-type}>}%
 \begin{itemdecl}
-constexpr value_type fetch_@\placeholdernc{key}@(difference_type operand,
-                     memory_order order = memory_order::seq_cst) const noexcept;
+constexpr value_type fetch_@\placeholdernc{key}@(@\seeabovenc@ operand,
+                               memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4312,8 +4312,8 @@ the \tcode{<} operator does not establish a strict weak ordering
 \indexlibrarymember{store_max}{atomic_ref<\placeholder{pointer-type}>}%
 \indexlibrarymember{store_min}{atomic_ref<\placeholder{pointer-type}>}%
 \begin{itemdecl}
-constexpr void store_@\placeholdernc{key}@(@\UNSP{see above}@ operand,
-                     memory_order order = memory_order::seq_cst) const noexcept;
+constexpr void store_@\placeholdernc{key}@(@\seeabovenc@ operand,
+                         memory_order order = memory_order::seq_cst) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5871,8 +5871,8 @@ in \tref{atomic.types.pointer.comp}.
 \indexlibrarymember{fetch_min}{atomic<T*>}%
 \indexlibrarymember{fetch_sub}{atomic<T*>}%
 \begin{itemdecl}
-T* fetch_@\placeholdernc{key}@(ptrdiff_t operand, memory_order order = memory_order::seq_cst) volatile noexcept;
-constexpr T* fetch_@\placeholdernc{key}@(ptrdiff_t operand, memory_order order = memory_order::seq_cst) noexcept;
+T* fetch_@\placeholdernc{key}@(@\seeabovenc@ operand, memory_order order = memory_order::seq_cst) volatile noexcept;
+constexpr T* fetch_@\placeholdernc{key}@(@\seeabovenc@ operand, memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Fixes NB US 198-317 (C++26 CD).

Fixes cplusplus/nbballot#892