### PR TITLE
[exec.run.loop] update run_loop count representation to use code format

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -6485,7 +6485,7 @@ run_loop() noexcept;
 \begin{itemdescr}
 \pnum
 \ensures
-The \tcode{run_loop} instance's count is 0 and
+The \tcode{run_loop} instance's count is \tcode{0} and
 its state is starting.
 \end{itemdescr}
 
@@ -6497,7 +6497,7 @@ its state is starting.
 \begin{itemdescr}
 \pnum
 \effects
-If the \tcode{run_loop} instance's count is not 0 or
+If the \tcode{run_loop} instance's count is not \tcode{0} or
 if its state is running,
 invokes \tcode{terminate}\iref{except.terminate}.
 Otherwise, has no effects.
@@ -6515,11 +6515,11 @@ Otherwise, has no effects.
 Blocks\iref{defns.block} until one of the following conditions is \tcode{true}:
 \begin{itemize}
 \item
-The \tcode{run_loop} instance's count is 0 and its state is finishing,
+The \tcode{run_loop} instance's count is \tcode{0} and its state is finishing,
 in which case \exposid{pop-front} sets the state to finished
 and returns \tcode{nullptr}; or
 \item
-the \tcode{run_loop} instance's count is greater than 0,
+the \tcode{run_loop} instance's count is greater than \tcode{0},
 in which case an item is removed from the front of the queue,
 the count is decremented by \tcode{1}, and
 the removed item is returned.
@@ -6534,7 +6534,7 @@ void @\exposid{push-back}@(@\exposid{run-loop-opstate-base}@* item);
 \pnum
 \effects
 Adds \tcode{item} to the back of the queue and
-increments the \tcode{run_loop} instance's count by 1.
+increments the \tcode{run_loop} instance's count by \tcode{1}.
 
 \pnum
 \sync


### PR DESCRIPTION
[[run.loop.members]/p2](https://eel.is/c++draft/exec#run.loop.members-2) ends with two periods.

<img width="884" height="78" alt="image" src="https://github.com/user-attachments/assets/53a214e4-9044-411c-b1a5-afa9e3eaa814" />

i notice also that the whole [exec.run.loop] section is inconsistent about putting numbers in code font. this pr addresses the issue by uniformly applying `\tcode` to numbers.