### PR TITLE
[thread.mutex.requirements.mutex.general] fix grammar

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -7329,7 +7329,7 @@ construction is incorrect.
 The implementation provides lock and unlock operations, as described below.
 For purposes of determining the existence of a data race, these behave as
 atomic operations\iref{intro.multithread}. The lock and unlock operations on
-a single mutex appears to occur in a single total order.
+a single mutex appear to occur in a single total order.
 \begin{note}
 This
 can be viewed as the modification order\iref{intro.multithread} of the


### PR DESCRIPTION
The lock and unlock operations are plural.