### PR TITLE
P3836R2 Make `optional<T&>` trivially copyable

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -4543,6 +4543,9 @@ When an \tcode{optional<T\&>} contains a value,
 the \defnx{contained value}{contained value!\idxcode{optional.ref}}
 is a reference to \tcode{*\exposid{val}}.
 
+\pnum
+Each type \tcode{optional<T\&>} is a trivially copyable class\iref{class.prop}.
+
 \rSec3[optional.ref.ctor]{Constructors}
 
 \begin{itemdecl}


### PR DESCRIPTION
Fixes #8468.
Fixes NB US 134-215 (C++26 CD).

Also fixes https://github.com/cplusplus/papers/issues/2441.
Also fixes https://github.com/cplusplus/nbballot/issues/785.