### PR TITLE
[diff.expr] Include conversions involving pointers to cv void in the changes

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2967,7 +2967,8 @@ Common.
 
 \diffref{conv.ptr}
 \change
-Converting \tcode{\keyword{void}*} to a pointer-to-object type requires casting.
+Converting a prvalue of type ``pointer to \cv{} \tcode{void}''
+to a pointer-to-object type requires casting.
 \begin{example}
 \begin{codeblock}
 char a[10];
@@ -2977,7 +2978,7 @@ void foo() {
 }
 \end{codeblock}
 
-C accepts this usage of pointer to \keyword{void} being assigned
+C accepts this usage of ``pointer to \keyword{void}'' being assigned
 to a pointer to object type.
 \Cpp{} does not.
 \end{example}


### PR DESCRIPTION
This fixes two issues:

1. Conversions from `const void*` to `const int*` are implicit in C as well, but they are missing from the C annex. I don't think this needs a CWG issue.

2. The notation referring to `void*` in  this area is weird. Example of better notation: https://github.com/cplusplus/draft/blob/ca77cdb10021c757b0fbe4d83b5991ac7d935db8/source/expressions.tex#L1049-L1053
   Basically, we don't use "code spellings" in code wording, but prefer the "quoted" type notation.