### PR TITLE
[basic.fundamental] Remove note which explains the purpose of `int`

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5331,11 +5331,6 @@ The range of representable values for a signed integer type is
 $-2^{N-1}$ to $2^{N-1}-1$ (inclusive),
 where $N$ is called the \defn{width} of the type.
 \indextext{integral type!implementation-defined \tcode{sizeof}}%
-\begin{note}
-Plain \tcode{int}s are intended to have
-the natural width suggested by the architecture of the execution environment;
-the other signed integer types are provided to meet special needs.
-\end{note}
 
 \pnum
 \indextext{type!\idxcode{unsigned}}%


### PR DESCRIPTION
Fixes #6825.