### PR TITLE
[cpp.pre] Apply unicode markup to last parts of [pre]

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -310,7 +310,7 @@ between preprocessing tokens
 within a preprocessing directive
 (from just after the directive-introducing token
 through just before the terminating new-line character)
-are space and horizontal-tab
+are \unicode{0020}{space} and \unicode{0009}{character tabulation}
 (including spaces that have replaced comments
 or possibly other whitespace characters
 in translation phase 3).


### PR DESCRIPTION
This should complete the process of applying unicode code point markup to denote specific characters for the grammar in the preprocessing clause.