### PR TITLE
[meta] reflect_constant_array of an empty range returns const array<T,0>

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -6281,7 +6281,7 @@ Let $P$ be
   initialized with \tcode{\{[:$V$:]...\}}.
 \item
   Otherwise, the template parameter object
-  of type \tcode{array<T, 0>}
+  of type \tcode{const array<T, 0>}
   initialized with \tcode{\{\}}.
 \end{itemize}
 


### PR DESCRIPTION
Marek Poláček asked in SG7 Mattermost if it should return `const` or not, I think for consistency it should be. If others agree this is PR fixing it.