### PR TITLE
[2026-03 LWG Motion 19] P3981R2 Better return types in `std::inplace_vector` and `std::exception_ptr_cast`

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10989,9 +10989,9 @@ namespace std {
     constexpr void pop_back();
 
     template<class... Args>
-      constexpr pointer try_emplace_back(Args&&... args);
-    constexpr pointer try_push_back(const T& x);
-    constexpr pointer try_push_back(T&& x);
+      constexpr optional<reference> try_emplace_back(Args&&... args);
+    constexpr optional<reference> try_push_back(const T& x);
+    constexpr optional<reference> try_push_back(T&& x);
     template<@\exposconcept{container-compatible-range}@<T> R>
       constexpr ranges::borrowed_iterator_t<R> try_append_range(R&& rg);
 
@@ -11303,9 +11303,9 @@ If an exception is thrown, there are no effects on \tcode{*this}.
 \indexlibrarymember{try_push_back}{inplace_vector}%
 \begin{itemdecl}
 template<class... Args>
-  constexpr pointer try_emplace_back(Args&&... args);
-constexpr pointer try_push_back(const T& x);
-constexpr pointer try_push_back(T&& x);
+  constexpr optional<reference> try_emplace_back(Args&&... args);
+constexpr optional<reference> try_push_back(const T& x);
+constexpr optional<reference> try_push_back(T&& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11331,8 +11331,8 @@ Otherwise, there are no effects.
 
 \pnum
 \returns
-\keyword{nullptr} if \tcode{size() == capacity()} is \tcode{true},
-otherwise \tcode{addressof(back())}.
+\keyword{nullopt} if \tcode{size() == capacity()} is \tcode{true},
+otherwise \tcode{optional<reference>(in_place, back())}.
 
 \pnum
 \throws

--- a/source/support.tex
+++ b/source/support.tex
@@ -671,7 +671,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_erase_if}@                          202002L
   // also in \libheader{string}, \libheader{deque}, \libheader{forward_list}, \libheader{list}, \libheader{vector}, \libheader{map}, \libheader{set}, \libheader{unordered_map},
   // \libheader{unordered_set}
-#define @\defnlibxname{cpp_lib_exception_ptr_cast}@                202506L // also in \libheader{exception}
+#define @\defnlibxname{cpp_lib_exception_ptr_cast}@                202603L // also in \libheader{exception}
 #define @\defnlibxname{cpp_lib_exchange_function}@                 201304L // freestanding, also in \libheader{utility}
 #define @\defnlibxname{cpp_lib_execution}@                         201902L // also in \libheader{execution}
 #define @\defnlibxname{cpp_lib_expected}@                          202211L // also in \libheader{expected}
@@ -727,7 +727,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_indirect}@                          202502L // also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_initializer_list}@                  202511L
   // freestanding, also in \libheader{initializer_list}
-#define @\defnlibxname{cpp_lib_inplace_vector}@                    202406L // also in \libheader{inplace_vector}
+#define @\defnlibxname{cpp_lib_inplace_vector}@                    202603L // also in \libheader{inplace_vector}
 #define @\defnlibxname{cpp_lib_int_pow2}@                          202002L // freestanding, also in \libheader{bit}
 #define @\defnlibxname{cpp_lib_integer_comparison_functions}@      202002L // freestanding, also in \libheader{utility}
 #define @\defnlibxname{cpp_lib_integer_sequence}@                  202511L // freestanding, also in \libheader{utility}
@@ -3853,7 +3853,8 @@ namespace std {
   constexpr exception_ptr current_exception() noexcept;
   [[noreturn]] constexpr void rethrow_exception(exception_ptr p);
   template<class E> constexpr exception_ptr make_exception_ptr(E e) noexcept;
-  template<class E> constexpr const E* exception_ptr_cast(const exception_ptr& p) noexcept;
+  template<class E>
+    constexpr optional<const E&> exception_ptr_cast(const exception_ptr& p) noexcept;
   template<class E> void exception_ptr_cast(const exception_ptr&&) = delete;
 
   template<class T> [[noreturn]] constexpr void throw_with_nested(T&& t);
@@ -4234,7 +4235,8 @@ efficiency reasons.
 
 \indexlibraryglobal{exception_ptr_cast}%
 \begin{itemdecl}
-template<class E> constexpr const E* exception_ptr_cast(const exception_ptr& p) noexcept;
+template<class E>
+  constexpr optional<const E&> exception_ptr_cast(const exception_ptr& p) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4251,11 +4253,12 @@ without binding to the exception object itself.
 
 \pnum
 \returns
-A pointer to the exception object referred to by \tcode{p},
+An \tcode{optional} containing a reference
+to the exception object referred to by \tcode{p},
 if \tcode{p} is not null and
 a handler of type \tcode{const E\&}
 would be a match\iref{except.handle} for that exception object.
-Otherwise, \tcode{nullptr}.
+Otherwise, \tcode{nullopt}.
 \end{itemdescr}
 
 \rSec2[except.nested]{\tcode{nested_exception}}


### PR DESCRIPTION
Fixes NB PL-006, US 68-122, US 150-228, and GB 08-225 (C++26 CD).
Fixes #8853

Also fixes https://github.com/cplusplus/papers/issues/2634
Also fixes https://github.com/cplusplus/nbballot/issues/813
Also fixes https://github.com/cplusplus/nbballot/issues/701
Also fixes https://github.com/cplusplus/nbballot/issues/799
Also fixes https://github.com/cplusplus/nbballot/issues/796