### PR TITLE
[diff.expr] Remove commentary about good practice in C

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2996,8 +2996,7 @@ char* c = (char*) b;
 \end{example}
 
 \howwide
-This is fairly widely used in C, but C++ requires a
-cast when assigning pointer-to-void to pointer-to-object.
+Common.
 
 \diffref{expr.arith.conv}
 \change


### PR DESCRIPTION
C deliberately supports implicit conversion from void* to object*. Using an explicit cast (for assigning the result of malloc, for example) is not considered good practice in C, though it's required in C++.

I'm not aware of any C translators that warn about such assignments.