### PR TITLE
[container.node] Exposition-only formatting for node handle members

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -2378,16 +2378,16 @@ public:
   using allocator_type = @\seebelownc{}@;
 
 private:
-  using container_node_type = @\unspecnc@;                  // \expos
-  using ator_traits = allocator_traits<allocator_type>;     // \expos
+  using @\exposid{container-node-type}@ = @\unspecnc@;                  // \expos
+  using @\exposid{ator-traits}@ = allocator_traits<allocator_type>;     // \expos
 
-  typename ator_traits::template
-    rebind_traits<container_node_type>::pointer ptr_;       // \expos
-  optional<allocator_type> alloc_;                          // \expos
+  typename @\exposid{ator-traits}@::template
+    rebind_traits<@\exposid{container-node-type}@>::pointer @\exposid{ptr_}@;       // \expos
+  optional<allocator_type> @\exposid{alloc_}@;                          // \expos
 
 public:
   // \ref{container.node.cons}, constructors, copy, and assignment
-  constexpr @\placeholdernc{node-handle}@() noexcept : ptr_(), alloc_() {}
+  constexpr @\placeholdernc{node-handle}@() noexcept : @\exposid{ptr_}@(), @\exposid{alloc_}@() {}
   constexpr @\placeholdernc{node-handle}@(@\placeholdernc{node-handle}@&&) noexcept;
   constexpr @\placeholdernc{node-handle}@& operator=(@\placeholdernc{node-handle}@&&);
 
@@ -2405,8 +2405,8 @@ public:
 
   // \ref{container.node.modifiers}, modifiers
   constexpr void swap(@\placeholdernc{node-handle}@&)
-    noexcept(ator_traits::propagate_on_container_swap::value ||
-             ator_traits::is_always_equal::value);
+    noexcept(@\exposid{ator-traits}@::propagate_on_container_swap::value ||
+             @\exposid{ator-traits}@::is_always_equal::value);
 
   friend constexpr void swap(@\placeholdernc{node-handle}@& x, @\placeholdernc{node-handle}@& y) noexcept(noexcept(x.swap(y))) {
     x.swap(y);
@@ -2424,9 +2424,9 @@ constexpr @\placeholdernc{node-handle}@(@\placeholdernc{node-handle}@&& nh) noex
 \pnum
 \effects
 Constructs a \exposid{node-handle} object initializing
-\tcode{ptr_} with \tcode{nh.ptr_}.  Move constructs \tcode{alloc_} with
-\tcode{nh.alloc_}.  Assigns \keyword{nullptr} to \tcode{nh.ptr_} and assigns
-\tcode{nullopt} to \tcode{nh.alloc_}.
+\exposid{ptr_} with \tcode{nh.\exposid{ptr_}}.  Move constructs \exposid{alloc_} with
+\tcode{nh.\exposid{alloc_}}.  Assigns \keyword{nullptr} to \tcode{nh.\exposid{ptr_}} and assigns
+\tcode{nullopt} to \tcode{nh.\exposid{alloc_}}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -2436,28 +2436,29 @@ constexpr @\placeholdernc{node-handle}@& operator=(@\placeholdernc{node-handle}@
 \begin{itemdescr}
 \pnum
 \expects
-Either \tcode{!alloc_}, or
-\tcode{ator_traits::propagate_on_container_move_assignment::\-value}
-is \tcode{true}, or \tcode{alloc_ ==  nh.alloc_}.
+Either \tcode{!\exposid{alloc_}} is \tcode{true}, or
+\tcode{\exposidnc{ator-traits}::propagate_on_container_move_assign\-ment::value}
+is \tcode{true}, or \tcode{\exposid{alloc_} == nh.\exposid{alloc_}} is \tcode{true}.
 
 \pnum
 \effects
 \begin{itemize}
 \item
-If \tcode{ptr_ != nullptr}, destroys the \tcode{value_type}
-subobject in the \tcode{container_node_type} object pointed to by \tcode{ptr_}
-by calling \tcode{ator_traits::destroy}, then deallocates \tcode{ptr_} by
-calling \tcode{ator_traits::template rebind_traits<container_node_type>::deallocate}.
+If \tcode{\exposid{ptr_} != nullptr} is \tcode{true}, destroys the \tcode{value_type}
+subobject in the \exposid{container-node-type} object pointed to by \exposid{ptr_}
+by calling \tcode{\exposid{ator-traits}::destroy}, then deallocates \exposid{ptr_} by
+calling \tcode{\exposid{ator-\-traits}::template rebind_traits<\exposid{container-node-type}>::deallocate}.
 \item
-Assigns \tcode{nh.ptr_} to \tcode{ptr_}.
+Assigns \tcode{nh.\exposid{ptr_}} to \exposid{ptr_}.
 \item
-If \tcode{!alloc\textunderscore} or \tcode{ator_traits::propagate_on_container_move_assignment::value}
+If \tcode{!\exposid{alloc_}} is \tcode{true} or
+\tcode{\exposid{ator-traits}::propagate_on_container_move_assignment::value}
 is \tcode{true}, \linebreak
-move assigns \tcode{nh.alloc_} to \tcode{alloc_}.
+move assigns \tcode{nh.\exposid{alloc_}} to \exposid{alloc_}.
 \item
 Assigns
-\keyword{nullptr} to \tcode{nh.ptr_} and assigns \tcode{nullopt} to
-\tcode{nh.alloc_}.
+\keyword{nullptr} to \tcode{nh.\exposid{ptr_}} and assigns \tcode{nullopt} to
+\tcode{nh.\exposid{alloc_}}.
 \end{itemize}
 
 \pnum
@@ -2478,10 +2479,10 @@ constexpr ~@\placeholdernc{node-handle}@();
 \begin{itemdescr}
 \pnum
 \effects
-If \tcode{ptr_ != nullptr}, destroys the \tcode{value_type} subobject
-in the \tcode{container_node_type} object pointed to by \tcode{ptr_} by calling
-\tcode{ator_traits::destroy}, then deallocates \tcode{ptr_} by calling
-\tcode{ator_traits::template rebind_traits<container_node_type>::deallocate}.
+If \tcode{\exposid{ptr_} != nullptr} is \tcode{true}, destroys the \tcode{value_type} subobject
+in the \exposid{container-node-type} object pointed to by \exposid{ptr_} by calling
+\tcode{\exposid{ator-traits}::destroy}, then deallocates \exposid{ptr_} by calling
+\tcode{\exposid{ator-\-traits}::template rebind_traits<\exposid{container-node-type}>::deallocate}.
 \end{itemdescr}
 
 \rSec3[container.node.observers]{Observers}
@@ -2498,7 +2499,7 @@ constexpr value_type& value() const;
 \pnum
 \returns
 A reference to the \tcode{value_type} subobject in the
-\tcode{container_node_type} object pointed to by \tcode{ptr_}.
+\exposid{container-node-type} object pointed to by \exposid{ptr_}.
 
 \pnum
 \throws
@@ -2517,8 +2518,8 @@ key_type& key() const;
 \pnum
 \returns
 A non-const reference to the \tcode{key_type} member of the
-\tcode{value_type} subobject in the \tcode{contain\-er_node_type} object
-pointed to by \tcode{ptr_}.
+\tcode{value_type} subobject in the \exposid{contain\-er-node-type} object
+pointed to by \exposid{ptr_}.
 
 \pnum
 \throws
@@ -2541,8 +2542,8 @@ constexpr mapped_type& mapped() const;
 \pnum
 \returns
 A reference to the \tcode{mapped_type} member of the
-\tcode{value_type} subobject in the \tcode{container_node_type} object
-pointed to by \tcode{ptr_}.
+\tcode{value_type} subobject in the \exposid{container-\-node-type} object
+pointed to by \exposid{ptr_}.
 
 \pnum
 \throws
@@ -2560,7 +2561,7 @@ constexpr allocator_type get_allocator() const;
 
 \pnum
 \returns
-\tcode{*alloc_}.
+\tcode{*\exposid{alloc_}}.
 
 \pnum
 \throws
@@ -2574,7 +2575,7 @@ constexpr explicit operator bool() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{ptr_ != nullptr}.
+\tcode{\exposid{ptr_} != nullptr}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -2584,29 +2585,29 @@ constexpr bool empty() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{ptr_ == nullptr}.
+\tcode{\exposid{ptr_} == nullptr}.
 \end{itemdescr}
 
 \rSec3[container.node.modifiers]{Modifiers}
 
 \begin{itemdecl}
 constexpr void swap(@\placeholdernc{node-handle}@& nh)
-  noexcept(ator_traits::propagate_on_container_swap::value ||
-           ator_traits::is_always_equal::value);
+  noexcept(@\exposid{ator-traits}@::propagate_on_container_swap::value ||
+           @\exposid{ator-traits}@::is_always_equal::value);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{!alloc_}, or \tcode{!nh.alloc_}, or
-\tcode{ator_traits::propagate_on_container_swap::value} is \tcode{true},
-or \tcode{alloc_ == nh.alloc_}.
+\tcode{!\exposid{alloc_}} is \tcode{true}, or \tcode{!nh.\exposid{alloc_}}, or
+\tcode{\exposid{ator-traits}::propagate_on_container_swap::\-value} is \tcode{true},
+or \tcode{\exposid{alloc_} == nh.\exposid{alloc_}} is \tcode{true}.
 
 \pnum
 \effects
-Calls \tcode{swap(ptr_, nh.ptr_)}. If \tcode{!alloc_}, or
-\tcode{!nh.alloc_}, or \tcode{ator_traits::propagate_on_container_swap::value}
-is \tcode{true} calls \tcode{swap(alloc_, nh.alloc_)}.
+Calls \tcode{swap(\exposid{ptr_}, nh.\exposid{ptr_})}. If \tcode{!\exposid{alloc_}} is \tcode{true}, or
+\tcode{!nh.\exposid{alloc_}} is \tcode{true}, or \tcode{\exposid{ator-traits}::\-propagate_on_container_swap::value}
+is \tcode{true} calls \tcode{swap(\exposid{alloc_}, nh.\exposid{alloc_})}.
 \end{itemdescr}
 
 \rSec2[container.insert.return]{Insert return type}


### PR DESCRIPTION
Also changes `container_node_type` and `ator_traits` to _`container-node-type`_ and _`ator-traits`_ respectively. And adds missed "is `true`".