### PR TITLE
[concept.regularinvocable], [iterator.concept.winc] Replace "annotation" with "comment"

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -1261,8 +1261,8 @@ The \tcode{invoke} function call expression shall be
 equality-preserving\iref{concepts.equality} and
 shall not modify the function object or the arguments.
 \begin{note}
-This requirement supersedes the annotation in the definition of
-\libconcept{invocable}.
+This requirement supersedes the ``not required to be equality-preserving'' comment
+in the definition of \libconcept{invocable}.
 \end{note}
 
 \pnum

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1588,7 +1588,8 @@ The \libconcept{incrementable} concept specifies requirements on types that can 
 and post-increment operators. The increment operations are required to be equality-preserving,
 and the type is required to be \libconcept{equality_comparable}.
 \begin{note}
-This supersedes the annotations on the increment expressions
+This supersedes the ``not required to be equality-preserving'' comments
+on the increment expressions
 in the definition of \libconcept{weakly_incrementable}.
 \end{note}
 


### PR DESCRIPTION
Fixes NB US 71-128 (C++26 CD).
Fixes https://github.com/cplusplus/nbballot/issues/707.

The NB comment only asks to replace "annotation" with "comment", which makes sense considering that we have a language construct called "annotation" now.

I went a step further and copied the contents of this comment here. This seems helpful because you immediately understand what the contents of those comments are without having to navigate elsewhere.

Note that "not required to be equality-preserving" is a special comment used in a large number of places, defined in https://eel.is/c++draft/concepts.equality#4 My intuition was initially to use a *Remarks* element instead, but that would be too large of a change.