### PR TITLE
[special] Add "direct" when defining "potentially constructed subobjects"

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1227,7 +1227,7 @@ is more constrained\iref{temp.constr.order}.
 \end{itemize}
 
 \pnum
-For a class, its non-static data members, its non-virtual direct base classes,
+For a class, its direct non-static data members, its non-virtual direct base classes,
 and, if the class is not abstract\iref{class.abstract}, its virtual base
 classes are called its \term{potentially constructed subobjects}.
 


### PR DESCRIPTION
The definition has "non-static data members". Only the direct ones are intended.