### PR TITLE
[cpp.module] Drop meaningless sentence about keywords as macros CWG3074

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1220,12 +1220,6 @@ int infinity_zero () {
 \end{bnf}
 
 \pnum
-A \grammarterm{pp-module} shall not
-appear in a context where \tcode{module}
-or (if it is the first preprocessing token of the \grammarterm{pp-module}) \tcode{export}
-is an identifier defined as an object-like macro.
-
-\pnum
 The \grammarterm{pp-tokens}, if any, of a \grammarterm{pp-module}
 shall be of the form:
 \begin{ncsimplebnf}
@@ -1279,12 +1273,6 @@ so it is not removed at the end of phase 4.
     \opt{\keyword{export}} \keyword{import} header-name-tokens \opt{pp-tokens} \terminal{;} new-line\br
     \opt{\keyword{export}} \keyword{import} pp-tokens \terminal{;} new-line
 \end{bnf}
-
-\pnum
-A \grammarterm{pp-import} shall not
-appear in a context where \tcode{import}
-or (if it is the first preprocessing token of the \grammarterm{pp-import}) \tcode{export}
-is an identifier defined as an object-like macro.
 
 \pnum
 The preprocessing tokens after the \tcode{import} preprocessing token


### PR DESCRIPTION
The `module` and `export` macros can no longer be defined as object-like macros, so there is no context that p1 can apply to any more.