### PR TITLE
[exec.then] add missing `\exposid`

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -3790,7 +3790,7 @@ namespace std::execution {
     static constexpr auto @\exposid{complete}@ =
       []<class Tag, class... Args>
         (auto, auto& fn, auto& rcvr, Tag, Args&&... args) noexcept -> void {
-          if constexpr (@\libconcept{same_as}@<Tag, @\exposid{decayed-typeof}@<set-cpo>>) {
+          if constexpr (@\libconcept{same_as}@<Tag, @\exposid{decayed-typeof}@<@\exposid{set-cpo}@>>) {
             @\exposid{TRY-SET-VALUE}@(rcvr,
                           invoke(std::move(fn), std::forward<Args>(args)...));
           } else {


### PR DESCRIPTION
`set-cpo` needs to be formatted as an `\exposid`.

<img width="384" height="72" alt="image" src="https://github.com/user-attachments/assets/52026e2b-fa69-4476-ac60-eb7866f876ef" />
