### PR TITLE
[intro.execution] Replace "or" with "and"; clarify wording

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -6337,9 +6337,9 @@ the constituent expressions of the \grammarterm{initializer} of the \grammarterm
 \item
 if $E$ is a function call\iref{expr.call} or implicitly invokes a function,
 the constituent expressions of each default argument\iref{dcl.fct.default}
-used in the call, or
+used in the call, and
 \item
-if $E$ creates an aggregate object\iref{dcl.init.aggr},
+if $E$ performs aggregate initialization\iref{dcl.init.aggr},
 the constituent expressions of each default member initializer\iref{class.mem}
 used in the initialization.
 \end{itemize}


### PR DESCRIPTION
The set of immediate subexpressions should be a union of the sets enumerated by the list, rather than just one alternative.