### PR TITLE
[text.encoding.id] Add colon after "as follows" for consistency

### DIFF
--- a/source/text.tex
+++ b/source/text.tex
@@ -5698,7 +5698,7 @@ namespace std {
 The \tcode{text_encoding::id} enumeration
 contains an enumerator for each known registered character encoding.
 For each encoding, the corresponding enumerator is derived from
-the alias beginning with ``\tcode{cs}'', as follows
+the alias beginning with ``\tcode{cs}'', as follows:
 \begin{itemize}
 \item
 \tcode{csUnicode} is mapped to \tcode{text_encoding::id::UCS2},


### PR DESCRIPTION
There exist 210 "as follows:" in this draft but only this one before a list