### PR TITLE
[lex.pptoken] Turn non-normative text into a note

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -583,18 +583,16 @@ string literal.
 Each preprocessing token that is converted to a token\iref{lex.token}
 shall have the lexical form of a keyword, an identifier, a literal,
 or an operator or punctuator.
-
-\pnum
 \indexgrammar{\idxgram{import-keyword}}%
 \indexgrammar{\idxgram{module-keyword}}%
 \indexgrammar{\idxgram{export-keyword}}%
+\begin{note}
 The \grammarterm{import-keyword} is produced
 by processing an \keyword{import} directive\iref{cpp.import},
 the \grammarterm{module-keyword} is produced
 by preprocessing a \keyword{module} directive\iref{cpp.module}, and
 the \grammarterm{export-keyword} is produced
 by preprocessing either of the previous two directives.
-\begin{note}
 None has any observable spelling.
 \end{note}
 


### PR DESCRIPTION
The references to creating keyword placeholders for module syntax are non-normative, simply pointing to the normative text in [cpp].  Therefore, extend the note at the end of the paragraph to cover the whole paragraph.  Then remove the line number to attach the note to the preceding paragraph on on making tokens out of preprocessing tokens.