### PR TITLE
[class.base.init] Add "direct" for _mem-initializer-id_-named members

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -5524,7 +5524,7 @@ for the hidden base class can be specified using a qualified name.
 Unless the
 \grammarterm{mem-initializer-id}
 names the constructor's class,
-a non-static data member of the constructor's class, or
+a direct non-static data member of the constructor's class, or
 a direct or virtual base of that class,
 the
 \grammarterm{mem-initializer}


### PR DESCRIPTION
A _mem-initializer-id_ cannot be used to initialize a base class data member from a derived class constructor; therefore, we mean _direct_ non-static data member.