### PR TITLE
[diff.basic] Fix errors in entry about C "compatible" types

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2927,9 +2927,8 @@ Deletion of semantically well-defined feature.
 \difficulty
 Semantic transformation.
 The ``typesafe linkage'' mechanism will find many, but not all,
-of such problems.
-Those problems not found by typesafe linkage will continue to
-function properly,
+such problems.
+Some cases are allowed by \Cpp{}
 according to the ``layout compatibility rules'' of this
 document.
 \howwide


### PR DESCRIPTION
* Use enum example instead of example outdated since C99

  C99 subclause 6.2.7, "Compatible type and composite type", had this sentence:
  > If one is declared with a tag, the other shall be declared with the same tag.

* Stop claiming, as harmless, type-based aliasing violations