### PR TITLE
[specialized.algorithms] Use `\exposid` for "voidify", not `\placeholder(nc)`

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -13562,7 +13562,7 @@ Some algorithms specified in \ref{specialized.algorithms}
 make use of the following exposition-only function templates:
 \begin{codeblock}
 template<class T>
-  constexpr void* @\placeholdernc{voidify}@(T& obj) noexcept {
+  constexpr void* @\exposid{voidify}@(T& obj) noexcept {
     return addressof(obj);
   }
 
@@ -13758,7 +13758,7 @@ template<class NoThrowForwardIterator>
 Equivalent to:
 \begin{codeblock}
 for (; first != last; ++first)
-  ::new (@\placeholdernc{voidify}@(*first)) iterator_traits<NoThrowForwardIterator>::value_type;
+  ::new (@\exposid{voidify}@(*first)) iterator_traits<NoThrowForwardIterator>::value_type;
 \end{codeblock}
 \end{itemdescr}
 
@@ -13780,7 +13780,7 @@ namespace ranges {
 Equivalent to:
 \begin{codeblock}
 for (; first != last; ++first)
-  ::new (@\placeholdernc{voidify}@(*first)) remove_reference_t<iter_reference_t<I>>;
+  ::new (@\exposid{voidify}@(*first)) remove_reference_t<iter_reference_t<I>>;
 return first;
 \end{codeblock}
 \end{itemdescr}
@@ -13798,7 +13798,7 @@ template<class NoThrowForwardIterator, class Size>
 Equivalent to:
 \begin{codeblock}
 for (; n > 0; (void)++first, --n)
-  ::new (@\placeholdernc{voidify}@(*first)) iterator_traits<NoThrowForwardIterator>::value_type;
+  ::new (@\exposid{voidify}@(*first)) iterator_traits<NoThrowForwardIterator>::value_type;
 return first;
 \end{codeblock}
 \end{itemdescr}
@@ -13837,7 +13837,7 @@ template<class NoThrowForwardIterator>
 Equivalent to:
 \begin{codeblock}
 for (; first != last; ++first)
-  ::new (@\placeholdernc{voidify}@(*first)) iterator_traits<NoThrowForwardIterator>::value_type();
+  ::new (@\exposid{voidify}@(*first)) iterator_traits<NoThrowForwardIterator>::value_type();
 \end{codeblock}
 \end{itemdescr}
 
@@ -13859,7 +13859,7 @@ namespace ranges {
 Equivalent to:
 \begin{codeblock}
 for (; first != last; ++first)
-  ::new (@\placeholdernc{voidify}@(*first)) remove_reference_t<iter_reference_t<I>>();
+  ::new (@\exposid{voidify}@(*first)) remove_reference_t<iter_reference_t<I>>();
 return first;
 \end{codeblock}
 \end{itemdescr}
@@ -13877,7 +13877,7 @@ template<class NoThrowForwardIterator, class Size>
 Equivalent to:
 \begin{codeblock}
 for (; n > 0; (void)++first, --n)
-  ::new (@\placeholdernc{voidify}@(*first)) iterator_traits<NoThrowForwardIterator>::value_type();
+  ::new (@\exposid{voidify}@(*first)) iterator_traits<NoThrowForwardIterator>::value_type();
 return first;
 \end{codeblock}
 \end{itemdescr}
@@ -13920,7 +13920,7 @@ template<class InputIterator, class NoThrowForwardIterator>
 Equivalent to:
 \begin{codeblock}
 for (; first != last; ++result, (void)++first)
-  ::new (@\placeholdernc{voidify}@(*result)) iterator_traits<NoThrowForwardIterator>::value_type(*first);
+  ::new (@\exposid{voidify}@(*result)) iterator_traits<NoThrowForwardIterator>::value_type(*first);
 \end{codeblock}
 
 \pnum
@@ -13953,7 +13953,7 @@ namespace ranges {
 Equivalent to:
 \begin{codeblock}
 for (; ifirst != ilast && ofirst != olast; ++ofirst, (void)++ifirst)
-  ::new (@\placeholdernc{voidify}@(*ofirst)) remove_reference_t<iter_reference_t<O>>(*ifirst);
+  ::new (@\exposid{voidify}@(*ofirst)) remove_reference_t<iter_reference_t<O>>(*ifirst);
 return {std::move(ifirst), ofirst};
 \end{codeblock}
 \end{itemdescr}
@@ -13975,7 +13975,7 @@ template<class InputIterator, class Size, class NoThrowForwardIterator>
 Equivalent to:
 \begin{codeblock}
 for (; n > 0; ++result, (void)++first, --n)
-  ::new (@\placeholdernc{voidify}@(*result)) iterator_traits<NoThrowForwardIterator>::value_type(*first);
+  ::new (@\exposid{voidify}@(*result)) iterator_traits<NoThrowForwardIterator>::value_type(*first);
 \end{codeblock}
 
 \pnum
@@ -14028,7 +14028,7 @@ template<class InputIterator, class NoThrowForwardIterator>
 Equivalent to:
 \begin{codeblock}
 for (; first != last; (void)++result, ++first)
-  ::new (@\placeholdernc{voidify}@(*result))
+  ::new (@\exposid{voidify}@(*result))
     iterator_traits<NoThrowForwardIterator>::value_type(@\exposid{deref-move}@(first));
 return result;
 \end{codeblock}
@@ -14059,7 +14059,7 @@ namespace ranges {
 Equivalent to:
 \begin{codeblock}
 for (; ifirst != ilast && ofirst != olast; ++ofirst, (void)++ifirst)
-  ::new (@\placeholder{voidify}@(*ofirst))
+  ::new (@\exposid{voidify}@(*ofirst))
     remove_reference_t<iter_reference_t<O>>(ranges::iter_move(ifirst));
 return {std::move(ifirst), ofirst};
 \end{codeblock}
@@ -14088,7 +14088,7 @@ template<class InputIterator, class Size, class NoThrowForwardIterator>
 Equivalent to:
 \begin{codeblock}
 for (; n > 0; ++result, (void)++first, --n)
-  ::new (@\placeholdernc{voidify}@(*result))
+  ::new (@\exposid{voidify}@(*result))
     iterator_traits<NoThrowForwardIterator>::value_type(@\exposid{deref-move}@(first));
 return {first, result};
 \end{codeblock}
@@ -14141,7 +14141,7 @@ template<class NoThrowForwardIterator, class T>
 Equivalent to:
 \begin{codeblock}
 for (; first != last; ++first)
-  ::new (@\placeholdernc{voidify}@(*first)) iterator_traits<NoThrowForwardIterator>::value_type(x);
+  ::new (@\exposid{voidify}@(*first)) iterator_traits<NoThrowForwardIterator>::value_type(x);
 \end{codeblock}
 \end{itemdescr}
 
@@ -14163,7 +14163,7 @@ namespace ranges {
 Equivalent to:
 \begin{codeblock}
 for (; first != last; ++first)
-  ::new (@\placeholdernc{voidify}@(*first)) remove_reference_t<iter_reference_t<I>>(x);
+  ::new (@\exposid{voidify}@(*first)) remove_reference_t<iter_reference_t<I>>(x);
 return first;
 \end{codeblock}
 \end{itemdescr}
@@ -14181,7 +14181,7 @@ template<class NoThrowForwardIterator, class Size, class T>
 Equivalent to:
 \begin{codeblock}
 for (; n--; ++first)
-  ::new (@\placeholdernc{voidify}@(*first)) iterator_traits<NoThrowForwardIterator>::value_type(x);
+  ::new (@\exposid{voidify}@(*first)) iterator_traits<NoThrowForwardIterator>::value_type(x);
 return first;
 \end{codeblock}
 \end{itemdescr}
@@ -14233,9 +14233,9 @@ If \tcode{is_array_v<T>} is \tcode{true}, \tcode{sizeof...(Args)} is zero.
 Equivalent to:
 \begin{codeblock}
 if constexpr (is_array_v<T>)
-  return ::new (@\placeholdernc{voidify}@(*location)) T[1]();
+  return ::new (@\exposid{voidify}@(*location)) T[1]();
 else
-  return ::new (@\placeholdernc{voidify}@(*location)) T(std::forward<Args>(args)...);
+  return ::new (@\exposid{voidify}@(*location)) T(std::forward<Args>(args)...);
 \end{codeblock}
 \end{itemdescr}
 

--- a/source/exec.tex
+++ b/source/exec.tex
@@ -5119,7 +5119,7 @@ is initialized with a callable object equivalent to the following lambda:
     explicit op_state(pair<assoc_t, sender_ref_t> parts, Rcvr& r)
       : @\exposid{assoc}@(std::move(parts.first)) {
       if (@\exposid{assoc}@) {
-        ::new (@\placeholdernc{voidify}@(@\exposid{op}@)) op_t(connect(std::move(*parts.second), std::move(r)));
+        ::new (@\exposid{voidify}@(@\exposid{op}@)) op_t(connect(std::move(*parts.second), std::move(r)));
       } else {
         @\exposid{rcvr}@ = addressof(r);
       }


### PR DESCRIPTION
Fixes #8559.

This should be applied after motions; we're adding some more `\placeholdernc{voidify}` these motions.

A rebase will be needed.