### PR TITLE
[expr.prim.id.unqual] Fix misplaced example

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1592,6 +1592,35 @@ If $E$ is not declared \keyword{mutable},
 the type of such an identifier will typically be \keyword{const} qualified.
 \end{note}
 
+\begin{example}
+\begin{codeblock}
+void f() {
+  float x, &r = x;
+
+  [=]() -> decltype((x)) {      // lambda returns \tcode{float const\&} because this lambda is not \tcode{mutable} and
+                                // \tcode{x} is an lvalue
+    decltype(x) y1;             // \tcode{y1} has type \tcode{float}
+    decltype((x)) y2 = y1;      // \tcode{y2} has type \tcode{float const\&}
+    decltype(r) r1 = y1;        // \tcode{r1} has type \tcode{float\&}
+    decltype((r)) r2 = y2;      // \tcode{r2} has type \tcode{float const\&}
+    return y2;
+  };
+
+  [=](decltype((x)) y) {
+    decltype((x)) z = x;        // OK, \tcode{y} has type \tcode{float\&}, \tcode{z} has type \tcode{float const\&}
+  };
+
+  [=] {
+    [](decltype((x)) y) {};     // OK, lambda takes a parameter of type \tcode{float const\&}
+
+    [x=1](decltype((x)) y) {
+      decltype((x)) z = x;      // OK, \tcode{y} has type \tcode{int\&}, \tcode{z} has type \tcode{int const\&}
+    };
+  };
+}
+\end{codeblock}
+\end{example}
+
 \pnum
 Otherwise,
 if the \grammarterm{unqualified-id}
@@ -1749,36 +1778,6 @@ to hold the result object as specified in \ref{class.temporary},
 and the postcondition assertion
 is sequenced before the initialization of the result object\iref{expr.call},
 $E$ refers to the most recently initialized such temporary object.
-
-
-\begin{example}
-\begin{codeblock}
-void f() {
-  float x, &r = x;
-
-  [=]() -> decltype((x)) {      // lambda returns \tcode{float const\&} because this lambda is not \tcode{mutable} and
-                                // \tcode{x} is an lvalue
-    decltype(x) y1;             // \tcode{y1} has type \tcode{float}
-    decltype((x)) y2 = y1;      // \tcode{y2} has type \tcode{float const\&}
-    decltype(r) r1 = y1;        // \tcode{r1} has type \tcode{float\&}
-    decltype((r)) r2 = y2;      // \tcode{r2} has type \tcode{float const\&}
-    return y2;
-  };
-
-  [=](decltype((x)) y) {
-    decltype((x)) z = x;        // OK, \tcode{y} has type \tcode{float\&}, \tcode{z} has type \tcode{float const\&}
-  };
-
-  [=] {
-    [](decltype((x)) y) {};     // OK, lambda takes a parameter of type \tcode{float const\&}
-
-    [x=1](decltype((x)) y) {
-      decltype((x)) z = x;      // OK, \tcode{y} has type \tcode{int\&}, \tcode{z} has type \tcode{int const\&}
-    };
-  };
-}
-\end{codeblock}
-\end{example}
 
 \pnum
 An \defnadj{implicitly movable}{entity} is


### PR DESCRIPTION
#7695 detached this example from the paragraph that discusses lambda captures, which appears inadvertent. This PR moves the example back.