### PR TITLE
[text], [numerics], [exec] Remove remaining `typename` in aliases

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -5390,7 +5390,7 @@ namespace std::execution {
 
   private:
     using @\exposid{alloc-t}@ =                                                         // \expos
-      typename allocator_traits<Alloc>::template rebind_alloc<@\exposid{spawn-future-state}@>;
+      allocator_traits<Alloc>::template rebind_alloc<@\exposid{spawn-future-state}@>;
 
     @\exposid{alloc-t}@ @\exposid{alloc}@;                                                          // \expos
     @\exposid{ssource-t}@ @\exposid{ssource}@;                                                      // \expos
@@ -5905,7 +5905,7 @@ namespace std::execution {
 
   private:
     using @\exposid{alloc-t}@ =                                         // \expos
-      typename allocator_traits<Alloc>::template rebind_alloc<@\exposid{spawn-state}@>;
+      allocator_traits<Alloc>::template rebind_alloc<@\exposid{spawn-state}@>;
 
     @\exposid{alloc-t}@ @\exposid{alloc}@;                                          // \expos
     @\exposid{op-t}@ @\exposid{op}@;                                                // \expos

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -13012,7 +13012,7 @@ namespace std::linalg {
     struct mapping {
     private:
       using @\exposid{nested-mapping-type}@ =
-        typename Layout::template mapping<@\exposid{transpose-extents-t}@<Extents>>;   // \expos
+        Layout::template mapping<@\exposid{transpose-extents-t}@<Extents>>;  // \expos
 
     public:
       using extents_type = Extents;

--- a/source/text.tex
+++ b/source/text.tex
@@ -10842,10 +10842,8 @@ namespace std {
   template<class BidirectionalIterator>
     class sub_match : public pair<BidirectionalIterator, BidirectionalIterator> {
     public:
-      using value_type      =
-              typename iterator_traits<BidirectionalIterator>::value_type;
-      using difference_type =
-              typename iterator_traits<BidirectionalIterator>::difference_type;
+      using value_type      = iterator_traits<BidirectionalIterator>::value_type;
+      using difference_type = iterator_traits<BidirectionalIterator>::difference_type;
       using iterator        = BidirectionalIterator;
       using string_type     = basic_string<value_type>;
 
@@ -11171,12 +11169,10 @@ namespace std {
       using reference       = value_type&;
       using const_iterator  = @\impdefx{type of \tcode{match_results::const_iterator}}@;
       using iterator        = const_iterator;
-      using difference_type =
-              typename iterator_traits<BidirectionalIterator>::difference_type;
+      using difference_type = iterator_traits<BidirectionalIterator>::difference_type;
       using size_type       = allocator_traits<Allocator>::size_type;
       using allocator_type  = Allocator;
-      using char_type       =
-              typename iterator_traits<BidirectionalIterator>::value_type;
+      using char_type       = iterator_traits<BidirectionalIterator>::value_type;
       using string_type     = basic_string<char_type>;
 
       // \ref{re.results.const}, construct/copy/destroy


### PR DESCRIPTION
Follows up #8371. Some line breaking cases are overlooked before.