### PR TITLE
[intro.refs], [numeric.limits] Remove all references to ISO/IEC 10967-1:2012

### DIFF
--- a/source/back.tex
+++ b/source/back.tex
@@ -7,10 +7,6 @@
 \bibitem{iso4217}
   ISO 4217:2015,
   \doccite{Codes for the representation of currencies}
-\bibitem{iso10967-1}
-  ISO/IEC 10967-1:2012,
-  \doccite{Information technology --- Language independent arithmetic ---
-    Part 1: Integer and floating point arithmetic}
 \bibitem{iso14882:2023}
   ISO/IEC 14882:2023,
   \doccite{Programming Languages --- \Cpp{}}

--- a/source/support.tex
+++ b/source/support.tex
@@ -1109,11 +1109,6 @@ Non-arithmetic standard types, such as
 \pnum
 \indextext{signal-safe!\idxcode{numeric_limits} members}%
 Each member function defined in this subclause is signal-safe\iref{support.signal}.
-\begin{note}
-\indextext{LIA-1}%
-The arithmetic specification described in ISO/IEC 10967-1:2012 is
-commonly termed LIA-1.
-\end{note}
 
 \indexlibrarymember{min}{numeric_limits}%
 \begin{itemdecl}
@@ -1323,10 +1318,6 @@ static constexpr T round_error() noexcept;
 \begin{itemdescr}
 \pnum
 Measure of the maximum rounding error.
-\begin{footnote}
-Rounding error is described in ISO/IEC 10967-1:2012 Section 5.2.4 and
-Annex C Rationale Section C.5.2.4 --- Rounding and rounding constants.
-\end{footnote}
 \end{itemdescr}
 
 \indexlibrarymember{min_exponent}{numeric_limits}%
@@ -1433,9 +1424,6 @@ static constexpr bool has_quiet_NaN;
 \pnum
 \tcode{true} if the type has a representation for a quiet (non-signaling) ``Not a
 Number''.
-\begin{footnote}
-Required by ISO/IEC 10967-1:2012.
-\end{footnote}
 
 \pnum
 Meaningful for all floating-point types.
@@ -1455,9 +1443,6 @@ static constexpr bool has_signaling_NaN;
 \begin{itemdescr}
 \pnum
 \tcode{true} if the type has a representation for a signaling ``Not a Number''.
-\begin{footnote}
-Required by ISO/IEC 10967-1:2012.
-\end{footnote}
 
 \pnum
 Meaningful for all floating-point types.
@@ -1477,9 +1462,6 @@ static constexpr T infinity() noexcept;
 \begin{itemdescr}
 \pnum
 Representation of positive infinity, if available.
-\begin{footnote}
-Required by ISO/IEC 10967-1:2012.
-\end{footnote}
 
 \pnum
 Meaningful for all specializations for which
@@ -1496,9 +1478,6 @@ static constexpr T quiet_NaN() noexcept;
 \begin{itemdescr}
 \pnum
 Representation of a quiet ``Not a Number'', if available.
-\begin{footnote}
-Required by ISO/IEC 10967-1:2012.
-\end{footnote}
 
 \pnum
 Meaningful for all specializations for which
@@ -1515,9 +1494,6 @@ static constexpr T signaling_NaN() noexcept;
 \begin{itemdescr}
 \pnum
 Representation of a signaling ``Not a Number'', if available.
-\begin{footnote}
-Required by ISO/IEC 10967-1:2012.
-\end{footnote}
 
 \pnum
 Meaningful for all specializations for which
@@ -1535,9 +1511,6 @@ static constexpr T denorm_min() noexcept;
 \indextext{number!subnormal}%
 \pnum
 Minimum positive subnormal value, if available.
-\begin{footnote}
-Required by ISO/IEC 10967-1:2012.
-\end{footnote}
 Otherwise, minimum positive normalized value.
 
 \pnum
@@ -1573,9 +1546,6 @@ static constexpr bool is_bounded;
 \begin{itemdescr}
 \pnum
 \tcode{true} if the set of values representable by the type is finite.
-\begin{footnote}
-Required by ISO/IEC 10967-1:2012.
-\end{footnote}
 \begin{note}
 All fundamental types\iref{basic.fundamental} are bounded. This member would be \tcode{false} for arbitrary
 precision types.
@@ -1593,9 +1563,6 @@ static constexpr bool is_modulo;
 \begin{itemdescr}
 \pnum
 \tcode{true} if the type is modulo.
-\begin{footnote}
-Required by ISO/IEC 10967-1:2012.
-\end{footnote}
 A type is modulo if, for any operation involving \tcode{+}, \tcode{-}, or
 \tcode{*} on values of that type whose result would fall outside the range
 \crange{min()}{max()}, the value returned differs from the true value by an
@@ -1622,9 +1589,6 @@ static constexpr bool traps;
 \tcode{true}
 if, at the start of the program, there exists a value of the type that would cause
 an arithmetic operation using that value to trap.
-\begin{footnote}
-Required by ISO/IEC 10967-1:2012.
-\end{footnote}
 
 \pnum
 Meaningful for all specializations.
@@ -1642,7 +1606,6 @@ if tinyness is detected before rounding.
 \begin{footnote}
 Refer to
 \IsoFloatUndated{}.
-Required by ISO/IEC 10967-1:2012.
 \end{footnote}
 
 \pnum
@@ -1659,7 +1622,6 @@ static constexpr float_round_style round_style;
 The rounding style for the type.
 \begin{footnote}
 Equivalent to \tcode{FLT_ROUNDS}.
-Required by ISO/IEC 10967-1:2012.
 \end{footnote}
 
 \pnum


### PR DESCRIPTION
Fixes #8666.

Note that Jonathan wants SG6 to give an ack; see https://github.com/cplusplus/draft/issues/8666#issuecomment-3665372486