### PR TITLE
[specialized.algorithms] Remove typename after new

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -13726,8 +13726,7 @@ template<class NoThrowForwardIterator>
 Equivalent to:
 \begin{codeblock}
 for (; first != last; ++first)
-  ::new (@\placeholdernc{voidify}@(*first))
-    typename iterator_traits<NoThrowForwardIterator>::value_type;
+  ::new (@\placeholdernc{voidify}@(*first)) iterator_traits<NoThrowForwardIterator>::value_type;
 \end{codeblock}
 \end{itemdescr}
 
@@ -13767,8 +13766,7 @@ template<class NoThrowForwardIterator, class Size>
 Equivalent to:
 \begin{codeblock}
 for (; n > 0; (void)++first, --n)
-  ::new (@\placeholdernc{voidify}@(*first))
-    typename iterator_traits<NoThrowForwardIterator>::value_type;
+  ::new (@\placeholdernc{voidify}@(*first)) iterator_traits<NoThrowForwardIterator>::value_type;
 return first;
 \end{codeblock}
 \end{itemdescr}
@@ -13807,8 +13805,7 @@ template<class NoThrowForwardIterator>
 Equivalent to:
 \begin{codeblock}
 for (; first != last; ++first)
-  ::new (@\placeholdernc{voidify}@(*first))
-    typename iterator_traits<NoThrowForwardIterator>::value_type();
+  ::new (@\placeholdernc{voidify}@(*first)) iterator_traits<NoThrowForwardIterator>::value_type();
 \end{codeblock}
 \end{itemdescr}
 
@@ -13848,8 +13845,7 @@ template<class NoThrowForwardIterator, class Size>
 Equivalent to:
 \begin{codeblock}
 for (; n > 0; (void)++first, --n)
-  ::new (@\placeholdernc{voidify}@(*first))
-    typename iterator_traits<NoThrowForwardIterator>::value_type();
+  ::new (@\placeholdernc{voidify}@(*first)) iterator_traits<NoThrowForwardIterator>::value_type();
 return first;
 \end{codeblock}
 \end{itemdescr}
@@ -13892,8 +13888,7 @@ template<class InputIterator, class NoThrowForwardIterator>
 Equivalent to:
 \begin{codeblock}
 for (; first != last; ++result, (void)++first)
-  ::new (@\placeholdernc{voidify}@(*result))
-    typename iterator_traits<NoThrowForwardIterator>::value_type(*first);
+  ::new (@\placeholdernc{voidify}@(*result)) iterator_traits<NoThrowForwardIterator>::value_type(*first);
 \end{codeblock}
 
 \pnum
@@ -13948,8 +13943,7 @@ template<class InputIterator, class Size, class NoThrowForwardIterator>
 Equivalent to:
 \begin{codeblock}
 for (; n > 0; ++result, (void)++first, --n)
-  ::new (@\placeholdernc{voidify}@(*result))
-    typename iterator_traits<NoThrowForwardIterator>::value_type(*first);
+  ::new (@\placeholdernc{voidify}@(*result)) iterator_traits<NoThrowForwardIterator>::value_type(*first);
 \end{codeblock}
 
 \pnum
@@ -14003,7 +13997,7 @@ Equivalent to:
 \begin{codeblock}
 for (; first != last; (void)++result, ++first)
   ::new (@\placeholdernc{voidify}@(*result))
-    typename iterator_traits<NoThrowForwardIterator>::value_type(@\exposid{deref-move}@(first));
+    iterator_traits<NoThrowForwardIterator>::value_type(@\exposid{deref-move}@(first));
 return result;
 \end{codeblock}
 \end{itemdescr}
@@ -14063,7 +14057,7 @@ Equivalent to:
 \begin{codeblock}
 for (; n > 0; ++result, (void)++first, --n)
   ::new (@\placeholdernc{voidify}@(*result))
-    typename iterator_traits<NoThrowForwardIterator>::value_type(@\exposid{deref-move}@(first));
+    iterator_traits<NoThrowForwardIterator>::value_type(@\exposid{deref-move}@(first));
 return {first, result};
 \end{codeblock}
 \end{itemdescr}
@@ -14115,8 +14109,7 @@ template<class NoThrowForwardIterator, class T>
 Equivalent to:
 \begin{codeblock}
 for (; first != last; ++first)
-  ::new (@\placeholdernc{voidify}@(*first))
-    typename iterator_traits<NoThrowForwardIterator>::value_type(x);
+  ::new (@\placeholdernc{voidify}@(*first)) iterator_traits<NoThrowForwardIterator>::value_type(x);
 \end{codeblock}
 \end{itemdescr}
 
@@ -14156,8 +14149,7 @@ template<class NoThrowForwardIterator, class Size, class T>
 Equivalent to:
 \begin{codeblock}
 for (; n--; ++first)
-  ::new (@\placeholdernc{voidify}@(*first))
-    typename iterator_traits<NoThrowForwardIterator>::value_type(x);
+  ::new (@\placeholdernc{voidify}@(*first)) iterator_traits<NoThrowForwardIterator>::value_type(x);
 return first;
 \end{codeblock}
 \end{itemdescr}


### PR DESCRIPTION
The `typename` keyword is not needed to identify a dependent type in a `new` expression.

This PR contributes to #3637 by resolving all current uses of `typename` in a `new` expression in the library.