### PR TITLE
P3868R1 Allow #line before module declarations

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -18,7 +18,7 @@
 
 \begin{bnf}
 \nontermdef{module-file}\br
-    \opt{pp-global-module-fragment} pp-module \opt{group} \opt{pp-private-module-fragment}
+    \opt{line-directives} \opt{pp-global-module-fragment} pp-module \opt{group} \opt{pp-private-module-fragment}
 \end{bnf}
 
 \begin{bnf}
@@ -55,11 +55,16 @@
     \terminal{\# define } identifier lparen \terminal{... )} replacement-list new-line\br
     \terminal{\# define } identifier lparen identifier-list \terminal{, ... )} replacement-list new-line\br
     \terminal{\# undef \ } identifier new-line\br
-    \terminal{\# line \ \ } pp-tokens new-line\br
+    line-directive\br
     \terminal{\# error \ } \opt{pp-tokens} new-line\br
     \terminal{\# warning} \opt{pp-tokens} new-line\br
     \terminal{\# pragma } \opt{pp-tokens} new-line\br
     \terminal{\# }new-line
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{line-directives}\br
+    line-directive \opt{line-directives}
 \end{bnf}
 
 \begin{bnf}
@@ -2061,6 +2066,11 @@ a macro name.
 \rSec1[cpp.line]{Line control}%
 \indextext{preprocessing directive!line control}%
 \indextext{\idxcode{\#line}|see{preprocessing directive, line control}}
+
+\begin{bnf}
+\nontermdef{line-directive}\br
+    \terminal{\# line} pp-tokens new-line
+\end{bnf}
 
 \pnum
 The \grammarterm{string-literal} of a


### PR DESCRIPTION
Fixes NB US 55-102 (C++26 CD).

 - Retained position of #line alternative within control-line.

Fixes #8458 
Also fixes cplusplus/papers#2472
Also fixes cplusplus/nbballot#680