### PR TITLE
[specialized.algorithms.general] Make deref-move constexpr

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -13533,7 +13533,7 @@ template<class T>
   }
 
 template<class I>
-  decltype(auto) @\exposid{deref-move}@(I& it) {
+  constexpr decltype(auto) @\exposid{deref-move}@(I& it) {
     if constexpr (is_lvalue_reference_v<decltype(*it)>)
       return std::move(*it);
     else


### PR DESCRIPTION
`std::uninitialized_move` and `std::uninitialized_move_n` are constexpr and invoke *`deref-move`*, but *`deref-move`* is not constexpr. This looks like an obvious mistake.