### PR TITLE
[2026-03 LWG Motion 12] P3059R2 Making user-defined constructors of view iterators/sentinels private

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -3119,7 +3119,8 @@ namespace std::ranges {
     requires @\exposconcept{weakly-equality-comparable-with}@<W, Bound> && @\libconcept{copyable}@<W>
   struct iota_view<W, Bound>::@\exposid{iterator}@ {
   private:
-    W @\exposid{value_}@ = W();             // \expos
+    W @\exposid{value_}@ = W();                             // \expos
+    constexpr explicit @\exposid{iterator}@(W value);       // \expos
 
   public:
     using iterator_concept = @\seebelow@;
@@ -3129,7 +3130,6 @@ namespace std::ranges {
     using difference_type = @\placeholdernc{IOTA-DIFF-T}@(W);
 
     @\exposid{iterator}@() requires @\libconcept{default_initializable}@<W> = default;
-    constexpr explicit @\exposid{iterator}@(W value);
 
     constexpr W operator*() const noexcept(is_nothrow_copy_constructible_v<W>);
 
@@ -3500,11 +3500,11 @@ namespace std::ranges {
     requires @\exposconcept{weakly-equality-comparable-with}@<W, Bound> && @\libconcept{copyable}@<W>
   struct iota_view<W, Bound>::@\exposid{sentinel}@ {
   private:
-    Bound @\exposid{bound_}@ = Bound();     // \expos
+    Bound @\exposid{bound_}@ = Bound();                     // \expos
+    constexpr explicit @\exposid{sentinel}@(Bound bound);   // \expos
 
   public:
     @\exposid{sentinel}@() = default;
-    constexpr explicit @\exposid{sentinel}@(Bound bound);
 
     friend constexpr bool operator==(const @\exposid{iterator}@& x, const @\exposid{sentinel}@& y);
 
@@ -4100,8 +4100,6 @@ namespace std::ranges {
     using difference_type = ptrdiff_t;
     using value_type = Val;
 
-    constexpr explicit @\exposid{iterator}@(basic_istream_view& parent) noexcept;
-
     @\exposid{iterator}@(const @\exposid{iterator}@&) = delete;
     @\exposid{iterator}@(@\exposid{iterator}@&&) = default;
 
@@ -4116,7 +4114,8 @@ namespace std::ranges {
     friend bool operator==(const @\exposid{iterator}@& x, default_sentinel_t);
 
   private:
-    basic_istream_view* @\exposid{parent_}@;                                // \expos
+    constexpr explicit @\exposid{iterator}@(basic_istream_view& parent) noexcept;   // \expos
+    basic_istream_view* @\exposid{parent_}@;                                        // \expos
   };
 }
 \end{codeblock}
@@ -4880,8 +4879,9 @@ namespace std::ranges {
     requires @\libconcept{view}@<V> && is_object_v<Pred>
   class filter_view<V, Pred>::@\exposid{iterator}@ {
   private:
-    iterator_t<V> @\exposid{current_}@ = iterator_t<V>();   // \expos
-    filter_view* @\exposid{parent_}@ = nullptr;             // \expos
+    iterator_t<V> @\exposid{current_}@ = iterator_t<V>();                           // \expos
+    filter_view* @\exposid{parent_}@ = nullptr;                                     // \expos
+    constexpr @\exposid{iterator}@(filter_view& parent, iterator_t<V> current);     // \expos
 
   public:
     using iterator_concept  = @\seebelownc@;
@@ -4890,7 +4890,6 @@ namespace std::ranges {
     using difference_type   = range_difference_t<V>;
 
     @\exposid{iterator}@() requires @\libconcept{default_initializable}@<iterator_t<V>> = default;
-    constexpr @\exposid{iterator}@(filter_view& parent, iterator_t<V> current);
 
     constexpr const iterator_t<V>& base() const & noexcept;
     constexpr iterator_t<V> base() &&;
@@ -5135,11 +5134,11 @@ namespace std::ranges {
     requires @\libconcept{view}@<V> && is_object_v<Pred>
   class filter_view<V, Pred>::@\exposid{sentinel}@ {
   private:
-    sentinel_t<V> @\exposid{end_}@ = sentinel_t<V>();       // \expos
+    sentinel_t<V> @\exposid{end_}@ = sentinel_t<V>();               // \expos
+    constexpr explicit @\exposid{sentinel}@(filter_view& parent);   // \expos
 
   public:
     @\exposid{sentinel}@() = default;
-    constexpr explicit @\exposid{sentinel}@(filter_view& parent);
 
     constexpr sentinel_t<V> base() const;
 
@@ -5380,10 +5379,11 @@ namespace std::ranges {
   template<bool Const>
   class transform_view<V, F>::@\exposid{iterator}@ {
   private:
-    using @\exposidnc{Parent}@ = @\exposidnc{maybe-const}@<Const, transform_view>;          // \expos
-    using @\exposidnc{Base}@ = @\exposidnc{maybe-const}@<Const, V>;                         // \expos
-    iterator_t<@\exposidnc{Base}@> @\exposid{current_}@ = iterator_t<@\exposidnc{Base}@>();             // \expos
-    @\exposidnc{Parent}@* @\exposid{parent_}@ = nullptr;                                  // \expos
+    using @\exposidnc{Parent}@ = @\exposidnc{maybe-const}@<Const, transform_view>;                  // \expos
+    using @\exposidnc{Base}@ = @\exposidnc{maybe-const}@<Const, V>;                                 // \expos
+    iterator_t<@\exposidnc{Base}@> @\exposid{current_}@ = iterator_t<@\exposidnc{Base}@>();                     // \expos
+    @\exposidnc{Parent}@* @\exposid{parent_}@ = nullptr;                                          // \expos
+    constexpr @\exposid{iterator}@(@\exposid{Parent}@& parent, iterator_t<@\exposidnc{Base}@> current);       // \expos
 
   public:
     using iterator_concept  = @\seebelownc@;
@@ -5393,7 +5393,6 @@ namespace std::ranges {
     using difference_type   = range_difference_t<@\exposid{Base}@>;
 
     @\exposid{iterator}@() requires @\libconcept{default_initializable}@<iterator_t<@\exposid{Base}@>> = default;
-    constexpr @\exposid{iterator}@(@\exposid{Parent}@& parent, iterator_t<@\exposid{Base}@> current);
     constexpr @\exposid{iterator}@(@\exposid{iterator}@<!Const> i)
       requires Const && @\libconcept{convertible_to}@<iterator_t<V>, iterator_t<@\exposid{Base}@>>;
 
@@ -5767,10 +5766,10 @@ namespace std::ranges {
     using @\exposid{Parent}@ = @\exposid{maybe-const}@<Const, transform_view>;  // \expos
     using @\exposid{Base}@ = @\exposid{maybe-const}@<Const, V>;                 // \expos
     sentinel_t<@\exposid{Base}@> @\exposid{end_}@ = sentinel_t<@\exposid{Base}@>();         // \expos
+    constexpr explicit @\exposid{sentinel}@(sentinel_t<@\exposid{Base}@> end);  // \expos
 
   public:
     @\exposid{sentinel}@() = default;
-    constexpr explicit @\exposid{sentinel}@(sentinel_t<@\exposid{Base}@> end);
     constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> i)
       requires Const && @\libconcept{convertible_to}@<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
 
@@ -6109,10 +6108,10 @@ namespace std::ranges {
     template<bool OtherConst>
       using @\exposid{CI}@ = counted_iterator<iterator_t<@\exposid{maybe-const}@<OtherConst, V>>>;  // \expos
     sentinel_t<@\exposid{Base}@> @\exposid{end_}@ = sentinel_t<@\exposid{Base}@>();                             // \expos
+    constexpr explicit @\exposid{sentinel}@(sentinel_t<@\exposid{Base}@> end);                      // \expos
 
   public:
     @\exposid{sentinel}@() = default;
-    constexpr explicit @\exposid{sentinel}@(sentinel_t<@\exposid{Base}@> end);
     constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> s)
       requires Const && @\libconcept{convertible_to}@<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
 
@@ -6292,14 +6291,14 @@ namespace std::ranges {
              @\libconcept{indirect_unary_predicate}@<const Pred, iterator_t<V>>
   template<bool Const>
   class take_while_view<V, Pred>::@\exposidnc{sentinel}@ {
-    using @\exposidnc{Base}@ = @\exposidnc{maybe-const}@<Const, V>;                 // \expos
+    using @\exposidnc{Base}@ = @\exposidnc{maybe-const}@<Const, V>;                                        // \expos
 
-    sentinel_t<@\exposidnc{Base}@> @\exposid{end_}@ = sentinel_t<@\exposidnc{Base}@>();         // \expos
-    const Pred* @\exposid{pred_}@ = nullptr;                        // \expos
+    sentinel_t<@\exposidnc{Base}@> @\exposid{end_}@ = sentinel_t<@\exposidnc{Base}@>();                                 // \expos
+    const Pred* @\exposid{pred_}@ = nullptr;                                                // \expos
+    constexpr explicit @\exposid{sentinel}@(sentinel_t<@\exposid{Base}@> end, const Pred* pred);       // \expos
 
   public:
     @\exposid{sentinel}@() = default;
-    constexpr explicit @\exposid{sentinel}@(sentinel_t<@\exposid{Base}@> end, const Pred* pred);
     constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> s)
       requires Const && @\libconcept{convertible_to}@<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
 
@@ -7152,11 +7151,11 @@ namespace std::ranges {
     using @\exposid{Parent}@ = @\exposid{maybe-const}@<Const, join_view>;       // \expos
     using @\exposid{Base}@ = @\exposid{maybe-const}@<Const, V>;                 // \expos
     sentinel_t<@\exposid{Base}@> @\exposid{end_}@ = sentinel_t<@\exposid{Base}@>();         // \expos
+    constexpr explicit @\exposid{sentinel}@(@\exposid{Parent}@& parent);        //  \expos
 
   public:
     @\exposid{sentinel}@() = default;
 
-    constexpr explicit @\exposid{sentinel}@(@\exposid{Parent}@& parent);
     constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> s)
       requires Const && @\libconcept{convertible_to}@<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
 
@@ -8000,6 +7999,10 @@ namespace std::ranges {
                                                             // if \tcode{V} models \libconcept{forward_range}
 
     bool @\exposid{trailing_empty_}@ = false;                           // \expos
+    constexpr explicit @\exposid{outer-iterator}@(@\exposid{Parent}@& parent)      // \expos
+      requires (!@\libconcept{forward_range}@<@\exposid{Base}@>);
+    constexpr @\exposid{outer-iterator}@(@\exposid{Parent}@& parent, iterator_t<@\exposid{Base}@> current)    // \expos
+      requires @\libconcept{forward_range}@<@\exposid{Base}@>;
 
   public:
     using iterator_concept  =
@@ -8013,10 +8016,6 @@ namespace std::ranges {
     using difference_type   = range_difference_t<@\exposid{Base}@>;
 
     @\exposid{outer-iterator}@() = default;
-    constexpr explicit @\exposid{outer-iterator}@(@\exposid{Parent}@& parent)
-      requires (!@\libconcept{forward_range}@<@\exposid{Base}@>);
-    constexpr @\exposid{outer-iterator}@(@\exposid{Parent}@& parent, iterator_t<@\exposid{Base}@> current)
-      requires @\libconcept{forward_range}@<@\exposid{Base}@>;
     constexpr @\exposid{outer-iterator}@(@\exposid{outer-iterator}@<!Const> i)
       requires Const && @\libconcept{convertible_to}@<iterator_t<V>, iterator_t<@\exposid{Base}@>>;
 
@@ -8234,9 +8233,10 @@ namespace std::ranges {
   template<bool Const>
   struct lazy_split_view<V, Pattern>::@\exposid{inner-iterator}@ {
   private:
-    using @\exposidnc{Base}@ = @\exposidnc{maybe-const}@<Const, V>;                     // \expos
-    @\exposidnc{outer-iterator}@<Const> @\exposid{i_}@ = @\exposidnc{outer-iterator}@<Const>();     // \expos
-    bool @\exposid{incremented_}@ = false;                              // \expos
+    using @\exposidnc{Base}@ = @\exposidnc{maybe-const}@<Const, V>;                             // \expos
+    @\exposidnc{outer-iterator}@<Const> @\exposid{i_}@ = @\exposidnc{outer-iterator}@<Const>();             // \expos
+    bool @\exposid{incremented_}@ = false;                                      // \expos
+    constexpr explicit @\exposid{inner-iterator}@(@\exposidnc{outer-iterator}@<Const> i);     // \expos
 
   public:
     using iterator_concept  = @\exposid{outer-iterator}@<Const>::iterator_concept;
@@ -8247,7 +8247,6 @@ namespace std::ranges {
     using difference_type   = range_difference_t<@\exposid{Base}@>;
 
     @\exposid{inner-iterator}@() = default;
-    constexpr explicit @\exposid{inner-iterator}@(@\exposid{outer-iterator}@<Const> i);
 
     constexpr const iterator_t<@\exposid{Base}@>& base() const & noexcept;
     constexpr iterator_t<@\exposid{Base}@> base() && requires @\libconcept{forward_range}@<V>;
@@ -8558,10 +8557,12 @@ namespace std::ranges {
              @\libconcept{indirectly_comparable}@<iterator_t<V>, iterator_t<Pattern>, ranges::equal_to>
   class split_view<V, Pattern>::@\exposid{iterator}@ {
   private:
-    split_view* @\exposid{parent_}@ = nullptr;                              // \expos
-    iterator_t<V> @\exposid{cur_}@ = iterator_t<V>();                       // \expos
-    subrange<iterator_t<V>> @\exposid{next_}@ = subrange<iterator_t<V>>();  // \expos
-    bool @\exposid{trailing_empty_}@ = false;                               // \expos
+    split_view* @\exposid{parent_}@ = nullptr;                                      // \expos
+    iterator_t<V> @\exposid{cur_}@ = iterator_t<V>();                               // \expos
+    subrange<iterator_t<V>> @\exposid{next_}@ = subrange<iterator_t<V>>();          // \expos
+    bool @\exposid{trailing_empty_}@ = false;                                       // \expos
+    constexpr @\exposid{iterator}@(split_view& parent, iterator_t<V> current,       // \expos
+                     subrange<iterator_t<V>> next);
 
   public:
     using iterator_concept = forward_iterator_tag;
@@ -8570,7 +8571,6 @@ namespace std::ranges {
     using difference_type = range_difference_t<V>;
 
     @\exposid{iterator}@() = default;
-    constexpr @\exposid{iterator}@(split_view& parent, iterator_t<V> current, subrange<iterator_t<V>> next);
 
     constexpr iterator_t<V> base() const;
     constexpr value_type operator*() const;
@@ -8685,10 +8685,10 @@ namespace std::ranges {
   struct split_view<V, Pattern>::@\exposid{sentinel}@ {
   private:
     sentinel_t<V> @\exposid{end_}@ = sentinel_t<V>();               // \expos
+    constexpr explicit @\exposid{sentinel}@(split_view& parent);    // \expos
 
   public:
     @\exposid{sentinel}@() = default;
-    constexpr explicit @\exposid{sentinel}@(split_view& parent);
 
     friend constexpr bool operator==(const @\exposid{iterator}@& x, const @\exposid{sentinel}@& y);
   };
@@ -10349,6 +10349,7 @@ namespace std::ranges {
     iterator_t<@\exposid{Base}@> @\exposid{current_}@ = iterator_t<@\exposid{Base}@>();     // \expos
 
     static constexpr decltype(auto) @\exposid{get-element}@(const iterator_t<@\exposid{Base}@>& i);     // \expos
+    constexpr explicit @\exposid{iterator}@(iterator_t<@\exposid{Base}@> current);                      // \expos
 
   public:
     using iterator_concept = @\seebelow@;
@@ -10357,7 +10358,6 @@ namespace std::ranges {
     using difference_type = range_difference_t<@\exposid{Base}@>;
 
     @\exposid{iterator}@() requires @\libconcept{default_initializable}@<iterator_t<@\exposid{Base}@>> = default;
-    constexpr explicit @\exposid{iterator}@(iterator_t<@\exposid{Base}@> current);
     constexpr @\exposid{iterator}@(@\exposid{iterator}@<!Const> i)
       requires Const && @\libconcept{convertible_to}@<iterator_t<V>, iterator_t<@\exposid{Base}@>>;
 
@@ -10744,12 +10744,12 @@ namespace std::ranges {
   template<bool Const>
   class elements_view<V, N>::@\exposid{sentinel}@ {
   private:
-    using @\exposid{Base}@ = @\exposid{maybe-const}@<Const, V>;                 // \expos
+    using @\exposid{Base}@ = @\exposidnc{maybe-const}@<Const, V>;                 // \expos
     sentinel_t<@\exposid{Base}@> @\exposid{end_}@ = sentinel_t<@\exposid{Base}@>();         // \expos
+    constexpr explicit @\exposid{sentinel}@(sentinel_t<@\exposid{Base}@> end);  // \expos
 
   public:
     @\exposid{sentinel}@() = default;
-    constexpr explicit @\exposid{sentinel}@(sentinel_t<@\exposid{Base}@> end);
     constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> other)
       requires Const && @\libconcept{convertible_to}@<sentinel_t<V>, sentinel_t<@\exposid{Base}@>>;
 


### PR DESCRIPTION
Fixes NB GB 09-257 (C++26 CD).

Fixes #8846

Also fixes cplusplus/papers#1726
Also fixes cplusplus/nbballot#832