### PR TITLE
[charconv.from.chars] Clarify how from_chars treats the sign of zero in floating-point underflow

### DIFF
--- a/source/text.tex
+++ b/source/text.tex
@@ -271,6 +271,11 @@ Otherwise,
 \tcode{value} is set to the parsed value,
 after rounding according to \tcode{round_to_nearest}\iref{round.style}, and
 the member \tcode{ec} is value-initialized.
+\begin{note}
+If the parsed value is too small to be represented,
+\tcode{ec} is value-initialized and
+\tcode{value} is set to a zero with the same sign as the parsed value before rounding.
+\end{note}
 
 \indexlibraryglobal{from_chars}%
 \begin{itemdecl}


### PR DESCRIPTION
This clarification is meant to prevent bugs like https://gcc.gnu.org/bugzilla/show_bug.cgi?id=123078

Consider parsing `"-1e-1000000000000000"` with `std::from_chars`.

From https://eel.is/c++draft/charconv.from.chars#1.sentence-7, it follows that this tiny value is rounded according to `round_to_nearest`, which is supposed to correspond to the ISO/IEC 605559 rounding mode roundTiesToEven. See also https://cplusplus.github.io/LWG/issue4474 (this is not tentatively ready yet, but so far no one in LWG objected that `float_round_style` corresponds to ISO/IEC 60559 rounding modes) (or to C23 `FLT_ROUNDS`).

All ISO/IEC 60559 rounding modes preserve the sign in the case of underflow, so a value too small to be represented should result in negative zero.