### PR TITLE
[simd.complex.access], [simd.complex.math] Wrap "cmplx-func" placeholder in `\tcode`

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -19989,9 +19989,9 @@ template<@\exposconcept{simd-complex}@ V> constexpr V atanh(const V& v);
 \returns
 A \tcode{basic_vec} object \tcode{ret} where the $i^\text{th}$ element is
 initialized to the result of \tcode{\placeholder{cmplx-func}(v[$i$])} for all
-$i$ in the range \range{0}{V::size()}, where \placeholder{cmplx-func} is the
+$i$ in the range \range{0}{V::size()}, where \tcode{\placeholder{cmplx-func}} is the
 corresponding function from \libheader{complex}. If in an invocation of
-\placeholder{cmplx-func} for index $i$ a domain, pole, or range error would
+\tcode{\placeholder{cmplx-func}} for index $i$ a domain, pole, or range error would
 occur, the value of \tcode{ret[$i$]} is unspecified.
 
 \pnum
@@ -20013,9 +20013,9 @@ template<@\exposconcept{simd-complex}@ V> constexpr V pow(const V& x, const V& y
 \returns
 A \tcode{basic_vec} object \tcode{ret} where the $i^\text{th}$ element is
 initialized to the result of \tcode{\placeholder{cmplx-func}(x[$i$], y[$i$])}
-for all $i$ in the range \range{0}{V::size()}, where \placeholder{cmplx-func}
+for all $i$ in the range \range{0}{V::size()}, where \tcode{\placeholder{cmplx-func}}
 is the corresponding function from \libheader{complex}. If in an invocation of
-\placeholder{cmplx-func} for index $i$ a domain, pole, or range error would
+\tcode{\placeholder{cmplx-func}} for index $i$ a domain, pole, or range error would
 occur, the value of \tcode{ret[$i$]} is unspecified.
 
 \pnum


### PR DESCRIPTION
Without `\tcode`, it renders as regular italics, but we want code font italics.