### PR TITLE
[basic.scope.pdecl], [temp] Replace "expansion statement" with "expansion-statement"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1333,7 +1333,7 @@ The locus of a \grammarterm{for-range-declaration}
 of a range-based \keyword{for} statement\iref{stmt.ranged}
 is immediately after the \grammarterm{for-range-initializer}.
 The locus of a \grammarterm{for-range-declaration}
-of an expansion statement\iref{stmt.expand}
+of an \grammarterm{expansion-statement}\iref{stmt.expand}
 is immediately after the \grammarterm{expansion-initializer}.
 
 \pnum

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -173,7 +173,7 @@ if it is
 \item a template,
 \item an entity defined\iref{basic.def} or created\iref{class.temporary}
       within the \grammarterm{compound-statement}
-      of an expansion statement\iref{stmt.expand},
+      of an \grammarterm{expansion-statement}\iref{stmt.expand},
 \item an entity defined or created in a templated entity,
 \item a member of a templated entity,
 \item an enumerator for an enumeration that is a templated entity, or
@@ -5018,7 +5018,7 @@ and the innermost enclosing template is not instantiated, or
 no valid specialization,
 ignoring \grammarterm{static_assert-declaration}s that fail,
 can be generated for the \grammarterm{compound-statement}
-of an expansion statement and there is no instantiation of it, or
+of an \grammarterm{expansion-statement} and there is no instantiation of it, or
 \item
 no valid specialization,
 ignoring \grammarterm{static_assert-declaration}{s} that fail,
@@ -5747,7 +5747,7 @@ whose return type is dependent,
 a \grammarterm{conversion-function-id} that specifies a dependent type,
 \item
 a name $N$ introduced by the \grammarterm{for-range-declaration}
-of an expansion statement $S$
+of an \grammarterm{expansion-statement} $S$
 if the type specified for $N$ contains a placeholder type and either
 \begin{itemize}
 \item the \grammarterm{expansion-initializer} of $S$ is type-dependent or
@@ -5873,7 +5873,7 @@ it is type-dependent,
 it is the name of a constant template parameter,
 \item
 it is a name introduced by the \grammarterm{for-range-declaration}
-of an expansion statement\iref{stmt.expand},
+of an \grammarterm{expansion-statement}\iref{stmt.expand},
 \item
 it names a static data member that is a dependent member of the current
 instantiation and is not initialized in a \grammarterm{member-declarator},
@@ -6180,7 +6180,7 @@ the program is ill-formed, no diagnostic required.
 
 \pnum
 For the \grammarterm{compound-statement}
-of an expansion statement\iref{stmt.expand},
+of an \grammarterm{expansion-statement}\iref{stmt.expand},
 the point of instantiation is the point of instantiation
 of its enclosing templated entity, if any.
 Otherwise, it immediately follows the namespace-scope declaration


### PR DESCRIPTION
Fixes NB US 2-404 (C++26 CD).
Also fixes https://github.com/cplusplus/nbballot/issues/585.

This PR does a little bit more than the NB comment asked for. We have the bad language of
> *for-range-declaration* of an expansion statement

and

> *compound-statement* of an expansion statement

The NB comment only relates to the second case, but in general, if we talk about one grammatical thing being inside another, we should consistently use grammar font.