### PR TITLE
[cpp.module] Note that private module fragments are not partitions

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1253,6 +1253,11 @@ No \grammarterm{identifier} in
 the \grammarterm{pp-module-name} or \grammarterm{pp-module-partition}
 shall currently be defined as an object-like macro.
 
+\begin{note}
+A \grammarterm{pp-private-module-fragment} is not a
+\grammarterm{pp-module-partition} without a \grammarterm{pp-module-name}.
+\end{note}
+
 \pnum
 Any preprocessing tokens after the \tcode{module} preprocessing token
 in the \tcode{module} directive are processed just as in normal text.


### PR DESCRIPTION
Add a note to avoid repeating the confusion behind NB US US 56-103. The grammar production for pp-global-module-fragment is pages away from where it would otherwise match as an ill-formed module partition.