### PR TITLE
[utility.intcmp] Clarify the referenced type parameter

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -660,7 +660,7 @@ template<class R, class T>
 \begin{itemdescr}
 \pnum
 \mandates
-Each of \tcode{T} and \tcode{U} is
+Each of \tcode{T} and \tcode{R} is
 a signed or unsigned integer type\iref{basic.fundamental}.
 
 \pnum


### PR DESCRIPTION
in_range is worded as:
```
template<class R, class T>
  constexpr bool in_range(T t) noexcept;
```

with the mandate `Each of T and U is a signed or unsigned integer type`
The referenced U in the mandate seems to be a copy-paste error from the above `cmp_equal`