### PR TITLE
[intro.memory] Update outdated example

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3427,9 +3427,9 @@ struct {
 };
 \end{codeblock}
 contains four separate memory locations: The member \tcode{a} and bit-fields
-\tcode{d} and \tcode{e.ee} are each separate memory locations, and can be
+\tcode{d} and \tcode{e.ee} each occupy separate memory locations, and can be
 modified concurrently without interfering with each other. The bit-fields
-\tcode{b} and \tcode{c} together constitute the fourth memory location. The
+\tcode{b} and \tcode{c} together occupy the fourth memory location. The
 bit-fields \tcode{b} and \tcode{c} cannot be concurrently modified, but
 \tcode{b} and \tcode{a}, for example, can be.
 \end{example}


### PR DESCRIPTION
Since "memory location" is now defined as the storage occupied by certain objects, it is inaccurate to say that the various non-static data members "are" a memory location.