### PR TITLE
[2026-03 LWG Motion 32] P4052R0 Renaming saturation arithmetic functions

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -12272,15 +12272,15 @@ namespace std {
 
   // \ref{numeric.sat}, saturation arithmetic
   template<class T>
-    constexpr T add_sat(T x, T y) noexcept;
+    constexpr T saturating_add(T x, T y) noexcept;
   template<class T>
-    constexpr T sub_sat(T x, T y) noexcept;
+    constexpr T saturating_sub(T x, T y) noexcept;
   template<class T>
-    constexpr T mul_sat(T x, T y) noexcept;
+    constexpr T saturating_mul(T x, T y) noexcept;
   template<class T>
-    constexpr T div_sat(T x, T y) noexcept;
+    constexpr T saturating_div(T x, T y) noexcept;
   template<class T, class U>
-    constexpr T saturate_cast(U x) noexcept;
+    constexpr T saturating_cast(U x) noexcept;
 }
 \end{codeblock}
 
@@ -13424,10 +13424,10 @@ In the following descriptions, an arithmetic operation
 is performed as a mathematical operation with infinite range and then
 it is determined whether the mathematical result fits into the result type.
 
-\indexlibraryglobal{add_sat}%
+\indexlibraryglobal{saturating_add}%
 \begin{itemdecl}
 template<class T>
-  constexpr T add_sat(T x, T y) noexcept;
+  constexpr T saturating_add(T x, T y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -13442,10 +13442,10 @@ otherwise, either the largest or smallest representable value of type \tcode{T},
 whichever is closer to the value of $\tcode{x} + \tcode{y}$.
 \end{itemdescr}
 
-\indexlibraryglobal{sub_sat}%
+\indexlibraryglobal{saturating_sub}%
 \begin{itemdecl}
 template<class T>
-  constexpr T sub_sat(T x, T y) noexcept;
+  constexpr T saturating_sub(T x, T y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -13460,10 +13460,10 @@ otherwise, either the largest or smallest representable value of type \tcode{T},
 whichever is closer to the value of $\tcode{x} - \tcode{y}$.
 \end{itemdescr}
 
-\indexlibraryglobal{mul_sat}%
+\indexlibraryglobal{saturating_mul}%
 \begin{itemdecl}
 template<class T>
-  constexpr T mul_sat(T x, T y) noexcept;
+  constexpr T saturating_mul(T x, T y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -13478,10 +13478,10 @@ otherwise, either the largest or smallest representable value of type \tcode{T},
 whichever is closer to the value of $\tcode{x} \times \tcode{y}$.
 \end{itemdescr}
 
-\indexlibraryglobal{div_sat}%
+\indexlibraryglobal{saturating_div}%
 \begin{itemdecl}
 template<class T>
-  constexpr T div_sat(T x, T y) noexcept;
+  constexpr T saturating_div(T x, T y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -13508,10 +13508,10 @@ is not a core constant expression\iref{expr.const.core}.
 
 \rSec3[numeric.sat.cast]{Casting}
 
-\indexlibraryglobal{saturate_cast}%
+\indexlibraryglobal{saturating_cast}%
 \begin{itemdecl}
 template<class R, class T>
-  constexpr R saturate_cast(T x) noexcept;
+  constexpr R saturating_cast(T x) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/support.tex
+++ b/source/support.tex
@@ -826,7 +826,7 @@ the values of these macros with greater values.
   // freestanding, also in \libheader{functional}, \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_robust_nonmodifying_seq_ops}@       201304L // freestanding, also in \libheader{algorithm}
 #define @\defnlibxname{cpp_lib_sample}@                            201603L // freestanding, also in \libheader{algorithm}
-#define @\defnlibxname{cpp_lib_saturation_arithmetic}@             202311L // freestanding, also in \libheader{numeric}
+#define @\defnlibxname{cpp_lib_saturation_arithmetic}@             202603L // freestanding, also in \libheader{numeric}
 #define @\defnlibxname{cpp_lib_scoped_lock}@                       201703L // also in \libheader{mutex}
 #define @\defnlibxname{cpp_lib_semaphore}@                         201907L // also in \libheader{semaphore}
 #define @\defnlibxname{cpp_lib_senders}@                           202506L // also in \libheader{execution}


### PR DESCRIPTION
Fixes #8866
Fixes NB FR-026-265 (C++26 CD).

Also fixes https://github.com/cplusplus/papers/issues/2700
Also fixes https://github.com/cplusplus/nbballot/issues/840