### PR TITLE
[lex] Move definitions, and remove redundant use, of "[non]digit"

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -759,6 +759,19 @@ depending on the implementation.
     pp-number \terminal{.}
 \end{bnf}
 
+\begin{bnf}
+\nontermdef{nondigit} \textnormal{one of}\br
+    \terminal{a b c d e f g h i j k l m}\br
+    \terminal{n o p q r s t u v w x y z}\br
+    \terminal{A B C D E F G H I J K L M}\br
+    \terminal{N O P Q R S T U V W X Y Z _}
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{digit} \textnormal{one of}\br
+    \terminal{0 1 2 3 4 5 6 7 8 9}
+\end{bnf}
+
 \pnum
 Preprocessing number tokens lexically include
 all \grammarterm{integer-literal} tokens\iref{lex.icon} and
@@ -903,28 +916,13 @@ literals, and alternative tokens containing alphabetic characters.
 
 \begin{bnf}
 \nontermdef{identifier-start}\br
-    nondigit\br
+    \terminal{_}\br
     \textnormal{an element of the translation character set with the Unicode property XID_Start}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{identifier-continue}\br
-    digit\br
-    nondigit\br
     \textnormal{an element of the translation character set with the Unicode property XID_Continue}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{nondigit} \textnormal{one of}\br
-    \terminal{a b c d e f g h i j k l m}\br
-    \terminal{n o p q r s t u v w x y z}\br
-    \terminal{A B C D E F G H I J K L M}\br
-    \terminal{N O P Q R S T U V W X Y Z _}
-\end{bnf}
-
-\begin{bnf}
-\nontermdef{digit} \textnormal{one of}\br
-    \terminal{0 1 2 3 4 5 6 7 8 9}
 \end{bnf}
 
 \pnum


### PR DESCRIPTION
Move definitions of *digit* and *nondigit* under *pp-number* where they first appear; strike their use in *identifier-start* and *identifier-continue* where they are subsumed by the definitions based on Unicode character properties.
