### PR TITLE
[version.syn] Added freestanding for type_order

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -870,7 +870,7 @@ the values of these macros with greater values.
   // also in \libheader{utility}, \libheader{tuple}, \libheader{map}, \libheader{unordered_map}
 #define @\defnlibxname{cpp_lib_tuples_by_type}@                    201304L // freestanding, also in \libheader{utility}, \libheader{tuple}
 #define @\defnlibxname{cpp_lib_type_identity}@                     201806L // freestanding, also in \libheader{type_traits}
-#define @\defnlibxname{cpp_lib_type_order}@                        202506L // also in \libheader{compare}
+#define @\defnlibxname{cpp_lib_type_order}@                        202506L // freestanding, also in \libheader{compare}
 #define @\defnlibxname{cpp_lib_type_trait_variable_templates}@     201510L // freestanding, also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_uncaught_exceptions}@               201411L // freestanding, also in \libheader{exception}
 #define @\defnlibxname{cpp_lib_unordered_map_try_emplace}@         201411L // also in \libheader{unordered_map}


### PR DESCRIPTION
Although `<compare>` already shows `// all freestanding`, it still seems useful to add `freestanding` here, which is consistent with `__cpp_lib_three_way_comparison`, which is annotated with  `// freestanding, also in <compare>`.

Or is this LWG?