### PR TITLE
[basic.def] Remove incorrect grammarterm formatting for "declaration"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -188,7 +188,7 @@ A declaration may also have effects including:
 \pnum
 \indextext{declaration!function}%
 \indextext{definition}%
-Each entity declared by a \grammarterm{declaration} is
+Each entity declared by a declaration is
 also \defnx{defined}{define} by that declaration unless:
 \begin{itemize}
 \item


### PR DESCRIPTION
Fixes NB US 12-026 (C++26 CD).
Fixes https://github.com/cplusplus/nbballot/issues/601.

As explained in the NB comment, `\grammarterm{declaration}` in this place is wrong because e.g. https://eel.is/c++draft/basic.def#2.5 (*elaborated-type-specifier*) is not grammatically a *declaration*, but it is a "declaration" (https://eel.is/c++draft/basic.pre#5.14).

Paragraph 2 talks about "declarations" in general, not just about *declaration*s, so it's wrong to use grammarterm font.