### PR TITLE
[dcl.pre] Fix order of `-> void` and `static consteval` in lambda

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -391,7 +391,7 @@ void g(char c) {
 For a \grammarterm{consteval-block-declaration} $D$,
 the expression $E$ corresponding to $D$ is:
 \begin{codeblock}
-  [] -> void static consteval @\grammarterm{compound-statement}@ ()
+  [] static consteval -> void @\grammarterm{compound-statement}@ ()
 \end{codeblock}
 $E$ shall be a constant expression\iref{expr.const}.
 \begin{note}


### PR DESCRIPTION
The _trailing-return-type_ of the equivalent-to lambda expression needs to appear after the _lambda-specifier-seq_.

This is probably an error in [P2996R13](https://wg21.link/p2996r13) which wasn't fixed when applied to the working draft.