### PR TITLE
[thread.stoptoken] Index missing pieces in `<stop_token>`

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -1331,12 +1331,13 @@ Executes a stop request operation\iref{stoptoken.concepts}.
 
 \rSec3[stopcallback.inplace.general]{General}
 
+\indexlibraryglobal{inplace_stop_callback}%
 \begin{codeblock}
 namespace std {
   template<class CallbackFn>
   class inplace_stop_callback {
   public:
-    using callback_type = CallbackFn;
+    using @\libmember{callback_type}{inplace_stop_callback}@ = CallbackFn;
 
     // \ref{stopcallback.inplace.cons}, constructors and destructor
     template<class Initializer>
@@ -1381,6 +1382,7 @@ its associated callback function\iref{stoptoken.concepts}.
 
 \rSec3[stopcallback.inplace.cons]{Constructors and destructor}
 
+\indexlibraryctor{inplace_stop_callback}%
 \begin{itemdecl}
 template<class Initializer>
   explicit inplace_stop_callback(inplace_stop_token st, Initializer&& init)
@@ -1398,6 +1400,7 @@ Initializes \exposid{callback-fn} with \tcode{std::forward<Initializer>(init)}
 and executes a stoppable callback registration\iref{stoptoken.concepts}.
 \end{itemdescr}
 
+\indexlibrarydtor{inplace_stop_callback}%
 \begin{itemdecl}
 ~inplace_stop_callback();
 \end{itemdecl}


### PR DESCRIPTION
Entities the `std` namespace:
- `nostopstate_t`,
- `nostopstate`,
- `stop_callback_for_t`,
- `never_stop_token`,
- `inplace_stop_token`,
- `inplace_stop_source`,
- `inplace_stop_source`, and
- `inplace_stop_callback`.

Member alias templates:
- All `callback_type` alias templates.

Member functions:
- All member functions shown in the synopses, except for
  - defaulted `operator==`, and
  - the destructor of `inplace_stop_callback`, because it's doubtful whether it should be explicitly mentioned at all, see also [functions.within.classes].

Exposition-only member class _`callback-type`_ is skipped for now.

Fixes #8358.