### PR TITLE
[hive.cons] Fix typo "traits<alloc>" => "traits<Allocator>"

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -8298,7 +8298,7 @@ hive(hive&& x, const type_identity_t<Allocator>& alloc);
 \pnum
 \expects
 For the second overload,
-when \tcode{allocator_traits<alloc>::is_always_equal::value} is \tcode{false},
+when \tcode{allocator_traits<Allocator>::is_always_equal::\-value} is \tcode{false},
 \tcode{T} meets the \oldconcept{MoveInsertable} requirements.
 
 \pnum


### PR DESCRIPTION
In the precondition it says `allocator_traits<alloc>` but `alloc` is name of argument, not the type of allocator.