### PR TITLE
[pairs.pair, variant.ctor, tuple.cnstr] Only functions can be "constexpr-suitable"

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -825,7 +825,7 @@ throws an exception.
 The defaulted move and copy constructor, respectively, of \tcode{pair}
 is a constexpr function if and only if all required element-wise
 initializations for move and copy, respectively,
-would be constexpr-suitable\iref{dcl.constexpr}.
+would satisfy the requirements for a constexpr function.
 
 \pnum
 If \tcode{(is_trivially_destructible_v<T1> \&\& is_trivially_destructible_v<T2>)}
@@ -1815,7 +1815,7 @@ one of the types in \tcode{Types} throws an exception.
 The defaulted move and copy constructor, respectively, of
 \tcode{tuple} is a constexpr function if and only if all
 required element-wise initializations for move and copy, respectively,
-would be constexpr-suitable\iref{dcl.constexpr}.
+would satisfy the requirements for a constexpr function.
 The defaulted move and copy constructor of \tcode{tuple<>} are
 constexpr functions.
 
@@ -5900,9 +5900,9 @@ Any exception thrown by the value-initialization of $\tcode{T}_0$.
 
 \pnum
 \remarks
-This function is \keyword{constexpr} if and only if the
+This constructor is a constexpr function if and only if the
 value-initialization of the alternative type $\tcode{T}_0$
-would be constexpr-suitable\iref{dcl.constexpr}.
+would satisfy the requirements for a constexpr function.
 The exception specification is equivalent to
 \tcode{is_nothrow_default_constructible_v<$\tcode{T}_0$>}.
 \begin{note}


### PR DESCRIPTION
[[variant.ctor]/6](https://eel.is/c++draft/variant.ctor#6.sentence-1) currently has—

> `constexpr variant() noexcept(see below);`
>
> _Remarks:_ This function is `constexpr` if and only if the value-initialization of the alternative type `T_0` would be [constexpr-suitable](https://eel.is/c++draft/dcl.constexpr#3.sentence-1).

First glance: `constexpr` should not be in teletype font. We don't mean that this constructor is `constexpr`; we mean that this constructor is a [constexpr function](https://eel.is/c++draft/dcl.constexpr#def:specifier,constexpr,function) ([dcl.constexpr]/2).

Second glance: The only way for a function to be anything *but* [constexpr-suitable](https://eel.is/c++draft/dcl.constexpr#def:constexpr-suitable) is for it to be a coroutine. I don't think the value-initialization of `T_0` can be a coroutine. Therefore the whole "if and only if" predicate can be eliminated. Which leaves only "This function is constexpr," which is obvious from the declaration (in that [it uses the `constexpr` keyword](https://eel.is/c++draft/dcl.constexpr#2)).

Third glance: Actually it is a category error to talk about an "initialization" being "constexpr-suitable." A *function* (i.e. an entity) can be constexpr-suitable; it is not meaningful to talk about an *initialization* (nor an *expression*) being constexpr-suitable. So even if the sentence weren't redundant it would still fail to "type-check."

My initial suggestion: The function is already declared `constexpr`. Strike the _Remarks._

However, looking at the history, it looks like this wording got into its current state as a result of [commit 79aef519](https://github.com/cplusplus/draft/commit/79aef51943810dcf14654490fb6101bbc9e4a0f9) — which was just wrong — but the previous wording was clearly there to deal with the longstanding open question of how LWG is supposed to specify that a particular function call is "constexpr-friendly." We want to mandate that `std::variant<std::string> v;` must be constexpr-friendly, while `std::variant<std::regex> v;` is not (as of C++26) constexpr-friendly. To completely strike these sentences would probably be worse than the status quo, in that department.

Therefore this proposed change starts by merely reverting commit 79aef51943810dcf14654490fb6101bbc9e4a0f9 to get rid of the incorrect use of "constexpr-suitable," and then additionally un-teletypes the word `constexpr` in "is a `constexpr` function." (That was the last place it's teletyped anymore, after #6620.)
