### PR TITLE
[2026-03 LWG Motion 18] P3961R1 Less double indirection in function_ref (RU-220)

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -711,7 +711,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_freestanding_utility}@              202306L // freestanding, also in \libheader{utility}
 #define @\defnlibxname{cpp_lib_freestanding_variant}@              202311L // freestanding, also in \libheader{variant}
 #define @\defnlibxname{cpp_lib_fstream_native_handle}@             202306L // also in \libheader{fstream}
-#define @\defnlibxname{cpp_lib_function_ref}@                      202603L // freestanding, also in \libheader{functional}
+#define @\defnlibxname{cpp_lib_function_ref}@                      202604L // freestanding, also in \libheader{functional}
 #define @\defnlibxname{cpp_lib_gcd_lcm}@                           201606L // freestanding, also in \libheader{numeric}
 #define @\defnlibxname{cpp_lib_generator}@                         202207L // also in \libheader{generator}
 #define @\defnlibxname{cpp_lib_generic_associative_lookup}@        201304L // also in \libheader{map}, \libheader{set}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -14214,10 +14214,12 @@ encapsulate arbitrary callable objects.
 
 \pnum
 Let \tcode{t} be an object of a type that is a specialization of
-\tcode{function}, \tcode{copyable_function}, or \tcode{move_only_function},
+\tcode{function}, \tcode{copyable_function}, \tcode{move_only_function},
+or \tcode{function_ref},
 such that the target object \tcode{x} of \tcode{t} has a type that
 is a specialization of
-\tcode{function}, \tcode{copyable_function}, or \tcode{move_only_function}.
+\tcode{function}, \tcode{copyable_function}, \tcode{move_only_function},
+or \tcode{function_ref}.
 Each argument of the
 invocation of \tcode{x} evaluated as part of the invocation of \tcode{t}
 may alias an argument in the same position in the invocation of \tcode{t} that
@@ -15634,6 +15636,25 @@ is_invocable_r_v<R, T..., ArgTypes...>
 \end{codeblock}
 \end{itemdescr}
 
+\indextext{function_ref::is-convertible-from-specialization@\tcode{function_ref::\exposid{is-convertible-from-\brk{}specialization}}}%
+\begin{itemdecl}
+template<class F>
+  static constexpr bool @\exposid{is-convertible-from-specialization}@ = @\seebelow@;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+If \tcode{F} denotes a specialization
+\tcode{function_ref<R(Args...) \cvqual{cv2} noexcept(\placeholder{noex2})>}
+for some placeholders \cvqual{cv2} and \placeholder{noex2},
+\tcode{\exposid{is-convertible-from-specialization}<F>} is equal to:
+\begin{codeblock}
+is_convertible_v<R(&)(Args...) noexcept(@\placeholder{noex2}@), R(&)(Args...) noexcept(@\placeholder{noex}@)> &&
+is_convertible_v<int @\cv{}@&, int @\cvqual{cv2}@&>.
+\end{codeblock}
+Otherwise, \tcode{\exposid{is-convertible-from-specialization}<F>} is \tcode{false}.
+\end{itemdescr}
+
 \indexlibraryctor{function_ref}%
 \begin{itemdecl}
 template<class F> function_ref(F* f) noexcept;
@@ -15681,13 +15702,37 @@ Let \tcode{T} be \tcode{remove_reference_t<F>}.
 
 \pnum
 \effects
-Initializes
-\exposid{bound-entity} with \tcode{addressof(f)}, and
+If \tcode{\exposid{is-convertible-from-specialization}<remove_cv_t<T>>}
+is \tcode{false},
+initializes
+\exposid{bound-en\-tity} with \tcode{addressof(f)}, and
 \exposid{thunk-ptr} with the address of a function \tcode{\placeholder{thunk}}
 such that
-\tcode{\placeholder{thunk}(\exposid{bound-entity}, \placeholder{call-args}...)}
+\tcode{\placeholder{thunk}(\exposid{bound-\brk{}entity}, \placeholder{call-args}...)}
 is expression-equivalent\iref{defns.expression.equivalent} to
 \tcode{invoke_r<R>(static_cast<\cv{} T\&>(f), \placeholder{call-args}...)}.
+Otherwise, initializes \exposid{bound-entity}
+with the value of \tcode{f.\exposid{bound-entity}} and
+\exposid{thunk-\brk{}ptr} with the value of \tcode{f.\exposid{thunk-ptr}}.
+
+\pnum
+\remarks
+If \tcode{remove_cvref_t<F>} is a specialization of \tcode{function_ref},
+an implementation may initialize \exposid{bound-entity}
+with the value of \tcode{f.\exposid{bound-entity}} and \exposid{thunk-ptr}
+with the value of \tcode{f.\exposid{thunk-ptr}}.
+\begin{example}
+\begin{codeblock}
+void f1(std::string);
+void f2(std::string);
+
+function_ref<void(std::string)> r1(&f1);
+function_ref<void(std::string&&)> r2(r1);
+r2("");                 // \tcode{f1} is invoked
+r1 = &f2;
+r2("");                 // it is unspecified if \tcode{f1} or \tcode{f2} is invoked
+\end{codeblock}
+\end{example}
 \end{itemdescr}
 
 \indexlibraryctor{function_ref}%
@@ -15800,7 +15845,7 @@ template<class T> function_ref& operator=(T) = delete;
 \pnum
 \constraints
 \begin{itemize}
-\item \tcode{T} is not the same type as \tcode{function_ref},
+\item \tcode{\exposid{is-convertible-from-specialization}<T>} is \tcode{false},
 \item \tcode{is_pointer_v<T>} is \tcode{false}, and
 \item \tcode{T} is not a specialization of \tcode{constant_wrapper}.
 \end{itemize}


### PR DESCRIPTION
- Use code, not English, in definition of is-convertible-from-specialization
 
Fixes #8852

Also fixes cplusplus/papers#2608
Also fixes cplusplus/nbballot#790