### PR TITLE
[container.requirements] Complete index of container operations

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -223,6 +223,24 @@ An unsigned integer type
 that can represent any non-negative value of \tcode{X::difference_type}.
 \end{itemdescr}
 
+\indexlibraryctor{deque}%
+\indexlibraryctor{forward_list}%
+\indexlibraryctor{hive}%
+\indexlibraryctor{list}%
+\indexlibraryctor{vector}%
+\indexlibraryctor{inplace_vector}%
+\indexlibraryctor{map}%
+\indexlibraryctor{set}%
+\indexlibraryctor{multiset}%
+\indexlibraryctor{multimap}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
+\indexlibraryctor{flat_map}%
+\indexlibraryctor{flat_set}%
+\indexlibraryctor{flat_multiset}%
+\indexlibraryctor{flat_multimap}%
 \begin{itemdecl}
 X u;
 X u = X();
@@ -238,6 +256,24 @@ X u = X();
 Constant.
 \end{itemdescr}
 
+\indexlibraryctor{deque}%
+\indexlibraryctor{forward_list}%
+\indexlibraryctor{hive}%
+\indexlibraryctor{list}%
+\indexlibraryctor{vector}%
+\indexlibraryctor{inplace_vector}%
+\indexlibraryctor{map}%
+\indexlibraryctor{set}%
+\indexlibraryctor{multiset}%
+\indexlibraryctor{multimap}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
+\indexlibraryctor{flat_map}%
+\indexlibraryctor{flat_set}%
+\indexlibraryctor{flat_multiset}%
+\indexlibraryctor{flat_multimap}%
 \begin{itemdecl}
 X u(v);
 X u = v;
@@ -257,6 +293,24 @@ X u = v;
 Linear.
 \end{itemdescr}
 
+\indexlibraryctor{deque}%
+\indexlibraryctor{forward_list}%
+\indexlibraryctor{hive}%
+\indexlibraryctor{list}%
+\indexlibraryctor{vector}%
+\indexlibraryctor{inplace_vector}%
+\indexlibraryctor{map}%
+\indexlibraryctor{set}%
+\indexlibraryctor{multiset}%
+\indexlibraryctor{multimap}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
+\indexlibraryctor{flat_map}%
+\indexlibraryctor{flat_set}%
+\indexlibraryctor{flat_multiset}%
+\indexlibraryctor{flat_multimap}%
 \begin{itemdecl}
 X u(rv);
 X u = rv;
@@ -291,6 +345,7 @@ t = v
 Linear.
 \end{itemdescr}
 
+\indexcont{operator=}%
 \begin{itemdecl}
 t = rv
 \end{itemdecl}
@@ -314,6 +369,24 @@ If \tcode{t} and \tcode{rv} do not refer to the same object,
 Linear.
 \end{itemdescr}
 
+\indexlibrarydtor{deque}%
+\indexlibrarydtor{forward_list}%
+\indexlibrarydtor{hive}%
+\indexlibrarydtor{list}%
+\indexlibrarydtor{vector}%
+\indexlibrarydtor{inplace_vector}%
+\indexlibrarydtor{map}%
+\indexlibrarydtor{set}%
+\indexlibrarydtor{multiset}%
+\indexlibrarydtor{multimap}%
+\indexlibrarydtor{unordered_map}%
+\indexlibrarydtor{unordered_set}%
+\indexlibrarydtor{unordered_multiset}%
+\indexlibrarydtor{unordered_multimap}%
+\indexlibrarydtor{flat_map}%
+\indexlibrarydtor{flat_set}%
+\indexlibrarydtor{flat_multiset}%
+\indexlibrarydtor{flat_multimap}%
 \begin{itemdecl}
 a.~X()
 \end{itemdecl}
@@ -528,6 +601,7 @@ Linear for \tcode{array} and \tcode{inplace_vector}, and
 constant for all other standard containers.
 \end{itemdescr}
 
+\indexcont{swap}%
 \begin{itemdecl}
 swap(t, s)
 \end{itemdecl}
@@ -917,6 +991,7 @@ are implemented by constexpr functions.
 \indexlibrarymemberx{forward_list}{#1}%
 \indexlibrarymemberx{list}{#1}%
 \indexlibrarymemberx{vector}{#1}%
+\indexlibrarymemberx{inplace_vector}{#1}%
 \indexlibrarymemberx{map}{#1}%
 \indexlibrarymemberx{set}{#1}%
 \indexlibrarymemberx{multiset}{#1}%
@@ -1128,6 +1203,19 @@ c.get_allocator()
 Constant.
 \end{itemdescr}
 
+\indexlibraryctor{deque}%
+\indexlibraryctor{forward_list}%
+\indexlibraryctor{hive}%
+\indexlibraryctor{list}%
+\indexlibraryctor{vector}%
+\indexlibraryctor{map}%
+\indexlibraryctor{set}%
+\indexlibraryctor{multiset}%
+\indexlibraryctor{multimap}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
 \begin{itemdecl}
 X u;
 X u = X();
@@ -1147,6 +1235,19 @@ X u = X();
 Constant.
 \end{itemdescr}
 
+\indexlibraryctor{deque}%
+\indexlibraryctor{forward_list}%
+\indexlibraryctor{hive}%
+\indexlibraryctor{list}%
+\indexlibraryctor{vector}%
+\indexlibraryctor{map}%
+\indexlibraryctor{set}%
+\indexlibraryctor{multiset}%
+\indexlibraryctor{multimap}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
 \begin{itemdecl}
 X u(m);
 \end{itemdecl}
@@ -1161,6 +1262,19 @@ X u(m);
 Constant.
 \end{itemdescr}
 
+\indexlibraryctor{deque}%
+\indexlibraryctor{forward_list}%
+\indexlibraryctor{hive}%
+\indexlibraryctor{list}%
+\indexlibraryctor{vector}%
+\indexlibraryctor{map}%
+\indexlibraryctor{set}%
+\indexlibraryctor{multiset}%
+\indexlibraryctor{multimap}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
 \begin{itemdecl}
 X u(t, m);
 \end{itemdecl}
@@ -1179,6 +1293,19 @@ X u(t, m);
 Linear.
 \end{itemdescr}
 
+\indexlibraryctor{deque}%
+\indexlibraryctor{forward_list}%
+\indexlibraryctor{hive}%
+\indexlibraryctor{list}%
+\indexlibraryctor{vector}%
+\indexlibraryctor{map}%
+\indexlibraryctor{set}%
+\indexlibraryctor{multiset}%
+\indexlibraryctor{multimap}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
 \begin{itemdecl}
 X u(rv);
 \end{itemdecl}
@@ -1195,6 +1322,19 @@ the value of \tcode{rv.get_allocator()} before this construction.
 Constant.
 \end{itemdescr}
 
+\indexlibraryctor{deque}%
+\indexlibraryctor{forward_list}%
+\indexlibraryctor{hive}%
+\indexlibraryctor{list}%
+\indexlibraryctor{vector}%
+\indexlibraryctor{map}%
+\indexlibraryctor{set}%
+\indexlibraryctor{multiset}%
+\indexlibraryctor{multimap}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
 \begin{itemdecl}
 X u(rv, m);
 \end{itemdecl}
@@ -1215,6 +1355,19 @@ that \tcode{rv} had before this construction,
 Constant if \tcode{m == rv.get_allocator()}, otherwise linear.
 \end{itemdescr}
 
+\indexlibraryctor{deque}%
+\indexlibraryctor{forward_list}%
+\indexlibraryctor{hive}%
+\indexlibraryctor{list}%
+\indexlibraryctor{vector}%
+\indexlibraryctor{map}%
+\indexlibraryctor{set}%
+\indexlibraryctor{multiset}%
+\indexlibraryctor{multimap}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
 \begin{itemdecl}
 a = t
 \end{itemdecl}
@@ -1398,6 +1551,11 @@ if \tcode{X} meets the container requirements and
 the following statements and expressions are well-formed and have
 the specified semantics.
 
+\indexlibraryctor{deque}%
+\indexlibraryctor{forward_list}%
+\indexlibraryctor{list}%
+\indexlibraryctor{vector}%
+\indexlibraryctor{inplace_vector}%
 \begin{itemdecl}
 X u(n, t);
 \end{itemdecl}
@@ -1416,6 +1574,11 @@ Constructs a sequence container with \tcode{n} copies of \tcode{t}.
 \tcode{distance(u.begin(), u.end()) == n} is \tcode{true}.
 \end{itemdescr}
 
+\indexlibraryctor{deque}%
+\indexlibraryctor{forward_list}%
+\indexlibraryctor{list}%
+\indexlibraryctor{vector}%
+\indexlibraryctor{inplace_vector}%
 \begin{itemdecl}
 X u(i, j);
 \end{itemdecl}
@@ -1439,6 +1602,11 @@ Each iterator in the range \range{i}{j} is dereferenced exactly once.
 \tcode{distance(u.begin(), u.end()) == distance(i, j)} is \tcode{true}.
 \end{itemdescr}
 
+\indexlibraryctor{deque}%
+\indexlibraryctor{forward_list}%
+\indexlibraryctor{list}%
+\indexlibraryctor{vector}%
+\indexlibraryctor{inplace_vector}%
 \begin{itemdecl}
 X(from_range, rg)
 \end{itemdecl}
@@ -1472,6 +1640,11 @@ an implementation should not perform more than a single reallocation.
 \tcode{distance(begin(), end()) == ranges::distance(rg)} is \tcode{true}.
 \end{itemdescr}
 
+\indexlibraryctor{deque}%
+\indexlibraryctor{forward_list}%
+\indexlibraryctor{list}%
+\indexlibraryctor{vector}%
+\indexlibraryctor{inplace_vector}%
 \begin{itemdecl}
 X(il)
 \end{itemdecl}
@@ -1482,6 +1655,7 @@ X(il)
 Equivalent to \tcode{X(il.begin(), il.end())}.
 \end{itemdescr}
 
+\indexcont{operator=}%
 \begin{itemdecl}
 a = il
 \end{itemdecl}
@@ -1562,6 +1736,7 @@ Inserts a copy of \tcode{t} before \tcode{p}.
 An iterator that points to the copy of \tcode{t} inserted into \tcode{a}.
 \end{itemdescr}
 
+\indexcont{insert}%
 \begin{itemdecl}
 a.insert(p, rv)
 \end{itemdecl}
@@ -1586,6 +1761,7 @@ Inserts a copy of \tcode{rv} before \tcode{p}.
 An iterator that points to the copy of \tcode{rv} inserted into \tcode{a}.
 \end{itemdescr}
 
+\indexcont{insert}%
 \begin{itemdecl}
 a.insert(p, n, t)
 \end{itemdecl}
@@ -1611,6 +1787,7 @@ that points to the copy of the first element inserted into \tcode{a}, or
 \tcode{p} if \tcode{n == 0}.
 \end{itemdescr}
 
+\indexcont{insert}%
 \begin{itemdecl}
 a.insert(p, i, j)
 \end{itemdecl}
@@ -1679,6 +1856,7 @@ that points to the copy of the first element inserted into \tcode{a}, or
 \tcode{p} if \tcode{rg} is empty.
 \end{itemdescr}
 
+\indexcont{insert}%
 \begin{itemdecl}
 a.insert(p, il)
 \end{itemdecl}
@@ -1715,6 +1893,7 @@ prior to the element being erased.
 If no such element exists, \tcode{a.end()} is returned.
 \end{itemdescr}
 
+\indexcont{erase}%
 \begin{itemdecl}
 a.erase(q1, q2)
 \end{itemdecl}
@@ -1843,6 +2022,7 @@ If \tcode{R} models \tcode{ranges::\libconcept{approximately_sized_range}} and
 an implementation should not perform any reallocation.
 \end{itemdescr}
 
+\indexcont{assign}%
 \begin{itemdecl}
 a.assign(il)
 \end{itemdecl}
@@ -1853,6 +2033,7 @@ a.assign(il)
 Equivalent to \tcode{a.assign(il.begin(), il.end())}.
 \end{itemdescr}
 
+\indexcont{assign}%
 \begin{itemdecl}
 a.assign(n, t)
 \end{itemdecl}
@@ -1920,6 +2101,13 @@ some types of sequence containers but not others.
 Operations other than \tcode{prepend_range} and \tcode{append_range}
 are implemented so as to take amortized constant time.
 
+\indexlibrarymember{front}{basic_string}%
+\indexlibrarymember{front}{array}%
+\indexlibrarymember{front}{deque}%
+\indexlibrarymember{front}{forward_list}%
+\indexlibrarymember{front}{inplace_vector}%
+\indexlibrarymember{front}{list}%
+\indexlibrarymember{front}{vector}%
 \begin{itemdecl}
 a.front()
 \end{itemdecl}
@@ -1949,6 +2137,12 @@ Required for
 \tcode{vector}.
 \end{itemdescr}
 
+\indexlibrarymember{back}{basic_string}%
+\indexlibrarymember{back}{array}%
+\indexlibrarymember{back}{deque}%
+\indexlibrarymember{back}{inplace_vector}%
+\indexlibrarymember{back}{list}%
+\indexlibrarymember{back}{vector}%
 \begin{itemdecl}
 a.back()
 \end{itemdecl}
@@ -1982,6 +2176,9 @@ Required for
 \tcode{vector}.
 \end{itemdescr}
 
+\indexlibrarymember{emplace_front}{deque}%
+\indexlibrarymember{emplace_front}{forward_list}%
+\indexlibrarymember{emplace_front}{list}%
 \begin{itemdecl}
 a.emplace_front(args)
 \end{itemdecl}
@@ -2012,6 +2209,10 @@ Required for
 \tcode{list}.
 \end{itemdescr}
 
+\indexlibrarymember{emplace_back}{deque}%
+\indexlibrarymember{emplace_back}{inplace_vector}%
+\indexlibrarymember{emplace_back}{list}%
+\indexlibrarymember{emplace_back}{vector}%
 \begin{itemdecl}
 a.emplace_back(args)
 \end{itemdecl}
@@ -2045,6 +2246,9 @@ Required for
 \tcode{vector}.
 \end{itemdescr}
 
+\indexlibrarymember{push_front}{deque}%
+\indexlibrarymember{push_front}{forward_list}%
+\indexlibrarymember{push_front}{list}%
 \begin{itemdecl}
 a.push_front(t)
 \end{itemdecl}
@@ -2070,6 +2274,9 @@ Required for
 \tcode{list}.
 \end{itemdescr}
 
+\indexlibrarymember{push_front}{deque}%
+\indexlibrarymember{push_front}{forward_list}%
+\indexlibrarymember{push_front}{list}%
 \begin{itemdecl}
 a.push_front(rv)
 \end{itemdecl}
@@ -2095,6 +2302,9 @@ Required for
 \tcode{list}.
 \end{itemdescr}
 
+\indexlibrarymember{prepend_range}{deque}%
+\indexlibrarymember{prepend_range}{forward_list}%
+\indexlibrarymember{prepend_range}{list}%
 \begin{itemdecl}
 a.prepend_range(rg)
 \end{itemdecl}
@@ -2131,6 +2341,11 @@ Required for
 \tcode{list}.
 \end{itemdescr}
 
+\indexlibrarymember{push_back}{basic_string}%
+\indexlibrarymember{push_back}{deque}%
+\indexlibrarymember{push_back}{inplace_vector}%
+\indexlibrarymember{push_back}{list}%
+\indexlibrarymember{push_back}{vector}%
 \begin{itemdecl}
 a.push_back(t)
 \end{itemdecl}
@@ -2158,6 +2373,11 @@ Required for
 \tcode{vector}.
 \end{itemdescr}
 
+\indexlibrarymember{push_back}{basic_string}%
+\indexlibrarymember{push_back}{deque}%
+\indexlibrarymember{push_back}{inplace_vector}%
+\indexlibrarymember{push_back}{list}%
+\indexlibrarymember{push_back}{vector}%
 \begin{itemdecl}
 a.push_back(rv)
 \end{itemdecl}
@@ -2185,6 +2405,10 @@ Required for
 \tcode{vector}.
 \end{itemdescr}
 
+\indexlibrarymember{append_range}{deque}%
+\indexlibrarymember{append_range}{inplace_vector}%
+\indexlibrarymember{append_range}{list}%
+\indexlibrarymember{append_range}{vector}%
 \begin{itemdecl}
 a.append_range(rg)
 \end{itemdecl}
@@ -2216,6 +2440,9 @@ Required for
 \tcode{vector}.
 \end{itemdescr}
 
+\indexlibrarymember{pop_front}{deque}%
+\indexlibrarymember{pop_front}{forward_list}%
+\indexlibrarymember{pop_front}{list}%
 \begin{itemdecl}
 a.pop_front()
 \end{itemdecl}
@@ -2241,6 +2468,11 @@ Required for
 \tcode{list}.
 \end{itemdescr}
 
+\indexlibrarymember{pop_back}{basic_string}%
+\indexlibrarymember{pop_back}{deque}%
+\indexlibrarymember{pop_back}{inplace_vector}%
+\indexlibrarymember{pop_back}{list}%
+\indexlibrarymember{pop_back}{vector}%
 \begin{itemdecl}
 a.pop_back()
 \end{itemdecl}
@@ -2268,6 +2500,11 @@ Required for
 \tcode{vector}.
 \end{itemdescr}
 
+\indexlibrarymember{operator[]}{basic_string}%
+\indexlibrarymember{operator[]}{array}%
+\indexlibrarymember{operator[]}{deque}%
+\indexlibrarymember{operator[]}{inplace_vector}%
+\indexlibrarymember{operator[]}{vector}%
 \begin{itemdecl}
 a[n]
 \end{itemdecl}
@@ -2295,6 +2532,11 @@ Required for
 \tcode{vector}.
 \end{itemdescr}
 
+\indexlibrarymember{at}{basic_string}%
+\indexlibrarymember{at}{array}%
+\indexlibrarymember{at}{deque}%
+\indexlibrarymember{at}{inplace_vector}%
+\indexlibrarymember{at}{vector}%
 \begin{itemdecl}
 a.at(n)
 \end{itemdecl}
@@ -3102,6 +3344,10 @@ X(il)
 Equivalent to \tcode{X(il.begin(), il.end())}.
 \end{itemdescr}
 
+\indexlibrarymember{operator=}{set}%
+\indexlibrarymember{operator=}{map}%
+\indexlibrarymember{operator=}{multiset}%
+\indexlibrarymember{operator=}{multimap}%
 \begin{itemdecl}
 a = il
 \end{itemdecl}
@@ -4483,6 +4729,10 @@ using \tcode{hf} as the hash function and
 \bigoh{\tcode{n}}
 \end{itemdescr}
 
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
 \begin{itemdecl}
 X(n, hf)
 \end{itemdecl}
@@ -4503,6 +4753,10 @@ using \tcode{hf} as the hash function and
 \bigoh{\tcode{n}}
 \end{itemdescr}
 
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
 \begin{itemdecl}
 X(n)
 \end{itemdecl}
@@ -4524,6 +4778,10 @@ using \tcode{hasher()} as the hash function and
 \bigoh{\tcode{n}}
 \end{itemdescr}
 
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
 \begin{itemdecl}
 X a = X();
 X a;
@@ -4546,6 +4804,10 @@ using \tcode{hasher()} as the hash function and
 Constant.
 \end{itemdescr}
 
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
 \begin{itemdecl}
 X(i, j, n, hf, eq)
 \end{itemdecl}
@@ -4568,6 +4830,10 @@ inserts elements from \range{i}{j} into it.
 Average case \bigoh{N} ($N$ is \tcode{distance(i, j)}), worst case \bigoh{N^2}.
 \end{itemdescr}
 
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
 \begin{itemdecl}
 X(i, j, n, hf)
 \end{itemdecl}
@@ -4591,6 +4857,10 @@ inserts elements from \range{i}{j} into it.
 Average case \bigoh{N} ($N$ is \tcode{distance(i, j)}), worst case \bigoh{N^2}.
 \end{itemdescr}
 
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
 \begin{itemdecl}
 X(i, j, n)
 \end{itemdecl}
@@ -4615,6 +4885,10 @@ inserts elements from \range{i}{j} into it.
 Average case \bigoh{N} ($N$ is \tcode{distance(i, j)}), worst case \bigoh{N^2}.
 \end{itemdescr}
 
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
 \begin{itemdecl}
 X(i, j)
 \end{itemdecl}
@@ -4639,6 +4913,10 @@ inserts elements from \range{i}{j} into it.
 Average case \bigoh{N} ($N$ is \tcode{distance(i, j)}), worst case \bigoh{N^2}.
 \end{itemdescr}
 
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
 \begin{itemdecl}
 X(from_range, rg, n, hf, eq)
 \end{itemdecl}
@@ -4663,6 +4941,10 @@ Average case \bigoh{N} ($N$ is \tcode{ranges::distance(rg)}),
 worst case \bigoh{N^2}.
 \end{itemdescr}
 
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
 \begin{itemdecl}
 X(from_range, rg, n, hf)
 \end{itemdecl}
@@ -4688,6 +4970,10 @@ Average case \bigoh{N} ($N$ is \tcode{ranges::distance(rg)}),
 worst case \bigoh{N^2}.
 \end{itemdescr}
 
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
 \begin{itemdecl}
 X(from_range, rg, n)
 \end{itemdecl}
@@ -4714,6 +5000,10 @@ Average case \bigoh{N} ($N$ is \tcode{ranges::distance(rg)}),
 worst case \bigoh{N^2}.
 \end{itemdescr}
 
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
 \begin{itemdecl}
 X(from_range, rg)
 \end{itemdecl}
@@ -4740,6 +5030,10 @@ Average case \bigoh{N} ($N$ is \tcode{ranges::distance(rg)}),
 worst case \bigoh{N^2}.
 \end{itemdescr}
 
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
 \begin{itemdecl}
 X(il)
 \end{itemdecl}
@@ -4750,6 +5044,10 @@ X(il)
 Equivalent to \tcode{X(il.begin(), il.end())}.
 \end{itemdescr}
 
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
 \begin{itemdecl}
 X(il, n)
 \end{itemdecl}
@@ -4770,6 +5068,10 @@ X(il, n, hf)
 Equivalent to \tcode{X(il.begin(), il.end(), n, hf)}.
 \end{itemdescr}
 
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
 \begin{itemdecl}
 X(il, n, hf, eq)
 \end{itemdecl}
@@ -4780,6 +5082,10 @@ X(il, n, hf, eq)
 Equivalent to \tcode{X(il.begin(), il.end(), n, hf, eq)}.
 \end{itemdescr}
 
+\indexlibraryctor{unordered_set}%
+\indexlibraryctor{unordered_map}%
+\indexlibraryctor{unordered_multiset}%
+\indexlibraryctor{unordered_multimap}%
 \begin{itemdecl}
 X(b)
 \end{itemdecl}
@@ -4795,6 +5101,10 @@ copies the hash function, predicate, and maximum load factor.
 Average case linear in \tcode{b.size()}, worst case quadratic.
 \end{itemdescr}
 
+\indexlibrarymember{operator=}{unordered_set}%
+\indexlibrarymember{operator=}{unordered_map}%
+\indexlibrarymember{operator=}{unordered_multiset}%
+\indexlibrarymember{operator=}{unordered_multimap}%
 \begin{itemdecl}
 a = b
 \end{itemdecl}
@@ -4814,6 +5124,10 @@ copies the hash function, predicate, and maximum load factor.
 Average case linear in \tcode{b.size()}, worst case quadratic.
 \end{itemdescr}
 
+\indexlibrarymember{operator=}{unordered_set}%
+\indexlibrarymember{operator=}{unordered_map}%
+\indexlibrarymember{operator=}{unordered_multiset}%
+\indexlibrarymember{operator=}{unordered_multimap}%
 \begin{itemdecl}
 a = il
 \end{itemdecl}


### PR DESCRIPTION
Many container operations are specified entirely by the container requirements, so those container members should be indexed into this specification. There is precedent for many operations, but the current indexing is haphazard and incomplete. This change set thoroughly reviews and correctly indexes all itemdecl entries in the requirements clause, and omits indexing only for the abstract notion of container node types.