### PR TITLE
[atomics.types.generic.general] Replace `same_as` with `is_same_v`

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -4455,7 +4455,7 @@ The program is ill-formed if any of
 \item \tcode{is_move_constructible_v<T>},
 \item \tcode{is_copy_assignable_v<T>},
 \item \tcode{is_move_assignable_v<T>}, or
-\item \tcode{same_as<T, remove_cv_t<T>>},
+\item \tcode{is_same_v<T, remove_cv_t<T>>},
 \end{itemize}
 is \tcode{false}.
 \begin{note}


### PR DESCRIPTION
The `same_as` is missing `\libconcept`. This could be solved in two different ways:
- add `\libconcept`
- use `is_same_v` instead

I chose the latter approach because all the other conditions use type traits instead of concepts, so this also creates a bit of symmetry.