### PR TITLE
[cpp.module] Cannot treat module directive as normal text

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1252,14 +1252,6 @@ the \grammarterm{pp-module-name} or \grammarterm{pp-module-partition}
 shall currently be defined as an object-like macro.
 
 \pnum
-Any preprocessing tokens after the \tcode{module} preprocessing token
-in the \tcode{module} directive are processed just as in normal text.
-\begin{note}
-Each identifier currently defined as a macro name
-is replaced by its replacement list of preprocessing tokens.
-\end{note}
-
-\pnum
 The \tcode{module} and \tcode{export} (if it exists) preprocessing tokens
 are replaced by the \grammarterm{module-keyword} and
 \grammarterm{export-keyword} preprocessing tokens respectively.


### PR DESCRIPTION
With the application of papers restricting macros in module directives, there remain no valid transformations for treating any part of such a directive as normal text.