### PR TITLE
[character.seq.general, time.general] Define STATICALLY-WIDEN in a better place

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -789,6 +789,11 @@ array have defined contents up to and including an element determined by some
 predicate.
 A character sequence can be designated by a pointer value
 \tcode{\placeholder{S}} that points to its first element.
+\item
+\indextext{STATICALLY-WIDEN@\exposid{STATICALLY-WIDEN}}%
+Let \exposid{STATICALLY-WIDEN}\tcode{<charT>("...")} be
+\tcode{"..."} if \tcode{charT} is \tcode{char} and
+\tcode{L"..."} if \tcode{charT} is \keyword{wchar_t}.
 \end{itemize}
 
 \rSec5[byte.strings]{Byte strings}

--- a/source/time.tex
+++ b/source/time.tex
@@ -25,12 +25,6 @@ utilities, as summarized in \tref{time.summary}.
 \ref{ctime.syn}             & C library time utilities           & \tcode{<ctime>} \\
 \end{libsumtab}
 
-\pnum
-\indextext{STATICALLY-WIDEN@\exposid{STATICALLY-WIDEN}}%
-Let \exposid{STATICALLY-WIDEN}\tcode{<charT>("...")} be
-\tcode{"..."} if \tcode{charT} is \tcode{char} and
-\tcode{L"..."} if \tcode{charT} is \keyword{wchar_t}.
-
 \rSec1[time.syn]{Header \tcode{<chrono>} synopsis}
 
 \indexheader{chrono}%


### PR DESCRIPTION
The facility is now used from two different places ([time] and [format]) and is now better defined in the library introduction.

Fixes #6013.