### PR TITLE
[bit.cast] Adjust cross-reference for consteval-only type

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15705,7 +15705,7 @@ template<class To, class From>
 
 \pnum
 \mandates
-Neither \tcode{To} nor \tcode{From} are consteval-only types\iref{expr.const}.
+Neither \tcode{To} nor \tcode{From} are consteval-only types\iref{basic.types.general}.
 
 \pnum
 \constantwhen


### PR DESCRIPTION
... to point to the subclause ([basic.types.general]) containing the definition of the term.