### PR TITLE
[exec.when.all] Reverse the nesting of `\exposid` and `\tcode` for `impls-for<when_all_t>::complete`

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -4637,7 +4637,7 @@ equivalent to the following lambda expression:
 \end{codeblock}
 
 \pnum
-The member \exposid{\tcode{impls-for}<when_all_t>::\exposid{complete}}
+The member \tcode{\exposid{impls-for}<when_all_t>::\exposid{complete}}
 is initialized with a callable object
 equivalent to the following lambda expression:
 \begin{codeblock}


### PR DESCRIPTION
Fixes #8535.