### PR TITLE
[2026-03 LWG Motion 34] P3856R8 New reflection metafunction - is_structural_type (US NB comment 49)

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -242,6 +242,7 @@ namespace std {
   template<class T> struct is_final;
   template<class T> struct is_aggregate;
 
+  template<class T> struct is_structural;
   template<class T> struct is_signed;
   template<class T> struct is_unsigned;
   template<class T> struct is_bounded_array;
@@ -493,6 +494,8 @@ namespace std {
     constexpr bool @\libglobal{is_final_v}@ = is_final<T>::value;
   template<class T>
     constexpr bool @\libglobal{is_aggregate_v}@ = is_aggregate<T>::value;
+  template<class T>
+    constexpr bool @\libglobal{is_structural_v}@ = is_structural<T>::value;
   template<class T>
     constexpr bool @\libglobal{is_signed_v}@ = is_signed<T>::value;
   template<class T>
@@ -931,6 +934,12 @@ A union is a class type that
   \tcode{struct is_aggregate;}           &
  \tcode{T} is an aggregate type\iref{dcl.init.aggr} &
  \tcode{T} shall be an array type, a complete type, or \cv~\keyword{void}.              \\ \rowsep
+
+\indexlibraryglobal{is_structural}%
+\tcode{template<class T>}\br
+  \tcode{struct is_structural;}           &
+ \tcode{T} is a structural type\iref{temp.param} &
+ \tcode{remove_all_extents_t<T>} shall be a complete type or \cv~\keyword{void}.        \\ \rowsep
 
 \indexlibrary{\idxcode{is_signed}!class}%
 \tcode{template<class T>}\br
@@ -2901,6 +2910,7 @@ namespace std::meta {
   consteval bool is_abstract_type(info type);
   consteval bool is_final_type(info type);
   consteval bool is_aggregate_type(info type);
+  consteval bool is_structural_type(info type);
   consteval bool is_signed_type(info type);
   consteval bool is_unsigned_type(info type);
   consteval bool is_bounded_array_type(info type);
@@ -6732,6 +6742,7 @@ consteval bool @\libglobal{is_polymorphic_type}@(info type);
 consteval bool @\libglobal{is_abstract_type}@(info type);
 consteval bool @\libglobal{is_final_type}@(info type);
 consteval bool @\libglobal{is_aggregate_type}@(info type);
+consteval bool @\libglobal{is_structural_type}@(info type);
 consteval bool @\libglobal{is_signed_type}@(info type);
 consteval bool @\libglobal{is_unsigned_type}@(info type);
 consteval bool @\libglobal{is_bounded_array_type}@(info type);

--- a/source/support.tex
+++ b/source/support.tex
@@ -746,6 +746,8 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_is_null_pointer}@                   201309L // freestanding, also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_is_pointer_interconvertible}@       201907L // freestanding, also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_is_scoped_enum}@                    202011L // freestanding, also in \libheader{type_traits}
+#define @\defnlibxname{cpp_lib_is_structural}@                     202603L
+  // freestanding, also in \libheader{meta} and \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_is_sufficiently_aligned}@           202411L // freestanding, also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_is_swappable}@                      201603L // freestanding, also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_is_virtual_base_of}@                202406L // freestanding, also in \libheader{type_traits}


### PR DESCRIPTION
Fixes NB US 49-090 (C++26 CD).

Fixes #8868 

Also fixes cplusplus/papers#2460
Also fixes cplusplus/nbballot#667