### PR TITLE
[basic.fundamental] Harmonize "Type X is a distinct type..." wordings

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5521,7 +5521,7 @@ signed or unsigned integer type as its underlying type.
 \indextext{\idxcode{char8_t}|see{type, \tcode{char8_t}}}%
 \indextext{type!\idxcode{char8_t}}%
 \indextext{type!underlying!\idxcode{char8_t}}%
-Type \keyword{char8_t} denotes a distinct type
+Type \keyword{char8_t} is a distinct type
 whose underlying type is \tcode{\keyword{unsigned} \keyword{char}}.
 \indextext{\idxcode{char16_t}|see{type, \tcode{char16_t}}}%
 \indextext{\idxcode{char32_t}|see{type, \tcode{char32_t}}}%
@@ -5529,7 +5529,7 @@ whose underlying type is \tcode{\keyword{unsigned} \keyword{char}}.
 \indextext{type!\idxcode{char32_t}}%
 \indextext{type!underlying!\idxcode{char16_t}}%
 \indextext{type!underlying!\idxcode{char32_t}}%
-Types \keyword{char16_t} and \keyword{char32_t} denote distinct types
+Types \keyword{char16_t} and \keyword{char32_t} are distinct types
 whose underlying types are \tcode{std::uint_least16_t} and \tcode{std::uint_least32_t},
 respectively, in \libheaderref{cstdint}.
 
@@ -5656,13 +5656,14 @@ for a function with the return type \cv{}~\keyword{void},
 \end{note}
 
 \pnum
-The types denoted by \cv~\tcode{std::nullptr_t} are distinct types.
+Type \tcode{std::nullptr_t} is a distinct type.
 A prvalue of type \tcode{std::nullptr_t} is a null pointer
 constant\iref{conv.ptr}. Such values participate in the pointer and the
 pointer-to-member conversions\iref{conv.ptr,conv.mem}.
 \tcode{\keyword{sizeof}(std::nullptr_t)} shall be equal to \tcode{\keyword{sizeof}(\keyword{void}*)}.
 
 \pnum
+Type \tcode{std::meta::info} is a distinct type.
 A value of type \tcode{std::meta::info} is called a \defn{reflection}.
 There exists a unique \defnadj{null}{reflection};
 every other reflection is a representation of


### PR DESCRIPTION
Types are types; types do not denote types.

Here I don't know if there might be a reason we talk about cv nullptr_t being multiple distinct *types*, as if otherwise the reader might imagine const nullptr_t to be the same type as volatile nullptr_t. Otherwise, that sentence should clearly be just "std::nullptr_t is a distinct type."

Notably `std::meta::info` is *not* currently described as a distinct type. I don't think that's intentional; I think it's practically required to be a distinct type anyway. So I think this diff is editorial.