### PR TITLE
[iostream.forward.overview] Fix description for typedef-names, mention `basic_spanbuf` and its friends

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -408,9 +408,8 @@ is not the same type as
 \end{note}
 
 \pnum
-Other \grammarterm{typedef-name}{s} define instances of
-class templates
-specialized for
+Other \grammarterm{typedef-name}{s} designate
+class template specializations for
 \tcode{char}
 or
 \keyword{wchar_t}


### PR DESCRIPTION
It's arguably wrong to say "define" because these typedef-names don't cause anything to be defined. Perhaps we should say that they designate class template specializations.

Fixes #8378.