### PR TITLE
[expr.prim.lambda.capture] Insert linebreak in comment

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2800,7 +2800,8 @@ auto y = [&r = x, x = x+1]()->int {
             return x+2;
          }();                               // Updates \tcode{::x} to 6, and initializes \tcode{y} to 7.
 
-auto z = [a = 42](int a) { return 1; };     // error: parameter and conceptual local variable have the same name
+auto z = [a = 42](int a) { return 1; };     // error: parameter and conceptual local variable
+                                            // have the same name
 auto counter = [i=0]() mutable -> decltype(i) {     // OK, returns \tcode{int}
   return i++;
 };


### PR DESCRIPTION
Linebreak analog Example 2 with "// have the same name" moved into new line