### PR TITLE
[views.multidim] Index `submdspan_mapping`

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -22203,7 +22203,7 @@ namespace std {
         -> @\seebelow@;
 
     template<class... SliceSpecifiers>
-      friend constexpr auto submdspan_mapping(
+      friend constexpr auto @\libmember{submdspan_mapping}{layout_left::mapping}@(
         const mapping& src, SliceSpecifiers... slices) {
           return src.@\exposid{submdspan-mapping-impl}@(slices...);
       }
@@ -22532,7 +22532,7 @@ namespace std {
         -> @\seebelow@;
 
     template<class... SliceSpecifiers>
-      friend constexpr auto submdspan_mapping(
+      friend constexpr auto @\libmember{submdspan_mapping}{layout_right::mapping}@(
         const mapping& src, SliceSpecifiers... slices) {
           return src.@\exposid{submdspan-mapping-impl}@(slices...);
       }
@@ -22863,7 +22863,7 @@ namespace std {
         -> @\seebelow@;
 
     template<class... SliceSpecifiers>
-      friend constexpr auto submdspan_mapping(
+      friend constexpr auto @\libmember{submdspan_mapping}{layout_stride::mapping}@(
         const mapping& src, SliceSpecifiers... slices) {
           return src.@\exposid{submdspan-mapping-impl}@(slices...);
       }
@@ -23278,7 +23278,7 @@ namespace std {
         -> @\seebelow@;
 
     template<class... SliceSpecifiers>
-      friend constexpr auto submdspan_mapping(const mapping& src, SliceSpecifiers... slices) {
+      friend constexpr auto @\libmember{submdspan_mapping}{layout_left_padded::mapping}@(const mapping& src, SliceSpecifiers... slices) {
       return src.@\exposid{submdspan-mapping-impl}@(slices...);
     }
   };
@@ -23913,7 +23913,7 @@ namespace std {
         -> @\seebelow@;
 
     template<class... SliceSpecifiers>
-      friend constexpr auto submdspan_mapping(const mapping& src, SliceSpecifiers... slices) {
+      friend constexpr auto @\libmember{submdspan_mapping}{layout_right_padded::mapping}@(const mapping& src, SliceSpecifiers... slices) {
       return src.@\exposid{submdspan-mapping-impl}@(slices...);
     }
   };
@@ -26013,6 +26013,7 @@ Let:
 \end{itemize}
 
 \pnum
+\indexlibraryglobal{submdspan_mapping}%
 For the purpose of this section,
 the meaning of \tcode{submdspan_mapping} is established
 as if by performing argument-dependent lookup only\iref{basic.lookup.argdep}.


### PR DESCRIPTION
Fixes #8792.

Avoid `<PaddingValue>` in indexing because we're already using `layout_{left,right}_padded::mapping` in indices.