### PR TITLE
[lex.phases] Do not recognize UCNs in d-char sequences

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -139,6 +139,7 @@ to form the next preprocessing token
 except when matching a
 \grammarterm{c-char-sequence},
 \grammarterm{s-char-sequence},
+\grammarterm{d-char-sequence},
 \grammarterm{r-char-sequence},
 \grammarterm{h-char-sequence}, or
 \grammarterm{q-char-sequence},


### PR DESCRIPTION
We do not recognize universal-character-names when lexing character sequences for literals, and that should include d-char-sequences for raw string literals.

Note that d-char-sequences are limited to a subset of the basic character set that excludes the \ that would mark the start of a universal-character-name, but if we recognized the UCN then that \ would be consumed when recognizing the universal-character-name, and the transformed character would then be ill-formed as either not a member of the basic character set, or as a UCN denoting an element of the basic character set.  Rather than creating such an obscure error condition, it is simpler to not recognize UCNs for d-char-sequences just as we do not for any other character sequence and diagnose a more consistent error.