### PR TITLE
[basic.string.hash] Index hash specializations of basic_string aliases

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -5380,6 +5380,11 @@ wstring to_wstring(long double val);
 \rSec2[basic.string.hash]{Hash support}
 
 \indexlibrarymember{hash}{basic_string}%
+\indexlibrarymember{hash}{string}%
+\indexlibrarymember{hash}{u8string}%
+\indexlibrarymember{hash}{u16string}%
+\indexlibrarymember{hash}{u32string}%
+\indexlibrarymember{hash}{wstring}%
 \begin{itemdecl}
 template<class A> struct hash<basic_string<char, char_traits<char>, A>>;
 template<class A> struct hash<basic_string<char8_t, char_traits<char8_t>, A>>;


### PR DESCRIPTION
Applies the same indexing for the `basic_string` aliases that we have for the `basic_string_veiw` aliases.