### PR TITLE
[2026-03 LWG Motion 30] P4156R0 Rename `meta::has_ellipsis_parameter` to `meta::is_vararg_function`

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -2766,7 +2766,7 @@ namespace std::meta {
   consteval bool is_function_parameter(info r);
   consteval bool is_explicit_object_parameter(info r);
   consteval bool has_default_argument(info r);
-  consteval bool has_ellipsis_parameter(info r);
+  consteval bool is_vararg_function(info r);
 
   consteval bool is_template(info r);
   consteval bool is_function_template(info r);
@@ -4480,16 +4480,16 @@ If \tcode{r} represents a parameter $P$ of a function $F$, then:
 Otherwise, \tcode{false}.
 \end{itemdescr}
 
-\indexlibraryglobal{has_ellipsis_parameter}%
+\indexlibraryglobal{is_vararg_function}%
 \begin{itemdecl}
-consteval bool has_ellipsis_parameter(info r);
+consteval bool is_vararg_function(info r);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \returns
 \tcode{true} if \tcode{r} represents a function or function type
-that has an ellipsis in its parameter-type-list\iref{dcl.fct}.
+that is a vararg function\iref{dcl.fct}.
 Otherwise, \tcode{false}.
 \end{itemdescr}
 


### PR DESCRIPTION
Fixes NB FR-017-155 (C++26 CD).

Fixes #8864
Fixes cplusplus/papers#2728

Also fixes https://github.com/cplusplus/nbballot/issues/734