### PR TITLE
[optional.ref.assign] Add missing Returns element

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -4748,6 +4748,10 @@ template<class U>
 \pnum
 \effects
 Equivalent to: \tcode{\exposid{convert-ref-init-val}(std::forward<U>(u))}.
+
+\pnum
+\returns
+\tcode{*\exposid{val}}.
 \end{itemdescr}
 
 \rSec3[optional.ref.swap]{Swap}


### PR DESCRIPTION
Notice that the return type is `T&`, but *`convert-ref-init-val`* is a `void` member function.

The intent is obviously to return `*val`; this seems like an editorial slip-up (unfortunately resulting in a normative defect).