### PR TITLE
[vector.bool.fmt][container.adaptors.format] Add missing `constexpr`

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10735,7 +10735,7 @@ namespace std {
         parse(ParseContext& ctx);
 
     template<class FormatContext>
-      typename FormatContext::iterator
+      constexpr typename FormatContext::iterator
         format(const T& ref, FormatContext& ctx) const;
   };
 }
@@ -10756,7 +10756,7 @@ Equivalent to: \tcode{return \exposid{underlying_}.parse(ctx);}
 \indexlibrarymember{format}{formatter}%
 \begin{itemdecl}
 template<class FormatContext>
-  typename FormatContext::iterator
+  constexpr typename FormatContext::iterator
     format(const T& ref, FormatContext& ctx) const;
 \end{itemdecl}
 
@@ -20308,7 +20308,7 @@ For each of
 \tcode{queue},
 \tcode{priority_queue}, and
 \tcode{stack},
-the library provides the following formatter specialization
+the library provides the following constexpr-enabled formatter specialization
 where \tcode{\placeholder{adaptor-type}} is the name of the template:
 
 \indexlibraryglobal{formatter}%
@@ -20330,7 +20330,7 @@ namespace std {
         parse(ParseContext& ctx);
 
     template<class FormatContext>
-      typename FormatContext::iterator
+      constexpr typename FormatContext::iterator
         format(@\exposid{maybe-const-adaptor}@& r, FormatContext& ctx) const;
   };
 }
@@ -20352,7 +20352,7 @@ Equivalent to: \tcode{return \exposid{underlying_}.parse(ctx);}
 \indexlibrarymember{format}{formatter}%
 \begin{itemdecl}
 template<class FormatContext>
-  typename FormatContext::iterator
+  constexpr typename FormatContext::iterator
     format(@\exposid{maybe-const-adaptor}@& r, FormatContext& ctx) const;
 \end{itemdecl}
 


### PR DESCRIPTION
This PR completes the previously missing `constexpr` addition from P3391R2 and consistently adds `constexpr` to function descriptions.