### PR TITLE
[expr.const] Use different classes for unrelated parts of the example

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -9383,11 +9383,12 @@ consteval {                                 // \#1
   std::meta::define_aggregate(^^S7, {});    // error: consteval block \#1 does not enclose itself,
                                             // but encloses \tcode{S7}
 
+  struct S8;                                // local class
   consteval {                               // \#2
     std::meta::define_aggregate(^^S6, {});  // error: consteval block \#1 encloses
                                             // consteval block \#2 but not \tcode{S6}
 
-    std::meta::define_aggregate(^^S7, {});  // OK, consteval block \#1 encloses both \#2 and \tcode{S7}
+    std::meta::define_aggregate(^^S8, {});  // OK, consteval block \#1 encloses both \#2 and \tcode{S8}
   }
 }
 \end{codeblock}


### PR DESCRIPTION
Fixes #8425.