### PR TITLE
[basic.types.general] Improve presentation of comments in example

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5230,7 +5230,7 @@ UNKA** arrpp;
 void foo() {
   xp++;                         // error: \tcode{X} is incomplete
   arrp++;                       // error: incomplete type
-  arrpp++;                      // OK, sizeof \tcode{UNKA*} is known
+  arrpp++;                      // OK, \tcode{sizeof(UNKA*)} is known
 }
 
 struct X { int i; };            // now \tcode{X} is a complete type
@@ -5238,8 +5238,8 @@ int arr[10];                    // now the type of \tcode{arr} is complete
 
 X x;
 void bar() {
-  xp = &x;                      // OK; type is ``pointer to \tcode{X}''
-  arrp = &arr;                  // OK; qualification conversion\iref{conv.qual}
+  xp = &x;                      // OK, type is ``pointer to \tcode{X}''
+  arrp = &arr;                  // OK, qualification conversion\iref{conv.qual}
   xp++;                         // OK, \tcode{X} is complete
   arrp++;                       // error: \tcode{UNKA} can't be completed
 }


### PR DESCRIPTION
* Put "sizeof" in code font
* Consistently use a comma after "OK"