### PR TITLE
[dcl.struct.bind] Fix tuple-like binding index to use SB_i instead of v_i

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -7724,7 +7724,7 @@ shall be a well-formed integral constant expression
 whose value is non-negative;
 the structured binding size of \tcode{E} is equal to that value.
 Let \tcode{i} be an index prvalue of type \tcode{std::size_t}
-corresponding to $\tcode{v}_i$.
+corresponding to $\textrm{SB}_i$.
 If a search for the name \tcode{get}
 in the scope of \tcode{E}\iref{class.member.lookup}
 finds at least one declaration


### PR DESCRIPTION
P1061R10 introduced the SB<sub>i</sub> notation for post-expansion structured bindings but this sentence in p7 (tuple-like case) was not updated. The rest of the section (p6, p8, and the end of this same paragraph) already uses SB<sub>i</sub>.

See [std-discussion thread](https://lists.isocpp.org/std-discussion/2026/03/3312.php).