### PR TITLE
[inplace.vector.modifiers] Ensure correct type of returned iterator

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -11251,9 +11251,10 @@ Each iterator in the range \tcode{rg} is dereferenced at most once.
 
 \pnum
 \returns
-An iterator pointing to the first element of \tcode{rg}
+The first iterator in the range
+\countedrange{ranges::begin(rg)}{n}
 that was not inserted into \tcode{*this},
-or \tcode{ranges::end(rg)} if no such element exists.
+where \tcode{n} is the number of elements in \tcode{rg}.
 
 \pnum
 \complexity


### PR DESCRIPTION
Fixes #7486.

This is largely using @jwakely's proposed wording from https://github.com/cplusplus/draft/issues/7486#issuecomment-2546353089, with minor adjustments.

The PR fixes a normative defect that was introduced editorially in #7115. I assume that this needs no LWG issue because the defect is relatively new and wouldn't have existed without editorial errors anyway.