### PR TITLE
[simd] Canonicalize subclause headings

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -17558,7 +17558,7 @@ Equivalent to: \tcode{return V::size() - i.\exposid{offset_};}
 
 \rSec2[simd.class]{Class template \tcode{basic_vec}}
 
-\rSec3[simd.overview]{Class template \tcode{basic_vec} overview}
+\rSec3[simd.overview]{Overview}
 
 \indexlibraryglobal{basic_vec}%
 \begin{codeblock}
@@ -17700,7 +17700,7 @@ Appropriate types are non-standard vector types which are available in the
 implementation.
 \end{note}
 
-\rSec3[simd.ctor]{\tcode{basic_vec} constructors}
+\rSec3[simd.ctor]{Constructors}
 
 \indexlibraryctor{basic_vec}
 \begin{itemdecl}
@@ -17904,7 +17904,7 @@ if the floating-point conversion rank of \tcode{T::value_type} is greater than
 or equal to the floating-point conversion rank of \tcode{V::value_type}.
 \end{itemdescr}
 
-\rSec3[simd.subscr]{\tcode{basic_vec} subscript operator}
+\rSec3[simd.subscr]{Subscript operator}
 
 \indexlibrarymember{operator[]}{basic_vec}
 \begin{itemdecl}
@@ -17937,7 +17937,7 @@ template<@\exposconcept{simd-integral}@ I>
 Equivalent to: \tcode{return permute(*this, indices);}
 \end{itemdescr}
 
-\rSec3[simd.complex.access]{\tcode{basic_vec} complex accessors}
+\rSec3[simd.complex.access]{Complex accessors}
 
 \indexlibrarymember{real}{basic_vec}
 \indexlibrarymember{imag}{basic_vec}
@@ -17990,7 +17990,7 @@ operator[]($i$).imag())} or \tcode{value_type(operator[]($i$).real(), v[$i$])}
 for \tcode{real} and \tcode{imag} respectively, for all $i$ in the range \range{0}{size()}.
 \end{itemdescr}
 
-\rSec3[simd.unary]{\tcode{basic_vec} unary operators}
+\rSec3[simd.unary]{Unary operators}
 
 \pnum
 Effects in \ref{simd.unary} are applied as unary element-wise operations.
@@ -18136,7 +18136,7 @@ A \tcode{basic_vec} object where the $i^\text{th}$ element is initialized to
 
 \rSec2[simd.nonmembers]{\tcode{basic_vec} non-member operations}
 
-\rSec3[simd.binary]{\tcode{basic_vec} binary operators}
+\rSec3[simd.binary]{Binary operators}
 
 \indexlibrarymember{operator+}{basic_vec}
 \indexlibrarymember{operator-}{basic_vec}
@@ -18200,7 +18200,7 @@ the result of applying \placeholder{op} to \tcode{v[$i$]} and \tcode{n} for all
 $i$ in the range of \range{0}{size()}.
 \end{itemdescr}
 
-\rSec3[simd.cassign]{\tcode{basic_vec} compound assignment}
+\rSec3[simd.cassign]{Compound assignment}
 
 \indexlibrarymember{operator+=}{basic_vec}
 \indexlibrarymember{operator-=}{basic_vec}
@@ -18265,7 +18265,7 @@ Let \placeholder{op} be the operator.
 Equivalent to: \tcode{return operator \placeholder{op} (lhs, basic_vec(n));}
 \end{itemdescr}
 
-\rSec3[simd.comparison]{\tcode{basic_vec} compare operators}
+\rSec3[simd.comparison]{Comparison operators}
 
 \indexlibrarymember{operator==}{basic_vec}
 \indexlibrarymember{operator!=}{basic_vec}
@@ -18298,7 +18298,7 @@ A \tcode{basic_mask} object initialized with the results of applying
 operation.
 \end{itemdescr}
 
-\rSec3[simd.cond]{\tcode{basic_vec} exposition only conditional operators}
+\rSec3[simd.cond]{Exposition-only conditional operators}
 
 \begin{itemdecl}
 friend constexpr basic_vec
@@ -18313,7 +18313,7 @@ A \tcode{basic_vec} object where the $i^\text{th}$ element equals
 \range{0}{size()}.
 \end{itemdescr}
 
-\rSec3[simd.reductions]{\tcode{basic_vec} reductions}
+\rSec3[simd.reductions]{Reductions}
 
 \indexlibrarymember{reduce}{simd}
 \begin{itemdecl}
@@ -18472,7 +18472,7 @@ Otherwise, returns the value of a selected element \tcode{x[$j$]} for which
 \tcode{mask}.
 \end{itemdescr}
 
-\rSec3[simd.loadstore]{\tcode{basic_vec} load and store functions}
+\rSec3[simd.loadstore]{Load and store functions}
 
 \indexlibrarymember{unchecked_load}{simd}
 \begin{itemdecl}
@@ -18766,7 +18766,7 @@ For all $i$ in the range of \range{0}{basic_vec<T, Abi>::size()}, if
 \tcode{ranges::data(r)[$i$] = v[$i$]}.
 \end{itemdescr}
 
-\rSec3[simd.permute.static]{\tcode{vec} static permute}
+\rSec3[simd.permute.static]{Static permute}
 
 \indexlibrarymember{permute}{simd}
 \begin{itemdecl}
@@ -18823,7 +18823,7 @@ $i^\text{th}$ element is initialized to the result of
 The default argument for template parameter \tcode{N} is \tcode{V::size()}.
 \end{itemdescr}
 
-\rSec3[simd.permute.dynamic]{\tcode{vec} dynamic permute}
+\rSec3[simd.permute.dynamic]{Dynamic permute}
 
 \indexlibrarymember{permute}{simd}
 \begin{itemdecl}
@@ -18845,7 +18845,7 @@ element is initialized to the result of \tcode{v[indices[$i$]]} for all $i$ in
 the range \range{0}{I::size()}.
 \end{itemdescr}
 
-\rSec3[simd.permute.mask]{\tcode{vec} mask permute}
+\rSec3[simd.permute.mask]{Mask permute}
 
 \indexlibrarymember{compress}{simd}
 \begin{itemdecl}
@@ -18940,7 +18940,7 @@ element is initialized to the result of \tcode{\exposidnc{select-value}($i$)}
 for all $i$ in the range \range{0}{V::size()}.
 \end{itemdescr}
 
-\rSec3[simd.permute.memory]{\tcode{simd} memory permute}
+\rSec3[simd.permute.memory]{Memory permute}
 
 \indexlibrarymember{unchecked_gather_from}{simd}
 \begin{itemdecl}
@@ -19121,7 +19121,7 @@ For all $i$ in the range \range{0}{I::size()}, if \tcode{mask[$i$] \&\&
 \tcode{ranges::data(out)[indices[$i$]] = v[$i$]}.
 \end{itemdescr}
 
-\rSec3[simd.creation]{\tcode{basic_vec} and \tcode{basic_mask} creation}
+\rSec3[simd.creation]{Creation}
 
 \indexlibrarymember{chunk}{simd}
 \begin{itemdecl}
@@ -19757,7 +19757,7 @@ Sets \tcode{*iptr} to \tcode{ret.second}.
 \tcode{ret.first}.
 \end{itemdescr}
 
-\rSec3[simd.bit]{\tcode{basic_vec} bit library}
+\rSec3[simd.bit]{Bit manipulation}
 
 \indexlibrarymember{byteswap}{simd}
 \begin{itemdecl}
@@ -19924,7 +19924,7 @@ the result of \tcode{\placeholder{bit-func}(v[$i$])} for all $i$ in the range
 function from \libheader{bit}.
 \end{itemdescr}
 
-\rSec3[simd.complex.math]{\tcode{vec} complex math}
+\rSec3[simd.complex.math]{Complex math}
 
 \indexlibrarymember{real}{simd}
 \indexlibrarymember{imag}{simd}
@@ -20024,7 +20024,7 @@ It is unspecified whether \tcode{errno}\iref{errno} is accessed.
 
 \rSec2[simd.mask.class]{Class template \tcode{basic_mask}}
 
-\rSec3[simd.mask.overview]{Class template \tcode{basic_mask} overview}
+\rSec3[simd.mask.overview]{Overview}
 
 \begin{codeblock}
 namespace std::simd {
@@ -20153,7 +20153,7 @@ Appropriate types are non-standard vector types which are available in the
 implementation.
 \end{note}
 
-\rSec3[simd.mask.ctor]{\tcode{basic_mask} constructors}
+\rSec3[simd.mask.ctor]{Constructors}
 
 \indexlibraryctor{basic_mask}
 \begin{itemdecl}
@@ -20234,7 +20234,7 @@ $M$ is less than \tcode{size()}, the remaining elements are initialized to
 zero.
 \end{itemdescr}
 
-\rSec3[simd.mask.subscr]{\tcode{basic_mask} subscript operator}
+\rSec3[simd.mask.subscr]{Subscript operator}
 
 \indexlibrarymember{operator[]}{basic_mask}
 \begin{itemdecl}
@@ -20267,7 +20267,7 @@ template<@\exposconcept{simd-integral}@ I>
 Equivalent to: \tcode{return permute(*this, indices);}
 \end{itemdescr}
 
-\rSec3[simd.mask.unary]{\tcode{basic_mask} unary operators}
+\rSec3[simd.mask.unary]{Unary operators}
 
 \indexlibrarymember{operator!}{basic_mask}
 \indexlibrarymember{operator+}{basic_mask}
@@ -20291,7 +20291,7 @@ results of applying \placeholder{op} to \tcode{operator[]($i$)} for all $i$ in
 the range of \range{0}{size()}.
 \end{itemdescr}
 
-\rSec3[simd.mask.conv]{\tcode{basic_mask} conversions}
+\rSec3[simd.mask.conv]{Conversions}
 
 \indexlibrarymember{operator basic_vec}{basic_mask}
 \begin{itemdecl}
@@ -20349,7 +20349,7 @@ Nothing.
 
 \rSec2[simd.mask.nonmembers]{\tcode{basic_mask} non-member operations}
 
-\rSec3[simd.mask.binary]{\tcode{basic_mask} binary operators}
+\rSec3[simd.mask.binary]{Binary operators}
 
 \indexlibrarymember{operator\&\&}{basic_mask}
 \indexlibrarymember{operator||}{basic_mask}
@@ -20380,7 +20380,7 @@ A \tcode{basic_mask} object initialized with the results of applying
 operation.
 \end{itemdescr}
 
-\rSec3[simd.mask.cassign]{\tcode{basic_mask} compound assignment}
+\rSec3[simd.mask.cassign]{Compound assignment}
 
 \indexlibrarymember{operator\&=}{basic_mask}
 \indexlibrarymember{operator|=}{basic_mask}
@@ -20408,7 +20408,7 @@ binary element-wise operation.
 \tcode{lhs}.
 \end{itemdescr}
 
-\rSec3[simd.mask.comparison]{\tcode{basic_mask} comparisons}
+\rSec3[simd.mask.comparison]{Comparisons}
 
 \indexlibrarymember{operator==}{basic_mask}
 \indexlibrarymember{operator!=}{basic_mask}
@@ -20442,7 +20442,7 @@ A \tcode{basic_mask} object initialized with the results of applying
 operation.
 \end{itemdescr}
 
-\rSec3[simd.mask.cond]{\tcode{basic_mask} exposition only conditional operators}
+\rSec3[simd.mask.cond]{Exposition-only conditional operators}
 
 \begin{itemdecl}
 friend constexpr basic_mask @\exposid{simd-select-impl}@(
@@ -20493,7 +20493,7 @@ A \tcode{vec<T0, size()>} object where the $i^\text{th}$ element equals
 \tcode{mask[$i$] ? a : b} for all $i$ in the range of \range{0}{size()}.
 \end{itemdescr}
 
-\rSec3[simd.mask.reductions]{\tcode{basic_mask} reductions}
+\rSec3[simd.mask.reductions]{Reductions}
 
 \indexlibrarymember{all_of}{simd}
 \begin{itemdecl}


### PR DESCRIPTION
Remove parts redundant with headings of superordinate subclauses.

Fixes #8313