### PR TITLE
[iterator.synopsis] Make `<iterator>` "mostly freestanding"

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -31,6 +31,7 @@ as summarized in \tref{iterators.summary}.
 
 \indexheader{iterator}%
 \begin{codeblock}
+// mostly freestanding
 #include <compare>              // see \ref{compare.syn}
 #include <concepts>             // see \ref{concepts.syn}
 #include <initializer_list>     // see \ref{initializer.list.syn}
@@ -46,30 +47,30 @@ namespace std {
 
   // \ref{iterator.assoc.types}, associated types
   // \ref{incrementable.traits}, incrementable traits
-  template<class> struct incrementable_traits;                                      // freestanding
+  template<class> struct incrementable_traits;
   template<class T>
-    using iter_difference_t = @\seebelow@;                                            // freestanding
+    using iter_difference_t = @\seebelow@;
 
   // \ref{readable.traits}, indirectly readable traits
-  template<class> struct indirectly_readable_traits;                                // freestanding
+  template<class> struct indirectly_readable_traits;
   template<class T>
-    using iter_value_t = @\seebelow@;                                                 // freestanding
+    using iter_value_t = @\seebelow@;
 
   // \ref{iterator.traits}, iterator traits
-  template<class I> struct iterator_traits;                                         // freestanding
-  template<class T> requires is_object_v<T> struct iterator_traits<T*>;             // freestanding
+  template<class I> struct iterator_traits;
+  template<class T> requires is_object_v<T> struct iterator_traits<T*>;
 
   template<@\exposconcept{dereferenceable}@ T>
-    using @\libglobal{iter_reference_t}@ = decltype(*declval<T&>());                              // freestanding
+    using @\libglobal{iter_reference_t}@ = decltype(*declval<T&>());
 
   namespace ranges {
     // \ref{iterator.cust}, customization point objects
     inline namespace @\unspec@ {
       // \ref{iterator.cust.move}, \tcode{ranges::iter_move}
-      inline constexpr @\unspec@ iter_move = @\unspec@;                         // freestanding
+      inline constexpr @\unspec@ iter_move = @\unspec@;
 
       // \ref{iterator.cust.swap}, \tcode{ranges::iter_swap}
-      inline constexpr @\unspec@ iter_swap = @\unspec@;                         // freestanding
+      inline constexpr @\unspec@ iter_swap = @\unspec@;
     }
   }
 
@@ -77,452 +78,448 @@ namespace std {
     requires requires(T& t) {
       { ranges::iter_move(t) } -> @\exposconcept{can-reference}@;
     }
-  using @\libglobal{iter_rvalue_reference_t}@                                                     // freestanding
-    = decltype(ranges::iter_move(declval<T&>()));
+  using @\libglobal{iter_rvalue_reference_t}@ = decltype(ranges::iter_move(declval<T&>()));
 
   // \ref{iterator.concepts}, iterator concepts
   // \ref{iterator.concept.readable}, concept \libconcept{indirectly_readable}
   template<class In>
-    concept indirectly_readable = @\seebelow@;                                        // freestanding
+    concept indirectly_readable = @\seebelow@;
 
   // \ref{indirectcallable.traits}, indirect callable traits
   template<@\libconcept{indirectly_readable}@ T>
     using @\exposidnc{indirect-value-t}@ = @\seebelow@;         // \expos
 
   template<@\libconcept{indirectly_readable}@ T>
-    using @\libglobal{iter_common_reference_t}@ =                                                 // freestanding
+    using @\libglobal{iter_common_reference_t}@ =
       common_reference_t<iter_reference_t<T>, @\exposid{indirect-value-t}@<T>>;
 
   // \ref{iterator.concept.writable}, concept \libconcept{indirectly_writable}
   template<class Out, class T>
-    concept indirectly_writable = @\seebelow@;                                        // freestanding
+    concept indirectly_writable = @\seebelow@;
 
   // \ref{iterator.concept.winc}, concept \libconcept{weakly_incrementable}
   template<class I>
-    concept weakly_incrementable = @\seebelow@;                                       // freestanding
+    concept weakly_incrementable = @\seebelow@;
 
   // \ref{iterator.concept.inc}, concept \libconcept{incrementable}
   template<class I>
-    concept incrementable = @\seebelow@;                                              // freestanding
+    concept incrementable = @\seebelow@;
 
   // \ref{iterator.concept.iterator}, concept \libconcept{input_or_output_iterator}
   template<class I>
-    concept input_or_output_iterator = @\seebelow@;                                   // freestanding
+    concept input_or_output_iterator = @\seebelow@;
 
   // \ref{iterator.concept.sentinel}, concept \libconcept{sentinel_for}
   template<class S, class I>
-    concept sentinel_for = @\seebelow@;                                               // freestanding
+    concept sentinel_for = @\seebelow@;
 
   // \ref{iterator.concept.sizedsentinel}, concept \libconcept{sized_sentinel_for}
   template<class S, class I>
-    constexpr bool disable_sized_sentinel_for = false;                              // freestanding
+    constexpr bool disable_sized_sentinel_for = false;
 
   template<class S, class I>
-    concept sized_sentinel_for = @\seebelow@;                                         // freestanding
+    concept sized_sentinel_for = @\seebelow@;
 
   // \ref{iterator.concept.input}, concept \libconcept{input_iterator}
   template<class I>
-    concept input_iterator = @\seebelow@;                                             // freestanding
+    concept input_iterator = @\seebelow@;
 
   // \ref{iterator.concept.output}, concept \libconcept{output_iterator}
   template<class I, class T>
-    concept output_iterator = @\seebelow@;                                            // freestanding
+    concept output_iterator = @\seebelow@;
 
   // \ref{iterator.concept.forward}, concept \libconcept{forward_iterator}
   template<class I>
-    concept forward_iterator = @\seebelow@;                                           // freestanding
+    concept forward_iterator = @\seebelow@;
 
   // \ref{iterator.concept.bidir}, concept \libconcept{bidirectional_iterator}
   template<class I>
-    concept bidirectional_iterator = @\seebelow@;                                     // freestanding
+    concept bidirectional_iterator = @\seebelow@;
 
   // \ref{iterator.concept.random.access}, concept \libconcept{random_access_iterator}
   template<class I>
-    concept random_access_iterator = @\seebelow@;                                     // freestanding
+    concept random_access_iterator = @\seebelow@;
 
   // \ref{iterator.concept.contiguous}, concept \libconcept{contiguous_iterator}
   template<class I>
-    concept contiguous_iterator = @\seebelow@;                                        // freestanding
+    concept contiguous_iterator = @\seebelow@;
 
   // \ref{indirectcallable}, indirect callable requirements
   // \ref{indirectcallable.indirectinvocable}, indirect callables
   template<class F, class I>
-    concept indirectly_unary_invocable = @\seebelow@;                                 // freestanding
+    concept indirectly_unary_invocable = @\seebelow@;
 
   template<class F, class I>
-    concept indirectly_regular_unary_invocable = @\seebelow@;                         // freestanding
+    concept indirectly_regular_unary_invocable = @\seebelow@;
 
   template<class F, class I>
-    concept indirect_unary_predicate = @\seebelow@;                                   // freestanding
+    concept indirect_unary_predicate = @\seebelow@;
 
   template<class F, class I1, class I2>
-    concept indirect_binary_predicate = @\seebelow@;                                  // freestanding
+    concept indirect_binary_predicate = @\seebelow@;
 
   template<class F, class I1, class I2 = I1>
-    concept indirect_equivalence_relation = @\seebelow@;                              // freestanding
+    concept indirect_equivalence_relation = @\seebelow@;
 
   template<class F, class I1, class I2 = I1>
-    concept indirect_strict_weak_order = @\seebelow@;                                 // freestanding
+    concept indirect_strict_weak_order = @\seebelow@;
 
   template<class F, class... Is>
     requires (@\libconcept{indirectly_readable}@<Is> && ...) && @\libconcept{invocable}@<F, iter_reference_t<Is>...>
-      using @\libglobal{indirect_result_t}@ = invoke_result_t<F, iter_reference_t<Is>...>;        // freestanding
+      using @\libglobal{indirect_result_t}@ = invoke_result_t<F, iter_reference_t<Is>...>;
 
   // \ref{projected}, projected
   template<@\libconcept{indirectly_readable}@ I, @\libconcept{indirectly_regular_unary_invocable}@<I> Proj>
-    using projected = @\seebelow@;                                                    // freestanding
+    using projected = @\seebelow@;
 
   template<@\libconcept{indirectly_readable}@ I, @\libconcept{indirectly_regular_unary_invocable}@<I> Proj>
-  using projected_value_t =                                                         // freestanding
+  using projected_value_t =
     remove_cvref_t<invoke_result_t<Proj&, iter_value_t<I>&>>;
 
   // \ref{alg.req}, common algorithm requirements
   // \ref{alg.req.ind.move}, concept \libconcept{indirectly_movable}
   template<class In, class Out>
-    concept indirectly_movable = @\seebelow@;                                         // freestanding
+    concept indirectly_movable = @\seebelow@;
 
   template<class In, class Out>
-    concept indirectly_movable_storable = @\seebelow@;                                // freestanding
+    concept indirectly_movable_storable = @\seebelow@;
 
   // \ref{alg.req.ind.copy}, concept \libconcept{indirectly_copyable}
   template<class In, class Out>
-    concept indirectly_copyable = @\seebelow@;                                        // freestanding
+    concept indirectly_copyable = @\seebelow@;
 
   template<class In, class Out>
-    concept indirectly_copyable_storable = @\seebelow@;                               // freestanding
+    concept indirectly_copyable_storable = @\seebelow@;
 
   // \ref{alg.req.ind.swap}, concept \libconcept{indirectly_swappable}
   template<class I1, class I2 = I1>
-    concept indirectly_swappable = @\seebelow@;                                       // freestanding
+    concept indirectly_swappable = @\seebelow@;
 
   // \ref{alg.req.ind.cmp}, concept \libconcept{indirectly_comparable}
   template<class I1, class I2, class R, class P1 = identity, class P2 = identity>
-    concept indirectly_comparable = @\seebelow@;                                      // freestanding
+    concept indirectly_comparable = @\seebelow@;
 
   // \ref{alg.req.permutable}, concept \libconcept{permutable}
   template<class I>
-    concept permutable = @\seebelow@;                                                 // freestanding
+    concept permutable = @\seebelow@;
 
   // \ref{alg.req.mergeable}, concept \libconcept{mergeable}
   template<class I1, class I2, class Out,
            class R = ranges::less, class P1 = identity, class P2 = identity>
-    concept mergeable = @\seebelow@;                                                  // freestanding
+    concept mergeable = @\seebelow@;
 
   // \ref{alg.req.sortable}, concept \libconcept{sortable}
   template<class I, class R = ranges::less, class P = identity>
-    concept sortable = @\seebelow@;                                                   // freestanding
+    concept sortable = @\seebelow@;
 
   // \ref{iterator.primitives}, primitives
   // \ref{std.iterator.tags}, iterator tags
-  struct input_iterator_tag { };                                                    // freestanding
-  struct output_iterator_tag { };                                                   // freestanding
-  struct forward_iterator_tag: public input_iterator_tag { };                       // freestanding
-  struct bidirectional_iterator_tag: public forward_iterator_tag { };               // freestanding
-  struct random_access_iterator_tag: public bidirectional_iterator_tag { };         // freestanding
-  struct contiguous_iterator_tag: public random_access_iterator_tag { };            // freestanding
+  struct input_iterator_tag { };
+  struct output_iterator_tag { };
+  struct forward_iterator_tag: public input_iterator_tag { };
+  struct bidirectional_iterator_tag: public forward_iterator_tag { };
+  struct random_access_iterator_tag: public bidirectional_iterator_tag { };
+  struct contiguous_iterator_tag: public random_access_iterator_tag { };
 
   // \ref{iterator.operations}, iterator operations
   template<class InputIterator, class Distance>
     constexpr void
-      advance(InputIterator& i, Distance n);                                        // freestanding
+      advance(InputIterator& i, Distance n);
   template<class InputIterator>
     constexpr typename iterator_traits<InputIterator>::difference_type
-      distance(InputIterator first, InputIterator last);                            // freestanding
+      distance(InputIterator first, InputIterator last);
   template<class InputIterator>
     constexpr InputIterator
-      next(InputIterator x,                                                         // freestanding
+      next(InputIterator x,
            typename iterator_traits<InputIterator>::difference_type n = 1);
   template<class BidirectionalIterator>
     constexpr BidirectionalIterator
-      prev(BidirectionalIterator x,                                                 // freestanding
+      prev(BidirectionalIterator x,
            typename iterator_traits<BidirectionalIterator>::difference_type n = 1);
 
   // \ref{range.iter.ops}, range iterator operations
   namespace ranges {
     // \ref{range.iter.op.advance}, \tcode{ranges::advance}
     template<@\libconcept{input_or_output_iterator}@ I>
-      constexpr void advance(I& i, iter_difference_t<I> n);                         // freestanding
+      constexpr void advance(I& i, iter_difference_t<I> n);
     template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
-      constexpr void advance(I& i, S bound);                                        // freestanding
+      constexpr void advance(I& i, S bound);
     template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
-      constexpr iter_difference_t<I> advance(I& i, iter_difference_t<I> n,          // freestanding
-                                             S bound);
+      constexpr iter_difference_t<I> advance(I& i, iter_difference_t<I> n, S bound);
 
     // \ref{range.iter.op.distance}, \tcode{ranges::distance}
     template<class I, @\libconcept{sentinel_for}@<I> S>
       requires (!@\libconcept{sized_sentinel_for}@<S, I>)
-      constexpr iter_difference_t<I> distance(I first, S last);                     // freestanding
+      constexpr iter_difference_t<I> distance(I first, S last);
     template<class I, @\libconcept{sized_sentinel_for}@<decay_t<I>> S>
-      constexpr iter_difference_t<decay_t<I>> distance(I&& first, S last);          // freestanding
+      constexpr iter_difference_t<decay_t<I>> distance(I&& first, S last);
     template<@\libconcept{range}@ R>
-      constexpr range_difference_t<R> distance(R&& r);                              // freestanding
+      constexpr range_difference_t<R> distance(R&& r);
 
     // \ref{range.iter.op.next}, \tcode{ranges::next}
     template<@\libconcept{input_or_output_iterator}@ I>
-      constexpr I next(I x);                                                        // freestanding
+      constexpr I next(I x);
     template<@\libconcept{input_or_output_iterator}@ I>
-      constexpr I next(I x, iter_difference_t<I> n);                                // freestanding
+      constexpr I next(I x, iter_difference_t<I> n);
     template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
-      constexpr I next(I x, S bound);                                               // freestanding
+      constexpr I next(I x, S bound);
     template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
-      constexpr I next(I x, iter_difference_t<I> n, S bound);                       // freestanding
+      constexpr I next(I x, iter_difference_t<I> n, S bound);
 
     // \ref{range.iter.op.prev}, \tcode{ranges::prev}
     template<@\libconcept{bidirectional_iterator}@ I>
-      constexpr I prev(I x);                                                        // freestanding
+      constexpr I prev(I x);
     template<@\libconcept{bidirectional_iterator}@ I>
-      constexpr I prev(I x, iter_difference_t<I> n);                                // freestanding
+      constexpr I prev(I x, iter_difference_t<I> n);
     template<@\libconcept{bidirectional_iterator}@ I>
-      constexpr I prev(I x, iter_difference_t<I> n, I bound);                       // freestanding
+      constexpr I prev(I x, iter_difference_t<I> n, I bound);
   }
 
   // \ref{predef.iterators}, predefined iterators and sentinels
   // \ref{reverse.iterators}, reverse iterators
-  template<class Iterator> class reverse_iterator;                                  // freestanding
+  template<class Iterator> class reverse_iterator;
 
   template<class Iterator1, class Iterator2>
-    constexpr bool operator==(                                                      // freestanding
+    constexpr bool operator==(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
-    constexpr bool operator!=(                                                      // freestanding
+    constexpr bool operator!=(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
-    constexpr bool operator<(                                                       // freestanding
+    constexpr bool operator<(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
-    constexpr bool operator>(                                                       // freestanding
+    constexpr bool operator>(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
-    constexpr bool operator<=(                                                      // freestanding
+    constexpr bool operator<=(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
-    constexpr bool operator>=(                                                      // freestanding
+    constexpr bool operator>=(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y);
   template<class Iterator1, @\libconcept{three_way_comparable_with}@<Iterator1> Iterator2>
     constexpr compare_three_way_result_t<Iterator1, Iterator2>
-      operator<=>(const reverse_iterator<Iterator1>& x,                             // freestanding
+      operator<=>(const reverse_iterator<Iterator1>& x,
                   const reverse_iterator<Iterator2>& y);
 
   template<class Iterator1, class Iterator2>
-    constexpr auto operator-(                                                       // freestanding
+    constexpr auto operator-(
       const reverse_iterator<Iterator1>& x,
       const reverse_iterator<Iterator2>& y) -> decltype(y.base() - x.base());
   template<class Iterator>
-    constexpr reverse_iterator<Iterator> operator+(                                 // freestanding
+    constexpr reverse_iterator<Iterator> operator+(
       iter_difference_t<Iterator> n,
       const reverse_iterator<Iterator>& x);
 
   template<class Iterator>
-    constexpr reverse_iterator<Iterator> make_reverse_iterator(Iterator i);         // freestanding
+    constexpr reverse_iterator<Iterator> make_reverse_iterator(Iterator i);
 
   template<class Iterator1, class Iterator2>
     requires (!@\libconcept{sized_sentinel_for}@<Iterator1, Iterator2>)
-    constexpr bool @\libspec{disable_sized_sentinel_for}{reverse_iterator}@<reverse_iterator<Iterator1>,          // freestanding
+    constexpr bool @\libspec{disable_sized_sentinel_for}{reverse_iterator}@<reverse_iterator<Iterator1>,
                                               reverse_iterator<Iterator2>> = true;
 
   // \ref{insert.iterators}, insert iterators
-  template<class Container> class back_insert_iterator;                             // freestanding
+  template<class Container> class back_insert_iterator;
   template<class Container>
-    constexpr back_insert_iterator<Container> back_inserter(Container& x);          // freestanding
+    constexpr back_insert_iterator<Container> back_inserter(Container& x);
 
-  template<class Container> class front_insert_iterator;                            // freestanding
+  template<class Container> class front_insert_iterator;
   template<class Container>
-    constexpr front_insert_iterator<Container> front_inserter(Container& x);        // freestanding
+    constexpr front_insert_iterator<Container> front_inserter(Container& x);
 
-  template<class Container> class insert_iterator;                                  // freestanding
+  template<class Container> class insert_iterator;
   template<class Container>
     constexpr insert_iterator<Container>
-      inserter(Container& x, ranges::iterator_t<Container> i);                      // freestanding
+      inserter(Container& x, ranges::iterator_t<Container> i);
 
   // \ref{const.iterators}, constant iterators and sentinels
   // \ref{const.iterators.alias}, alias templates
   template<@\libconcept{indirectly_readable}@ I>
-    using iter_const_reference_t = @\seebelow@;                                       // freestanding
+    using iter_const_reference_t = @\seebelow@;
   template<class Iterator>
     concept @\exposconcept{constant-iterator}@ = @\seebelow@; // \expos
   template<@\libconcept{input_iterator}@ I>
-    using const_iterator = @\seebelow@;                                               // freestanding
+    using const_iterator = @\seebelow@;
   template<@\libconcept{semiregular}@ S>
-    using const_sentinel = @\seebelow@;                                               // freestanding
+    using const_sentinel = @\seebelow@;
 
   // \ref{const.iterators.iterator}, class template \tcode{basic_const_iterator}
   template<@\libconcept{input_iterator}@ Iterator>
-    class basic_const_iterator;                                                     // freestanding
+    class basic_const_iterator;
 
   template<class T, @\libconcept{common_with}@<T> U>
     requires @\libconcept{input_iterator}@<common_type_t<T, U>>
-  struct common_type<basic_const_iterator<T>, U> {                                  // freestanding
+  struct common_type<basic_const_iterator<T>, U> {
     using type = basic_const_iterator<common_type_t<T, U>>;
   };
   template<class T, @\libconcept{common_with}@<T> U>
     requires @\libconcept{input_iterator}@<common_type_t<T, U>>
-  struct common_type<U, basic_const_iterator<T>> {                                  // freestanding
+  struct common_type<U, basic_const_iterator<T>> {
     using type = basic_const_iterator<common_type_t<T, U>>;
   };
   template<class T, @\libconcept{common_with}@<T> U>
     requires @\libconcept{input_iterator}@<common_type_t<T, U>>
-  struct common_type<basic_const_iterator<T>, basic_const_iterator<U>> {            // freestanding
+  struct common_type<basic_const_iterator<T>, basic_const_iterator<U>> {
     using type = basic_const_iterator<common_type_t<T, U>>;
   };
 
   template<@\libconcept{input_iterator}@ I>
-    constexpr const_iterator<I> @\libglobal{make_const_iterator}@(I it) { return it; }            // freestanding
+    constexpr const_iterator<I> @\libglobal{make_const_iterator}@(I it) { return it; }
 
   template<@\libconcept{semiregular}@ S>
-    constexpr const_sentinel<S> @\libglobal{make_const_sentinel}@(S s) { return s; }              // freestanding
+    constexpr const_sentinel<S> @\libglobal{make_const_sentinel}@(S s) { return s; }
 
   // \ref{move.iterators}, move iterators and sentinels
-  template<class Iterator> class move_iterator;                                     // freestanding
+  template<class Iterator> class move_iterator;
 
   template<class Iterator1, class Iterator2>
-    constexpr bool operator==(                                                      // freestanding
+    constexpr bool operator==(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
-    constexpr bool operator<(                                                       // freestanding
+    constexpr bool operator<(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
-    constexpr bool operator>(                                                       // freestanding
+    constexpr bool operator>(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
-    constexpr bool operator<=(                                                      // freestanding
+    constexpr bool operator<=(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
   template<class Iterator1, class Iterator2>
-    constexpr bool operator>=(                                                      // freestanding
+    constexpr bool operator>=(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y);
   template<class Iterator1, @\libconcept{three_way_comparable_with}@<Iterator1> Iterator2>
     constexpr compare_three_way_result_t<Iterator1, Iterator2>
-      operator<=>(const move_iterator<Iterator1>& x,                                // freestanding
+      operator<=>(const move_iterator<Iterator1>& x,
                   const move_iterator<Iterator2>& y);
 
   template<class Iterator1, class Iterator2>
-    constexpr auto operator-(                                                       // freestanding
+    constexpr auto operator-(
       const move_iterator<Iterator1>& x, const move_iterator<Iterator2>& y)
         -> decltype(x.base() - y.base());
   template<class Iterator>
     constexpr move_iterator<Iterator>
-      operator+(iter_difference_t<Iterator> n, const move_iterator<Iterator>& x);   // freestanding
+      operator+(iter_difference_t<Iterator> n, const move_iterator<Iterator>& x);
 
   template<class Iterator>
-    constexpr move_iterator<Iterator> make_move_iterator(Iterator i);               // freestanding
+    constexpr move_iterator<Iterator> make_move_iterator(Iterator i);
 
   template<class Iterator1, class Iterator2>
     requires (!@\libconcept{sized_sentinel_for}@<Iterator1, Iterator2>)
-    constexpr bool @\libspec{disable_sized_sentinel_for}{move_iterator}@<move_iterator<Iterator1>,             // freestanding
+    constexpr bool @\libspec{disable_sized_sentinel_for}{move_iterator}@<move_iterator<Iterator1>,
                                               move_iterator<Iterator2>> = true;
 
-  template<@\libconcept{semiregular}@ S> class move_sentinel;                                      // freestanding
+  template<@\libconcept{semiregular}@ S> class move_sentinel;
 
   // \ref{iterators.common}, common iterators
   template<@\libconcept{input_or_output_iterator}@ I, @\libconcept{sentinel_for}@<I> S>
     requires (!@\libconcept{same_as}@<I, S> && @\libconcept{copyable}@<I>)
-      class common_iterator;                                                        // freestanding
+      class common_iterator;
 
   template<class I, class S>
-    struct incrementable_traits<common_iterator<I, S>>;                             // freestanding
+    struct incrementable_traits<common_iterator<I, S>>;
 
   template<@\libconcept{input_iterator}@ I, class S>
-    struct iterator_traits<common_iterator<I, S>>;                                  // freestanding
+    struct iterator_traits<common_iterator<I, S>>;
 
   // \ref{default.sentinel}, default sentinel
-  struct default_sentinel_t;                                                        // freestanding
-  inline constexpr default_sentinel_t @\libglobal{default_sentinel}@{};                           // freestanding
+  struct default_sentinel_t;
+  inline constexpr default_sentinel_t @\libglobal{default_sentinel}@{};
 
   // \ref{iterators.counted}, counted iterators
-  template<@\libconcept{input_or_output_iterator}@ I> class counted_iterator;                      // freestanding
+  template<@\libconcept{input_or_output_iterator}@ I> class counted_iterator;
 
   template<@\libconcept{input_iterator}@ I>
     requires @\seebelow@
-    struct iterator_traits<counted_iterator<I>>;                                    // freestanding
+    struct iterator_traits<counted_iterator<I>>;
 
   // \ref{unreachable.sentinel}, unreachable sentinel
-  struct unreachable_sentinel_t;                                                    // freestanding
-  inline constexpr unreachable_sentinel_t @\libglobal{unreachable_sentinel}@{};                   // freestanding
+  struct unreachable_sentinel_t;
+  inline constexpr unreachable_sentinel_t @\libglobal{unreachable_sentinel}@{};
 
   // \ref{stream.iterators}, stream iterators
   template<class T, class charT = char, class traits = char_traits<charT>,
            class Distance = ptrdiff_t>
-  class istream_iterator;
+  class istream_iterator;                                                           // hosted
   template<class T, class charT, class traits, class Distance>
-    bool operator==(const istream_iterator<T,charT,traits,Distance>& x,
+    bool operator==(const istream_iterator<T,charT,traits,Distance>& x,             // hosted
                     const istream_iterator<T,charT,traits,Distance>& y);
 
   template<class T, class charT = char, class traits = char_traits<charT>>
-    class ostream_iterator;
+    class ostream_iterator;                                                         // hosted
 
   template<class charT, class traits = char_traits<charT>>
-    class istreambuf_iterator;
+    class istreambuf_iterator;                                                      // hosted
   template<class charT, class traits>
-    bool operator==(const istreambuf_iterator<charT,traits>& a,
+    bool operator==(const istreambuf_iterator<charT,traits>& a,                     // hosted
                     const istreambuf_iterator<charT,traits>& b);
 
   template<class charT, class traits = char_traits<charT>>
-    class ostreambuf_iterator;
+    class ostreambuf_iterator;                                                      // hosted
 
   // \ref{iterator.range}, range access
   template<class C> constexpr auto
-    begin(C& c) noexcept(noexcept(c.begin())) -> decltype(c.begin());               // freestanding
+    begin(C& c) noexcept(noexcept(c.begin())) -> decltype(c.begin());
   template<class C> constexpr auto
-    begin(const C& c) noexcept(noexcept(c.begin())) -> decltype(c.begin());         // freestanding
+    begin(const C& c) noexcept(noexcept(c.begin())) -> decltype(c.begin());
   template<class C> constexpr auto
-    end(C& c) noexcept(noexcept(c.end())) -> decltype(c.end());                     // freestanding
+    end(C& c) noexcept(noexcept(c.end())) -> decltype(c.end());
   template<class C> constexpr auto
-    end(const C& c) noexcept(noexcept(c.end())) -> decltype(c.end());               // freestanding
-  template<class T, size_t N> constexpr T* begin(T (&array)[N]) noexcept;           // freestanding
-  template<class T, size_t N> constexpr T* end(T (&array)[N]) noexcept;             // freestanding
+    end(const C& c) noexcept(noexcept(c.end())) -> decltype(c.end());
+  template<class T, size_t N> constexpr T* begin(T (&array)[N]) noexcept;
+  template<class T, size_t N> constexpr T* end(T (&array)[N]) noexcept;
   template<class C> constexpr auto
-    cbegin(const C& c) noexcept(noexcept(std::begin(c)))
-      -> decltype(std::begin(c));                                                   // freestanding
+    cbegin(const C& c) noexcept(noexcept(std::begin(c))) -> decltype(std::begin(c));
   template<class C> constexpr auto
-    cend(const C& c) noexcept(noexcept(std::end(c))) -> decltype(std::end(c));      // freestanding
+    cend(const C& c) noexcept(noexcept(std::end(c))) -> decltype(std::end(c));
   template<class C> constexpr auto
-    rbegin(C& c) noexcept(noexcept(c.rbegin())) -> decltype(c.rbegin());            // freestanding
+    rbegin(C& c) noexcept(noexcept(c.rbegin())) -> decltype(c.rbegin());
   template<class C> constexpr auto
-    rbegin(const C& c) noexcept(noexcept(c.rbegin())) -> decltype(c.rbegin());      // freestanding
+    rbegin(const C& c) noexcept(noexcept(c.rbegin())) -> decltype(c.rbegin());
   template<class C> constexpr auto
-    rend(C& c) noexcept(noexcept(c.rend())) -> decltype(c.rend());                  // freestanding
+    rend(C& c) noexcept(noexcept(c.rend())) -> decltype(c.rend());
   template<class C> constexpr auto
-    rend(const C& c) noexcept(noexcept(c.rend())) -> decltype(c.rend());            // freestanding
+    rend(const C& c) noexcept(noexcept(c.rend())) -> decltype(c.rend());
   template<class T, size_t N> constexpr reverse_iterator<T*>
-    rbegin(T (&array)[N]) noexcept;                                                 // freestanding
+    rbegin(T (&array)[N]) noexcept;
   template<class T, size_t N> constexpr reverse_iterator<T*>
-    rend(T (&array)[N]) noexcept;                                                   // freestanding
+    rend(T (&array)[N]) noexcept;
   template<class E> constexpr reverse_iterator<const E*>
-    rbegin(initializer_list<E> il) noexcept;                                        // freestanding
+    rbegin(initializer_list<E> il) noexcept;
   template<class E> constexpr reverse_iterator<const E*>
-    rend(initializer_list<E> il) noexcept;                                          // freestanding
+    rend(initializer_list<E> il) noexcept;
   template<class C> constexpr auto
-    crbegin(const C& c) noexcept(noexcept(std::rbegin(c)))
-      -> decltype(std::rbegin(c));                                                  // freestanding
+    crbegin(const C& c) noexcept(noexcept(std::rbegin(c))) -> decltype(std::rbegin(c));
   template<class C> constexpr auto
-    crend(const C& c) noexcept(noexcept(std::rend(c))) -> decltype(std::rend(c));   // freestanding
+    crend(const C& c) noexcept(noexcept(std::rend(c))) -> decltype(std::rend(c));
 
   template<class C> constexpr auto
-    size(const C& c) noexcept(noexcept(c.size())) -> decltype(c.size());            // freestanding
+    size(const C& c) noexcept(noexcept(c.size())) -> decltype(c.size());
   template<class T, size_t N> constexpr size_t
-    size(const T (&array)[N]) noexcept;                                             // freestanding
+    size(const T (&array)[N]) noexcept;
 
   template<class C> constexpr auto
     ssize(const C& c) noexcept(noexcept(c.size()))
-      -> common_type_t<ptrdiff_t, make_signed_t<decltype(c.size())>>;               // freestanding
+      -> common_type_t<ptrdiff_t, make_signed_t<decltype(c.size())>>;
   template<class T, ptrdiff_t N> constexpr ptrdiff_t
-    ssize(const T (&array)[N]) noexcept;                                            // freestanding
+    ssize(const T (&array)[N]) noexcept;
 
   template<class C> constexpr auto
-    empty(const C& c) noexcept(noexcept(c.empty())) -> decltype(c.empty());         // freestanding
+    empty(const C& c) noexcept(noexcept(c.empty())) -> decltype(c.empty());
   template<class T, size_t N> constexpr bool
-    empty(const T (&array)[N]) noexcept;                                            // freestanding
+    empty(const T (&array)[N]) noexcept;
 
   template<class C> constexpr auto
-    data(C& c) noexcept(noexcept(c.data())) -> decltype(c.data());                  // freestanding
+    data(C& c) noexcept(noexcept(c.data())) -> decltype(c.data());
   template<class C> constexpr auto
-    data(const C& c) noexcept(noexcept(c.data())) -> decltype(c.data());            // freestanding
-  template<class T, size_t N> constexpr T* data(T (&array)[N]) noexcept;            // freestanding
+    data(const C& c) noexcept(noexcept(c.data())) -> decltype(c.data());
+  template<class T, size_t N> constexpr T* data(T (&array)[N]) noexcept;
 }
 \end{codeblock}
 


### PR DESCRIPTION
Fixes #8545. Also reduces weird line break for a few functions and type aliases.