### PR TITLE
[fs.path.native.obs] [fs.path.generic.obs] qualify std::format

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -14727,7 +14727,7 @@ std::string display_string() const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{format("\{\}", *this)}.
+\tcode{std::format("\{\}", *this)}.
 \begin{note}
 The returned string is suitable for use with formatting\iref{format.functions}
 and print functions\iref{print.fun}.
@@ -14801,7 +14801,7 @@ std::string generic_display_string() const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{format("\{:g\}", *this)}.
+\tcode{std::format("\{:g\}", *this)}.
 \begin{note}
 The returned string is suitable for use with formatting\iref{format.functions}
 and print functions\iref{print.fun}.


### PR DESCRIPTION
Fixes NB comment US 190-305 (C++26 CD).

Fixes https://github.com/cplusplus/nbballot/issues/880