### PR TITLE
[lex.ext] Remove \grammarterm for consistency

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -2254,7 +2254,7 @@ operator ""@\placeholder{X}@(@\placeholder{f}@L)
 Otherwise, \placeholder{S} shall contain a raw literal operator
 or a numeric literal operator template\iref{over.literal} but not both.
 If \placeholder{S} contains a raw literal operator,
-the \grammarterm{literal} \placeholder{L} is treated as a call of the form
+the literal \placeholder{L} is treated as a call of the form
 \begin{codeblock}
 operator ""@\placeholder{X}@("@\placeholder{f}@")
 \end{codeblock}


### PR DESCRIPTION
In this chapter there exist 6 "literal L" without \grammarterm and only this one with \grammarterm.