### PR TITLE
[2026-03 LWG Motion 31] P3953R3 Rename `std::runtime_format`

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -7801,7 +7801,7 @@ template<class... Args>
 \effects
 Equivalent to:
 \begin{codeblock}
-print(stream, runtime_format(string(fmt.get()) + '\n'), std::forward<Args>(args)...);
+print(stream, dynamic_format(string(fmt.get()) + '\n'), std::forward<Args>(args)...);
 \end{codeblock}
 \end{itemdescr}
 

--- a/source/support.tex
+++ b/source/support.tex
@@ -678,7 +678,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_filesystem}@                        201703L // also in \libheader{filesystem}
 #define @\defnlibxname{cpp_lib_flat_map}@                          202511L // also in \libheader{flat_map}
 #define @\defnlibxname{cpp_lib_flat_set}@                          202511L // also in \libheader{flat_set}
-#define @\defnlibxname{cpp_lib_format}@                            202311L // also in \libheader{format}
+#define @\defnlibxname{cpp_lib_format}@                            202603L // also in \libheader{format}
 #define @\defnlibxname{cpp_lib_format_path}@                       202506L // also in \libheader{filesystem}
 #define @\defnlibxname{cpp_lib_format_ranges}@                     202207L // also in \libheader{format}
 #define @\defnlibxname{cpp_lib_format_uchar}@                      202311L // also in \libheader{format}

--- a/source/text.tex
+++ b/source/text.tex
@@ -5751,18 +5751,18 @@ namespace std {
   template<class charT, class... Args>
     struct basic_format_string;
 
-  template<class charT> struct @\exposid{runtime-format-string}@ {                  // \expos
+  template<class charT> struct @\exposid{dynamic-format-string}@ {                  // \expos
   private:
     basic_string_view<charT> @\exposid{str}@;                                       // \expos
   public:
-    constexpr @\exposid{runtime-format-string}@(basic_string_view<charT> s) noexcept : @\exposid{str}@(s) {}
-    @\exposid{runtime-format-string}@(const @\exposid{runtime-format-string}@&) = delete;
-    @\exposid{runtime-format-string}@& operator=(const @\exposid{runtime-format-string}@&) = delete;
+    constexpr @\exposid{dynamic-format-string}@(basic_string_view<charT> s) noexcept : @\exposid{str}@(s) {}
+    @\exposid{dynamic-format-string}@(const @\exposid{dynamic-format-string}@&) = delete;
+    @\exposid{dynamic-format-string}@& operator=(const @\exposid{dynamic-format-string}@&) = delete;
   };
-  constexpr @\exposid{runtime-format-string}@<char>
-    runtime_format(string_view fmt) noexcept { return fmt; }
-  constexpr @\exposid{runtime-format-string}@<wchar_t>
-    runtime_format(wstring_view fmt) noexcept { return fmt; }
+  constexpr @\exposid{dynamic-format-string}@<char>
+    dynamic_format(string_view fmt) noexcept { return fmt; }
+  constexpr @\exposid{dynamic-format-string}@<wchar_t>
+    dynamic_format(wstring_view fmt) noexcept { return fmt; }
 
   template<class... Args>
     using @\libglobal{format_string}@ = basic_format_string<char, type_identity_t<Args>...>;
@@ -6692,7 +6692,7 @@ namespace std {
 
   public:
     template<class T> consteval basic_format_string(const T& s);
-    constexpr basic_format_string(@\exposid{runtime-format-string}@<charT> s) noexcept : str(s.@\exposid{str}@) {}
+    constexpr basic_format_string(@\exposid{dynamic-format-string}@<charT> s) noexcept : str(s.@\exposid{str}@) {}
 
     constexpr basic_string_view<charT> get() const noexcept { return @\exposid{str}@; }
   };


### PR DESCRIPTION
Fixes #8865

Also fixes https://github.com/cplusplus/papers/issues/2604