### PR TITLE
[cpp.line] Simplify specification of line directives

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -47,15 +47,15 @@
 
 \begin{bnf}
 \nontermdef{control-line}\br
-    \terminal{\# include} pp-tokens new-line\br
     pp-import\br
+    line-directive\br
+    \terminal{\# include} pp-tokens new-line\br
     \terminal{\# embed \ } pp-tokens new-line\br
     \terminal{\# define } identifier replacement-list new-line\br
     \terminal{\# define } identifier lparen \opt{identifier-list} \terminal{)} replacement-list new-line\br
     \terminal{\# define } identifier lparen \terminal{... )} replacement-list new-line\br
     \terminal{\# define } identifier lparen identifier-list \terminal{, ... )} replacement-list new-line\br
     \terminal{\# undef \ } identifier new-line\br
-    \terminal{\# line \ \ } pp-tokens new-line\br
     \terminal{\# error \ } \opt{pp-tokens} new-line\br
     \terminal{\# warning} \opt{pp-tokens} new-line\br
     \terminal{\# pragma } \opt{pp-tokens} new-line\br
@@ -2070,11 +2070,19 @@ a macro name.
 \indextext{preprocessing directive!line control}%
 \indextext{\idxcode{\#line}|see{preprocessing directive, line control}}
 
+\begin{bnf}
+\nontermdef{line-directive}\br
+    \terminal{\# line} digit-sequence \opt{string-literal} new-line\br
+    \terminal{\# line} pp-tokens new-line
+\end{bnf}
+
 \pnum
-The \grammarterm{string-literal} of a
-\tcode{\#line}
-directive, if present,
+The \grammarterm{string-literal}, if present,
 shall be a character string literal.
+
+\pnum
+If the digit sequence interpreted as a decimal integer is zero
+or a number greater than 2147483647, the program is ill-formed.
 
 \pnum
 The
@@ -2087,41 +2095,21 @@ in translation phase 1\iref{lex.phases}
 while processing the source file to the current preprocessing token.
 
 \pnum
-A preprocessing directive of the form
-\begin{ncsimplebnf}
-\terminal{\# line} digit-sequence new-line
-\end{ncsimplebnf}
+A \grammarterm{line-directive} that matches the first form
 causes the implementation to behave as if
 the following sequence of source lines begins with a
 source line that has a line number as specified
-by the digit sequence (interpreted as a decimal integer).
-If the digit sequence specifies zero
-or a number greater than 2147483647,
-the program is ill-formed.
+by the digit sequence (interpreted as a decimal integer)
+and the presumed name of the source file becomes
+the contents of the character string literal, if present.
 
 \pnum
-A preprocessing directive of the form
-\begin{ncsimplebnf}
-\terminal{\# line} digit-sequence \terminal{"} \opt{s-char-sequence} \terminal{"} new-line
-\end{ncsimplebnf}
-sets the presumed line number similarly and changes the
-presumed name of the source file to be the contents
-of the character string literal.
-
-\pnum
-A preprocessing directive of the form
-\begin{ncsimplebnf}
-\terminal{\# line} pp-tokens new-line
-\end{ncsimplebnf}
-(that does not match one of the two previous forms)
-is permitted.
-The preprocessing tokens after
-\tcode{line}
-on the directive are processed just as in normal text
-(each identifier currently defined as a macro name is replaced by its
-replacement list of preprocessing tokens).
+The \grammarterm{pp-tokens} of a \grammarterm{line-directive} that does not
+match the first form are processed just as in normal text
+(i.e., each identifier currently defined as a macro name is replaced by
+its replacement list of preprocessing tokens).
 If the directive resulting after all replacements does not match
-one of the two previous forms, the program is ill-formed;
+the first form, the program is ill-formed;
 otherwise, the result is processed as appropriate.
 
 \rSec1[cpp.error]{Diagnostic directives}%


### PR DESCRIPTION
This change set addresses a variety of concerns to produce a simpler and clearer specification for line directives.  It makes no functional changes, but changes words sufficiently to require a Core review.  A motivation behind this PR is to simplify the changes for the proposal to allow line directives before the global module fragment, https://wg21.link/P3868.

The line directive is given its own grammar production that formally states what used to be described in text restrictions and interpretations of the generic sequence of preprocessing tokens.

The other issue to address is that the specification refers to a _string-literal_ that is not present in the grammar. However, the constraints on that string literal are sufficient to replace that quoted _s-char-sequence_ in the grammar production with _string-literal_.

