### PR TITLE
[lex.literal.kinds] Strike incomplete footnote

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1149,10 +1149,6 @@ otherwise.
 \indextext{constant}%
 \indextext{literal!constant}%
 There are several kinds of literals.
-\begin{footnote}
-The term ``literal'' generally designates, in this
-document, those tokens that are called ``constants'' in C.
-\end{footnote}
 
 \begin{bnf}
 \nontermdef{literal}\br


### PR DESCRIPTION
It may be that the notion of literal in C++ and constant in C were at one point close to a 1--1 mapping, but that it not strictly the case any more.  C++ has user-defined literals, in C string-literals are distinct from constants, and C specifies enumerators as literals too.

Rather thsn clean up the footnote, or make clear that the correspondance is weak, simply strike it.