### PR TITLE
[const.wrap.class] Add missing this to compound assignment operators

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -822,34 +822,34 @@ namespace std {
         -> constant_wrapper<Y--> { return {}; }
 
     template<@\exposconcept{constexpr-param}@ T, @\exposconcept{constexpr-param}@ R>
-      constexpr auto operator+=(T, R) noexcept
+      constexpr auto operator+=(this T, R) noexcept
         -> constant_wrapper<(T::value += R::value)> { return {}; }
     template<@\exposconcept{constexpr-param}@ T, @\exposconcept{constexpr-param}@ R>
-      constexpr auto operator-=(T, R) noexcept
+      constexpr auto operator-=(this T, R) noexcept
         -> constant_wrapper<(T::value -= R::value)> { return {}; }
     template<@\exposconcept{constexpr-param}@ T, @\exposconcept{constexpr-param}@ R>
-      constexpr auto operator*=(T, R) noexcept
+      constexpr auto operator*=(this T, R) noexcept
         -> constant_wrapper<(T::value *= R::value)> { return {}; }
     template<@\exposconcept{constexpr-param}@ T, @\exposconcept{constexpr-param}@ R>
-      constexpr auto operator/=(T, R) noexcept
+      constexpr auto operator/=(this T, R) noexcept
         -> constant_wrapper<(T::value /= R::value)> { return {}; }
     template<@\exposconcept{constexpr-param}@ T, @\exposconcept{constexpr-param}@ R>
-      constexpr auto operator%=(T, R) noexcept
+      constexpr auto operator%=(this T, R) noexcept
         -> constant_wrapper<(T::value %= R::value)> { return {}; }
     template<@\exposconcept{constexpr-param}@ T, @\exposconcept{constexpr-param}@ R>
-      constexpr auto operator&=(T, R) noexcept
+      constexpr auto operator&=(this T, R) noexcept
         -> constant_wrapper<(T::value &= R::value)> { return {}; }
     template<@\exposconcept{constexpr-param}@ T, @\exposconcept{constexpr-param}@ R>
-      constexpr auto operator|=(T, R) noexcept
+      constexpr auto operator|=(this T, R) noexcept
         -> constant_wrapper<(T::value |= R::value)> { return {}; }
     template<@\exposconcept{constexpr-param}@ T, @\exposconcept{constexpr-param}@ R>
-      constexpr auto operator^=(T, R) noexcept
+      constexpr auto operator^=(this T, R) noexcept
         -> constant_wrapper<(T::value ^= R::value)> { return {}; }
     template<@\exposconcept{constexpr-param}@ T, @\exposconcept{constexpr-param}@ R>
-      constexpr auto operator<<=(T, R) noexcept
+      constexpr auto operator<<=(this T, R) noexcept
         -> constant_wrapper<(T::value <<= R::value)> { return {}; }
     template<@\exposconcept{constexpr-param}@ T, @\exposconcept{constexpr-param}@ R>
-      constexpr auto operator>>=(T, R) noexcept
+      constexpr auto operator>>=(this T, R) noexcept
         -> constant_wrapper<(T::value >>= R::value)> { return {}; }
   };
 


### PR DESCRIPTION
This corrects a misapplication of LWG4383.