### PR TITLE
[basic.lookup.general] Clarify that type-only lookup can find type aliases

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1731,11 +1731,11 @@ is therefore hidden by any other entity in its scope.
 \indextext{type-only!lookup|see{lookup, type-only}}%
 However, if a lookup is \defnx{type-only}{lookup!type-only},
 only declarations of
-types and templates whose specializations are types are considered;
+types, type aliases, and templates whose specializations are such are considered;
 furthermore, if declarations
 of a type alias and of its underlying entity are found,
-the declaration of the type alias is discarded
-instead of the type declaration.
+declarations of the type alias are discarded
+instead of the type declarations.
 
 \rSec2[class.member.lookup]{Member name lookup}%
 \indextext{lookup!member name}%


### PR DESCRIPTION
Clarify that type aliases are also included here (as already indicated by the second part of this sentence).

As a drive-by fix, change singular "declaration" to plural "declarations", since a search can find multiple declarations of the same entity.