### PR TITLE
[module.global.frag] Remove irrelevant note about preprocessor

### DIFF
--- a/source/modules.tex
+++ b/source/modules.tex
@@ -588,13 +588,6 @@ import M1;              // error: cyclic interface dependency $\mathtt{M3} \righ
 \end{bnf}
 
 \pnum
-\begin{note}
-Prior to phase 4 of translation,
-only preprocessing directives can appear
-in the \grammarterm{declaration-seq}\iref{cpp.pre}.
-\end{note}
-
-\pnum
 A \grammarterm{global-module-fragment} specifies the contents of the
 \defn{global module fragment} for a module unit.
 The global module fragment can be used to provide declarations


### PR DESCRIPTION
[module.global.frag] is entirely part of phase 7 of translation, and it makes no sense to talk of preprocessing directive in the grammar term *declaration-seq*.  Strike the note rather than try to turn it into something meaningful.