### PR TITLE
[basic.def] Remove redundant items from list

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -249,24 +249,6 @@ an \grammarterm{alias-declaration}\iref{dcl.typedef},
 \item it is
 a \grammarterm{namespace-alias-definition}\iref{namespace.alias},
 \item it is
-a \grammarterm{using-declaration}\iref{namespace.udecl},
-\item it is
-a \grammarterm{deduction-guide}\iref{temp.deduct.guide},
-\item it is
-a \grammarterm{static_assert-declaration}\iref{dcl.pre},
-\item it is
-a \grammarterm{consteval-block-declaration},
-\item
-it is an
-\grammarterm{attribute-declaration}\iref{dcl.pre},
-\item
-it is an
-\grammarterm{empty-declaration}\iref{dcl.pre},
-\item it is
-a \grammarterm{using-directive}\iref{namespace.udir},
-\item it is
-a \grammarterm{using-enum-declaration}\iref{enum.udecl},
-\item it is
 a \grammarterm{template-declaration}\iref{temp.pre}
 whose \grammarterm{template-head} is not followed by
 either a \grammarterm{concept-definition} or a \grammarterm{declaration}


### PR DESCRIPTION
Remove declarations that do not introduce any entities from the list specifying which declarations do not define the entities they introduce.