### PR TITLE
[dcl.type.pack.index] Clarify pack-index-specifier rules

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1537,7 +1537,7 @@ forces \tcode{char} objects to be signed; it is redundant in other contexts.
 
 \pnum
 The \grammarterm{typedef-name} $P$ in a \grammarterm{pack-index-specifier}
-shall denote a pack.
+shall be an \grammarterm{identifier} that denotes a pack.
 
 \pnum
 The \grammarterm{constant-expression} shall be


### PR DESCRIPTION
Currently, [dcl.type.pack.index] reads:

> ```
> pack-index-specifier:
>     typedef-name ... [ constant-expression ]
> ```
> The _typedef-name_ `P` in a _pack-index-specifier_ shall denote a pack.

A _typedef-name_ is either an _identifier_ or a _simple-template-id_, which suggests that maybe `something<Ts>...[0]` is valid in addition to `Ts...[0]`, but the first sentence here restricts that case, since a _simple-template-id_ can never denote a pack.

But to figure that out is kind of a logic puzzle. Can we just say that more directly?

> The _typedef-name_ `P` in a _pack-index-specifier_ shall <ins>be an _identifier_ that</ins> denote<ins>s</ins> a pack.