### PR TITLE
[meta.reflection.result] move declaration of TCls earlier

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -6119,9 +6119,14 @@ Let $V$ be:
 \end{itemize}
 
 \pnum
+Let \tcode{TCls} be the invented template:
+\begin{codeblock}
+template<T P> struct TCls;
+\end{codeblock}
+
+\pnum
 \returns
-\tcode{template_arguments_of(\reflexpr{TCls<$V$>})[0]},
-with \tcode{TCls} as defined below.
+\tcode{template_arguments_of(\reflexpr{TCls<$V$>})[0]}.
 \begin{note}
 This is a reflection of an object for class types,
 and a reflection of a value otherwise.
@@ -6130,11 +6135,7 @@ and a reflection of a value otherwise.
 \pnum
 \throws
 \tcode{meta::exception} unless
-the \grammarterm{template-id} \tcode{TCls<$V$>} would be valid
-given the invented template
-\begin{codeblock}
-template<T P> struct TCls;
-\end{codeblock}
+the \grammarterm{template-id} \tcode{TCls<$V$>} would be valid.
 
 \pnum
 \begin{example}


### PR DESCRIPTION
Fixes NB US 117-178 (C++26 CD).

Fixes https://github.com/cplusplus/nbballot/issues/747

But I wonder if we should name this something other than `TCls` seeing as that name is used for a class template in at least five examples elsewhere in reflection wording. Maybe the invented template here should have a different name to avoid any risk of confusion.