### PR TITLE
[linalg] Index defined-in-class functions and related class members

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -12051,17 +12051,17 @@ namespace std::linalg {
   template<class Triangle, class StorageOrder>
   class @\libglobal{layout_blas_packed}@ {
   public:
-    using triangle_type = Triangle;
-    using storage_order_type = StorageOrder;
+    using @\libmember{triangle_type}{layout_blas_packed}@ = Triangle;
+    using @\libmember{storage_order_type}{layout_blas_packed}@ = StorageOrder;
 
     template<class Extents>
-    struct mapping {
+    struct @\libmember{mapping}{layout_blas_packed}@ {
     public:
-      using extents_type = Extents;
-      using index_type = extents_type::index_type;
-      using size_type = extents_type::size_type;
-      using rank_type = extents_type::rank_type;
-      using layout_type = layout_blas_packed;
+      using @\libmember{extents_type}{layout_blas_packed::mapping}@ = Extents;
+      using @\libmember{index_type}{layout_blas_packed::mapping}@ = extents_type::index_type;
+      using @\libmember{size_type}{layout_blas_packed::mapping}@ = extents_type::size_type;
+      using @\libmember{rank_type}{layout_blas_packed::mapping}@ = extents_type::rank_type;
+      using @\libmember{layout_type}{layout_blas_packed::mapping}@ = layout_blas_packed;
 
       // \ref{linalg.layout.packed.cons}, constructors
       constexpr mapping() noexcept = default;
@@ -12074,28 +12074,28 @@ namespace std::linalg {
       constexpr mapping& operator=(const mapping&) noexcept = default;
 
       // \ref{linalg.layout.packed.obs}, observers
-      constexpr const extents_type& extents() const noexcept { return @\exposid{extents_}@; }
+      constexpr const extents_type& @\libmember{extents}{layout_blas_packed::mapping}@() const noexcept { return @\exposid{extents_}@; }
 
       constexpr index_type required_span_size() const noexcept;
 
       template<class Index0, class Index1>
         constexpr index_type operator() (Index0 ind0, Index1 ind1) const noexcept;
 
-      static constexpr bool is_always_unique() noexcept {
+      static constexpr bool @\libmember{is_always_unique}{layout_blas_packed::mapping}@() noexcept {
         return (extents_type::static_extent(0) != dynamic_extent &&
                 extents_type::static_extent(0) < 2) ||
                (extents_type::static_extent(1) != dynamic_extent &&
                 extents_type::static_extent(1) < 2);
       }
-      static constexpr bool is_always_exhaustive() noexcept { return true; }
-      static constexpr bool is_always_strided() noexcept
+      static constexpr bool @\libmember{is_always_exhaustive}{layout_blas_packed::mapping}@() noexcept { return true; }
+      static constexpr bool @\libmember{is_always_strided}{layout_blas_packed::mapping}@() noexcept
         { return is_always_unique(); }
 
-      constexpr bool is_unique() const noexcept {
+      constexpr bool @\libmember{is_unique}{layout_blas_packed::mapping}@() const noexcept {
         return @\exposid{extents_}@.extent(0) < 2;
       }
-      constexpr bool is_exhaustive() const noexcept { return true; }
-      constexpr bool is_strided() const noexcept {
+      constexpr bool @\libmember{is_exhaustive}{layout_blas_packed::mapping}@() const noexcept { return true; }
+      constexpr bool @\libmember{is_strided}{layout_blas_packed::mapping}@() const noexcept {
         return @\exposid{extents_}@.extent(0) < 2;
       }
 
@@ -12604,11 +12604,11 @@ namespace std::linalg {
   template<class ScalingFactor, class NestedAccessor>
   class @\libglobal{scaled_accessor}@ {
   public:
-    using element_type =
+    using @\libmember{element_type}{scaled_accessor}@ =
       const decltype(declval<ScalingFactor>() * declval<NestedAccessor::element_type>());
-    using reference = remove_const_t<element_type>;
-    using data_handle_type = NestedAccessor::data_handle_type;
-    using offset_policy = scaled_accessor<ScalingFactor, NestedAccessor::offset_policy>;
+    using @\libmember{reference}{scaled_accessor}@ = remove_const_t<element_type>;
+    using @\libmember{data_handle_type}{scaled_accessor}@ = NestedAccessor::data_handle_type;
+    using @\libmember{offset_policy}{scaled_accessor}@ = scaled_accessor<ScalingFactor, NestedAccessor::offset_policy>;
 
     constexpr scaled_accessor() = default;
     template<class OtherNestedAccessor>
@@ -12776,11 +12776,11 @@ namespace std::linalg {
   template<class NestedAccessor>
   class @\libglobal{conjugated_accessor}@ {
   public:
-    using element_type =
+    using @\libmember{element_type}{conjugated_accessor}@ =
       const decltype(@\exposid{conj-if-needed}@(declval<NestedAccessor::element_type>()));
-    using reference = remove_const_t<element_type>;
-    using data_handle_type = NestedAccessor::data_handle_type;
-    using offset_policy = conjugated_accessor<NestedAccessor::offset_policy>;
+    using @\libmember{reference}{conjugated_accessor}@ = remove_const_t<element_type>;
+    using @\libmember{data_handle_type}{conjugated_accessor}@ = NestedAccessor::data_handle_type;
+    using @\libmember{offset_policy}{conjugated_accessor}@ = conjugated_accessor<NestedAccessor::offset_policy>;
 
     constexpr conjugated_accessor() = default;
     constexpr conjugated_accessor(const NestedAccessor& acc);
@@ -12793,7 +12793,7 @@ namespace std::linalg {
     constexpr typename offset_policy::data_handle_type
       offset(data_handle_type p, size_t i) const;
 
-    constexpr const NestedAccessor& nested_accessor() const noexcept { return @\exposid{nested-accessor_}@; }
+    constexpr const NestedAccessor& @\libmember{nested_accessor}{conjugated_accessor}@() const noexcept { return @\exposid{nested-accessor_}@; }
 
   private:
     NestedAccessor @\exposid{nested-accessor_}@{};                           // \expos
@@ -12996,45 +12996,45 @@ namespace std::linalg {
   template<class Layout>
   class @\libglobal{layout_transpose}@ {
   public:
-    using nested_layout_type = Layout;
+    using @\libmember{nested_layout_type}{layout_transpose}@ = Layout;
 
     template<class Extents>
-    struct mapping {
+    struct @\libmember{mapping}{layout_transpose}@ {
     private:
       using @\exposid{nested-mapping-type}@ =
         Layout::template mapping<@\exposid{transpose-extents-t}@<Extents>>;  // \expos
 
     public:
-      using extents_type = Extents;
-      using index_type = extents_type::index_type;
-      using size_type = extents_type::size_type;
-      using rank_type = extents_type::rank_type;
-      using layout_type = layout_transpose;
+      using @\libmember{extents_type}{layout_transpose::mapping}@ = Extents;
+      using @\libmember{index_type}{layout_transpose::mapping}@ = extents_type::index_type;
+      using @\libmember{size_type}{layout_transpose::mapping}@ = extents_type::size_type;
+      using @\libmember{rank_type}{layout_transpose::mapping}@ = extents_type::rank_type;
+      using @\libmember{layout_type}{layout_transpose::mapping}@ = layout_transpose;
 
       constexpr explicit mapping(const @\exposid{nested-mapping-type}@&);
 
-      constexpr const extents_type& extents() const noexcept { return @\exposid{extents_}@; }
+      constexpr const extents_type& @\libmember{extents}{layout_transpose::mapping}@() const noexcept { return @\exposid{extents_}@; }
 
-      constexpr index_type required_span_size() const
-        { return @\exposid{nested-mapping_}@.required_span_size();
+      constexpr index_type @\libmember{required_span_size}{layout_transpose::mapping}@() const
+        { return @\exposid{nested-mapping_}@.required_span_size(); }
 
       template<class Index0, class Index1>
-        constexpr index_type operator()(Index0 ind0, Index1 ind1) const
+        constexpr index_type @\libmember{operator()}{layout_transpose::mapping}@(Index0 ind0, Index1 ind1) const
         { return @\exposid{nested-mapping_}@(ind1, ind0); }
 
-      constexpr const @\exposid{nested-mapping-type}@& nested_mapping() const noexcept
+      constexpr const @\exposid{nested-mapping-type}@& @\libmember{nested_mapping}{layout_transpose::mapping}@() const noexcept
         { return @\exposid{nested-mapping_}@; }
 
-      static constexpr bool is_always_unique() noexcept
+      static constexpr bool @\libmember{is_always_unique}{layout_transpose::mapping}@() noexcept
         { return @\exposid{nested-mapping-type}@::is_always_unique(); }
-      static constexpr bool is_always_exhaustive() noexcept
+      static constexpr bool @\libmember{is_always_exhaustive}{layout_transpose::mapping}@() noexcept
         { return @\exposid{nested-mapping-type}@::is_always_exhaustive(); }
-      static constexpr bool is_always_strided() noexcept
+      static constexpr bool @\libmember{is_always_strided}{layout_transpose::mapping}@() noexcept
         { return @\exposid{nested-mapping-type}@::is_always_strided(); }
 
-      constexpr bool is_unique() const { return @\exposid{nested-mapping_}@.is_unique(); }
-      constexpr bool is_exhaustive() const { return @\exposid{nested-mapping_}@.is_exhaustive(); }
-      constexpr bool is_strided() const { return @\exposid{nested-mapping_}@.is_strided(); }
+      constexpr bool @\libmember{is_unique}{layout_transpose::mapping}@() const { return @\exposid{nested-mapping_}@.is_unique(); }
+      constexpr bool @\libmember{is_exhaustive}{layout_transpose::mapping}@() const { return @\exposid{nested-mapping_}@.is_exhaustive(); }
+      constexpr bool @\libmember{is_strided}{layout_transpose::mapping}@() const { return @\exposid{nested-mapping_}@.is_strided(); }
 
       constexpr index_type stride(size_t r) const;
 


### PR DESCRIPTION
Affected classes:
- `layout_blas_packed`
- `layout_blas_packed::mapping`
- `scaled_accessor`
- `layout_transpose`
- `layout_transpose::mapping`

Drive-by fix:
- add a missing close brace `}` to the end of `layout_transpose::mapping::required_span_size`

Follows-up #8549.