### PR TITLE
[cpp.pre][cpp.module] Consolidate preprocessor grammar in one clause

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -17,21 +17,6 @@
 \end{bnf}
 
 \begin{bnf}
-\nontermdef{module-file}\br
-    \opt{pp-global-module-fragment} pp-module \opt{group} \opt{pp-private-module-fragment}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{pp-global-module-fragment}\br
-    \keyword{module} \terminal{;} new-line \opt{group}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{pp-private-module-fragment}\br
-    \keyword{module} \terminal{:} \keyword{private} \terminal{;} new-line \opt{group}
-\end{bnf}
-
-\begin{bnf}
 \nontermdef{group}\br
     group-part\br
     group group-part
@@ -1213,6 +1198,21 @@ int infinity_zero () {
 
 \rSec1[cpp.module]{Module directive}
 \indextext{preprocessing directive!module}%
+
+\begin{bnf}
+\nontermdef{module-file}\br
+    \opt{pp-global-module-fragment} pp-module \opt{group} \opt{pp-private-module-fragment}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{pp-global-module-fragment}\br
+    \keyword{module} \terminal{;} new-line \opt{group}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{pp-private-module-fragment}\br
+    \keyword{module} \terminal{:} \keyword{private} \terminal{;} new-line \opt{group}
+\end{bnf}
 
 \begin{bnf}
 \nontermdef{pp-module}\br


### PR DESCRIPTION
The grammar around module directives is quite precise and involved, yet spread across two clauses, the preamble and the module directive clauses.  This change set consolidates all the grannar for a _module-file_ into the module directive clause, making it easier to grasp all at once. None of these terms are referenced from outside the clause.