### PR TITLE
[lex.string] Remove unused term from the index

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1851,7 +1851,6 @@ chosen in an \impldef{choice of larger or smaller value of
 
 \pnum
 \indextext{literal!string}%
-\indextext{character string}%
 \indextext{string!type of}%
 \indextext{type!\idxcode{wchar_t}}%
 \indextext{prefix!\idxcode{L}}%


### PR DESCRIPTION
While "character string" is indexed for this block of text, there is no definition for this term present.  Searching the standard for this term, outside a 5 or 6 uses in library clauses, the only other matches are as prefixes for the larger term of power,
"character string literal".  As this term appears to be unused, and has no definition, let's remove it from the index.