### PR TITLE
[ub] and [ifndr] remove extra line breaks after ubxref and ifndrxref

### DIFF
--- a/source/ifndr.tex
+++ b/source/ifndr.tex
@@ -14,7 +14,7 @@ diagnostic required cases and will not exhaustively cover all possible ways of i
 \rSec2[ifndr.lex.name]{Identifiers}
 
 \pnum
-\ifndrxref{lex.name.reserved} \\
+\ifndrxref{lex.name.reserved}
 Some identifiers are reserved for use by \Cpp{} implementations and shall not be used otherwise; no
 diagnostic is required.
 
@@ -37,7 +37,7 @@ int main() {
 \rSec2[ifndr.basic.def.odr]{One-definition rule}
 
 \pnum
-\ifndrxref{basic.def.odr.exact.one.def} \\
+\ifndrxref{basic.def.odr.exact.one.def}
 Every program shall contain exactly one definition of every non-inline function or variable that is odr-used in
 that program outside of a discarded statement\iref{stmt.if}; no diagnostic required.
 
@@ -57,7 +57,7 @@ auto x = g();   // ill-formed, no diagnostic required, function \tcode{g} is use
 
 
 \pnum
-\ifndrxref{basic.def.odr.unnamed.enum.same.type} \\
+\ifndrxref{basic.def.odr.unnamed.enum.same.type}
 If, at any point in the program, there is more than one reachable unnamed enumeration definition in the same scope that have
 the same first enumerator name and do not have typedef names for linkage purposes\iref{dcl.enum}, those unnamed enumeration
 types shall be the same; no diagnostic required.
@@ -84,7 +84,7 @@ auto n = decltype(a)::b;        // ill-formed no diagnostic required, more than 
 \rSec2[ifndr.class.member.lookup]{Member name lookup}
 
 \pnum
-\ifndrxref{class.member.lookup.name.refers.diff.decl} \\
+\ifndrxref{class.member.lookup.name.refers.diff.decl}
 A name N used in a class S shall refer to the same declaration in its context and when re-evaluated in the completed scope of S.
 
 \pnum
@@ -131,7 +131,7 @@ int main() {
 \rSec2[ifndr.expr.prim.req]{Requires expressions}
 
 \pnum
-\ifndrxref{expr.prim.req.always.sub.fail} \\
+\ifndrxref{expr.prim.req.always.sub.fail}
 If the substitution of template arguments into a \grammarterm{requirement}
 would always result in a substitution failure, the program is ill-formed; no diagnostic required.
 
@@ -151,7 +151,7 @@ template <typename T> concept C = requires {
 \rSec2[ifndr.stmt.ambig]{Ambiguity resolution}
 
 \pnum
-\ifndrxref{stmt.ambig.bound.diff.parse} \\
+\ifndrxref{stmt.ambig.bound.diff.parse}
 If, during
 parsing, a name in a template parameter is bound differently than it would be bound during a trial parse,
 the program is ill-formed. No diagnostic is required.
@@ -181,7 +181,7 @@ int main() {
 \rSec2[ifndr.dcl.align]{Alignment specifier}
 
 \pnum
-\ifndrxref{dcl.align.diff.translation.units} \\
+\ifndrxref{dcl.align.diff.translation.units}
 No diagnostic is required if declarations of an entity have different \grammarterm{alignment-specifier}s in different
 translation units.
 
@@ -199,9 +199,7 @@ extern S* p;
 \rSec2[ifndr.dcl.attr.noreturn]{Noreturn attribute}
 
 \pnum
-\ifndrxref{dcl.attr.noreturn.trans.unit.mismatch} \\
-
-\pnum
+\ifndrxref{dcl.attr.noreturn.trans.unit.mismatch}
 \begin{example}
 \begin{codeblocktu}{Translation unit \#1}
 [[noreturn]] void f() {}
@@ -216,7 +214,7 @@ void f(int i);          // ill-formed no diagnostic required, declared without \
 \rSec2[ifndr.module.unit]{Module units and purviews}
 
 \pnum
-\ifndrxref{module.unit.reserved.identifiers} \\
+\ifndrxref{module.unit.reserved.identifiers}
 All \grammarterm{module-name}s either beginning with an identifier consisting of
 std followed by zero or more digits or containing a reserved identifier\iref{lex.token} are reserved and shall not be
 specified in a \grammarterm{module-declaration}; no diagnostic is required.
@@ -234,7 +232,7 @@ export module te__st;   // ill-formed no diagnostic required, \tcode{te__st} is 
 
 
 \pnum
-\ifndrxref{module.unit.named.module.no.partition} \\
+\ifndrxref{module.unit.named.module.no.partition}
 A named module shall contain exactly one module interface
 unit with no module-partition, known as the primary module interface unit of the module; no diagnostic is
 required.
@@ -253,7 +251,7 @@ export import :Internals;       // ill-formed no diagnostic required, module par
 \rSec2[ifndr.class.base.init]{Initializing bases and members}
 
 \pnum
-\ifndrxref{class.base.init.delegate.itself} \\
+\ifndrxref{class.base.init.delegate.itself}
 If a constructor delegates to itself directly or indirectly,
 the program is ill-formed, no diagnostic required
 
@@ -273,7 +271,7 @@ struct C {
 \rSec2[ifndr.class.virtual]{Virtual functions}
 
 \pnum
-\ifndrxref{class.virtual.pure.or.defined} \\
+\ifndrxref{class.virtual.pure.or.defined}
 A virtual function must be declared pure or defined, no diagnostic required. A virtual function declared pure can be defined
 out of line
 
@@ -296,7 +294,7 @@ int main() {
 \rSec2[ifndr.over.literal]{User-defined literals}
 
 \pnum
-\ifndrxref{over.literal.reserved} \\
+\ifndrxref{over.literal.reserved}
 Some literal suffix identifiers are
 reserved for future standardization. A declaration whose literal-operator-id uses such a literal
 suffix identifier is ill-formed, no diagnostic required.
@@ -314,7 +312,7 @@ double operator"" _Bq(long double);     // ill-formed, no diagnostic required, /
 \rSec2[ifndr.temp.pre]{Preamble}
 
 \pnum
-\ifndrxref{temp.pre.reach.def} \\
+\ifndrxref{temp.pre.reach.def}
 A definition of a function template, member function of a class template, variable template, or static data
 member of a class template shall be reachable from the end of every definition domain\iref{basic.def.odr} in which it is
 implicitly instantiated\iref{temp.inst} unless the corresponding specialization is explicitly instantiated\iref{temp.explicit} in
@@ -340,7 +338,7 @@ int main() {
 \rSec2[ifndr.temp.arg.template]{Template template arguments}
 
 \pnum
-\ifndrxref{temp.arg.template.sat.constraints} \\
+\ifndrxref{temp.arg.template.sat.constraints}
 Any partial specializations\iref{temp.spec.partial} associated with the primary template are considered when a specialization
 based on the template template-parameter is instantiated. If a specialization is not reachable from the point of
 instantiation, and it would have been selected had it been reachable, the program is ill-formed, no diagnostic
@@ -372,7 +370,7 @@ template<class T> struct A<T*> {
 \rSec2[ifndr.constr.atomic]{Atomic constraints}
 
 \pnum
-\ifndrxref{temp.constr.atomic.equiv.but.not.equiv} \\
+\ifndrxref{temp.constr.atomic.equiv.but.not.equiv}
 If the validity or meaning of the program depends on whether two atomic
 constraints are equivalent,
 and they are functionally equivalent but not equivalent, the program is ill-formed, no diagnostic required.
@@ -392,7 +390,7 @@ f2<0>();        // ill-formed, no diagnostic required,
 \end{example}
 
 \pnum
-\ifndrxref{temp.constr.atomic.sat.result.diff} \\
+\ifndrxref{temp.constr.atomic.sat.result.diff}
 If, at different points in the program, the satisfaction result is different for identical atomic constraints and template arguments, the program is ill-formed, no diagnostic required.
 
 \pnum
@@ -413,7 +411,7 @@ static_assert(Complete<A>);     // ill-formed no diagnostic required, satisfacti
 \rSec2[ifndr.temp.constr.normal]{Constraint normalization}
 
 \pnum
-\ifndrxref{temp.constr.normal.invalid} \\
+\ifndrxref{temp.constr.normal.invalid}
 If during constraint normalization any such substitution results in an invalid type or expression,
 the program is ill-formed; no diagnostic is required
 
@@ -431,7 +429,7 @@ template<typename V> concept C = B<V&>; // Ill-formed no diagnostic required, it
 \rSec2[ifndr.temp.spec.partial]{Partial specialization}
 
 \pnum
-\ifndrxref{temp.spec.partial.general.partial.reachable} \\
+\ifndrxref{temp.spec.partial.general.partial.reachable}
 A partial specialization shall be reachable from any use of a template specialization that would make use of the
 partial specialization as the result of an implicit or explicit instantiation; no diagnostic is required.
 
@@ -457,7 +455,7 @@ public:
 \rSec2[ifndr.temp.names]{Names of template specializations}
 
 \pnum
-\ifndrxref{temp.names.sat.constraints} \\
+\ifndrxref{temp.names.sat.constraints}
 When the template-name of a simple-template-id names a constrained non-function template or a constrained
 template template-parameter, and all template-arguments in the simple-template-id are non-dependent\iref{temp.dep.temp},
 the associated constraints\iref{temp.constr.decl} of the constrained template shall be satisfied\iref{temp.constr.constr}.
@@ -481,7 +479,7 @@ struct S2 { Ptr<int> x; };      // ill-formed, no diagnostic required
 \rSec3[ifndr.temp.over.link]{Function template overloading}
 
 \pnum
-\ifndrxref{temp.over.link.equiv.not.equiv} \\
+\ifndrxref{temp.over.link.equiv.not.equiv}
 If the validity or meaning of the program depends on whether two constructs are equivalent, and they are
 functionally equivalent but not equivalent, the program is ill-formed, no diagnostic required.
 
@@ -502,7 +500,7 @@ template <int I> void f(A<I>, A<I+1+2+3+4>);
 \rSec3[ifndr.temp.res.general]{General}
 
 \pnum
-\ifndrxref{temp.res.general.default.but.not.found} \\
+\ifndrxref{temp.res.general.default.but.not.found}
 If the validity or meaning of the program would be changed by considering a default argument or default
 template argument introduced in a declaration that is reachable from the point of instantiation of a
 specialization\iref{temp.point} but is not found by lookup for the specialization, the program is ill-formed, no
@@ -519,7 +517,7 @@ diagnostic required.
 \rSec3[ifndr.temp.point]{Point of instantiation}
 
 \pnum
-\ifndrxref{temp.point.diff.pt.diff.meaning} \\
+\ifndrxref{temp.point.diff.pt.diff.meaning}
 A specialization for a class template has at most one point of instantiation within a translation unit. A
 specialization for any template may have points of instantiation in multiple translation units. If two different
 points of instantiation give a template specialization different meanings according to the one-definition
@@ -553,7 +551,7 @@ static_assert(is_complete<X>::value);
 \rSec2[ifndr.temp.explicit]{Explicit instantiation}
 
 \pnum
-\ifndrxref{temp.explicit.decl.implicit.inst} \\
+\ifndrxref{temp.explicit.decl.implicit.inst}
 An entity that is the subject of
 an explicit instantiation declaration and that is also used in a way that would otherwise cause an implicit
 instantiation\iref{temp.inst} in the translation unit shall be the subject of an explicit instantiation definition
@@ -578,7 +576,7 @@ int main() {
 \rSec3[ifndr.temp.deduct.general]{General}
 
 \pnum
-\ifndrxref{temp.deduct.general.diff.order} \\
+\ifndrxref{temp.deduct.general.diff.order}
 If substitution
 into different declarations of the same function template would cause template instantiations to occur in a
 different order or not at all, the program is ill-formed; no diagnostic required.

--- a/source/ub.tex
+++ b/source/ub.tex
@@ -93,7 +93,7 @@ struct Y {
 \rSec2[ub.basic.align]{Object alignment}
 
 \pnum
-\ubxref{basic.align.object.alignment} \\
+\ubxref{basic.align.object.alignment}
 All instances of a type must be created in storage that meets the alignment
 requirement of that type.
 
@@ -280,7 +280,7 @@ void f() {
 \end{example}
 
 \pnum
-\ubxref{original.type.implicit.destructor} \\
+\ubxref{original.type.implicit.destructor}
 The behavior of an implicit destructor call when the type that is not
 the original type occupies the storage.
 
@@ -302,7 +302,7 @@ void h() {
 
 
 \pnum
-\ubxref{creating.within.const.complete.obj} \\
+\ubxref{creating.within.const.complete.obj}
 Creating a new object within the storage that a const complete object with static, thread, or automatic
 storage duration occupies, or within the storage that such a const object used to occupy before its lifetime
 ended, results in undefined behavior
@@ -327,7 +327,7 @@ void h() {
 \rSec2[ub.basic.indet]{Indeterminate and erroneous values}
 
 \pnum
-\ubxref{basic.indet.value} \\
+\ubxref{basic.indet.value}
 When the result of an evaluation is
 an indeterminate value
 (but not just an erroneous value)
@@ -346,7 +346,7 @@ void g() {
 \rSec2[ub.basic.stc.dynamic]{Dynamic storage Duration}
 
 \pnum
-\ubxref{basic.stc.alloc.dealloc.constraint} \\
+\ubxref{basic.stc.alloc.dealloc.constraint}
 If the behavior of an allocation or deallocation function does not satisfy the semantic constraints
 specified
 in~\ref{basic.stc.dynamic.allocation} and~\ref{basic.stc.dynamic.deallocation}.
@@ -371,7 +371,7 @@ void operator delete(void* ptr) noexcept {
 \end{example}
 
 \pnum
-\ubxref{basic.stc.alloc.dealloc.throw} \\
+\ubxref{basic.stc.alloc.dealloc.throw}
 If a call to a deallocation function
 terminates by throwing an exception
 the behavior is undefined.
@@ -394,7 +394,7 @@ void f()
 \rSec2[ub.basic.stc.alloc.zero.dereference]{Zero-sized allocation dereference}
 
 \pnum
-\ubxref{basic.stc.alloc.zero.dereference} \\
+\ubxref{basic.stc.alloc.zero.dereference}
 The pointer returned when invoking an allocation function with a size of zero
 cannot be dereferenced.
 
@@ -412,7 +412,7 @@ void test()
 \rSec2[ub.basic.compound]{Compound types}
 
 \pnum
-\ubxref{basic.compound.invalid.pointer} \\
+\ubxref{basic.compound.invalid.pointer}
 Indirection or
 the invocation of a deallocation function
 with a pointer value referencing storage
@@ -438,7 +438,7 @@ void f()
 \rSec2[ub.intro.execution]{Sequential execution}
 
 \pnum
-\ubxref{intro.execution.unsequenced.modification} \\
+\ubxref{intro.execution.unsequenced.modification}
 If a side effect on a
 memory location\iref{intro.memory} is unsequenced relative to either another side effect on the same memory location or
 a value computation using the value of any object in the same memory location, and they are not potentially
@@ -460,7 +460,7 @@ void g(int i) {
 \rSec2[ub.intro.races]{Data races}
 
 \pnum
-\ubxref{intro.races.data} \\
+\ubxref{intro.races.data}
 The execution of a program contains a data race if it contains two potentially concurrent conflicting actions,
 at least one of which is not atomic, and neither happens before the other, except for the special case for
 signal handlers described in~\ref{intro.races}. Any such data race results in undefined behavior.
@@ -478,8 +478,7 @@ std::thread t1{f}, t2{f}, t3{f};
 \rSec2[ub.intro.progress]{Forward progress}
 
 \pnum
-\ubxref{intro.progress.stops} \\
-
+\ubxref{intro.progress.stops}
 The behavior is undefined if a thread of execution that has not terminated stops
 making execution steps.
 
@@ -502,7 +501,7 @@ int main() {
 \rSec2[ub.basic.start.main]{main function}
 
 \pnum
-\ubxref{basic.start.main.exit.during.destruction} \\
+\ubxref{basic.start.main.exit.during.destruction}
 If \tcode{std::exit} is called to
 end a program during the destruction of an object with static or thread storage duration, the program has
 undefined behavior.
@@ -527,7 +526,7 @@ int main() {}
 \rSec2[ub.basic.start.term]{Termination}
 
 \pnum
-\ubxref{basic.start.term.use.after.destruction} \\
+\ubxref{basic.start.term.use.after.destruction}
 If a function contains a block-scope object of static or thread storage duration that has been destroyed and the
 function is called during the destruction of an object with static or thread storage duration, the program has
 undefined behavior if the flow of control passes through the definition of the previously destroyed block-scope
@@ -561,7 +560,7 @@ int main() {}
 
 
 \pnum
-\ubxref{basic.start.term.signal.handler} \\
+\ubxref{basic.start.term.signal.handler}
 If there is a use of a standard library object or function not permitted within signal handlers\iref{support.runtime} that
 does not happen before\iref{intro.multithread} completion of destruction of objects with static storage duration and execution
 of std::atexit registered functions\iref{support.start.term}, the program has undefined behavior.
@@ -577,7 +576,7 @@ of std::atexit registered functions\iref{support.start.term}, the program has un
 \rSec2[ub.expr.eval]{Result of Expression not Mathematically Defined/out of Range}
 
 \pnum
-\ubxref{expr.expr.eval} \\
+\ubxref{expr.expr.eval}
 If during the evaluation of an expression, the result is not mathematically defined or not in the range of
 representable values for its type, the behavior is undefined.
 
@@ -596,7 +595,7 @@ int main() {
 \rSec2[ub.basic.lval]{Value category}
 
 \pnum
-\ubxref{expr.basic.lvalue.strict.aliasing.violation} \\
+\ubxref{expr.basic.lvalue.strict.aliasing.violation}
 If a program attempts to access\iref{defns.access} the stored value of an object
 whose dynamic type is $T$ through a glvalue whose type is not
 similar\iref{conv.rval} to $T$ (or its corresponding signed or unsigned types)
@@ -621,7 +620,7 @@ int main() {
 \end{example}
 
 \pnum
-\ubxref{expr.basic.lvalue.union.initialization} \\
+\ubxref{expr.basic.lvalue.union.initialization}
 If a program invokes a defaulted copy/move constructor or copy/move assignment
 operator of a union with an argument that is not an object of a similar type
 within its lifetime, the behavior is undefined.
@@ -641,7 +640,7 @@ void f()
 \rSec2[ub.expr.type]{Type}
 
 \pnum
-\ubxref{expr.type.reference.lifetime} \\
+\ubxref{expr.type.reference.lifetime}
 Evaluating a reference when an equivalent use of a pointer denoting the same object
 would be invalid has undefined behavior.
 
@@ -661,7 +660,7 @@ void g()
 \rSec2[ub.conv.lval]{Lvalue-to-rvalue conversion}
 
 \pnum
-\ubxref{conv.lval.valid.representation} \\
+\ubxref{conv.lval.valid.representation}
 Performing an
 lvalue-to-rvalue conversion
 on an object whose
@@ -685,7 +684,7 @@ bool f() {
 \rSec2[ub.conv.double]{Floating-point conversions}
 
 \pnum
-\ubxref{conv.double.out.of.range} \\
+\ubxref{conv.double.out.of.range}
 Converting a floating point value to a type that cannot represent the value is undefined behavior.
 
 \pnum
@@ -708,7 +707,7 @@ int main() {
 \rSec2[ub.conv.fpint]{Floating-integral conversions}
 
 \pnum
-\ubxref{conv.fpint.int.not.represented} \\
+\ubxref{conv.fpint.int.not.represented}
 When converting a floating-point value to an integer type and vice versa if
 the value is not representable in the destination type it is undefined behavior.
 
@@ -727,7 +726,7 @@ int main() {
 \end{example}
 
 \pnum
-\ubxref{conv.fpint.float.not.represented} \\
+\ubxref{conv.fpint.float.not.represented}
 When converting a value of integer or unscoped enumeration type to a
 floating-point type, if the value is not representable in the destination type
 it is undefined behavior.
@@ -747,7 +746,7 @@ int main() {
 \rSec2[ub.conv.ptr]{Pointer conversions}
 
 \pnum
-\ubxref{conv.ptr.virtual.base} \\
+\ubxref{conv.ptr.virtual.base}
 Converting
 a pointer to a derived class \tcode{D}
 to
@@ -773,7 +772,7 @@ void f()
 \rSec2[ub.conv.mem]{Pointer-to-member conversions}
 
 \pnum
-\ubxref{conv.member.missing.member} \\
+\ubxref{conv.member.missing.member}
 The conversion of
 a pointer to a member of a base class
 to a pointer to member of a derived class
@@ -800,7 +799,7 @@ void f()
 \rSec2[ub.expr.call]{Function call}
 
 \pnum
-\ubxref{expr.call.different.type} \\
+\ubxref{expr.call.different.type}
 Calling a function through an expression whose function type is different from the function type of the called
 function's definition results in undefined behavior.
 
@@ -824,7 +823,7 @@ int main() {
 \rSec2[ub.expr.ref]{Class member access}
 
 \pnum
-\ubxref{expr.ref.member.not.similar} \\
+\ubxref{expr.ref.member.not.similar}
 If \tcode{E2} is a non-static member and the result of \tcode{E1} is an object whose type
 is not similar\iref{conv.qual} to the type of \tcode{E1}, the behavior is undefined.
 
@@ -845,7 +844,7 @@ void f() {
 
 
 \pnum
-\ubxref{expr.dynamic.cast.pointer.lifetime} \\
+\ubxref{expr.dynamic.cast.pointer.lifetime}
 Evaluating a \keyword{dynamic_cast} on a non-null pointer that points to
 an object (of polymorphic type) of the wrong type or to an object
 not within its lifetime has undefined behavior.
@@ -863,7 +862,7 @@ void f() {
 
 
 \pnum
-\ubxref{expr.dynamic.cast.glvalue.lifetime} \\
+\ubxref{expr.dynamic.cast.glvalue.lifetime}
 Evaluating a \keyword{dynamic_cast} on a reference that
 denotes an object (of polymorphic type) of the wrong type or an object
 not within its lifetime has undefined behavior.
@@ -882,7 +881,7 @@ void f() {
 \rSec2[ub.expr.static.cast]{Static cast}
 
 \pnum
-\ubxref{expr.static.cast.base.class} \\
+\ubxref{expr.static.cast.base.class}
 We can cast a base class B to a reference to derived class D (with certain restrictions wrt to cv qualifiers)
 as long B is a base class subobject of type D, otherwise the behavior is undefined.
 
@@ -902,7 +901,7 @@ void f() {
 \end{example}
 
 \pnum
-\ubxref{expr.static.cast.enum.outside.range} \\
+\ubxref{expr.static.cast.enum.outside.range}
 If the enumeration type does not have a fixed underlying
 type, the value is unchanged if the original value is within the range of the enumeration values\iref{dcl.enum}, and
 otherwise, the behavior is undefined.
@@ -919,7 +918,7 @@ void f() {
 \end{example}
 
 \pnum
-\ubxref{expr.static.cast.fp.outside.range} \\
+\ubxref{expr.static.cast.fp.outside.range}
 An explicit conversion of a
 floating-point value that is outside the range of the
 target type has undefined behavior.
@@ -941,7 +940,7 @@ void f() {
 
 
 \pnum
-\ubxref{expr.static.cast.downcast.wrong.derived.type} \\
+\ubxref{expr.static.cast.downcast.wrong.derived.type}
 Down-casting to the wrong derived type is undefined behavior.
 
 \pnum
@@ -959,7 +958,7 @@ void f() {
 \end{example}
 
 \pnum
-\ubxref{expr.static.cast.does.not.contain.orignal.member} \\
+\ubxref{expr.static.cast.does.not.contain.orignal.member}
 We can cast a pointer to mamber of dervied class D to a pointer to memeber of base class D (with certain restrictions wrt to cv qualifiers)
 as long B contains the original member, is a base or derived class of the class containing the original member, otherwise the behavior is undefined.
 
@@ -987,7 +986,7 @@ int main() {
 \rSec2[ub.expr.unary.op]{Unary operators}
 
 \pnum
-\ubxref{expr.unary.dereference} \\
+\ubxref{expr.unary.dereference}
 Dereferencing a pointer that does not point to an object or function
 has undefined behavior.
 
@@ -1006,7 +1005,7 @@ int f()
 \rSec2[ub.expr.new]{New}
 
 \pnum
-\ubxref{expr.new.non.allocating.null} \\
+\ubxref{expr.new.non.allocating.null}
 If the allocation
 function is a non-allocating form\iref{new.delete.placement} that returns null, the behavior is undefined.
 
@@ -1038,7 +1037,7 @@ int main() {
 \rSec2[ub.expr.delete]{Delete}
 
 \pnum
-\ubxref{expr.delete.mismatch} \\
+\ubxref{expr.delete.mismatch}
 Using array delete on the result of a single object new expression is undefined behavior.
 
 \pnum
@@ -1050,7 +1049,7 @@ delete[] x;         // undefined behavior, allocated using single object new exp
 \end{example}
 
 \pnum
-\ubxref{expr.delete.array.mismatch} \\
+\ubxref{expr.delete.array.mismatch}
 Using single object delete on the result of an array new expression is undefined behavior.
 
 \pnum
@@ -1063,7 +1062,7 @@ delete x;           // undefined behavior, allocated using array new expression
 
 
 \pnum
-\ubxref{expr.delete.dynamic.type.differ} \\
+\ubxref{expr.delete.dynamic.type.differ}
 If the static type of the object to be deleted is different from its dynamic
 type and the selected deallocation function (see below) is not a destroying operator delete, the static type
 shall be a base class of the dynamic type of the object to be deleted and the static type shall have a virtual
@@ -1089,7 +1088,7 @@ void f() {
 
 
 \pnum
-\ubxref{expr.delete.dynamic.array.dynamic.type.differ} \\
+\ubxref{expr.delete.dynamic.array.dynamic.type.differ}
 In an array delete expression, if the dynamic type of the object to be deleted differs from its static type, the behavior is undefined.
 
 \pnum
@@ -1117,7 +1116,7 @@ void f(int i) {
 \rSec2[ub.expr.mptr.oper]{Pointer-to-member operators}
 
 \pnum
-\ubxref{expr.mptr.oper.not.contain.member} \\
+\ubxref{expr.mptr.oper.not.contain.member}
 Abbreviating \grammarterm{pm-expression}.*\grammarterm{cast-expression} as \tcode{E1.*E2}, \tcode{E1} is called the object expression. If the dynamic type
 of \tcode{E1} does not contain the member to which \tcode{E2} refers, the behavior is undefined.
 
@@ -1140,7 +1139,7 @@ void f() {
 
 
 \pnum
-\ubxref{expr.mptr.oper.member.func.null} \\
+\ubxref{expr.mptr.oper.member.func.null}
 If the second operand is the null
 member pointer value\iref{conv.mem}, the behavior is undefined.
 
@@ -1163,7 +1162,7 @@ void f() {
 \rSec2[ub.expr.mul]{Multiplicative operators}
 
 \pnum
-\ubxref{expr.mul.div.by.zero} \\
+\ubxref{expr.mul.div.by.zero}
 Division by zero is undefined behavior.
 
 \pnum
@@ -1179,7 +1178,7 @@ int main() {
 \end{example}
 
 \pnum
-\ubxref{expr.mul.representable.type.result} \\
+\ubxref{expr.mul.representable.type.result}
 If the
 quotient a/b is representable in the type of the result, (a/b)*b + a\%b is equal to a; otherwise, the behavior
 of both a/b and a\%b is undefined.
@@ -1200,7 +1199,7 @@ int main() {
 \rSec2[ub.expr.add]{Additive operators}
 
 \pnum
-\ubxref{expr.add.out.of.bounds} \\
+\ubxref{expr.add.out.of.bounds}
 Creating an out of bounds pointer is undefined behavior.
 
 \pnum
@@ -1226,7 +1225,7 @@ int main() {
 \end{example}
 
 \pnum
-\ubxref{expr.add.sub.diff.pointers} \\
+\ubxref{expr.add.sub.diff.pointers}
 Subtracting pointers that are not part of the same array is undefined behavior.
 
 \pnum
@@ -1244,7 +1243,7 @@ void f() {
 \end{example}
 
 \pnum
-\ubxref{expr.add.not.similar} \\
+\ubxref{expr.add.not.similar}
 For addition or subtraction, if the expressions P or Q have type ``pointer to cv T'', where T and the array
 element type are not similar\iref{conv.rval}, the behavior is undefined.
 
@@ -1276,7 +1275,7 @@ int main() {
 \rSec2[ub.expr.shift]{Shift operators}
 
 \pnum
-\ubxref{expr.shift.neg.and.width} \\
+\ubxref{expr.shift.neg.and.width}
 Shifting by a negative amount or equal or greater than the bit-width of a type is undefined behavior.
 
 \pnum
@@ -1294,7 +1293,7 @@ int y2 = 1 >> 32;       // undefined behavior, shift is equal to the bit width o
 \rSec2[ub.expr.assign]{Assignment and compound assignment operators}
 
 \pnum
-\ubxref{expr.assign.overlap} \\
+\ubxref{expr.assign.overlap}
 Overlap in the storage between the source and destination may result in undefined behavior.
 
 \pnum
@@ -1311,7 +1310,7 @@ x = *c;         // undefined behavior, source overlaps storage of destination
 \rSec2[ub.stmt.return]{The return statement}
 
 \pnum
-\ubxref{stmt.return.flow.off} \\
+\ubxref{stmt.return.flow.off}
 Flowing off the end of a function other
 than main or a coroutine results in undefined behavior.
 
@@ -1334,7 +1333,7 @@ void b() {
 \rSec2[ub.return.coroutine]{The co_return statement}
 
 \pnum
-\ubxref{stmt.return.coroutine.flow.off} \\
+\ubxref{stmt.return.coroutine.flow.off}
 Falling off the end of a coroutine function body that does not return void is undefined behavior.
 
 \pnum
@@ -1396,7 +1395,7 @@ int main() {
 \rSec2[ub.stmt.dcl]{Declaration statement}
 
 \pnum
-\ubxref{stmt.dcl.local.static.init.recursive} \\
+\ubxref{stmt.dcl.local.static.init.recursive}
 If control re-enters the declaration recursively while the
 variable is being initialized, the behavior is undefined.
 
@@ -1418,7 +1417,7 @@ int foo(int i) {
 \rSec2[ub.dcl.type.cv]{The cv-qualifiers}
 
 \pnum
-\ubxref{dcl.type.cv.modify.const.obj} \\
+\ubxref{dcl.type.cv.modify.const.obj}
 Any attempt to modify a const object during its lifetime results in
 undefined behavior.
 
@@ -1433,7 +1432,7 @@ int* iq = const_cast<int*>(ciq);    // cast required
 
 
 \pnum
-\ubxref{dcl.type.cv.access.volatile} \\
+\ubxref{dcl.type.cv.access.volatile}
 If an attempt is made to
 access an object defined with a volatile-qualified type through the use of a non-volatile glvalue, the behavior
 is undefined
@@ -1450,7 +1449,7 @@ std::cout << y;         // undefined behavior, accessing volatile through non-vo
 \rSec2[ub.dcl.ref]{References}
 
 \pnum
-\ubxref{dcl.ref.incompatible.function} \\
+\ubxref{dcl.ref.incompatible.function}
 Initializing a reference to a function
 with a value that is a function
 that is not call-compatible\iref{expr.call}
@@ -1466,7 +1465,7 @@ void (&g)(int) = reinterpret_cast<void (&)(int)>(f);    // undefined behavior
 \end{example}
 
 \pnum
-\ubxref{dcl.ref.incompatible.type} \\
+\ubxref{dcl.ref.incompatible.type}
 Initializing a reference to an object
 with a value that is not
 type-accessible\iref{basic.lval} through
@@ -1482,7 +1481,7 @@ int& i = reinterpret_cast<int&>(g);     // undefined behavior
 \end{example}
 
 \pnum
-\ubxref{dcl.ref.uninitialized.reference} \\
+\ubxref{dcl.ref.uninitialized.reference}
 Evaluating a reference
 prior to initializing that
 reference has undefined behavior.
@@ -1503,7 +1502,7 @@ int &ir1 = i3;
 \rSec2[ub.dcl.fct.def.coroutine]{Coroutine definitions}
 
 \pnum
-\ubxref{dcl.fct.def.coroutine.resume.not.suspended} \\
+\ubxref{dcl.fct.def.coroutine.resume.not.suspended}
 Invoking a resumption member function for a coroutine that is not suspended results in undefined behavior.
 
 \pnum
@@ -1560,7 +1559,7 @@ int main() {
 
 
 \pnum
-\ubxref{dcl.fct.def.coroutine.destroy.not.suspended} \\
+\ubxref{dcl.fct.def.coroutine.destroy.not.suspended}
 Invoking destroy() on a coroutine that is not suspended is undefined behavior.
 
 \pnum
@@ -1618,7 +1617,7 @@ int main() {
 \rSec2[ub.dcl.attr.assume]{Assumption attribute}
 
 \pnum
-\ubxref{dcl.attr.assume.false} \\
+\ubxref{dcl.attr.assume.false}
 If am assumption expression would not evaluate to true at the point where it
 appears the behavior is undefined.
 
@@ -1640,7 +1639,7 @@ int f() {
 \rSec2[ub.dcl.attr.noreturn]{Noreturn attribute}
 
 \pnum
-\ubxref{dcl.attr.noreturn.eventually.returns} \\
+\ubxref{dcl.attr.noreturn.eventually.returns}
 If a function f is called where f was previously declared with the \tcode{noreturn} attribute and f eventually returns,
 the behavior is undefined.
 
@@ -1664,7 +1663,7 @@ int main() {
 \rSec2[ub.class.dtor]{Destructors}
 
 \pnum
-\ubxref{class.dtor.no.longer.exists} \\
+\ubxref{class.dtor.no.longer.exists}
 Once a destructor is invoked for an object, the object no longer exists; the behavior is undefined if the
 destructor is invoked for an object whose lifetime has ended.
 
@@ -1686,7 +1685,7 @@ int main() {
 \rSec2[ub.class.abstract]{Abstract classes}
 
 \pnum
-\ubxref{class.abstract.pure.virtual} \\
+\ubxref{class.abstract.pure.virtual}
 Calling a pure virtual function from a constructor or destructor in an abstract class is undefined behavior.
 
 \pnum
@@ -1709,7 +1708,7 @@ struct D : B {
 \rSec2[ub.class.base.init]{Initializing bases and members}
 
 \pnum
-\ubxref{class.base.init.mem.fun} \\
+\ubxref{class.base.init.mem.fun}
 It is undefined behavior to call a member function before all the \grammarterm{mem-initializer}s for base classes have completed.
 
 \pnum
@@ -1750,7 +1749,7 @@ public:
 \rSec2[ub.class.cdtor]{Construction and destruction}
 
 \pnum
-\ubxref{class.cdtor.before.ctor} \\
+\ubxref{class.cdtor.before.ctor}
 For an object with a non-trivial constructor, referring to any non-static member or base class of the object
 before the constructor begins execution results in undefined behavior. For an object with a non-trivial
 destructor, referring to any non-static member or base class of the object after the destructor finishes execution
@@ -1800,7 +1799,7 @@ struct Y {
 
 
 \pnum
-\ubxref{class.cdtor.after.dtor} \\
+\ubxref{class.cdtor.after.dtor}
 For an object with a non-trivial destructor,
 referring to any non-static member or base class of the object
 after the destructor finishes execution
@@ -1828,7 +1827,7 @@ void f()
 \end{example}
 
 \pnum
-\ubxref{class.cdtor.convert.pointer} \\
+\ubxref{class.cdtor.convert.pointer}
 When converting a pointer to a base class of an object,
 construction must have started and destruction must not have finished otherwise
 this is undefined behavior.
@@ -1855,7 +1854,7 @@ struct E : C, D, X {
 \end{example}
 
 \pnum
-\ubxref{class.cdtor.form.pointer} \\
+\ubxref{class.cdtor.form.pointer}
 When forming a pointer to
 a direct non-static member of a class,
 construction must have started
@@ -1877,7 +1876,7 @@ struct B {
 \end{example}
 
 \pnum
-\ubxref{class.cdtor.virtual.not.x} \\
+\ubxref{class.cdtor.virtual.not.x}
 When a virtual function is called directly or indirectly from a constructor or from a destructor,
 including during the construction or destruction of the class's non-static data members, and the object to
 which the call applies is the object (call it \tcode{x}) under construction or destruction, the function called is the
@@ -1920,7 +1919,7 @@ B::B(V *v, A *a) {
 
 
 \pnum
-\ubxref{class.cdtor.typeid} \\
+\ubxref{class.cdtor.typeid}
 If the operand of \tcode{typeid} refers to
 the object under construction or destruction and the static type of the operand is neither the constructor or
 destructor's class nor one of its bases, the behavior is undefined.
@@ -1951,7 +1950,7 @@ B::B(V *v, A *a) {
 
 
 \pnum
-\ubxref{class.cdtor.dynamic.cast} \\
+\ubxref{class.cdtor.dynamic.cast}
 If the operand of the
 \tcode{dynamic_cast} refers to the object under construction or destruction and the static type of the operand is
 not a pointer to or object of the constructor or destructor's own class or one of its bases, the \tcode{dynamic_cast}
@@ -1985,7 +1984,7 @@ B::B(V *v, A *a) {
 \rSec2[ub.temp.inst]{Implicit instantiation}
 
 \pnum
-\ubxref{temp.inst.inf.recursion} \\
+\ubxref{temp.inst.inf.recursion}
 The result of an infinite recursion in template instantiation is undefined.
 
 \pnum
@@ -2011,7 +2010,7 @@ int main() {
 \rSec2[ub.except.handle]{Handling an exception}
 
 \pnum
-\ubxref{except.handle.handler.ctor.dtor} \\
+\ubxref{except.handle.handler.ctor.dtor}
 Referring to any non-static member or base class of an object in the handler for a  \grammarterm{function-try-block} of a
 constructor or destructor for that object results in undefined behavior.
 


### PR DESCRIPTION
Removing trailing \\s from all \ubxref and \ifndrxref lines that had it, as well as blank lines that follow those commands, so that line breaking and spacing are consistent where we use these macros.