### PR TITLE
[dcl.type.general] Strike irrelevant footnote

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1232,13 +1232,6 @@ function, at least one \grammarterm{defining-type-specifier} that is not a
 \grammarterm{cv-qualifier} shall appear in a complete
 \grammarterm{type-specifier-seq} or a complete
 \grammarterm{decl-specifier-seq}.
-\begin{footnote}
-There is no special
-provision for a \grammarterm{decl-specifier-seq} that
-lacks a \grammarterm{type-specifier} or that has a
-\grammarterm{type-specifier} that only specifies \grammarterm{cv-qualifier}{s}.
-The ``implicit int'' rule of C is no longer supported.
-\end{footnote}
 
 \pnum
 \begin{note}


### PR DESCRIPTION
It is odd to state that there is no special rule where none is expected.  For the reference to C, does C23 even retain the implicit int rule?