### PR TITLE
[lib] Remove superfluous `typename` in alias declarations

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -6058,7 +6058,7 @@ The following exposition-only alias template may appear in deduction guides for 
 
 \begin{codeblock}
 template<class InputIterator>
-  using @\placeholdernc{iter-value-type}@ = typename iterator_traits<InputIterator>::value_type;  // \expos
+  using @\placeholdernc{iter-value-type}@ = iterator_traits<InputIterator>::value_type;  // \expos
 \end{codeblock}
 
 \rSec2[array.syn]{Header \tcode{<array>} synopsis}
@@ -6504,8 +6504,8 @@ namespace std {
     // types
     using value_type             = T;
     using allocator_type         = Allocator;
-    using pointer                = typename allocator_traits<Allocator>::pointer;
-    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using pointer                = allocator_traits<Allocator>::pointer;
+    using const_pointer          = allocator_traits<Allocator>::const_pointer;
     using reference              = value_type&;
     using const_reference        = const value_type&;
     using size_type              = @\impdefx{type of \tcode{deque::size_type}}@; // see \ref{container.requirements}
@@ -7012,8 +7012,8 @@ namespace std {
     // types
     using value_type      = T;
     using allocator_type  = Allocator;
-    using pointer         = typename allocator_traits<Allocator>::pointer;
-    using const_pointer   = typename allocator_traits<Allocator>::const_pointer;
+    using pointer         = allocator_traits<Allocator>::pointer;
+    using const_pointer   = allocator_traits<Allocator>::const_pointer;
     using reference       = value_type&;
     using const_reference = const value_type&;
     using size_type       = @\impdefx{type of \tcode{forward_list::size_type}}@; // see \ref{container.requirements}
@@ -8007,8 +8007,8 @@ namespace std {
     // types
     using value_type = T;
     using allocator_type = Allocator;
-    using pointer = typename allocator_traits<Allocator>::pointer;
-    using const_pointer = typename allocator_traits<Allocator>::const_pointer;
+    using pointer = allocator_traits<Allocator>::pointer;
+    using const_pointer = allocator_traits<Allocator>::const_pointer;
     using reference = value_type&;
     using const_reference = const value_type&;
     using size_type = @\impdef@;                               // see \ref{container.requirements}
@@ -9067,8 +9067,8 @@ namespace std {
     // types
     using value_type             = T;
     using allocator_type         = Allocator;
-    using pointer                = typename allocator_traits<Allocator>::pointer;
-    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using pointer                = allocator_traits<Allocator>::pointer;
+    using const_pointer          = allocator_traits<Allocator>::const_pointer;
     using reference              = value_type&;
     using const_reference        = const value_type&;
     using size_type              = @\impdefx{type of \tcode{list::size_type}}@; // see \ref{container.requirements}
@@ -9867,8 +9867,8 @@ namespace std {
     // types
     using value_type             = T;
     using allocator_type         = Allocator;
-    using pointer                = typename allocator_traits<Allocator>::pointer;
-    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using pointer                = allocator_traits<Allocator>::pointer;
+    using const_pointer          = allocator_traits<Allocator>::const_pointer;
     using reference              = value_type&;
     using const_reference        = const value_type&;
     using size_type              = @\impdefx{type of \tcode{vector::size_type}}@; // see \ref{container.requirements}
@@ -11381,8 +11381,7 @@ the header \libheaderrefx{set}{associative.set.syn} defines the class templates
 The following exposition-only alias templates may appear in deduction guides for associative containers:
 \begin{codeblock}
 template<class InputIterator>
-  using @\placeholder{iter-value-type}@ =
-    typename iterator_traits<InputIterator>::value_type;                // \expos
+  using @\placeholder{iter-value-type}@ = iterator_traits<InputIterator>::value_type;   // \expos
 template<class InputIterator>
   using @\placeholder{iter-key-type}@ = remove_const_t<
     tuple_element_t<0, @\exposid{iter-value-type}@<InputIterator>>>;                // \expos
@@ -11397,7 +11396,7 @@ template<ranges::@\libconcept{input_range}@ Range>
   using @\exposid{range-key-type}@ =
     remove_const_t<typename ranges::range_value_t<Range>::first_type>;  // \expos
 template<ranges::@\libconcept{input_range}@ Range>
-  using @\exposid{range-mapped-type}@ = typename ranges::range_value_t<Range>::second_type; // \expos
+  using @\exposid{range-mapped-type}@ = ranges::range_value_t<Range>::second_type; // \expos
 template<ranges::@\libconcept{input_range}@ Range>
   using @\exposid{range-to-alloc-type}@ =
     pair<add_const_t<typename ranges::range_value_t<Range>::first_type>,
@@ -11532,8 +11531,8 @@ namespace std {
     using value_type             = pair<const Key, T>;
     using key_compare            = Compare;
     using allocator_type         = Allocator;
-    using pointer                = typename allocator_traits<Allocator>::pointer;
-    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using pointer                = allocator_traits<Allocator>::pointer;
+    using const_pointer          = allocator_traits<Allocator>::const_pointer;
     using reference              = value_type&;
     using const_reference        = const value_type&;
     using size_type              = @\impdefx{type of \tcode{map::size_type}}@; // see \ref{container.requirements}
@@ -12275,8 +12274,8 @@ namespace std {
     using value_type             = pair<const Key, T>;
     using key_compare            = Compare;
     using allocator_type         = Allocator;
-    using pointer                = typename allocator_traits<Allocator>::pointer;
-    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using pointer                = allocator_traits<Allocator>::pointer;
+    using const_pointer          = allocator_traits<Allocator>::const_pointer;
     using reference              = value_type&;
     using const_reference        = const value_type&;
     using size_type              = @\impdefx{type of \tcode{multimap::size_type}}@; // see \ref{container.requirements}
@@ -12693,8 +12692,8 @@ namespace std {
     using value_type             = Key;
     using value_compare          = Compare;
     using allocator_type         = Allocator;
-    using pointer                = typename allocator_traits<Allocator>::pointer;
-    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using pointer                = allocator_traits<Allocator>::pointer;
+    using const_pointer          = allocator_traits<Allocator>::const_pointer;
     using reference              = value_type&;
     using const_reference        = const value_type&;
     using size_type              = @\impdefx{type of \tcode{set::size_type}}@; // see \ref{container.requirements}
@@ -13059,8 +13058,8 @@ namespace std {
     using value_type             = Key;
     using value_compare          = Compare;
     using allocator_type         = Allocator;
-    using pointer                = typename allocator_traits<Allocator>::pointer;
-    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using pointer                = allocator_traits<Allocator>::pointer;
+    using const_pointer          = allocator_traits<Allocator>::const_pointer;
     using reference              = value_type&;
     using const_reference        = const value_type&;
     using size_type              = @\impdefx{type of \tcode{multiset::size_type}}@; // see \ref{container.requirements}
@@ -13464,8 +13463,8 @@ namespace std {
     using hasher               = Hash;
     using key_equal            = Pred;
     using allocator_type       = Allocator;
-    using pointer              = typename allocator_traits<Allocator>::pointer;
-    using const_pointer        = typename allocator_traits<Allocator>::const_pointer;
+    using pointer              = allocator_traits<Allocator>::pointer;
+    using const_pointer        = allocator_traits<Allocator>::const_pointer;
     using reference            = value_type&;
     using const_reference      = const value_type&;
     using size_type            = @\impdefx{type of \tcode{unordered_map::size_type}}@; // see \ref{container.requirements}
@@ -14259,8 +14258,8 @@ namespace std {
     using hasher               = Hash;
     using key_equal            = Pred;
     using allocator_type       = Allocator;
-    using pointer              = typename allocator_traits<Allocator>::pointer;
-    using const_pointer        = typename allocator_traits<Allocator>::const_pointer;
+    using pointer              = allocator_traits<Allocator>::pointer;
+    using const_pointer        = allocator_traits<Allocator>::const_pointer;
     using reference            = value_type&;
     using const_reference      = const value_type&;
     using size_type            = @\impdefx{type of \tcode{unordered_multimap::size_type}}@; // see \ref{container.requirements}
@@ -14747,8 +14746,8 @@ namespace std {
     using hasher               = Hash;
     using key_equal            = Pred;
     using allocator_type       = Allocator;
-    using pointer              = typename allocator_traits<Allocator>::pointer;
-    using const_pointer        = typename allocator_traits<Allocator>::const_pointer;
+    using pointer              = allocator_traits<Allocator>::pointer;
+    using const_pointer        = allocator_traits<Allocator>::const_pointer;
     using reference            = value_type&;
     using const_reference      = const value_type&;
     using size_type            = @\impdefx{type of \tcode{unordered_set::size_type}}@; // see \ref{container.requirements}
@@ -15167,8 +15166,8 @@ namespace std {
     using hasher               = Hash;
     using key_equal            = Pred;
     using allocator_type       = Allocator;
-    using pointer              = typename allocator_traits<Allocator>::pointer;
-    using const_pointer        = typename allocator_traits<Allocator>::const_pointer;
+    using pointer              = allocator_traits<Allocator>::pointer;
+    using const_pointer        = allocator_traits<Allocator>::const_pointer;
     using reference            = value_type&;
     using const_reference      = const value_type&;
     using size_type            = @\impdefx{type of \tcode{unordered_multiset::size_type}}@; // see \ref{container.requirements}
@@ -15665,10 +15664,10 @@ namespace std {
   template<class T, class Container = deque<T>>
   class queue {
   public:
-    using value_type      = typename Container::value_type;
-    using reference       = typename Container::reference;
-    using const_reference = typename Container::const_reference;
-    using size_type       = typename Container::size_type;
+    using value_type      = Container::value_type;
+    using reference       = Container::reference;
+    using const_reference = Container::const_reference;
+    using size_type       = Container::size_type;
     using container_type  =          Container;
 
   protected:
@@ -16028,10 +16027,10 @@ namespace std {
            class Compare = less<typename Container::value_type>>
   class priority_queue {
   public:
-    using value_type      = typename Container::value_type;
-    using reference       = typename Container::reference;
-    using const_reference = typename Container::const_reference;
-    using size_type       = typename Container::size_type;
+    using value_type      = Container::value_type;
+    using reference       = Container::reference;
+    using const_reference = Container::const_reference;
+    using size_type       = Container::size_type;
     using container_type  = Container;
     using value_compare   = Compare;
 
@@ -16578,10 +16577,10 @@ namespace std {
   template<class T, class Container = deque<T>>
   class stack {
   public:
-    using value_type      = typename Container::value_type;
-    using reference       = typename Container::reference;
-    using const_reference = typename Container::const_reference;
-    using size_type       = typename Container::size_type;
+    using value_type      = Container::value_type;
+    using reference       = Container::reference;
+    using const_reference = Container::const_reference;
+    using size_type       = Container::size_type;
     using container_type  = Container;
 
   protected:
@@ -18912,8 +18911,8 @@ namespace std {
     using value_compare             = Compare;
     using reference                 = value_type&;
     using const_reference           = const value_type&;
-    using size_type                 = typename KeyContainer::size_type;
-    using difference_type           = typename KeyContainer::difference_type;
+    using size_type                 = KeyContainer::size_type;
+    using difference_type           = KeyContainer::difference_type;
     using iterator                  = @\impdefx{type of \tcode{flat_set::iterator}}@;  // see \ref{container.requirements}
     using const_iterator            = @\impdefx{type of \tcode{flat_set::const_iterator}}@;  // see \ref{container.requirements}
     using reverse_iterator          = std::reverse_iterator<iterator>;
@@ -19581,8 +19580,8 @@ namespace std {
     using value_compare             = Compare;
     using reference                 = value_type&;
     using const_reference           = const value_type&;
-    using size_type                 = typename KeyContainer::size_type;
-    using difference_type           = typename KeyContainer::difference_type;
+    using size_type                 = KeyContainer::size_type;
+    using difference_type           = KeyContainer::difference_type;
     using iterator                  = @\impdefx{type of \tcode{flat_multiset::iterator}}@;  // see \ref{container.requirements}
     using const_iterator            = @\impdefx{type of \tcode{flat_multiset::const_iterator}}@;  // see \ref{container.requirements}
     using reverse_iterator          = std::reverse_iterator<iterator>;
@@ -21937,9 +21936,9 @@ namespace std {
   class layout_left::mapping {
   public:
     using extents_type = Extents;
-    using index_type = typename extents_type::index_type;
-    using size_type = typename extents_type::size_type;
-    using rank_type = typename extents_type::rank_type;
+    using index_type = extents_type::index_type;
+    using size_type = extents_type::size_type;
+    using rank_type = extents_type::rank_type;
     using layout_type = layout_left;
 
     // \ref{mdspan.layout.left.cons}, constructors
@@ -22259,9 +22258,9 @@ namespace std {
   class layout_right::mapping {
   public:
     using extents_type = Extents;
-    using index_type = typename extents_type::index_type;
-    using size_type = typename extents_type::size_type;
-    using rank_type = typename extents_type::rank_type;
+    using index_type = extents_type::index_type;
+    using size_type = extents_type::size_type;
+    using rank_type = extents_type::rank_type;
     using layout_type = layout_right;
 
     // \ref{mdspan.layout.right.cons}, constructors
@@ -22584,9 +22583,9 @@ namespace std {
   class layout_stride::mapping {
   public:
     using extents_type = Extents;
-    using index_type = typename extents_type::index_type;
-    using size_type = typename extents_type::size_type;
-    using rank_type = typename extents_type::rank_type;
+    using index_type = extents_type::index_type;
+    using size_type = extents_type::size_type;
+    using rank_type = extents_type::rank_type;
     using layout_type = layout_stride;
 
   private:
@@ -22972,9 +22971,9 @@ namespace std {
     static constexpr size_t padding_value = PaddingValue;
 
     using extents_type = Extents;
-    using index_type = typename extents_type::index_type;
-    using size_type = typename extents_type::size_type;
-    using rank_type = typename extents_type::rank_type;
+    using index_type = extents_type::index_type;
+    using size_type = extents_type::size_type;
+    using rank_type = extents_type::rank_type;
     using layout_type = layout_left_padded<PaddingValue>;
 
   private:
@@ -23595,9 +23594,9 @@ namespace std {
     static constexpr size_t padding_value = PaddingValue;
 
     using extents_type = Extents;
-    using index_type = typename extents_type::index_type;
-    using size_type = typename extents_type::size_type;
-    using rank_type = typename extents_type::rank_type;
+    using index_type = extents_type::index_type;
+    using size_type = extents_type::size_type;
+    using rank_type = extents_type::rank_type;
     using layout_type = layout_right_padded<PaddingValue>;
 
   private:
@@ -24652,14 +24651,14 @@ namespace std {
     using extents_type = Extents;
     using layout_type = LayoutPolicy;
     using accessor_type = AccessorPolicy;
-    using mapping_type = typename layout_type::template mapping<extents_type>;
+    using mapping_type = layout_type::template mapping<extents_type>;
     using element_type = ElementType;
     using value_type = remove_cv_t<element_type>;
-    using index_type = typename extents_type::index_type;
-    using size_type = typename extents_type::size_type;
-    using rank_type = typename extents_type::rank_type;
-    using data_handle_type = typename accessor_type::data_handle_type;
-    using reference = typename accessor_type::reference;
+    using index_type = extents_type::index_type;
+    using size_type = extents_type::size_type;
+    using rank_type = extents_type::rank_type;
+    using data_handle_type = accessor_type::data_handle_type;
+    using reference = accessor_type::reference;
 
     static constexpr rank_type rank() noexcept { return extents_type::rank(); }
     static constexpr rank_type rank_dynamic() noexcept { return extents_type::rank_dynamic(); }

--- a/source/exec.tex
+++ b/source/exec.tex
@@ -4777,7 +4777,7 @@ is initialized with a callable object equivalent to the following lambda:
 []<class State, class Rcvr, class Tag, class... Args>(
     auto, State, Rcvr& rcvr, Tag, Args&&... args) noexcept -> void {
   if constexpr (@\libconcept{same_as}@<Tag, set_value_t>) {
-    using variant_type = typename State::type;
+    using variant_type = State::type;
     @\exposid{TRY-SET-VALUE}@(rcvr, variant_type(@\exposid{decayed-tuple}@<Args...>{std::forward<Args>(args)...}));
   } else {
     Tag()(std::move(rcvr), std::forward<Args>(args)...);
@@ -5057,7 +5057,7 @@ namespace std::execution {
     template<class Sndr, class... Env>
       static consteval void @\exposid{check-types}@() {                     // \expos
         using associate_data_t = remove_cvref_t<@\exposid{data-type}@<Sndr>>;
-        using child_type_t = typename associate_data_t::@\exposid{wrap-sender}@;
+        using child_type_t = associate_data_t::@\exposid{wrap-sender}@;
         (void)get_completion_signatures<child_type_t, @\exposid{FWD-ENV-T}@(Env)...>();
     }
   };

--- a/source/future.tex
+++ b/source/future.tex
@@ -293,11 +293,11 @@ namespace std {
   template<size_t Len, size_t Align = @\exposid{default-alignment}@> // \seebelow
     struct aligned_storage;
   template<size_t Len, size_t Align = @\exposid{default-alignment}@> // \seebelow
-    using @\libglobal{aligned_storage_t}@ = typename aligned_storage<Len, Align>::type;
+    using @\libglobal{aligned_storage_t}@ = aligned_storage<Len, Align>::type;
   template<size_t Len, class... Types>
     struct aligned_union;
   template<size_t Len, class... Types>
-    using @\libglobal{aligned_union_t}@ = typename aligned_union<Len, Types...>::type;
+    using @\libglobal{aligned_union_t}@ = aligned_union<Len, Types...>::type;
 }
 \end{codeblock}
 

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -1814,9 +1814,9 @@ namespace std {
   class basic_ios : public ios_base {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     // \ref{iostate.flags}, flags functions
@@ -2999,9 +2999,9 @@ namespace std {
   class basic_streambuf {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     virtual ~basic_streambuf();
@@ -4310,9 +4310,9 @@ namespace std {
   public:
     // types (inherited from \tcode{basic_ios}\iref{ios})
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     // \ref{istream.cons}, constructor/destructor
@@ -5803,9 +5803,9 @@ namespace std {
       public basic_ostream<charT, traits> {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     // \ref{iostream.cons}, constructor
@@ -5934,9 +5934,9 @@ namespace std {
   public:
     // types (inherited from \tcode{basic_ios}\iref{ios})
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     // \ref{ostream.cons}, constructor/destructor
@@ -8038,9 +8038,9 @@ namespace std {
   class basic_stringbuf : public basic_streambuf<charT, traits> {
   public:
     using char_type      = charT;
-    using int_type       = typename traits::int_type;
-    using pos_type       = typename traits::pos_type;
-    using off_type       = typename traits::off_type;
+    using int_type       = traits::int_type;
+    using pos_type       = traits::pos_type;
+    using off_type       = traits::off_type;
     using traits_type    = traits;
     using allocator_type = Allocator;
 
@@ -8898,9 +8898,9 @@ namespace std {
   class basic_istringstream : public basic_istream<charT, traits> {
   public:
     using char_type      = charT;
-    using int_type       = typename traits::int_type;
-    using pos_type       = typename traits::pos_type;
-    using off_type       = typename traits::off_type;
+    using int_type       = traits::int_type;
+    using pos_type       = traits::pos_type;
+    using off_type       = traits::off_type;
     using traits_type    = traits;
     using allocator_type = Allocator;
 
@@ -9269,9 +9269,9 @@ namespace std {
   class basic_ostringstream : public basic_ostream<charT, traits> {
   public:
     using char_type      = charT;
-    using int_type       = typename traits::int_type;
-    using pos_type       = typename traits::pos_type;
-    using off_type       = typename traits::off_type;
+    using int_type       = traits::int_type;
+    using pos_type       = traits::pos_type;
+    using off_type       = traits::off_type;
     using traits_type    = traits;
     using allocator_type = Allocator;
 
@@ -9640,9 +9640,9 @@ namespace std {
   class basic_stringstream : public basic_iostream<charT, traits> {
   public:
     using char_type      = charT;
-    using int_type       = typename traits::int_type;
-    using pos_type       = typename traits::pos_type;
-    using off_type       = typename traits::off_type;
+    using int_type       = traits::int_type;
+    using pos_type       = traits::pos_type;
+    using off_type       = traits::off_type;
     using traits_type    = traits;
     using allocator_type = Allocator;
 
@@ -10091,9 +10091,9 @@ namespace std {
     : public basic_streambuf<charT, traits> {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     // \ref{spanbuf.cons}, constructors
@@ -10418,9 +10418,9 @@ namespace std {
     : public basic_istream<charT, traits> {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     // \ref{ispanstream.cons}, constructors
@@ -10606,9 +10606,9 @@ namespace std {
     : public basic_ostream<charT, traits> {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     // \ref{ospanstream.cons}, constructors
@@ -10745,9 +10745,9 @@ namespace std {
     : public basic_iostream<charT, traits> {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     // \ref{spanstream.cons}, constructors
@@ -10989,9 +10989,9 @@ namespace std {
   class basic_filebuf : public basic_streambuf<charT, traits> {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
     using native_handle_type = @\impdefx{type of \tcode{native_handle_type}}@;   // see \ref{file.native}
 
@@ -11788,11 +11788,11 @@ namespace std {
   class basic_ifstream : public basic_istream<charT, traits> {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
-    using native_handle_type = typename basic_filebuf<charT, traits>::native_handle_type;
+    using native_handle_type = basic_filebuf<charT, traits>::native_handle_type;
 
     // \ref{ifstream.cons}, constructors
     basic_ifstream();
@@ -12047,11 +12047,11 @@ namespace std {
   class basic_ofstream : public basic_ostream<charT, traits> {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
-    using native_handle_type = typename basic_filebuf<charT, traits>::native_handle_type;
+    using native_handle_type = basic_filebuf<charT, traits>::native_handle_type;
 
     // \ref{ofstream.cons}, constructors
     basic_ofstream();
@@ -12304,11 +12304,11 @@ namespace std {
   class basic_fstream : public basic_iostream<charT, traits> {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
-    using native_handle_type = typename basic_filebuf<charT, traits>::native_handle_type;
+    using native_handle_type = basic_filebuf<charT, traits>::native_handle_type;
 
     // \ref{fstream.cons}, constructors
     basic_fstream();
@@ -12621,9 +12621,9 @@ namespace std {
   class basic_syncbuf : public basic_streambuf<charT, traits> {
   public:
     using char_type      = charT;
-    using int_type       = typename traits::int_type;
-    using pos_type       = typename traits::pos_type;
-    using off_type       = typename traits::off_type;
+    using int_type       = traits::int_type;
+    using pos_type       = traits::pos_type;
+    using off_type       = traits::off_type;
     using traits_type    = traits;
     using allocator_type = Allocator;
 
@@ -12934,9 +12934,9 @@ namespace std {
   class basic_osyncstream : public basic_ostream<charT, traits> {
   public:
     using char_type   = charT;
-    using int_type    = typename traits::int_type;
-    using pos_type    = typename traits::pos_type;
-    using off_type    = typename traits::off_type;
+    using int_type    = traits::int_type;
+    using pos_type    = traits::pos_type;
+    using off_type    = traits::off_type;
     using traits_type = traits;
 
     using allocator_type = Allocator;

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -771,7 +771,7 @@ namespace std {
   template<class T>
     requires requires { typename T::difference_type; }
   struct incrementable_traits<T> {
-    using difference_type = typename T::difference_type;
+    using difference_type = T::difference_type;
   };
 
   template<class T>
@@ -1016,11 +1016,11 @@ then
 \tcode{iterator_traits<I>}
 has the following publicly accessible members:
 \begin{codeblock}
-using iterator_category = typename I::iterator_category;
-using value_type        = typename I::value_type;
-using difference_type   = typename I::difference_type;
+using iterator_category = I::iterator_category;
+using value_type        = I::value_type;
+using difference_type   = I::difference_type;
 using pointer           = @\seebelow@;
-using reference         = typename I::reference;
+using reference         = I::reference;
 \end{codeblock}
 If the \grammarterm{qualified-id} \tcode{I::pointer} is valid and
 denotes a type, then \tcode{iterator_traits<I>::pointer} names that type;
@@ -1034,8 +1034,8 @@ Otherwise, if \tcode{I} satisfies the exposition-only concept
 publicly accessible members:
 \begin{codeblock}
 using iterator_category = @\seebelow@;
-using value_type        = typename indirectly_readable_traits<I>::value_type;
-using difference_type   = typename incrementable_traits<I>::difference_type;
+using value_type        = indirectly_readable_traits<I>::value_type;
+using difference_type   = incrementable_traits<I>::difference_type;
 using pointer           = @\seebelow@;
 using reference         = @\seebelow@;
 \end{codeblock}
@@ -3201,7 +3201,7 @@ namespace std {
     using iterator_category = @\seebelow@;
     using value_type        = iter_value_t<Iterator>;
     using difference_type   = iter_difference_t<Iterator>;
-    using pointer           = typename iterator_traits<Iterator>::pointer;
+    using pointer           = iterator_traits<Iterator>::pointer;
     using reference         = iter_reference_t<Iterator>;
 
     constexpr reverse_iterator();
@@ -5920,9 +5920,9 @@ namespace std {
     using value_type = iter_value_t<I>;                         // present only
                         // if \tcode{I} models \libconcept{indirectly_readable}
     using difference_type = iter_difference_t<I>;
-    using iterator_concept = typename I::iterator_concept;      // present only
+    using iterator_concept = I::iterator_concept;               // present only
                         // if the \grammarterm{qualified-id} \tcode{I::iterator_concept} is valid and denotes a type
-    using iterator_category = typename I::iterator_category;    // present only
+    using iterator_category = I::iterator_category;             // present only
                         // if the \grammarterm{qualified-id} \tcode{I::iterator_category} is valid and denotes a type
     constexpr counted_iterator() requires @\libconcept{default_initializable}@<I> = default;
     constexpr counted_iterator(I x, iter_difference_t<I> n);
@@ -6892,12 +6892,12 @@ namespace std {
   public:
     using iterator_category = input_iterator_tag;
     using value_type        = charT;
-    using difference_type   = typename traits::off_type;
+    using difference_type   = traits::off_type;
     using pointer           = @\unspec@;
     using reference         = charT;
     using char_type         = charT;
     using traits_type       = traits;
-    using int_type          = typename traits::int_type;
+    using int_type          = traits::int_type;
     using streambuf_type    = basic_streambuf<charT,traits>;
     using istream_type      = basic_istream<charT,traits>;
 

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -777,7 +777,7 @@ struct @\exposid{ptr-traits-elem}@          // \expos
 
 template<class T> requires requires { typename T::element_type; }
 struct @\exposid{ptr-traits-elem}@<T>
-{ using type = typename T::element_type; };
+{ using type = T::element_type; };
 
 template<template<class...> class SomePointer, class T, class... Args>
   requires (!requires { typename SomePointer<T, Args...>::element_type; })
@@ -1657,7 +1657,7 @@ namespace std {
   template<class Alloc> struct allocator_traits {
     using allocator_type     = Alloc;
 
-    using value_type         = typename Alloc::value_type;
+    using value_type         = Alloc::value_type;
 
     using pointer            = @\seebelow@;
     using const_pointer      = @\seebelow@;
@@ -5980,8 +5980,8 @@ namespace std {
   public:
     using value_type = T;
     using allocator_type = Allocator;
-    using pointer = typename allocator_traits<Allocator>::pointer;
-    using const_pointer = typename allocator_traits<Allocator>::const_pointer;
+    using pointer = allocator_traits<Allocator>::pointer;
+    using const_pointer = allocator_traits<Allocator>::const_pointer;
 
     // \ref{indirect.ctor}, constructors
     constexpr explicit indirect();
@@ -6838,8 +6838,8 @@ namespace std {
   public:
     using value_type = T;
     using allocator_type = Allocator;
-    using pointer = typename allocator_traits<Allocator>::pointer;
-    using const_pointer = typename allocator_traits<Allocator>::const_pointer;
+    using pointer = allocator_traits<Allocator>::pointer;
+    using const_pointer = allocator_traits<Allocator>::const_pointer;
 
     // \ref{polymorphic.ctor}, constructors
     constexpr explicit polymorphic();
@@ -8650,13 +8650,13 @@ namespace std {
     using outer_allocator_type = OuterAlloc;
     using inner_allocator_type = @\seebelow@;
 
-    using value_type           = typename OuterTraits::value_type;
-    using size_type            = typename OuterTraits::size_type;
-    using difference_type      = typename OuterTraits::difference_type;
-    using pointer              = typename OuterTraits::pointer;
-    using const_pointer        = typename OuterTraits::const_pointer;
-    using void_pointer         = typename OuterTraits::void_pointer;
-    using const_void_pointer   = typename OuterTraits::const_void_pointer;
+    using value_type           = OuterTraits::value_type;
+    using size_type            = OuterTraits::size_type;
+    using difference_type      = OuterTraits::difference_type;
+    using pointer              = OuterTraits::pointer;
+    using const_pointer        = OuterTraits::const_pointer;
+    using void_pointer         = OuterTraits::void_pointer;
+    using const_void_pointer   = OuterTraits::const_void_pointer;
 
     using propagate_on_container_copy_assignment = @\seebelow@;
     using propagate_on_container_move_assignment = @\seebelow@;

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -307,17 +307,17 @@ namespace std {
   template<class T> struct add_cv;
 
   template<class T>
-    using @\libglobal{remove_const_t}@    = typename remove_const<T>::type;
+    using @\libglobal{remove_const_t}@    = remove_const<T>::type;
   template<class T>
-    using @\libglobal{remove_volatile_t}@ = typename remove_volatile<T>::type;
+    using @\libglobal{remove_volatile_t}@ = remove_volatile<T>::type;
   template<class T>
-    using @\libglobal{remove_cv_t}@       = typename remove_cv<T>::type;
+    using @\libglobal{remove_cv_t}@       = remove_cv<T>::type;
   template<class T>
-    using @\libglobal{add_const_t}@       = typename add_const<T>::type;
+    using @\libglobal{add_const_t}@       = add_const<T>::type;
   template<class T>
-    using @\libglobal{add_volatile_t}@    = typename add_volatile<T>::type;
+    using @\libglobal{add_volatile_t}@    = add_volatile<T>::type;
   template<class T>
-    using @\libglobal{add_cv_t}@          = typename add_cv<T>::type;
+    using @\libglobal{add_cv_t}@          = add_cv<T>::type;
 
   // \ref{meta.trans.ref}, reference modifications
   template<class T> struct remove_reference;
@@ -325,38 +325,38 @@ namespace std {
   template<class T> struct add_rvalue_reference;
 
   template<class T>
-    using @\libglobal{remove_reference_t}@     = typename remove_reference<T>::type;
+    using @\libglobal{remove_reference_t}@     = remove_reference<T>::type;
   template<class T>
-    using @\libglobal{add_lvalue_reference_t}@ = typename add_lvalue_reference<T>::type;
+    using @\libglobal{add_lvalue_reference_t}@ = add_lvalue_reference<T>::type;
   template<class T>
-    using @\libglobal{add_rvalue_reference_t}@ = typename add_rvalue_reference<T>::type;
+    using @\libglobal{add_rvalue_reference_t}@ = add_rvalue_reference<T>::type;
 
   // \ref{meta.trans.sign}, sign modifications
   template<class T> struct make_signed;
   template<class T> struct make_unsigned;
 
   template<class T>
-    using @\libglobal{make_signed_t}@   = typename make_signed<T>::type;
+    using @\libglobal{make_signed_t}@   = make_signed<T>::type;
   template<class T>
-    using @\libglobal{make_unsigned_t}@ = typename make_unsigned<T>::type;
+    using @\libglobal{make_unsigned_t}@ = make_unsigned<T>::type;
 
   // \ref{meta.trans.arr}, array modifications
   template<class T> struct remove_extent;
   template<class T> struct remove_all_extents;
 
   template<class T>
-    using @\libglobal{remove_extent_t}@      = typename remove_extent<T>::type;
+    using @\libglobal{remove_extent_t}@      = remove_extent<T>::type;
   template<class T>
-    using @\libglobal{remove_all_extents_t}@ = typename remove_all_extents<T>::type;
+    using @\libglobal{remove_all_extents_t}@ = remove_all_extents<T>::type;
 
   // \ref{meta.trans.ptr}, pointer modifications
   template<class T> struct remove_pointer;
   template<class T> struct add_pointer;
 
   template<class T>
-    using @\libglobal{remove_pointer_t}@ = typename remove_pointer<T>::type;
+    using @\libglobal{remove_pointer_t}@ = remove_pointer<T>::type;
   template<class T>
-    using @\libglobal{add_pointer_t}@    = typename add_pointer<T>::type;
+    using @\libglobal{add_pointer_t}@    = add_pointer<T>::type;
 
   // \ref{meta.trans.other}, other transformations
   template<class T> struct type_identity;
@@ -375,29 +375,29 @@ namespace std {
   template<class T> struct unwrap_ref_decay;
 
   template<class T>
-    using @\libglobal{type_identity_t}@    = typename type_identity<T>::type;
+    using @\libglobal{type_identity_t}@    = type_identity<T>::type;
   template<class T>
-    using @\libglobal{remove_cvref_t}@     = typename remove_cvref<T>::type;
+    using @\libglobal{remove_cvref_t}@     = remove_cvref<T>::type;
   template<class T>
-    using @\libglobal{decay_t}@            = typename decay<T>::type;
+    using @\libglobal{decay_t}@            = decay<T>::type;
   template<bool B, class T = void>
-    using @\libglobal{enable_if_t}@        = typename enable_if<B, T>::type;
+    using @\libglobal{enable_if_t}@        = enable_if<B, T>::type;
   template<bool B, class T, class F>
-    using @\libglobal{conditional_t}@      = typename conditional<B, T, F>::type;
+    using @\libglobal{conditional_t}@      = conditional<B, T, F>::type;
   template<class... T>
-    using @\libglobal{common_type_t}@      = typename common_type<T...>::type;
+    using @\libglobal{common_type_t}@      = common_type<T...>::type;
   template<class... T>
-    using @\libglobal{common_reference_t}@ = typename common_reference<T...>::type;
+    using @\libglobal{common_reference_t}@ = common_reference<T...>::type;
   template<class T>
-    using @\libglobal{underlying_type_t}@  = typename underlying_type<T>::type;
+    using @\libglobal{underlying_type_t}@  = underlying_type<T>::type;
   template<class Fn, class... ArgTypes>
-    using @\libglobal{invoke_result_t}@    = typename invoke_result<Fn, ArgTypes...>::type;
+    using @\libglobal{invoke_result_t}@    = invoke_result<Fn, ArgTypes...>::type;
   template<class Fn, class Tuple>
-    using @\libglobal{apply_result_t}@     = typename apply_result<Fn, Tuple>::type;
+    using @\libglobal{apply_result_t}@     = apply_result<Fn, Tuple>::type;
   template<class T>
-    using unwrap_reference_t = typename unwrap_reference<T>::type;
+    using unwrap_reference_t = unwrap_reference<T>::type;
   template<class T>
-    using unwrap_ref_decay_t = typename unwrap_ref_decay<T>::type;
+    using unwrap_ref_decay_t = unwrap_ref_decay<T>::type;
   template<class...>
     using @\libglobal{void_t}@             = void;
 
@@ -841,7 +841,7 @@ namespace std {
   struct constant_wrapper : cw-operators {
     static constexpr const auto & value = X.@\exposid{data}@;
     using type = constant_wrapper;
-    using value_type = typename decltype(X)::@\exposid{type}@;
+    using value_type = decltype(X)::@\exposid{type}@;
 
     template<@\exposconcept{constexpr-param}@ R>
       constexpr auto operator=(R) const noexcept

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -3479,7 +3479,7 @@ namespace std {
   class discard_block_engine {
   public:
     // types
-    using result_type = typename Engine::result_type;
+    using result_type = Engine::result_type;
 
     // engine characteristics
     static constexpr size_t block_size = p;
@@ -3732,7 +3732,7 @@ namespace std {
   class shuffle_order_engine {
   public:
     // types
-    using result_type = typename Engine::result_type;
+    using result_type = Engine::result_type;
 
     // engine characteristics
     static constexpr size_t table_size = k;
@@ -12068,9 +12068,9 @@ namespace std::linalg {
     struct mapping {
     public:
       using extents_type = Extents;
-      using index_type = typename extents_type::index_type;
-      using size_type = typename extents_type::size_type;
-      using rank_type = typename extents_type::rank_type;
+      using index_type = extents_type::index_type;
+      using size_type = extents_type::size_type;
+      using rank_type = extents_type::rank_type;
       using layout_type = layout_blas_packed;
 
       // \ref{linalg.layout.packed.cons}, constructors
@@ -12789,7 +12789,7 @@ namespace std::linalg {
     using element_type =
       add_const_t<decltype(@\exposid{conj-if-needed}@(declval<NestedAccessor::element_type>()))>;
     using reference = remove_const_t<element_type>;
-    using data_handle_type = typename NestedAccessor::data_handle_type;
+    using data_handle_type = NestedAccessor::data_handle_type;
     using offset_policy = conjugated_accessor<NestedAccessor::offset_policy>;
 
     constexpr conjugated_accessor() = default;
@@ -13016,9 +13016,9 @@ namespace std::linalg {
 
     public:
       using extents_type = Extents;
-      using index_type = typename extents_type::index_type;
-      using size_type = typename extents_type::size_type;
-      using rank_type = typename extents_type::rank_type;
+      using index_type = extents_type::index_type;
+      using size_type = extents_type::size_type;
+      using rank_type = extents_type::rank_type;
       using layout_type = layout_transpose;
 
       constexpr explicit mapping(const @\exposid{nested-mapping-type}@&);
@@ -16256,7 +16256,7 @@ template<class V>
     @\exposconcept{simd-vec-type}@<V> && @\libconcept{integral}@<typename V::value_type>;
 
 template<class V>
-  using @\exposidnc{simd-complex-value-type}@ = typename V::value_type::value_type; // \expos
+  using @\exposidnc{simd-complex-value-type}@ = V::value_type::value_type; // \expos
 
 template<class V>
   concept @\defexposconceptnc{simd-complex}@ =                                             // \expos
@@ -16512,9 +16512,9 @@ namespace std::simd {
     constexpr size_t @\libmember{alignment_v}{simd}@ = alignment<T, U>::value;
 
   template<class T, class V> struct rebind { using type = @\seebelow@; };
-  template<class T, class V> using @\libmember{rebind_t}{simd}@ = typename rebind<T, V>::type;
+  template<class T, class V> using @\libmember{rebind_t}{simd}@ = rebind<T, V>::type;
   template<@\exposid{simd-size-type}@ N, class V> struct resize { using type = @\seebelow@; };
-  template<@\exposid{simd-size-type}@ N, class V> using @\libmember{resize_t}{simd}@ = typename resize<N, V>::type;
+  template<@\exposid{simd-size-type}@ N, class V> using @\libmember{resize_t}{simd}@ = resize<N, V>::type;
 
   // \ref{simd.flags}, load and store flags
   template<class... Flags> struct flags;
@@ -17312,7 +17312,7 @@ namespace std::simd {
     constexpr @\exposidnc{simd-iterator}@(V& d, @\exposidnc{simd-size-type}@ off) noexcept;         // \expos
 
   public:
-    using value_type = typename V::value_type;
+    using value_type = V::value_type;
     using iterator_category = input_iterator_tag;
     using iterator_concept = random_access_iterator_tag;
     using difference_type = @\exposid{simd-size-type}@;

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -8227,7 +8227,7 @@ namespace std::ranges {
     bool @\exposid{incremented_}@ = false;                              // \expos
 
   public:
-    using iterator_concept  = typename @\exposid{outer-iterator}@<Const>::iterator_concept;
+    using iterator_concept  = @\exposid{outer-iterator}@<Const>::iterator_concept;
 
     using iterator_category = @\seebelownc@;                    // present only if \exposid{Base}
                                                             // models \libconcept{forward_range}
@@ -12151,7 +12151,7 @@ namespace std::ranges {
 
   public:
     using iterator_category = @\seebelownc@;                        // not always present
-    using iterator_concept  = typename @\exposid{ziperator}@<Const>::iterator_concept;
+    using iterator_concept  = @\exposid{ziperator}@<Const>::iterator_concept;
     using value_type =
       remove_cvref_t<invoke_result_t<@\exposid{maybe-const}@<Const, F>&,
                                      range_reference_t<@\exposid{maybe-const}@<Const, Views>>...>>;
@@ -13395,7 +13395,7 @@ namespace std::ranges {
 
   public:
     using iterator_category = @\seebelow@;
-    using iterator_concept  = typename @\exposid{inner-iterator}@<Const>::iterator_concept;
+    using iterator_concept  = @\exposid{inner-iterator}@<Const>::iterator_concept;
     using value_type =
       remove_cvref_t<invoke_result_t<@\exposid{maybe-const}@<Const, F>&,
                                      @\exposid{REPEAT}@(range_reference_t<@\exposid{Base}@>, N)...>>;

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -2040,10 +2040,10 @@ namespace std {
     using traits_type            = traits;
     using value_type             = charT;
     using allocator_type         = Allocator;
-    using size_type              = typename allocator_traits<Allocator>::size_type;
-    using difference_type        = typename allocator_traits<Allocator>::difference_type;
-    using pointer                = typename allocator_traits<Allocator>::pointer;
-    using const_pointer          = typename allocator_traits<Allocator>::const_pointer;
+    using size_type              = allocator_traits<Allocator>::size_type;
+    using difference_type        = allocator_traits<Allocator>::difference_type;
+    using pointer                = allocator_traits<Allocator>::pointer;
+    using const_pointer          = allocator_traits<Allocator>::const_pointer;
     using reference              = value_type&;
     using const_reference        = const value_type&;
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -4826,7 +4826,7 @@ namespace std {
     using type = @\seebelow@;
   };
   template<class... Ts>
-    using common_comparison_category_t = typename common_comparison_category<Ts...>::type;
+    using common_comparison_category_t = common_comparison_category<Ts...>::type;
 
   // \ref{cmp.concept}, concept \libconcept{three_way_comparable}
   template<class T, class Cat = partial_ordering>
@@ -4838,7 +4838,7 @@ namespace std {
   template<class T, class U = T> struct compare_three_way_result;
 
   template<class T, class U = T>
-    using compare_three_way_result_t = typename compare_three_way_result<T, U>::type;
+    using compare_three_way_result_t = compare_three_way_result<T, U>::type;
 
   // \ref{comparisons.three.way}, class \tcode{compare_three_way}
   struct compare_three_way;
@@ -5826,7 +5826,7 @@ then \tcode{coroutine_traits<R, ArgTypes...>} has the following publicly
 accessible member:
 
 \begin{codeblock}
-using promise_type = typename R::promise_type;
+using promise_type = R::promise_type;
 \end{codeblock}
 
 Otherwise, \tcode{coroutine_traits<R, ArgTypes...>} has no members.

--- a/source/text.tex
+++ b/source/text.tex
@@ -1684,7 +1684,7 @@ namespace std {
   template<class charT>
     class ctype_byname : public ctype<charT> {
     public:
-      using mask = typename ctype<charT>::mask;
+      using mask = ctype<charT>::mask;
       explicit ctype_byname(const char*, size_t refs = 0);
       explicit ctype_byname(const string&, size_t refs = 0);
 
@@ -7448,7 +7448,7 @@ namespace std {
   class basic_format_parse_context {
   public:
     using char_type = charT;
-    using const_iterator = typename basic_string_view<charT>::const_iterator;
+    using const_iterator = basic_string_view<charT>::const_iterator;
     using iterator = const_iterator;
 
   private:
@@ -8428,7 +8428,7 @@ namespace std {
     class handle;
 
   private:
-    using char_type = typename Context::char_type;                              // \expos
+    using char_type = Context::char_type;                                       // \expos
 
     variant<monostate, bool, char_type,
             int, unsigned int, long long int, unsigned long long int,
@@ -10341,9 +10341,9 @@ namespace std {
       // types
       using value_type  =          charT;
       using traits_type =          traits;
-      using string_type = typename traits::string_type;
+      using string_type = traits::string_type;
       using flag_type   =          regex_constants::syntax_option_type;
-      using locale_type = typename traits::locale_type;
+      using locale_type = traits::locale_type;
 
       // \ref{re.synopt}, constants
       static constexpr flag_type icase = regex_constants::icase;
@@ -11173,7 +11173,7 @@ namespace std {
       using iterator        = const_iterator;
       using difference_type =
               typename iterator_traits<BidirectionalIterator>::difference_type;
-      using size_type       = typename allocator_traits<Allocator>::size_type;
+      using size_type       = allocator_traits<Allocator>::size_type;
       using allocator_type  = Allocator;
       using char_type       =
               typename iterator_traits<BidirectionalIterator>::value_type;

--- a/source/time.tex
+++ b/source/time.tex
@@ -1248,7 +1248,7 @@ namespace std::chrono {
   class duration {
   public:
     using rep    = Rep;
-    using period = typename Period::type;
+    using period = Period::type;
 
   private:
     rep rep_;       // \expos
@@ -2220,8 +2220,8 @@ namespace std::chrono {
   public:
     using clock    = Clock;
     using duration = Duration;
-    using rep      = typename duration::rep;
-    using period   = typename duration::period;
+    using rep      = duration::rep;
+    using period   = duration::period;
 
   private:
     duration d_;                                                // \expos

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1588,7 +1588,7 @@ namespace std {
     struct tuple_element<I, tuple<Types...>>;
 
   template<size_t I, class T>
-    using @\libglobal{tuple_element_t}@ = typename tuple_element<I, T>::type;
+    using @\libglobal{tuple_element_t}@ = tuple_element<I, T>::type;
 
   // \ref{tuple.elem}, element access
   template<size_t I, class... Types>
@@ -5567,7 +5567,7 @@ namespace std {
   template<size_t I, class T> struct variant_alternative;       // \notdef
   template<size_t I, class T> struct variant_alternative<I, const T>;
   template<size_t I, class T>
-    using @\libglobal{variant_alternative_t}@ = typename variant_alternative<I, T>::type;
+    using @\libglobal{variant_alternative_t}@ = variant_alternative<I, T>::type;
 
   template<size_t I, class... Types>
     struct variant_alternative<I, variant<Types...>>;

--- a/tools/check-source.sh
+++ b/tools/check-source.sh
@@ -133,11 +133,15 @@ grep -ne 'template\s\+<' $texlib |
 
 # In library declarations, constexpr should not follow explicit
 grep -ne '\bexplicit\b.*\bconstexpr\b' $texlib |
-    fail 'explicit constexpr' || failed=1
+    fail 'wrong order: explicit constexpr' || failed=1
 
 # In library declarations, static should not follow constexpr
 grep -ne '\bconstexpr\b.*\sstatic\s' $texlib |
-    fail 'constexpr static' || failed=1
+    fail 'wrong order: constexpr static' || failed=1
+
+# In library declarations, type aliases should not use typename
+grep -ne "using.*= typename" $texlib |
+    fail 'type alias with typename' || failed=1
 
 # "Class" heading without namespace
 for f in $texlib; do


### PR DESCRIPTION
Fixes NB US 64-127 (C++26 CD).

Also add an automatic check.

Fixes cplusplus/nbballot#706