### PR TITLE
[cpp.pre] Move paragraph introducing preprocessor to first

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -174,6 +174,17 @@
 \end{bnf}
 
 \pnum
+The implementation can
+process and skip sections of source files conditionally,
+include other source files,
+import macros from header units,
+and replace macros.
+These capabilities are called
+\defn{preprocessing},
+because conceptually they occur
+before translation of the resulting translation unit.
+
+\pnum
 A \defn{preprocessing directive} consists of a sequence of preprocessing tokens
 that satisfies the following constraints:
 At the start of translation phase 4,
@@ -303,17 +314,6 @@ are space and horizontal-tab
 (including spaces that have replaced comments
 or possibly other whitespace characters
 in translation phase 3).
-
-\pnum
-The implementation can
-process and skip sections of source files conditionally,
-include other source files,
-import macros from header units,
-and replace macros.
-These capabilities are called
-\defn{preprocessing},
-because conceptually they occur
-before translation of the resulting translation unit.
 
 \pnum
 The preprocessing tokens within a preprocessing directive


### PR DESCRIPTION
The paragraph with no normative text that outlines the broad capabilities of the preprocessor has slippee further down this clause as new text is added. The most appropriate place for introductory text is the first sentence of the introductory clause, so moved accordingly.