### PR TITLE
[basic.start.dynamic] Fix example

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -7481,8 +7481,8 @@ extern A a;
 extern B b;
 
 int main() {
-  a.Use();
   b.Use();
+  a.Use();
 }
 \end{codeblock}
 


### PR DESCRIPTION
The last sentence of this example talks about `a` being initialized "after the first statement of `main`", which doesn't make sense since that statement odr-uses it (assuming `Use` is not a static member).