### PR TITLE
[expr.prim.lambda.closure] Fix sentence re: immediate function nature

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2345,9 +2345,10 @@ the corresponding \grammarterm{lambda-expression}{'s}
 \grammarterm{parameter-declaration-clause}
 is followed by \keyword{constexpr} or \keyword{consteval}, or
 it is constexpr-suitable\iref{dcl.constexpr}.
-It is an immediate function\iref{dcl.constexpr}
+It is an immediate function\iref{expr.const}
 if the corresponding \grammarterm{lambda-expression}{'s}
-\grammarterm{parameter-declaration-clause} is followed by \keyword{consteval}.
+\grammarterm{parameter-declaration-clause} is followed by \keyword{consteval};
+otherwise, it is an immediate-escalating function.
 \begin{example}
 \begin{codeblock}
 auto ID = [](auto a) { return a; };


### PR DESCRIPTION
... by adjusting the cross-reference to point to [expr.const], where immediate function is defined, and hinting at the possibility of being an immediate function by being immediate-escalating.