### PR TITLE
[intro.memory] Merge footnote on CHAR_BIT into main text

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3368,11 +3368,10 @@ and the eight-bit code units of the Unicode
 UTF-8 encoding form
 and is composed of a contiguous sequence of
 bits,
-\begin{footnote}
-The number of bits in a byte is reported by the macro
-\tcode{CHAR_BIT} in the header \libheaderref{climits}.
-\end{footnote}
 the number of which is \impldef{bits in a byte}.
+\begin{note}
+See the macro \libmacro{CHAR_BIT} in the header \libheaderref{climits}.
+\end{note}
 The memory available to a \Cpp{} program consists of one or more sequences of
 contiguous bytes.
 Every byte has a unique address.


### PR DESCRIPTION
The footnote on `CHAR_BIT` is information relevant to the main text of the corresponding paragraph, where it can usefully be indexed.