### PR TITLE
[lib] Adjust \indexlibrarymember{class}{member} to \indexlibrarymembe…

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -6154,10 +6154,10 @@ The types \tcode{iterator} and \tcode{const_iterator} meet
 the constexpr iterator requirements\iref{iterator.requirements.general}.
 
 \indexlibraryglobal{array}%
-\indexlibrarymember{array}{begin}%
-\indexlibrarymember{array}{end}%
-\indexlibrarymember{array}{size}%
-\indexlibrarymember{array}{max_size}%
+\indexlibrarymember{begin}{array}%
+\indexlibrarymember{end}{array}%
+\indexlibrarymember{size}{array}%
+\indexlibrarymember{max_size}{array}%
 \begin{codeblock}
 namespace std {
   template<class T, size_t N>
@@ -6245,7 +6245,7 @@ template<class T, class... U>
 
 \rSec3[array.members]{Member functions}
 
-\indexlibrarymember{array}{size}%
+\indexlibrarymember{size}{array}%
 \begin{itemdecl}
 constexpr size_type size() const noexcept;
 \end{itemdecl}
@@ -6256,7 +6256,7 @@ constexpr size_type size() const noexcept;
 \tcode{N}.
 \end{itemdescr}
 
-\indexlibrarymember{array}{data}%
+\indexlibrarymember{data}{array}%
 \begin{itemdecl}
 constexpr T* data() noexcept;
 constexpr const T* data() const noexcept;
@@ -6269,7 +6269,7 @@ A pointer such that \range{data()}{data() + size()} is a valid range. For a
 non-empty array, \tcode{data() == addressof(front())} is \keyword{true}.
 \end{itemdescr}
 
-\indexlibrarymember{array}{fill}%
+\indexlibrarymember{fill}{array}%
 \begin{itemdecl}
 constexpr void fill(const T& u);
 \end{itemdecl}
@@ -6280,7 +6280,7 @@ constexpr void fill(const T& u);
 As if by \tcode{fill_n(begin(), N, u)}.
 \end{itemdescr}
 
-\indexlibrarymember{array}{swap}%
+\indexlibrarymember{swap}{array}%
 \begin{itemdecl}
 constexpr void swap(array& y) noexcept(is_nothrow_swappable_v<T>);
 \end{itemdecl}
@@ -6300,7 +6300,7 @@ become associated with the other container.
 
 \rSec3[array.special]{Specialized algorithms}
 
-\indexlibrarymember{array}{swap}%
+\indexlibrarymember{swap}{array}%
 \begin{itemdecl}
 template<class T, size_t N>
   constexpr void swap(array<T, N>& x, array<T, N>& y) noexcept(noexcept(x.swap(y)));
@@ -6407,7 +6407,7 @@ template<size_t I, class T, size_t N>
 \tcode{I < N} is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrarymember{array}{get}%
+\indexlibrarymember{get}{array}%
 \begin{itemdecl}
 template<size_t I, class T, size_t N>
   constexpr T& get(array<T, N>& a) noexcept;
@@ -20621,7 +20621,7 @@ template<class R>
 
 \rSec4[span.sub]{Subviews}
 
-\indexlibrarymember{span}{first}%
+\indexlibrarymember{first}{span}%
 \begin{itemdecl}
 template<size_t Count> constexpr span<element_type, Count> first() const;
 \end{itemdecl}
@@ -20641,7 +20641,7 @@ Equivalent to: \tcode{return R\{data(), Count\};}
 where \tcode{R} is the return type.
 \end{itemdescr}
 
-\indexlibrarymember{span}{last}%
+\indexlibrarymember{last}{span}%
 \begin{itemdecl}
 template<size_t Count> constexpr span<element_type, Count> last() const;
 \end{itemdecl}
@@ -20661,7 +20661,7 @@ Equivalent to: \tcode{return R\{data() + (size() - Count), Count\};}
 where \tcode{R} is the return type.
 \end{itemdescr}
 
-\indexlibrarymember{span}{subspan}%
+\indexlibrarymember{subspan}{span}%
 \begin{itemdecl}
 template<size_t Offset, size_t Count = dynamic_extent>
   constexpr span<element_type, @\seebelow@> subspan() const;
@@ -20700,7 +20700,7 @@ Count != dynamic_extent ? Count
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{span}{first}%
+\indexlibrarymember{first}{span}%
 \begin{itemdecl}
 constexpr span<element_type, dynamic_extent> first(size_type count) const;
 \end{itemdecl}
@@ -20715,7 +20715,7 @@ constexpr span<element_type, dynamic_extent> first(size_type count) const;
 Equivalent to: \tcode{return \{data(), count\};}
 \end{itemdescr}
 
-\indexlibrarymember{span}{last}%
+\indexlibrarymember{last}{span}%
 \begin{itemdecl}
 constexpr span<element_type, dynamic_extent> last(size_type count) const;
 \end{itemdecl}
@@ -20730,7 +20730,7 @@ constexpr span<element_type, dynamic_extent> last(size_type count) const;
 Equivalent to: \tcode{return \{data() + (size() - count), count\};}
 \end{itemdescr}
 
-\indexlibrarymember{span}{subspan}%
+\indexlibrarymember{subspan}{span}%
 \begin{itemdecl}
 constexpr span<element_type, dynamic_extent> subspan(
   size_type offset, size_type count = dynamic_extent) const;
@@ -20754,7 +20754,7 @@ return {data() + offset, count == dynamic_extent ? size() - offset : count};
 
 \rSec4[span.obs]{Observers}
 
-\indexlibrarymember{span}{size}%
+\indexlibrarymember{size}{span}%
 \begin{itemdecl}
 constexpr size_type size() const noexcept;
 \end{itemdecl}
@@ -20765,7 +20765,7 @@ constexpr size_type size() const noexcept;
 Equivalent to: \tcode{return \exposid{size_};}
 \end{itemdescr}
 
-\indexlibrarymember{span}{size_bytes}%
+\indexlibrarymember{size_bytes}{span}%
 \begin{itemdecl}
 constexpr size_type size_bytes() const noexcept;
 \end{itemdecl}
@@ -20776,7 +20776,7 @@ constexpr size_type size_bytes() const noexcept;
 Equivalent to: \tcode{return size() * sizeof(element_type);}
 \end{itemdescr}
 
-\indexlibrarymember{span}{empty}%
+\indexlibrarymember{empty}{span}%
 \begin{itemdecl}
 constexpr bool empty() const noexcept;
 \end{itemdecl}
@@ -20808,7 +20808,7 @@ constexpr reference operator[](size_type idx) const;
 Nothing.
 \end{itemdescr}
 
-\indexlibrarymember{span}{at}%
+\indexlibrarymember{at}{span}%
 \begin{itemdecl}
 constexpr reference at(size_type idx) const;
 \end{itemdecl}
@@ -20823,7 +20823,7 @@ constexpr reference at(size_type idx) const;
 \tcode{out_of_range} if \tcode{idx >= size()} is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrarymember{span}{front}%
+\indexlibrarymember{front}{span}%
 \begin{itemdecl}
 constexpr reference front() const;
 \end{itemdecl}
@@ -20842,7 +20842,7 @@ constexpr reference front() const;
 Nothing.
 \end{itemdescr}
 
-\indexlibrarymember{span}{back}%
+\indexlibrarymember{back}{span}%
 \begin{itemdecl}
 constexpr reference back() const;
 \end{itemdecl}
@@ -20861,7 +20861,7 @@ constexpr reference back() const;
 Nothing.
 \end{itemdescr}
 
-\indexlibrarymember{span}{data}%
+\indexlibrarymember{data}{span}%
 \begin{itemdecl}
 constexpr pointer data() const noexcept;
 \end{itemdecl}
@@ -20896,7 +20896,7 @@ All requirements on container iterators\iref{container.reqmts} apply to
 \tcode{span::iterator} as well.
 \end{itemdescr}
 
-\indexlibrarymember{span}{begin}%
+\indexlibrarymember{begin}{span}%
 \begin{itemdecl}
 constexpr iterator begin() const noexcept;
 \end{itemdecl}
@@ -20909,7 +20909,7 @@ If \tcode{empty()} is \tcode{true}, then it returns the
 same value as \tcode{end()}.
 \end{itemdescr}
 
-\indexlibrarymember{span}{end}%
+\indexlibrarymember{end}{span}%
 \begin{itemdecl}
 constexpr iterator end() const noexcept;
 \end{itemdecl}
@@ -20920,7 +20920,7 @@ constexpr iterator end() const noexcept;
 An iterator which is the past-the-end value.
 \end{itemdescr}
 
-\indexlibrarymember{span}{rbegin}%
+\indexlibrarymember{rbegin}{span}%
 \begin{itemdecl}
 constexpr reverse_iterator rbegin() const noexcept;
 \end{itemdecl}
@@ -20931,7 +20931,7 @@ constexpr reverse_iterator rbegin() const noexcept;
 Equivalent to: \tcode{return reverse_iterator(end());}
 \end{itemdescr}
 
-\indexlibrarymember{span}{rend}%
+\indexlibrarymember{rend}{span}%
 \begin{itemdecl}
 constexpr reverse_iterator rend() const noexcept;
 \end{itemdecl}

--- a/source/text.tex
+++ b/source/text.tex
@@ -625,7 +625,7 @@ avoid data races on it\iref{res.on.data.races}.
 
 \rSec5[locale.category]{Type \tcode{locale::category}}
 
-\indexlibrarymember{locale}{category}%
+\indexlibrarymember{category}{locale}%
 \begin{itemdecl}
 using category = int;
 \end{itemdecl}
@@ -750,7 +750,7 @@ represents the set of all possible specializations on a bool parameter.
 
 \rSec5[locale.facet]{Class \tcode{locale::facet}}
 
-\indexlibrarymember{locale}{facet}%
+\indexlibrarymember{facet}{locale}%
 \begin{codeblock}
 namespace std {
   class locale::facet {
@@ -825,7 +825,7 @@ by reference to other facets.
 
 \rSec5[locale.id]{Class \tcode{locale::id}}
 
-\indexlibrarymember{locale}{id}%
+\indexlibrarymember{id}{locale}%
 \begin{codeblock}
 namespace std {
   class locale::id {
@@ -1006,7 +1006,7 @@ Creates a copy of \tcode{other}, replacing the current value.
 
 \rSec4[locale.members]{Members}
 
-\indexlibrarymember{locale}{combine}%
+\indexlibrarymember{combine}{locale}%
 \begin{itemdecl}
 template<class Facet> locale combine(const locale& other) const;
 \end{itemdecl}
@@ -1030,7 +1030,7 @@ The newly created locale.
 The resulting locale has no name.
 \end{itemdescr}
 
-\indexlibrarymember{locale}{name}%
+\indexlibrarymember{name}{locale}%
 \begin{itemdecl}
 string name() const;
 \end{itemdecl}
@@ -1042,7 +1042,7 @@ The name of \tcode{*this}, if it has one;
 otherwise, the string \tcode{"*"}.
 \end{itemdescr}
 
-\indexlibrarymember{locale}{encoding}%
+\indexlibrarymember{encoding}{locale}%
 \begin{itemdecl}
 text_encoding encoding() const;
 \end{itemdecl}
@@ -1061,7 +1061,7 @@ associated with the locale \tcode{*this}.
 
 \rSec4[locale.operators]{Operators}
 
-\indexlibrarymember{locale}{operator==}%
+\indexlibrarymember{operator==}{locale}%
 \begin{itemdecl}
 bool operator==(const locale& other) const;
 \end{itemdecl}
@@ -1076,7 +1076,7 @@ each has a name and the names are identical;
 \tcode{false} otherwise.
 \end{itemdescr}
 
-\indexlibrarymember{locale}{operator()}%
+\indexlibrarymember{operator()}{locale}%
 \begin{itemdecl}
 template<class charT, class traits, class Allocator>
   bool operator()(const basic_string<charT, traits, Allocator>& s1,
@@ -1115,7 +1115,7 @@ std::sort(v.begin(), v.end(), loc);
 
 \rSec4[locale.statics]{Static members}
 
-\indexlibrarymember{locale}{global}%
+\indexlibrarymember{global}{locale}%
 \begin{itemdecl}
 static locale global(const locale& loc);
 \end{itemdecl}
@@ -1147,7 +1147,7 @@ when \tcode{setlocale} is invoked.
 \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{locale}{classic}%
+\indexlibrarymember{classic}{locale}%
 \begin{itemdecl}
 static const locale& classic();
 \end{itemdecl}
@@ -1168,7 +1168,7 @@ This locale, its facets, and their member functions, do not change with time.
 
 \rSec3[locale.global.templates]{\tcode{locale} globals}
 
-\indexlibrarymember{locale}{use_facet}%
+\indexlibrarymember{use_facet}{locale}%
 \begin{itemdecl}
 template<class Facet> const Facet& use_facet(const locale& loc);
 \end{itemdecl}
@@ -1194,7 +1194,7 @@ The reference returned remains valid
 at least as long as any copy of \tcode{loc} exists.
 \end{itemdescr}
 
-\indexlibrarymember{locale}{has_facet}%
+\indexlibrarymember{has_facet}{locale}%
 \begin{itemdecl}
 template<class Facet> bool has_facet(const locale& loc) noexcept;
 \end{itemdecl}
@@ -1406,7 +1406,7 @@ to the implementation's native character set.
 
 \rSec5[locale.ctype.members]{\tcode{ctype} members}
 
-\indexlibrarymember{ctype}{is}%
+\indexlibrarymember{is}{ctype}%
 \begin{itemdecl}
 bool         is(mask m, charT c) const;
 const charT* is(const charT* low, const charT* high, mask* vec) const;
@@ -1418,7 +1418,7 @@ const charT* is(const charT* low, const charT* high, mask* vec) const;
 \tcode{do_is(m, c)} or \tcode{do_is(low, high, vec)}.
 \end{itemdescr}
 
-\indexlibrarymember{ctype}{scan_is}%
+\indexlibrarymember{scan_is}{ctype}%
 \begin{itemdecl}
 const charT* scan_is(mask m, const charT* low, const charT* high) const;
 \end{itemdecl}
@@ -1429,7 +1429,7 @@ const charT* scan_is(mask m, const charT* low, const charT* high) const;
 \tcode{do_scan_is(m, low, high)}.
 \end{itemdescr}
 
-\indexlibrarymember{ctype}{scan_not}%
+\indexlibrarymember{scan_not}{ctype}%
 \begin{itemdecl}
 const charT* scan_not(mask m, const charT* low, const charT* high) const;
 \end{itemdecl}
@@ -1440,7 +1440,7 @@ const charT* scan_not(mask m, const charT* low, const charT* high) const;
 \tcode{do_scan_not(m, low, high)}.
 \end{itemdescr}
 
-\indexlibrarymember{ctype}{toupper}%
+\indexlibrarymember{toupper}{ctype}%
 \begin{itemdecl}
 charT        toupper(charT c) const;
 const charT* toupper(charT* low, const charT* high) const;
@@ -1452,7 +1452,7 @@ const charT* toupper(charT* low, const charT* high) const;
 \tcode{do_toupper(c)} or \tcode{do_toupper(low, high)}.
 \end{itemdescr}
 
-\indexlibrarymember{ctype}{tolower}%
+\indexlibrarymember{tolower}{ctype}%
 \begin{itemdecl}
 charT        tolower(charT c) const;
 const charT* tolower(charT* low, const charT* high) const;
@@ -1464,7 +1464,7 @@ const charT* tolower(charT* low, const charT* high) const;
 \tcode{do_tolower(c)} or \tcode{do_tolower(low, high)}.
 \end{itemdescr}
 
-\indexlibrarymember{ctype}{widen}%
+\indexlibrarymember{widen}{ctype}%
 \begin{itemdecl}
 charT       widen(char c) const;
 const char* widen(const char* low, const char* high, charT* to) const;
@@ -1476,7 +1476,7 @@ const char* widen(const char* low, const char* high, charT* to) const;
 \tcode{do_widen(c)} or \tcode{do_widen(low, high, to)}.
 \end{itemdescr}
 
-\indexlibrarymember{ctype}{narrow}%
+\indexlibrarymember{narrow}{ctype}%
 \begin{itemdecl}
 char         narrow(charT c, char dfault) const;
 const charT* narrow(const charT* low, const charT* high, char dfault, char* to) const;
@@ -1490,7 +1490,7 @@ const charT* narrow(const charT* low, const charT* high, char dfault, char* to) 
 
 \rSec5[locale.ctype.virtuals]{\tcode{ctype} virtual functions}
 
-\indexlibrarymember{ctype}{do_is}%
+\indexlibrarymember{do_is}{ctype}%
 \begin{itemdecl}
 bool         do_is(mask m, charT c) const;
 const charT* do_is(const charT* low, const charT* high, mask* vec) const;
@@ -1530,7 +1530,7 @@ such that \tcode{is(m, *p)} would return \tcode{true};
 otherwise, returns \tcode{high}.
 \end{itemdescr}
 
-\indexlibrarymember{ctype}{do_scan_not}%
+\indexlibrarymember{do_scan_not}{ctype}%
 \begin{itemdecl}
 const charT* do_scan_not(mask m, const charT* low, const charT* high) const;
 \end{itemdecl}
@@ -1548,7 +1548,7 @@ such that \tcode{is(m, *p)} would return \tcode{false};
 otherwise, returns \tcode{high}.
 \end{itemdescr}
 
-\indexlibrarymember{ctype}{do_toupper}%
+\indexlibrarymember{do_toupper}{ctype}%
 \begin{itemdecl}
 charT        do_toupper(charT c) const;
 const charT* do_toupper(charT* low, const charT* high) const;
@@ -1571,7 +1571,7 @@ its argument if not.
 The second form returns \tcode{high}.
 \end{itemdescr}
 
-\indexlibrarymember{ctype}{do_tolower}%
+\indexlibrarymember{do_tolower}{ctype}%
 \begin{itemdecl}
 charT        do_tolower(charT c) const;
 const charT* do_tolower(charT* low, const charT* high) const;
@@ -1594,7 +1594,7 @@ its argument if not.
 The second form returns \tcode{high}.
 \end{itemdescr}
 
-\indexlibrarymember{ctype}{do_widen}%
+\indexlibrarymember{do_widen}{ctype}%
 \begin{itemdecl}
 charT        do_widen(char c) const;
 const char*  do_widen(const char* low, const char* high, charT* dest) const;
@@ -1634,7 +1634,7 @@ The first form returns the transformed value.
 The second form returns \tcode{high}.
 \end{itemdescr}
 
-\indexlibrarymember{ctype}{do_narrow}%
+\indexlibrarymember{do_narrow}{ctype}%
 \begin{itemdecl}
 char         do_narrow(charT c, char dfault) const;
 const charT* do_narrow(const charT* low, const charT* high, char dfault, char* dest) const;
@@ -2042,7 +2042,7 @@ the specialized \tcode{do_in} or \tcode{do_out} members.
 
 \rSec5[locale.codecvt.members]{Members}
 
-\indexlibrarymember{codecvt}{out}%
+\indexlibrarymember{out}{codecvt}%
 \begin{itemdecl}
 result out(
   stateT& state,
@@ -2056,7 +2056,7 @@ result out(
 \tcode{do_out(state, from, from_end, from_next, to, to_end, to_next)}.
 \end{itemdescr}
 
-\indexlibrarymember{codecvt}{unshift}%
+\indexlibrarymember{unshift}{codecvt}%
 \begin{itemdecl}
 result unshift(stateT& state, externT* to, externT* to_end, externT*& to_next) const;
 \end{itemdecl}
@@ -2067,7 +2067,7 @@ result unshift(stateT& state, externT* to, externT* to_end, externT*& to_next) c
 \tcode{do_unshift(state, to, to_end, to_next)}.
 \end{itemdescr}
 
-\indexlibrarymember{codecvt}{in}%
+\indexlibrarymember{in}{codecvt}%
 \begin{itemdecl}
 result in(
   stateT& state,
@@ -2081,7 +2081,7 @@ result in(
 \tcode{do_in(state, from, from_end, from_next, to, to_end, to_next)}.
 \end{itemdescr}
 
-\indexlibrarymember{codecvt}{encoding}%
+\indexlibrarymember{encoding}{codecvt}%
 \begin{itemdecl}
 int encoding() const noexcept;
 \end{itemdecl}
@@ -2092,7 +2092,7 @@ int encoding() const noexcept;
 \tcode{do_encoding()}.
 \end{itemdescr}
 
-\indexlibrarymember{codecvt}{always_noconv}%
+\indexlibrarymember{always_noconv}{codecvt}%
 \begin{itemdecl}
 bool always_noconv() const noexcept;
 \end{itemdecl}
@@ -2103,7 +2103,7 @@ bool always_noconv() const noexcept;
 \tcode{do_always_noconv()}.
 \end{itemdescr}
 
-\indexlibrarymember{codecvt}{length}%
+\indexlibrarymember{length}{codecvt}%
 \begin{itemdecl}
 int length(stateT& state, const externT* from, const externT* from_end, size_t max) const;
 \end{itemdecl}
@@ -2114,7 +2114,7 @@ int length(stateT& state, const externT* from, const externT* from_end, size_t m
 \tcode{do_length(state, from, from_end, max)}.
 \end{itemdescr}
 
-\indexlibrarymember{codecvt}{max_length}%
+\indexlibrarymember{max_length}{codecvt}%
 \begin{itemdecl}
 int max_length() const noexcept;
 \end{itemdecl}
@@ -2127,8 +2127,8 @@ int max_length() const noexcept;
 
 \rSec5[locale.codecvt.virtuals]{Virtual functions}
 
-\indexlibrarymember{codecvt}{do_out}%
-\indexlibrarymember{codecvt}{do_in}%
+\indexlibrarymember{do_out}{codecvt}%
+\indexlibrarymember{do_in}{codecvt}%
 \begin{itemdecl}
 result do_out(
   stateT& state,
@@ -2242,7 +2242,7 @@ to identify a cache of seek offsets.
 \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{codecvt}{do_unshift}%
+\indexlibrarymember{do_unshift}{codecvt}%
 \begin{itemdecl}
 result do_unshift(stateT& state, externT* to, externT* to_end, externT*& to_next) const;
 \end{itemdecl}
@@ -2284,7 +2284,7 @@ to terminate a sequence given the value of \tcode{state}\\
 \end{floattable}
 \end{itemdescr}
 
-\indexlibrarymember{codecvt}{do_encoding}%
+\indexlibrarymember{do_encoding}{codecvt}%
 \begin{itemdecl}
 int do_encoding() const noexcept;
 \end{itemdecl}
@@ -2305,7 +2305,7 @@ after those that yield the final \tcode{internT} character.
 \end{footnote}
 \end{itemdescr}
 
-\indexlibrarymember{codecvt}{do_always_noconv}%
+\indexlibrarymember{do_always_noconv}{codecvt}%
 \begin{itemdecl}
 bool do_always_noconv() const noexcept;
 \end{itemdecl}
@@ -2318,7 +2318,7 @@ for all valid argument values.
 \tcode{codecvt<char, char, mbstate_t>} returns \tcode{true}.
 \end{itemdescr}
 
-\indexlibrarymember{codecvt}{do_length}%
+\indexlibrarymember{do_length}{codecvt}%
 \begin{itemdecl}
 int do_length(stateT& state, const externT* from, const externT* from_end, size_t max) const;
 \end{itemdecl}
@@ -2348,7 +2348,7 @@ The specialization \tcode{codecvt<char, char, mbstate_t>},
 returns the lesser of \tcode{max} and \tcode{(from_end - from)}.
 \end{itemdescr}
 
-\indexlibrarymember{codecvt}{do_max_length}%
+\indexlibrarymember{do_max_length}{codecvt}%
 \begin{itemdecl}
 int do_max_length() const noexcept;
 \end{itemdecl}
@@ -2493,7 +2493,7 @@ from an input sequence such as an istream.
 
 \rSec5[facet.num.get.members]{Members}
 
-\indexlibrarymember{num_get}{get}%
+\indexlibrarymember{get}{num_get}%
 \begin{itemdecl}
 iter_type get(iter_type in, iter_type end, ios_base& str,
               ios_base::iostate& err, bool& val) const;
@@ -2527,7 +2527,7 @@ iter_type get(iter_type in, iter_type end, ios_base& str,
 
 \rSec5[facet.num.get.virtuals]{Virtual functions}
 
-\indexlibrarymember{num_get}{do_get}%
+\indexlibrarymember{do_get}{num_get}%
 \begin{itemdecl}
 iter_type do_get(iter_type in, iter_type end, ios_base& str,
                  ios_base::iostate& err, long& val) const;
@@ -2845,7 +2845,7 @@ is used to format numeric values to a character sequence such as an ostream.
 
 \rSec5[facet.num.put.members]{Members}
 
-\indexlibrarymember{num_put}{put}%
+\indexlibrarymember{put}{num_put}%
 \begin{itemdecl}
 iter_type put(iter_type out, ios_base& str, char_type fill, bool val) const;
 iter_type put(iter_type out, ios_base& str, char_type fill, long val) const;
@@ -2865,7 +2865,7 @@ iter_type put(iter_type out, ios_base& str, char_type fill, const void* val) con
 
 \rSec5[facet.num.put.virtuals]{Virtual functions}
 
-\indexlibrarymember{num_put}{do_put}%
+\indexlibrarymember{do_put}{num_put}%
 \begin{itemdecl}
 iter_type do_put(iter_type out, ios_base& str, char_type fill, long val) const;
 iter_type do_put(iter_type out, ios_base& str, char_type fill, long long val) const;
@@ -3202,7 +3202,7 @@ no grouping constraint is applied.
 
 \rSec5[facet.numpunct.members]{Members}
 
-\indexlibrarymember{numpunct}{decimal_point}%
+\indexlibrarymember{decimal_point}{numpunct}%
 \begin{itemdecl}
 char_type decimal_point() const;
 \end{itemdecl}
@@ -3213,7 +3213,7 @@ char_type decimal_point() const;
 \tcode{do_decimal_point()}.
 \end{itemdescr}
 
-\indexlibrarymember{numpunct}{thousands_sep}%
+\indexlibrarymember{thousands_sep}{numpunct}%
 \begin{itemdecl}
 char_type thousands_sep() const;
 \end{itemdecl}
@@ -3224,7 +3224,7 @@ char_type thousands_sep() const;
 \tcode{do_thousands_sep()}.
 \end{itemdescr}
 
-\indexlibrarymember{numpunct}{grouping}%
+\indexlibrarymember{grouping}{numpunct}%
 \begin{itemdecl}
 string grouping() const;
 \end{itemdecl}
@@ -3235,8 +3235,8 @@ string grouping() const;
 \tcode{do_grouping()}.
 \end{itemdescr}
 
-\indexlibrarymember{numpunct}{truename}%
-\indexlibrarymember{numpunct}{falsename}%
+\indexlibrarymember{truename}{numpunct}%
+\indexlibrarymember{falsename}{numpunct}%
 \begin{itemdecl}
 string_type truename()  const;
 string_type falsename() const;
@@ -3253,7 +3253,7 @@ respectively.
 
 \rSec5[facet.numpunct.virtuals]{Virtual functions}
 
-\indexlibrarymember{numpunct}{do_decimal_point}%
+\indexlibrarymember{do_decimal_point}{numpunct}%
 \begin{itemdecl}
 char_type do_decimal_point() const;
 \end{itemdecl}
@@ -3265,7 +3265,7 @@ A character for use as the decimal radix separator.
 The required specializations return \tcode{'.'} or \tcode{L'.'}.
 \end{itemdescr}
 
-\indexlibrarymember{numpunct}{do_thousands_sep}%
+\indexlibrarymember{do_thousands_sep}{numpunct}%
 \begin{itemdecl}
 char_type do_thousands_sep() const;
 \end{itemdecl}
@@ -3277,7 +3277,7 @@ A character for use as the digit group separator.
 The required specializations return \tcode{','} or \tcode{L','}.
 \end{itemdescr}
 
-\indexlibrarymember{numpunct}{do_grouping}%
+\indexlibrarymember{do_grouping}{numpunct}%
 \begin{itemdecl}
 string do_grouping() const;
 \end{itemdecl}
@@ -3304,8 +3304,8 @@ the size of the digit group is unlimited.
 The required specializations return the empty string, indicating no grouping.
 \end{itemdescr}
 
-\indexlibrarymember{numpunct}{do_truename}%
-\indexlibrarymember{numpunct}{do_falsename}%
+\indexlibrarymember{do_truename}{numpunct}%
+\indexlibrarymember{do_falsename}{numpunct}%
 \begin{itemdecl}
 string_type do_truename()  const;
 string_type do_falsename() const;
@@ -3396,7 +3396,7 @@ in the range \range{low}{high}.
 
 \rSec5[locale.collate.members]{Members}
 
-\indexlibrarymember{collate}{compare}%
+\indexlibrarymember{compare}{collate}%
 \begin{itemdecl}
 int compare(const charT* low1, const charT* high1,
             const charT* low2, const charT* high2) const;
@@ -3408,7 +3408,7 @@ int compare(const charT* low1, const charT* high1,
 \tcode{do_compare(low1, high1, low2, high2)}.
 \end{itemdescr}
 
-\indexlibrarymember{collate}{transform}%
+\indexlibrarymember{transform}{collate}%
 \begin{itemdecl}
 string_type transform(const charT* low, const charT* high) const;
 \end{itemdecl}
@@ -3419,7 +3419,7 @@ string_type transform(const charT* low, const charT* high) const;
 \tcode{do_transform(low, high)}.
 \end{itemdescr}
 
-\indexlibrarymember{collate}{hash}%
+\indexlibrarymember{hash}{collate}%
 \begin{itemdecl}
 long hash(const charT* low, const charT* high) const;
 \end{itemdecl}
@@ -3432,7 +3432,7 @@ long hash(const charT* low, const charT* high) const;
 
 \rSec5[locale.collate.virtuals]{Virtual functions}
 
-\indexlibrarymember{collate}{do_compare}%
+\indexlibrarymember{do_compare}{collate}%
 \begin{itemdecl}
 int do_compare(const charT* low1, const charT* high1,
                const charT* low2, const charT* high2) const;
@@ -3450,7 +3450,7 @@ namely \tcode{collate<char>} and \tcode{collate<wchar_t>},
 implement a lexicographical comparison\iref{alg.lex.comparison}.
 \end{itemdescr}
 
-\indexlibrarymember{collate}{do_transform}%
+\indexlibrarymember{do_transform}{collate}%
 \begin{itemdecl}
 string_type do_transform(const charT* low, const charT* high) const;
 \end{itemdecl}
@@ -3467,7 +3467,7 @@ This function is useful when one string is being compared to many other strings.
 \end{footnote}
 \end{itemdescr}
 
-\indexlibrarymember{collate}{do_hash}%
+\indexlibrarymember{do_hash}{collate}%
 \begin{itemdecl}
 long do_hash(const charT* low, const charT* high) const;
 \end{itemdecl}
@@ -3610,7 +3610,7 @@ in \tcode{err}.
 
 \rSec5[locale.time.get.members]{Members}
 
-\indexlibrarymember{time_get}{date_order}%
+\indexlibrarymember{date_order}{time_get}%
 \begin{itemdecl}
 dateorder date_order() const;
 \end{itemdecl}
@@ -3621,7 +3621,7 @@ dateorder date_order() const;
 \tcode{do_date_order()}.
 \end{itemdescr}
 
-\indexlibrarymember{time_get}{get_time}%
+\indexlibrarymember{get_time}{time_get}%
 \begin{itemdecl}
 iter_type get_time(iter_type s, iter_type end, ios_base& str,
                    ios_base::iostate& err, tm* t) const;
@@ -3633,7 +3633,7 @@ iter_type get_time(iter_type s, iter_type end, ios_base& str,
 \tcode{do_get_time(s, end, str, err, t)}.
 \end{itemdescr}
 
-\indexlibrarymember{time_get}{get_date}%
+\indexlibrarymember{get_date}{time_get}%
 \begin{itemdecl}
 iter_type get_date(iter_type s, iter_type end, ios_base& str,
                    ios_base::iostate& err, tm* t) const;
@@ -3645,8 +3645,8 @@ iter_type get_date(iter_type s, iter_type end, ios_base& str,
 \tcode{do_get_date(s, end, str, err, t)}.
 \end{itemdescr}
 
-\indexlibrarymember{time_get}{get_weekday}%
-\indexlibrarymember{time_get}{get_monthname}%
+\indexlibrarymember{get_weekday}{time_get}%
+\indexlibrarymember{get_monthname}{time_get}%
 \begin{itemdecl}
 iter_type get_weekday(iter_type s, iter_type end, ios_base& str,
                       ios_base::iostate& err, tm* t) const;
@@ -3662,7 +3662,7 @@ or
 \tcode{do_get_monthname(s, end, str, err, t)}.
 \end{itemdescr}
 
-\indexlibrarymember{time_get}{get_year}%
+\indexlibrarymember{get_year}{time_get}%
 \begin{itemdecl}
 iter_type get_year(iter_type s, iter_type end, ios_base& str,
                    ios_base::iostate& err, tm* t) const;
@@ -3766,7 +3766,7 @@ whether multi-character sequences are considered while doing so.
 
 \rSec5[locale.time.get.virtuals]{Virtual functions}
 
-\indexlibrarymember{time_get}{do_date_order}%
+\indexlibrarymember{do_date_order}{time_get}%
 \begin{itemdecl}
 dateorder do_date_order() const;
 \end{itemdecl}
@@ -3784,7 +3784,7 @@ Returns \tcode{no_order} if the date format specified by \tcode{'x'}
 contains other variable components (e.g., Julian day, week number, week day).
 \end{itemdescr}
 
-\indexlibrarymember{time_get}{do_get_time}%
+\indexlibrarymember{do_get_time}{time_get}%
 \begin{itemdecl}
 iter_type do_get_time(iter_type s, iter_type end, ios_base& str,
                       ios_base::iostate& err, tm* t) const;
@@ -3806,7 +3806,7 @@ An iterator pointing immediately beyond
 the last character recognized as possibly part of a valid time.
 \end{itemdescr}
 
-\indexlibrarymember{time_get}{do_get_date}%
+\indexlibrarymember{do_get_date}{time_get}%
 \begin{itemdecl}
 iter_type do_get_date(iter_type s, iter_type end, ios_base& str,
                       ios_base::iostate& err, tm* t) const;
@@ -3843,8 +3843,8 @@ An iterator pointing immediately beyond
 the last character recognized as possibly part of a valid date.
 \end{itemdescr}
 
-\indexlibrarymember{time_get}{do_get_weekday}%
-\indexlibrarymember{time_get}{do_get_monthname}%
+\indexlibrarymember{do_get_weekday}{time_get}%
+\indexlibrarymember{do_get_monthname}{time_get}%
 \begin{itemdecl}
 iter_type do_get_weekday(iter_type s, iter_type end, ios_base& str,
                          ios_base::iostate& err, tm* t) const;
@@ -3868,7 +3868,7 @@ An iterator pointing immediately beyond the last character recognized
 as part of a valid name.
 \end{itemdescr}
 
-\indexlibrarymember{time_get}{do_get_year}%
+\indexlibrarymember{do_get_year}{time_get}%
 \begin{itemdecl}
 iter_type do_get_year(iter_type s, iter_type end, ios_base& str,
                       ios_base::iostate& err, tm* t) const;
@@ -4163,7 +4163,7 @@ namespace std {
 
 \rSec5[locale.money.get.members]{Members}
 
-\indexlibrarymember{money_get}{get}%
+\indexlibrarymember{get}{money_get}%
 \begin{itemdecl}
 iter_type get(iter_type s, iter_type end, bool intl, ios_base& f,
               ios_base::iostate& err, long double& quant) const;
@@ -4179,7 +4179,7 @@ iter_type get(iter_type s, iter_type end, bool intl, ios_base& f,
 
 \rSec5[locale.money.get.virtuals]{Virtual functions}
 
-\indexlibrarymember{money_get}{do_get}%
+\indexlibrarymember{do_get}{money_get}%
 \begin{itemdecl}
 iter_type do_get(iter_type s, iter_type end, bool intl, ios_base& str,
                  ios_base::iostate& err, long double& units) const;
@@ -4330,7 +4330,7 @@ namespace std {
 
 \rSec5[locale.money.put.members]{Members}
 
-\indexlibrarymember{money_put}{put}%
+\indexlibrarymember{put}{money_put}%
 \begin{itemdecl}
 iter_type put(iter_type s, bool intl, ios_base& f, char_type fill, long double quant) const;
 iter_type put(iter_type s, bool intl, ios_base& f, char_type fill, const string_type& quant) const;
@@ -4344,7 +4344,7 @@ iter_type put(iter_type s, bool intl, ios_base& f, char_type fill, const string_
 
 \rSec5[locale.money.put.virtuals]{Virtual functions}
 
-\indexlibrarymember{money_put}{do_put}%
+\indexlibrarymember{do_put}{money_put}%
 \begin{itemdecl}
 iter_type do_put(iter_type s, bool intl, ios_base& str,
                  char_type fill, long double units) const;
@@ -4552,15 +4552,15 @@ defined identically as the member \tcode{numpunct<>::do_grouping()}.
 
 \rSec5[locale.moneypunct.members]{Members}
 
-\indexlibrarymember{moneypunct}{decimal_point}%
-\indexlibrarymember{moneypunct}{thousands_sep}%
-\indexlibrarymember{moneypunct}{grouping}%
-\indexlibrarymember{moneypunct}{curr_symbol}%
-\indexlibrarymember{moneypunct}{positive_sign}%
-\indexlibrarymember{moneypunct}{negative_sign}%
-\indexlibrarymember{moneypunct}{frac_digits}%
-\indexlibrarymember{moneypunct}{positive_sign}%
-\indexlibrarymember{moneypunct}{negative_sign}%
+\indexlibrarymember{decimal_point}{moneypunct}%
+\indexlibrarymember{thousands_sep}{moneypunct}%
+\indexlibrarymember{grouping}{moneypunct}%
+\indexlibrarymember{curr_symbol}{moneypunct}%
+\indexlibrarymember{positive_sign}{moneypunct}%
+\indexlibrarymember{negative_sign}{moneypunct}%
+\indexlibrarymember{frac_digits}{moneypunct}%
+\indexlibrarymember{positive_sign}{moneypunct}%
+\indexlibrarymember{negative_sign}{moneypunct}%
 \begin{codeblock}
 charT       decimal_point() const;
 charT       thousands_sep() const;
@@ -4581,7 +4581,7 @@ virtual member function
 
 \rSec5[locale.moneypunct.virtuals]{Virtual functions}
 
-\indexlibrarymember{moneypunct}{do_decimal_point}%
+\indexlibrarymember{do_decimal_point}{moneypunct}%
 \begin{itemdecl}
 charT do_decimal_point() const;
 \end{itemdecl}
@@ -4596,7 +4596,7 @@ In common U.S. locales this is \tcode{'.'}.
 \end{footnote}
 \end{itemdescr}
 
-\indexlibrarymember{moneypunct}{do_thousands_sep}%
+\indexlibrarymember{do_thousands_sep}{moneypunct}%
 \begin{itemdecl}
 charT do_thousands_sep() const;
 \end{itemdecl}
@@ -4611,7 +4611,7 @@ In common U.S. locales this is \tcode{','}.
 \end{footnote}
 \end{itemdescr}
 
-\indexlibrarymember{moneypunct}{do_grouping}%
+\indexlibrarymember{do_grouping}{moneypunct}%
 \begin{itemdecl}
 string do_grouping() const;
 \end{itemdecl}
@@ -4627,7 +4627,7 @@ the value is \tcode{"\textbackslash003"} \textit{not} \tcode{"3"}.
 \end{footnote}
 \end{itemdescr}
 
-\indexlibrarymember{moneypunct}{do_curr_symbol}%
+\indexlibrarymember{do_curr_symbol}{moneypunct}%
 \begin{itemdecl}
 string_type do_curr_symbol() const;
 \end{itemdecl}
@@ -4644,8 +4644,8 @@ followed by a space.
 \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{moneypunct}{do_positive_sign}%
-\indexlibrarymember{moneypunct}{do_negative_sign}%
+\indexlibrarymember{do_positive_sign}{moneypunct}%
+\indexlibrarymember{do_negative_sign}{moneypunct}%
 \begin{itemdecl}
 string_type do_positive_sign() const;
 string_type do_negative_sign() const;
@@ -4663,7 +4663,7 @@ This is usually the empty string.
 returns the string to use to indicate a negative value.
 \end{itemdescr}
 
-\indexlibrarymember{moneypunct}{do_frac_digits}%
+\indexlibrarymember{do_frac_digits}{moneypunct}%
 \begin{itemdecl}
 int do_frac_digits() const;
 \end{itemdecl}
@@ -4677,8 +4677,8 @@ In common U.S. locales, this is 2.
 \end{footnote}
 \end{itemdescr}
 
-\indexlibrarymember{moneypunct}{do_pos_format}%
-\indexlibrarymember{moneypunct}{do_neg_format}%
+\indexlibrarymember{do_pos_format}{moneypunct}%
+\indexlibrarymember{do_neg_format}{moneypunct}%
 \begin{itemdecl}
 pattern do_pos_format() const;
 pattern do_neg_format() const;
@@ -4775,7 +4775,7 @@ can be obtained only by calling member \tcode{open}.
 
 \rSec5[locale.messages.members]{Members}
 
-\indexlibrarymember{messages}{open}%
+\indexlibrarymember{open}{messages}%
 \begin{itemdecl}
 catalog open(const string& name, const locale& loc) const;
 \end{itemdecl}
@@ -4786,7 +4786,7 @@ catalog open(const string& name, const locale& loc) const;
 \tcode{do_open(name, loc)}.
 \end{itemdescr}
 
-\indexlibrarymember{messages}{get}%
+\indexlibrarymember{get}{messages}%
 \begin{itemdecl}
 string_type get(catalog cat, int set, int msgid, const string_type& dfault) const;
 \end{itemdecl}
@@ -4797,7 +4797,7 @@ string_type get(catalog cat, int set, int msgid, const string_type& dfault) cons
 \tcode{do_get(cat, set, msgid, dfault)}.
 \end{itemdescr}
 
-\indexlibrarymember{messages}{close}%
+\indexlibrarymember{close}{messages}%
 \begin{itemdecl}
 void close(catalog cat) const;
 \end{itemdecl}
@@ -4810,7 +4810,7 @@ Calls \tcode{do_close(cat)}.
 
 \rSec5[locale.messages.virtuals]{Virtual functions}
 
-\indexlibrarymember{messages}{do_open}%
+\indexlibrarymember{do_open}{messages}%
 \begin{itemdecl}
 catalog do_open(const string& name, const locale& loc) const;
 \end{itemdecl}
@@ -4834,7 +4834,7 @@ The locale argument \tcode{loc} is used for
 character set code conversion when retrieving messages, if needed.
 \end{itemdescr}
 
-\indexlibrarymember{messages}{do_get}%
+\indexlibrarymember{do_get}{messages}%
 \begin{itemdecl}
 string_type do_get(catalog cat, int set, int msgid, const string_type& dfault) const;
 \end{itemdecl}
@@ -7749,7 +7749,7 @@ basic_format_arg<basic_format_context> arg(size_t id) const noexcept;
 \tcode{args_.get(id)}.
 \end{itemdescr}
 
-\indexlibrarymember{locale}{basic_format_context}%
+\indexlibrarymember{basic_format_context}{locale}%
 \begin{itemdecl}
 std::locale locale();
 \end{itemdecl}
@@ -10033,7 +10033,7 @@ The specializations \tcode{regex_traits<char>} and
 \tcode{regex_traits<wchar_t>} meet the
 requirements for a regular expression traits class\iref{re.req}.
 
-\indexlibrarymember{regex_traits}{char_class_type}%
+\indexlibrarymember{char_class_type}{regex_traits}%
 \begin{itemdecl}
 using char_class_type = @\textit{bitmask_type}@;
 \end{itemdecl}
@@ -10056,7 +10056,7 @@ static size_t length(const char_type* p);
 \tcode{char_traits<charT>::length(p)}.
 \end{itemdescr}
 
-\indexlibrarymember{regex_traits}{translate}%
+\indexlibrarymember{translate}{regex_traits}%
 \begin{itemdecl}
 charT translate(charT c) const;
 \end{itemdecl}
@@ -10067,7 +10067,7 @@ charT translate(charT c) const;
 \tcode{c}.
 \end{itemdescr}
 
-\indexlibrarymember{regex_traits}{translate_nocase}%
+\indexlibrarymember{translate_nocase}{regex_traits}%
 \begin{itemdecl}
 charT translate_nocase(charT c) const;
 \end{itemdecl}
@@ -10078,7 +10078,7 @@ charT translate_nocase(charT c) const;
 \tcode{use_facet<ctype<charT>>(getloc()).tolower(c)}.
 \end{itemdescr}
 
-\indexlibrarymember{regex_traits}{transform}%
+\indexlibrarymember{transform}{regex_traits}%
 \begin{itemdecl}
 template<class ForwardIterator>
   string_type transform(ForwardIterator first, ForwardIterator last) const;
@@ -10095,7 +10095,7 @@ return use_facet<collate<charT>>(
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{regex_traits}{transform_primary}%
+\indexlibrarymember{transform_primary}{regex_traits}%
 \begin{itemdecl}
 template<class ForwardIterator>
   string_type transform_primary(ForwardIterator first, ForwardIterator last) const;
@@ -10114,7 +10114,7 @@ can be converted into a primary sort key then returns that key,
 otherwise returns an empty string.
 \end{itemdescr}
 
-\indexlibrarymember{regex_traits}{lookup_collatename}%
+\indexlibrarymember{lookup_collatename}{regex_traits}%
 \begin{itemdecl}
 template<class ForwardIterator>
   string_type lookup_collatename(ForwardIterator first, ForwardIterator last) const;
@@ -10130,7 +10130,7 @@ Returns an empty string if the character sequence is not a
 valid collating element.
 \end{itemdescr}
 
-\indexlibrarymember{regex_traits}{lookup_classname}%
+\indexlibrarymember{lookup_classname}{regex_traits}%
 \begin{itemdecl}
 template<class ForwardIterator>
   char_class_type lookup_classname(
@@ -10164,7 +10164,7 @@ For \tcode{regex_traits<wchar_t>}, at least the wide character names
 in \tref{re.traits.classnames} shall be recognized.
 \end{itemdescr}
 
-\indexlibrarymember{regex_traits}{isctype}%
+\indexlibrarymember{isctype}{regex_traits}%
 \begin{itemdecl}
 bool isctype(charT c, char_class_type f) const;
 \end{itemdecl}
@@ -10575,7 +10575,7 @@ Same as \tcode{basic_regex(il.begin(), il.end(), f)}.
 
 \rSec3[re.regex.assign]{Assignment}
 
-\indexlibrarymember{basic_regex}{operator=}%
+\indexlibrarymember{operator=}{basic_regex}%
 \begin{itemdecl}
 basic_regex& operator=(const basic_regex& e);
 \end{itemdecl}
@@ -10587,7 +10587,7 @@ basic_regex& operator=(const basic_regex& e);
 \tcode{e.flags()} and \tcode{e.mark_count()}, respectively.
 \end{itemdescr}
 
-\indexlibrarymember{basic_regex}{operator=}%
+\indexlibrarymember{operator=}{basic_regex}%
 \begin{itemdecl}
 basic_regex& operator=(basic_regex&& e) noexcept;
 \end{itemdecl}
@@ -10600,7 +10600,7 @@ basic_regex& operator=(basic_regex&& e) noexcept;
 \tcode{e} is in a valid state with unspecified value.
 \end{itemdescr}
 
-\indexlibrarymember{basic_regex}{operator=}%
+\indexlibrarymember{operator=}{basic_regex}%
 \begin{itemdecl}
 basic_regex& operator=(const charT* p);
 \end{itemdecl}
@@ -10611,7 +10611,7 @@ basic_regex& operator=(const charT* p);
 Equivalent to: \tcode{return assign(p);}
 \end{itemdescr}
 
-\indexlibrarymember{basic_regex}{operator=}%
+\indexlibrarymember{operator=}{basic_regex}%
 \begin{itemdecl}
 basic_regex& operator=(initializer_list<charT> il);
 \end{itemdecl}
@@ -10622,7 +10622,7 @@ basic_regex& operator=(initializer_list<charT> il);
 Equivalent to: \tcode{return assign(il.begin(), il.end());}
 \end{itemdescr}
 
-\indexlibrarymember{basic_regex}{operator=}%
+\indexlibrarymember{operator=}{basic_regex}%
 \begin{itemdecl}
 template<class ST, class SA>
   basic_regex& operator=(const basic_string<charT, ST, SA>& s);
@@ -10634,7 +10634,7 @@ template<class ST, class SA>
 Equivalent to: \tcode{return assign(s);}
 \end{itemdescr}
 
-\indexlibrarymember{basic_regex}{assign}%
+\indexlibrarymember{assign}{basic_regex}%
 \begin{itemdecl}
 basic_regex& assign(const basic_regex& e);
 \end{itemdecl}
@@ -10645,7 +10645,7 @@ basic_regex& assign(const basic_regex& e);
 Equivalent to: \tcode{return *this = e;}
 \end{itemdescr}
 
-\indexlibrarymember{basic_regex}{assign}%
+\indexlibrarymember{assign}{basic_regex}%
 \begin{itemdecl}
 basic_regex& assign(basic_regex&& e) noexcept;
 \end{itemdecl}
@@ -10656,7 +10656,7 @@ basic_regex& assign(basic_regex&& e) noexcept;
 Equivalent to: \tcode{return *this = std::move(e);}
 \end{itemdescr}
 
-\indexlibrarymember{basic_regex}{assign}%
+\indexlibrarymember{assign}{basic_regex}%
 \begin{itemdecl}
 basic_regex& assign(const charT* p, flag_type f = regex_constants::ECMAScript);
 \end{itemdecl}
@@ -10667,7 +10667,7 @@ basic_regex& assign(const charT* p, flag_type f = regex_constants::ECMAScript);
 Equivalent to: \tcode{return assign(string_type(p), f);}
 \end{itemdescr}
 
-\indexlibrarymember{basic_regex}{assign}%
+\indexlibrarymember{assign}{basic_regex}%
 \begin{itemdecl}
 basic_regex& assign(const charT* p, size_t len, flag_type f = regex_constants::ECMAScript);
 \end{itemdecl}
@@ -10678,7 +10678,7 @@ basic_regex& assign(const charT* p, size_t len, flag_type f = regex_constants::E
 Equivalent to: \tcode{return assign(string_type(p, len), f);}
 \end{itemdescr}
 
-\indexlibrarymember{basic_regex}{assign}%
+\indexlibrarymember{assign}{basic_regex}%
 \begin{itemdecl}
 template<class ST, class SA>
   basic_regex& assign(const basic_string<charT, ST, SA>& s,
@@ -10707,7 +10707,7 @@ returns the number of marked sub-expressions within the expression.
 \tcode{regex_error} if \tcode{s} is not a valid regular expression.
 \end{itemdescr}
 
-\indexlibrarymember{basic_regex}{assign}%
+\indexlibrarymember{assign}{basic_regex}%
 \begin{itemdecl}
 template<class InputIterator>
   basic_regex& assign(InputIterator first, InputIterator last,
@@ -10792,7 +10792,7 @@ parameter \tcode{traits} stored within the object.
 \end{itemdescr}
 
 \rSec3[re.regex.swap]{Swap}
-\indexlibrarymember{basic_regex}{swap}%
+\indexlibrarymember{swap}{basic_regex}%
 
 \indexlibrarymember{swap}{basic_regex}%
 \begin{itemdecl}
@@ -10817,7 +10817,7 @@ Constant time.
 
 \rSec3[re.regex.nonmemb]{Non-member functions}
 
-\indexlibrarymember{basic_regex}{swap}%
+\indexlibrarymember{swap}{basic_regex}%
 \begin{itemdecl}
 template<class charT, class traits>
   void swap(basic_regex<charT, traits>& lhs, basic_regex<charT, traits>& rhs);
@@ -10879,7 +10879,7 @@ Value-initializes the \tcode{pair} base class subobject and the member
 \tcode{matched}.
 \end{itemdescr}
 
-\indexlibrarymember{sub_match}{length}%
+\indexlibrarymember{length}{sub_match}%
 \begin{itemdecl}
 difference_type length() const;
 \end{itemdecl}
@@ -10901,7 +10901,7 @@ operator string_type() const;
 \tcode{matched ?\ string_type(first, second) :\ string_type()}.
 \end{itemdescr}
 
-\indexlibrarymember{sub_match}{str}%
+\indexlibrarymember{str}{sub_match}%
 \begin{itemdecl}
 string_type str() const;
 \end{itemdecl}
@@ -10912,7 +10912,7 @@ string_type str() const;
 \tcode{matched ?\ string_type(first, second) :\ string_type()}.
 \end{itemdescr}
 
-\indexlibrarymember{sub_match}{compare}%
+\indexlibrarymember{compare}{sub_match}%
 \begin{itemdecl}
 int compare(const sub_match& s) const;
 \end{itemdecl}
@@ -10923,7 +10923,7 @@ int compare(const sub_match& s) const;
 \tcode{str().compare(s.str())}.
 \end{itemdescr}
 
-\indexlibrarymember{sub_match}{compare}%
+\indexlibrarymember{compare}{sub_match}%
 \begin{itemdecl}
 int compare(const string_type& s) const;
 \end{itemdecl}
@@ -10934,7 +10934,7 @@ int compare(const string_type& s) const;
 \tcode{str().compare(s)}.
 \end{itemdescr}
 
-\indexlibrarymember{sub_match}{compare}%
+\indexlibrarymember{compare}{sub_match}%
 \begin{itemdecl}
 int compare(const value_type* s) const;
 \end{itemdecl}
@@ -10945,7 +10945,7 @@ int compare(const value_type* s) const;
 \tcode{str().compare(s)}.
 \end{itemdescr}
 
-\indexlibrarymember{sub_match}{swap}%
+\indexlibrarymember{swap}{sub_match}%
 \begin{itemdecl}
 void swap(sub_match& s) noexcept(@\seebelow@);
 \end{itemdecl}
@@ -10978,7 +10978,7 @@ Let \tcode{\placeholdernc{SM-CAT}(I)} be
 compare_three_way_result_t<basic_string<typename iterator_traits<I>::value_type>>
 \end{codeblock}
 
-\indexlibrarymember{sub_match}{operator==}%
+\indexlibrarymember{operator==}{sub_match}%
 \begin{itemdecl}
 template<class BiIter>
   bool operator==(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs);
@@ -10990,7 +10990,7 @@ template<class BiIter>
 \tcode{lhs.compare(rhs) == 0}.
 \end{itemdescr}
 
-\indexlibrarymember{sub_match}{operator<=>}%
+\indexlibrarymember{operator<=>}{sub_match}%
 \begin{itemdecl}
 template<class BiIter>
   auto operator<=>(const sub_match<BiIter>& lhs, const sub_match<BiIter>& rhs);
@@ -11037,7 +11037,7 @@ static_cast<@\placeholdernc{SM-CAT}@(BiIter)>(lhs.compare(
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{sub_match}{operator==}%
+\indexlibrarymember{operator==}{sub_match}%
 \begin{itemdecl}
 template<class BiIter>
   bool operator==(const sub_match<BiIter>& lhs,
@@ -11050,7 +11050,7 @@ template<class BiIter>
 \tcode{lhs.compare(rhs) == 0}.
 \end{itemdescr}
 
-\indexlibrarymember{sub_match}{operator<=>}%
+\indexlibrarymember{operator<=>}{sub_match}%
 \begin{itemdecl}
 template<class BiIter>
   auto operator<=>(const sub_match<BiIter>& lhs,
@@ -11063,7 +11063,7 @@ template<class BiIter>
 \tcode{static_cast<\placeholdernc{SM-CAT}(BiIter)>(lhs.compare(rhs) <=> 0)}.
 \end{itemdescr}
 
-\indexlibrarymember{sub_match}{operator==}%
+\indexlibrarymember{operator==}{sub_match}%
 \begin{itemdecl}
 template<class BiIter>
   bool operator==(const sub_match<BiIter>& lhs,
@@ -11076,7 +11076,7 @@ template<class BiIter>
 \tcode{lhs.compare(typename sub_match<BiIter>::string_type(1, rhs)) == 0}.
 \end{itemdescr}
 
-\indexlibrarymember{sub_match}{operator<=>}%
+\indexlibrarymember{operator<=>}{sub_match}%
 \begin{itemdecl}
 template<class BiIter>
   auto operator<=>(const sub_match<BiIter>& lhs,
@@ -11095,7 +11095,7 @@ static_cast<@\placeholdernc{SM-CAT}@(BiIter)>(lhs.compare(
 \end{itemdescr}
 
 \indexlibraryglobal{basic_ostream}%
-\indexlibrarymember{sub_match}{operator<<}%
+\indexlibrarymember{operator<<}{sub_match}%
 \begin{itemdecl}
 template<class charT, class ST, class BiIter>
   basic_ostream<charT, ST>&
@@ -11139,7 +11139,7 @@ modifying such an object, its result state becomes fully established. The effect
 most member functions from a \tcode{match_results} object that is not ready are undefined.
 
 \pnum
-\indexlibrarymember{match_results}{matched}%
+\indexlibrarymember{matched}{match_results}%
 The \tcode{sub_match} object stored at index 0 represents sub-expression 0,
 i.e., the whole match. In this case the \tcode{sub_match} member
 \tcode{matched} is always \tcode{true}. The \tcode{sub_match}
@@ -11304,7 +11304,7 @@ The second form throws nothing if
 \tcode{a == m.get_allocator()} is \tcode{true}.
 \end{itemdescr}
 
-\indexlibrarymember{match_results}{operator=}%
+\indexlibrarymember{operator=}{match_results}%
 \begin{itemdecl}
 match_results& operator=(const match_results& m);
 \end{itemdecl}
@@ -11315,7 +11315,7 @@ match_results& operator=(const match_results& m);
 As specified in \tref{re.results.const}.
 \end{itemdescr}
 
-\indexlibrarymember{match_results}{operator=}%
+\indexlibrarymember{operator=}{match_results}%
 \begin{itemdecl}
 match_results& operator=(match_results&& m);
 \end{itemdecl}
@@ -11341,7 +11341,7 @@ As specified in \tref{re.results.const}.
 
 \rSec3[re.results.state]{State}
 
-\indexlibrarymember{match_results}{ready}%
+\indexlibrarymember{ready}{match_results}%
 \begin{itemdecl}
 bool ready() const;
 \end{itemdecl}
@@ -11355,7 +11355,7 @@ bool ready() const;
 
 \rSec3[re.results.size]{Size}
 
-\indexlibrarymember{match_results}{size}%
+\indexlibrarymember{size}{match_results}%
 \begin{itemdecl}
 size_type size() const;
 \end{itemdecl}
@@ -11374,7 +11374,7 @@ effects of those algorithms on their \tcode{match_results} arguments.
 \end{note}
 \end{itemdescr}
 
-\indexlibrarymember{match_results}{max_size}%
+\indexlibrarymember{max_size}{match_results}%
 \begin{itemdecl}
 size_type max_size() const;
 \end{itemdecl}
@@ -11386,7 +11386,7 @@ The maximum number of \tcode{sub_match} elements that can be
 stored in \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{match_results}{empty}%
+\indexlibrarymember{empty}{match_results}%
 \begin{itemdecl}
 bool empty() const;
 \end{itemdecl}
@@ -11430,7 +11430,7 @@ The distance from the start of the target sequence
 to \tcode{(*this)[sub].first}.
 \end{itemdescr}
 
-\indexlibrarymember{match_results}{str}%
+\indexlibrarymember{str}{match_results}%
 \begin{itemdecl}
 string_type str(size_type sub = 0) const;
 \end{itemdecl}
@@ -11445,7 +11445,7 @@ string_type str(size_type sub = 0) const;
 \tcode{string_type((*this)[sub])}.
 \end{itemdescr}
 
-\indexlibrarymember{match_results}{operator[]}%
+\indexlibrarymember{operator[]}{match_results}%
 \begin{itemdecl}
 const_reference operator[](size_type n) const;
 \end{itemdecl}
@@ -11465,7 +11465,7 @@ character sequence that matched the whole regular expression. If
 unmatched sub-expression.
 \end{itemdescr}
 
-\indexlibrarymember{match_results}{prefix}%
+\indexlibrarymember{prefix}{match_results}%
 \begin{itemdecl}
 const_reference prefix() const;
 \end{itemdecl}
@@ -11482,7 +11482,7 @@ character sequence from the start of the string being
 matched/searched to the start of the match found.
 \end{itemdescr}
 
-\indexlibrarymember{match_results}{suffix}%
+\indexlibrarymember{suffix}{match_results}%
 \begin{itemdecl}
 const_reference suffix() const;
 \end{itemdecl}
@@ -11499,7 +11499,7 @@ character sequence from the end of the match found to the end of the
 string being matched/searched.
 \end{itemdescr}
 
-\indexlibrarymember{match_results}{begin}%
+\indexlibrarymember{begin}{match_results}%
 \begin{itemdecl}
 const_iterator begin() const;
 const_iterator cbegin() const;
@@ -11512,7 +11512,7 @@ A starting iterator that enumerates over all the
 sub-expressions stored in \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{match_results}{end}%
+\indexlibrarymember{end}{match_results}%
 \begin{itemdecl}
 const_iterator end() const;
 const_iterator cend() const;
@@ -11527,7 +11527,7 @@ sub-expressions stored in \tcode{*this}.
 
 \rSec3[re.results.form]{Formatting}
 
-\indexlibrarymember{match_results}{format}%
+\indexlibrarymember{format}{match_results}%
 \begin{itemdecl}
 template<class OutputIter>
   OutputIter format(
@@ -11556,7 +11556,7 @@ specifiers and escape sequences are recognized.
 \tcode{out}.
 \end{itemdescr}
 
-\indexlibrarymember{match_results}{format}%
+\indexlibrarymember{format}{match_results}%
 \begin{itemdecl}
 template<class OutputIter, class ST, class SA>
   OutputIter format(
@@ -11574,7 +11574,7 @@ return format(out, fmt.data(), fmt.data() + fmt.size(), flags);
 \end{codeblock}
 \end{itemdescr}
 
-\indexlibrarymember{match_results}{format}%
+\indexlibrarymember{format}{match_results}%
 \begin{itemdecl}
 template<class ST, class SA>
   basic_string<char_type, ST, SA> format(
@@ -11600,7 +11600,7 @@ format(back_inserter(result), fmt, flags);
 \tcode{result}.
 \end{itemdescr}
 
-\indexlibrarymember{match_results}{format}%
+\indexlibrarymember{format}{match_results}%
 \begin{itemdecl}
 string_type format(
   const char_type* fmt,
@@ -11641,7 +11641,7 @@ allocator has been replaced, a copy of the most recent replacement.
 
 \rSec3[re.results.swap]{Swap}
 
-\indexlibrarymember{match_results}{swap}%
+\indexlibrarymember{swap}{match_results}%
 \begin{itemdecl}
 void swap(match_results& that);
 \end{itemdecl}
@@ -11662,7 +11662,7 @@ sequence of matched sub-expressions that were in \tcode{*this}.
 Constant time.
 \end{itemdescr}
 
-\indexlibrarymember{match_results}{swap}%
+\indexlibrarymember{swap}{match_results}%
 \begin{itemdecl}
 template<class BidirectionalIterator, class Allocator>
   void swap(match_results<BidirectionalIterator, Allocator>& m1,
@@ -12508,7 +12508,7 @@ is not defined. For any other iterator value a \tcode{const
 sub_match<BidirectionalIterator>*} is returned.
 
 \pnum
-\indexlibrarymember{regex_token_iterator}{operator==}%
+\indexlibrarymember{operator==}{regex_token_iterator}%
 It is impossible to store things
 into \tcode{regex_token_iterator}s. Two end-of-sequence iterators are always
 equal. An end-of-sequence iterator is not equal to a
@@ -12679,7 +12679,7 @@ sets \tcode{*this} to an end-of-sequence iterator.
 
 \rSec4[re.tokiter.comp]{Comparisons}
 
-\indexlibrarymember{regex_token_iterator}{operator==}%
+\indexlibrarymember{operator==}{regex_token_iterator}%
 \begin{itemdecl}
 bool operator==(const regex_token_iterator& right) const;
 \end{itemdecl}
@@ -12696,7 +12696,7 @@ iterator or a suffix iterator. Otherwise returns \tcode{true} if \tcode{position
 
 \rSec4[re.tokiter.deref]{Indirection}
 
-\indexlibrarymember{regex_token_iterator}{operator*}%
+\indexlibrarymember{operator*}{regex_token_iterator}%
 \begin{itemdecl}
 const value_type& operator*() const;
 \end{itemdecl}
@@ -12721,7 +12721,7 @@ const value_type* operator->() const;
 
 \rSec4[re.tokiter.incr]{Increment}
 
-\indexlibrarymember{regex_token_iterator}{operator++}%
+\indexlibrarymember{operator++}{regex_token_iterator}%
 \begin{itemdecl}
 regex_token_iterator& operator++();
 \end{itemdecl}
@@ -12760,7 +12760,7 @@ Otherwise, sets \tcode{*this} to an end-of-sequence iterator.
 \tcode{*this}.
 \end{itemdescr}
 
-\indexlibrarymember{regex_token_iterator}{operator++}%
+\indexlibrarymember{operator++}{regex_token_iterator}%
 \begin{itemdecl}
 regex_token_iterator& operator++(int);
 \end{itemdecl}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -1503,7 +1503,7 @@ namespace std {
 \rSec3[thread.thread.id]{Class \tcode{thread::id}}
 
 \indexlibraryglobal{thread::id}%
-\indexlibrarymember{thread}{id}%
+\indexlibrarymember{id}{thread}%
 \begin{codeblock}
 namespace std {
   class thread::id {


### PR DESCRIPTION
…r{member}{class}

According to the [Style Guidelines](https://github.com/cplusplus/draft/wiki/Specification-Style-Guidelines#indexes), the `\indexlibrarymember` command should take the member name as its first parameter and the class name as the second. After reviewing all existing `\indexlibrarymember` calls, I found the following classes violate this rule (some even use different orders within the same class): 

+ array
+ span
+ locale
+ ctype
+ codecvt
+ num_get
+ num_put
+ numpunct
+ collate
+ time_get
+ money_get
+ money_put
+ moneypunct
+ messages
+ regex_traits
+ basic_regex
+ sub_match
+ match_results
+ regex_token_iterator
+ thread

(note: "span" is also used as a member name in iostreams.tex, but the iostreams.tex file does not contain such issues).