### PR TITLE
[simd.expos], [simd.syn] Synchronize synopsis references with subclause headings

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -16277,7 +16277,7 @@ template<class BinaryOperation, class T>
 template<class T> using @\exposidnc{native-abi} = \seebelownc@;                      // \expos
 template<class T, @\exposidnc{simd-size-type}@ N> using @\exposidnc{deduce-abi-t} = \seebelownc@;  // \expos
 
-// \ref{simd.flags}, Load and store flags
+// \ref{simd.flags}, load and store flags
 struct @\exposidnc{convert-flag}@;                                                 // \expos
 struct @\exposidnc{aligned-flag}@;                                                 // \expos
 template<size_t N> struct @\exposidnc{overaligned-flag}@;                          // \expos
@@ -16533,7 +16533,7 @@ namespace std::simd {
   template<class T, @\exposid{simd-size-type}@ N = @\exposid{simd-size-v}@<T, @\exposid{native-abi}@<T>>>
     using @\libmember{vec}{simd}@ = basic_vec<T, @\exposid{deduce-abi-t}@<T, N>>;
 
-  // \ref{simd.reductions}, \tcode{basic_vec} reductions
+  // \ref{simd.reductions}, reductions
   template<class T, class Abi, class BinaryOperation = plus<>>
     constexpr T reduce(const basic_vec<T, Abi>&, BinaryOperation = {});
   template<class T, class Abi, class BinaryOperation = plus<>>
@@ -16552,7 +16552,7 @@ namespace std::simd {
     constexpr T reduce_max(const basic_vec<T, Abi>&,
                            const typename basic_vec<T, Abi>::mask_type&) noexcept;
 
-  // \ref{simd.loadstore}, \tcode{basic_vec} load and store functions
+  // \ref{simd.loadstore}, load and store functions
   template<class V = @\seebelow@, ranges::@\libconcept{contiguous_range}@ R, class... Flags>
     requires ranges::@\libconcept{sized_range}@<R>
     constexpr V unchecked_load(R&& r, flags<Flags...> f = {});
@@ -16642,7 +16642,7 @@ namespace std::simd {
     constexpr void partial_store(const basic_vec<T, Abi>& v, I first, S last,
       const typename basic_vec<T, Abi>::mask_type& mask, flags<Flags...> f = {});
 
-  // \ref{simd.permute.static}, permute by static index generator
+  // \ref{simd.permute.static}, static permute
   static constexpr @\exposid{simd-size-type}@ @\libmember{zero_element}{simd}@   = @\impdefx{value of \tcode{simd::zero_element}}@;
   static constexpr @\exposid{simd-size-type}@ @\libmember{uninit_element}{simd}@ = @\impdefx{value of \tcode{simd::uninit_element}}@;
 
@@ -16651,13 +16651,13 @@ namespace std::simd {
   template<@\exposid{simd-size-type}@ N = @\seebelow@, @\exposconcept{simd-mask-type}@ M, class IdxMap>
     constexpr resize_t<N, M> permute(const M& v, IdxMap&& idxmap);
 
-  // \ref{simd.permute.dynamic}, permute by dynamic index
+  // \ref{simd.permute.dynamic}, dynamic permute
   template<@\exposconcept{simd-vec-type}@ V, @\exposconcept{simd-integral}@ I>
     constexpr resize_t<I::size(), V> permute(const V& v, const I& indices);
   template<@\exposconcept{simd-mask-type}@ M, @\exposconcept{simd-integral}@ I>
     constexpr resize_t<I::size(), M> permute(const M& v, const I& indices);
 
-  // \ref{simd.permute.mask}, permute by active mask bits
+  // \ref{simd.permute.mask}, mask permute
   template<@\exposconcept{simd-vec-type}@ V>
     constexpr V compress(const V& v, const typename V::mask_type& selector);
   template<@\exposconcept{simd-mask-type}@ M>
@@ -16676,7 +16676,7 @@ namespace std::simd {
     constexpr M expand(const M& v, const type_identity_t<M>& selector,
                        const M& original = {});
 
-  // \ref{simd.permute.memory}, permute to and from memory
+  // \ref{simd.permute.memory}, memory permute
   template<class V = @\seebelow@, ranges::@\libconcept{contiguous_range}@ R, @\exposconcept{simd-integral}@ I, class... Flags>
     requires ranges::@\libconcept{sized_range}@<R>
     constexpr V unchecked_gather_from(R&& in, const I& indices, flags<Flags...> f = {});
@@ -16711,7 +16711,7 @@ namespace std::simd {
     constexpr void partial_scatter_to(const V& v, R&& out, const typename I::mask_type& mask,
                                       const I& indices, flags<Flags...> f = {});
 
-  // \ref{simd.creation}, \tcode{basic_vec} and \tcode{basic_mask} creation
+  // \ref{simd.creation}, creation
   template<class T, class Abi>
     constexpr auto chunk(const basic_vec<typename T::value_type, Abi>& x) noexcept;
   template<class T, class Abi>
@@ -16956,7 +16956,7 @@ namespace std::simd {
     constexpr rebind_t<make_signed_t<typename V::value_type>, V>
       popcount(const V& v) noexcept;
 
-  // \ref{simd.complex.math}, \tcode{vec} complex math
+  // \ref{simd.complex.math}, complex math
   template<@\exposconcept{simd-complex}@ V>
     constexpr rebind_t<@\exposid{simd-complex-value-type<V>}@, V> real(const V&) noexcept;
 
@@ -17002,7 +17002,7 @@ namespace std::simd {
   template<class T, @\exposid{simd-size-type}@ N = @\exposid{simd-size-v}@<T, @\exposid{native-abi}@<T>>>
     using @\libmember{mask}{simd}@ = basic_mask<sizeof(T), @\exposid{deduce-abi-t}@<T, N>>;
 
-  // \ref{simd.mask.reductions}, \tcode{basic_mask} reductions
+  // \ref{simd.mask.reductions}, reductions
   template<size_t Bytes, class Abi>
     constexpr bool all_of(const basic_mask<Bytes, Abi>&) noexcept;
   template<size_t Bytes, class Abi>


### PR DESCRIPTION
Fixes NB US 181-294 (C++26 CD).
Fixes https://github.com/cplusplus/nbballot/issues/869.