### PR TITLE
[stoptoken.concepts] Remove superfluous \item

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -631,7 +631,6 @@ the callback invocation shall not be added to the list of callback invocations.
 If the callback invocation was added to stop state's list of callbacks,
 \tcode{scb} shall be associated with the stop state.
 \end{itemize}
-\item
 \begin{note}
 If \tcode{t.stop_possible()} is \tcode{false},
 there is no requirement


### PR DESCRIPTION
(3.2.2) is empty because of this superfluous \item