### PR TITLE
[basic.scope.pdecl] Clarify comment in example

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1351,7 +1351,7 @@ The locus of a \grammarterm{template-parameter} is immediately after it.
 \begin{codeblock}
 typedef unsigned char T;
 template<class T
-  = T               // lookup finds the \grammarterm{typedef-name}
+  = T               // lookup finds \tcode{::T}
   , T               // lookup finds the template parameter
     N = 0> struct A { };
 \end{codeblock}


### PR DESCRIPTION
The name of a type template parameter is also a *typedef-name*.