### PR TITLE
[implimits] Reduce size of an object to 65,535

### DIFF
--- a/source/limits.tex
+++ b/source/limits.tex
@@ -53,7 +53,7 @@ Characters in one logical source line\iref{lex.phases} [65\,536].
 Characters in a \grammarterm{string-literal}\iref{lex.string}
 (after concatenation\iref{lex.phases}) [65\,536].
 \item%
-Size of an object\iref{intro.object} [262\,144].
+Size of an object\iref{intro.object} [65\,535].
 \item%
 Nesting levels for
 \tcode{\#include}


### PR DESCRIPTION
The current gurantee is excessively high. To remain compatible with 16-bit platforms (where `size_t` is 16-bit), the size of an object has to be representable as a 16-bit unsigned integer.

The current limit of 262,144 makes C++ effectively unimplementable on 16-bit architectures, unless `size_t` uses multi-precision arithmetic.