### PR TITLE
[linalg.transp.layout.transpose] Fix misplaced data members of `layout_transpose::mapping`

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -13040,11 +13040,11 @@ namespace std::linalg {
 
       template<class OtherExtents>
         friend constexpr bool operator==(const mapping& x, const mapping<OtherExtents>& y);
-    };
 
-  private:
-    @\exposid{nested-mapping-type}@ @\exposid{nested-mapping_}@;                         // \expos
-    extents_type @\exposid{extents_}@;                                       // \expos
+    private:
+      @\exposid{nested-mapping-type}@ @\exposid{nested-mapping_}@;                       // \expos
+      extents_type @\exposid{extents_}@;                                     // \expos
+    };
   };
 }
 \end{codeblock}


### PR DESCRIPTION
The intent is that _`nested-mapping_`_ and _`extents_`_ belong to `layout_transpose::mapping` but not `layout_transpose`. This can also be inferred from their usages.

Towards #7214.