### PR TITLE
[cpp.predefined] Tidy specification of __FILE__ and __LINE__

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -2219,20 +2219,20 @@ shall be supplied.
 \item
 \indextext{__file__@\mname{FILE}}%
 \mname{FILE}\\
-The presumed name of the current source file (a character string
-literal).
-\begin{footnote}
-The presumed source file name can be changed by the \tcode{\#line} directive.
-\end{footnote}
+A character string literal representing the presumed name of
+the current source file.
+\begin{note}
+The presumed source file name can be changed by the \tcode{\#line} directive\iref{cpp.line}.
+\end{note}
 
 \item
 \indextext{__line__@\mname{LINE}}%
 \mname{LINE}\\
-The presumed line number (within the current source file) of the current source line
-(an integer literal).
-\begin{footnote}
-The presumed line number can be changed by the \tcode{\#line} directive.
-\end{footnote}
+An integer literal representing the presumed line number of
+the current source line within the current source file.
+\begin{note}
+The presumed line number can be changed by the \tcode{\#line} directive\iref{cpp.line}.
+\end{note}
 
 \item
 \indextext{stdc__embed_not_found__@\mname{STDC_EMBED_NOT_FOUND}}%


### PR DESCRIPTION
This PR moves the normative parentheticals into the main text, promotes the corresponding footnotes to regular notes, and adds cross-references to the #line directive.