### PR TITLE
[indirect.assign] Replace incorrect "_t" with "_v" in Mandates

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -6441,7 +6441,7 @@ constexpr indirect& operator=(indirect&& other)
 \begin{itemdescr}
 \pnum
 \mandates
-\tcode{is_copy_constructible_t<T>} is \tcode{true}.
+\tcode{is_copy_constructible_v<T>} is \tcode{true}.
 
 \pnum
 \effects


### PR DESCRIPTION
Fixes #8382.