### PR TITLE
[basic.fundamental] Use `std::` prefix consistently for library type aliases

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5482,7 +5482,7 @@ whose underlying type is \tcode{\keyword{unsigned} \keyword{char}}.
 \indextext{type!underlying!\idxcode{char16_t}}%
 \indextext{type!underlying!\idxcode{char32_t}}%
 Types \keyword{char16_t} and \keyword{char32_t} denote distinct types
-whose underlying types are \tcode{uint_least16_t} and \tcode{uint_least32_t},
+whose underlying types are \tcode{std::uint_least16_t} and \tcode{std::uint_least32_t},
 respectively, in \libheaderref{cstdint}.
 
 \pnum


### PR DESCRIPTION
Later in [basic.fundamental], we use `std::nullptr_t`. To my understanding, we generally want to use `std::` when referring to library types from within core wording.

Perhaps there would have been an argument that `uint_least16_t` is a "C thing" and so unlike `std::nullptr_t`, it doesn't need a `std::` prefix, but now `nullptr_t` also exists in C23 which defeats any justification for this local inconsistency.