### PR TITLE
P3860R1 Proposed Resolution for NB Comment GB13-309 `atomic_ref<T>` is not convertible to `atomic_ref<const T>`

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -3161,6 +3161,8 @@ namespace std {
 
     constexpr explicit atomic_ref(T&);
     constexpr atomic_ref(const atomic_ref&) noexcept;
+    template<class U>
+      constexpr atomic_ref(const atomic_ref<U>&) noexcept;
     atomic_ref& operator=(const atomic_ref&) = delete;
 
     constexpr void store(value_type, memory_order = memory_order::seq_cst) const noexcept;
@@ -3308,6 +3310,24 @@ constexpr atomic_ref(const atomic_ref& ref) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\ensures
+\tcode{*this} references the object referenced by \tcode{ref}.
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class U>
+  constexpr atomic_ref(const atomic_ref<U>&) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\begin{itemize}
+\item \tcode{T} and \tcode{U} are similar types\iref{conv.qual}, and
+\item \tcode{is_convertible_v<U*, T*>} is \tcode{true}.
+\end{itemize}
+
 \pnum
 \ensures
 \tcode{*this} references the object referenced by \tcode{ref}.
@@ -3638,6 +3658,8 @@ namespace std {
 
     constexpr explicit atomic_ref(@\placeholder{integral-type}@&);
     constexpr atomic_ref(const atomic_ref&) noexcept;
+    template<class U>
+      constexpr atomic_ref(const atomic_ref<U>&) noexcept;
     atomic_ref& operator=(const atomic_ref&) = delete;
 
     constexpr void store(value_type, memory_order = memory_order::seq_cst) const noexcept;
@@ -3860,6 +3882,8 @@ namespace std {
 
     constexpr explicit atomic_ref(@\placeholder{floating-point-type}@&);
     constexpr atomic_ref(const atomic_ref&) noexcept;
+    template<class U>
+      constexpr atomic_ref(const atomic_ref<U>&) noexcept;
     atomic_ref& operator=(const atomic_ref&) = delete;
 
     constexpr void store(value_type,
@@ -4152,6 +4176,8 @@ namespace std {
 
     constexpr explicit atomic_ref(@\placeholder{pointer-type}@&);
     constexpr atomic_ref(const atomic_ref&) noexcept;
+    template<class U>
+      constexpr atomic_ref(const atomic_ref<U>&) noexcept;
     atomic_ref& operator=(const atomic_ref&) = delete;
 
     constexpr void store(value_type, memory_order = memory_order::seq_cst) const noexcept;


### PR DESCRIPTION
Fixes NB GB 13-309 (C++26 CD).

Fixes #8466.
Also fixes cplusplus/papers#2464
Also fixes cplusplus/nbballot#884
