### PR TITLE
[exec.get.compl.sched] Rename completion-tag to completion-fn-tag and reorder text.

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -1030,34 +1030,38 @@ shall provide at least the parallel forward progress guarantee.
 \rSec2[exec.get.compl.sched]{\tcode{execution::get_completion_scheduler}}
 
 \pnum
-\tcode{get_completion_scheduler<\exposid{completion-tag>}} obtains
+The name \tcode{get_completion_scheduler} denotes a query object template.
+
+\pnum
+Let \exposid{completion-fn} be a completion function\iref{exec.async.ops};
+let \exposid{completion-fn-tag} be
+the associated completion tag of \exposid{completion-fn};
+let \tcode{args} be a pack of subexpressions; and
+let \tcode{sndr} be a subexpression
+such that \tcode{\libconcept{sender}<decltype((sndr))>} is \tcode{true} and
+\tcode{get_completion_scheduler<\exposid{completion-fn-tag}>(get_env(sndr))}
+is well-formed and denotes a scheduler \tcode{sch}.
+
+\pnum
+\tcode{get_completion_scheduler<\exposid{completion-fn-tag>}} obtains
 the completion scheduler associated with a completion tag
 from a sender's attributes.
 
 \pnum
-The name \tcode{get_completion_scheduler} denotes a query object template.
 For a subexpression \tcode{q},
-the expression \tcode{get_completion_scheduler<\exposid{completion-tag}>(q)}
-is ill-formed if \exposid{completion-tag} is not one of
+the expression \tcode{get_completion_scheduler<\exposid{completion-fn-tag}>(q)}
+is ill-formed if \exposid{completion-fn-tag} is not one of
 \tcode{set_value_t}, \tcode{set_error_t}, or \tcode{set_stopped_t}.
-Otherwise, \tcode{get_completion_scheduler<\exposid{completion-tag}>(q)}
+Otherwise, \tcode{get_completion_scheduler<\exposid{completion-fn-tag}>(q)}
 is expression-equivalent to
 \begin{codeblock}
-@\exposid{MANDATE-NOTHROW}@(@\exposid{AS-CONST}@(q).query(get_completion_scheduler<@\exposid{completion-tag}@>))
+@\exposid{MANDATE-NOTHROW}@(@\exposid{AS-CONST}@(q).query(get_completion_scheduler<@\exposid{completion-fn-tag}@>))
 \end{codeblock}
 \mandates
 If the expression above is well-formed,
 its type satisfies \libconcept{scheduler}.
 
 \pnum
-Let \exposid{completion-fn} be a completion function\iref{exec.async.ops};
-let \exposid{completion-tag} be
-the associated completion tag of \exposid{completion-fn};
-let \tcode{args} be a pack of subexpressions; and
-let \tcode{sndr} be a subexpression
-such that \tcode{\libconcept{sender}<decltype((sndr))>} is \tcode{true} and
-\tcode{get_completion_scheduler<\exposid{completion-tag}>(get_env(sndr))}
-is well-formed and denotes a scheduler \tcode{sch}.
 If an asynchronous operation
 created by connecting \tcode{sndr} with a receiver \tcode{rcvr}
 causes the evaluation of \tcode{\exposid{completion-fn}(rcvr, args...)},
@@ -1067,7 +1071,7 @@ that belongs to \tcode{sch}'s associated execution resource.
 
 \pnum
 The expression
-\tcode{forwarding_query(get_completion_scheduler<\exposid{completion-tag}>)}
+\tcode{forwarding_query(get_completion_scheduler<\exposid{completion-fn-tag}>)}
 is a core constant expression and has value \tcode{true}.
 
 \rSec2[exec.get.await.adapt]{\tcode{execution::get_await_completion_adaptor}}


### PR DESCRIPTION
The renaming avoids a clash with the concept "completion-tag" defined in [exec.snd.expos]. The reordering makes it so that names are defined before they are referenced.