### PR TITLE
[2026-03 LWG Motion 6] P4012R1 Value-preserving consteval broadcast to simd::vec

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -18030,7 +18030,7 @@ namespace std::simd {
 
     // \ref{simd.ctor}, \tcode{basic_vec} constructors
     template<class U>
-      constexpr explicit(@\seebelow@) basic_vec(U&& value) noexcept;
+      constexpr basic_vec(U&& value) noexcept;
     template<class U, class UAbi>
       constexpr explicit(@\seebelow@) basic_vec(const basic_vec<U, UAbi>&) noexcept;
     template<class G>
@@ -18170,7 +18170,7 @@ otherwise an unspecified non-array object type.
 
 \indexlibraryctor{basic_vec}
 \begin{itemdecl}
-template<class U> constexpr explicit(@\seebelow@) basic_vec(U&& value) noexcept;
+template<class U> constexpr basic_vec(U&& value) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -18179,29 +18179,25 @@ Let \tcode{From} denote the type \tcode{remove_cvref_t<U>}.
 
 \pnum
 \constraints
-\tcode{U} satisfies \tcode{\exposconcept{explicitly-convertible-to}<value_type>}.
+\begin{itemize}
+\item
+\tcode{U} satisfies \tcode{\libconcept{convertible_to}<value_type>} and
+\tcode{From} is not an arithmetic type and
+does not satisfy \exposconcept{constexpr-wrapper-like},
+\item
+\tcode{From} is an arithmetic type and
+the conversion from \tcode{From} to \tcode{value_type}
+is value-preserving\iref{simd.general}, or
+\item
+\tcode{From} satisfies \exposconcept{constexpr-wrapper-like},
+\tcode{remove_cvref_t<decltype(From::value)>} is an arithmetic type, and
+\tcode{From::value} is representable by \tcode{value_type}.
+\end{itemize}
 
 \pnum
 \effects
 Initializes each element to the value of the argument after conversion to
 \tcode{value_type}.
-
-\pnum
-\remarks
-The expression inside \tcode{explicit} evaluates to \tcode{false} if and only if
-\tcode{U} satisfies \tcode{\libconcept{convertible_to}<value_type>}, and either
-\begin{itemize}
- \item
-   \tcode{From} is not an arithmetic type and does not satisfy
-   \exposconcept{constexpr-wrapper-like},
- \item
-   \tcode{From} is an arithmetic type and the conversion from \tcode{From} to
-   \tcode{value_type} is value-preserving\iref{simd.general}, or
- \item
-   \tcode{From} satisfies \exposconcept{constexpr-wrapper-like},
-   \tcode{remove_cvref_t<decltype(From::value)>} is an arithmetic type, and
-   \tcode{From::value} is representable by \tcode{value_type}.
-\end{itemize}
 \end{itemdescr}
 
 \indexlibraryctor{basic_vec}


### PR DESCRIPTION
Fixes #8840
Fixes NB DE-286 (C++26 CD).

Also fixes https://github.com/cplusplus/papers/issues/2648
Also fixes https://github.com/cplusplus/nbballot/issues/861