### PR TITLE
[lex.comment] Add a note that comments are replaced by a single space

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -525,6 +525,12 @@ are treated just like other characters. Similarly, the comment
 characters \tcode{//} and \tcode{/*} have no special meaning within a
 \tcode{/*} comment.
 \end{note}
+\begin{note}
+Comments are turned into \unicode{0020}{space} characters in
+phase 3 of translation as part of decomposing a source file into
+preprocessing tokens and sequences of whitespace characters.
+\end{note}
+
 \indextext{comment|)}
 
 \rSec1[lex.pptoken]{Preprocessing tokens}


### PR DESCRIPTION
Add a note about the transience of comments, that are immediately replaced by space characters as they are parsed.