### PR TITLE
[out.ptr.t][inout.ptr.t] Get rid of TBAA-violating implication

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -5509,7 +5509,7 @@ has undefined behavior.
 
 \pnum
 \begin{note}
-\tcode{reinterpret_cast<void**>(static_cast<Pointer*>(*this))}
+\tcode{start_lifetime_as<void*>(\&const_cast<Pointer\&>(p))}
 can be a viable implementation strategy for some implementations.
 \end{note}
 \end{itemdescr}
@@ -5745,7 +5745,7 @@ has undefined behavior.
 
 \pnum
 \begin{note}
-\tcode{reinterpret_cast<void**>(static_cast<Pointer*>(*this))}
+\tcode{start_lifetime_as<void*>(\&const_cast<Pointer\&>(p))}
 can be a viable implementation strategy for some implementations.
 \end{note}
 \end{itemdescr}


### PR DESCRIPTION
On many platforms, we can just reuse the object/value representation of the raw pointer stored within `(in)out_ptr_t` for `operator void**`. However, directly use of `reinterpret_cast` violates the strict aliasing rule ([basic.lval]/11). At the time when `out_ptr_t` and `inout_ptr_t` were added to C++23, there was not yet any standard utility bypassing the strict aliasing rule, and thus the notes had to indicate core UB and were only applicable for implementations that didn't aggressively perform type-based aliasing analysis (TBAA).

Luckily, `start_lifetime_as` was added later, making it possible to reuse value representation without UB. This PR uses `start_lifetime_as` in the notes, and thus makes them probably applicable for implementations that have compatible representations for `T*` and `void*`.

Note that `start_lifetime_as` can cause conflicts on object creation, but conflicts are already allowed in [out.ptr.t]/5 and [inout.ptr.t]/5.