### PR TITLE
[format] Consistently add `constexpr` to function descriptions

### DIFF
--- a/source/text.tex
+++ b/source/text.tex
@@ -6722,7 +6722,7 @@ the same as in \ref{algorithms.requirements}.
 \indexlibraryglobal{format}%
 \begin{itemdecl}
 template<class... Args>
-  string format(format_string<Args...> fmt, Args&&... args);
+  constexpr string format(format_string<Args...> fmt, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6737,7 +6737,7 @@ return vformat(fmt.@\exposid{str}@, make_format_args(args...));
 \indexlibraryglobal{format}%
 \begin{itemdecl}
 template<class... Args>
-  wstring format(wformat_string<Args...> fmt, Args&&... args);
+  constexpr wstring format(wformat_string<Args...> fmt, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6781,8 +6781,8 @@ return vformat(loc, fmt.@\exposid{str}@, make_wformat_args(args...));
 
 \indexlibraryglobal{vformat}%
 \begin{itemdecl}
-string vformat(string_view fmt, format_args args);
-wstring vformat(wstring_view fmt, wformat_args args);
+constexpr string vformat(string_view fmt, format_args args);
+constexpr wstring vformat(wstring_view fmt, wformat_args args);
 string vformat(const locale& loc, string_view fmt, format_args args);
 wstring vformat(const locale& loc, wstring_view fmt, wformat_args args);
 \end{itemdecl}
@@ -6803,7 +6803,7 @@ As specified in~\ref{format.err.report}.
 \indexlibraryglobal{format_to}%
 \begin{itemdecl}
 template<class Out, class... Args>
-  Out format_to(Out out, format_string<Args...> fmt, Args&&... args);
+  constexpr Out format_to(Out out, format_string<Args...> fmt, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6818,7 +6818,7 @@ return vformat_to(std::move(out), fmt.@\exposid{str}@, make_format_args(args...)
 \indexlibraryglobal{format_to}%
 \begin{itemdecl}
 template<class Out, class... Args>
-  Out format_to(Out out, wformat_string<Args...> fmt, Args&&... args);
+  constexpr Out format_to(Out out, wformat_string<Args...> fmt, Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6863,9 +6863,9 @@ return vformat_to(std::move(out), loc, fmt.@\exposid{str}@, make_wformat_args(ar
 \indexlibraryglobal{vformat_to}%
 \begin{itemdecl}
 template<class Out>
-  Out vformat_to(Out out, string_view fmt, format_args args);
+  constexpr Out vformat_to(Out out, string_view fmt, format_args args);
 template<class Out>
-  Out vformat_to(Out out, wstring_view fmt, wformat_args args);
+  constexpr Out vformat_to(Out out, wstring_view fmt, wformat_args args);
 template<class Out>
   Out vformat_to(Out out, const locale& loc, string_view fmt, format_args args);
 template<class Out>
@@ -6905,11 +6905,13 @@ As specified in~\ref{format.err.report}.
 \indexlibraryglobal{format_to_n}%
 \begin{itemdecl}
 template<class Out, class... Args>
-  format_to_n_result<Out> format_to_n(Out out, iter_difference_t<Out> n,
-                                      format_string<Args...> fmt, Args&&... args);
+  constexpr format_to_n_result<Out> format_to_n(Out out, iter_difference_t<Out> n,
+                                                format_string<Args...> fmt,
+                                                Args&&... args);
 template<class Out, class... Args>
-  format_to_n_result<Out> format_to_n(Out out, iter_difference_t<Out> n,
-                                      wformat_string<Args...> fmt, Args&&... args);
+  constexpr format_to_n_result<Out> format_to_n(Out out, iter_difference_t<Out> n,
+                                                wformat_string<Args...> fmt,
+                                                Args&&... args);
 template<class Out, class... Args>
   format_to_n_result<Out> format_to_n(Out out, iter_difference_t<Out> n,
                                       const locale& loc, format_string<Args...> fmt,
@@ -6962,9 +6964,9 @@ As specified in~\ref{format.err.report}.
 \indexlibraryglobal{formatted_size}%
 \begin{itemdecl}
 template<class... Args>
-  size_t formatted_size(format_string<Args...> fmt, Args&&... args);
+  constexpr size_t formatted_size(format_string<Args...> fmt, Args&&... args);
 template<class... Args>
-  size_t formatted_size(wformat_string<Args...> fmt, Args&&... args);
+  constexpr size_t formatted_size(wformat_string<Args...> fmt, Args&&... args);
 template<class... Args>
   size_t formatted_size(const locale& loc, format_string<Args...> fmt, Args&&... args);
 template<class... Args>
@@ -7771,7 +7773,7 @@ by wrapping those in temporary objects with a uniform interface
 
 \indexlibrarymember{arg}{basic_format_context}%
 \begin{itemdecl}
-basic_format_arg<basic_format_context> arg(size_t id) const noexcept;
+constexpr basic_format_arg<basic_format_context> arg(size_t id) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7795,7 +7797,7 @@ and \tcode{std::locale()} otherwise.
 
 \indexlibrarymember{out}{basic_format_context}%
 \begin{itemdecl}
-iterator out();
+constexpr iterator out();
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -7806,7 +7808,7 @@ Equivalent to: \tcode{return std::move(out_);}
 
 \indexlibrarymember{advance_to}{basic_format_context}%
 \begin{itemdecl}
-void advance_to(iterator it);
+constexpr void advance_to(iterator it);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8114,7 +8116,7 @@ An iterator past the end of the \fmtgrammarterm{range-format-spec}.
 template<ranges::@\libconcept{input_range}@ R, class FormatContext>
     requires @\libconcept{formattable}@<ranges::range_reference_t<R>, charT> &&
              @\libconcept{same_as}@<remove_cvref_t<ranges::range_reference_t<R>>, T>
-  typename FormatContext::iterator
+  constexpr typename FormatContext::iterator
     format(R&& r, FormatContext& ctx) const;
 \end{itemdecl}
 
@@ -8222,7 +8224,7 @@ Equivalent to: \tcode{return \exposid{underlying_}.parse(ctx);}
 \indexlibrarymemberexpos{format}{range-default-formatter}%
 \begin{itemdecl}
 template<class FormatContext>
-  typename FormatContext::iterator
+  constexpr typename FormatContext::iterator
     format(@\exposid{maybe-const-r}@& elems, FormatContext& ctx) const;
 \end{itemdecl}
 
@@ -8302,7 +8304,7 @@ Equivalent to: \tcode{return \exposid{underlying_}.parse(ctx);}
 \indexlibrarymemberexpos{format}{range-default-formatter}%
 \begin{itemdecl}
 template<class FormatContext>
-  typename FormatContext::iterator
+  constexpr typename FormatContext::iterator
     format(@\exposid{maybe-const-map}@& r, FormatContext& ctx) const;
 \end{itemdecl}
 
@@ -8368,7 +8370,7 @@ Equivalent to: \tcode{return \exposid{underlying_}.parse(ctx);}
 \indexlibrarymemberexpos{format}{range-default-formatter}%
 \begin{itemdecl}
 template<class FormatContext>
-  typename FormatContext::iterator
+  constexpr typename FormatContext::iterator
     format(@\exposid{maybe-const-set}@& r, FormatContext& ctx) const;
 \end{itemdecl}
 
@@ -8492,7 +8494,7 @@ The behavior of a program that adds specializations of
 
 \indexlibrary{\idxcode{basic_format_arg}!constructor|(}%
 \begin{itemdecl}
-basic_format_arg() noexcept;
+constexpr basic_format_arg() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8502,7 +8504,7 @@ basic_format_arg() noexcept;
 \end{itemdescr}
 
 \begin{itemdecl}
-template<class T> explicit basic_format_arg(T& v) noexcept;
+template<class T> constexpr explicit basic_format_arg(T& v) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8574,7 +8576,7 @@ for that pointer to member type.
 
 \indexlibrarymember{operator bool}{basic_format_arg}%
 \begin{itemdecl}
-explicit operator bool() const noexcept;
+constexpr explicit operator bool() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8586,7 +8588,7 @@ explicit operator bool() const noexcept;
 \indexlibrarymember{visit}{basic_format_arg}%
 \begin{itemdecl}
 template<class Visitor>
-  decltype(auto) visit(this basic_format_arg arg, Visitor&& vis);
+  constexpr decltype(auto) visit(this basic_format_arg arg, Visitor&& vis);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8598,7 +8600,7 @@ Equivalent to: \tcode{return arg.value.visit(std::forward<Visitor>(vis));}
 \indexlibrarymember{visit}{basic_format_arg}%
 \begin{itemdecl}
 template<class R, class Visitor>
-  R visit(this basic_format_arg arg, Visitor&& vis);
+  constexpr R visit(this basic_format_arg arg, Visitor&& vis);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8630,7 +8632,7 @@ namespace std {
 
 \indexlibraryctor{basic_format_arg::handle}%
 \begin{itemdecl}
-template<class T> explicit handle(T& val) noexcept;
+template<class T> constexpr explicit handle(T& val) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8667,7 +8669,7 @@ Initializes
 
 \indexlibrarymember{format}{basic_format_arg::handle}%
 \begin{itemdecl}
-void format(basic_format_parse_context<char_type>& parse_ctx, Context& format_ctx) const;
+constexpr void format(basic_format_parse_context<char_type>& parse_ctx, Context& format_ctx) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8693,7 +8695,8 @@ An instance of \exposid{format-arg-store} stores formatting arguments.
 \indexlibraryglobal{make_format_args}%
 \begin{itemdecl}
 template<class Context = format_context, class... Args>
-  @\exposid{format-arg-store}@<Context, Args...> make_format_args(Args&... fmt_args);
+  constexpr @\exposid{format-arg-store}@<Context, Args...>
+    make_format_args(Args&... fmt_args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8714,7 +8717,8 @@ whose \exposid{args} data member is initialized with
 \indexlibraryglobal{make_wformat_args}%
 \begin{itemdecl}
 template<class... Args>
-  @\exposid{format-arg-store}@<wformat_context, Args...> make_wformat_args(Args&... args);
+  constexpr @\exposid{format-arg-store}@<wformat_context, Args...>
+    make_wformat_args(Args&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8762,7 +8766,7 @@ and packing the former.
 \indexlibraryctor{basic_format_args}%
 \begin{itemdecl}
 template<class... Args>
-  basic_format_args(const @\exposid{format-arg-store}@<Context, Args...>& store) noexcept;
+  constexpr basic_format_args(const @\exposid{format-arg-store}@<Context, Args...>& store) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8775,7 +8779,7 @@ Initializes
 
 \indexlibrarymember{get}{basic_format_args}%
 \begin{itemdecl}
-basic_format_arg<Context> get(size_t i) const noexcept;
+constexpr basic_format_arg<Context> get(size_t i) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -8945,7 +8949,7 @@ An iterator past the end of the \fmtgrammarterm{tuple-format-spec}.
 \indexlibrarymember{format}{formatter}%
 \begin{itemdecl}
 template<class FormatContext>
-  typename FormatContext::iterator
+  constexpr typename FormatContext::iterator
     format(@\seebelow@& elems, FormatContext& ctx) const;
 \end{itemdecl}
 


### PR DESCRIPTION
P3391R2 only added `constexpr` to synopses but not descriptions for some formatting functions. This PR consistently adds `constexpr` to the descriptions.