### PR TITLE
[iterator.concept.winc] Refactor definition of "integer-like type"

### DIFF
--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1445,15 +1445,12 @@ The width of an integer-class type is greater than
 that of every integral type of the same signedness.
 
 \pnum
-A type \tcode{I} other than \cv{}~\tcode{bool} is \defn{integer-like}
-if it models \tcode{\libconcept{integral}<I>} or
-if it is an integer-class type.
-An integer-like type \tcode{I} is \defn{signed-integer-like}
-if it models \tcode{\libconcept{signed_integral}<I>} or
-if it is a signed-integer-class type.
-An integer-like type \tcode{I} is \defn{unsigned-integer-like}
-if it models \tcode{\libconcept{unsigned_integral}<I>} or
-if it is an unsigned-integer-class type.
+Integer-class types and integral types\iref{basic.fundamental} other than \cv{}~\tcode{bool}
+are collectively called \defnadjx{integer-like}{types}{type}.
+Signed-integer-class types and types that model \tcode{\libconcept{signed_integral}}
+are collectively called \defnadjx{signed-integer-like}{types}{type}.
+Unsigned-integer-class types, and types other than \cv{}~\tcode{bool} that model \tcode{\libconcept{unsigned_integral}},
+are collectively called \defnadjx{unsigned-integer-like}{types}{type}.
 
 \pnum
 For every integer-class type \tcode{I},


### PR DESCRIPTION
- "`I` models `integral<I>`" is not how we say it: the `<I>` shouldn't be there.
- The concept `integral` is modeled only by integral types. Cut out the middleman.
- Make the sentence structure less hypothetical; use "collectively called" as we usually do.
- Clearly specify that cv bool is *not* integer-like, rather than leaving it out of the premise.