### PR TITLE
[namespace.qual] Remove references to undefined meta-variable

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2626,22 +2626,22 @@ namespace AB {
 
 void h()
 {
-  AB::g();          // \tcode{g} is declared directly in \tcode{AB}, therefore \tcode{S} is $\{ \tcode{AB::g()} \}$ and \tcode{AB::g()} is chosen
+  AB::g();          // \tcode{g} is declared directly in \tcode{AB}, therefore lookup result is $\{ \tcode{AB::g()} \}$ and \tcode{AB::g()} is chosen
 
   AB::f(1);         // \tcode{f} is not declared directly in \tcode{AB} so the rules are applied recursively to \tcode{A} and \tcode{B};
                     // namespace \tcode{Y} is not searched and \tcode{Y::f(float)} is not considered;
-                    // \tcode{S} is $\{ \tcode{A::f(int)}, \tcode{B::f(char)} \}$ and overload resolution chooses \tcode{A::f(int)}
+                    // lookup result is $\{ \tcode{A::f(int)}, \tcode{B::f(char)} \}$ and overload resolution chooses \tcode{A::f(int)}
 
   AB::f('c');       // as above but resolution chooses \tcode{B::f(char)}
 
   AB::x++;          // \tcode{x} is not declared directly in \tcode{AB}, and is not declared in \tcode{A} or \tcode{B}, so the rules
-                    // are applied recursively to \tcode{Y} and \tcode{Z}, \tcode{S} is $\{ \}$ so the program is ill-formed
+                    // are applied recursively to \tcode{Y} and \tcode{Z}, lookup result is $\{ \}$ so the program is ill-formed
 
   AB::i++;          // \tcode{i} is not declared directly in \tcode{AB} so the rules are applied recursively to \tcode{A} and \tcode{B},
-                    // \tcode{S} is $\{ \tcode{A::i}, \tcode{B::i} \}$ so the use is ambiguous and the program is ill-formed
+                    // lookup result is $\{ \tcode{A::i}, \tcode{B::i} \}$ so the use is ambiguous and the program is ill-formed
 
   AB::h(16.8);      // \tcode{h} is not declared directly in \tcode{AB} and not declared directly in \tcode{A} or \tcode{B} so the rules
-                    // are applied recursively to \tcode{Y} and \tcode{Z}, \tcode{S} is $\{ \tcode{Y::h(int)}, \tcode{Z::h(double)} \}$ and
+                    // are applied recursively to \tcode{Y} and \tcode{Z}, lookup result is $\{ \tcode{Y::h(int)}, \tcode{Z::h(double)} \}$ and
                     // overload resolution chooses \tcode{Z::h(double)}
 }
 \end{codeblock}
@@ -2672,7 +2672,7 @@ namespace BC {
 
 void f()
 {
-  BC::a++;          // OK, \tcode{S} is $\{ \tcode{A::a}, \tcode{A::a} \}$
+  BC::a++;          // OK, lookup result is $\{ \tcode{A::a}, \tcode{A::a} \}$
 }
 
 namespace D {
@@ -2686,7 +2686,7 @@ namespace BD {
 
 void g()
 {
-  BD::a++;          // OK, \tcode{S} is $\{ \tcode{A::a}, \tcode{A::a} \}$
+  BD::a++;          // OK, lookup result is $\{ \tcode{A::a}, \tcode{A::a} \}$
 }
 \end{codeblock}
 \end{example}
@@ -2712,10 +2712,10 @@ namespace B {
 
 void f()
 {
-  A::a++;           // OK, \tcode{a} declared directly in \tcode{A}, \tcode{S} is $\{ \tcode{A::a} \}$
-  B::a++;           // OK, both \tcode{A} and \tcode{B} searched (once), \tcode{S} is $\{ \tcode{A::a} \}$
-  A::b++;           // OK, both \tcode{A} and \tcode{B} searched (once), \tcode{S} is $\{ \tcode{B::b} \}$
-  B::b++;           // OK, \tcode{b} declared directly in \tcode{B}, \tcode{S} is $\{ \tcode{B::b} \}$
+  A::a++;           // OK, \tcode{a} declared directly in \tcode{A}, lookup result is $\{ \tcode{A::a} \}$
+  B::a++;           // OK, both \tcode{A} and \tcode{B} searched (once), lookup result is $\{ \tcode{A::a} \}$
+  A::b++;           // OK, both \tcode{A} and \tcode{B} searched (once), lookup result is $\{ \tcode{B::b} \}$
+  B::b++;           // OK, \tcode{b} declared directly in \tcode{B}, lookup result is $\{ \tcode{B::b} \}$
 }
 \end{codeblock}
 \end{example}


### PR DESCRIPTION
"`S`" (previously denoting the "namespace-qualified lookup set") vanished with P1787 but the examples continue to refer to it.