### PR TITLE
[lib] Fix indexing for certain operators

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -3071,7 +3071,7 @@ the \tcode{exception_ptr} error completion signature from the set.
 
 \rSec3[exec.adapt.obj]{Closure objects}
 
-\indexlibrarymisc{\idxcode{operator|}}{pipeable sender adaptor closure objects}%
+\indexlibrarymisc{\idxcode{operator"|}}{pipeable sender adaptor closure objects}%
 \pnum
 A \defnadj{pipeable}{sender adaptor closure object} is a function object
 that accepts one or more \libconcept{sender} arguments and returns a \libconcept{sender}.

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -17591,7 +17591,7 @@ Every type in the parameter pack \tcode{Flags} is one of \tcode{\exposid{convert
 
 \rSec3[simd.flags.oper]{\tcode{flags} operators}
 
-\indexlibrarymember{operator|}{simd::flags}
+\indexlibrarymember{operator"|}{simd::flags}
 \begin{itemdecl}
 template<class... Other>
   friend consteval auto operator|(flags a, flags<Other...> b);
@@ -18388,7 +18388,7 @@ Decrements every element by one.
 A copy of \tcode{*this} before decrementing.
 \end{itemdescr}
 
-\indexlibrarymember{operator!}{basic_vec}
+\indexlibrarymember{operator"!}{basic_vec}
 \begin{itemdecl}
 constexpr mask_type operator!() const noexcept;
 \end{itemdecl}
@@ -18404,7 +18404,7 @@ A \tcode{basic_mask} object with the $i^\text{th}$ element set to
 \tcode{!operator[]($i$)} for all $i$ in the range of \range{0}{size()}.
 \end{itemdescr}
 
-\indexlibrarymember{operator~}{basic_vec}
+\indexlibrarymember{operator\~{}}{basic_vec}
 \begin{itemdecl}
 constexpr basic_vec operator~() const noexcept;
 \end{itemdecl}
@@ -18461,7 +18461,7 @@ A \tcode{basic_vec} object where the $i^\text{th}$ element is initialized to
 \indexlibrarymember{operator/}{basic_vec}
 \indexlibrarymember{operator\%}{basic_vec}
 \indexlibrarymember{operator\&}{basic_vec}
-\indexlibrarymember{operator|}{basic_vec}
+\indexlibrarymember{operator"|}{basic_vec}
 \indexlibrarymember{operator\caret}{basic_vec}
 \indexlibrarymember{operator<<}{basic_vec}
 \indexlibrarymember{operator>>}{basic_vec}
@@ -18525,7 +18525,7 @@ $i$ in the range of \range{0}{size()}.
 \indexlibrarymember{operator/=}{basic_vec}
 \indexlibrarymember{operator\%=}{basic_vec}
 \indexlibrarymember{operator\&=}{basic_vec}
-\indexlibrarymember{operator|=}{basic_vec}
+\indexlibrarymember{operator"|=}{basic_vec}
 \indexlibrarymember{operator\caret=}{basic_vec}
 \indexlibrarymember{operator<<=}{basic_vec}
 \indexlibrarymember{operator>>=}{basic_vec}
@@ -18585,7 +18585,7 @@ Equivalent to: \tcode{return operator \placeholder{op} (lhs, basic_vec(n));}
 \rSec3[simd.comparison]{Comparison operators}
 
 \indexlibrarymember{operator==}{basic_vec}
-\indexlibrarymember{operator!=}{basic_vec}
+\indexlibrarymember{operator"!=}{basic_vec}
 \indexlibrarymember{operator>=}{basic_vec}
 \indexlibrarymember{operator<=}{basic_vec}
 \indexlibrarymember{operator>}{basic_vec}
@@ -20619,10 +20619,10 @@ Equivalent to: \tcode{return permute(*this, indices);}
 
 \rSec3[simd.mask.unary]{Unary operators}
 
-\indexlibrarymember{operator!}{basic_mask}
+\indexlibrarymember{operator"!}{basic_mask}
 \indexlibrarymember{operator+}{basic_mask}
 \indexlibrarymember{operator-}{basic_mask}
-\indexlibrarymember{operator~}{basic_mask}
+\indexlibrarymember{operator\~{}}{basic_mask}
 \begin{itemdecl}
 constexpr basic_mask operator!() const noexcept;
 constexpr @\seebelow@ operator+() const noexcept;
@@ -20713,9 +20713,9 @@ Nothing.
 \rSec3[simd.mask.binary]{Binary operators}
 
 \indexlibrarymember{operator\&\&}{basic_mask}
-\indexlibrarymember{operator||}{basic_mask}
+\indexlibrarymember{operator"|"|}{basic_mask}
 \indexlibrarymember{operator\&}{basic_mask}
-\indexlibrarymember{operator|}{basic_mask}
+\indexlibrarymember{operator"|}{basic_mask}
 \indexlibrarymember{operator\caret}{basic_mask}
 \begin{itemdecl}
 friend constexpr basic_mask
@@ -20744,7 +20744,7 @@ operation.
 \rSec3[simd.mask.cassign]{Compound assignment}
 
 \indexlibrarymember{operator\&=}{basic_mask}
-\indexlibrarymember{operator|=}{basic_mask}
+\indexlibrarymember{operator"|=}{basic_mask}
 \indexlibrarymember{operator\caret=}{basic_mask}
 \begin{itemdecl}
 friend constexpr basic_mask&
@@ -20772,7 +20772,7 @@ binary element-wise operation.
 \rSec3[simd.mask.comparison]{Comparisons}
 
 \indexlibrarymember{operator==}{basic_mask}
-\indexlibrarymember{operator!=}{basic_mask}
+\indexlibrarymember{operator"!=}{basic_mask}
 \indexlibrarymember{operator>=}{basic_mask}
 \indexlibrarymember{operator<=}{basic_mask}
 \indexlibrarymember{operator<}{basic_mask}

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -4213,7 +4213,7 @@ assert(ranges::equal(ints | views::filter(even), views::filter(ints, even)));
 
 \rSec2[range.adaptor.object]{Range adaptor objects}
 
-\indexlibrarymisc{\idxcode{operator|}}{range adaptor closure objects}%
+\indexlibrarymisc{\idxcode{operator"|}}{range adaptor closure objects}%
 \pnum
 A \defnadj{range adaptor closure}{object} is a unary function object that accepts
 a range argument. For


### PR DESCRIPTION
Some operator functions were not properly indexed previously due to the weirdness of LaTeX. They need to be escaped for indexing.

- `operator!` -> `operator"!`
- `operator!=` -> `operator"!=`
- `operator~` -> `operator\~{}`
- `operator|` -> `operator"|`
- `operator||` -> `operator"|"|`
- `operator|=` -> `operator"|=`