### PR TITLE
[version.syn][initializer.list.syn] Formatting and removal of comments

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -4671,10 +4671,10 @@ namespace std {
     constexpr initializer_list() noexcept;
 
     constexpr const E* data() const noexcept;
-    constexpr size_t size() const noexcept;     // number of elements
+    constexpr size_t size() const noexcept;
     constexpr bool empty() const noexcept;
-    constexpr const E* begin() const noexcept;  // first element
-    constexpr const E* end() const noexcept;    // one past the last element
+    constexpr const E* begin() const noexcept;
+    constexpr const E* end() const noexcept;
   };
 }
 \end{codeblock}


### PR DESCRIPTION
In [version.syn], apply a previously dropped comment formatting change. See https://github.com/cplusplus/draft/pull/8544#discussion_r2537192983.

In [initializer.list.syn], remove redundant "tutorial comments". Address https://github.com/cplusplus/draft/pull/8544#discussion_r2534395711.