### PR TITLE
[lex.pptoken][module][cpp] Index keyword placeholders]

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -586,6 +586,9 @@ shall have the lexical form of a keyword, an identifier, a literal,
 or an operator or punctuator.
 
 \pnum
+\indextext{keyword placeholder!export-keyword}%
+\indextext{keyword placeholder!import-keyword}%
+\indextext{keyword placeholder!module-keyword}%
 The \grammarterm{import-keyword} is produced
 by processing an \keyword{import} directive\iref{cpp.import},
 the \grammarterm{module-keyword} is produced
@@ -1014,6 +1017,9 @@ reserved to the implementation for use as a name in the global namespace.%
 \indextext{identifier|)}
 
 \rSec1[lex.key]{Keywords}
+\indextext{keyword placeholder!export-keyword}%
+\indextext{keyword placeholder!import-keyword}%
+\indextext{keyword placeholder!module-keyword}%
 
 \begin{bnf}
 \nontermdef{keyword}\br

--- a/source/modules.tex
+++ b/source/modules.tex
@@ -4,6 +4,8 @@
 \gramSec[gram.module]{Modules}
 
 \rSec1[module.unit]{Module units and purviews}
+\indextext{keyword placeholder!export-keyword}%
+\indextext{keyword placeholder!module-keyword}%
 
 \begin{bnf}
 \nontermdef{module-declaration}\br
@@ -401,6 +403,7 @@ export namespace N {
 \end{note}
 
 \rSec1[module.import]{Import declaration}%
+\indextext{keyword placeholder!import-keyword}%
 
 \begin{bnf}
 \nontermdef{module-import-declaration}\br
@@ -581,6 +584,7 @@ import M1;              // error: cyclic interface dependency $\mathtt{M3} \righ
 \end{example}
 
 \rSec1[module.global.frag]{Global module fragment}
+\indextext{keyword placeholder!module-keyword}%
 
 \begin{bnf}
 \nontermdef{global-module-fragment}\br
@@ -805,6 +809,7 @@ int c = use_h<int>();           // OK
 \end{example}
 
 \rSec1[module.private.frag]{Private module fragment}
+\indextext{keyword placeholder!module-keyword}%
 
 \begin{bnf}
 \nontermdef{private-module-fragment}\br

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1260,6 +1260,8 @@ is replaced by its replacement list of preprocessing tokens.
 \end{note}
 
 \pnum
+\indextext{keyword placeholder!export-keyword}%
+\indextext{keyword placeholder!module-keyword}%
 The \tcode{module} and \tcode{export} (if it exists) preprocessing tokens
 are replaced by the \grammarterm{module-keyword} and
 \grammarterm{export-keyword} preprocessing tokens respectively.
@@ -1317,6 +1319,8 @@ while processing the \grammarterm{group} of a \grammarterm{module-file},
 the program is ill-formed.
 
 \pnum
+\indextext{keyword placeholder!export-keyword}%
+\indextext{keyword placeholder!import-keyword}%
 In all three forms of \grammarterm{pp-import},
 the \tcode{import} and \tcode{export} (if it exists) preprocessing tokens
 are replaced by the \grammarterm{import-keyword} and


### PR DESCRIPTION
Fixes #6844 

Index the keyword placeholders, _export-keyword_, _import-keyword_, and _module-keyword_.