### PR TITLE
[simd.permute.mask] clarify list is in ascending order

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -18923,7 +18923,7 @@ Let:
 \begin{itemize}
 \item
 \exposid{set-indices} be a list of the index positions of \tcode{true}
-elements in \tcode{selector}.
+elements in \tcode{selector}, in ascending order.
 \item
 \tcode{\exposidnc{bit-lookup}($b$)} be a function which returns the index
 where $b$ appears in \tcode{\exposid{set-indices}}.


### PR DESCRIPTION
Fixes NB US 183-290 (C++26 CD).

Fixes cplusplus/nbballot#865