### PR TITLE
[basic.link] Reword to avoid confusion with a defined term

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -2984,8 +2984,7 @@ otherwise,
 \indextext{friend function!linkage of}%
 if the entity is a function or function template
 declared in a friend declaration and
-a corresponding non-friend declaration is reachable,
-%FIXME: Which declaration is "that prior declaration"?
+a prior non-friend declaration of the entity is reachable,
 %FIXME: "prior" with respect to what? And what about dependent lookup?
 the name has the linkage determined from that prior declaration,
 \item


### PR DESCRIPTION
"Corresponding" looks like a use of the term "[correspond](https://eel.is/c++draft/basic.scope.scope#def:correspond)", which is not what is meant here.