### PR TITLE
[class.mem.general] Fix wording regarding layout-compatible types CWG3169

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -880,8 +880,8 @@ The common initial sequence of \tcode{A} and \tcode{E} is empty.
 \pnum
 Two standard-layout struct\iref{class.prop} types are
 \defnx{layout-compatible classes}{layout-compatible!class} if
-their common initial sequence comprises all members and bit-fields of
-both classes\iref{basic.types}.
+their common initial sequence comprises all non-static data members and
+bit-fields of both classes\iref{basic.types}.
 
 \pnum
 Two standard-layout unions are layout-compatible if they


### PR DESCRIPTION
According to the current wording:
```cpp
struct A{int x;};
struct B{int x;void foo(){}};
```
These types are not layout-compatible because the member function is not included in the common initial sequence. Moreover, even if A had the same member function it would not be included in the common initial sequence so B cannot be layout-compatible with any other type. There are more related issues:
```cpp
union C{char x;};
union D{alignas(2)char x;};
```
The current wording for layout-compatible unions does not mention alignment, so the current wording says these types are layout-compatible even though they clearly ought not to be.
```cpp
union E{int x:4;};
union F{int x:8;};
```
The current wording for layout-compatible unions does not mention bit-field widths, so the current wording says these types are layout-compatible even though they clearly ought not to be.
```cpp
union G{int x;};
union H{[[no_unique_address]]int x;};
```
The current wording for layout-compatible unions does not mention no_unique_address, so the current wording says these types are layout-compatible even though they clearly ought not to be if no_unique_address is supported.
```cpp
union I{char x;};
union J{char x;int:10;};
```
The current wording for layout-compatible unions does not mention unnamed bit-fields as they are not members, so the current wording says these types are layout-compatible even though they clearly ought not to be.
```cpp
struct K{char x;};
struct alignas(2)L{char x;};
```
The current wording for layout-compatible classes and layout-compatible unions (layout-compatible unions are not layout-compatible classes, despite being classes and layout-compatible) does not mention alignas applied to the type, so the current wording says these types are layout-compatible even though they clearly ought not to be.
```cpp
struct M{char x;};
struct N{alignas(1)char x;};
```
The current wording does not clearly define what "same alignment requirements" means, there is some compiler divergence here about whether or not these types are layout-compatible.

I have only proposed changes to the first issue since it seems the most clear and requires only a small change to fix. If any of the other issues listed here could be fixed editorially too, I would be willing to include fixes for them too.