### PR TITLE
[except.handle] Mark as note: exception object access via handler declaration

### DIFF
--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -741,11 +741,14 @@ destruction of any objects with automatic storage duration initialized
 within the handler.
 
 \pnum
+\begin{note}
 When the handler declares an object,
 any changes to that object will not affect the exception object.
 When the handler declares a reference to an object,
 any changes to the referenced object are changes to the
-exception object and will have effect should that object be rethrown.%
+exception object.
+\end{note}
+%
 \indextext{exception handling!handler!match|)}%
 \indextext{exception handling!handler|)}
 


### PR DESCRIPTION
The subject paragraph (https://wg21.link/except.handle#16) is merely an observation and is redundant as normative text. Make it a note, and strike the end of the last sentence as it creates an impression that the exception object cannot be observed without rethrowing.