### PR TITLE
[atomics.types.int] Use the terms "character type" and "standard integer type" instead of listing each type

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -4961,23 +4961,10 @@ This function is an atomic notifying operation\iref{atomics.wait}.
 \indexlibrary{\idxcode{atomic<\placeholder{integral-type}>}}%
 \pnum
 There are specializations of the \tcode{atomic}
-class template for the integral types
-\tcode{char},
-\tcode{signed char},
-\tcode{unsigned char},
-\tcode{short},
-\tcode{unsigned short},
-\tcode{int},
-\tcode{unsigned int},
-\tcode{long},
-\tcode{unsigned long},
-\tcode{long long},
-\tcode{unsigned long long},
-\keyword{char8_t},
-\keyword{char16_t},
-\keyword{char32_t},
-\keyword{wchar_t},
-and any other types needed by the typedefs in the header \libheaderref{cstdint}.
+class template for
+each character type\iref{basic.fundamental},
+each standard integer type, and
+any other types needed by the typedefs in the header \libheaderref{cstdint}.
 For each such type \tcode{\placeholder{integral-type}}, the specialization
 \tcode{atomic<\placeholder{integral-type}>} provides additional atomic operations appropriate to integral types.
 \begin{note}


### PR DESCRIPTION
We have the terms "character type" and "standard integer type", so we may as well use them in the standard library instead of listing all types within those sets exhaustively.

It's really difficult to tell what the design intent is when you have a list of 15 types and need to figure out which ones are on this list, and which types are missing (but you would have expected to see).

There is also wording asymmetry: https://eel.is/c++draft/atomics.types.float#1 simply says there is a specialization for each "cv-unqualified floating type" in bulk, instead of listing `float`, `double,` and `long double`.