### PR TITLE
[numerics.c.ckdint] Add cross-reference to [basic.fundamental]

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -20648,7 +20648,7 @@ template<class type1, class type2, class type3>
 \pnum
 \mandates
 Each of the types \tcode{type1}, \tcode{type2}, and \tcode{type3} is a
-cv-unqualified signed or unsigned integer type.
+cv-unqualified signed or unsigned integer type\iref{basic.fundamental}.
 
 \pnum
 \remarks


### PR DESCRIPTION
This fixes two problems:
- "cv-unqualified" is redundant here; the set of signed or unsigned integer types  does not include any cv-qualified types.
- Usually, we cross reference [basic.fundamental] when using the term "signed or unsigned integer type", and there is no obvious reason why we shouldn't also do this here, for consistency.