### PR TITLE
[expr.const] Definition domain fixes for "usable in constant expressions"

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -9223,7 +9223,9 @@ a reference member of any of the above.
 \end{itemize}
 
 \pnum
-An object or reference is \defnx{usable in constant expressions}{usable in constant expressions!object or reference} at point $P$
+An object or reference is
+\defnx{usable in constant expressions}{usable in constant expressions!object or reference}
+at point $P$
 if it is an object or reference
 that is potentially usable in constant expressions at $P$ and
 is constexpr-representable at $P$.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -9192,7 +9192,7 @@ it has reference or non-volatile const-qualified integral or enumeration type.
 
 \pnum
 A constant-initialized potentially-constant variable $V$ is
-\defn{usable in constant expressions} at a point $P$ if
+\defnx{usable in constant expressions}{usable in constant expressions!variable} at a point $P$ if
 $V$'s initializing declaration $D$ is reachable from $P$ and
 \begin{itemize}
 \item $V$ is constexpr,
@@ -9222,7 +9222,7 @@ a reference member of any of the above.
 \end{itemize}
 
 \pnum
-An object or reference is \defn{usable in constant expressions} at point $P$
+An object or reference is \defnx{usable in constant expressions}{usable in constant expressions!object or reference} at point $P$
 if it is an object or reference
 that is potentially usable in constant expressions at $P$ and
 is constexpr-representable at $P$.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -9191,9 +9191,10 @@ it is constexpr or
 it has reference or non-volatile const-qualified integral or enumeration type.
 
 \pnum
-A constant-initialized potentially-constant variable $V$ is
+A variable $V$ is
 \defnx{usable in constant expressions}{usable in constant expressions!variable} at a point $P$ if
-$V$'s initializing declaration $D$ is reachable from $P$ and
+$V$ is constant-initialized and potentially-constant,
+$V$'s initializing declaration $D$ is reachable from $P$, and
 \begin{itemize}
 \item $V$ is constexpr,
 \item $V$ is not initialized to a TU-local value, or


### PR DESCRIPTION
- Fix index entries to identify the domains of the definitions
- Fix wording error that restricted the domain of the definition for variables