### PR TITLE
[class.mem.general] Fix data member definition to include anonymous union members

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -669,8 +669,8 @@ declare at least one member name of the class
 or declare at least one unnamed bit-field.
 
 \pnum
-A \defn{data member} is a non-function member introduced by a
-\grammarterm{member-declarator}.
+A \defn{data member} is either a non-function member introduced by a
+\grammarterm{member-declarator} or an anonymous union member.
 A \defn{member function} is a member that is a function.
 Nested types are classes\iref{class.name,class.nest} and
 enumerations\iref{dcl.enum} declared in the class and arbitrary types


### PR DESCRIPTION
Anonymous union members are not introduced by _member-declarator_.

Fixes cplusplus/draft#4939.