### PR TITLE
[exec.spawn.future] add missing \tcode

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -5339,9 +5339,9 @@ namespace std::execution {
 \end{codeblock}
 
 \pnum
-Let \placeholder{ssource-t} be an unspecified type
+Let \tcode{\placeholder{ssource-t}} be an unspecified type
 that models \exposconcept{stoppable-source} and
-let \tcode{ssource} be an lvalue of type \placeholder{ssource-t}.
+let \tcode{ssource} be an lvalue of type \tcode{\placeholder{ssource-t}}.
 Let \tcode{\placeholder{stoken-t}} be \tcode{decltype(ssource.get_token())}.
 Let \exposid{future-spawned-sender} be the alias template:
 


### PR DESCRIPTION
"_ssource-t_" in [exec.spawn.future/p6](https://eel.is/c++draft/exec#spawn.future-6) should be in code font.

<img width="229" height="104" alt="image" src="https://github.com/user-attachments/assets/7c21e963-65ee-46cd-9854-11e6d9bbdcce" />
