### PR TITLE
[intro.races] Replace "library call" with "evaluation"; mark example

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -6747,9 +6747,12 @@ where the first operation is $A$, and
 every subsequent operation is an atomic read-modify-write operation.
 
 \pnum
-Certain library calls \defn{synchronize with} other library calls performed by
-another thread. For example, an atomic store-release synchronizes with a
+Certain evaluations \defn{synchronize with} other evaluations performed by
+another thread.
+\begin{example}
+An atomic store-release synchronizes with a
 load-acquire that takes its value from the store\iref{atomics.order}.
+\end{example}
 \begin{note}
 Except in the specified cases, reading a later value does not
 necessarily ensure visibility as described below. Such a requirement would


### PR DESCRIPTION
"Synchronizes with" is sometimes applied to evaluations other than invocations of library functions.