### PR TITLE
[basic.pre] Split names and entities into its own subclause

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -31,6 +31,8 @@ part of the language. Such concepts are discussed in the relevant
 Clauses.
 \end{note}
 
+\rSec1[basic.name]{Names and entities}
+
 \pnum
 A \defn{name} is an \grammarterm{identifier}\iref{lex.name},
 \grammarterm{conversion-function-id}\iref{class.conv.fct},
@@ -171,7 +173,7 @@ translation unit.
 \indextext{declaration!definition versus}%
 \indextext{declaration}%
 \indextext{declaration!name}%
-A declaration\iref{basic.pre} may (re)introduce
+A declaration\iref{basic.name} may (re)introduce
 one or more names and/or entities into a translation
 unit.
 If so, the
@@ -377,7 +379,7 @@ Each of the following is termed a \defnadj{definable}{item}:
 \item a class type\iref{class},
 \item an enumeration type\iref{dcl.enum},
 \item a function\iref{dcl.fct},
-\item a variable\iref{basic.pre},
+\item a variable\iref{basic.name},
 \item a templated entity\iref{temp.pre},
 \item a default argument for a parameter
 (for a function in a given scope)\iref{dcl.fct.default}, or
@@ -587,7 +589,7 @@ in~\ref{dcl.init}. A destructor for a class is odr-used if it is potentially
 invoked\iref{class.dtor}.
 
 \pnum
-A local entity\iref{basic.pre}
+A local entity\iref{basic.name}
 is \defn{odr-usable} in a scope\iref{basic.scope.scope} if
 \begin{itemize}
 \item either the local entity is not \tcode{*\keyword{this}}, or
@@ -1248,7 +1250,7 @@ to contain the instantiations of any declarations that inhabit $S$.
 
 \pnum
 \indextext{declaration!locus|see{locus}}%
-The \defn{locus} of a declaration\iref{basic.pre} that is a declarator
+The \defn{locus} of a declaration\iref{basic.name} that is a declarator
 is immediately after the complete declarator\iref{dcl.decl}.
 \begin{example}
 \begin{codeblock}
@@ -1716,7 +1718,7 @@ int main() { return sq(9); }    // OK, \tcode{sq} from module \tcode{Q}
 A \defnadj{single}{search} in a scope $S$
 for a name $N$ from a program point $P$
 finds all declarations that precede $P$
-to which any name that is the same as $N$\iref{basic.pre} is bound in $S$.
+to which any name that is the same as $N$\iref{basic.name} is bound in $S$.
 If any such declaration is a \grammarterm{using-declarator}
 whose terminal name\iref{expr.prim.id.unqual}
 is not dependent\iref{temp.dep.type},
@@ -2839,7 +2841,7 @@ A \grammarterm{splice-specifier}
 whose converted \grammarterm{constant-expression} represents
 a construct $X$ is said to \defn{designate} either
 \begin{itemize}
-\item the underlying entity of $X$ if $X$ is an entity\iref{basic.pre}, or
+\item the underlying entity of $X$ if $X$ is an entity\iref{basic.name}, or
 \item $X$ otherwise.
 \end{itemize}
 \begin{note}
@@ -3459,7 +3461,7 @@ occupies storage in the way that objects do.
 \end{note}
 The properties of an
 object are determined when the object is created. An object can have a
-name\iref{basic.pre}. An object has a storage
+name\iref{basic.name}. An object has a storage
 duration\iref{basic.stc} which influences its
 lifetime\iref{basic.life}. An object has a
 type\iref{basic.types}.
@@ -5669,7 +5671,7 @@ every other reflection is a representation of
 \begin{itemize}
 \item a value of scalar type\iref{temp.param},
 \item an object with static storage duration\iref{basic.stc},
-\item a variable\iref{basic.pre},
+\item a variable\iref{basic.name},
 \item a structured binding\iref{dcl.struct.bind},
 \item a function\iref{dcl.fct},
 \item a function parameter,

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1581,7 +1581,7 @@ the \grammarterm{unqualified-id}
 appears in a \grammarterm{lambda-expression}
 at program point $P$,
 \item
-the entity is a local entity\iref{basic.pre}
+the entity is a local entity\iref{basic.name}
 or a variable declared by an \grammarterm{init-capture}\iref{expr.prim.lambda.capture},
 \item
 naming the entity within the \grammarterm{compound-statement} of
@@ -2748,7 +2748,7 @@ is the corresponding contract-assertion scope\iref{basic.scope.contract}.
 
 \pnum
 The \grammarterm{identifier} in a \grammarterm{simple-capture}
-shall denote a local entity\iref{basic.lookup.unqual,basic.pre}.
+shall denote a local entity\iref{basic.lookup.unqual,basic.name}.
 The \grammarterm{simple-capture}{s} \keyword{this} and \tcode{* \keyword{this}}
 denote the local entity \tcode{*\keyword{this}}.
 An entity that is designated by a
@@ -3573,7 +3573,7 @@ a destructor,
 \item
 an unnamed bit-field, or
 \item
-a local entity\iref{basic.pre} such that
+a local entity\iref{basic.name} such that
 \begin{itemize}
 \item
 there is a lambda scope that intervenes
@@ -6837,7 +6837,7 @@ a function-local predefined variable\iref{dcl.fct.def.general},
 a local parameter introduced by
 a \grammarterm{requires-expression}\iref{expr.prim.req}, or
 \item
-a local entity $E$\iref{basic.pre} for which a lambda scope intervenes
+a local entity $E$\iref{basic.name} for which a lambda scope intervenes
 between the point at which $E$ was introduced and $R$,
 \end{itemize}
 then $R$ is ill-formed.


### PR DESCRIPTION
All the normative text in [basic.pre] specifies the notions of names and entities, so introduce an appropriately named subclause after the introductory material.