### PR TITLE
[2026-03 LWG Motion 22] P3450R1 Extend `std::is_within_lifetime`

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -628,7 +628,8 @@ namespace std {
 
   // \ref{meta.const.eval}, constant evaluation context
   constexpr bool is_constant_evaluated() noexcept;
-  consteval bool is_within_lifetime(const auto*) noexcept;
+  template<class U = void, class T>
+    consteval bool is_within_lifetime(const T*) noexcept;
 }
 \end{codeblock}
 
@@ -2581,14 +2582,21 @@ constexpr void f(unsigned char *p, int n) {
 
 \indexlibraryglobal{is_within_lifetime}%
 \begin{itemdecl}
-consteval bool is_within_lifetime(const auto* p) noexcept;
+template<class U = void, class T>
+  consteval bool is_within_lifetime(const T* p) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
+\mandates
+\tcode{static_cast<const volatile U*>(p)} is well-formed.
+
+\pnum
 \returns
 \tcode{true} if \tcode{p} is a pointer to an object that is
-within its lifetime\iref{basic.life}; otherwise, \tcode{false}.
+within its lifetime\iref{basic.life} and
+\tcode{static_cast<const volatile U*>(p)} is a constant subexpression;
+otherwise, \tcode{false}.
 
 \pnum
 \remarks

--- a/source/support.tex
+++ b/source/support.tex
@@ -749,7 +749,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_is_sufficiently_aligned}@           202411L // freestanding, also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_is_swappable}@                      201603L // freestanding, also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_is_virtual_base_of}@                202406L // freestanding, also in \libheader{type_traits}
-#define @\defnlibxname{cpp_lib_is_within_lifetime}@                202306L // freestanding, also in \libheader{type_traits}
+#define @\defnlibxname{cpp_lib_is_within_lifetime}@                202603L // freestanding, also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_jthread}@                           201911L // also in \libheader{stop_token}, \libheader{thread}
 #define @\defnlibxname{cpp_lib_latch}@                             201907L // also in \libheader{latch}
 #define @\defnlibxname{cpp_lib_launder}@                           201606L // freestanding, also in \libheader{new}


### PR DESCRIPTION
Fixes #8856
Fixes NB US 82-145 (C++26 CD).

Also fixes https://github.com/cplusplus/nbballot/issues/724
Also fixes https://github.com/cplusplus/papers/issues/2113