### PR TITLE
[simd.math] Wrap code `\placeholder`s in `\tcode`

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -19465,8 +19465,8 @@ template<class V0, class V1>
 \begin{itemdescr}
 \pnum
 Let \tcode{Ret} denote the return type of the specialization of a function
-template with the name \placeholder{math-func}.
-Let \placeholder{math-func-vec} denote:
+template with the name \tcode{\placeholder{math-func}}.
+Let \tcode{\placeholder{math-func-vec}} denote:
 \begin{codeblock}
 template<class... Args>
 Ret @\placeholder{math-func-vec}@(Args... args) {
@@ -19479,10 +19479,10 @@ Ret @\placeholder{math-func-vec}@(Args... args) {
 \pnum
 \returns
 A value \tcode{ret} of type \tcode{Ret}, that is element-wise equal to the
-result of calling \placeholder{math-func-vec} with the arguments of the above
+result of calling \tcode{\placeholder{math-func-vec}} with the arguments of the above
 functions.
-If in an invocation of a scalar overload of \placeholder{math-func} for index
-\tcode{i} in \placeholder{math-func-vec} a domain, pole, or range error would
+If in an invocation of a scalar overload of \tcode{\placeholder{math-func}} for index
+\tcode{i} in \tcode{\placeholder{math-func-vec}} a domain, pole, or range error would
 occur, the value of \tcode{ret[i]} is unspecified.
 
 \pnum
@@ -19626,8 +19626,8 @@ template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-vec-t}@<V> sp
 \begin{itemdescr}
 \pnum
 Let \tcode{Ret} denote the return type of the specialization of a function
-template with the name \placeholder{math-func}.
-Let \placeholder{math-func-vec} denote:
+template with the name \tcode{\placeholder{math-func}}.
+Let \tcode{\placeholder{math-func-vec}} denote:
 \begin{codeblock}
 template<class... Args>
 Ret @\placeholder{math-func-vec}@(Args... args) {
@@ -19640,10 +19640,10 @@ Ret @\placeholder{math-func-vec}@(Args... args) {
 \pnum
 \returns
 A value \tcode{ret} of type \tcode{Ret}, that is element-wise approximately
-equal to the result of calling \placeholder{math-func-vec} with the arguments
+equal to the result of calling \tcode{\placeholder{math-func-vec}} with the arguments
 of the above functions.
-If in an invocation of a scalar overload of \placeholder{math-func} for index
-\tcode{i} in \placeholder{math-func-vec} a domain, pole, or range error would
+If in an invocation of a scalar overload of \tcode{\placeholder{math-func}} for index
+\tcode{i} in \tcode{\placeholder{math-func-vec}} a domain, pole, or range error would
 occur, the value of \tcode{ret[i]} is unspecified.
 
 \pnum
@@ -19660,7 +19660,7 @@ template<@\exposconcept{math-floating-point}@ V>
 \begin{itemdescr}
 \pnum
 Let \tcode{Ret} be \tcode{\exposid{deduced-vec-t}<V>}.
-Let \placeholder{frexp-vec} denote:
+Let \tcode{\placeholder{frexp-vec}} denote:
 \begin{codeblock}
 template<class V>
 pair<Ret, rebind_t<int, Ret>> @\placeholder{frexp-vec}@(const V& x) {
@@ -19673,7 +19673,7 @@ pair<Ret, rebind_t<int, Ret>> @\placeholder{frexp-vec}@(const V& x) {
 \end{codeblock}
 Let \tcode{ret} be a value of type \tcode{pair<Ret, rebind_t<int, Ret>>}
 that is the same value as the result of calling
-\placeholder{frexp-vec}\tcode{(x)}.
+\tcode{\placeholder{frexp-vec}(x)}.
 
 \pnum
 \effects
@@ -19694,7 +19694,7 @@ template<class V0, class V1>
 \begin{itemdescr}
 \pnum
 Let \tcode{Ret} be \tcode{\exposid{math-common-simd-t}<V0, V1>}.
-Let \placeholder{remquo-vec} denote:
+Let \tcode{\placeholder{remquo-vec}} denote:
 \begin{codeblock}
 template<class V0, class V1>
 pair<Ret, rebind_t<int, Ret>> @\placeholder{remquo-vec}@(const V0& x, const V1& y) {
@@ -19708,9 +19708,9 @@ pair<Ret, rebind_t<int, Ret>> @\placeholder{remquo-vec}@(const V0& x, const V1& 
 \end{codeblock}
 Let \tcode{ret} be a value of type \tcode{pair<Ret, rebind_t<int, Ret>>}
 that is the same value as the result of calling
-\placeholder{remquo-vec}\tcode{(x, y)}.
+\tcode{\placeholder{remquo-vec}(x, y)}.
 If in an invocation of a scalar overload of \tcode{remquo} for index \tcode{i}
-in \placeholder{remquo-vec} a domain, pole, or range error would occur, the
+in \tcode{\placeholder{remquo-vec}} a domain, pole, or range error would occur, the
 value of \tcode{ret[i]} is unspecified.
 
 \pnum
@@ -19736,7 +19736,7 @@ template<class T, class Abi>
 \begin{itemdescr}
 \pnum
 Let \tcode{V} be \tcode{basic_vec<T, Abi>}.
-Let \placeholder{modf-vec} denote:
+Let \tcode{\placeholder{modf-vec}} denote:
 \begin{codeblock}
 pair<V, V> @\placeholder{modf-vec}@(const V& x) {
   T r1[Ret::size()];
@@ -19747,7 +19747,7 @@ pair<V, V> @\placeholder{modf-vec}@(const V& x) {
 }
 \end{codeblock}
 Let \tcode{ret} be a value of type \tcode{pair<V, V>} that is the same value as
-the result of calling \placeholder{modf-vec}\tcode{(value)}.
+the result of calling \tcode{\placeholder{modf-vec}(value)}.
 
 \pnum
 \effects


### PR DESCRIPTION
`\placeholder` in regular prose renders as plain italics, but we want this to be code font and italics.