### PR TITLE
[utilities] Use "Result:" element in \itemdescrs of types to describe the type.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -1408,7 +1408,7 @@ template<size_t I, class T1, class T2>
 $\tcode{I} < 2$.
 
 \pnum
-\ctype
+\result
 The type \tcode{T1} if \tcode{I} is 0, otherwise the type \tcode{T2}.
 \end{itemdescr}
 
@@ -2788,7 +2788,7 @@ template<size_t I, class... Types>
 $\tcode{I} < \tcode{sizeof...(Types)}$.
 
 \pnum
-\ctype
+\result
 \tcode{TI} is the
 type of the $\tcode{I}^\text{th}$ element of \tcode{Types},
 where indexing is zero-based.
@@ -3076,6 +3076,9 @@ struct basic_common_reference<TTuple, UTuple, TQual, UQual> {
 \tcode{tuple<common_reference_t<TQual<TTypes>, UQual<UTypes>>...>}
 denotes a type.
 \end{itemize}
+
+\pnum
+\result
 The member \grammarterm{typedef-name} \tcode{type} denotes the type
 \tcode{tuple<common_reference_t<TQual<TTypes>, \linebreak{}UQual<UTypes>>...>}.
 \end{itemdescr}
@@ -3104,7 +3107,10 @@ struct common_type<TTuple, UTuple> {
 \item
 \tcode{tuple<common_type_t<TTypes, UTypes>...>} denotes a type.
 \end{itemize}
-The member \grammarterm{typedef-name} \tcode{type} denotes the type
+
+\pnum
+\result
+The member \grammarterm{typedef-name} \tcode{type} denotes the type\\
 \tcode{tuple<common_type_t<TTypes, UTypes>...>}.
 \end{itemdescr}
 
@@ -6508,7 +6514,7 @@ variant_alternative<I, variant<Types...>>::type
 $\tcode{I} < \tcode{sizeof...(Types)}$.
 
 \pnum
-\ctype
+\result
 The type $\tcode{T}_I$.
 \end{itemdescr}
 


### PR DESCRIPTION
This replaces the use of the ad-hoc element "Type:" in three places with "Result", and adds "Result:" in other cases that didn't have an element at all.