### PR TITLE
[headers] "C library" fixes

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1317,7 +1317,6 @@ It is intentional that there is no \Cpp{} header
 for any of these C headers:
 \libnoheader{complex.h},
 \libnoheader{iso646.h},
-\libnoheader{codecvt.h},
 \libnoheader{stdatomic.h},
 \libnoheader{stdbool.h},
 \libnoheader{stdnoreturn.h},

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1311,11 +1311,17 @@ shown in \tref{headers.cpp}.
 \pnum
 The facilities of the C standard library are provided in the
 \indextext{library!C standard}%
-additional headers shown in \tref{headers.cpp.c}.%
+additional headers shown in \tref{headers.cpp.c} and in \tref{c.headers}.%
 \begin{footnote}
 It is intentional that there is no \Cpp{} header
 for any of these C headers:
+\libnoheader{complex.h},
+\libnoheader{iso646.h},
+\libnoheader{codecvt.h},
+\libnoheader{stdatomic.h},
+\libnoheader{stdbool.h},
 \libnoheader{stdnoreturn.h},
+\libnoheader{tgmath.h},
 \libnoheader{threads.h}.
 \end{footnote}
 


### PR DESCRIPTION
* State normatively that the <name.h> C headers are part of the "C library".
* Update the list of <name.h> headers which intentionally have no <cname> counterpart.

Fixes #7850.