### PR TITLE
[locale.categories] Index `X_base` classes and their members

### DIFF
--- a/source/text.tex
+++ b/source/text.tex
@@ -1321,21 +1321,21 @@ one virtual function calls another virtual function.
 namespace std {
   class ctype_base {
   public:
-    using mask = @\seebelow@;
+    using @\libmember{mask}{ctype_base}@ = @\seebelow@;
 
     // numeric values are for exposition only.
-    static constexpr mask space  = 1 << 0;
-    static constexpr mask print  = 1 << 1;
-    static constexpr mask cntrl  = 1 << 2;
-    static constexpr mask upper  = 1 << 3;
-    static constexpr mask lower  = 1 << 4;
-    static constexpr mask alpha  = 1 << 5;
-    static constexpr mask digit  = 1 << 6;
-    static constexpr mask punct  = 1 << 7;
-    static constexpr mask xdigit = 1 << 8;
-    static constexpr mask blank  = 1 << 9;
-    static constexpr mask alnum  = alpha | digit;
-    static constexpr mask graph  = alnum | punct;
+    static constexpr mask @\libmember{space}{ctype_base}@  = 1 << 0;
+    static constexpr mask @\libmember{print}{ctype_base}@  = 1 << 1;
+    static constexpr mask @\libmember{cntrl}{ctype_base}@  = 1 << 2;
+    static constexpr mask @\libmember{upper}{ctype_base}@  = 1 << 3;
+    static constexpr mask @\libmember{lower}{ctype_base}@  = 1 << 4;
+    static constexpr mask @\libmember{alpha}{ctype_base}@  = 1 << 5;
+    static constexpr mask @\libmember{digit}{ctype_base}@  = 1 << 6;
+    static constexpr mask @\libmember{punct}{ctype_base}@  = 1 << 7;
+    static constexpr mask @\libmember{xdigit}{ctype_base}@ = 1 << 8;
+    static constexpr mask @\libmember{blank}{ctype_base}@  = 1 << 9;
+    static constexpr mask @\libmember{alnum}{ctype_base}@  = alpha | digit;
+    static constexpr mask @\libmember{graph}{ctype_base}@  = alnum | punct;
   };
 }
 \end{codeblock}
@@ -1353,7 +1353,7 @@ namespace std {
   template<class charT>
     class ctype : public locale::facet, public ctype_base {
     public:
-      using char_type = charT;
+      using @\libmember{char_type}{ctype}@ = charT;
 
       explicit ctype(size_t refs = 0);
 
@@ -1371,7 +1371,7 @@ namespace std {
       char         narrow(charT c, char dfault) const;
       const charT* narrow(const charT* low, const charT* high, char dfault, char* to) const;
 
-      static locale::id id;
+      static locale::id @\libmember{id}{ctype}@;
 
     protected:
       ~ctype();
@@ -1684,7 +1684,7 @@ namespace std {
   template<class charT>
     class ctype_byname : public ctype<charT> {
     public:
-      using mask = ctype<charT>::mask;
+      using @\libmember{mask}{ctype_byname}@ = ctype<charT>::mask;
       explicit ctype_byname(const char*, size_t refs = 0);
       explicit ctype_byname(const string&, size_t refs = 0);
 
@@ -1704,7 +1704,7 @@ namespace std {
   template<>
     class ctype<char> : public locale::facet, public ctype_base {
     public:
-      using char_type = char;
+      using @\libmember{char_type}{ctype<char>}@ = char;
 
       explicit ctype(const mask* tab = nullptr, bool del = false, size_t refs = 0);
 
@@ -1723,8 +1723,8 @@ namespace std {
       char  narrow(char c, char dfault) const;
       const char* narrow(const char* low, const char* high, char dfault, char* to) const;
 
-      static locale::id id;
-      static const size_t table_size = @\impdef@;
+      static locale::id @\libmember{id}{ctype<char>}@;
+      static const size_t @\libmember{table_size}{ctype<char>}@ = @\impdef@;
 
       const mask* table() const noexcept;
       static const mask* classic_table() noexcept;
@@ -1954,20 +1954,21 @@ in the \tcode{ctype} class template\iref{locale.ctype.members}.
 
 \rSec5[locale.codecvt.general]{General}
 
+\indexlibraryglobal{codecvt_base}%
 \indexlibraryglobal{codecvt}%
 \begin{codeblock}
 namespace std {
   class codecvt_base {
   public:
-    enum result { ok, partial, error, noconv };
+    enum @\libmember{result}{codecvt_base}@ { @\libmember{ok}{codecvt_base}@, @\libmember{partial}{codecvt_base}@, @\libmember{error}{codecvt_base}@, @\libmember{noconv}{codecvt_base}@ };
   };
 
   template<class internT, class externT, class stateT>
     class codecvt : public locale::facet, public codecvt_base {
     public:
-      using intern_type = internT;
-      using extern_type = externT;
-      using state_type  = stateT;
+      using @\libmember{intern_type}{codecvt}@ = internT;
+      using @\libmember{extern_type}{codecvt}@ = externT;
+      using @\libmember{state_type}{codecvt}@  = stateT;
 
       explicit codecvt(size_t refs = 0);
 
@@ -1990,7 +1991,7 @@ namespace std {
       int length(stateT&, const externT* from, const externT* end, size_t max) const;
       int max_length() const noexcept;
 
-      static locale::id id;
+      static locale::id @\libmember{id}{codecvt}@;
 
     protected:
       ~codecvt();
@@ -2429,8 +2430,8 @@ namespace std {
   template<class charT, class InputIterator = istreambuf_iterator<charT>>
     class num_get : public locale::facet {
     public:
-      using char_type = charT;
-      using iter_type = InputIterator;
+      using @\libmember{char_type}{num_get}@ = charT;
+      using @\libmember{iter_type}{num_get}@ = InputIterator;
 
       explicit num_get(size_t refs = 0);
 
@@ -2457,7 +2458,7 @@ namespace std {
       iter_type get(iter_type in, iter_type end, ios_base&,
                     ios_base::iostate& err, void*& v) const;
 
-      static locale::id id;
+      static locale::id @\libmember{id}{num_get}@;
 
     protected:
       ~num_get();
@@ -2808,8 +2809,8 @@ namespace std {
   template<class charT, class OutputIterator = ostreambuf_iterator<charT>>
     class num_put : public locale::facet {
     public:
-      using char_type = charT;
-      using iter_type = OutputIterator;
+      using @\libmember{char_type}{num_put}@ = charT;
+      using @\libmember{iter_type}{num_put}@ = OutputIterator;
 
       explicit num_put(size_t refs = 0);
 
@@ -2822,7 +2823,7 @@ namespace std {
       iter_type put(iter_type s, ios_base& f, char_type fill, long double v) const;
       iter_type put(iter_type s, ios_base& f, char_type fill, const void* v) const;
 
-      static locale::id id;
+      static locale::id @\libmember{id}{num_put}@;
 
     protected:
       ~num_put();
@@ -3110,8 +3111,8 @@ namespace std {
   template<class charT>
     class numpunct : public locale::facet {
     public:
-      using char_type   = charT;
-      using string_type = basic_string<charT>;
+      using @\libmember{char_type}{numpunct}@   = charT;
+      using @\libmember{string_type}{numpunct}@ = basic_string<charT>;
 
       explicit numpunct(size_t refs = 0);
 
@@ -3121,7 +3122,7 @@ namespace std {
       string_type truename()      const;
       string_type falsename()     const;
 
-      static locale::id id;
+      static locale::id @\libmember{id}{numpunct}@;
 
     protected:
       ~numpunct();                                              // virtual
@@ -3332,8 +3333,8 @@ namespace std {
     class numpunct_byname : public numpunct<charT> {
     // this class is specialized for \tcode{char} and \keyword{wchar_t}.
     public:
-      using char_type   = charT;
-      using string_type = basic_string<charT>;
+      using @\libmember{char_type}{numpunct_byname}@   = charT;
+      using @\libmember{string_type}{numpunct_byname}@ = basic_string<charT>;
 
       explicit numpunct_byname(const char*, size_t refs = 0);
       explicit numpunct_byname(const string&, size_t refs = 0);
@@ -3356,8 +3357,8 @@ namespace std {
   template<class charT>
     class collate : public locale::facet {
     public:
-      using char_type   = charT;
-      using string_type = basic_string<charT>;
+      using @\libmember{char_type}{collate}@   = charT;
+      using @\libmember{string_type}{collate}@ = basic_string<charT>;
 
       explicit collate(size_t refs = 0);
 
@@ -3366,7 +3367,7 @@ namespace std {
       string_type transform(const charT* low, const charT* high) const;
       long hash(const charT* low, const charT* high) const;
 
-      static locale::id id;
+      static locale::id @\libmember{id}{collate}@;
 
     protected:
       ~collate();
@@ -3494,7 +3495,7 @@ namespace std {
   template<class charT>
     class collate_byname : public collate<charT> {
     public:
-      using string_type = basic_string<charT>;
+      using @\libmember{string_type}{collate_byname}@ = basic_string<charT>;
 
       explicit collate_byname(const char*, size_t refs = 0);
       explicit collate_byname(const string&, size_t refs = 0);
@@ -3528,19 +3529,20 @@ to determine formatting details.
 
 \rSec5[locale.time.get.general]{General}
 
+\indexlibraryglobal{time_base}%
 \indexlibraryglobal{time_get}%
 \begin{codeblock}
 namespace std {
   class time_base {
   public:
-    enum dateorder { no_order, dmy, mdy, ymd, ydm };
+    enum @\libmember{dateorder}{time_base}@ { @\libmember{no_order}{time_base}@, @\libmember{dmy}{time_base}@, @\libmember{mdy}{time_base}@, @\libmember{ymd}{time_base}@, @\libmember{ydm}{time_base}@ };
   };
 
   template<class charT, class InputIterator = istreambuf_iterator<charT>>
     class time_get : public locale::facet, public time_base {
     public:
-      using char_type = charT;
-      using iter_type = InputIterator;
+      using @\libmember{char_type}{time_get}@ = charT;
+      using @\libmember{iter_type}{time_get}@ = InputIterator;
 
       explicit time_get(size_t refs = 0);
 
@@ -3561,7 +3563,7 @@ namespace std {
                     ios_base::iostate& err, tm* t, const char_type* fmt,
                     const char_type* fmtend) const;
 
-      static locale::id id;
+      static locale::id @\libmember{id}{time_get}@;
 
     protected:
       ~time_get();
@@ -3951,8 +3953,8 @@ namespace std {
   template<class charT, class InputIterator = istreambuf_iterator<charT>>
     class time_get_byname : public time_get<charT, InputIterator> {
     public:
-      using dateorder = time_base::dateorder;
-      using iter_type = InputIterator;
+      using @\libmember{dateorder}{time_get_byname}@ = time_base::dateorder;
+      using @\libmember{iter_type}{time_get_byname}@ = InputIterator;
 
       explicit time_get_byname(const char*, size_t refs = 0);
       explicit time_get_byname(const string&, size_t refs = 0);
@@ -3973,8 +3975,8 @@ namespace std {
   template<class charT, class OutputIterator = ostreambuf_iterator<charT>>
     class time_put : public locale::facet {
     public:
-      using char_type = charT;
-      using iter_type = OutputIterator;
+      using @\libmember{char_type}{time_put}@ = charT;
+      using @\libmember{iter_type}{time_put}@ = OutputIterator;
 
       explicit time_put(size_t refs = 0);
 
@@ -3984,7 +3986,7 @@ namespace std {
       iter_type put(iter_type s, ios_base& f, char_type fill,
                     const tm* tmb, char format, char modifier = 0) const;
 
-      static locale::id id;
+      static locale::id @\libmember{id}{time_put}@;
 
     protected:
       ~time_put();
@@ -4094,8 +4096,8 @@ namespace std {
   template<class charT, class OutputIterator = ostreambuf_iterator<charT>>
     class time_put_byname : public time_put<charT, OutputIterator> {
     public:
-      using char_type = charT;
-      using iter_type = OutputIterator;
+      using @\libmember{char_type}{time_put_byname}@ = charT;
+      using @\libmember{iter_type}{time_put_byname}@ = OutputIterator;
 
       explicit time_put_byname(const char*, size_t refs = 0);
       explicit time_put_byname(const string&, size_t refs = 0);
@@ -4136,9 +4138,9 @@ namespace std {
   template<class charT, class InputIterator = istreambuf_iterator<charT>>
     class money_get : public locale::facet {
     public:
-      using char_type   = charT;
-      using iter_type   = InputIterator;
-      using string_type = basic_string<charT>;
+      using @\libmember{char_type}{money_get}@   = charT;
+      using @\libmember{iter_type}{money_get}@   = InputIterator;
+      using @\libmember{string_type}{money_get}@ = basic_string<charT>;
 
       explicit money_get(size_t refs = 0);
 
@@ -4149,7 +4151,7 @@ namespace std {
                     ios_base& f, ios_base::iostate& err,
                     string_type& digits) const;
 
-      static locale::id id;
+      static locale::id @\libmember{id}{money_get}@;
 
     protected:
       ~money_get();
@@ -4305,9 +4307,9 @@ namespace std {
   template<class charT, class OutputIterator = ostreambuf_iterator<charT>>
     class money_put : public locale::facet {
     public:
-      using char_type   = charT;
-      using iter_type   = OutputIterator;
-      using string_type = basic_string<charT>;
+      using @\libmember{char_type}{money_put}@   = charT;
+      using @\libmember{iter_type}{money_put}@   = OutputIterator;
+      using @\libmember{string_type}{money_put}@ = basic_string<charT>;
 
       explicit money_put(size_t refs = 0);
 
@@ -4316,7 +4318,7 @@ namespace std {
       iter_type put(iter_type s, bool intl, ios_base& f,
                     char_type fill, const string_type& digits) const;
 
-      static locale::id id;
+      static locale::id @\libmember{id}{money_put}@;
 
     protected:
       ~money_put();
@@ -4417,20 +4419,21 @@ to produce output that cannot be parsed using \tcode{num_get<>::get}.
 
 \rSec5[locale.moneypunct.general]{General}
 
+\indexlibraryglobal{money_base}%
 \indexlibraryglobal{moneypunct}%
 \begin{codeblock}
 namespace std {
   class money_base {
   public:
-    enum part { none, space, symbol, sign, value };
-    struct pattern { char field[4]; };
+    enum @\libmember{part}{money_base}@ { @\libmember{none}{money_base}@, @\libmember{space}{money_base}@, @\libmember{symbol}{money_base}@, @\libmember{sign}{money_base}@, @\libmember{value}{money_base}@ };
+    struct @\libmember{pattern}{money_base}@ { char @\libmember{field}{money_base::pattern}@[4]; };
   };
 
   template<class charT, bool International = false>
     class moneypunct : public locale::facet, public money_base {
     public:
-      using char_type   = charT;
-      using string_type = basic_string<charT>;
+      using @\libmember{char_type}{moneypunct}@   = charT;
+      using @\libmember{string_type}{moneypunct}@ = basic_string<charT>;
 
       explicit moneypunct(size_t refs = 0);
 
@@ -4444,8 +4447,8 @@ namespace std {
       pattern     pos_format()    const;
       pattern     neg_format()    const;
 
-      static locale::id id;
-      static const bool intl = International;
+      static locale::id @\libmember{id}{moneypunct}@;
+      static const bool @\libmember{intl}{moneypunct}@ = International;
 
     protected:
       ~moneypunct();
@@ -4711,8 +4714,8 @@ namespace std {
   template<class charT, bool Intl = false>
     class moneypunct_byname : public moneypunct<charT, Intl> {
     public:
-      using pattern     = money_base::pattern;
-      using string_type = basic_string<charT>;
+      using @\libmember{pattern}{moneypunct_byname}@     = money_base::pattern;
+      using @\libmember{string_type}{moneypunct_byname}@ = basic_string<charT>;
 
       explicit moneypunct_byname(const char*, size_t refs = 0);
       explicit moneypunct_byname(const string&, size_t refs = 0);
@@ -4735,19 +4738,20 @@ implements retrieval of strings from message catalogs.
 
 \rSec5[locale.messages.general]{General}
 
+\indexlibraryglobal{messages_base}%
 \indexlibraryglobal{messages}%
 \begin{codeblock}
 namespace std {
   class messages_base {
   public:
-    using catalog = @\textit{unspecified signed integer type}@;
+    using @\libmember{catalog}{messages_base}@ = @\textit{unspecified signed integer type}@;
   };
 
   template<class charT>
     class messages : public locale::facet, public messages_base {
     public:
-      using char_type   = charT;
-      using string_type = basic_string<charT>;
+      using @\libmember{char_type}{messages}@   = charT;
+      using @\libmember{string_type}{messages}@ = basic_string<charT>;
 
       explicit messages(size_t refs = 0);
 
@@ -4756,7 +4760,7 @@ namespace std {
                       const string_type& dfault) const;
       void close(catalog c) const;
 
-      static locale::id id;
+      static locale::id @\libmember{id}{messages}@;
 
     protected:
       ~messages();
@@ -4881,8 +4885,8 @@ namespace std {
   template<class charT>
     class messages_byname : public messages<charT> {
     public:
-      using catalog     = messages_base::catalog;
-      using string_type = basic_string<charT>;
+      using @\libmember{catalog}{messages_byname}@     = messages_base::catalog;
+      using @\libmember{string_type}{messages_byname}@ = basic_string<charT>;
 
       explicit messages_byname(const char*, size_t refs = 0);
       explicit messages_byname(const string&, size_t refs = 0);


### PR DESCRIPTION
Enumerators of each unscoped enumeration type are indexed as members of the enclosing class of the enumeration.

(Attempted to fix) #6080.