### PR TITLE
[lib] Replace bad uses of "instantiation" with "specialization"

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -2345,12 +2345,12 @@ For all \tcode{U} (including \tcode{T}),
 
 \pnum
 \remarks
-If \tcode{Allocator} is a class template instantiation of the form
+If \tcode{Allocator} is a class template specialization of the form
 \tcode{SomeAllocator<T, Args>}, where \tcode{Args} is zero or more type
 arguments, and \tcode{Allocator} does not supply a \tcode{rebind} member
 template, the standard \tcode{allocator_traits} template uses
 \tcode{SomeAllocator<U, Args>} in place of \tcode{Allocator::re\-bind<U>::other}
-by default. For allocator types that are not template instantiations of the
+by default. For allocator types that are not template specializations of the
 above form, no default is provided.
 
 \pnum
@@ -3072,7 +3072,7 @@ original template.
 Let \tcode{\placeholder{F}} denote
 a standard library function\iref{global.functions},
 a standard library static member function,
-or an instantiation
+or a specialization
 of a standard library function template.
 Unless \tcode{\placeholder{F}} is designated
 an \defnadj{addressable}{function},
@@ -3094,7 +3094,7 @@ to \tcode{\placeholder{F}}
 or
 if it attempts to form a pointer-to-member designating
 either a standard library non-static member function\iref{member.functions}
-or an instantiation of a standard library member function template.
+or a specialization of a standard library member function template.
 
 \pnum
 Let \tcode{\placeholder{F}} denote

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -841,7 +841,7 @@ template<class U> using rebind = @\seebelow@;
 the \grammarterm{qualified-id} \tcode{Ptr::rebind<U>} is valid and denotes a
 type\iref{temp.deduct}; otherwise,
 \tcode{SomePointer<U, Args>} if
-\tcode{Ptr} is a class template instantiation of the form \tcode{SomePointer<T, Args>},
+\tcode{Ptr} is a class template specialization of the form \tcode{SomePointer<T, Args>},
 where \tcode{Args} is zero or more type arguments; otherwise, the instantiation of
 \tcode{rebind} is ill-formed.
 \end{itemdescr}
@@ -1836,7 +1836,7 @@ template<class T> using rebind_alloc = @\seebelow@;
 \templalias \tcode{Alloc::rebind<T>::other} if
 the \grammarterm{qualified-id} \tcode{Alloc::rebind<T>::other} is valid and denotes a
 type\iref{temp.deduct}; otherwise,
-\tcode{Alloc<T, Args>} if \tcode{Alloc} is a class template instantiation
+\tcode{Alloc<T, Args>} if \tcode{Alloc} is a class template specialization
 of the form \tcode{Alloc<U, Args>}, where \tcode{Args} is zero or more type arguments;
 otherwise, the instantiation of \tcode{rebind_alloc} is ill-formed.
 \end{itemdescr}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -51,7 +51,7 @@ In other words, value types.
 These include arithmetic types,
 pointers, the library class
 \tcode{complex},
-and instantiations of
+and specializations of
 \tcode{valarray}
 for value types.
 \end{footnote}
@@ -4452,7 +4452,7 @@ Exactly $k$ invocations of \tcode{g} per attempt.
 \pnum
 \begin{note}
 If the values $g_i$ produced by \tcode{g} are uniformly distributed,
-the instantiation's results are distributed as uniformly as possible.
+\tcode{generate_canonical}'s results are distributed as uniformly as possible.
 Obtaining a value in this way
 can be a useful step
 in the process of transforming

--- a/source/text.tex
+++ b/source/text.tex
@@ -7734,7 +7734,7 @@ that appends to \tcode{wstring}.
 \recommended
 For a given type \tcode{charT},
 implementations should provide
-a single instantiation of \tcode{basic_format_context}
+a single specialization of \tcode{basic_format_context}
 for appending to
 \tcode{basic_string<charT>},
 \tcode{vector<charT>},

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -293,9 +293,9 @@ exception is thrown then a lock shall not have been acquired for the current exe
 \pnum
 A type \tcode{L} meets the \defnoldconcept{TimedLockable} requirements if it meets the \oldconcept{Lockable}
 requirements and the following expressions are well-formed and have the specified semantics
-(\tcode{m} denotes a value of type \tcode{L}, \tcode{rel_time} denotes a value of an
-instantiation of \tcode{duration}\iref{time.duration}, and \tcode{abs_time} denotes a value
-of an instantiation of \tcode{time_point}\iref{time.point}).
+(\tcode{m} denotes a value of type \tcode{L}, \tcode{rel_time} denotes a value of a
+specialization of \tcode{duration}\iref{time.duration}, and \tcode{abs_time} denotes a value
+of a specialization of \tcode{time_point}\iref{time.point}).
 
 \begin{itemdecl}
 m.try_lock_for(rel_time)
@@ -7555,10 +7555,10 @@ The \defn{timed mutex types} are the standard library types \tcode{timed_mutex},
 \tcode{recursive_timed_mutex}, and \tcode{shared_timed_mutex}. They
 meet the requirements set out below.
 In this description, \tcode{m} denotes an object of a mutex type,
-\tcode{rel_time} denotes an object of an
-instantiation of \tcode{duration}\iref{time.duration}, and \tcode{abs_time} denotes an
-object of an
-instantiation of \tcode{time_point}\iref{time.point}.
+\tcode{rel_time} denotes an object of a
+specialization of \tcode{duration}\iref{time.duration}, and \tcode{abs_time} denotes an
+object of a
+specialization of \tcode{time_point}\iref{time.point}.
 \begin{note}
 The timed mutex types meet the \oldconcept{TimedLockable}
 requirements\iref{thread.req.lockable.timed}.
@@ -7949,9 +7949,9 @@ timed mutex types\iref{thread.timedmutex.requirements},
 shared mutex types\iref{thread.sharedmutex.requirements}, and additionally
 meet the requirements set out below. In this description,
 \tcode{m} denotes an object of a shared timed mutex type,
-\tcode{rel_time} denotes an object of an instantiation of
+\tcode{rel_time} denotes an object of a specialization of
 \tcode{duration}\iref{time.duration}, and
-\tcode{abs_time} denotes an object of an instantiation of
+\tcode{abs_time} denotes an object of a specialization of
 \tcode{time_point}\iref{time.point}.
 \begin{note}
 The shared timed mutex types meet the \oldconcept{SharedTimedLockable}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1512,8 +1512,8 @@ Subclause~\ref{tuple} describes the tuple library that provides a tuple type as
 the class template \tcode{tuple} that can be instantiated with any number
 of arguments. Each template argument specifies
 the type of an element in the \tcode{tuple}.  Consequently, tuples are
-heterogeneous, fixed-size collections of values. An instantiation of \tcode{tuple} with
-two arguments is similar to an instantiation of \tcode{pair} with the same two arguments.
+heterogeneous, fixed-size collections of values. A specialization of \tcode{tuple} with
+two arguments behaves similarly to a specialization of \tcode{pair} with the same two arguments.
 See~\ref{pairs}.
 
 \pnum


### PR DESCRIPTION
Affected sections:
- [allocator.requirements.general]
- [namespace.std]
- [pointer.traits.types]
- [allocator.traits.types]
- [tuple.general]
- [format.context]
- [numeric.requirements]
- [rand.util.canonical]
- [thread.req.lockable.timed]
- [thread.sharedtimedmutex.requirements.general]

In [rand.util.canonical], it would be clearer to just say `generate_canonical` instead of "the instantiation" or "the specialization".

Drive-by change:
- In [tuple.general], change "is similar to" to "behaves similarly to" to avoid confusing with "similar types" in the core specification.

Fixes #8222.