### PR TITLE
[basic.lookup.unqual] Rephrase to avoid incorrect use of "lookup context"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2063,7 +2063,8 @@ int x = g<B, T2>();                     // \#1 calls \tcode{B::operator U1 T1::*
 \pnum
 In a friend declaration \grammarterm{declarator}
 whose \grammarterm{declarator-id} is a \grammarterm{qualified-id}
-whose lookup context\iref{basic.lookup.qual} is a class or namespace $S$,
+whose \grammarterm{nested-name-specifier}
+designates a class or namespace $S$\iref{expr.prim.id.qual},
 lookup for an unqualified name
 that appears after the \grammarterm{declarator-id}
 performs a search in the scope associated with $S$.


### PR DESCRIPTION
"Lookup context" defined for names; a *qualified-id* is never a name.