### PR TITLE
[exec.cmplsig] add missing \exposid

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -6107,7 +6107,7 @@ names the type
                     @\itcorr[1]\exposid{META-APPLY}@(Tuple, Ts@$_{m-1}$@...))
 \end{codeblock}
 where $m$ is the size of the pack \tcode{TagFns} and
-\tcode{META-APPLY(T, As...)} is equivalent to:
+\tcode{\exposid{META-APPLY}(T, As...)} is equivalent to:
 \begin{codeblock}
 typename @\exposid{indirect-meta-apply}@<@\exposid{always-true}@<As...>>::template @\exposid{meta-apply}@<T, As...>
 \end{codeblock}


### PR DESCRIPTION
[[exec.cmplsig]/p6](https://eel.is/c++draft/exec#cmplsig-6) uses the exposition-only _`META-APPLY`_ without putting it in italics.

<img width="383" height="65" alt="image" src="https://github.com/user-attachments/assets/03872fc4-56a0-4d66-8cba-fe658b3bcd47" />
