### PR TITLE
[temp.names] Restore braced-init-list in definition of template-argument

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -718,7 +718,8 @@ A template specialization\iref{temp.spec} can be referred to by a
   constant-expression\br
   type-id\br
   \opt{nested-name-specifier} template-name\br
-  nested-name-specifier \terminal{template} template-name
+  nested-name-specifier \terminal{template} template-name\br
+  braced-init-list
 \end{bnf}
 
 \pnum


### PR DESCRIPTION
It was unintentionally deleted by commit e3f552ff09eb42cec8ee0590e4b8aa716996b282.