### PR TITLE
[algorithm.syn] Fix typo

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -1297,7 +1297,7 @@ namespace std {
     constexpr typename iterator_traits<InputIterator>::difference_type
       count(InputIterator first, InputIterator last, const T& value);
   template<class ExecutionPolicy, class ForwardIterator,
-           class T = iterator_traits<InputIterator>::value_type>
+           class T = iterator_traits<ForwardIterator>::value_type>
     typename iterator_traits<ForwardIterator>::difference_type
       count(ExecutionPolicy&& exec,                             // freestanding-deleted, see \ref{algorithms.parallel.overloads}
             ForwardIterator first, ForwardIterator last, const T& value);


### PR DESCRIPTION
There's no `InputIterator` in scope. It should be `ForwardIterator` to match [alg.count].