### PR TITLE
[re.regex.general] Fix indentation for member types of `basic_regex`

### DIFF
--- a/source/text.tex
+++ b/source/text.tex
@@ -10339,10 +10339,10 @@ namespace std {
     class basic_regex {
     public:
       // types
-      using value_type  =          charT;
-      using traits_type =          traits;
+      using value_type  = charT;
+      using traits_type = traits;
       using string_type = traits::string_type;
-      using flag_type   =          regex_constants::syntax_option_type;
+      using flag_type   = regex_constants::syntax_option_type;
       using locale_type = traits::locale_type;
 
       // \ref{re.synopt}, constants


### PR DESCRIPTION
After removing redundant `typename`, some indent spaces no longer make sense and thus should be removed.