### PR TITLE
[lex.token] Strike useless footnote

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -874,10 +874,7 @@ The set of alternative tokens is defined in
 
 \pnum
 \indextext{\idxgram{token}}%
-There are five kinds of tokens: identifiers, keywords, literals,%
-\begin{footnote}
-Literals include strings and character and numeric literals.
-\end{footnote}
+There are five kinds of tokens: identifiers, keywords, literals,
 operators, and other separators.
 \indextext{whitespace}%
 Comments and the characters \unicode{0020}{space}, \unicode{0009}{character tabulation},


### PR DESCRIPTION
This footnote on some kinds of literals adds no value -- it does not convey anything surprising other than raising the question of how the subset of literals mentioned is chosen.