### PR TITLE
[2026-03 LWG Motion 9] P4140R0 Proposed resolution for US70-126: allow incomplete types in type order

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -5708,6 +5708,10 @@ If an explicit specialization or partial specialization of \tcode{type_order} is
 the program is ill-formed.
 
 \pnum
+The templates \tcode{type_order} and \tcode{type_order_v}
+may be instantiated with incomplete types as arguments.
+
+\pnum
 \recommended
 The order should be lexicographical on parameter-type-lists and template argument lists.
 \end{itemdescr}


### PR DESCRIPTION
Fixes NB US 70-126 (C++26 CD).
Fixes #8843
Fixes cplusplus/papers#2719

Also fixes https://github.com/cplusplus/nbballot/issues/705