### PR TITLE
[template.bitset.general][vector.bool.pspc] Make subclauses for `reference` nested classes

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10489,21 +10489,8 @@ namespace std {
     using reverse_iterator       = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
-    // bit reference
-    class @\libmember{reference}{vector<bool>}@ {
-    public:
-      constexpr reference(const reference& x) noexcept;
-      constexpr ~reference();
-      constexpr reference& operator=(bool x) noexcept;
-      constexpr reference& operator=(const reference& x) noexcept;
-      constexpr const reference& operator=(bool x) const noexcept;
-      constexpr operator bool() const noexcept;
-      constexpr void flip() noexcept;   // flips the bit
-
-      friend constexpr void swap(reference x, reference y) noexcept;
-      friend constexpr void swap(reference x, bool& y) noexcept;
-      friend constexpr void swap(bool& x, reference y) noexcept;
-    };
+    // \ref{vector.bool.reference}, bit reference
+    class reference;
 
     // construct/copy/destroy
     constexpr vector() noexcept(noexcept(Allocator())) : vector(Allocator()) { }
@@ -10607,13 +10594,35 @@ There is no requirement that the data be stored as a contiguous allocation
 of \tcode{bool} values. A space-optimized representation of bits is
 recommended instead.
 
+\rSec3[vector.bool.reference]{Class \tcode{vector<bool>::reference}}%
 \pnum
 \tcode{reference}
 is a class that simulates a reference to a single bit in the sequence.
 
+\indexlibrarymember{reference}{vector<bool>}%
+\begin{codeblock}
+namespace std {
+  template<class Allocator>
+  class vector<bool, Allocator>::reference {
+  public:
+    constexpr reference(const reference& x) noexcept;
+    constexpr ~reference();
+    constexpr reference& operator=(bool x) noexcept;
+    constexpr reference& operator=(const reference& x) noexcept;
+    constexpr const reference& operator=(bool x) const noexcept;
+    constexpr operator bool() const noexcept;
+    constexpr void flip() noexcept;     // flips the bit
+
+    friend constexpr void swap(reference x, reference y) noexcept;
+    friend constexpr void swap(reference x, bool& y) noexcept;
+    friend constexpr void swap(bool& x, reference y) noexcept;
+  };
+}
+\end{codeblock}
+
 \indexlibraryctor{vector<bool>::reference}%
 \begin{itemdecl}
-constexpr reference::reference(const reference& x) noexcept;
+constexpr reference(const reference& x) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10624,7 +10633,7 @@ Initializes \tcode{*this} to refer to the same bit as \tcode{x}.
 
 \indexlibrarydtor{vector<bool>::reference}%
 \begin{itemdecl}
-constexpr reference::~reference();
+constexpr ~reference();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10635,9 +10644,9 @@ None.
 
 \indexlibrarymember{operator=}{vector<bool>::reference}%
 \begin{itemdecl}
-constexpr reference& reference::operator=(bool x) noexcept;
-constexpr reference& reference::operator=(const reference& x) noexcept;
-constexpr const reference& reference::operator=(bool x) const noexcept;
+constexpr reference& operator=(bool x) noexcept;
+constexpr reference& operator=(const reference& x) noexcept;
+constexpr const reference& operator=(bool x) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10653,7 +10662,7 @@ and clears it otherwise.
 
 \indexlibrarymember{flip}{vector<bool>::reference}%
 \begin{itemdecl}
-constexpr void reference::flip() noexcept;
+constexpr void flip() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10681,7 +10690,7 @@ y = b;
 \end{codeblock}
 \end{itemdescr}
 
-
+\rSec3[vector.bool.members]{\tcode{vector<bool>} members}
 
 \indexlibrarymember{flip}{vector<bool>}%
 \begin{itemdecl}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -10533,22 +10533,8 @@ namespace std {
 namespace std {
   template<size_t N> class bitset {
   public:
-    // bit reference
-    class reference {
-    public:
-      constexpr reference(const reference& x) noexcept;
-      constexpr ~reference();
-      constexpr reference& operator=(bool x) noexcept;              // for \tcode{b[i] = x;}
-      constexpr reference& operator=(const reference& x) noexcept;  // for \tcode{b[i] = b[j];}
-      constexpr const reference& operator=(bool x) const noexcept;
-      constexpr operator bool() const noexcept;                     // for \tcode{x = b[i];}
-      constexpr bool operator~() const noexcept;                    // flips the bit
-      constexpr reference& flip() noexcept;                         // for \tcode{b[i].flip();}
-
-      friend constexpr void swap(reference x, reference y) noexcept;
-      friend constexpr void swap(reference x, bool& y) noexcept;
-      friend constexpr void swap(bool& x, reference y) noexcept;
-    };
+    // \ref{bitset.reference}, bit reference
+    class reference;
 
     // \ref{bitset.cons}, constructors
     constexpr bitset() noexcept;
@@ -10625,6 +10611,8 @@ The class template
 \tcode{bitset<N>}
 describes an object that can store a sequence consisting of a fixed number of
 bits, \tcode{N}.
+The class \tcode{bitset<N>::reference} simulates a reference
+to a single bit in the sequence.
 
 \pnum
 Each bit represents either the value zero (reset) or one (set).
@@ -10642,84 +10630,6 @@ integral type, bit position \tcode{pos} corresponds to the
 \tcode{1 << pos}.
 The integral value corresponding to two
 or more bits is the sum of their bit values.
-
-\pnum
-\tcode{reference}
-is a class that simulates a reference to a single bit in the sequence.
-
-\indexlibraryctor{bitset::reference}%
-\begin{itemdecl}
-constexpr reference::reference(const reference& x) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Initializes \tcode{*this} to refer to the same bit as \tcode{x}.
-\end{itemdescr}
-
-\indexlibrarydtor{bitset::reference}%
-\begin{itemdecl}
-constexpr reference::~reference();
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-None.
-\end{itemdescr}
-
-\indexlibrarymember{operator=}{bitset::reference}%
-\begin{itemdecl}
-constexpr reference& reference::operator=(bool x) noexcept;
-constexpr reference& reference::operator=(const reference& x) noexcept;
-constexpr const reference& reference::operator=(bool x) const noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Sets the bit referred to by \tcode{*this} if \tcode{bool(x)} is \tcode{true},
-and clears it otherwise.
-
-\pnum
-\returns
-\tcode{*this}.
-\end{itemdescr}
-
-\indexlibrarymember{swap}{bitset::reference}%
-\begin{itemdecl}
-constexpr void swap(reference x, reference y) noexcept;
-constexpr void swap(reference x, bool& y) noexcept;
-constexpr void swap(bool& x, reference y) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Exchanges the values denoted by \tcode{x} and \tcode{y} as if by:
-
-\begin{codeblock}
-bool b = x;
-x = y;
-y = b;
-\end{codeblock}
-\end{itemdescr}
-
-\indexlibrarymember{flip}{bitset::reference}%
-\begin{itemdecl}
-constexpr reference& reference::flip() noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Equivalent to \tcode{*this = !*this}.
-
-\pnum
-\returns
-\tcode{*this}.
-\end{itemdescr}
 
 \pnum
 The functions described in \ref{template.bitset} can report three kinds of
@@ -10744,6 +10654,103 @@ error is associated with exceptions of type
 \tcode{overflow_error}\iref{overflow.error}.
 \indexlibraryglobal{overflow_error}%
 \end{itemize}
+
+\rSec3[bitset.reference]{Class \tcode{bitset<N>::reference}}%
+\indexlibrarymember{reference}{bitset}%
+\begin{codeblock}
+namespace std {
+  template<size_t N>
+  class bitset<N>::reference {
+  public:
+    constexpr reference(const reference& x) noexcept;
+    constexpr ~reference();
+    constexpr reference& operator=(bool x) noexcept;                // for \tcode{b[i] = x;}
+    constexpr reference& operator=(const reference& x) noexcept;    // for \tcode{b[i] = b[j];}
+    constexpr const reference& operator=(bool x) const noexcept;
+    constexpr operator bool() const noexcept;                       // for \tcode{x = b[i];}
+    constexpr bool operator~() const noexcept;                      // flips the bit
+    constexpr reference& flip() noexcept;                           // for \tcode{b[i].flip();}
+
+    friend constexpr void swap(reference x, reference y) noexcept;
+    friend constexpr void swap(reference x, bool& y) noexcept;
+    friend constexpr void swap(bool& x, reference y) noexcept;
+  };
+}
+\end{codeblock}
+
+\indexlibraryctor{bitset::reference}%
+\begin{itemdecl}
+constexpr reference(const reference& x) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Initializes \tcode{*this} to refer to the same bit as \tcode{x}.
+\end{itemdescr}
+
+\indexlibrarydtor{bitset::reference}%
+\begin{itemdecl}
+constexpr ~reference();
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+None.
+\end{itemdescr}
+
+\indexlibrarymember{operator=}{bitset::reference}%
+\begin{itemdecl}
+constexpr reference& operator=(bool x) noexcept;
+constexpr reference& operator=(const reference& x) noexcept;
+constexpr const reference& operator=(bool x) const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Sets the bit referred to by \tcode{*this} if \tcode{bool(x)} is \tcode{true},
+and clears it otherwise.
+
+\pnum
+\returns
+\tcode{*this}.
+\end{itemdescr}
+
+\indexlibrarymember{flip}{bitset::reference}%
+\begin{itemdecl}
+constexpr reference& flip() noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to \tcode{*this = !*this}.
+
+\pnum
+\returns
+\tcode{*this}.
+\end{itemdescr}
+
+\indexlibrarymember{swap}{bitset::reference}%
+\begin{itemdecl}
+constexpr void swap(reference x, reference y) noexcept;
+constexpr void swap(reference x, bool& y) noexcept;
+constexpr void swap(bool& x, reference y) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Exchanges the values denoted by \tcode{x} and \tcode{y} as if by:
+
+\begin{codeblock}
+bool b = x;
+x = y;
+y = b;
+\end{codeblock}
+\end{itemdescr}
 
 \rSec3[bitset.cons]{Constructors}
 


### PR DESCRIPTION
Consistent with other nested classes within the standard library.  This formulation leads to slightly clearer specification for the member functions that now use appropriately qualified names.