### PR TITLE
[time.syn] Use `\placeholder` instead of `\term`

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -160,19 +160,19 @@ namespace std::chrono {
                   minutes* offset = nullptr);
 
   // convenience typedefs
-  using nanoseconds  = duration<@\term{signed integer type of at least 64 bits}@, nano>;
-  using microseconds = duration<@\term{signed integer type of at least 55 bits}@, micro>;
-  using milliseconds = duration<@\term{signed integer type of at least 45 bits}@, milli>;
-  using seconds      = duration<@\term{signed integer type of at least 35 bits}@>;
-  using minutes      = duration<@\term{signed integer type of at least 29 bits}@, ratio<  60>>;
-  using hours        = duration<@\term{signed integer type of at least 23 bits}@, ratio<3600>>;
-  using days         = duration<@\term{signed integer type of at least 25 bits}@,
+  using nanoseconds  = duration<@\placeholder{signed integer type of at least 64 bits}@, nano>;
+  using microseconds = duration<@\placeholder{signed integer type of at least 55 bits}@, micro>;
+  using milliseconds = duration<@\placeholder{signed integer type of at least 45 bits}@, milli>;
+  using seconds      = duration<@\placeholder{signed integer type of at least 35 bits}@>;
+  using minutes      = duration<@\placeholder{signed integer type of at least 29 bits}@, ratio<  60>>;
+  using hours        = duration<@\placeholder{signed integer type of at least 23 bits}@, ratio<3600>>;
+  using days         = duration<@\placeholder{signed integer type of at least 25 bits}@,
                                 ratio_multiply<ratio<24>, hours::period>>;
-  using weeks        = duration<@\term{signed integer type of at least 22 bits}@,
+  using weeks        = duration<@\placeholder{signed integer type of at least 22 bits}@,
                                 ratio_multiply<ratio<7>, days::period>>;
-  using years        = duration<@\term{signed integer type of at least 17 bits}@,
+  using years        = duration<@\placeholder{signed integer type of at least 17 bits}@,
                                 ratio_multiply<ratio<146097, 400>, days::period>>;
-  using months       = duration<@\term{signed integer type of at least 20 bits}@,
+  using months       = duration<@\placeholder{signed integer type of at least 20 bits}@,
                                 ratio_divide<years::period, ratio<12>>>;
 
   // \ref{time.point.nonmember}, \tcode{time_point} arithmetic


### PR DESCRIPTION
"Signed integer type of at least N bits" are not terms defined in [time.syn], so perhaps we should use `\placeholder` instead.