### PR TITLE
[concepts.callable.general, concept.invocable] add function types and references

### DIFF
--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -1223,13 +1223,15 @@ fundamental types like \tcode{int} and that are comparable with
 
 \pnum
 The concepts in \ref{concepts.callable} describe the requirements on
-callable types\iref{func.def} and their arguments.
+function types, callable types\iref{func.def}, and references to such types,
+and on their arguments.
 
 \rSec2[concept.invocable]{Concept \cname{invocable}}
 
 \pnum
-The \libconcept{invocable} concept specifies a relationship between a callable
-type\iref{func.def} \tcode{F} and a set of argument types \tcode{Args...} which
+The \libconcept{invocable} concept specifies a relationship between \tcode{F}
+(where \tcode{F} is a function type, a callable type\iref{func.def}, or a
+reference to such a type) and a set of argument types \tcode{Args...} which
 can be evaluated by the library function \tcode{invoke}\iref{func.invoke}.
 
 \begin{itemdecl}


### PR DESCRIPTION
This is a follow-up to PR #8255 (and fixes Issue #8241).

In [\[concepts.callable.general\]](https://eel.is/c++draft/concepts.callable.general) and [\[concept.invocable\]](https://eel.is/c++draft/concept.invocable), it would be more appropriate to use "function types, callable types, and references to such types" instead of "callable types".