### PR TITLE
[cpp.replace.general] Promote footnote to note

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1535,6 +1535,12 @@ to the identifiers listed in \tref{lex.name.special}, or
 to the \grammarterm{attribute-token}{s} described in~\ref{dcl.attr},
 except that the macro names \tcode{likely} and \tcode{unlikely} may be
 defined as function-like macros and may be undefined.
+\begin{note}
+An alternative token\iref{lex.digraph} is not an identifier,
+even when its spelling consists entirely of letters and underscores.
+Therefore it is not possible to define a macro
+whose name is the same as that of an alternative token.
+\end{note}
 
 \pnum
 If a
@@ -1564,12 +1570,6 @@ they are never scanned for macro names or parameters.
 \end{footnote}
 to be replaced by the replacement list of preprocessing tokens
 that constitute the remainder of the directive.
-\begin{footnote}
-An alternative token\iref{lex.digraph} is not an identifier,
-even when its spelling consists entirely of letters and underscores.
-Therefore it is not possible to define a macro
-whose name is the same as that of an alternative token.
-\end{footnote}
 The replacement list is then rescanned for more macro names as
 specified in \ref{cpp.rescan}.
 


### PR DESCRIPTION
We now have a paragraph where the footnote would be more appropriately attached as a note.