### PR TITLE
Refine cross references into [expr.const]

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -13510,7 +13510,7 @@ and \tcode{x == numeric_limits<T>::min() \&\& y == -1} is \tcode{true},
 \remarks
 A function call expression
 that violates the precondition in the \Fundescx{Preconditions} element
-is not a core constant expression\iref{expr.const}.
+is not a core constant expression\iref{expr.const.core}.
 \end{itemdescr}
 
 \rSec3[numeric.sat.cast]{Casting}

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -498,7 +498,7 @@ is \defnx{odr-used}{odr-use} by $N$ unless
 \begin{itemize}
 \item
 \tcode{x} is a reference
-that is usable in constant expressions at $P$\iref{expr.const}, or
+that is usable in constant expressions at $P$\iref{expr.const.init}, or
 \item
 $N$ is an element of the set of potential results of an expression $E$, where
 \begin{itemize}
@@ -739,7 +739,7 @@ defined\iref{class.derived}, or
 
 \pnum
 If a definable item \tcode{D} is defined in a translation unit
-by an injected declaration $X$\iref{expr.const} and
+by an injected declaration $X$\iref{expr.const.reflect} and
 another translation unit contains a definition of \tcode{D},
 that definition shall be an injected declaration
 having the same characteristic sequence as $X$;
@@ -781,7 +781,7 @@ template specializations\iref{temp.spec.partial.match}, except that a name can r
 a non-volatile const object with internal or no linkage if the object
 \begin{itemize}
 \item has the same literal type in all definitions of \tcode{D},
-\item is initialized with a constant expression\iref{expr.const},
+\item is initialized with a constant expression\iref{expr.const.const},
 \item is not odr-used in any definition of \tcode{D}, and
 \item has the same value in all definitions of \tcode{D},
 \end{itemize}
@@ -2834,7 +2834,7 @@ only namespace names are considered.%
 \pnum
 The \grammarterm{constant-expression} of a \grammarterm{splice-specifier}
 shall be a converted constant expression of
-type \tcode{std::meta::info}\iref{expr.const}.
+type \tcode{std::meta::info}\iref{expr.const.const}.
 A \grammarterm{splice-specifier}
 whose converted \grammarterm{constant-expression} represents
 a construct $X$ is said to \defn{designate} either
@@ -3171,7 +3171,7 @@ $D$ contains
 a \grammarterm{reflect-expression} or a \grammarterm{splice-specifier}
 that, respectively, represents or designates $E$,
 \item
-$D$ is an injected declaration\iref{expr.const}
+$D$ is an injected declaration\iref{expr.const.reflect}
 whose characteristic sequence contains a reflection
 that represents
 a data member description ($T$, $N$, $A$, $W$, $\mathit{NUA}$)\iref{class.mem.general}
@@ -5351,7 +5351,7 @@ an object whose lifetime begins and ends
 during the evaluation of a core constant expression.
 \end{itemize}
 Every function of consteval-only type shall be
-an immediate function\iref{expr.const}.
+an immediate function\iref{expr.const.imm}.
 
 \rSec2[basic.fundamental]{Fundamental types}
 
@@ -6368,9 +6368,9 @@ A \defn{full-expression} is
 \item
 an unevaluated operand\iref{expr.context},
 \item
-a \grammarterm{constant-expression}\iref{expr.const},
+a \grammarterm{constant-expression}\iref{expr.const.core},
 \item
-an immediate invocation\iref{expr.const},
+an immediate invocation\iref{expr.const.imm},
 \item
 an \grammarterm{init-declarator}\iref{dcl.decl}
 (including such introduced by a structured binding\iref{dcl.struct.bind}) or
@@ -6437,7 +6437,7 @@ that defines the default argument.
 \indextext{value computation|(}%
 Reading an object designated by a \keyword{volatile} glvalue\iref{basic.lval},
 modifying an object,
-producing an injected declaration\iref{expr.const},
+producing an injected declaration\iref{expr.const.reflect},
 calling a library I/O function, or
 calling a function that does any of those operations
 are all \defn{side effects},
@@ -6617,7 +6617,7 @@ signal handler is usually unsequenced with respect to the rest of the program.
 
 \pnum
 During the evaluation of an expression
-as a core constant expression\iref{expr.const},
+as a core constant expression\iref{expr.const.core},
 evaluations of operands of individual operators and
 of subexpressions of individual expressions
 that are otherwise either unsequenced or indeterminately sequenced
@@ -7311,7 +7311,7 @@ Within each of these phases of initiation, initialization occurs as follows.
 \indextext{initialization!constant}%
 \defnx{Constant initialization}{constant initialization} is performed
 if a variable with static or thread storage duration
-is constant-initialized\iref{expr.const}.
+is constant-initialized\iref{expr.const.init}.
 \indextext{initialization!zero-initialization}%
 If constant initialization is not performed, a variable with static
 storage duration\iref{basic.stc.static} or thread storage
@@ -7562,7 +7562,7 @@ any object with static storage duration.
 
 \pnum
 The destruction of a complete object with thread storage duration within a given thread
-and having constant destruction\iref{expr.const}
+and having constant destruction\iref{expr.const.defns}
 is sequenced after the destruction of any other complete object
 with thread storage duration within the thread.
 The destruction of a complete object with static storage duration
@@ -7801,7 +7801,7 @@ exits via an exception, or
 \item
 the evaluation of the predicate
 is performed in a context that is
-manifestly constant-evaluated\iref{expr.const}
+manifestly constant-evaluated\iref{expr.const.defns}
 and the predicate
 is not a core constant expression.
 \end{itemize}
@@ -7822,7 +7822,7 @@ or terminating the program.
 \pnum
 \indexdefn{contract evaluation semantics!terminating}%
 If a contract violation occurs
-in a context that is manifestly constant-evaluated\iref{expr.const},
+in a context that is manifestly constant-evaluated\iref{expr.const.defns},
 and the evaluation semantic is
 a terminating semantic,
 the program is ill-formed.

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -717,7 +717,7 @@ specifies a \defn{default member initializer} for the member, and
 shall not directly or indirectly cause the implicit definition of a
 defaulted default constructor for the enclosing class or the
 exception specification of that constructor.
-An immediate invocation\iref{expr.const} that
+An immediate invocation\iref{expr.const.imm} that
 is a potentially-evaluated subexpression\iref{intro.execution}
 of a default member initializer
 is neither evaluated nor checked for whether it
@@ -2750,7 +2750,7 @@ of integral or enumeration type,
 its declaration in the class definition can specify a
 \grammarterm{brace-or-equal-initializer} in which every
 \grammarterm{initializer-clause} that is an \grammarterm{assignment-expression}
-is a constant expression\iref{expr.const}.
+is a constant expression\iref{expr.const.const}.
 The member shall still be defined in a namespace scope if
 it is odr-used\iref{term.odr.use} in the program and the
 namespace scope definition shall not contain an \grammarterm{initializer}.
@@ -6341,7 +6341,7 @@ always an lvalue.
 \end{itemize}
 Copy elision is not permitted
 where an expression is evaluated in a context
-requiring a constant expression\iref{expr.const}
+requiring a constant expression\iref{expr.const.const}
 and in constant initialization\iref{basic.start.static}.
 \begin{note}
 It is possible that copy elision is performed
@@ -6377,7 +6377,7 @@ constexpr A g() {
 }
 
 constexpr A a;          // well-formed, \tcode{a.p} points to \tcode{a}
-constexpr A b = g();    // error: \tcode{b.p} would be dangling\iref{expr.const}
+constexpr A b = g();    // error: \tcode{b.p} would be dangling\iref{expr.const.const}
 
 void h() {
   A c = g();            // well-formed, \tcode{c.p} can point to \tcode{c} or be dangling

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -22032,7 +22032,7 @@ M::is_always_unique()
 \begin{itemdescr}
 \pnum
 \result
-A constant expression\iref{expr.const} of type \tcode{bool}.
+A constant expression\iref{expr.const.const} of type \tcode{bool}.
 
 \pnum
 \returns
@@ -22052,7 +22052,7 @@ M::is_always_exhaustive()
 \begin{itemdescr}
 \pnum
 \result
-A constant expression\iref{expr.const} of type \tcode{bool}.
+A constant expression\iref{expr.const.const} of type \tcode{bool}.
 
 \pnum
 \returns
@@ -22072,7 +22072,7 @@ M::is_always_strided()
 \begin{itemdescr}
 \pnum
 \result
-A constant expression\iref{expr.const} of type \tcode{bool}.
+A constant expression\iref{expr.const.const} of type \tcode{bool}.
 
 \pnum
 \returns

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -328,7 +328,7 @@ implicitly convertible to the type ``pointer to \tcode{\keyword{const} \keyword{
 In a \grammarterm{static_assert-declaration},
 the \grammarterm{constant-expression} $E$
 is contextually converted to \keyword{bool} and
-the converted expression shall be a constant expression\iref{expr.const}.
+the converted expression shall be a constant expression\iref{expr.const.const}.
 If the value of the expression $E$ when so converted is \tcode{true} or
 the expression is evaluated in the context of a template definition,
 the declaration has no effect and
@@ -393,11 +393,11 @@ the expression $E$ corresponding to $D$ is:
 \begin{codeblock}
   [] static consteval -> void @\grammarterm{compound-statement}@ ()
 \end{codeblock}
-$E$ shall be a constant expression\iref{expr.const}.
+$E$ shall be a constant expression\iref{expr.const.const}.
 \begin{note}
 The evaluation of the expression
 corresponding to a \grammarterm{consteval-block-declaration}\iref{lex.phases}
-can produce injected declarations as side effects.
+can produce injected declarations\iref{expr.const.reflect} as side effects.
 \end{note}
 \begin{example}
 \begin{codeblock}
@@ -720,7 +720,7 @@ see~\ref{class.conv.ctor} and~\ref{class.conv.fct}.
 \pnum
 In an \grammarterm{explicit-specifier},
 the \grammarterm{constant-expression}, if supplied, shall be a
-contextually converted constant expression of type \tcode{bool}\iref{expr.const}.
+contextually converted constant expression of type \tcode{bool}\iref{expr.const.const}.
 The \grammarterm{explicit-specifier} \keyword{explicit}
 without a \grammarterm{constant-expression} is equivalent to
 the \grammarterm{explicit-specifier} \tcode{explicit(true)}.
@@ -918,7 +918,7 @@ constexpr pixel::pixel(int a)
   : x(a), y(x)                  // OK, definition
   { square(x); }
 constexpr pixel small(2);       // error: \tcode{square} not defined, so \tcode{small(2)}
-                                // not constant\iref{expr.const} so \keyword{constexpr} not satisfied
+                                // not constant\iref{expr.const.core} so \keyword{constexpr} not satisfied
 
 constexpr void square(int &x) { // OK, definition
   x *= x;
@@ -938,7 +938,7 @@ declares that function to be
 a \defnx{constexpr function}{specifier!\idxcode{constexpr}!function}.
 \begin{note}
 A function declared with the \keyword{consteval} specifier
-is an immediate function\iref{expr.const}.
+is an immediate function\iref{expr.const.imm}.
 \end{note}
 A destructor, an allocation function, or a deallocation function
 shall not be declared with the \keyword{consteval} specifier.
@@ -992,7 +992,7 @@ in all respects except that
 \begin{itemize}
 \item
 an invocation of a constexpr function
-can appear in a constant expression\iref{expr.const} and
+can appear in a constant expression\iref{expr.const.core} and
 \item
 copy elision is not performed in a constant expression\iref{class.copy.elision}.
 \end{itemize}
@@ -1026,7 +1026,7 @@ declares the object as const.
 Such an object
 shall have literal type and
 shall be initialized.
-A \keyword{constexpr} variable shall be constant-initializable\iref{expr.const}.
+A \keyword{constexpr} variable shall be constant-initializable\iref{expr.const.init}.
 A \keyword{constexpr} variable that is an object,
 as well as any temporary to which a \keyword{constexpr} reference is bound,
 shall have constant destruction.
@@ -1274,7 +1274,7 @@ these could be introduced by typedefs.
 \pnum
 \begin{note}
 Declaring a variable \keyword{const} can affect its linkage\iref{dcl.stc}
-and its usability in constant expressions\iref{expr.const}. As
+and its usability in constant expressions\iref{expr.const.init}. As
 described in~\ref{dcl.init}, the definition of an object or subobject
 of const-qualified type must specify an initializer or be subject to
 default-initialization.
@@ -1541,7 +1541,7 @@ shall denote a pack.
 
 \pnum
 The \grammarterm{constant-expression} shall be
-a converted constant expression\iref{expr.const} of type \tcode{std::size_t}
+a converted constant expression\iref{expr.const.const} of type \tcode{std::size_t}
 whose value $V$, termed the index,
 is such that $0 \le V < \tcode{sizeof...($P$)}$.
 
@@ -1755,7 +1755,7 @@ in~\ref{dcl.spec.auto}.
 
 \pnum
 If the operand of a \grammarterm{decltype-specifier} is a prvalue
-and is not a (possibly parenthesized) immediate invocation\iref{expr.const},
+and is not a (possibly parenthesized) immediate invocation\iref{expr.const.imm},
 the temporary materialization conversion is not applied\iref{conv.rval}
 and no result object is provided for the prvalue.
 The type of the prvalue may be incomplete or an abstract class type.
@@ -3470,7 +3470,7 @@ is ``\placeholder{derived-declarator-type-list} \tcode{T}'',
 the type of the \grammarterm{declarator-id} in \tcode{D} is
 ``\placeholder{derived-declarator-type-list} array of \tcode{N} \tcode{T}''.
 The \grammarterm{constant-expression}
-shall be a converted constant expression of type \tcode{std::size_t}\iref{expr.const}.
+shall be a converted constant expression of type \tcode{std::size_t}\iref{expr.const.const}.
 \indextext{bound, of array}%
 Its value \tcode{N} specifies the \defnx{array bound}{array!bound},
 i.e., the number of elements in the array;
@@ -4381,7 +4381,7 @@ copy-initialization semantics\iref{dcl.init}.
 The names in the
 default argument are looked up, and the semantic constraints are checked,
 at the point where the default argument appears, except that
-an immediate invocation\iref{expr.const} that
+an immediate invocation\iref{expr.const.imm} that
 is a potentially-evaluated subexpression\iref{intro.execution} of
 the \grammarterm{initializer-clause} in a \grammarterm{parameter-declaration} is
 neither evaluated
@@ -5412,7 +5412,7 @@ int c = b;
 \end{itemize}
 
 \pnum
-An immediate invocation\iref{expr.const} that is not evaluated where
+An immediate invocation\iref{expr.const.imm} that is not evaluated where
 it appears\iref{dcl.fct.default,class.mem.general}
 is evaluated and checked for whether it is
 a constant expression at the point where
@@ -7092,7 +7092,7 @@ while enabling a stable binary interface to an evolving code base.
 A non-user-provided defaulted function
 (i.e., implicitly declared or explicitly defaulted in the class)
 that is not defined as deleted is implicitly defined when it is odr-used\iref{basic.def.odr}
-or needed for constant evaluation\iref{expr.const}.
+or needed for constant evaluation\iref{expr.const.defns}.
 \begin{note}
 The implicit definition of a non-user-provided defaulted function
 does not bind any names.
@@ -7969,7 +7969,7 @@ prior to the closing brace is the underlying
 type
 and the \grammarterm{constant-expression} in the \grammarterm{enumerator-definition}
 shall be a converted constant expression of the underlying
-type\iref{expr.const}.
+type\iref{expr.const.const}.
 If the underlying
 type is not fixed,
 the type of each enumerator prior to the closing brace is determined as
@@ -7979,7 +7979,7 @@ follows:
 \item If an
 initializer is specified for an enumerator, the
 \grammarterm{constant-expression} shall be an integral constant
-expression\iref{expr.const}. If the expression has
+expression\iref{expr.const.const}. If the expression has
 unscoped enumeration type, the enumerator has the underlying type of that
 enumeration type, otherwise it has the same type as the expression.
 

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -781,7 +781,7 @@ as a suffix of a function declarator\iref{dcl.fct}.
 \indextext{exception specification!noexcept!constant expression and}%
 In a \grammarterm{noexcept-specifier}, the \grammarterm{constant-expression},
 if supplied, shall be a contextually converted constant expression
-of type \keyword{bool}\iref{expr.const};
+of type \keyword{bool}\iref{expr.const.const};
 that constant expression is the exception specification of
 the function type in which the \grammarterm{noexcept-specifier} appears.
 A \tcode{(} token that follows \keyword{noexcept} is part of the

--- a/source/exec.tex
+++ b/source/exec.tex
@@ -2226,7 +2226,7 @@ users may specialize \tcode{enable_sender} to
 model \libconcept{sender}, and
 \tcode{false} for types that do not.
 Such specializations shall
-be usable in constant expressions\iref{expr.const} and
+be usable in constant expressions\iref{expr.const.init} and
 have type \tcode{const bool}.
 
 \pnum

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2034,7 +2034,7 @@ shall be an \grammarterm{identifier} that denotes a pack.
 
 \pnum
 The \grammarterm{constant-expression} shall be
-a converted constant expression\iref{expr.const} of type \tcode{std::size_t}
+a converted constant expression\iref{expr.const.const} of type \tcode{std::size_t}
 whose value $V$, termed the index,
 is such that $0 \le V < \tcode{sizeof...($P$)}$.
 
@@ -5719,7 +5719,7 @@ The result of \keyword{sizeof} and \tcode{\keyword{sizeof}...} is a prvalue of t
 \tcode{std::size_t}.
 \begin{note}
 A \keyword{sizeof} expression
-is an integral constant expression\iref{expr.const}.
+is an integral constant expression\iref{expr.const.const}.
 The \grammarterm{typedef-name} \tcode{std::size_t} is declared in the standard header
 \libheader{cstddef}\iref{cstddef.syn,support.types.layout}.
 \end{note}
@@ -5738,7 +5738,7 @@ to one of those types.
 The result is a prvalue of type \tcode{std::size_t}.
 \begin{note}
 An \keyword{alignof} expression
-is an integral constant expression\iref{expr.const}.
+is an integral constant expression\iref{expr.const.const}.
 The \grammarterm{typedef-name} \tcode{std::size_t} is declared in the standard header
 \libheader{cstddef}\iref{cstddef.syn,support.types.layout}.
 \end{note}
@@ -5772,7 +5772,7 @@ the full-expression of the operand is potentially-throwing\iref{except.spec}, an
 \tcode{true} otherwise.
 \begin{note}
 A \grammarterm{noexcept-expression}
-is an integral constant expression\iref{expr.const}.
+is an integral constant expression\iref{expr.const.const}.
 \end{note}
 \indextext{expression!unary|)}
 
@@ -5916,7 +5916,7 @@ to the associated array type.
 \pnum
 Every \grammarterm{constant-expression} in a
 \grammarterm{noptr-new-declarator} shall be a converted constant
-expression\iref{expr.const} of type \tcode{std::size_t} and
+expression\iref{expr.const.const} of type \tcode{std::size_t} and
 its value shall be greater than zero.
 \begin{example}
 Given the definition \tcode{int n = 42},
@@ -6097,7 +6097,7 @@ the allocation of another \grammarterm{new-expression}.
 
 \pnum
 During an evaluation of a constant expression,
-a call to a replaceable allocation function is always omitted\iref{expr.const}.
+a call to a replaceable allocation function is always omitted\iref{expr.const.core}.
 
 \pnum
 The implementation may

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -213,7 +213,7 @@ constructs that it does not support.
 \definition{constant evaluation}{defns.const.eval}
 \indexdefn{constant evaluation}%
 evaluation that is performed as part of evaluating an expression
-as a core constant expression\iref{expr.const}
+as a core constant expression\iref{expr.const.core}
 
 \definition{constant subexpression}{defns.const.subexpr}
 \indexdefn{constant subexpression}%
@@ -265,7 +265,7 @@ well-defined behavior that the implementation is recommended to diagnose
 Erroneous behavior is always the consequence of incorrect program code.
 Implementations are allowed, but not required,
 to diagnose it\iref{intro.compliance.general}.
-Evaluation of a constant expression\iref{expr.const}
+Evaluation of a constant expression\iref{expr.const.core}
 never exhibits behavior specified as erroneous in \ref{intro} through \ref{\lastcorechapter}.
 \end{defnote}
 
@@ -525,7 +525,7 @@ During constant evaluation,
 it is
 \impldef{whether runtime-undefined behavior results in the expression being deemed non-constant}
 whether runtime-undefined behavior results in the expression being deemed non-constant
-(as specified in~\ref{expr.const}) and
+(as specified in~\ref{expr.const.core}) and
 \item
 runtime-undefined behavior has no other effect.
 \end{itemize}
@@ -670,7 +670,7 @@ characteristic of the environment (with or without the issuance of a
 \termref{defns.diagnostic}{diagnostic message}{}), to terminating a translation or execution (with the
 issuance of a diagnostic message). Many incorrect program constructs do
 not engender undefined behavior; they are required to be diagnosed.
-Evaluation of a constant expression\iref{expr.const} never exhibits behavior explicitly
+Evaluation of a constant expression\iref{expr.const.core} never exhibits behavior explicitly
 specified as undefined in \ref{intro} through \ref{\lastcorechapter}.
 \end{defnote}
 
@@ -782,7 +782,7 @@ the implementation does not support that construct, or
 \item
 a contract assertion\iref{basic.contract.eval}
 evaluated with a checking semantic
-in a manifestly constant-evaluated context\iref{expr.const}
+in a manifestly constant-evaluated context\iref{expr.const.defns}
 resulting in a contract violation,
 \end{itemize}
 a conforming implementation
@@ -805,7 +805,7 @@ a translation unit with
 a \grammarterm{static_assert-declaration} that fails\iref{dcl.pre}, or
 \item
 a contract assertion evaluated with a terminating semantic\iref{basic.contract.eval}
-in a manifestly constant-evaluated context\iref{expr.const}
+in a manifestly constant-evaluated context\iref{expr.const.defns}
 resulting in a contract violation.
 \end{itemize}
 

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -1752,7 +1752,7 @@ users may specialize \tcode{disable_sized_sentinel_for}
 for cv-unqualified non-array object types \tcode{S} and \tcode{I}
 if \tcode{S} and/or \tcode{I} is a program-defined type.
 Such specializations shall
-be usable in constant expressions\iref{expr.const} and
+be usable in constant expressions\iref{expr.const.init} and
 have type \tcode{const bool}.
 
 \pnum
@@ -6591,7 +6591,7 @@ Constructs the end-of-stream iterator, value-initializing \tcode{value}.
 \pnum
 \remarks
 If the initializer \tcode{T()} in the declaration \tcode{auto x = T();}
-is a constant initializer\iref{expr.const},
+is a constant initializer\iref{expr.const.init},
 then these constructors are \keyword{constexpr} constructors.
 \end{itemdescr}
 

--- a/source/limits.tex
+++ b/source/limits.tex
@@ -111,7 +111,7 @@ Nested \grammarterm{linkage-specification}s\iref{dcl.link} [1\,024].
 \item%
 Recursive constexpr function invocations\iref{dcl.constexpr} [512].
 \item%
-Full-expressions evaluated within a core constant expression\iref{expr.const} [1\,048\,576].
+Full-expressions evaluated within a core constant expression\iref{expr.const.core} [1\,048\,576].
 \item%
 Template parameters in a template declaration\iref{temp.param} [1\,024].
 \item%

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -871,7 +871,7 @@ namespace std {
 \pnum
 The class template \tcode{constant_wrapper} aids in metaprogramming by ensuring
 that the evaluation of expressions comprised entirely of \tcode{constant_wrapper}
-are core constant expressions\iref{expr.const},
+are core constant expressions\iref{expr.const.core},
 regardless of the context in which they appear.
 In particular, this enables use of \tcode{constant_wrapper} values
 that are passed as arguments to constexpr functions to be used in constant expressions.
@@ -3352,7 +3352,7 @@ consteval bool is_string_literal(const char32_t* p);
 \returns
 \begin{itemize}
 \item
-  If \tcode{p} points to an unspecified object\iref{expr.const},
+  If \tcode{p} points to an unspecified object\iref{expr.const.core},
   \tcode{false}.
 \item
   Otherwise, if \tcode{p} points to a subobject
@@ -4085,7 +4085,7 @@ consteval info object_of(info r);
   and if that variable is a reference $R$, then either
   \begin{itemize}
   \item
-    $R$ is usable in constant expressions\iref{expr.const}, or
+    $R$ is usable in constant expressions\iref{expr.const.init}, or
   \item
     the lifetime of $R$ began within the core constant expression
     currently under evaluation.
@@ -5986,7 +5986,7 @@ Let $E$ be
 \returns
 A \tcode{vector} containing all of the reflections $R$
 representing each annotation applying to each declaration of $E$ that precedes either
-some point in the evaluation context\iref{expr.const} or
+some point in the evaluation context\iref{expr.const.reflect} or
 a point immediately following the \grammarterm{class-specifier}
 of the outermost class for which such a point is in a complete-class context.
 For any two reflections $R_1$ and $R_2$ in the returned \tcode{vector},
@@ -6679,7 +6679,7 @@ the corresponding data member description represented by $r_K$.
 
 \pnum
 \effects
-Produces an injected declaration $D$\iref{expr.const}
+Produces an injected declaration $D$\iref{expr.const.reflect}
 that defines $C$ and has properties as follows:
 \begin{itemize}
 \item
@@ -6690,7 +6690,7 @@ that defines $C$ and has properties as follows:
   follows immediately after the core constant expression
   currently under evaluation.
 \item
-  The characteristic sequence of $D$\iref{expr.const}
+  The characteristic sequence of $D$\iref{expr.const.reflect}
   is the sequence of reflection values $r_K$.
 \item
   If $C$ is a specialization of a templated class $T$,

--- a/source/modules.tex
+++ b/source/modules.tex
@@ -921,7 +921,7 @@ During the implicit instantiation of any construct
 that resulted from the evaluation of an expression
 as a core constant expression,
 the instantiation context contains
-each point in the evaluation context\iref{expr.const}.
+each point in the evaluation context\iref{expr.const.reflect}.
 \begin{note}
 Implicit instantiations can result
 from invocations of library functions\iref{meta.reflection}.

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -20145,7 +20145,7 @@ the result of \tcode{std::bit_ceil(v[$i$])} for all $i$ in the range
 \pnum
 \remarks
 A function call expression that violates the precondition in the \expects
-element is not a core constant expression\iref{expr.const}.
+element is not a core constant expression\iref{expr.const.core}.
 \end{itemdescr}
 
 \indexlibrarymember{bit_floor}{simd}

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -574,7 +574,7 @@ Therefore it is not subject to this replacement.
 
 \pnum
 The resulting tokens comprise the controlling constant expression
-which is evaluated according to the rules of~\ref{expr.const}
+which is evaluated according to the rules of~\ref{expr.const.core}
 using arithmetic that has at least the ranges specified
 in~\ref{support.limits}. For the purposes of this token conversion and evaluation
 all signed and unsigned integer types

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -1409,7 +1409,7 @@ template<class>
 Pursuant to \ref{namespace.std}, users may specialize \tcode{enable_borrowed_range}
 for cv-unqualified program-defined types.
 Such specializations shall be
-usable in constant expressions\iref{expr.const} and
+usable in constant expressions\iref{expr.const.init} and
 have type \tcode{const bool}.
 
 \pnum
@@ -1518,7 +1518,7 @@ Pursuant to \ref{namespace.std},
 users may specialize \tcode{disable_sized_range}
 for cv-unqualified program-defined types.
 Such specializations shall
-be usable in constant expressions\iref{expr.const} and
+be usable in constant expressions\iref{expr.const.init} and
 have type \tcode{const bool}.
 
 \pnum
@@ -1623,7 +1623,7 @@ to \tcode{true}
 for cv-unqualified program-defined types that model \libconcept{view},
 and \tcode{false} for types that do not.
 Such specializations shall
-be usable in constant expressions\iref{expr.const} and
+be usable in constant expressions\iref{expr.const.init} and
 have type \tcode{const bool}.
 \end{itemdescr}
 

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -320,7 +320,7 @@ In other words, the \keyword{else} is associated with the nearest un-elsed
 If the \keyword{if} statement is of the form \tcode{if constexpr},
 the value of the condition
 is contextually converted to \keyword{bool} and
-the converted expression shall be a constant expression\iref{expr.const};
+the converted expression shall be a constant expression\iref{expr.const.const};
 this
 form is called a \defn{constexpr if} statement. If the value of the
 converted condition is \tcode{false}, the first substatement is a
@@ -405,7 +405,7 @@ constexpr void f(bool b) {
 
 \pnum
 If a consteval if statement is evaluated in a context
-that is manifestly constant-evaluated\iref{expr.const},
+that is manifestly constant-evaluated\iref{expr.const.defns},
 the first substatement is executed.
 \begin{note}
 The first substatement is an immediate function context.
@@ -461,7 +461,7 @@ more case labels as follows:
 \keyword{case} constant-expression \terminal{:}
 \end{ncbnf}
 where the \grammarterm{constant-expression} shall be
-a converted constant expression\iref{expr.const} of the
+a converted constant expression\iref{expr.const.const} of the
 adjusted type of the switch condition. No two of the case constants in
 the same switch shall have the same value after conversion.
 
@@ -584,7 +584,7 @@ a \tcode{while}, \tcode{do}, or \tcode{for} statement
 (or \tcode{true}, if the \tcode{for} statement has no \grammarterm{expression}).
 A \defnadj{trivial infinite}{loop} is a trivially empty iteration statement
 for which the converted controlling expression is a constant expression,
-when interpreted as a \grammarterm{constant-expression}\iref{expr.const}, and
+when interpreted as a \grammarterm{constant-expression}\iref{expr.const.const}, and
 evaluates to \tcode{true}.
 The \grammarterm{statement} of a trivial infinite loop is replaced with
 a call to the function \tcode{std::this_thread::yield}\iref{thread.thread.this};
@@ -902,7 +902,7 @@ the program is ill-formed if
 \tcode{\placeholder{i}} is not representable as such a value.
 \begin{note}
 The instantiation is ill-formed if \exposid{range}
-is not a constant expression\iref{expr.const}.
+is not a constant expression\iref{expr.const.const}.
 \end{note}
 
 \item

--- a/source/support.tex
+++ b/source/support.tex
@@ -5703,7 +5703,7 @@ of a template instantiation.
 \pnum
 There is an \impldef{total ordering of all types} total ordering of all types.
 For any (possibly incomplete) types \tcode{X} and \tcode{Y},
-the expression \tcode{\exposid{TYPE-ORDER}(X, Y)} is a constant expression\iref{expr.const}
+the expression \tcode{\exposid{TYPE-ORDER}(X, Y)} is a constant expression\iref{expr.const.const}
 of type \tcode{strong_ordering}\iref{cmp.strongord}.
 Its value is \tcode{strong_ordering::less} if \tcode{X} precedes \tcode{Y}
 in this implementation-defined total order,

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -1320,7 +1320,7 @@ of (possibly deduced) type \tcode{T}
 is determined from its template argument $A$ as follows.
 If \tcode{T} is not a class type and
 $A$ is not a \grammarterm{braced-init-list},
-$A$ shall be a converted constant expression\iref{expr.const}
+$A$ shall be a converted constant expression\iref{expr.const.const}
 of type \tcode{T}; the value of $P$ is $A$ (as converted).
 
 \pnum
@@ -1349,7 +1349,7 @@ the initialization would be ill-formed, or
 \item
 the full-expression of an invented \grammarterm{init-declarator}
 for the initialization would not be a constant expression
-when interpreted as a \grammarterm{constant-expression}\iref{expr.const}, or
+when interpreted as a \grammarterm{constant-expression}\iref{expr.const.const}, or
 \item
 the initialization would cause $P$ to not be template-argument-equivalent\iref{temp.type} to \tcode{v},
 \end{itemize}
@@ -5130,7 +5130,7 @@ was a pack expansion and the corresponding pack is empty, or
 \item an instantiation uses a default argument or default template argument
 that had not been defined at the point at which the template was defined, or
 
-\item constant expression evaluation\iref{expr.const} within the template
+\item constant expression evaluation\iref{expr.const.core} within the template
 instantiation uses
   \begin{itemize}
   \item the value of a const object of integral or unscoped enumeration type or
@@ -5361,7 +5361,7 @@ An expression may be
 \defnx{type-dependent}{expression!type-dependent}
 (that is, its type may depend on a template parameter) or
 \defnx{value-dependent}{expression!value-dependent}
-(that is, its value when evaluated as a constant expression\iref{expr.const}
+(that is, its value when evaluated as a constant expression\iref{expr.const.const}
 may depend on a template parameter)
 as described below.
 
@@ -5953,7 +5953,7 @@ instantiation and is not initialized in a \grammarterm{member-declarator},
 it names a static member function that is a dependent member of the current
 instantiation, or
 \item
-it names a potentially-constant variable\iref{expr.const}
+it names a potentially-constant variable\iref{expr.const.init}
 that is initialized with an expression that is value-dependent.
 \end{itemize}
 
@@ -6022,7 +6022,7 @@ An expression of the form \tcode{\&}\grammarterm{qualified-id} where the
 instantiation is value-dependent.
 An expression of the form \tcode{\&}\grammarterm{cast-expression}
 is also value-dependent if evaluating \grammarterm{cast-expression}
-as a core constant expression\iref{expr.const} succeeds and
+as a core constant expression\iref{expr.const.core} succeeds and
 the result of the evaluation refers to a templated entity
 that is an object with static or thread storage duration or a member function.
 
@@ -6585,7 +6585,7 @@ an inline function,
 declared with a type deduced
 from its initializer or return value\iref{dcl.spec.auto},
 \item
-a potentially-constant variable\iref{expr.const}, or
+a potentially-constant variable\iref{expr.const.init}, or
 \item
 a specialization of a templated class.
 \end{itemize}
@@ -6795,7 +6795,7 @@ that requires the value of the default argument.
 The existence of a definition of a variable or function
 is considered to affect the semantics of the program
 if the variable or function
-is needed for constant evaluation by an expression\iref{expr.const},
+is needed for constant evaluation by an expression\iref{expr.const.defns},
 even if constant evaluation of the expression is not required or
 if constant expression evaluation does not use the definition.
 

--- a/source/text.tex
+++ b/source/text.tex
@@ -6700,7 +6700,7 @@ Direct-non-list-initializes \exposid{str} with \tcode{s}.
 
 \pnum
 \remarks
-A call to this function is not a core constant expression\iref{expr.const}
+A call to this function is not a core constant expression\iref{expr.const.core}
 unless there exist \tcode{args} of types \tcode{Args}
 such that \exposid{str} is a format string for \tcode{args}.
 \end{itemdescr}
@@ -7107,7 +7107,7 @@ template<class T>
 Pursuant to \ref{namespace.std},
 users may specialize \tcode{enable_nonlocking_formatter_optimization} for
 cv-unqualified program-defined types.
-Such specializations shall be usable in constant expressions\iref{expr.const}
+Such specializations shall be usable in constant expressions\iref{expr.const.init}
 and have type \tcode{const bool}.
 \end{itemdescr}
 
@@ -7606,7 +7606,7 @@ This indicates mixing of automatic and manual argument indexing.
 \remarks
 Let \tcode{\placeholder{cur-arg-id}} be the value of \tcode{next_arg_id_} prior to this call.
 Call expressions where \tcode{\placeholder{cur-arg-id} >= num_args_} is \tcode{true}
-are not core constant expressions\iref{expr.const}.
+are not core constant expressions\iref{expr.const.core}.
 \end{itemdescr}
 
 \indexlibrarymember{check_arg_id}{basic_format_parse_context}%
@@ -7633,7 +7633,7 @@ This indicates mixing of automatic and manual argument indexing.
 
 \pnum
 \remarks
-A call to this function is a core constant expression\iref{expr.const} only if
+A call to this function is a core constant expression\iref{expr.const.core} only if
 \tcode{id < num_args_} is \tcode{true}.
 \end{itemdescr}
 
@@ -7912,7 +7912,7 @@ Otherwise, \tcode{format_kind<R>} is \tcode{range_format::sequence}.
 Pursuant to \ref{namespace.std}, users may specialize \tcode{format_kind}
 for cv-unqualified program-defined types
 that model \tcode{ranges::\libconcept{input_range}}.
-Such specializations shall be usable in constant expressions\iref{expr.const}
+Such specializations shall be usable in constant expressions\iref{expr.const.init}
 and have type \tcode{const range_format}.
 \end{itemdescr}
 

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16067,7 +16067,7 @@ Nothing.
 \remarks
 A function call expression
 that violates the precondition in the \expects element
-is not a core constant expression\iref{expr.const}.
+is not a core constant expression\iref{expr.const.core}.
 \end{itemdescr}
 
 \indexlibraryglobal{bit_floor}%


### PR DESCRIPTION
Following #8816.