### PR TITLE
[lex.pptoken] Turn non-normative text into a note

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -561,6 +561,8 @@ match the other preprocessing token categories.
 If a \unicode{0027}{apostrophe}, a \unicode{0022}{quotation mark},
 or any character not in the basic character set
 matches the last category, the program is ill-formed.
+
+\pnum
 Preprocessing tokens can be separated by
 \indextext{whitespace}%
 whitespace;
@@ -571,12 +573,14 @@ this consists of comments\iref{lex.comment}, or whitespace characters
 new-line,
 \unicode{000b}{line tabulation}, and
 \unicode{000c}{form feed}), or both.
+\begin{note}
 As described in \ref{cpp}, in certain
 circumstances during translation phase 4, whitespace (or the absence
 thereof) serves as more than preprocessing token separation. Whitespace
 can appear within a preprocessing token only as part of a header name or
 between the quotation characters in a character literal or
 string literal.
+\end{note}
 
 \pnum
 Each preprocessing token that is converted to a token\iref{lex.token}


### PR DESCRIPTION
The last part of this paragraph is non-normative, so turn it into a note.  Also, the preceding sentence defining whitespace characters is mostly unrelated to the precedingd defintion of preprocessing tokens, so start a new paragraph to more clearly show the comment assoication.