### PR TITLE
[dcl.attr.fallthrough] Use `\defnadj` for "fallthrought statement"

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -9780,8 +9780,7 @@ unless the implementation can issue such diagnostic messages.
 \pnum
 The \grammarterm{attribute-token} \tcode{fallthrough}
 may be applied to a null statement\iref{stmt.expr};
-\indextext{statement!fallthrough}
-such a statement is a fallthrough statement.
+such a statement is a \defnadj{fallthrough}{statement}.
 No \grammarterm{attribute-argument-clause} shall be present.
 A fallthrough statement may only appear within
 an enclosing \keyword{switch} statement\iref{stmt.switch}.


### PR DESCRIPTION
The term "fallthrough statement" should be properly introduced in italic style text.

Fixes #8230.