### PR TITLE
[lex.key] Emphasize that keywords are created in phase 6

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1021,7 +1021,7 @@ reserved to the implementation for use as a name in the global namespace.%
 \indextext{keyword|(}%
 The identifiers shown in \tref{lex.key} are reserved for use
 as keywords (that is, they are unconditionally treated as keywords in
-phase 7) except in an \grammarterm{attribute-token}\iref{dcl.attr.grammar}.
+phases 6 and 7) except in an \grammarterm{attribute-token}\iref{dcl.attr.grammar}.
 \begin{note}
 The \keyword{register} keyword is unused but
 is reserved for future use.


### PR DESCRIPTION
This was overlooked in CWG3094, applied with commit 94055b39a90285d8ae15f8f864a39a328f42a359.

Fixes cplusplus/CWG#855