### PR TITLE
[basic.link], [expr.ref] Harmonize font for tuple representing direct base class relationship

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3268,10 +3268,10 @@ it is a reflection value\iref{basic.fundamental} that represents
 \item
 an entity, value, or object that is TU-local,
 \item
-a direct base class relationship (\tcode{D}, \tcode{B})\iref{class.derived.general}
-for which either \tcode{D} or \tcode{B} is TU-local, or
+a direct base class relationship $(D, B)$\iref{class.derived.general}
+for which either $D$ or $B$ is TU-local, or
 \item
-a data member description ($T$, $N$, $A$, $W$, $\mathit{NUA}$)\iref{class.mem.general}
+a data member description $(T, N, A, W, \mathit{NUA})$\iref{class.mem.general}
 for which $T$ is TU-local.
 \end{itemize}
 \end{itemize}


### PR DESCRIPTION
Fixes NB US 1-405 (C++26 CD).

Fixes https://github.com/cplusplus/nbballot/issues/586.

This only changes the spellings in core wording, in [basic.link] and [expr.ref].

@jensmaurer requested in https://github.com/cplusplus/nbballot/issues/586#issuecomment-3363206752 that code font should not be used. That seems to be the path of least resistance, although, to be fair, a direct base class relationship is always between two types, and we tend to use code font for types. Using math font also leads to a quirky change in [expr.ref] where `\tcode{T1}` becomes `$\mathit{T1}$`.

In [meta.reflection], the wording uses `$(D, B)$` consistently everywhere. This spelling also appears once in <https://eel.is/c++draft/expr.ref#8.6>. I think we should aim to spell both the base class relationship and the data member description tuples *entirely* in math context, including the parentheses, which is already the most common form.

Maybe we could revisit these font choices later, but for now, let's just make it consistent with a fairly small change, and move on.