### PR TITLE
[library] Remove references to typedef-name

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -530,10 +530,10 @@ and member functions\iref{functions.within.classes}.
 \rSec3[expos.only.entity]{Exposition-only entities, etc.}
 
 \pnum
-Several entities and \grammarterm{typedef-name}{s}
+Several entities
 defined in \ref{\firstlibchapter} through \ref{\lastlibchapter} and \ref{depr}
 are only defined for the purpose of exposition.
-The declaration of such an entity or \grammarterm{typedef-name}
+The declaration of such an entity
 is followed by a comment ending in \expos.
 
 \pnum
@@ -978,7 +978,7 @@ An implementation may use any technique that provides equivalent observable beha
 \pnum
 \indextext{item!freestanding|see{freestanding item}}%
 A \defn{freestanding item} is
-a declaration, entity, \grammarterm{typedef-name}, or macro
+a declaration, entity, or macro
 that is required to be present in
 a freestanding implementation and a hosted implementation.
 
@@ -1034,8 +1034,7 @@ namespace std {
 \pnum
 \indextext{entity!freestanding item}%
 \indextext{deduction guide!freestanding item}%
-\indextext{\idxgram{typedef-name}!freestanding item}%
-An entity, deduction guide, or \grammarterm{typedef-name}
+An entity or deduction guide
 is a freestanding item if its introducing declaration is not followed by
 a comment that includes \textit{hosted}, and is:
 \begin{itemize}
@@ -1045,7 +1044,7 @@ a comment that includes \textit{hosted}, and is:
 \item a deduction guide of a freestanding item,
 \item an enclosing namespace of a freestanding item,
 \item a friend of a freestanding item,
-\item denoted by a \grammarterm{typedef-name} that is a freestanding item, or
+\item denoted by a type alias that is a freestanding item, or
 \item denoted by an alias template that is a freestanding item.
 \end{itemize}
 
@@ -1662,7 +1661,7 @@ A freestanding implementation provides
 a (possibly empty) implementation-defined subset of
 the hosted library facilities.
 Unless otherwise specified, the requirements on
-each declaration, entity, \grammarterm{typedef-name}, and macro
+each declaration, entity, and macro
 provided in this way are the same as
 the corresponding requirements for a hosted implementation,
 except that not all of the members of the namespaces are required to be present.


### PR DESCRIPTION
Fixes NB US 62-114 (C++26 CD).

Fixes https://github.com/cplusplus/nbballot/issues/692.