### PR TITLE
[basic.fundamental] Exhaustively list what values can be represented by floating-point types P3938

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5560,6 +5560,24 @@ the object and value representations and accuracy of operations
 of floating-point types are \impldef{representation of floating-point types}.
 
 \pnum
+A floating-point type shall at least represent a subset of rational numbers.
+Depending on the implementation-defined value representation for the type,
+it may additionally represent the non-finite values
+\begin{itemize}
+\item infinity,
+\item a set of quiet ``Not a Number'' values, and
+\item a set of signaling ``Not a Number'' values.
+\end{itemize}
+For any of the above (including zero),
+a floating-point type may either represent a single value or
+two distinct values with negative and positive sign.
+\begin{note}
+A floating-point type which adheres to \IsoFloatUndated{}
+is capable of representing a negative and positive variant
+of all the above\iref{numeric.limits.members}.
+\end{note}
+
+\pnum
 The minimum range of representable values for a floating-point type is
 the most negative finite floating-point number representable
 in that type through


### PR DESCRIPTION
This is branching off from https://github.com/cplusplus/CWG/issues/814#issuecomment-3548366174

There are various mentions of NaNs, positive and negative zeros, infinities, etc. scattered throughout the standard. We do a bad job of comprehensively listing these possibilities in one place.

It's also not obvious whether we consider floating-point types to *require* having a positive and negative zero, positive and/or negative infinity, NaN values, and whatnot. This is really difficult to figure out.

My understanding of the wording is that floating-point types are only *guaranteed* to represent some rational numbers; anything else, such as NaNs, infinities, negative zeros, etc. may or may not exist, based on the representation of `float` chosen by the implementation.