### PR TITLE
[meta.define.static] qualify names from namespace meta

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -3391,7 +3391,7 @@ template<ranges::@\libconcept{input_range}@ R>
 \effects
 Equivalent to:
 \begin{codeblock}
-return extract<const ranges::range_value_t<R>*>(meta::reflect_constant_string(r));
+return meta::extract<const ranges::range_value_t<R>*>(meta::reflect_constant_string(r));
 \end{codeblock}
 \end{itemdescr}
 
@@ -3408,8 +3408,8 @@ Equivalent to:
 \begin{codeblock}
 using T = ranges::range_value_t<R>;
 meta::info array = meta::reflect_constant_array(r);
-if (is_array_type(type_of(array))) {
-  return span<const T>(extract<const T*>(array), extent(type_of(array)));
+if (meta::is_array_type(meta::type_of(array))) {
+  return span<const T>(meta::extract<const T*>(array), meta::extent(meta::type_of(array)));
 } else {
   return span<const T>();
 }
@@ -3428,8 +3428,8 @@ template<class T>
 Equivalent to:
 \begin{codeblock}
 using U = remove_cvref_t<T>;
-if constexpr (is_class_type(^^U)) {
-  return addressof(extract<const U&>(meta::reflect_constant(std::forward<T>(t))));
+if constexpr (meta::is_class_type(^^U)) {
+  return addressof(meta::extract<const U&>(meta::reflect_constant(std::forward<T>(t))));
 } else {
   return define_static_array(span(addressof(t), 1)).data();
 }


### PR DESCRIPTION
Within library wording we don't do ADL, only unqualified lookup (as per [contents] p3). This means that all the metafunctions in namespace std need to qualify names from namespace std::meta in order to find them.

This also fixes the bug that name lookup in the Effects: of define_static_array would find std::extent and not perform ADL to find std::meta::extent, even if ADL was performed here.