### PR TITLE
[expr.static.cast] Use "values of the enumeration"

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4815,8 +4815,8 @@ if necessary, and
 then to the enumeration type.
 If the enumeration type does not have a fixed underlying type,
 the value is unchanged
-if the original value is within the range
-of the enumeration values\iref{dcl.enum}, and
+if the original value is one of
+the values of the enumeration\iref{dcl.enum}, and
 otherwise, the behavior is undefined.
 A value of floating-point type can also be explicitly converted to an enumeration type.
 The resulting value is the same as converting the original value to the

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4961,8 +4961,8 @@ if necessary, and
 then to the enumeration type.
 If the enumeration type does not have a fixed underlying type,
 the value is unchanged
-if the original value is within the range
-of the enumeration values\iref{dcl.enum}, and
+if the original value is one of
+the values of the enumeration\iref{dcl.enum}, and
 otherwise, the behavior is undefined\ubdef{expr.static.cast.enum.outside.range}.
 A value of floating-point type can also be explicitly converted to an enumeration type.
 The resulting value is the same as converting the original value to the


### PR DESCRIPTION
In [dcl.enum], we introduce "the values of the enumeration" but not "the range of the enumeration values". It's probably better to use the exactly introduced phrase.

Fixes #8784.