### PR TITLE
[time.syn] Add missing name qualification

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -840,7 +840,7 @@ namespace std {
   template<class charT> struct formatter<chrono::year_month_weekday, charT>;
   template<class charT> struct formatter<chrono::year_month_weekday_last, charT>;
   template<class Rep, class Period, class charT>
-    struct formatter<chrono::hh_mm_ss<duration<Rep, Period>>, charT>;
+    struct formatter<chrono::hh_mm_ss<chrono::duration<Rep, Period>>, charT>;
   template<class charT> struct formatter<chrono::sys_info, charT>;
   template<class charT> struct formatter<chrono::local_info, charT>;
   template<class Duration, class TimeZonePtr, class charT>


### PR DESCRIPTION
Bugs in header synopses prevent automated tools from working correctly with them.