### PR TITLE
[alg.remove] Fix a typo

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -7604,7 +7604,7 @@ template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-acces
 
 \begin{itemdescr}
 \pnum
-Let $E$ be
+Let $E(\tcode{i})$ be
 \begin{itemize}
 \item \tcode{bool(*i == value)} for \tcode{remove};
 \item \tcode{bool(pred(*i))} for \tcode{remove_if};
@@ -7621,7 +7621,7 @@ meets the \oldconcept{MoveAssignable} requirements (\tref{cpp17.moveassignable})
 \pnum
 \effects
 Eliminates all the elements referred to by iterator \tcode{i}
-in the range \range{first}{last} for which $E$ holds.
+in the range \range{first}{last} for which $E(\tcode{i})$ holds.
 
 \pnum
 \returns


### PR DESCRIPTION
The `E` in the code is actually meant to be a function on an iterator `i`; amend both usages to `E(i)`. This was already done everywhere else (for instance in copy_if or unique_copy).