### PR TITLE
Remove redundant "C++" qualifier from "C++ program"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3376,7 +3376,7 @@ the number of which is \impldef{bits in a byte}.
 \begin{note}
 See the macro \libmacro{CHAR_BIT} in the header \libheaderref{climits}.
 \end{note}
-The memory available to a \Cpp{} program consists of one or more sequences of
+The memory available to a program consists of one or more sequences of
 contiguous bytes.
 Every byte has a unique address.
 
@@ -3439,7 +3439,7 @@ bit-fields \tcode{b} and \tcode{c} cannot be concurrently modified, but
 
 \pnum
 \indextext{object model|(}%
-The constructs in a \Cpp{} program create, destroy, refer to, access, and
+The constructs in a program create, destroy, refer to, access, and
 manipulate objects.
 An \defn{object} is created
 by a definition\iref{basic.def},
@@ -6648,7 +6648,7 @@ one specific thread, and can be accessed by a different thread only indirectly
 through a pointer or reference\iref{basic.compound}.
 \end{footnote}
 Under a hosted
-implementation, a \Cpp{} program can have more than one thread running
+implementation, a program can have more than one thread running
 concurrently. The execution of each thread proceeds as defined by the remainder
 of this document. The execution of the entire program consists of an execution
 of all of its threads.
@@ -6966,7 +6966,7 @@ rules.
 \pnum
 \begin{note}
 It is possible that transformations that introduce a speculative read of a potentially
-shared memory location do not preserve the semantics of the \Cpp{} program as
+shared memory location do not preserve the semantics of the program as
 defined in this document, since they potentially introduce a data race. However,
 they are typically valid in the context of an optimizing compiler that targets a
 specific machine with well-defined semantics for data races. They would be

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -7555,7 +7555,7 @@ shall not be potentially-throwing\iref{except.spec}.
 Certain functions
 for which a definition is supplied by the implementation
 are \defnx{replaceable}{function!replaceable}.
-A \Cpp{} program may
+A program may
 provide a definition with the signature of a replaceable function,
 called a \defnadj{replacement}{function}.
 The replacement function

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2433,7 +2433,7 @@ or within \grammarterm{assertion-statement}s\iref{stmt.contract.assert}
 within the body of $L$,
 the program is ill-formed.
 \begin{note}
-Adding a contract assertion to an existing \Cpp{} program cannot
+Adding a contract assertion to an existing program cannot
 cause additional captures.
 \end{note}
 \begin{example}
@@ -6068,7 +6068,7 @@ and the deallocation function's name is
 An implementation is expected to provide default definitions for the global
 allocation
 functions\iref{basic.stc.dynamic,new.delete.single,new.delete.array}.
-A \Cpp{} program can provide alternative definitions of
+A program can provide alternative definitions of
 these functions\iref{replacement.functions} and/or class-specific
 versions\iref{class.free}.
 The set of allocation and deallocation functions that can be called
@@ -6539,7 +6539,7 @@ it is \tcode{\keyword{operator} \keyword{delete}} for a single-object delete exp
 \indextext{\idxcode{operator delete}}%
 An implementation provides default definitions of the global
 deallocation functions\iref{new.delete.single,new.delete.array}.
-A \Cpp{} program can provide alternative definitions of these
+A program can provide alternative definitions of these
 functions\iref{replacement.functions}, and/or class-specific
 versions\iref{class.free}.
 \end{note}

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -38,7 +38,7 @@ conditionally-supported-directives\iref{cpp.pre} and pragmas\iref{cpp.pragma},
 if any, is
 called a \defnadj{preprocessing}{translation unit}.
 \begin{note}
-A \Cpp{} program need not all be translated at the same time.
+A program need not all be translated at the same time.
 Translation units can be separately translated and then later linked
 to produce an executable program\iref{basic.link}.
 \end{note}
@@ -779,7 +779,7 @@ a \grammarterm{floating-point-literal} token.%
 \pnum
 \indextext{operator|(}%
 \indextext{punctuator|(}%
-The lexical representation of \Cpp{} programs includes a number of
+The lexical representation of programs includes a number of
 preprocessing tokens that are used in the syntax of the preprocessor or
 are converted into tokens for operators and punctuators:
 


### PR DESCRIPTION
Partially addresses #8514.

All programs in the C++ Standard are C++ programs, so there should be no distinction between the terms "program" and "C++ program".  This PR addresses redundant use of "C++" in the Core language clauses, while skipping any review of clauses 1--4 where, stylistically, the C++ epithet may remain appropriate.  A more nuanced review of those clauses may follow.

Similarly, we would largely ignore use in [lib-intro] and [support] when reviewing usage in the library clauses.