### PR TITLE
[2026-03 LWG Motion 26] P3787R2 Adjoints to "Enabling list-initialization for algorithms": uninitialized_fill

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -14123,7 +14123,8 @@ are left in a valid but unspecified state.
 
 \indexlibraryglobal{uninitialized_fill}%
 \begin{itemdecl}
-template<class NoThrowForwardIterator, class T>
+template<class NoThrowForwardIterator,
+         class T = iterator_traits<NoThrowForwardIterator>::value_type>
   constexpr void uninitialized_fill(NoThrowForwardIterator first,
                                     NoThrowForwardIterator last, const T& x);
 \end{itemdecl}
@@ -14141,10 +14142,10 @@ for (; first != last; ++first)
 \indexlibraryglobal{uninitialized_fill}%
 \begin{itemdecl}
 namespace ranges {
-  template<@\exposconcept{nothrow-forward-iterator}@ I, @\exposconcept{nothrow-sentinel-for}@<I> S, class T>
+  template<@\exposconcept{nothrow-forward-iterator}@ I, @\exposconcept{nothrow-sentinel-for}@<I> S, class T = iter_value_t<I>>
     requires @\libconcept{constructible_from}@<iter_value_t<I>, const T&>
     constexpr I uninitialized_fill(I first, S last, const T& x);
-  template<@\exposconcept{nothrow-forward-range}@ R, class T>
+  template<@\exposconcept{nothrow-forward-range}@ R, class T = range_value_t<R>>
     requires @\libconcept{constructible_from}@<range_value_t<R>, const T&>
     constexpr borrowed_iterator_t<R> uninitialized_fill(R&& r, const T& x);
 }
@@ -14163,7 +14164,8 @@ return first;
 
 \indexlibraryglobal{uninitialized_fill_n}%
 \begin{itemdecl}
-template<class NoThrowForwardIterator, class Size, class T>
+template<class NoThrowForwardIterator, class Size,
+         class T = iterator_traits<NoThrowForwardIterator>::value_type>
   constexpr NoThrowForwardIterator
     uninitialized_fill_n(NoThrowForwardIterator first, Size n, const T& x);
 \end{itemdecl}
@@ -14182,7 +14184,7 @@ return first;
 \indexlibraryglobal{uninitialized_fill_n}%
 \begin{itemdecl}
 namespace ranges {
-  template<@\exposconcept{nothrow-forward-iterator}@ I, class T>
+  template<@\exposconcept{nothrow-forward-iterator}@ I, class T = iter_value_t<I>>
     requires @\libconcept{constructible_from}@<iter_value_t<I>, const T&>
     constexpr I uninitialized_fill_n(I first, iter_difference_t<I> n, const T& x);
 }

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -415,47 +415,52 @@ namespace std {
                                O ofirst, S olast);                          // see \ref{algorithms.parallel.overloads}
   }
 
-  template<class NoThrowForwardIterator, class T>
+  template<class NoThrowForwardIterator,
+           class T = iterator_traits<NoThrowForwardIterator>::value_type>
     constexpr void uninitialized_fill(NoThrowForwardIterator first,                 // freestanding
                                       NoThrowForwardIterator last, const T& x);
-  template<class ExecutionPolicy, class NoThrowForwardIterator, class T>
+  template<class ExecutionPolicy, class NoThrowForwardIterator,
+           class T = iterator_traits<NoThrowForwardIterator>::value_type>
     void uninitialized_fill(ExecutionPolicy&& exec,                         // freestanding-deleted,
                             NoThrowForwardIterator first,                   // see \ref{algorithms.parallel.overloads}
                             NoThrowForwardIterator last,
                             const T& x);
-  template<class NoThrowForwardIterator, class Size, class T>
+  template<class NoThrowForwardIterator, class Size,
+           class T = iterator_traits<NoThrowForwardIterator>::value_type>
     constexpr NoThrowForwardIterator
       uninitialized_fill_n(NoThrowForwardIterator first, Size n, const T& x);       // freestanding
-  template<class ExecutionPolicy, class NoThrowForwardIterator, class Size, class T>
+  template<class ExecutionPolicy, class NoThrowForwardIterator, class Size,
+           class T = iterator_traits<NoThrowForwardIterator>::value_type>
     NoThrowForwardIterator
       uninitialized_fill_n(ExecutionPolicy&& exec,                          // freestanding-deleted,
                            NoThrowForwardIterator first,                    // see \ref{algorithms.parallel.overloads}
                            Size n, const T& x);
 
   namespace ranges {
-    template<@\exposconcept{nothrow-forward-iterator}@ I, @\exposconcept{nothrow-sentinel-for}@<I> S, class T>
+    template<@\exposconcept{nothrow-forward-iterator}@ I, @\exposconcept{nothrow-sentinel-for}@<I> S, class T = iter_value_t<I>>
       requires @\libconcept{constructible_from}@<iter_value_t<I>, const T&>
         constexpr I uninitialized_fill(I first, S last, const T& x);                // freestanding
-    template<@\exposconcept{nothrow-forward-range}@ R, class T>
+    template<@\exposconcept{nothrow-forward-range}@ R, class T = range_value_t<R>>
       requires @\libconcept{constructible_from}@<range_value_t<R>, const T&>
         constexpr borrowed_iterator_t<R> uninitialized_fill(R&& r, const T& x);     // freestanding
 
-    template<@\exposconcept{nothrow-forward-iterator}@ I, class T>
+    template<@\exposconcept{nothrow-forward-iterator}@ I, class T = iter_value_t<I>>
       requires @\libconcept{constructible_from}@<iter_value_t<I>, const T&>
         constexpr I uninitialized_fill_n(I first,                                   // freestanding
                                          iter_difference_t<I> n, const T& x);
 
     template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{nothrow-random-access-iterator}@ I,
-             @\exposconcept{nothrow-sized-sentinel-for}@<I> S, class T>
+             @\exposconcept{nothrow-sized-sentinel-for}@<I> S, class T = iter_value_t<I>>
       requires @\libconcept{constructible_from}@<iter_value_t<I>, const T&>
         I uninitialized_fill(Ep&& exec, I first, S last, const T& x);       // freestanding-deleted,
                                                                             // see \ref{algorithms.parallel.overloads}
-    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{nothrow-sized-random-access-range}@ R, class T>
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{nothrow-sized-random-access-range}@ R,
+             class T = range_value_t<R>>
       requires @\libconcept{constructible_from}@<range_value_t<R>, const T&>
         borrowed_iterator_t<R> uninitialized_fill(Ep&& exec, R&& r,         // freestanding-deleted,
                                                   const T& x);              // see \ref{algorithms.parallel.overloads}
 
-    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{nothrow-random-access-iterator}@ I, class T>
+    template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{nothrow-random-access-iterator}@ I, class T = iter_value_t<I>>
       requires @\libconcept{constructible_from}@<iter_value_t<I>, const T&>
         I uninitialized_fill_n(Ep&& exec, I first,                          // freestanding-deleted,
                                iter_difference_t<I> n, const T& x);         // see \ref{algorithms.parallel.overloads}

--- a/source/support.tex
+++ b/source/support.tex
@@ -568,8 +568,8 @@ the values of these macros with greater values.
 \begin{codeblock}
 #define @\defnlibxname{cpp_lib_adaptor_iterator_pair_constructor}@ 202106L // also in \libheader{stack}, \libheader{queue}
 #define @\defnlibxname{cpp_lib_addressof_constexpr}@               201603L // freestanding, also in \libheader{memory}
-#define @\defnlibxname{cpp_lib_algorithm_default_value_type}@      202403L
-  // also in \libheader{algorithm}, \libheader{ranges}, \libheader{string}, \libheader{deque}, \libheader{list}, \libheader{forward_list}, \libheader{vector}
+#define @\defnlibxname{cpp_lib_algorithm_default_value_type}@      202603L
+  // also in \libheader{algorithm}, \libheader{ranges}, \libheader{string}, \libheader{deque}, \libheader{list}, \libheader{forward_list}, \libheader{vector}, \libheader{memory}
 #define @\defnlibxname{cpp_lib_algorithm_iterator_requirements}@   202207L
   // also in \libheader{algorithm}, \libheader{numeric}, \libheader{memory}
 #define @\defnlibxname{cpp_lib_aligned_accessor}@                  202411L // freestanding, also in \libheader{mdspan}


### PR DESCRIPTION
Fixes NB FR-027-267 (C++26 CD).

Fixes #8860

Also fixes cplusplus/papers#2394
Also fixes cplusplus/nbballot#842