### PR TITLE
[linalg.scaled.scaledaccessor] Add scaling_factor and nested_accessor to index

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -12620,8 +12620,8 @@ namespace std::linalg {
     constexpr reference access(data_handle_type p, size_t i) const;
     constexpr offset_policy::data_handle_type offset(data_handle_type p, size_t i) const;
 
-    constexpr const ScalingFactor& scaling_factor() const noexcept { return @\exposid{scaling-factor}@; }
-    constexpr const NestedAccessor& nested_accessor() const noexcept { return @\exposid{nested-accessor}@; }
+    constexpr const ScalingFactor& @\libmember{scaling_factor}{scaled_accessor}@() const noexcept { return @\exposid{scaling-factor}@; }
+    constexpr const NestedAccessor& @\libmember{nested_accessor}{scaled_accessor}@() const noexcept { return @\exposid{nested-accessor}@; }
 
   private:
     ScalingFactor @\exposid{scaling-factor}@{};                              // \expos


### PR DESCRIPTION
Part of #7214

These two member functions are defined inline, not in any subclause, so this is the appropriate place to index them.