### PR TITLE
[intro.object] Remove redundant "non-bit-field"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3666,7 +3666,7 @@ const bool b4 = il.begin() != &test1;   // always \tcode{true}
 const bool b5 = r != &test1;            // always \tcode{true}
 \end{codeblock}
 \end{example}
-The address of a non-bit-field subobject of zero size is
+The address of a subobject of zero size is
 the address of an unspecified byte of storage
 occupied by the complete object of that subobject.
 


### PR DESCRIPTION
According to [[class.bit]/1](https://eel.is/c++draft/class.bit#1.sentence-4), a bit-field cannot have class type; according to [[intro.object]/8.2](https://eel.is/c++draft/intro.object#8.2), an object of non-class type cannot have zero size; ergo, excluding bit-fields when talking about subobjects of zero size is unnecessary.