### PR TITLE
[temp.type] Replace "values are identical" with "value representations are identical" P3938

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -2481,7 +2481,7 @@ they are of the same type and
 they are of integral type and their values are the same, or
 
 \item
-they are of floating-point type and their values are identical, or
+they are of floating-point type and their value representations are identical, or
 
 \item
 they are of type \tcode{std::nullptr_t}, or


### PR DESCRIPTION
This fixes a really confusing bit of terminology:
- for integral types, values are template-argument-equivalent if they are "the same"
- for floating-point types, values are template-argument-equivalent if they are "identical"

It is not obvious what the distinction between "same" and "identical" is, given that these are synonyms.

However, the CWG intent is clear on this:
- https://wg21.link/p1714r1 talked about identical value representations, but the paper was rejected.
- https://wg21.link/p1907r1 implemented those changes in response to C++20 NB comments in an omnibus paper that solves a bunch of NB comments. While the wording is different, the design intent is still to implement P1714R1.

@jensmaurer the latter is your paper by the way.