### PR TITLE
[const.wrap.class] Remove superfluous parameter in trailing requires clause

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -768,7 +768,7 @@ namespace std {
     // call and index
     template<@\exposconcept{constexpr-param}@ T, @\exposconcept{constexpr-param}@... Args>
       constexpr auto operator()(this T, Args...) noexcept
-        requires requires(Args...) { constant_wrapper<T::value(Args::value...)>(); }
+        requires requires { constant_wrapper<T::value(Args::value...)>(); }
           { return constant_wrapper<T::value(Args::value...)>{}; }
     template<@\exposconcept{constexpr-param}@ T, @\exposconcept{constexpr-param}@... Args>
       constexpr auto operator[](this T, Args...) noexcept


### PR DESCRIPTION
Fixes NB US 80-148 (C++26 CD).

Fixes cplusplus/nbballot#727