### PR TITLE
[lib] Remove redundant `typename` in default template arguments

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -16785,8 +16785,8 @@ for
 \begin{codeblock}
 namespace std::simd {
   // \ref{simd.traits}, type traits
-  template<class T, class U = typename T::value_type> struct alignment;
-  template<class T, class U = typename T::value_type>
+  template<class T, class U = T::value_type> struct alignment;
+  template<class T, class U = T::value_type>
     constexpr size_t @\libmember{alignment_v}{simd}@ = alignment<T, U>::value;
 
   template<class T, class V> struct rebind { using type = @\seebelow@; };
@@ -17607,7 +17607,7 @@ namespace std {
 
 \indexlibrarymember{alignment}{simd}
 \begin{itemdecl}
-template<class T, class U = typename T::value_type> struct alignment { @\seebelow@ };
+template<class T, class U = T::value_type> struct alignment { @\seebelow@ };
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -16595,8 +16595,8 @@ for
 \begin{codeblock}
 namespace std::simd {
   // \ref{simd.traits}, type traits
-  template<class T, class U = typename T::value_type> struct alignment;
-  template<class T, class U = typename T::value_type>
+  template<class T, class U = T::value_type> struct alignment;
+  template<class T, class U = T::value_type>
     constexpr size_t @\libmember{alignment_v}{simd}@ = alignment<T, U>::value;
 
   template<class T, class V> struct rebind { using type = @\seebelow@; };
@@ -17454,7 +17454,7 @@ namespace std {
 
 \indexlibrarymember{alignment}{simd}
 \begin{itemdecl}
-template<class T, class U = typename T::value_type> struct alignment { @\seebelow@ };
+template<class T, class U = T::value_type> struct alignment { @\seebelow@ };
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/text.tex
+++ b/source/text.tex
@@ -7136,7 +7136,7 @@ that models
 
 \begin{codeblock}
 template<class T, class Context,
-         class Formatter = typename Context::template formatter_type<remove_const_t<T>>>
+         class Formatter = Context::template formatter_type<remove_const_t<T>>>
   concept @\defexposconcept{formattable-with}@ =                // \expos
     @\libconcept{semiregular}@<Formatter> &&
     requires(Formatter& f, const Formatter& cf, T&& t, Context fc,
@@ -9606,7 +9606,7 @@ namespace std {
 
   // \ref{re.regiter}, class template \tcode{regex_iterator}
   template<class BidirectionalIterator,
-           class charT = typename iterator_traits<BidirectionalIterator>::value_type,
+           class charT = iterator_traits<BidirectionalIterator>::value_type,
            class traits = regex_traits<charT>>
     class regex_iterator;
 
@@ -9617,7 +9617,7 @@ namespace std {
 
   // \ref{re.tokiter}, class template \tcode{regex_token_iterator}
   template<class BidirectionalIterator,
-           class charT = typename iterator_traits<BidirectionalIterator>::value_type,
+           class charT = iterator_traits<BidirectionalIterator>::value_type,
            class traits = regex_traits<charT>>
     class regex_token_iterator;
 
@@ -12299,7 +12299,7 @@ the same arguments.
 \begin{codeblock}
 namespace std {
   template<class BidirectionalIterator,
-           class charT = typename iterator_traits<BidirectionalIterator>::value_type,
+           class charT = iterator_traits<BidirectionalIterator>::value_type,
            class traits = regex_traits<charT>>
     class regex_iterator {
     public:
@@ -12570,7 +12570,7 @@ equal when they are constructed from the same arguments.
 \begin{codeblock}
 namespace std {
   template<class BidirectionalIterator,
-           class charT = typename iterator_traits<BidirectionalIterator>::value_type,
+           class charT = iterator_traits<BidirectionalIterator>::value_type,
            class traits = regex_traits<charT>>
     class regex_token_iterator {
     public:

--- a/source/text.tex
+++ b/source/text.tex
@@ -7139,7 +7139,7 @@ that models
 
 \begin{codeblock}
 template<class T, class Context,
-         class Formatter = typename Context::template formatter_type<remove_const_t<T>>>
+         class Formatter = Context::template formatter_type<remove_const_t<T>>>
   concept @\defexposconcept{formattable-with}@ =                // \expos
     @\libconcept{semiregular}@<Formatter> &&
     requires(Formatter& f, const Formatter& cf, T&& t, Context fc,
@@ -9609,7 +9609,7 @@ namespace std {
 
   // \ref{re.regiter}, class template \tcode{regex_iterator}
   template<class BidirectionalIterator,
-           class charT = typename iterator_traits<BidirectionalIterator>::value_type,
+           class charT = iterator_traits<BidirectionalIterator>::value_type,
            class traits = regex_traits<charT>>
     class regex_iterator;
 
@@ -9620,7 +9620,7 @@ namespace std {
 
   // \ref{re.tokiter}, class template \tcode{regex_token_iterator}
   template<class BidirectionalIterator,
-           class charT = typename iterator_traits<BidirectionalIterator>::value_type,
+           class charT = iterator_traits<BidirectionalIterator>::value_type,
            class traits = regex_traits<charT>>
     class regex_token_iterator;
 
@@ -12302,7 +12302,7 @@ the same arguments.
 \begin{codeblock}
 namespace std {
   template<class BidirectionalIterator,
-           class charT = typename iterator_traits<BidirectionalIterator>::value_type,
+           class charT = iterator_traits<BidirectionalIterator>::value_type,
            class traits = regex_traits<charT>>
     class regex_iterator {
     public:
@@ -12557,7 +12557,7 @@ equal when they are constructed from the same arguments.
 \begin{codeblock}
 namespace std {
   template<class BidirectionalIterator,
-           class charT = typename iterator_traits<BidirectionalIterator>::value_type,
+           class charT = iterator_traits<BidirectionalIterator>::value_type,
            class traits = regex_traits<charT>>
     class regex_token_iterator {
     public:

--- a/source/time.tex
+++ b/source/time.tex
@@ -65,7 +65,7 @@ namespace std::chrono {
   template<class Rep, class Period = ratio<1>> class duration;
 
   // \ref{time.point}, class template \tcode{time_point}
-  template<class Clock, class Duration = typename Clock::duration> class time_point;
+  template<class Clock, class Duration = Clock::duration> class time_point;
 }
 
 namespace std {
@@ -2216,7 +2216,7 @@ that value will be assigned to \tcode{*offset} if \tcode{offset} is non-null.
 \indexlibraryglobal{time_point}%
 \begin{codeblock}
 namespace std::chrono {
-  template<class Clock, class Duration = typename Clock::duration>
+  template<class Clock, class Duration = Clock::duration>
   class time_point {
   public:
     using clock    = Clock;

--- a/source/time.tex
+++ b/source/time.tex
@@ -65,7 +65,7 @@ namespace std::chrono {
   template<class Rep, class Period = ratio<1>> class duration;
 
   // \ref{time.point}, class template \tcode{time_point}
-  template<class Clock, class Duration = typename Clock::duration> class time_point;
+  template<class Clock, class Duration = Clock::duration> class time_point;
 }
 
 namespace std {
@@ -2217,7 +2217,7 @@ that value will be assigned to \tcode{*offset} if \tcode{offset} is non-null.
 \indexlibraryglobal{time_point}%
 \begin{codeblock}
 namespace std::chrono {
-  template<class Clock, class Duration = typename Clock::duration>
+  template<class Clock, class Duration = Clock::duration>
   class time_point {
   public:
     using clock    = Clock;

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -101,7 +101,7 @@ namespace std {
   template<class T>
     struct @\exposidnc{cw-fixed-value}@;              // \expos
 
-  template<@\exposidnc{cw-fixed-value}@ X, class = typename decltype(X)::@\exposid{type}@>
+  template<@\exposidnc{cw-fixed-value}@ X, class = decltype(X)::@\exposid{type}@>
     struct constant_wrapper;
 
   template<class T>


### PR DESCRIPTION
Towards #3637. We did such changes when applying P2248R8.

Affected sections and components:
- [format.formattable]
  - _`formattable-with`_
- [re.syn]
  - `regex_iterator`
  - `regex_token_iterator`
- [re.regiter.general]
  - `regex_iterator`
- [re.tokiter.general]
  - `regex_token_iterator`
- [simd.syn]
  - `simd::alignment`
  - `simd::alignment_v`
- [simd.traits]
  - `simd::alignment`
- [time.syn]
  - `time_point`
- [time.point.general]
  - `time_point`