### PR TITLE
[lex.token] Strike mention of whitespace in phase 7

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -879,15 +879,6 @@ There are five kinds of tokens: identifiers, keywords, literals,%
 Literals include strings and character and numeric literals.
 \end{footnote}
 operators, and other separators.
-\indextext{whitespace}%
-Comments and the characters \unicode{0020}{space}, \unicode{0009}{character tabulation},
-\unicode{000b}{line tabulation}, \unicode{000c}{form feed}, and new-line
-(collectively, ``whitespace''), as described below, are ignored except
-as they serve to separate tokens.
-\begin{note}
-Whitespace can separate otherwise adjacent identifiers, keywords, numeric
-literals, and alternative tokens containing alphabetic characters.
-\end{note}
 \indextext{token|)}
 
 \rSec1[lex.name]{Identifiers}


### PR DESCRIPTION
It is meaningless to talk of whitespace separating tokens in phase 7 as whitespace is discarded at the end of phase 4.