### PR TITLE
[string.view.synop] index string_view aliases

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -561,11 +561,11 @@ namespace std {
                  basic_string_view<charT, traits> str);                 // hosted
 
   // \tcode{basic_string_view} \grammarterm{typedef-name}s
-  using string_view    = basic_string_view<char>;
-  using u8string_view  = basic_string_view<char8_t>;
-  using u16string_view = basic_string_view<char16_t>;
-  using u32string_view = basic_string_view<char32_t>;
-  using wstring_view   = basic_string_view<wchar_t>;
+  using @\libglobal{string_view}@    = basic_string_view<char>;
+  using @\libglobal{u8string_view}@  = basic_string_view<char8_t>;
+  using @\libglobal{u16string_view}@ = basic_string_view<char16_t>;
+  using @\libglobal{u32string_view}@ = basic_string_view<char32_t>;
+  using @\libglobal{wstring_view}@   = basic_string_view<wchar_t>;
 
   // \ref{string.view.hash}, hash support
   template<class T> struct hash;


### PR DESCRIPTION
Applies the same indexing for the `basic_string_view` aliases that we have for the `basic_string` aliases.