### PR TITLE
[2026-03 CWG Motion 10] P4143R0 Constant evaluation when?

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -8316,8 +8316,7 @@ Expressions that satisfy these requirements,
 assuming that copy elision\iref{class.copy.elision} is not performed,
 are called constant expressions.
 \begin{note}
-Constant expressions can be evaluated
-during translation.
+Certain constant expressions are evaluated during translation\iref{lex.phases}.
 \end{note}
 
 \pnum
@@ -9070,12 +9069,13 @@ when interpreted as a \grammarterm{constant-expression}
 with all contract assertions
 using the ignore evaluation semantic\iref{basic.contract.eval},
 \begin{note}
-Within this evaluation,
+In the course of this determination,
 \tcode{std::is_constant_evaluated()}\iref{meta.const.eval}
-returns \keyword{true}.
+has the value \keyword{true}.
 \end{note}
 \begin{note}
-The initialization, when evaluated,
+Furthermore, if the initialization is manifestly constant-evaluated,
+its evaluation during translation
 can still evaluate contract assertions
 with other evaluation semantics,
 resulting in a diagnostic or ill-formed program
@@ -9529,6 +9529,8 @@ if it is
 \begin{itemize}
 \item a \grammarterm{constant-expression}, or
 \item the condition of a constexpr if statement\iref{stmt.if}, or
+\item the expression corresponding to
+a \grammarterm{consteval-block-declaration}\iref{dcl.pre}, or
 \item an immediate invocation, or
 \item the result of substitution into an atomic constraint expression
 to determine whether it is satisfied\iref{temp.constr.atomic}, or
@@ -9537,7 +9539,7 @@ that is usable in constant expressions or
 has constant initialization\iref{basic.start.static}.
 \begin{footnote}
 Testing this condition
-can involve a trial evaluation of its initializer,
+can involve a notional evaluation of its initializer,
 with evaluations of contract assertions
 using the ignore evaluation semantic\iref{basic.contract.eval},
 as described above.

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -227,11 +227,14 @@ but its use in certain constant expressions could require
 that it be instantiated at an earlier point\iref{temp.inst}.
 \end{note}
 
-Each instantiation results in new program constructs.
 The program is ill-formed if any instantiation fails.
 
 During the analysis and translation of tokens,
-certain expressions are evaluated\iref{expr.const}.
+each manifestly constant-evaluated expression is evaluated\iref{expr.const}.
+The values of these expressions affect
+the types named and reflection values used in the program and
+thus the syntactic analysis.
+Their evaluation also can produce side effects that affect that analysis.
 Constructs appearing at a program point $P$ are analyzed
 in a context where each side effect of evaluating an expression $E$
 as a full-expression is complete if and only if
@@ -261,19 +264,19 @@ class S {
     void fn() {
       /* @$p_1$@ */ Incomplete i;    // OK
     }
-  }; /* @$p_2$@ */
+  } /* @$p_2$@ */ ;
 
   consteval {
     define_aggregate(^^Incomplete, {});
   }
-}; /* @$p_3$@ */
+} /* @$p_3$@ */ ;
 \end{codeblock}
 Constructs at $p_1$ are analyzed in a context
-where the side effect of the call to \tcode{define_aggregate} is evaluated
+where the side effect of the call to \tcode{define_aggregate} is complete
 because
 \begin{itemize}
 \item
-$E$ is the expression corresponding to a consteval block, and
+the call appears in a consteval block, and
 \item
 $p_1$ is in a complete-class context of \tcode{S} and
 the consteval block is reachable from $p_3$.


### PR DESCRIPTION
Fixes NB US 33-065 (C++26 CD).

Fixes #8831
Also fixes cplusplus/papers#2687
Also fixes cplusplus/nbballot#641