### PR TITLE
[cpp.cond] Keywords are not identifiers while preprocessing

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -553,11 +553,11 @@ evaluations of
 \grammarterm{has-embed-expression}s, and
 \grammarterm{has-attribute-expression}s
 have been performed,
-all remaining identifiers (including those lexically identical to keywords)
+all remaining identifiers (including those lexically identical to keywords),
 except for
 \tcode{true}
 and
-\tcode{false}
+\tcode{false},
 are replaced with the \grammarterm{pp-number}
 \tcode{0},
 and then each preprocessing token is converted into a token.


### PR DESCRIPTION
Move seemingly normative reference to keywords in #if expressions into a note.