### PR TITLE
P3774R1 Rename `std::nontype`, and make it broadly useful

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -709,7 +709,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_freestanding_utility}@              202306L // freestanding, also in \libheader{utility}
 #define @\defnlibxname{cpp_lib_freestanding_variant}@              202311L // freestanding, also in \libheader{variant}
 #define @\defnlibxname{cpp_lib_fstream_native_handle}@             202306L // also in \libheader{fstream}
-#define @\defnlibxname{cpp_lib_function_ref}@                      202306L // freestanding, also in \libheader{functional}
+#define @\defnlibxname{cpp_lib_function_ref}@                      202511L // freestanding, also in \libheader{functional}
 #define @\defnlibxname{cpp_lib_gcd_lcm}@                           201606L // freestanding, also in \libheader{numeric}
 #define @\defnlibxname{cpp_lib_generator}@                         202207L // also in \libheader{generator}
 #define @\defnlibxname{cpp_lib_generic_associative_lookup}@        201304L // also in \libheader{map}, \libheader{set}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -213,14 +213,14 @@ namespace std {
     };
   template<size_t I> constexpr in_place_index_t<I> in_place_index{};
 
-  // \tcode{nontype} argument tag%
-\indexlibraryglobal{nontype_t}%
-\indexlibraryglobal{nontype}
+  // \tcode{constant_arg} argument tag%
+\indexlibraryglobal{constant_arg_t}%
+\indexlibraryglobal{constant_arg}
   template<auto V>
-    struct nontype_t {
-      explicit nontype_t() = default;
+    struct constant_arg_t {
+      explicit constant_arg_t() = default;
     };
-  template<auto V> constexpr nontype_t<V> nontype{};
+  template<auto V> constexpr constant_arg_t<V> constant_arg{};
 
   // \ref{variant.monostate}, class \tcode{monostate}%
 \indexlibraryglobal{monostate}
@@ -15077,9 +15077,9 @@ namespace std {
     // \ref{func.wrap.ref.ctor}, constructors and assignment operators
     template<class F> function_ref(F*) noexcept;
     template<class F> constexpr function_ref(F&&) noexcept;
-    template<auto f> constexpr function_ref(nontype_t<f>) noexcept;
-    template<auto f, class U> constexpr function_ref(nontype_t<f>, U&&) noexcept;
-    template<auto f, class T> constexpr function_ref(nontype_t<f>, @\cv{}@ T*) noexcept;
+    template<auto f> constexpr function_ref(constant_arg_t<f>) noexcept;
+    template<auto f, class U> constexpr function_ref(constant_arg_t<f>, U&&) noexcept;
+    template<auto f, class T> constexpr function_ref(constant_arg_t<f>, @\cv{}@ T*) noexcept;
 
     constexpr function_ref(const function_ref&) noexcept = default;
     constexpr function_ref& operator=(const function_ref&) noexcept = default;
@@ -15100,9 +15100,9 @@ namespace std {
   template<class F>
     function_ref(F*) -> function_ref<F>;
   template<auto f>
-    function_ref(nontype_t<f>) -> function_ref<@\seebelow@>;
+    function_ref(constant_arg_t<f>) -> function_ref<@\seebelow@>;
   template<auto f, class T>
-    function_ref(nontype_t<f>, T&&) -> function_ref<@\seebelow@>;
+    function_ref(constant_arg_t<f>, T&&) -> function_ref<@\seebelow@>;
 }
 \end{codeblock}
 
@@ -15210,7 +15210,7 @@ is expression-equivalent\iref{defns.expression.equivalent} to
 
 \indexlibraryctor{function_ref}%
 \begin{itemdecl}
-template<auto f> constexpr function_ref(nontype_t<f>) noexcept;
+template<auto f> constexpr function_ref(constant_arg_t<f>) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -15241,7 +15241,7 @@ is expression-equivalent\iref{defns.expression.equivalent} to
 \indexlibraryctor{function_ref}%
 \begin{itemdecl}
 template<auto f, class U>
-  constexpr function_ref(nontype_t<f>, U&& obj) noexcept;
+  constexpr function_ref(constant_arg_t<f>, U&& obj) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -15275,7 +15275,7 @@ is expression-equivalent\iref{defns.expression.equivalent} to
 \indexlibraryctor{function_ref}%
 \begin{itemdecl}
 template<auto f, class T>
-  constexpr function_ref(nontype_t<f>, @\cv{}@ T* obj) noexcept;
+  constexpr function_ref(constant_arg_t<f>, @\cv{}@ T* obj) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -15318,7 +15318,7 @@ template<class T> function_ref& operator=(T) = delete;
 \begin{itemize}
 \item \tcode{T} is not the same type as \tcode{function_ref},
 \item \tcode{is_pointer_v<T>} is \tcode{false}, and
-\item \tcode{T} is not a specialization of \tcode{nontype_t}.
+\item \tcode{T} is not a specialization of \tcode{constant_arg_t}.
 \end{itemize}
 \end{itemdescr}
 
@@ -15351,7 +15351,7 @@ template<class F>
 
 \begin{itemdecl}
 template<auto f>
-  function_ref(nontype_t<f>) -> function_ref<@\seebelow@>;
+  function_ref(constant_arg_t<f>) -> function_ref<@\seebelow@>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -15369,7 +15369,7 @@ The deduced type is \tcode{function_ref<F>}.
 
 \begin{itemdecl}
 template<auto f, class T>
-  function_ref(nontype_t<f>, T&&) -> function_ref<@\seebelow@>;
+  function_ref(constant_arg_t<f>, T&&) -> function_ref<@\seebelow@>;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Fixes #8469.
Also fixes https://github.com/cplusplus/papers/issues/2388.

While this doesn't directly implement the changes in those papers/issues, after merging this PR, we can also close:
- https://github.com/cplusplus/papers/issues/2369 (predecessor paper)
- https://github.com/cplusplus/nbballot/issues/788 (rejected alternative)
- https://github.com/cplusplus/nbballot/issues/779 (rejected alternative)
- https://github.com/cplusplus/papers/issues/2398 (informative paper)
- https://github.com/cplusplus/papers/issues/2473 (rejected alternative)