### PR TITLE
[simd.alg] Avoid the word "shall" in Preconditions

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -19304,7 +19304,7 @@ template<class T, class Abi>
 
 \pnum
 \expects
-No element in \tcode{lo} shall be greater than the corresponding element in
+No element in \tcode{lo} is greater than the corresponding element in
 \tcode{hi}.
 
 \pnum


### PR DESCRIPTION
We normally use "shall" as a requirement for the implementation or for the program. Using it in a *Preconditions*: element seems wrong. 