### PR TITLE
[meta.syn] Add function parameter names

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -3089,7 +3089,7 @@ namespace std::meta {
 
   // \ref{meta.reflection.extract}, value extraction
   template<class T>
-    consteval T extract(info);
+    consteval T extract(info r);
 
   // \ref{meta.reflection.substitute}, reflection substitution
   template<class R>
@@ -3113,7 +3113,7 @@ namespace std::meta {
   consteval info data_member_spec(info type, data_member_options options);
   consteval bool is_data_member_spec(info r);
   template<@\libconcept{reflection_range}@ R = initializer_list<info>>
-    consteval info define_aggregate(info type_class, R&&);
+    consteval info define_aggregate(info type_class, R&& mdescrs);
 
   // associated with \ref{meta.unary.cat}, primary type categories
   consteval bool is_void_type(info type);


### PR DESCRIPTION
These two seem to be the only ones where the function parameter names are omitted in the declaration. 
Add names to ensure consistency.