### PR TITLE
[mdspan.sub.map.right] Replace `layout_left` with `layout_right` and `_rank` with `rank_`

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -25767,19 +25767,19 @@ otherwise,
 if \tcode{Sub\-Extents::rank() == 0} is \tcode{true};
 \item
 otherwise,
-\tcode{submdspan_mapping_result\{layout_left::mapping(sub_ext), offset\}},
+\tcode{submdspan_mapping_result\{layout_right::mapping(sub_ext), offset\}},
 if
   \begin{itemize}
   \item
   for each $k$ in the range \range{\exposid{rank_} - SubExtents::rank() + 1}{\exposid{rank_}},
   \tcode{is_convertible_v<$S_k$, full_extent_t>} is \tcode{true}; and
   \item
-  for $k$ equal to \exposid{_rank} - \tcode{SubExtents::rank()},
+  for $k$ equal to \exposid{rank_} - \tcode{SubExtents::rank()},
   $S_k$ is a unit-stride slice for \tcode{mapping};
   \end{itemize}
 \begin{note}
 If the above conditions are true,
-all $S_k$ with $k < \tcode{\exposid{_rank} - SubExtents::rank()}$
+all $S_k$ with $k < \tcode{\exposid{rank_} - SubExtents::rank()}$
 are convertible to \tcode{index_type}.
 \end{note}
 \item


### PR DESCRIPTION
Fixes #7552.

This fixes misapplications of P2642R6 that were not spotted in #6919.