### PR TITLE
[atomics.types.float] Align parameters in function declarations

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -5416,56 +5416,56 @@ namespace std {
     @\placeholdernc{floating-point-type}@ exchange(@\placeholdernc{floating-point-type}@,
                                  memory_order = memory_order::seq_cst) volatile noexcept;
     constexpr @\placeholdernc{floating-point-type}@ exchange(@\placeholdernc{floating-point-type}@,
-                                 memory_order = memory_order::seq_cst) noexcept;
+                                           memory_order = memory_order::seq_cst) noexcept;
     bool compare_exchange_weak(@\placeholder{floating-point-type}@&, @\placeholdernc{floating-point-type}@,
                                memory_order, memory_order) volatile noexcept;
     constexpr bool compare_exchange_weak(@\placeholder{floating-point-type}@&, @\placeholdernc{floating-point-type}@,
-                               memory_order, memory_order) noexcept;
+                                         memory_order, memory_order) noexcept;
     bool compare_exchange_strong(@\placeholder{floating-point-type}@&, @\placeholdernc{floating-point-type}@,
                                  memory_order, memory_order) volatile noexcept;
     constexpr bool compare_exchange_strong(@\placeholder{floating-point-type}@&, @\placeholdernc{floating-point-type}@,
-                                 memory_order, memory_order) noexcept;
+                                           memory_order, memory_order) noexcept;
     bool compare_exchange_weak(@\placeholder{floating-point-type}@&, @\placeholdernc{floating-point-type}@,
                                memory_order = memory_order::seq_cst) volatile noexcept;
     constexpr bool compare_exchange_weak(@\placeholder{floating-point-type}@&, @\placeholdernc{floating-point-type}@,
-                               memory_order = memory_order::seq_cst) noexcept;
+                                         memory_order = memory_order::seq_cst) noexcept;
     bool compare_exchange_strong(@\placeholder{floating-point-type}@&, @\placeholdernc{floating-point-type}@,
                                  memory_order = memory_order::seq_cst) volatile noexcept;
     constexpr bool compare_exchange_strong(@\placeholder{floating-point-type}@&, @\placeholdernc{floating-point-type}@,
-                                 memory_order = memory_order::seq_cst) noexcept;
+                                           memory_order = memory_order::seq_cst) noexcept;
 
     @\placeholdernc{floating-point-type}@ fetch_add(@\placeholdernc{floating-point-type}@,
                                   memory_order = memory_order::seq_cst) volatile noexcept;
     constexpr @\placeholdernc{floating-point-type}@ fetch_add(@\placeholdernc{floating-point-type}@,
-                                  memory_order = memory_order::seq_cst) noexcept;
+                                            memory_order = memory_order::seq_cst) noexcept;
     @\placeholdernc{floating-point-type}@ fetch_sub(@\placeholdernc{floating-point-type}@,
                                   memory_order = memory_order::seq_cst) volatile noexcept;
     constexpr @\placeholdernc{floating-point-type}@ fetch_sub(@\placeholdernc{floating-point-type}@,
-                                  memory_order = memory_order::seq_cst) noexcept;
+                                            memory_order = memory_order::seq_cst) noexcept;
     @\placeholdernc{floating-point-type}@ fetch_max(@\placeholdernc{floating-point-type}@,
                                   memory_order = memory_order::seq_cst) volatile noexcept;
     constexpr @\placeholdernc{floating-point-type}@ fetch_max(@\placeholdernc{floating-point-type}@,
-                                  memory_order = memory_order::seq_cst) noexcept;
+                                            memory_order = memory_order::seq_cst) noexcept;
     @\placeholdernc{floating-point-type}@ fetch_min(@\placeholdernc{floating-point-type}@,
                                   memory_order = memory_order::seq_cst) volatile noexcept;
     constexpr @\placeholdernc{floating-poin-type}@t fetch_min(@\placeholdernc{floating-point-type}@,
-                                  memory_order = memory_order::seq_cst) noexcept;
+                                            memory_order = memory_order::seq_cst) noexcept;
     @\placeholdernc{floating-point-type}@ fetch_fmaximum(@\placeholdernc{floating-point-type}@,
-                                  memory_order = memory_order::seq_cst) volatile noexcept;
+                                       memory_order = memory_order::seq_cst) volatile noexcept;
     constexpr @\placeholdernc{floating-point-type}@ fetch_fmaximum(@\placeholdernc{floating-point-type}@,
-                                  memory_order = memory_order::seq_cst) noexcept;
+                                                 memory_order = memory_order::seq_cst) noexcept;
     @\placeholdernc{floating-point-type}@ fetch_fminimum(@\placeholdernc{floating-point-type}@,
-                                  memory_order = memory_order::seq_cst) volatile noexcept;
+                                       memory_order = memory_order::seq_cst) volatile noexcept;
     constexpr @\placeholdernc{floating-point-type}@ fetch_fminimum(@\placeholdernc{floating-point-type}@,
-                                  memory_order = memory_order::seq_cst) noexcept;
-    @\placeholdernc{floating-point-type}@ fetch_fmaximum_num(@\placeholdernc{floating-point-type}@,
-                                  memory_order = memory_order::seq_cst) volatile noexcept;
-    constexpr @\placeholdernc{floating-point-type}@ fetch_fmaximum_num(@\placeholdernc{floating-point-type}@,
-                                  memory_order = memory_order::seq_cst) noexcept;
-    @\placeholdernc{floating-point-type}@ fetch_fminimum_num(@\placeholdernc{floating-point-type}@,
-                                  memory_order = memory_order::seq_cst) volatile noexcept;
-    constexpr @\placeholdernc{floating-point-type}@ fetch_fminimum_num(@\placeholdernc{floating-point-type}@,
-                                  memory_order = memory_order::seq_cst) noexcept;
+                                                 memory_order = memory_order::seq_cst) noexcept;
+    @\placeholdernc{floating-point-type}@ fetch_fmaximum_num(
+      @\placeholdernc{floating-point-type}@, memory_order = memory_order::seq_cst) volatile noexcept;
+    constexpr @\placeholdernc{floating-point-type}@ fetch_fmaximum_num(
+      @\placeholdernc{floating-point-type}@, memory_order = memory_order::seq_cst) noexcept;
+    @\placeholdernc{floating-point-type}@ fetch_fminimum_num(
+      @\placeholdernc{floating-point-type}@, memory_order = memory_order::seq_cst) volatile noexcept;
+    constexpr @\placeholdernc{floating-point-type}@ fetch_fminimum_num(
+      @\placeholdernc{floating-point-type}@, memory_order = memory_order::seq_cst) noexcept;
 
     void store_add(@\placeholdernc{floating-point-type}@,
                    memory_order = memory_order::seq_cst) volatile noexcept;
@@ -5484,21 +5484,21 @@ namespace std {
     constexpr void store_min(@\placeholdernc{floating-point-type}@,
                              memory_order = memory_order::seq_cst) noexcept;
     void store_fmaximum(@\placeholdernc{floating-point-type}@,
-                            memory_order = memory_order::seq_cst) volatile noexcept;
+                        memory_order = memory_order::seq_cst) volatile noexcept;
     constexpr void store_fmaximum(@\placeholdernc{floating-point-type}@,
-                            memory_order = memory_order::seq_cst) noexcept;
+                                  memory_order = memory_order::seq_cst) noexcept;
     void store_fminimum(@\placeholdernc{floating-point-type}@,
-                            memory_order = memory_order::seq_cst) volatile noexcept;
+                        memory_order = memory_order::seq_cst) volatile noexcept;
     constexpr void store_fminimum(@\placeholdernc{floating-point-type}@,
-                            memory_order = memory_order::seq_cst) noexcept;
+                                  memory_order = memory_order::seq_cst) noexcept;
     void store_fmaximum_num(@\placeholdernc{floating-point-type}@,
                             memory_order = memory_order::seq_cst) volatile noexcept;
     constexpr void store_fmaximum_num(@\placeholdernc{floating-point-type}@,
-                            memory_order = memory_order::seq_cst) noexcept;
+                                      memory_order = memory_order::seq_cst) noexcept;
     void store_fminimum_num(@\placeholdernc{floating-point-type}@,
                             memory_order = memory_order::seq_cst) volatile noexcept;
     constexpr void store_fminimum_num(@\placeholdernc{floating-point-type}@,
-                            memory_order = memory_order::seq_cst) noexcept;
+                                      memory_order = memory_order::seq_cst) noexcept;
 
     @\placeholdernc{floating-point-type}@ operator+=(@\placeholder{floating-point-type}@) volatile noexcept;
     constexpr @\placeholdernc{floating-point-type}@ operator+=(@\placeholder{floating-point-type}@) noexcept;
@@ -5551,10 +5551,10 @@ which are specified below.
 \indexlibrarymember{fetch_max}{atomic<\placeholder{floating-point-type}>}%
 \indexlibrarymember{fetch_min}{atomic<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
-@\placeholder{floating-point-type}@ fetch_@\placeholdernc{key}@(@\placeholder{floating-point-type}@ operand,
-                               memory_order order = memory_order::seq_cst) volatile noexcept;
-constexpr @\placeholder{floating-point-type}@ fetch_@\placeholdernc{key}@(@\placeholder{floating-point-type}@ operand,
-                                         memory_order order = memory_order::seq_cst) noexcept;
+@\placeholdernc{floating-point-type}@ fetch_@\placeholdernc{key}@(@\placeholder{floating-point-type}@ operand,
+                              memory_order order = memory_order::seq_cst) volatile noexcept;
+constexpr @\placeholdernc{floating-point-type}@ fetch_@\placeholdernc{key}@(@\placeholder{floating-point-type}@ operand,
+                                        memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -5634,9 +5634,9 @@ should treat negative zero as smaller than positive zero.
 \indexlibrarymember{store_fminimum_num}{atomic<\placeholder{floating-point-type}>}%
 \begin{itemdecl}
 void store_@\placeholdernc{key}@(@\placeholdernc{floating-point-type}@ operand,
-  memory_order order = memory_order::seq_cst) volatile noexcept;
+               memory_order order = memory_order::seq_cst) volatile noexcept;
 constexpr void store_@\placeholdernc{key}@(@\placeholdernc{floating-point-type}@ operand,
-  memory_order order = memory_order::seq_cst) noexcept;
+                         memory_order order = memory_order::seq_cst) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Fixes https://github.com/cplusplus/nbballot/issues/891.

The parameter indentation in the subclause is broken in four different ways:
- In the first block with `exchange`, `fetch_max`, etc. it looks like `constexpr` was added without adding then necessary indentation to the second line of the declaration, resulting in misalignment.
- For `store_fmaximum` and some others, an *attempt* was made to align the parameters, but unsuccessfully.
- In the definition of `fetch_key`, there is one space too much indentation, and we forgot to use `placeholdernc` rather than `placeholder`.
- In the definition of `store_key`, we just used two-space indentation rather than trying to align parameters at all.

