### PR TITLE
[2026-03 LWG Motion 20] P4022R0 Remove `try_append_range` from `inplace_vector` for now

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10992,8 +10992,6 @@ namespace std {
       constexpr optional<reference> try_emplace_back(Args&&... args);
     constexpr optional<reference> try_push_back(const T& x);
     constexpr optional<reference> try_push_back(T&& x);
-    template<@\exposconcept{container-compatible-range}@<T> R>
-      constexpr ranges::borrowed_iterator_t<R> try_append_range(R&& rg);
 
     template<class... Args>
       constexpr reference unchecked_emplace_back(Args&&... args);
@@ -11345,45 +11343,6 @@ Constant.
 \pnum
 \remarks
 If an exception is thrown, there are no effects on \tcode{*this}.
-\end{itemdescr}
-
-\indexlibrarymember{try_append_range}{inplace_vector}%
-\begin{itemdecl}
-template<@\exposconcept{container-compatible-range}@<T> R>
-  constexpr ranges::borrowed_iterator_t<R> try_append_range(R&& rg);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\expects
-\tcode{value_type} is \oldconcept{EmplaceConstructible}
-into \tcode{inplace_vector} from\\\tcode{*ranges::begin(rg)}.
-
-\pnum
-\effects
-Appends copies of initial elements in \tcode{rg} before \tcode{end()},
-until all elements are inserted or \tcode{size() == capacity()} is \tcode{true}.
-Each iterator in the range \tcode{rg} is dereferenced at most once.
-
-\pnum
-\returns
-The first iterator in the range
-\countedrange{ranges::begin(rg)}{n}
-that was not inserted into \tcode{*this},
-where \tcode{n} is the number of elements in \tcode{rg}.
-
-\pnum
-\complexity
-Linear in the number of elements inserted.
-
-\pnum
-\remarks
-Let $n$ be the value of \tcode{size()} prior to this call.
-If an exception is thrown after the insertion of $k$ elements, then
-\tcode{size()} equals $n + k$,
-elements in the range \tcode{begin() + \range{0}{$n$}} are not modified, and
-elements in the range \tcode{begin() + \range{$n$}{$n + k$}} correspond to
-the inserted elements.
 \end{itemdescr}
 
 \indexlibrarymember{unchecked_emplace_back}{inplace_vector}%


### PR DESCRIPTION
Fixes #8854

Also fixes https://github.com/cplusplus/papers/issues/2655