### PR TITLE
[expr.new] Precise cross-reference for throwing exceptions

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -6259,7 +6259,7 @@ it indicates failure to allocate storage by throwing a
 \indextext{\idxcode{bad_alloc}}%
 \indexlibraryglobal{bad_alloc}%
 \tcode{std::bad_alloc}
-exception\iref{basic.stc.dynamic.allocation,except,bad.alloc};
+exception\iref{basic.stc.dynamic.allocation,except.throw,bad.alloc};
 it returns a non-null pointer otherwise. If the allocation function
 has a non-throwing exception specification,
 it returns null to indicate failure to allocate storage


### PR DESCRIPTION
Rather than reference the whole of clause 14, reference the specific clause for throwing an exception.

In addition to being more precise, this PR is forward looking to the tentative plan to dissolve the larger exception clause across the standard for C++29 (#7317) that would invalidate the more general reference.

Also (subjective personal opinion) cross-references to whole clauses look ugly when the vast majority of cross-references are entirely numeric ids.