### PR TITLE
[meta.unary.prop] [meta.rel] P/R for LWG3967

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -1425,8 +1425,8 @@ The compilation of the
  \tcode{struct is_nothrow_constructible;}   &
  \tcode{is_constructible_v<T,} \tcode{ Args...>} is \tcode{true}
  and the
- variable definition for \tcode{is_constructible}, as defined below, is known not to
- throw any exceptions\iref{expr.unary.noexcept}.
+ variable definition for \tcode{is_constructible}, as defined below,
+ contains no potentially-throwing expression\iref{except.spec}.
  &
  \tcode{T} and all types in the template parameter pack \tcode{Args}
  shall be complete types, \cv{}~\keyword{void},
@@ -1460,8 +1460,9 @@ The compilation of the
 \indexlibraryglobal{is_nothrow_assignable}%
 \tcode{template<class T, class U>}\br
   \tcode{struct is_nothrow_assignable;} &
-  \tcode{is_assignable_v<T, U>} is \tcode{true} and the assignment is known not to
-  throw any exceptions\iref{expr.unary.noexcept}. &
+  \tcode{is_assignable_v<T, U>} is \tcode{true} and
+  the expression in the definition of \tcode{is_assignable<T, U>}
+  is not potentially-throwing\iref{except.spec}. &
   \tcode{T} and \tcode{U} shall be complete types, \cv{}~\keyword{void},
   or arrays of unknown bound. \\ \rowsep
 
@@ -1487,9 +1488,8 @@ The compilation of the
 \tcode{template<class T, class U>}\br
   \tcode{struct is_nothrow_swappable_with;} &
   \tcode{is_swappable_with_v<T, U>} is \tcode{true} and
-  each \tcode{swap} expression of the definition of
-  \tcode{is_swappable_with<T, U>} is known not to throw
-  any exceptions\iref{expr.unary.noexcept}. &
+  no \tcode{swap} expression in the definition of
+  \tcode{is_swappable_with<T, U>} is potentially-throwing\iref{except.spec}. &
   \tcode{T} and \tcode{U} shall be complete types,
   \cv{}~\keyword{void}, or
   arrays of unknown bound. \\ \rowsep
@@ -1507,8 +1507,10 @@ The compilation of the
 \indexlibraryglobal{is_nothrow_destructible}%
 \tcode{template<class T>}\br
   \tcode{struct is_nothrow_destructible;} &
-  \tcode{is_destructible_v<T>} is \tcode{true} and the indicated destructor is known
-  not to throw any exceptions\iref{expr.unary.noexcept}. &
+  \tcode{is_destructible_v<T>} is \tcode{true} and
+  either \tcode{T} is a reference type or
+  the expression in the definition of \tcode{is_destructible<T>}
+  is not potentially-throwing\iref{except.spec}. &
   \tcode{T} shall be a complete type,
   \cv{}~\keyword{void}, or an array of unknown
   bound.                \\ \rowsep
@@ -1824,7 +1826,7 @@ Let \tcode{\placeholdernc{ELEMS-OF}(T)} be the parameter pack
  \tcode{struct is_nothrow_convertible;}     &
  \tcode{is_convertible_v<From, To>} is \tcode{true} and
  the conversion, as defined by \tcode{is_convertible},
- is known not to throw any exceptions\iref{expr.unary.noexcept} &
+ is not a potentially-throwing expression\iref{except.spec}. &
  \tcode{From} and \tcode{To} shall be complete types,
  \cv{}~\keyword{void}, or arrays of unknown bound.  \\ \rowsep
 
@@ -1874,7 +1876,7 @@ Let \tcode{\placeholdernc{ELEMS-OF}(T)} be the parameter pack
  \tcode{struct is_nothrow_invocable;}              &
  \tcode{is_invocable_v<}\br\tcode{Fn, ArgTypes...>} is \tcode{true} and
  the expression \tcode{\placeholdernc{INVOKE}(declval<Fn>(), declval<ArgTypes>()...)}
- is known not to throw any exceptions\iref{expr.unary.noexcept}       &
+ is not potentially-throwing\iref{except.spec}. &
  \tcode{Fn} and all types in the template parameter pack \tcode{ArgTypes}
  shall be complete types, \cv{}~\keyword{void}, or
  arrays of unknown bound.                                             \\ \rowsep
@@ -1884,7 +1886,7 @@ Let \tcode{\placeholdernc{ELEMS-OF}(T)} be the parameter pack
  \tcode{struct is_nothrow_invocable_r;}              &
  \tcode{is_invocable_r_v<}\br\tcode{R, Fn, ArgTypes...>} is \tcode{true} and
  the expression \tcode{\placeholdernc{INVOKE}<R>(declval<Fn>(), declval<ArgTypes>()...)}
- is known not to throw any exceptions\iref{expr.unary.noexcept}       &
+ is not potentially-throwing\iref{except.spec}. &
  \tcode{Fn}, \tcode{R}, and all types in the template parameter pack \tcode{ArgTypes}
  shall be complete types, \cv{}~\keyword{void}, or
  arrays of unknown bound.                                             \\ \rowsep
@@ -1905,7 +1907,7 @@ Let \tcode{\placeholdernc{ELEMS-OF}(T)} be the parameter pack
  \tcode{struct is_nothrow_applicable;}              &
  \tcode{is_applicable_v<}\br\tcode{Fn, Tuple>} is \tcode{true} and
  the expression \tcode{\placeholdernc{INVOKE}(declval<Fn>(), \placeholdernc{ELEMS-OF}(Tuple)...)}
- is known not to throw any exceptions\iref{expr.unary.noexcept}.       &
+ is not potentially-throwing\iref{except.spec}. &
  \tcode{Fn} and \tcode{Tuple}
  shall be complete types, \cv{}~\keyword{void}, or
  arrays of unknown bound.                                             \\


### PR DESCRIPTION
https://cplusplus.github.io/LWG/issue3967

This intends to eliminate all instances of "is known not to throw any exception" from the library clauses. "Is known" is too vague a condition (known to whom?); we ought to define it explicitly in terms of potentially-throwing expressions, i.e., we expect these traits to exactly match the result of the `noexcept` operator.