### PR TITLE
[set.difference] Fix sentence

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -10716,8 +10716,8 @@ The elements in the constructed range are sorted.
   Otherwise, \tcode{\{j1, result_last\}}
   for the overloads in namespace \tcode{ranges},
   where the iterator \tcode{j1}
-  points to positions past the last copied or skipped elements
-  in \range{first1}{last1} and \range{first2}{last2}, respectively.
+  points to the position past the last copied or skipped element
+  in \range{first1}{last1}.
 \end{itemize}
 
 \pnum


### PR DESCRIPTION
A misapplication of P3179R9.

Fixes NB US 165-264 (C++26 CD).

Fixes cplusplus/nbballot#839