### PR TITLE
[lex.phases] Make note on the notion of file more prominent

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -42,6 +42,13 @@ A \Cpp{} program need not all be translated at the same time.
 Translation units can be separately translated and then later linked
 to produce an executable program\iref{basic.link}.
 \end{note}
+\begin{note}
+Source files, translation units, and translated translation units
+need not necessarily be stored as files, nor need there be any one-to-one
+correspondence between these entities and any external representation.
+The description is conceptual only,
+and does not specify any particular implementation.
+\end{note}
 \indextext{compilation!separate|)}
 
 \rSec1[lex.phases]{Phases of translation}%
@@ -191,13 +198,6 @@ module units and header units
 on which the current translation unit has an interface
 dependency\iref{module.unit,module.import}
 are required to be available.
-\begin{note}
-Source files, translation
-units and translated translation units need not necessarily be stored as
-files, nor need there be any one-to-one correspondence between these
-entities and any external representation. The description is conceptual
-only, and does not specify any particular implementation.
-\end{note}
 \begin{note}
 Previously translated translation units can be preserved individually or in libraries.
 The separate translation units of a program communicate\iref{basic.link} by (for example)


### PR DESCRIPTION
The notion that when the standard refers to files does not necessarily imply a file in a traditional filing system is more fundamental than its late appearance in the middle of phase 7 of translation.  Move that note right to the top of [lex] where we first talk of storing the program text in source files, where is will be understood even before the phases of translation.