### PR TITLE
[basic.fundamental] Rephrase note

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5544,8 +5544,8 @@ an \impldef{underlying type of \tcode{bool}} unsigned integer type.
 The values of type \keyword{bool} are
 \keyword{true} and \keyword{false}.
 \begin{note}
-There are no \keyword{signed}, \keyword{unsigned},
-\keyword{short}, or \tcode{\keyword{long} \keyword{bool}} types or values.
+The type specifiers \keyword{signed}, \keyword{unsigned},
+\keyword{short}, and \keyword{long} cannot be combined with \keyword{bool}.
 \end{note}
 
 \pnum


### PR DESCRIPTION
The current note can be misread as attaching only the `long` modifier to `bool` (and talking about just the "`signed`", "`unsigned`", and "`short`" types otherwise, all of which *are* valid *type-id*s).
