### PR TITLE
[lex.charset] Move reference to glyphs to appropriate place

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -317,6 +317,9 @@ A Unicode scalar value is any code point that is not a surrogate code point.
 \pnum
 The \defnadj{basic}{character set} is a subset of the translation character set,
 consisting of 99 characters as specified in \tref{lex.charset.basic}.
+In this document,
+glyphs are often used to identify
+elements of the basic character set.
 \begin{note}
 Unicode short names are given only as a means to identifying the character;
 the numerical value has no other meaning in this context.
@@ -548,9 +551,6 @@ characters \tcode{//} and \tcode{/*} have no special meaning within a
 \pnum
 A preprocessing token is the minimal lexical element of the language in translation
 phases 3 through 5.
-In this document,
-glyphs are used to identify
-elements of the basic character set\iref{lex.charset}.
 The categories of preprocessing token are: header names,
 placeholder tokens produced by preprocessing \tcode{import} and \tcode{module} directives
 (\grammarterm{import-keyword}, \grammarterm{module-keyword}, and \grammarterm{export-keyword}),


### PR DESCRIPTION
The statement that glyphs are used to identify members of the basic character set does not belong separating two sentences introducing and then defining preprocessing tokens.

Also, we do not *exlusively* use glyphs for this purpose but also directly call out Unicode code points too, so tone down the phrasing to glyphs are *often* used to ...