### PR TITLE
[2026-03 LWG Motion 24] P4144R1 Remove span’s initializer_list constructor for C++26

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -275,32 +275,6 @@ The C standard library does not define this behavior.
 Valid \CppXXIII{} code that calls \tcode{realloc}
 with a non-null pointer and a size of zero is erroneous and may change behavior.
 
-\rSec2[diff.cpp23.containers]{\ref{containers}: containers library}
-
-\diffref{span.overview}
-\change
-\tcode{span<const T>} is constructible from \tcode{initializer_list<T>}.
-\rationale
-Permit passing a braced initializer list to a function taking \tcode{span}.
-\effect
-Valid \CppXXIII{} code that relies on the lack of this constructor
-may refuse to compile, or change behavior in this revision of \Cpp{}.
-\begin{example}
-\begin{codeblock}
-void one(pair<int, int>);       // \#1
-void one(span<const int>);      // \#2
-void t1() { one({1, 2}); }      // ambiguous between \#1 and \#2; previously called \#1
-
-void two(span<const int, 2>);
-void t2() { two({{1, 2}}); }    // ill-formed; previously well-formed
-
-void *a[10];
-int x = span<void* const>{a, 0}.size();     // \tcode{x} is \tcode{2}; previously \tcode{0}
-any b[10];
-int y = span<const any>{b, b + 10}.size();  // \tcode{y} is \tcode{2}; previously \tcode{10}
-\end{codeblock}
-\end{example}
-
 \rSec2[diff.cpp23.strings]{\ref{strings}: strings library}
 
 \diffref{string.conversions}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -20402,8 +20402,6 @@ In addition to being available via inclusion of the \libheaderref{span} header,
 
 \indexheader{span}%
 \begin{codeblock}
-#include <initializer_list>     // see \ref{initializer.list.syn}
-
 // mostly freestanding
 namespace std {
   // constants
@@ -20487,7 +20485,6 @@ namespace std {
       constexpr span(const array<T, N>& arr) noexcept;
     template<class R>
       constexpr explicit(extent != dynamic_extent) span(R&& r);
-    constexpr explicit(extent != dynamic_extent) span(std::initializer_list<value_type> il);
     constexpr span(const span& other) noexcept = default;
     template<class OtherElementType, size_t OtherExtent>
       constexpr explicit(@\seebelow@) span(const span<OtherElementType, OtherExtent>& s) noexcept;
@@ -20746,27 +20743,6 @@ Initializes \exposid{data_} with \tcode{ranges::data(r)} and
 \pnum
 \throws
 What and when \tcode{ranges::data(r)} and \tcode{ranges::size(r)} throw.
-\end{itemdescr}
-
-\indexlibraryctor{span}%
-\begin{itemdecl}
-constexpr explicit(extent != dynamic_extent) span(std::initializer_list<value_type> il);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\constraints
-\tcode{is_const_v<element_type>} is \tcode{true}.
-
-\pnum
-\hardexpects
-If \tcode{extent} is not equal to \tcode{dynamic_extent},
-then \tcode{il.size() == extent} is \tcode{true}.
-
-\pnum
-\effects
-Initializes \exposid{data_} with \tcode{il.data()} and
-\exposid{size_} with \tcode{il.size()}.
 \end{itemdescr}
 
 \indexlibraryctor{span}%

--- a/source/support.tex
+++ b/source/support.tex
@@ -842,7 +842,6 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_smart_ptr_owner_equality}@          202306L // also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_source_location}@                   201907L // freestanding, also in \libheader{source_location}
 #define @\defnlibxname{cpp_lib_span}@                              202311L // freestanding, also in \libheader{span}
-#define @\defnlibxname{cpp_lib_span_initializer_list}@             202311L // freestanding, also in \libheader{span}
 #define @\defnlibxname{cpp_lib_spanstream}@                        202106L // also in \libheader{iosfwd}, \libheader{spanstream}
 #define @\defnlibxname{cpp_lib_ssize}@                             201902L // freestanding, also in \libheader{iterator}
 #define @\defnlibxname{cpp_lib_sstream_from_string_view}@          202306L // also in \libheader{sstream}


### PR DESCRIPTION
Fixes #8858
Fixes cplusplus/papers#2721

Also fixes https://github.com/cplusplus/papers/issues/2666