### PR TITLE
[cpp.pre] Add note on preprocessing directives in pp-global-module-fragment

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -302,6 +302,10 @@ with \impldef{supported forms of \#embed prefix parameters} semantics.
 At the start of phase 4 of translation,
 the \grammarterm{group} of a \grammarterm{pp-global-module-fragment} shall
 contain neither a \grammarterm{text-line} nor a \grammarterm{pp-import}.
+\begin{note}
+Executing preprocessing directives such as source file inclusion\iref{cpp.include}
+during phase 4 of translation can produce \grammarterm{text-line}s.
+\end{note}
 
 \pnum
 When in a group that is skipped\iref{cpp.cond}, the directive


### PR DESCRIPTION
Add a note confirming that executing preprocessor directives within the pp-global-module-fragment can produce text-lines.