### PR TITLE
[2026-03 LWG Motion 29] P3980R1 Task’s Allocator Use

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -7645,6 +7645,13 @@ template<@\libconcept{receiver}@ Rcvr>
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
+\mandates
+At least one of the expressions
+\tcode{allocator_type(get_allocator(get_env(rcvr)))} and
+\tcode{allocator_type()}
+is well-formed.
+
+\pnum
 \expects
 \tcode{bool(\exposid{handle})} is \tcode{true}.
 
@@ -7784,9 +7791,6 @@ namespace std::execution {
   template<class T, class Environment>
   class task<T, Environment>::promise_type {
   public:
-    template<class... Args>
-      promise_type(const Args&... args);
-
     task get_return_object() noexcept;
 
     static constexpr suspend_always @\libmember{initial_suspend}{task::promise_type}@() noexcept { return {}; }
@@ -7809,15 +7813,16 @@ namespace std::execution {
 
     @\unspec@ get_env() const noexcept;
 
-    template<class... Args>
-      void* operator new(size_t size, Args&&... args);
+    void* operator new(size_t size);
+    template<class Alloc, class... Args>
+      void* operator new(size_t size, allocator_arg_t, Alloc alloc, Args&&...);
+    template<class This, class Alloc, class... Args>
+      void* operator new(size_t size, const This&, allocator_arg_t, Alloc alloc, Args&&...);
 
     void operator delete(void* pointer, size_t size) noexcept;
 
   private:
     using @\exposidnc{error-variant}@ = @\seebelownc@;    // \expos
-
-    allocator_type    @\exposidnc{alloc}@;            // \expos
   };
 }
 \end{codeblock}
@@ -7833,25 +7838,6 @@ and \tcode{\exposid{SCHED}(\placeholder{prom})}
 associated with \tcode{\placeholder{tsk}}
 during evaluation of \tcode{task::\exposid{state}<Rcvr>::start}
 for some receiver \tcode{Rcvr}.
-
-\indexlibraryctor{task::promise_type}%
-\begin{itemdecl}
-template<class... Args>
-  promise_type(const Args&... args);
-\end{itemdecl}
-\begin{itemdescr}
-\pnum
-\mandates
-The first parameter of type \tcode{allocator_arg_t} (if any) is not
-the last parameter.
-
-\pnum
-\effects
-If \tcode{Args} contains an element of type \tcode{allocator_arg_t}
-then \exposid{alloc} is initialized with the corresponding next
-element of \tcode{args}.
-Otherwise, \exposid{alloc} is initialized with \tcode{allocator_type()}.
-\end{itemdescr}
 
 \indexlibrarymember{get_return_object}{task::promise_type}%
 \begin{itemdecl}
@@ -8007,7 +7993,10 @@ Equivalent to \tcode{\exposid{result}.emplace(std::forward<V>(v))}.
 An object \tcode{env} such that queries are forwarded as follows:
 \begin{itemize}
 \item \tcode{env.query(get_scheduler)} returns \tcode{scheduler_type(\exposid{SCHED}(*this))}.
-\item \tcode{env.query(get_allocator)} returns \exposid{alloc}.
+\item \tcode{env.query(get_allocator)} returns
+\tcode{allocator_type(get_allocator(get_env(\exposid{RCVR}(*this))\brk{}))}
+if this expression is well-formed and
+\tcode{allocator_type()} otherwise.
 \item \tcode{env.query(get_stop_token)} returns
 \tcode{\exposid{STATE}(*this).\exposid{get-stop-token}()}.
 \item For any other query \tcode{q} and arguments \tcode{a...} a
@@ -8020,28 +8009,33 @@ Otherwise \tcode{env.query(q, a...)} is ill-formed.
 
 \indexlibrarymember{operator new}{task::promise_type}%
 \begin{itemdecl}
-template<class... Args>
-  void* operator new(size_t size, const Args&... args);
+void* operator new(size_t size);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to:
+\tcode{return operator new(size, allocator_arg, allocator_type());}
+\end{itemdescr}
+
+\indexlibrarymember{operator new}{task::promise_type}%
+\begin{itemdecl}
+template<class Alloc, class... Args>
+  void* operator new(size_t size, allocator_arg_t, Alloc alloc, Args&&...);
+template<class This, class Alloc, class... Args>
+  void* operator new(size_t size, const This&, allocator_arg_t, Alloc alloc, Args&&...);
 \end{itemdecl}
 \begin{itemdescr}
 \pnum
-If there is no parameter with type \tcode{allocator_arg_t} then let
-\tcode{alloc} be \tcode{allocator_type()}.
-Otherwise, let \tcode{arg_next} be the parameter
-following the first \tcode{allocator_arg_t} parameter,
-and let \tcode{alloc} be \tcode{allocator_type(arg_next)}.
-Let \tcode{PAlloc} be \tcode{allocator_traits<allocator_type>::template
-rebind_alloc<U>}, where \tcode{U} is an unspecified type
+Let \tcode{PAlloc} be
+\tcode{allocator_traits<Alloc>::template rebind_alloc<U>},
+where \tcode{U} is an unspecified type
 whose size and alignment are both \mname{STDCPP_DEFAULT_NEW_ALIGNMENT}.
 
 \pnum
 \mandates
-\begin{itemize}
-\item The first parameter of type \tcode{allocator_arg_t} (if any) is not the last parameter.
-\item \tcode{allocator_type(arg_next)} is a valid expression if there is a parameter
-of type \tcode{allocator_arg_t}.
-\item \tcode{allocator_traits<PAlloc>::pointer} is a pointer type.
-\end{itemize}
+\tcode{allocator_traits<PAlloc>::pointer} is a pointer type.
 
 \pnum
 \effects


### PR DESCRIPTION
Fixes #8863
Fixes #8917
Fixes NB US 254-385, US 253-386, US 255-384, and US 261-391 (C++26 CD).

Also fixes https://github.com/cplusplus/papers/issues/2633
Also fixes cplusplus/papers#2493
Also fixes cplusplus/papers#2495
Also fixes cplusplus/papers#2494

Also fixes https://github.com/cplusplus/nbballot/issues/960
Also fixes https://github.com/cplusplus/nbballot/issues/961
Also fixes https://github.com/cplusplus/nbballot/issues/959
Also fixes https://github.com/cplusplus/nbballot/issues/966
