### PR TITLE
[linalg.scaled.scaledaccessor] Use kebab-underscore_ style for exposition-only members

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -12696,12 +12696,12 @@ namespace std::linalg {
     constexpr reference access(data_handle_type p, size_t i) const;
     constexpr offset_policy::data_handle_type offset(data_handle_type p, size_t i) const;
 
-    constexpr const ScalingFactor& @\libmember{scaling_factor}{scaled_accessor}@() const noexcept { return @\exposid{scaling-factor}@; }
-    constexpr const NestedAccessor& @\libmember{nested_accessor}{scaled_accessor}@() const noexcept { return @\exposid{nested-accessor}@; }
+    constexpr const ScalingFactor& @\libmember{scaling_factor}{scaled_accessor}@() const noexcept { return @\exposid{scaling-factor_}@; }
+    constexpr const NestedAccessor& @\libmember{nested_accessor}{scaled_accessor}@() const noexcept { return @\exposid{nested-accessor_}@; }
 
   private:
-    ScalingFactor @\exposid{scaling-factor}@{};                              // \expos
-    NestedAccessor @\exposid{nested-accessor}@{};                            // \expos
+    ScalingFactor @\exposid{scaling-factor_}@{};                              // \expos
+    NestedAccessor @\exposid{nested-accessor_}@{};                            // \expos
   };
 }
 \end{codeblock}
@@ -12737,10 +12737,10 @@ template<class OtherNestedAccessor>
 \effects
 \begin{itemize}
 \item
-Direct-non-list-initializes \exposid{scaling-factor}
+Direct-non-list-initializes \exposid{scaling-factor_}
 with \tcode{other.scaling_factor()}, and
 \item
-direct-non-list-initializes \exposid{nested-accessor}
+direct-non-list-initializes \exposid{nested-accessor_}
 with \tcode{other.nested_accessor()}.
 \end{itemize}
 \end{itemdescr}
@@ -12755,9 +12755,9 @@ constexpr scaled_accessor(const ScalingFactor& s, const NestedAccessor& a);
 \effects
 \begin{itemize}
 \item
-Direct-non-list-initializes \exposid{scaling-factor} with \tcode{s}, and
+Direct-non-list-initializes \exposid{scaling-factor_} with \tcode{s}, and
 \item
-direct-non-list-initializes \exposid{nested-accessor} with \tcode{a}.
+direct-non-list-initializes \exposid{nested-accessor_} with \tcode{a}.
 \end{itemize}
 \end{itemdescr}
 
@@ -12770,7 +12770,7 @@ constexpr reference access(data_handle_type p, size_t i) const;
 \pnum
 \returns
 \begin{codeblock}
-scaling_factor() * typename NestedAccessor::element_type(@\exposid{nested-accessor}@.access(p, i))
+scaling_factor() * typename NestedAccessor::element_type(@\exposid{nested-accessor_}@.access(p, i))
 \end{codeblock}
 \end{itemdescr}
 
@@ -12782,7 +12782,7 @@ constexpr offset_policy::data_handle_type offset(data_handle_type p, size_t i) c
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{\exposid{nested-accessor}.offset(p, i)}.
+\tcode{\exposid{nested-accessor_}.offset(p, i)}.
 \end{itemdescr}
 
 \rSec3[linalg.scaled.scaled]{Function template \tcode{scaled}}


### PR DESCRIPTION
The _`kebab-underscore_`_ style for exposition-only members seems to be consistently used among [linalg]. Although such style looks controversial, perhaps it's acceptable to achieve local consistency.

Towards #7214.