### PR TITLE
P3878R1 Standard library hardening should not use the 'observe' semantic

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -390,12 +390,9 @@ conditions that the function assumes to hold whenever it is called.
 \item
 When invoking the function in a hardened implementation,
 prior to any other observable side effects of the function,
-one or more contract assertions
+contract assertions
 whose predicates are as described in the hardened precondition
-are evaluated with a checking semantic\iref{basic.contract.eval}.
-If any of these assertions is evaluated with a non-terminating semantic
-and the contract-violation handler returns,
-the program has undefined behavior.
+are evaluated with a terminating semantic\iref{basic.contract.eval}.
 \item
 When invoking the function in a non-hardened implementation,
 if any hardened precondition is violated,


### PR DESCRIPTION
Also fixes NB RU-016 (C++26 CD).
Also fixes NB FR-001-014 (C++26 CD).
Also fixes NB FR-010-113 (C++26 CD).
Also fixes NB US 3-015 (C++26 CD).
Also fixes NB US 61-112 (C++26 CD).

Fixes #8476
Also fixes https://github.com/cplusplus/papers/issues/2532
Also fixes https://github.com/cplusplus/nbballot/issues/590
Also fixes https://github.com/cplusplus/nbballot/issues/588
Also fixes https://github.com/cplusplus/nbballot/issues/691
Also fixes https://github.com/cplusplus/nbballot/issues/589
Also fixes https://github.com/cplusplus/nbballot/issues/690
