### PR TITLE
[utility.intcmp] Rephrase integer type constraint of "standard or extended" as "signed or unsigned"

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -546,8 +546,8 @@ template<class T, class U>
 \begin{itemdescr}
 \pnum
 \mandates
-Both \tcode{T} and \tcode{U} are standard integer types or
-extended integer types\iref{basic.fundamental}.
+Each of \tcode{T} and \tcode{U} is
+a signed or unsigned integer type\iref{basic.fundamental}.
 
 \pnum
 \effects
@@ -585,8 +585,8 @@ template<class T, class U>
 \begin{itemdescr}
 \pnum
 \mandates
-Both \tcode{T} and \tcode{U} are standard integer types or
-extended integer types\iref{basic.fundamental}.
+Each of \tcode{T} and \tcode{U} is
+a signed or unsigned integer type\iref{basic.fundamental}.
 
 \pnum
 \effects
@@ -648,8 +648,8 @@ template<class R, class T>
 \begin{itemdescr}
 \pnum
 \mandates
-Both \tcode{T} and \tcode{R} are standard integer types or
-extended integer types\iref{basic.fundamental}.
+Each of \tcode{T} and \tcode{U} is
+a signed or unsigned integer type\iref{basic.fundamental}.
 
 \pnum
 \effects


### PR DESCRIPTION
"standard or extended" refers to the same set of types as "signed or unsigned". However, the latter constraint is far more common, and it would conveniently include additional sets of integers added in the future, such as bit-precise integers.

See also
- https://github.com/cplusplus/draft/pull/8546#pullrequestreview-3545939346
- https://github.com/eisenwave/cpp-proposals/issues/125#issue-3700026438