### PR TITLE
P3819R0 Remove evaluation_exception() from contract-violation handling for C++26

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -4435,7 +4435,6 @@ namespace std::contracts {
 
     const char* comment() const noexcept;
     contracts::detection_mode detection_mode() const noexcept;
-    exception_ptr evaluation_exception() const noexcept;
     bool is_terminating() const noexcept;
     assertion_kind kind() const noexcept;
     source_location location() const noexcept;
@@ -4551,22 +4550,6 @@ contracts::detection_mode detection_mode() const noexcept;
 The enumerator value
 corresponding to
 the manner in which the contract violation was identified.
-
-\end{itemdescr}
-
-\begin{itemdecl}
-exception_ptr evaluation_exception() const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-
-\pnum
-\returns
-If the contract violation occurred
-because the evaluation of the predicate exited via an exception,
-an \tcode{exception_ptr} object that refers to
-that exception or a copy of that exception;
-otherwise, a null \tcode{exception_ptr} object.
 
 \end{itemdescr}
 


### PR DESCRIPTION
Fixes #8470
Fixes NB GB 04-124, NL, US 69-125 (C++26 CD).

Also fixes https://github.com/cplusplus/papers/issues/2429
Also fixes https://github.com/cplusplus/nbballot/issues/704
Also fixes https://github.com/cplusplus/nbballot/issues/703
Also fixes https://github.com/cplusplus/nbballot/issues/982