### PR TITLE
[over.match.ref] Restore resolution of CWG2267 after applying P1787R6

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1162,8 +1162,7 @@ Let $R$ be a set of types including
 ``lvalue reference to \cvqual{cv2} \tcode{T2}''
 (when converting to an lvalue) and
 \item
-``\cvqual{cv2} \tcode{T2}''
-and ``rvalue reference to \cvqual{cv2} \tcode{T2}''
+``rvalue reference to \cvqual{cv2} \tcode{T2}''
 (when converting to an rvalue or an lvalue of function type)
 \end{itemize}
 for any \tcode{T2}.


### PR DESCRIPTION
Paper P1787R6 shows "or 'cv2 T2'" as existing text and leaves it unchanged, even though that was struck by CWG2267.  Other amendments made by CWG2267 are correctly shown as pre-existing text.