### PR TITLE
[exec.snd.expos] Delete unused expos-only concept "completion-tag".

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -1736,12 +1736,9 @@ denotes an unspecified empty trivially copyable class type
 that models \libconcept{semiregular}.
 \end{itemdescr}
 
+\pnum
 \begin{codeblock}
 namespace std::execution {
-  template<class Tag>
-  concept @\defexposconceptnc{completion-tag}@ =                                      // \expos
-    @\libconcept{same_as}@<Tag, set_value_t> || @\libconcept{same_as}@<Tag, set_error_t> || @\libconcept{same_as}@<Tag, set_stopped_t>;
-
   template<class Sndr, class Rcvr>                              // \expos
   using @\exposid{state-type}@ = decay_t<@\exposid{call-result-t}@<
     decltype(@\exposid{impls-for}@<tag_of_t<Sndr>>::@\exposid{get-state}@), Sndr, Rcvr&>>;


### PR DESCRIPTION
Also insert a missing \pnum before the now-split codeblock (see 8cef46b15b21d4ab1b96dce04c0d37e511d1ddc2).