### PR TITLE
[atomics.syn] Reword the freestanding specification

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -2449,11 +2449,11 @@ namespace std {
   template<class T>
     constexpr void atomic_store(atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
-    void atomic_store_explicit(volatile atomic<T>*,
-                               typename atomic<T>::value_type, memory_order) noexcept;
+    void atomic_store_explicit(volatile atomic<T>*, typename atomic<T>::value_type,
+                               memory_order) noexcept;
   template<class T>
-    constexpr void atomic_store_explicit(atomic<T>*,
-                                         typename atomic<T>::value_type, memory_order) noexcept;
+    constexpr void atomic_store_explicit(atomic<T>*, typename atomic<T>::value_type,
+                                         memory_order) noexcept;
   template<class T>
     T atomic_load(const volatile atomic<T>*) noexcept;
   template<class T>
@@ -2467,11 +2467,11 @@ namespace std {
   template<class T>
     constexpr T atomic_exchange(atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
-    T atomic_exchange_explicit(volatile atomic<T>*,
-                               typename atomic<T>::value_type, memory_order) noexcept;
+    T atomic_exchange_explicit(volatile atomic<T>*, typename atomic<T>::value_type,
+                               memory_order) noexcept;
   template<class T>
-    constexpr T atomic_exchange_explicit(atomic<T>*,
-                                         typename atomic<T>::value_type, memory_order) noexcept;
+    constexpr T atomic_exchange_explicit(atomic<T>*, typename atomic<T>::value_type,
+                                         memory_order) noexcept;
   template<class T>
     bool atomic_compare_exchange_weak(volatile atomic<T>*,
                                       typename atomic<T>::value_type*,
@@ -2514,151 +2514,141 @@ namespace std {
   template<class T>
     constexpr T atomic_fetch_add(atomic<T>*, typename atomic<T>::difference_type) noexcept;
   template<class T>
-    T atomic_fetch_add_explicit(volatile atomic<T>*,
-                                typename atomic<T>::difference_type, memory_order) noexcept;
+    T atomic_fetch_add_explicit(volatile atomic<T>*, typename atomic<T>::difference_type,
+                                memory_order) noexcept;
   template<class T>
-    constexpr T atomic_fetch_add_explicit(atomic<T>*,
-                                          typename atomic<T>::difference_type,
+    constexpr T atomic_fetch_add_explicit(atomic<T>*, typename atomic<T>::difference_type,
                                           memory_order) noexcept;
   template<class T>
     T atomic_fetch_sub(volatile atomic<T>*, typename atomic<T>::difference_type) noexcept;
   template<class T>
     constexpr T atomic_fetch_sub(atomic<T>*, typename atomic<T>::difference_type) noexcept;
   template<class T>
-    T atomic_fetch_sub_explicit(volatile atomic<T>*,
-                                typename atomic<T>::difference_type, memory_order) noexcept;
+    T atomic_fetch_sub_explicit(volatile atomic<T>*, typename atomic<T>::difference_type,
+                                memory_order) noexcept;
   template<class T>
-    constexpr T atomic_fetch_sub_explicit(atomic<T>*,
-                                          typename atomic<T>::difference_type,
+    constexpr T atomic_fetch_sub_explicit(atomic<T>*, typename atomic<T>::difference_type,
                                           memory_order) noexcept;
   template<class T>
     T atomic_fetch_and(volatile atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
     constexpr T atomic_fetch_and(atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
-    T atomic_fetch_and_explicit(volatile atomic<T>*,
-                                typename atomic<T>::value_type, memory_order) noexcept;
+    T atomic_fetch_and_explicit(volatile atomic<T>*, typename atomic<T>::value_type,
+                                memory_order) noexcept;
   template<class T>
-    constexpr T atomic_fetch_and_explicit(atomic<T>*,
-                                          typename atomic<T>::value_type, memory_order) noexcept;
+    constexpr T atomic_fetch_and_explicit(atomic<T>*, typename atomic<T>::value_type,
+                                          memory_order) noexcept;
   template<class T>
     T atomic_fetch_or(volatile atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
     constexpr T atomic_fetch_or(atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
-    T atomic_fetch_or_explicit(volatile atomic<T>*,
-                               typename atomic<T>::value_type, memory_order) noexcept;
+    T atomic_fetch_or_explicit(volatile atomic<T>*, typename atomic<T>::value_type,
+                               memory_order) noexcept;
   template<class T>
-    constexpr T atomic_fetch_or_explicit(atomic<T>*,
-                                         typename atomic<T>::value_type, memory_order) noexcept;
+    constexpr T atomic_fetch_or_explicit(atomic<T>*, typename atomic<T>::value_type,
+                                         memory_order) noexcept;
   template<class T>
     T atomic_fetch_xor(volatile atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
     constexpr T atomic_fetch_xor(atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
-    T atomic_fetch_xor_explicit(volatile atomic<T>*,
-                                typename atomic<T>::value_type, memory_order) noexcept;
+    T atomic_fetch_xor_explicit(volatile atomic<T>*, typename atomic<T>::value_type,
+                                memory_order) noexcept;
   template<class T>
-    constexpr T atomic_fetch_xor_explicit(atomic<T>*,
-                                          typename atomic<T>::value_type, memory_order) noexcept;
+    constexpr T atomic_fetch_xor_explicit(atomic<T>*, typename atomic<T>::value_type,
+                                          memory_order) noexcept;
   template<class T>
     T atomic_fetch_max(volatile atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
     constexpr T atomic_fetch_max(atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
-    T atomic_fetch_max_explicit(volatile atomic<T>*,
-                                typename atomic<T>::value_type, memory_order) noexcept;
+    T atomic_fetch_max_explicit(volatile atomic<T>*, typename atomic<T>::value_type,
+                                memory_order) noexcept;
   template<class T>
-    constexpr T atomic_fetch_max_explicit(atomic<T>*,
-                                          typename atomic<T>::value_type, memory_order) noexcept;
+    constexpr T atomic_fetch_max_explicit(atomic<T>*, typename atomic<T>::value_type,
+                                          memory_order) noexcept;
   template<class T>
     T atomic_fetch_min(volatile atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
     constexpr T atomic_fetch_min(atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
-    T atomic_fetch_min_explicit(volatile atomic<T>*,
-                                typename atomic<T>::value_type, memory_order) noexcept;
+    T atomic_fetch_min_explicit(volatile atomic<T>*, typename atomic<T>::value_type,
+                                memory_order) noexcept;
   template<class T>
-    constexpr T atomic_fetch_min_explicit(atomic<T>*,
-                                          typename atomic<T>::value_type, memory_order) noexcept;
+    constexpr T atomic_fetch_min_explicit(atomic<T>*, typename atomic<T>::value_type,
+                                          memory_order) noexcept;
 
   template<class T>
     void atomic_store_add(volatile atomic<T>*, typename atomic<T>::difference_type) noexcept;
   template<class T>
     constexpr void atomic_store_add(atomic<T>*, typename atomic<T>::difference_type) noexcept;
   template<class T>
-    void atomic_store_add_explicit(volatile atomic<T>*,
-                                   typename atomic<T>::difference_type, memory_order) noexcept;
+    void atomic_store_add_explicit(volatile atomic<T>*, typename atomic<T>::difference_type,
+                                   memory_order) noexcept;
   template<class T>
-    constexpr void atomic_store_add_explicit(atomic<T>*,
-                                             typename atomic<T>::difference_type,
+    constexpr void atomic_store_add_explicit(atomic<T>*, typename atomic<T>::difference_type,
                                              memory_order) noexcept;
   template<class T>
     void atomic_store_sub(volatile atomic<T>*, typename atomic<T>::difference_type) noexcept;
   template<class T>
     constexpr void atomic_store_sub(atomic<T>*, typename atomic<T>::difference_type) noexcept;
   template<class T>
-    void atomic_store_sub_explicit(volatile atomic<T>*,
-                                   typename atomic<T>::difference_type,
+    void atomic_store_sub_explicit(volatile atomic<T>*, typename atomic<T>::difference_type,
                                    memory_order) noexcept;
   template<class T>
-    constexpr void atomic_store_sub_explicit(atomic<T>*,
-                                             typename atomic<T>::difference_type,
+    constexpr void atomic_store_sub_explicit(atomic<T>*, typename atomic<T>::difference_type,
                                              memory_order) noexcept;
   template<class T>
     void atomic_store_and(volatile atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
     constexpr void atomic_store_and(atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
-    void atomic_store_and_explicit(volatile atomic<T>*,
-                                   typename atomic<T>::value_type, memory_order) noexcept;
+    void atomic_store_and_explicit(volatile atomic<T>*, typename atomic<T>::value_type,
+                                   memory_order) noexcept;
   template<class T>
-    constexpr void atomic_store_and_explicit(atomic<T>*,
-                                             typename atomic<T>::value_type,
+    constexpr void atomic_store_and_explicit(atomic<T>*, typename atomic<T>::value_type,
                                              memory_order) noexcept;
   template<class T>
     void atomic_store_or(volatile atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
     constexpr void atomic_store_or(atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
-    void atomic_store_or_explicit(volatile atomic<T>*,
-                                  typename atomic<T>::value_type, memory_order) noexcept;
+    void atomic_store_or_explicit(volatile atomic<T>*, typename atomic<T>::value_type,
+                                  memory_order) noexcept;
   template<class T>
-    constexpr void atomic_store_or_explicit(atomic<T>*,
-                                            typename atomic<T>::value_type,
+    constexpr void atomic_store_or_explicit(atomic<T>*, typename atomic<T>::value_type,
                                             memory_order) noexcept;
   template<class T>
     void atomic_store_xor(volatile atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
     constexpr void atomic_store_xor(atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
-    void atomic_store_xor_explicit(volatile atomic<T>*,
-                                   typename atomic<T>::value_type, memory_order) noexcept;
+    void atomic_store_xor_explicit(volatile atomic<T>*, typename atomic<T>::value_type,
+                                   memory_order) noexcept;
   template<class T>
-    constexpr void atomic_store_xor_explicit(atomic<T>*,
-                                             typename atomic<T>::value_type,
+    constexpr void atomic_store_xor_explicit(atomic<T>*, typename atomic<T>::value_type,
                                              memory_order) noexcept;
   template<class T>
     void atomic_store_max(volatile atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
     constexpr void atomic_store_max(atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
-    void atomic_store_max_explicit(volatile atomic<T>*,
-                                   typename atomic<T>::value_type, memory_order) noexcept;
+    void atomic_store_max_explicit(volatile atomic<T>*, typename atomic<T>::value_type,
+                                   memory_order) noexcept;
   template<class T>
-    constexpr void atomic_store_max_explicit(atomic<T>*,
-                                             typename atomic<T>::value_type,
+    constexpr void atomic_store_max_explicit(atomic<T>*, typename atomic<T>::value_type,
                                              memory_order) noexcept;
   template<class T>
     void atomic_store_min(volatile atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
     constexpr void atomic_store_min(atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
-    void atomic_store_min_explicit(volatile atomic<T>*,
-                                   typename atomic<T>::value_type, memory_order) noexcept;
+    void atomic_store_min_explicit(volatile atomic<T>*, typename atomic<T>::value_type,
+                                   memory_order) noexcept;
   template<class T>
-    constexpr void atomic_store_min_explicit(atomic<T>*,
-                                             typename atomic<T>::value_type,
+    constexpr void atomic_store_min_explicit(atomic<T>*, typename atomic<T>::value_type,
                                              memory_order) noexcept;
 
   template<class T>
@@ -2666,11 +2656,11 @@ namespace std {
   template<class T>
     constexpr void atomic_wait(const atomic<T>*, typename atomic<T>::value_type) noexcept;
   template<class T>
-    void atomic_wait_explicit(const volatile atomic<T>*,
-                              typename atomic<T>::value_type, memory_order) noexcept;
+    void atomic_wait_explicit(const volatile atomic<T>*, typename atomic<T>::value_type,
+                              memory_order) noexcept;
   template<class T>
-    constexpr void atomic_wait_explicit(const atomic<T>*,
-                                        typename atomic<T>::value_type, memory_order) noexcept;
+    constexpr void atomic_wait_explicit(const atomic<T>*, typename atomic<T>::value_type,
+                                        memory_order) noexcept;
   template<class T>
     void atomic_notify_one(volatile atomic<T>*) noexcept;
   template<class T>
@@ -2732,8 +2722,8 @@ namespace std {
   using atomic_intmax_t       = atomic<intmax_t>;
   using atomic_uintmax_t      = atomic<uintmax_t>;
 
-  using atomic_signed_lock_free   = @\seebelow@;                                    // hosted
-  using atomic_unsigned_lock_free = @\seebelow@;                                    // hosted
+  using atomic_signed_lock_free   = @\seebelow@;                  // hosted
+  using atomic_unsigned_lock_free = @\seebelow@;                  // hosted
 
   // \ref{atomics.flag}, flag type and operations
   struct atomic_flag;


### PR DESCRIPTION
Mark the `<atomic>` header `// mostly freestanding`, remove all the `// freestanding` comments, and add `// hosted` comments for `atomic_signed_lock_free` and `atomic_unsigned_lock_free`.

Fix https://github.com/cplusplus/nbballot/issues/882

cc @jwakely 