### PR TITLE
[expr.dynamic.cast] Replace "runtime check" with "dynamic check"

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4517,12 +4517,12 @@ the behavior is undefined.
 \pnum
 If \tcode{T} is ``pointer to \cv{} \keyword{void}'', then the result
 is a pointer to the most derived object pointed to by \tcode{v}.
-Otherwise, a runtime check is applied to see if the object pointed or
+Otherwise, a dynamic check is applied to see if the object pointed or
 referred to by \tcode{v} can be converted to the type pointed or
 referred to by \tcode{T}.
 
 \pnum
-Let \tcode{C} be the class type to which \tcode{T} points or refers. The runtime
+Let \tcode{C} be the class type to which \tcode{T} points or refers. The dynamic
 check logically executes as follows:
 
 \begin{itemize}
@@ -4539,7 +4539,7 @@ and public, the result points (refers) to the
 \tcode{C} subobject of the most derived object.
 
 \item Otherwise, the
-runtime check \term{fails}.
+dynamic check \term{fails}.
 \end{itemize}
 
 \pnum
@@ -4563,7 +4563,7 @@ void g() {
   ap = dynamic_cast<A*>(bp);        // fails
   bp = dynamic_cast<B*>(ap);        // fails
   ap = dynamic_cast<A*>(&d);        // succeeds
-  bp = dynamic_cast<B*>(&d);        // ill-formed (not a runtime check)
+  bp = dynamic_cast<B*>(&d);        // ill-formed (not a dynamic check)
 }
 
 class E : public D, public B { };

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4663,13 +4663,13 @@ the behavior is undefined\ubdef{expr.dynamic.cast.glvalue.lifetime}.
 \pnum
 If \tcode{T} is ``pointer to \cv{} \keyword{void}'', then the result
 is a pointer to the most derived object pointed to by \tcode{v}.
-Otherwise, a runtime check is applied to see if the object pointed or
+Otherwise, a dynamic check is applied to see if the object pointed or
 referred to by \tcode{v} can be converted to the type pointed or
 referred to by \tcode{T}.
 
 \pnum
-Let \tcode{C} be the class type to which \tcode{T} points or refers. The runtime
-check logically executes as follows:
+Let \tcode{C} be the class type to which \tcode{T} points or refers.
+The dynamic check logically executes as follows:
 
 \begin{itemize}
 \item If, in the most derived object pointed (referred) to by \tcode{v},
@@ -4685,7 +4685,7 @@ and public, the result points (refers) to the
 \tcode{C} subobject of the most derived object.
 
 \item Otherwise, the
-runtime check \term{fails}.
+dynamic check \term{fails}.
 \end{itemize}
 
 \pnum
@@ -4709,7 +4709,7 @@ void g() {
   ap = dynamic_cast<A*>(bp);        // fails
   bp = dynamic_cast<B*>(ap);        // fails
   ap = dynamic_cast<A*>(&d);        // succeeds
-  bp = dynamic_cast<B*>(&d);        // ill-formed (not a runtime check)
+  bp = dynamic_cast<B*>(&d);        // ill-formed (not a dynamic check)
 }
 
 class E : public D, public B { };


### PR DESCRIPTION
Since C++20, such check can happen in constant evaluation, so it's no longer correct to call it "runtime check". This PR changes the phrase to "dynamic check", which is consistent with
- the "dynamic" in `dynamic_cast`, and
- P3953R3 - renaming `runtime_format` to `dynamic_format`.

Also slightly tweaks semantic line break as drive-by.

Fixes #6799.