### PR TITLE
[2026-03 LWG Motion 27] P3842R2 A conservative fix for constexpr uncaught_exceptions() and current_exception()

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -3845,19 +3845,20 @@ namespace std {
   terminate_handler set_terminate(terminate_handler f) noexcept;
   [[noreturn]] void terminate() noexcept;
 
-  constexpr int uncaught_exceptions() noexcept;
+  int uncaught_exceptions() noexcept;
 
   using exception_ptr = @\unspec@;
 
-  constexpr exception_ptr current_exception() noexcept;
+  constexpr exception_ptr @\exposid{current-exception}@() noexcept;    // \expos
+  exception_ptr current_exception() noexcept;
   [[noreturn]] constexpr void rethrow_exception(exception_ptr p);
   template<class E> constexpr exception_ptr make_exception_ptr(E e) noexcept;
   template<class E>
     constexpr optional<const E&> exception_ptr_cast(const exception_ptr& p) noexcept;
   template<class E> void exception_ptr_cast(const exception_ptr&&) = delete;
 
-  template<class T> [[noreturn]] constexpr void throw_with_nested(T&& t);
-  template<class E> constexpr void rethrow_if_nested(const E& e);
+  template<class T> [[noreturn]] void throw_with_nested(T&& t);
+  template<class E> void rethrow_if_nested(const E& e);
 }
 \end{codeblock}
 
@@ -4082,7 +4083,7 @@ May also be called directly by the program.
 
 \indexlibraryglobal{uncaught_exceptions}%
 \begin{itemdecl}
-constexpr int uncaught_exceptions() noexcept;
+int uncaught_exceptions() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4151,7 +4152,8 @@ All member functions are marked \tcode{constexpr}.
 
 \indexlibraryglobal{current_exception}%
 \begin{itemdecl}
-constexpr exception_ptr current_exception() noexcept;
+constexpr exception_ptr @\exposid{current-exception}@() noexcept;
+exception_ptr current_exception() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4221,15 +4223,9 @@ Creates an \tcode{exception_ptr} object that refers to a copy of \tcode{e}, as i
 try {
   throw e;
 } catch(...) {
-  return current_exception();
+  return @\exposid{current-exception}@();
 }
 \end{codeblock}
-
-\pnum
-\begin{note}
-This function is provided for convenience and
-efficiency reasons.
-\end{note}
 \end{itemdescr}
 
 \indexlibraryglobal{exception_ptr_cast}%
@@ -4267,18 +4263,18 @@ Otherwise, \tcode{nullopt}.
 namespace std {
   class nested_exception {
   public:
-    constexpr nested_exception() noexcept;
-    constexpr nested_exception(const nested_exception&) noexcept = default;
-    constexpr nested_exception& operator=(const nested_exception&) noexcept = default;
-    constexpr virtual ~nested_exception() = default;
+    nested_exception() noexcept;
+    nested_exception(const nested_exception&) noexcept = default;
+    nested_exception& operator=(const nested_exception&) noexcept = default;
+    virtual ~nested_exception() = default;
 
     // access functions
-    [[noreturn]] constexpr void rethrow_nested() const;
-    constexpr exception_ptr nested_ptr() const noexcept;
+    [[noreturn]] void rethrow_nested() const;
+    exception_ptr nested_ptr() const noexcept;
   };
 
-  template<class T> [[noreturn]] constexpr void throw_with_nested(T&& t);
-  template<class E> constexpr void rethrow_if_nested(const E& e);
+  template<class T> [[noreturn]] void throw_with_nested(T&& t);
+  template<class E> void rethrow_if_nested(const E& e);
 }
 \end{codeblock}
 
@@ -4295,7 +4291,7 @@ polymorphic class. Its presence can be tested for with \keyword{dynamic_cast}.
 
 \indexlibraryctor{nested_exception}%
 \begin{itemdecl}
-constexpr nested_exception() noexcept;
+nested_exception() noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4306,7 +4302,7 @@ The constructor calls \tcode{current_exception()} and stores the returned value.
 
 \indexlibrarymember{rethrow_nested}{nested_exception}%
 \begin{itemdecl}
-[[noreturn]] constexpr void rethrow_nested() const;
+[[noreturn]] void rethrow_nested() const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4318,7 +4314,7 @@ Otherwise, it throws the stored exception captured by \tcode{*this}.
 
 \indexlibrarymember{nested_ptr}{nested_exception}%
 \begin{itemdecl}
-constexpr exception_ptr nested_ptr() const noexcept;
+exception_ptr nested_ptr() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4329,7 +4325,7 @@ The stored exception captured by this \tcode{nested_exception} object.
 
 \indexlibrarymember{throw_with_nested}{nested_exception}%
 \begin{itemdecl}
-template<class T> [[noreturn]] constexpr void throw_with_nested(T&& t);
+template<class T> [[noreturn]] void throw_with_nested(T&& t);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4352,7 +4348,7 @@ and constructed from \tcode{std::forward<T>(t)}, otherwise
 
 \indexlibrarymember{rethrow_if_nested}{nested_exception}%
 \begin{itemdecl}
-template<class E> constexpr void rethrow_if_nested(const E& e);
+template<class E> void rethrow_if_nested(const E& e);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Fixes NB US 67-118, FI-121, DE-120, GB 03-119, PL-012 (C++26 CD).

Fixes #8861 

Also fixes cplusplus/papers#2451
Also fixes cplusplus/nbballot#697
Also fixes cplusplus/nbballot#700
Also fixes cplusplus/nbballot#699
Also fixes cplusplus/nbballot#698
Also fixes cplusplus/nbballot#696