### PR TITLE
[lex.ext] Remove redundant requirement

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -2223,7 +2223,6 @@ with \grammarterm{ud-suffix} \placeholder{X},
 first let \placeholder{S} be the set of declarations
 found by unqualified lookup for the \grammarterm{literal-operator-id}
 whose literal suffix identifier is \placeholder{X}\iref{basic.lookup.unqual}.
-\placeholder{S} shall not be empty.
 
 \pnum
 If \placeholder{L} is a \grammarterm{user-defined-integer-literal}, let \placeholder{n} be the literal


### PR DESCRIPTION
This requirement is redundant with the more general provision found in [basic.lookup.general].