### PR TITLE
Make checks scripts work on macOS + update readme 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,18 +13,25 @@ Get involved:
 - `How to tell if an issue is editorial <https://github.com/cplusplus/draft/wiki/How-to-tell-if-an-issue-is-editorial>`_
 - `How to submit a new issue/defect report <https://isocpp.org/std/submit-issue>`_ for non-editorial issues
 
-More information about the C++ standard can be found at `isocpp.org <http://isocpp.org/std>`_.
+More information about the C++ standard can be found at `isocpp.org <https://isocpp.org/std>`_.
 
----------------------------
-Getting Started on Mac OS X
----------------------------
+------------------------
+Getting Started on macOS
+------------------------
 
-Install the `MacTeX distribution <http://tug.org/mactex/>`_.
+Install the `MacTeX distribution <https://tug.org/mactex/>`_.
 
-If you are on a slow network, you'll want to get the `BasicTeX package <http://tug.org/mactex/morepackages.html>`_ instead,
+If you are on a slow network, you'll want to get the `BasicTeX package <https://tug.org/mactex/morepackages.html>`_ instead,
 then run the following command to install the other packages that the draft requires::
 
    sudo tlmgr install latexmk isodate substr relsize ulem fixme rsfs extract layouts enumitem l3packages l3kernel imakeidx splitindex xstring
+
+Using homebrew on macOS
+=======================
+
+Instead of downloading packages from the internet, you can use the `HomeBrew package manager <https://brew.sh>` to install all that is needed to build the draft and run checks on it:
+
+   brew install mactex gnu-sed
 
 ---------------------------------------
 Getting Started on Debian-based Systems

--- a/tools/check-output.sh
+++ b/tools/check-output.sh
@@ -11,6 +11,14 @@ function fail() {
     ! sed 's/^\(.\+\.tex\):/file=\1::/;s/^/::error /' | grep .
 }
 
+# If we detect GNU sed (on macOS installed with brew) then we will use it.
+# Otherwise the script can fail on macOS which ships with BSD sed.
+if command -v gsed >/dev/null 2>&1; then
+	GSED=$(command -v gsed)
+	sed() {
+		${GSED} "$@"
+	}
+fi
 
 # Discover "Overfull \[hv]box" and "Reference ... undefined" messages from LaTeX.
 sed -n '/\.tex/{s/^.*\/\([-a-z0-9]\+\.tex\).*$/\1/;h};

--- a/tools/check-source.sh
+++ b/tools/check-source.sh
@@ -21,6 +21,14 @@ function fail() {
     grep .
 }
 
+# If we detect GNU sed (on macOS installed with brew) then we will use it.
+# Otherwise the script can fail on macOS which ships with BSD sed.
+if command -v gsed >/dev/null 2>&1; then
+	GSED=$(command -v gsed)
+	sed() {
+		${GSED} "$@"
+	}
+fi
 
 # We require GNU tools.
 sed --version | grep -Fqe "GNU sed" || { echo "sed is not GNU sed"; exit 1; }


### PR DESCRIPTION
Scripts needs GNU sed, which is not available on macOS by default, but can be easily install with homebrew. If script detects presence of GNU sed, it will create a function to pass attributes from sed command to GNU sed.

I also updated `readme.rst` accordingly so it mentions homebrew so we don't need to point our users to download packages from internet, but they can just use the package manager. 

Also I updated `readme.rst` and made all links https.