### PR TITLE
[meta.syn] Synchronize `reflect_constant`/`reflect_object` parameters with definition

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -3109,9 +3109,9 @@ namespace std::meta {
 
   // \ref{meta.reflection.result}, expression result reflection
   template<class T>
-    consteval info reflect_constant(const T& value);
+    consteval info reflect_constant(T expr);
   template<class T>
-    consteval info reflect_object(T& object);
+    consteval info reflect_object(T& expr);
   template<class T>
     consteval info reflect_function(T& fn);
 


### PR DESCRIPTION
Fixes #8244.

This synchronizes the function signature with the definition in https://eel.is/c++draft/meta.reflection.result#lib:reflect_constant

The paper author has confirmed that the CWG intent is for the parameter to be `T value`; the use of `const T&` in the synopsis is an editorial oversight.