### PR TITLE
[stmt.pre] Streamline decl-specifier restrictions on conditions, etc.

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -147,11 +147,11 @@ as either an expression or a declaration,
 it is interpreted as the latter.
 
 \pnum
-Let $D$ be any \grammarterm{condition} or \grammarterm{for-range-declaration}.
-In the \grammarterm{decl-specifier-seq} of $D$,
+For any \grammarterm{condition} or \grammarterm{for-range-declaration} $D$,
+each \grammarterm{decl-specifier}
+in the \grammarterm{decl-specifier-seq} of $D$,
 including that of any \grammarterm{structured-binding-declaration} of $D$,
-each
-\grammarterm{decl-specifier} shall be either a \grammarterm{type-specifier}
+shall be either a \grammarterm{type-specifier}
 or \keyword{constexpr}.
 
 \rSec1[stmt.label]{Label}%


### PR DESCRIPTION
Avoid an abrupt shift from a mathematical introduction to the specification of additional normative requirements.

Expresses universal quantification more directly.