### PR TITLE
[cpp.line] Address string-literal vs s-char-sequence

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -613,7 +613,7 @@ shall apply before any \grammarterm{d-char}, \grammarterm{r-char}, or delimiting
 parenthesis is identified. The raw string literal is defined as the shortest sequence
 of characters that matches the raw-string pattern
 \begin{ncbnf}
-\opt{encoding-prefix} \terminal{R} raw-string
+\opt{encoding-prefix} raw-string
 \end{ncbnf}
 
 \item Otherwise, if the next three characters are \tcode{<::} and the subsequent character
@@ -1799,8 +1799,13 @@ chosen in an \impldef{choice of larger or smaller value of
 \indextext{literal!string}%
 \begin{bnf}
 \nontermdef{string-literal}\br
-    \opt{encoding-prefix} \terminal{"} \opt{s-char-sequence} \terminal{"}\br
-    \opt{encoding-prefix} \terminal{R} raw-string
+    \opt{encoding-prefix} plain-string-literal\br
+    \opt{encoding-prefix} raw-string
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{plain-string-literal}\br
+    \terminal{"} \opt{s-char-sequence} \terminal{"}
 \end{bnf}
 
 \begin{bnf}
@@ -1823,7 +1828,7 @@ chosen in an \impldef{choice of larger or smaller value of
 
 \begin{bnf}
 \nontermdef{raw-string}\br
-    \terminal{"} \opt{d-char-sequence} \terminal{(} \opt{r-char-sequence} \terminal{)} \opt{d-char-sequence} \terminal{"}
+    \terminal{R} \terminal{"} \opt{d-char-sequence} \terminal{(} \opt{r-char-sequence} \terminal{)} \opt{d-char-sequence} \terminal{"}
 \end{bnf}
 
 \begin{bnf}
@@ -2110,11 +2115,9 @@ what effect these sequences have on encoding state.
 
 \begin{bnf}
 \nontermdef{unevaluated-string}\br
-    string-literal
+    plain-string-literal\br
+    raw-string
 \end{bnf}
-
-\pnum
-An \grammarterm{unevaluated-string} shall have no \grammarterm{encoding-prefix}.
 
 \pnum
 Each \grammarterm{universal-character-name} and each \grammarterm{simple-escape-sequence} in an \grammarterm{unevaluated-string} is

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1805,7 +1805,7 @@ macro shall be followed by a parameter as the next preprocessing
 token in the replacement list.
 
 \pnum
-A \defn{character string literal} is a \grammarterm{string-literal} with no prefix.
+A \defn{character string literal} is a \grammarterm{plain-string-literal}.
 If, in the replacement list, a parameter is immediately
 preceded by a
 \tcode{\#}
@@ -2071,12 +2071,6 @@ a macro name.
 \indextext{\idxcode{\#line}|see{preprocessing directive, line control}}
 
 \pnum
-The \grammarterm{string-literal} of a
-\tcode{\#line}
-directive, if present,
-shall be a character string literal\iref{cpp.stringize}.
-
-\pnum
 The
 \defn{line number}
 of the current source line is
@@ -2102,11 +2096,11 @@ the program is ill-formed.
 \pnum
 A preprocessing directive of the form
 \begin{ncsimplebnf}
-\terminal{\# line} digit-sequence \terminal{"} \opt{string-literal} \terminal{"} new-line
+\terminal{\# line} digit-sequence plain-string-literal new-line
 \end{ncsimplebnf}
 sets the presumed line number similarly and changes the
 presumed name of the source file to be the contents
-of the character string literal.
+of the \grammarterm{plain-string-literal}.
 
 \pnum
 A preprocessing directive of the form

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -2074,7 +2074,7 @@ a macro name.
 The \grammarterm{string-literal} of a
 \tcode{\#line}
 directive, if present,
-shall be a character string literal.
+shall be a character string literal\iref{cpp.stringize}.
 
 \pnum
 The
@@ -2102,7 +2102,7 @@ the program is ill-formed.
 \pnum
 A preprocessing directive of the form
 \begin{ncsimplebnf}
-\terminal{\# line} digit-sequence \terminal{"} \opt{s-char-sequence} \terminal{"} new-line
+\terminal{\# line} digit-sequence \terminal{"} \opt{string-literal} \terminal{"} new-line
 \end{ncsimplebnf}
 sets the presumed line number similarly and changes the
 presumed name of the source file to be the contents


### PR DESCRIPTION
The text of this specification places a restriction on a _string-literal_ that is not present in the grammar, although the grammar is an exact match for a _string-literal_ with that restriction.

The restricted term is also used when specifying the effects of the line directive with a string, so prefer to move _string-literal_ into the grammar rather than strike that paragraph and adjust the specification for its effects.

Added a cross-reference to where character string literal is defined as it may not be obvious to all readers that this is a term of power, even though it is defined as a term and has an index entry.