### PR TITLE
[2026-03 LWG Motion 8] P3936R1 Safer atomic_ref::address (FR-030-310)

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -594,7 +594,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_atomic_lock_free_type_aliases}@     201907L // also in \libheader{atomic}
 #define @\defnlibxname{cpp_lib_atomic_min_max}@                    202506L // freestanding, also in \libheader{atomic}
 #define @\defnlibxname{cpp_lib_atomic_reductions}@                 202506L // freestanding, also in \libheader{atomic}
-#define @\defnlibxname{cpp_lib_atomic_ref}@                        202411L // freestanding, also in \libheader{atomic}
+#define @\defnlibxname{cpp_lib_atomic_ref}@                        202603L // freestanding, also in \libheader{atomic}
 #define @\defnlibxname{cpp_lib_atomic_shared_ptr}@                 201711L // also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_atomic_value_initialization}@       201911L // freestanding, also in \libheader{atomic}, \libheader{memory}
 #define @\defnlibxname{cpp_lib_atomic_wait}@                       201907L // freestanding, also in \libheader{atomic}

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -2398,6 +2398,10 @@ Timeout-related exceptions\iref{thread.req.timing}.
 \rSec2[atomics.general]{General}
 
 \pnum
+Let \tcode{\placeholdernc{COPYCV}(FROM, TO)} be an alias for type \tcode{TO}
+with the addition of \tcode{FROM}'s top-level cv-qualifiers.
+
+\pnum
 Subclause \ref{atomics} describes components for fine-grained atomic access.
 This access is provided via operations on atomic objects.
 
@@ -3153,6 +3157,7 @@ namespace std {
 
   public:
     using value_type = remove_cv_t<T>;
+    using @\exposid{address-return-type}@ = @\placeholdernc{COPYCV}@(T, void)*;       // \expos
     static constexpr size_t required_alignment = @\impdefx{required alignment for \tcode{atomic_ref} type's operations}@;
 
     static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic_ref} type's operations are always lock free}@;
@@ -3184,7 +3189,7 @@ namespace std {
     constexpr void wait(value_type, memory_order = memory_order::seq_cst) const noexcept;
     constexpr void notify_one() const noexcept;
     constexpr void notify_all() const noexcept;
-    constexpr T* address() const noexcept;
+    constexpr @\exposid{address-return-type}@ address() const noexcept;
   };
 }
 \end{codeblock}
@@ -3620,7 +3625,7 @@ on atomic object \tcode{*ptr}.
 
 \indexlibrarymember{address}{atomic_ref<T>}%
 \begin{itemdecl}
-constexpr T* address() const noexcept;
+constexpr @\exposid{address-return-type}@ address() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3657,6 +3662,7 @@ namespace std {
   public:
     using value_type = remove_cv_t<@\placeholder{integral-type}@>;
     using difference_type = value_type;
+    using @\exposid{address-return-type}@ = @\placeholdernc{COPYCV}@(@\placeholder{integral-type}@, void)*;       // \expos
     static constexpr size_t required_alignment = @\impdefx{required alignment for \tcode{atomic_ref} type's operations}@;
 
     static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic_ref} type's operations are always lock free}@;
@@ -3728,7 +3734,7 @@ namespace std {
     constexpr void wait(value_type, memory_order = memory_order::seq_cst) const noexcept;
     constexpr void notify_one() const noexcept;
     constexpr void notify_all() const noexcept;
-    constexpr @\placeholder{integral-type}@* address() const noexcept;
+    constexpr @\exposid{address-return-type}@ address() const noexcept;
   };
 }
 \end{codeblock}
@@ -3882,6 +3888,7 @@ namespace std {
   public:
     using value_type = remove_cv_t<@\placeholder{floating-point-type}@>;
     using difference_type = value_type;
+    using @\exposid{address-return-type}@ = @\placeholdernc{COPYCV}@(@\placeholder{floating-point-type}@, void)*;       // \expos
     static constexpr size_t required_alignment = @\impdefx{required alignment for \tcode{atomic_ref} type's operations}@;
 
     static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic_ref} type's operations are always lock free}@;
@@ -3949,7 +3956,7 @@ namespace std {
                         memory_order = memory_order::seq_cst) const noexcept;
     constexpr void notify_one() const noexcept;
     constexpr void notify_all() const noexcept;
-    constexpr @\placeholder{floating-point-type}@* address() const noexcept;
+    constexpr @\exposid{address-return-type}@ address() const noexcept;
   };
 }
 \end{codeblock}
@@ -4177,6 +4184,7 @@ namespace std {
   public:
     using value_type = remove_cv_t<@\placeholder{pointer-type}@>;
     using difference_type = ptrdiff_t;
+    using @\exposid{address-return-type}@ = @\placeholdernc{COPYCV}@(@\placeholder{pointer-type}@, void)*;       // \expos
     static constexpr size_t required_alignment = @\impdefx{required alignment for \tcode{atomic_ref} type's operations}@;
 
     static constexpr bool is_always_lock_free = @\impdefx{whether a given \tcode{atomic_ref} type's operations are always lock free}@;
@@ -4233,7 +4241,7 @@ namespace std {
     constexpr void wait(value_type, memory_order = memory_order::seq_cst) const noexcept;
     constexpr void notify_one() const noexcept;
     constexpr void notify_all() const noexcept;
-    constexpr @\placeholder{pointer-type}@* address() const noexcept;
+    constexpr @\placeholder{address-return-type}@ address() const noexcept;
   };
 }
 \end{codeblock}


### PR DESCRIPTION
Fixes NB FR-030-310 (C++26 CD).
Fixes #8842

Also fixes https://github.com/cplusplus/nbballot/issues/885
Also fixes https://github.com/cplusplus/papers/issues/2590