### PR TITLE
[expr.add] Simplify wording for pointer subtraction

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -7206,13 +7206,10 @@ or a complete object results in undefined behavior.
 \indextext{\idxcode{ptrdiff_t}}%
 \indextext{comparison!undefined pointer}%
 When two pointer expressions \tcode{P} and \tcode{Q} are subtracted,
-the type of the result is an \impldef{type of \tcode{ptrdiff_t}} signed
-integral type; this type shall be the same type that is named by
-\tcode{std::ptrdiff_t} in the \libheader{cstddef}
-header\iref{support.types.layout}.
+the result is a prvalue of type \tcode{std::ptrdiff_t}.
 \begin{itemize}
 \item If \tcode{P} and \tcode{Q} both evaluate to null pointer values,
-the result is 0.
+the value is 0.
 \item Otherwise, if \tcode{P} and \tcode{Q} point to, respectively,
 array elements $i$ and $j$
 of the same array object \tcode{x},
@@ -7225,6 +7222,10 @@ the behavior is undefined\iref{expr.pre}.
 \end{note}
 \item Otherwise, the behavior is undefined.
 \end{itemize}
+\begin{note}
+The \grammarterm{typedef-name} \tcode{std::ptrdiff_t} is declared in the standard header
+\libheader{cstddef}\iref{cstddef.syn,support.types.layout}.
+\end{note}
 
 \pnum
 For addition or subtraction, if the expressions \tcode{P} or \tcode{Q} have


### PR DESCRIPTION
Fixes #8564.

In short, the goal is to harmonize with the wording in https://eel.is/c++draft/expr.sizeof

We already say in in `<stddef.h>` (C) and in [supper.types.layout] that `ptrdiff_t` is implementation-defined, and saying it a third time here is just silly.