### PR TITLE
[class.union.anon] Tighten definition of "variant member"

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3410,10 +3410,10 @@ in~\ref{dcl.init.aggr}.
 \pnum
 \indextext{class!variant member of}%
 A \defnadj{union-like}{class} is a union or a class that has an anonymous union as a direct
-member. A union-like class \tcode{X} has a set of \defnx{variant members}{variant member}.
-If \tcode{X} is a union, a non-static data member of \tcode{X} that is not an anonymous
-union is a variant member of \tcode{X}. In addition, a non-static data member of an
-anonymous union that is a member of \tcode{X} is also a variant member of \tcode{X}.
+member.
+The \defnx{variant members}{variant member} of a union-like class \tcode{X} are the variant
+members of the anonymous union members of \tcode{X} and, if \tcode{X} is a union, the
+non-static data members of \tcode{X} other than anonymous union members.
 At most one variant member of a union may have a default member initializer.
 \begin{example}
 \begin{codeblock}


### PR DESCRIPTION
Rephrase the definition of variant members to address the following problems with the current wording:

- It creates a misleading reading of the "[in] addition, [ ... ]" sentence as applying only to the case where `X` is a union.
- It is not phrased as complete/exhaustive.