### PR TITLE
[simd.syn] Reorder declarations to match subclause order

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -16532,10 +16532,24 @@ namespace std::simd {
   template<class T, @\exposid{simd-size-type}@ N = @\exposid{simd-size-v}@<T, @\exposid{native-abi}@<T>>>
     using @\libmember{vec}{simd}@ = basic_vec<T, @\exposid{deduce-abi-t}@<T, N>>;
 
-  // \ref{simd.mask.class}, class template \tcode{basic_mask}
-  template<size_t Bytes, class Abi = @\exposid{native-abi}@<@\exposid{integer-from}@<Bytes>>> class basic_mask;
-  template<class T, @\exposid{simd-size-type}@ N = @\exposid{simd-size-v}@<T, @\exposid{native-abi}@<T>>>
-    using @\libmember{mask}{simd}@ = basic_mask<sizeof(T), @\exposid{deduce-abi-t}@<T, N>>;
+  // \ref{simd.reductions}, \tcode{basic_vec} reductions
+  template<class T, class Abi, class BinaryOperation = plus<>>
+    constexpr T reduce(const basic_vec<T, Abi>&, BinaryOperation = {});
+  template<class T, class Abi, class BinaryOperation = plus<>>
+    constexpr T reduce(
+      const basic_vec<T, Abi>& x, const typename basic_vec<T, Abi>::mask_type& mask,
+      BinaryOperation binary_op = {}, type_identity_t<T> identity_element = @\seebelow@);
+
+  template<class T, class Abi>
+    constexpr T reduce_min(const basic_vec<T, Abi>&) noexcept;
+  template<class T, class Abi>
+    constexpr T reduce_min(const basic_vec<T, Abi>&,
+                           const typename basic_vec<T, Abi>::mask_type&) noexcept;
+  template<class T, class Abi>
+    constexpr T reduce_max(const basic_vec<T, Abi>&) noexcept;
+  template<class T, class Abi>
+    constexpr T reduce_max(const basic_vec<T, Abi>&,
+                           const typename basic_vec<T, Abi>::mask_type&) noexcept;
 
   // \ref{simd.loadstore}, \tcode{basic_vec} load and store functions
   template<class V = @\seebelow@, ranges::@\libconcept{contiguous_range}@ R, class... Flags>
@@ -16714,46 +16728,6 @@ namespace std::simd {
     constexpr basic_mask<Bytes, @\exposid{deduce-abi-t}@<@\exposid{integer-from}@<Bytes>,
                               (basic_mask<Bytes, Abis>::size() + ...)>>
       cat(const basic_mask<Bytes, Abis>&...) noexcept;
-
-  // \ref{simd.mask.reductions}, \tcode{basic_mask} reductions
-  template<size_t Bytes, class Abi>
-    constexpr bool all_of(const basic_mask<Bytes, Abi>&) noexcept;
-  template<size_t Bytes, class Abi>
-    constexpr bool any_of(const basic_mask<Bytes, Abi>&) noexcept;
-  template<size_t Bytes, class Abi>
-    constexpr bool none_of(const basic_mask<Bytes, Abi>&) noexcept;
-  template<size_t Bytes, class Abi>
-    constexpr @\exposid{simd-size-type}@ reduce_count(const basic_mask<Bytes, Abi>&) noexcept;
-  template<size_t Bytes, class Abi>
-    constexpr @\exposid{simd-size-type}@ reduce_min_index(const basic_mask<Bytes, Abi>&);
-  template<size_t Bytes, class Abi>
-    constexpr @\exposid{simd-size-type}@ reduce_max_index(const basic_mask<Bytes, Abi>&);
-
-  constexpr bool all_of(@\libconcept{same_as}@<bool> auto) noexcept;
-  constexpr bool any_of(@\libconcept{same_as}@<bool> auto) noexcept;
-  constexpr bool none_of(@\libconcept{same_as}@<bool> auto) noexcept;
-  constexpr @\exposid{simd-size-type}@ reduce_count(@\libconcept{same_as}@<bool> auto) noexcept;
-  constexpr @\exposid{simd-size-type}@ reduce_min_index(@\libconcept{same_as}@<bool> auto);
-  constexpr @\exposid{simd-size-type}@ reduce_max_index(@\libconcept{same_as}@<bool> auto);
-
-  // \ref{simd.reductions}, \tcode{basic_vec} reductions
-  template<class T, class Abi, class BinaryOperation = plus<>>
-    constexpr T reduce(const basic_vec<T, Abi>&, BinaryOperation = {});
-  template<class T, class Abi, class BinaryOperation = plus<>>
-    constexpr T reduce(
-      const basic_vec<T, Abi>& x, const typename basic_vec<T, Abi>::mask_type& mask,
-      BinaryOperation binary_op = {}, type_identity_t<T> identity_element = @\seebelow@);
-
-  template<class T, class Abi>
-    constexpr T reduce_min(const basic_vec<T, Abi>&) noexcept;
-  template<class T, class Abi>
-    constexpr T reduce_min(const basic_vec<T, Abi>&,
-                           const typename basic_vec<T, Abi>::mask_type&) noexcept;
-  template<class T, class Abi>
-    constexpr T reduce_max(const basic_vec<T, Abi>&) noexcept;
-  template<class T, class Abi>
-    constexpr T reduce_max(const basic_vec<T, Abi>&,
-                           const typename basic_vec<T, Abi>::mask_type&) noexcept;
 
   // \ref{simd.alg}, algorithms
   template<class T, class Abi>
@@ -17021,6 +16995,32 @@ namespace std::simd {
     rebind_t<complex<typename V::value_type>, V> polar(const V& x, const V& y = {});
 
   template<@\exposconcept{simd-complex}@ V> constexpr V pow(const V& x, const V& y);
+
+  // \ref{simd.mask.class}, class template \tcode{basic_mask}
+  template<size_t Bytes, class Abi = @\exposid{native-abi}@<@\exposid{integer-from}@<Bytes>>> class basic_mask;
+  template<class T, @\exposid{simd-size-type}@ N = @\exposid{simd-size-v}@<T, @\exposid{native-abi}@<T>>>
+    using @\libmember{mask}{simd}@ = basic_mask<sizeof(T), @\exposid{deduce-abi-t}@<T, N>>;
+
+  // \ref{simd.mask.reductions}, \tcode{basic_mask} reductions
+  template<size_t Bytes, class Abi>
+    constexpr bool all_of(const basic_mask<Bytes, Abi>&) noexcept;
+  template<size_t Bytes, class Abi>
+    constexpr bool any_of(const basic_mask<Bytes, Abi>&) noexcept;
+  template<size_t Bytes, class Abi>
+    constexpr bool none_of(const basic_mask<Bytes, Abi>&) noexcept;
+  template<size_t Bytes, class Abi>
+    constexpr @\exposid{simd-size-type}@ reduce_count(const basic_mask<Bytes, Abi>&) noexcept;
+  template<size_t Bytes, class Abi>
+    constexpr @\exposid{simd-size-type}@ reduce_min_index(const basic_mask<Bytes, Abi>&);
+  template<size_t Bytes, class Abi>
+    constexpr @\exposid{simd-size-type}@ reduce_max_index(const basic_mask<Bytes, Abi>&);
+
+  constexpr bool all_of(@\libconcept{same_as}@<bool> auto) noexcept;
+  constexpr bool any_of(@\libconcept{same_as}@<bool> auto) noexcept;
+  constexpr bool none_of(@\libconcept{same_as}@<bool> auto) noexcept;
+  constexpr @\exposid{simd-size-type}@ reduce_count(@\libconcept{same_as}@<bool> auto) noexcept;
+  constexpr @\exposid{simd-size-type}@ reduce_min_index(@\libconcept{same_as}@<bool> auto);
+  constexpr @\exposid{simd-size-type}@ reduce_max_index(@\libconcept{same_as}@<bool> auto);
 }
 
 namespace std {


### PR DESCRIPTION
Fixes NB US 175-281 (C++26 CD).

Fixes https://github.com/cplusplus/nbballot/issues/856.