### PR TITLE
[expr.const] "with [...]" => "within the evaluation"

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -8861,7 +8861,7 @@ During the evaluation of an expression $E$ as a core constant expression,
 all \grammarterm{id-expression}s, \grammarterm{splice-expression}s, and
 uses of \tcode{*\keyword{this}}
 that refer to an object or reference
-whose lifetime did not begin with the evaluation of $E$
+whose lifetime did not begin within the evaluation of $E$
 are treated as referring to a specific instance of that object or reference
 whose lifetime and that of all subobjects (including all union members)
 includes the entire constant evaluation.


### PR DESCRIPTION
We use "within the evaluation of E" in various places. We also mean to use it here.