### PR TITLE
[basic.compound] Demote redundant wording to a note

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -6044,12 +6044,14 @@ if \placeholder{y} is an array element.
 \pnum
 \indextext{pointer|seealso{\tcode{void*}}}%
 \indextext{\idxcode{void*}!type}%
+A type ``pointer to \cv{}~\keyword{void}''
+shall have the same representation and alignment
+requirements as ``pointer to \cv{}~\keyword{char}''.
+\begin{note}
 A pointer to \cv{}~\keyword{void}
 can be used to point to objects of
-unknown type. Such a pointer shall be able to hold any object pointer.
-An object of type ``pointer to \cv{}~\keyword{void}''
-shall have the same representation and alignment
-requirements as an object of type ``pointer to \cv{}~\keyword{char}''.
+unknown type. Such a pointer can hold any object pointer.
+\end{note}
 
 \rSec2[basic.type.qualifier]{CV-qualifiers}
 


### PR DESCRIPTION
"Such a pointer shall be able to hold any object pointer" already follows from [[basic.compound]/3](https://eel.is/c++draft/basic.compound#3.sentence-8) and [[conv.ptr]/2](https://eel.is/c++draft/conv.ptr#2).
