### PR TITLE
[container.adaptors.general] Remove using typename from expos-only alias template

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -15581,8 +15581,7 @@ The following exposition-only alias template
 may appear in deduction guides for container adaptors:
 \begin{codeblock}
 template<class Allocator, class T>
-  using @\exposid{alloc-rebind}@ =                      // \expos
-    typename allocator_traits<Allocator>::template rebind_alloc<T>;
+  using @\exposid{alloc-rebind}@ = allocator_traits<Allocator>::template rebind_alloc<T>;   // \expos
 \end{codeblock}
 
 \rSec2[queue.syn]{Header \tcode{<queue>} synopsis}


### PR DESCRIPTION
This should be the last case of `typename` in a type alias or alias template in the library, after manually inspected a search for all `typename` in the rendered pdf file.