### PR TITLE
[simd] Add missing `\libconcept` to uses of `same_as`

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -18568,7 +18568,7 @@ Let
  \item
    \tcode{ranges::range_value_t<R>} is a vectorizable type,
  \item
-   \tcode{same_as<remove_cvref_t<V>, V>} is \tcode{true},
+   \tcode{\libconcept{same_as}<remove_cvref_t<V>, V>} is \tcode{true},
  \item
    \tcode{V} is an enabled specialization of \tcode{basic_vec}, and
  \item
@@ -18994,7 +18994,7 @@ Let:
 \item
 \tcode{ranges::range_value_t<R>} is a vectorizable type,
 \item
-\tcode{same_as<remove_cvref_t<V>, V>} is \tcode{true},
+\tcode{\libconcept{same_as}<remove_cvref_t<V>, V>} is \tcode{true},
 \item
 \tcode{V} is an enabled specialization of \tcode{basic_vec},
 \item
@@ -20471,7 +20471,7 @@ template<class T0, class T1>
 \constraints
 \begin{itemize}
  \item
-   \tcode{same_as<T0, T1>} is \tcode{true},
+   \tcode{\libconcept{same_as}<T0, T1>} is \tcode{true},
  \item
    \tcode{T0} is a vectorizable type, and
  \item


### PR DESCRIPTION
This follows the precedent of https://eel.is/c++draft/simd.complex.access#3.2, which says
> `same_as<...>` is modeled

We could probably also use `is_same_v` here instead, but that would create a local inconsistency with [simd.complex.access], and the three uses here are clearly wrong.