### PR TITLE
P3391R2 `constexpr std::format`

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -1927,12 +1927,12 @@ namespace std {
   float stof(const string& str, size_t* idx = nullptr);
   double stod(const string& str, size_t* idx = nullptr);
   long double stold(const string& str, size_t* idx = nullptr);
-  string to_string(int val);
-  string to_string(unsigned val);
-  string to_string(long val);
-  string to_string(unsigned long val);
-  string to_string(long long val);
-  string to_string(unsigned long long val);
+  constexpr string to_string(int val);
+  constexpr string to_string(unsigned val);
+  constexpr string to_string(long val);
+  constexpr string to_string(unsigned long val);
+  constexpr string to_string(long long val);
+  constexpr string to_string(unsigned long long val);
   string to_string(float val);
   string to_string(double val);
   string to_string(long double val);
@@ -1945,12 +1945,12 @@ namespace std {
   float stof(const wstring& str, size_t* idx = nullptr);
   double stod(const wstring& str, size_t* idx = nullptr);
   long double stold(const wstring& str, size_t* idx = nullptr);
-  wstring to_wstring(int val);
-  wstring to_wstring(unsigned val);
-  wstring to_wstring(long val);
-  wstring to_wstring(unsigned long val);
-  wstring to_wstring(long long val);
-  wstring to_wstring(unsigned long long val);
+  constexpr wstring to_wstring(int val);
+  constexpr wstring to_wstring(unsigned val);
+  constexpr wstring to_wstring(long val);
+  constexpr wstring to_wstring(unsigned long val);
+  constexpr wstring to_wstring(long long val);
+  constexpr wstring to_wstring(unsigned long long val);
   wstring to_wstring(float val);
   wstring to_wstring(double val);
   wstring to_wstring(long double val);
@@ -5273,12 +5273,12 @@ values for the return type.
 
 \indexlibraryglobal{to_string}%
 \begin{itemdecl}
-string to_string(int val);
-string to_string(unsigned val);
-string to_string(long val);
-string to_string(unsigned long val);
-string to_string(long long val);
-string to_string(unsigned long long val);
+constexpr string to_string(int val);
+constexpr string to_string(unsigned val);
+constexpr string to_string(long val);
+constexpr string to_string(unsigned long val);
+constexpr string to_string(long long val);
+constexpr string to_string(unsigned long long val);
 string to_string(float val);
 string to_string(double val);
 string to_string(long double val);
@@ -5360,12 +5360,12 @@ conversion can be performed. Throws \tcode{out_of_range} if \tcode{wcstof}, \tco
 
 \indexlibraryglobal{to_wstring}%
 \begin{itemdecl}
-wstring to_wstring(int val);
-wstring to_wstring(unsigned val);
-wstring to_wstring(long val);
-wstring to_wstring(unsigned long val);
-wstring to_wstring(long long val);
-wstring to_wstring(unsigned long long val);
+constexpr wstring to_wstring(int val);
+constexpr wstring to_wstring(unsigned val);
+constexpr wstring to_wstring(long val);
+constexpr wstring to_wstring(unsigned long val);
+constexpr wstring to_wstring(long long val);
+constexpr wstring to_wstring(unsigned long long val);
 wstring to_wstring(float val);
 wstring to_wstring(double val);
 wstring to_wstring(long double val);

--- a/source/support.tex
+++ b/source/support.tex
@@ -632,6 +632,7 @@ the values of these macros with greater values.
   // also in \libheader{exception}, \libheader{stdexcept}, \libheader{expected}, \libheader{optional}, \libheader{variant}, and \libheader{format}
 #define @\defnlibxname{cpp_lib_constexpr_flat_map}@                202502L // also in \libheader{flat_map}
 #define @\defnlibxname{cpp_lib_constexpr_flat_set}@                202502L // also in \libheader{flat_set}
+#define @\defnlibxname{cpp_lib_constexpr_format}@                  202511L // also in \libheader{format}
 #define @\defnlibxname{cpp_lib_constexpr_forward_list}@            202502L // also in \libheader{forward_list}
 #define @\defnlibxname{cpp_lib_constexpr_functional}@              201907L // freestanding, also in \libheader{functional}
 #define @\defnlibxname{cpp_lib_constexpr_inplace_vector}@          202502L // also in \libheader{inplace_vector}

--- a/source/text.tex
+++ b/source/text.tex
@@ -5755,12 +5755,14 @@ namespace std {
   private:
     basic_string_view<charT> @\exposid{str}@;                                       // \expos
   public:
-    @\exposid{runtime-format-string}@(basic_string_view<charT> s) noexcept : @\exposid{str}@(s) {}
+    constexpr @\exposid{runtime-format-string}@(basic_string_view<charT> s) noexcept : @\exposid{str}@(s) {}
     @\exposid{runtime-format-string}@(const @\exposid{runtime-format-string}@&) = delete;
     @\exposid{runtime-format-string}@& operator=(const @\exposid{runtime-format-string}@&) = delete;
   };
-  @\exposid{runtime-format-string}@<char> runtime_format(string_view fmt) noexcept { return fmt; }
-  @\exposid{runtime-format-string}@<wchar_t> runtime_format(wstring_view fmt) noexcept { return fmt; }
+  constexpr @\exposid{runtime-format-string}@<char>
+    runtime_format(string_view fmt) noexcept { return fmt; }
+  constexpr @\exposid{runtime-format-string}@<wchar_t>
+    runtime_format(wstring_view fmt) noexcept { return fmt; }
 
   template<class... Args>
     using @\libglobal{format_string}@ = basic_format_string<char, type_identity_t<Args>...>;
@@ -5769,32 +5771,32 @@ namespace std {
 
   // \ref{format.functions}, formatting functions
   template<class... Args>
-    string format(format_string<Args...> fmt, Args&&... args);
+    constexpr string format(format_string<Args...> fmt, Args&&... args);
   template<class... Args>
-    wstring format(wformat_string<Args...> fmt, Args&&... args);
+    constexpr wstring format(wformat_string<Args...> fmt, Args&&... args);
   template<class... Args>
     string format(const locale& loc, format_string<Args...> fmt, Args&&... args);
   template<class... Args>
     wstring format(const locale& loc, wformat_string<Args...> fmt, Args&&... args);
 
-  string vformat(string_view fmt, format_args args);
-  wstring vformat(wstring_view fmt, wformat_args args);
+  constexpr string vformat(string_view fmt, format_args args);
+  constexpr wstring vformat(wstring_view fmt, wformat_args args);
   string vformat(const locale& loc, string_view fmt, format_args args);
   wstring vformat(const locale& loc, wstring_view fmt, wformat_args args);
 
   template<class Out, class... Args>
-    Out format_to(Out out, format_string<Args...> fmt, Args&&... args);
+    constexpr Out format_to(Out out, format_string<Args...> fmt, Args&&... args);
   template<class Out, class... Args>
-    Out format_to(Out out, wformat_string<Args...> fmt, Args&&... args);
+    constexpr Out format_to(Out out, wformat_string<Args...> fmt, Args&&... args);
   template<class Out, class... Args>
     Out format_to(Out out, const locale& loc, format_string<Args...> fmt, Args&&... args);
   template<class Out, class... Args>
     Out format_to(Out out, const locale& loc, wformat_string<Args...> fmt, Args&&... args);
 
   template<class Out>
-    Out vformat_to(Out out, string_view fmt, format_args args);
+    constexpr Out vformat_to(Out out, string_view fmt, format_args args);
   template<class Out>
-    Out vformat_to(Out out, wstring_view fmt, wformat_args args);
+    constexpr Out vformat_to(Out out, wstring_view fmt, wformat_args args);
   template<class Out>
     Out vformat_to(Out out, const locale& loc, string_view fmt, format_args args);
   template<class Out>
@@ -5805,11 +5807,13 @@ namespace std {
     iter_difference_t<Out> size;
   };
   template<class Out, class... Args>
-    format_to_n_result<Out> format_to_n(Out out, iter_difference_t<Out> n,
-                                        format_string<Args...> fmt, Args&&... args);
+    constexpr format_to_n_result<Out> format_to_n(Out out, iter_difference_t<Out> n,
+                                                  format_string<Args...> fmt,
+                                                  Args&&... args);
   template<class Out, class... Args>
-    format_to_n_result<Out> format_to_n(Out out, iter_difference_t<Out> n,
-                                        wformat_string<Args...> fmt, Args&&... args);
+    constexpr format_to_n_result<Out> format_to_n(Out out, iter_difference_t<Out> n,
+                                                  wformat_string<Args...> fmt,
+                                                  Args&&... args);
   template<class Out, class... Args>
     format_to_n_result<Out> format_to_n(Out out, iter_difference_t<Out> n,
                                         const locale& loc, format_string<Args...> fmt,
@@ -5820,9 +5824,9 @@ namespace std {
                                         Args&&... args);
 
   template<class... Args>
-    size_t formatted_size(format_string<Args...> fmt, Args&&... args);
+    constexpr size_t formatted_size(format_string<Args...> fmt, Args&&... args);
   template<class... Args>
-    size_t formatted_size(wformat_string<Args...> fmt, Args&&... args);
+    constexpr size_t formatted_size(wformat_string<Args...> fmt, Args&&... args);
   template<class... Args>
     size_t formatted_size(const locale& loc, format_string<Args...> fmt, Args&&... args);
   template<class... Args>
@@ -5898,10 +5902,10 @@ namespace std {
   template<class Context, class... Args> class @\exposidnc{format-arg-store}@;        // \expos
 
   template<class Context = format_context, class... Args>
-    @\exposid{format-arg-store}@<Context, Args...>
+    constexpr @\exposid{format-arg-store}@<Context, Args...>
       make_format_args(Args&... fmt_args);
   template<class... Args>
-    @\exposid{format-arg-store}@<wformat_context, Args...>
+    constexpr @\exposid{format-arg-store}@<wformat_context, Args...>
       make_wformat_args(Args&... args);
 
   // \ref{format.error}, class \tcode{format_error}
@@ -6384,6 +6388,8 @@ When the \tcode{L} option is used, the form used for the conversion is called
 the \defnx{locale-specific form}{locale-specific form!format string}.
 The \tcode{L} option is only valid for arithmetic types, and
 its effect depends upon the type.
+A call to \tcode{format} on a given formatter specialization
+is not a constant subexpression if the locale-specific form is specified.
 \begin{itemize}
 \item
 For integral types, the locale-specific form
@@ -6672,7 +6678,7 @@ namespace std {
 
   public:
     template<class T> consteval basic_format_string(const T& s);
-    basic_format_string(@\exposid{runtime-format-string}@<charT> s) noexcept : str(s.@\exposid{str}@) {}
+    constexpr basic_format_string(@\exposid{runtime-format-string}@<charT> s) noexcept : str(s.@\exposid{str}@) {}
 
     constexpr basic_string_view<charT> get() const noexcept { return @\exposid{str}@; }
   };
@@ -6700,6 +6706,12 @@ such that \exposid{str} is a format string for \tcode{args}.
 \end{itemdescr}
 
 \rSec2[format.functions]{Formatting functions}
+
+\pnum
+A call to any of the functions defined in this subclause
+is a constant subexpression only if
+each of the used \tcode{formatter} specializations
+is a constexpr-enabled specialization\iref{format.formatter.spec}.
 
 \pnum
 In the description of the functions, operator \tcode{+} is used
@@ -7151,12 +7163,14 @@ a public, constexpr, non-static member function \tcode{set_debug_format()}
 which modifies the state of the \tcode{formatter} to be as if
 the type of the \fmtgrammarterm{std-format-spec}
 parsed by the last call to \tcode{parse} were \tcode{?}.
+A \defn{constexpr-enabled} specialization of \tcode{formatter}
+has its \tcode{format} member function declared \tcode{constexpr}.
 Each header that declares the template \tcode{formatter}
 provides the following enabled specializations:
 \begin{itemize}
 \item
 \indexlibrary{\idxcode{formatter}!specializations!character types}%
-The debug-enabled specializations
+The debug-enabled and constexpr-enabled specializations
 \begin{codeblock}
 template<> struct formatter<char, char>;
 template<> struct formatter<char, wchar_t>;
@@ -7166,7 +7180,7 @@ template<> struct formatter<wchar_t, wchar_t>;
 \item
 \indexlibrary{\idxcode{formatter}!specializations!string types}%
 For each \tcode{charT},
-the debug-enabled string type specializations
+the debug-enabled and constexpr-enabled string type specializations
 \begin{codeblock}
 template<> struct formatter<charT*, charT>;
 template<> struct formatter<const charT*, charT>;
@@ -7178,27 +7192,37 @@ template<class traits>
 \end{codeblock}
 
 \item
-\indexlibrary{\idxcode{formatter}!specializations!arithmetic types}%
+\indexlibrary{\idxcode{formatter}!specializations!integer types}%
 For each \tcode{charT},
-for each cv-unqualified arithmetic type \tcode{ArithmeticT}
-other than
-\tcode{char},
-\keyword{wchar_t},
-\keyword{char8_t},
-\keyword{char16_t}, or
-\keyword{char32_t},
+for each \tcode{IntegerT} that is either
+a signed or unsigned integer type or \tcode{bool},
+a constexpr-enabled specialization
+\begin{codeblock}
+template<> struct formatter<IntegerT, charT>;
+\end{codeblock}
+
+\item
+\indexlibrary{\idxcode{formatter}!specializations!floating-point types}%
+For each \tcode{charT},
+for each \tcode{FloatingT} that is a cv-unqualified floating-point type,
 a specialization
 \begin{codeblock}
-template<> struct formatter<ArithmeticT, charT>;
+template<> struct formatter<FloatingT, charT>;
 \end{codeblock}
 
 \item
 \indexlibrary{\idxcode{formatter}!specializations!pointer types}%
 \indexlibrary{\idxcode{formatter}!specializations!\idxcode{nullptr_t}}%
 For each \tcode{charT},
-the pointer type specializations
+the constexpr-enabled pointer type specialization
 \begin{codeblock}
 template<> struct formatter<nullptr_t, charT>;
+\end{codeblock}
+
+\item
+For each \tcode{charT},
+the pointer type specializations
+\begin{codeblock}
 template<> struct formatter<void*, charT>;
 template<> struct formatter<const void*, charT>;
 \end{codeblock}
@@ -7699,11 +7723,11 @@ namespace std {
     using char_type = charT;
     template<class T> using formatter_type = formatter<T, charT>;
 
-    basic_format_arg<basic_format_context> arg(size_t id) const noexcept;
+    constexpr basic_format_arg<basic_format_context> arg(size_t id) const noexcept;
     std::locale locale();
 
-    iterator out();
-    void advance_to(iterator it);
+    constexpr iterator out();
+    constexpr void advance_to(iterator it);
   };
 }
 \end{codeblock}
@@ -7919,7 +7943,7 @@ namespace std {
     template<ranges::@\libconcept{input_range}@ R, class FormatContext>
         requires @\libconcept{formattable}@<ranges::range_reference_t<R>, charT> &&
                  @\libconcept{same_as}@<remove_cvref_t<ranges::range_reference_t<R>>, T>
-      typename FormatContext::iterator
+      constexpr typename FormatContext::iterator
         format(R&& r, FormatContext& ctx) const;
   };
 }
@@ -8153,7 +8177,7 @@ namespace std {
         parse(ParseContext& ctx);
 
     template<class FormatContext>
-      typename FormatContext::iterator
+      constexpr typename FormatContext::iterator
         format(@\exposid{maybe-const-r}@& elems, FormatContext& ctx) const;
   };
 }
@@ -8229,7 +8253,7 @@ namespace std {
         parse(ParseContext& ctx);
 
     template<class FormatContext>
-      typename FormatContext::iterator
+      constexpr typename FormatContext::iterator
         format(@\exposid{maybe-const-map}@& r, FormatContext& ctx) const;
   };
 }
@@ -8308,7 +8332,7 @@ namespace std {
         parse(ParseContext& ctx);
 
     template<class FormatContext>
-      typename FormatContext::iterator
+      constexpr typename FormatContext::iterator
         format(@\exposid{maybe-const-set}@& r, FormatContext& ctx) const;
   };
 }
@@ -8371,7 +8395,7 @@ namespace std {
         parse(ParseContext& ctx);
 
     template<class FormatContext>
-      typename FormatContext::iterator
+      constexpr typename FormatContext::iterator
         format(@\seebelow@& str, FormatContext& ctx) const;
   };
 }
@@ -8443,17 +8467,17 @@ namespace std {
             const char_type*, basic_string_view<char_type>,
             const void*, handle> value;                                         // \expos
 
-    template<class T> explicit basic_format_arg(T& v) noexcept;                 // \expos
+    template<class T> constexpr explicit basic_format_arg(T& v) noexcept;       // \expos
 
   public:
-    basic_format_arg() noexcept;
+    constexpr basic_format_arg() noexcept;
 
-    explicit operator bool() const noexcept;
+    constexpr explicit operator bool() const noexcept;
 
     template<class Visitor>
-      decltype(auto) visit(this basic_format_arg arg, Visitor&& vis);
+      constexpr decltype(auto) visit(this basic_format_arg arg, Visitor&& vis);
     template<class R, class Visitor>
-      R visit(this basic_format_arg arg, Visitor&& vis);
+      constexpr R visit(this basic_format_arg arg, Visitor&& vis);
   };
 }
 \end{codeblock}
@@ -8592,14 +8616,14 @@ The class \tcode{handle} allows formatting an object of a user-defined type.
 namespace std {
   template<class Context>
   class basic_format_arg<Context>::handle {
-    const void* ptr_;                                           // \expos
+    const void* ptr_;                                                   // \expos
     void (*format_)(basic_format_parse_context<char_type>&,
-                    Context&, const void*);                     // \expos
+                    Context&, const void*);                             // \expos
 
-    template<class T> explicit handle(T& val) noexcept;         // \expos
+    template<class T> constexpr explicit handle(T& val) noexcept;       // \expos
 
   public:
-    void format(basic_format_parse_context<char_type>&, Context& ctx) const;
+    constexpr void format(basic_format_parse_context<char_type>&, Context& ctx) const;
   };
 }
 \end{codeblock}
@@ -8711,9 +8735,9 @@ namespace std {
 
   public:
     template<class... Args>
-      basic_format_args(const @\exposid{format-arg-store}@<Context, Args...>& store) noexcept;
+      constexpr basic_format_args(const @\exposid{format-arg-store}@<Context, Args...>& store) noexcept;
 
-    basic_format_arg<Context> get(size_t i) const noexcept;
+    constexpr basic_format_arg<Context> get(size_t i) const noexcept;
   };
 
   template<class Context, class... Args>
@@ -8788,7 +8812,7 @@ namespace std {
         parse(ParseContext& ctx);
 
     template<class FormatContext>
-      typename FormatContext::iterator
+      constexpr typename FormatContext::iterator
         format(@\seebelow@& elems, FormatContext& ctx) const;
   };
 


### PR DESCRIPTION
Fixes #8480
Fixes NB FR-028-271, US 167-270 (C++26 CD).

Also fixes https://github.com/cplusplus/papers/issues/2046
Also fixes https://github.com/cplusplus/nbballot/issues/845
Also fixes https://github.com/cplusplus/nbballot/issues/846
Also fixes https://github.com/cplusplus/nbballot/issues/844

Also fixes https://github.com/cplusplus/papers/issues/2102 (P3438R0 Make integral overloads of `std::to_string` `constexpr`)