### PR TITLE
[expr.const] Unmark introduction of "constant expression" as definition

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -8266,9 +8266,7 @@ requirements as detailed in this subclause; other contexts have different
 semantics depending on whether or not an expression satisfies these requirements.
 Expressions that satisfy these requirements,
 assuming that copy elision\iref{class.copy.elision} is not performed,
-are called
-\indexdefn{expression!constant}%
-\defnx{constant expressions}{constant expression}.
+are called constant expressions.
 \begin{note}
 Constant expressions can be evaluated
 during translation.


### PR DESCRIPTION
Fixes #6589.

As explained in that issue, this definition is a duplicate. It's not actually a definition, it's just falsely marked `\defnx`. The *actual* definition can be found below:

https://github.com/cplusplus/draft/blob/78635c91ac910e9c0953e1784eec648a214eb5ad/source/expressions.tex#L7811-L7815

@frederick-vs-ja was concerned that removing definition formatting would drop the requirement that copy elision is not performed. However, that is not the case; https://eel.is/c++draft/class.copy.elision#1.sentence-6 explains that copy elision is not performed in constant expressions. The intro fluff in the first (duplicate) definition in [expr.const] is just repeating that.