### PR TITLE
[class.abstract] Fix reference in abstract class note

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -4165,7 +4165,7 @@ struct C {
 \begin{note}
 An abstract class type cannot be used
 as a parameter or return type of
-a function being defined\iref{dcl.fct} or called\iref{expr.call},
+a function being defined\iref{dcl.fct.def.general} or called\iref{expr.call},
 except as specified in \ref{dcl.type.simple}.
 Further, an abstract class type cannot be used as
 the type of an explicit type conversion\iref{expr.static.cast,

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -4187,7 +4187,7 @@ struct C {
 \begin{note}
 An abstract class type cannot be used
 as a parameter or return type of
-a function being defined\iref{dcl.fct} or called\iref{expr.call},
+a function being defined\iref{dcl.fct.def.general} or called\iref{expr.call},
 except as specified in \ref{dcl.type.simple}.
 Further, an abstract class type cannot be used as
 the type of an explicit type conversion\iref{expr.static.cast,

--- a/source/text.tex
+++ b/source/text.tex
@@ -1305,7 +1305,7 @@ to fill out the specified width where necessary.
 
 \pnum
 The \tcode{put()} members make no provision for error reporting.
-(Any failures of the OutputIterator argument can be extracted from
+(Any failures of the \tcode{OutputIterator} argument can be extracted from
 the returned iterator.)
 The \tcode{get()} members take an \tcode{ios_base::iostate\&} argument
 whose value they ignore,


### PR DESCRIPTION
Referenced normative wording moved since [[P0929R2]](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0929r2.html).