### PR TITLE
[class.temporary] Clarify that list of contexts is exhaustive

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4768,8 +4768,8 @@ subexpression.
 \pnum
 \indextext{initializer!temporary and declarator}%
 \indextext{temporary!order of destruction of}%
-There are several contexts in which temporaries are destroyed at a different
-point than the end of the full-expression.
+Temporary objects are destroyed at a different point
+than the end of the full-expression in the following contexts:
 The first context is when a default constructor is called to initialize
 an element of an array with no corresponding initializer\iref{dcl.init}.
 The second context is when a copy constructor is called to copy an element of


### PR DESCRIPTION
Fixes NB US 19-037 (C++26 CD).
Fixes https://github.com/cplusplus/nbballot/issues/612.

We used to say "five" in this place before applying https://github.com/cplusplus/papers/issues/156, which replaced that with "several" because updating the counter each time is a bit silly.

However, this does lose the clarity that the list of lifetime extension contexts in [class.temporary] is exhaustive, so we need to add something like "all listed below" if don't want a counter but clearly have an exhaustive list.