### PR TITLE
[temp.constr.concept] Fix "no diagnostics is"

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1874,7 +1874,7 @@ Otherwise, let \tcode{CI$'$} be
 the normal form\iref{temp.constr.normal} of the concept-id
 after substitution of \tcode{C}.
 \begin{note}
-Normalization of \tcode{CI} might be ill-formed; no diagnostics is required.
+Normalization of \tcode{CI} might be ill-formed; no diagnostic is required.
 \end{note}
 
 \pnum


### PR DESCRIPTION
Replace "no diagnostics is" with the commonly used (and more grammatical) "no diagnostic is".