### PR TITLE
[2026-03 CWG Motion 6] P4004R1 Reconsider CWG 1395 "Partial ordering of variadic templates reconsidered"

### DIFF
--- a/source/templates.tex
+++ b/source/templates.tex
@@ -8782,18 +8782,16 @@ is replaced by the cv-unqualified version of
 \end{itemize}
 
 \pnum
-Using the resulting types
-\tcode{P}
-and
-\tcode{A},
+If \tcode{A} was transformed from a function parameter pack and
+\tcode{P} is not a parameter pack,
+type deduction fails.
+Otherwise, using the resulting types \tcode{P} and \tcode{A},
 the deduction is then done as described in~\ref{temp.deduct.type}.
 If \tcode{P} is a function parameter pack, the type \tcode{A} of each remaining
 parameter type of the argument template is compared with the type \tcode{P} of
 the \grammarterm{declarator-id} of the function parameter pack. Each comparison
 deduces template arguments for subsequent positions in the template parameter
 packs expanded by the function parameter pack.
-Similarly, if \tcode{A} was transformed from a function parameter pack,
-it is compared with each remaining parameter type of the parameter template.
 If deduction succeeds for a given type,
 the type from the argument template is considered to be at least as specialized
 as the type from the parameter template.


### PR DESCRIPTION
Fixes #8827

Also fixes cplusplus/papers#2640 