### PR TITLE
[streambuf.virt.put] Replace "effects" with "affects" in footnote

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4058,7 +4058,7 @@ specified.
 That is, for each class derived from a specialization of
 \tcode{basic_streambuf}
 in this Clause\iref{stringbuf,filebuf},
-a specification of how consuming a character effects the associated output sequence is given.
+a specification of how consuming a character affects the associated output sequence is given.
 There is no requirement on a program-defined class.
 \end{footnote}
 \item


### PR DESCRIPTION
Fixes https://github.com/cplusplus/nbballot/issues/878.

Use of "effect" as a verb seems inappropriate here; see https://www.merriam-webster.com/dictionary/effect

"affect (verb)" (https://www.merriam-webster.com/dictionary/affect) means to "to act on and cause a change", which is what we're trying to express here. Consuming a character *acts upon* the output sequence.