### PR TITLE
[basic.def] Fix note -- declarations cannot be empty

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -186,9 +186,8 @@ A declaration can also have effects including:
 \begin{itemize}
 \item a static assertion\iref{dcl.pre},
 \item controlling template instantiation\iref{temp.explicit},
-\item guiding template argument deduction for constructors\iref{temp.deduct.guide},
-\item use of attributes\iref{dcl.attr}, and
-\item nothing (in the case of an \grammarterm{empty-declaration}).
+\item guiding template argument deduction for constructors\iref{temp.deduct.guide}, and
+\item use of attributes\iref{dcl.attr}.
 \end{itemize}
 \end{note}
 


### PR DESCRIPTION
As noted during CWG review of another issue.