### PR TITLE
[Motions 2026 03 cwg 2] P4160R0 DR issues except <long list>

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3851,8 +3851,8 @@ The alignment requirement of a complete type can be queried using an
 the narrow character types\iref{basic.fundamental} shall have the weakest
 alignment requirement.
 \begin{note}
-This enables the ordinary character types to be used as the
-underlying type for an aligned memory area\iref{dcl.align}.
+The type \tcode{\keyword{unsigned} \keyword{char}} can be used as
+the element type of an array providing aligned storage\iref{dcl.align}.
 \end{note}
 
 \pnum

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5986,6 +5986,28 @@ alignment requirement.
 \end{note}
 
 \pnum
+A pointer value
+pointing to a potentially non-unique object $O$\iref{intro.object} is
+\indextext{value!associated with an evaluation}%
+\defn{associated with} the evaluation of
+\begin{itemize}
+\item
+the string-literal\iref{lex.string} that resulted in the string literal object,
+\item
+the initializer list\iref{dcl.init.list} that resulted in the backing array,
+or
+\item
+the initialization of
+the template parameter object\iref{temp.arg.nontype, meta.define.static}
+\end{itemize}
+that is $O$ or of which $O$ is a subobject.
+\begin{note}
+A pointer value obtained by pointer arithmetic\iref{expr.add}
+from a pointer value associated with an evaluation $E$
+is also associated with $E$.
+\end{note}
+
+\pnum
 A pointer value $P$ is
 \indextext{value!valid in the context of an evaluation}%
 \defn{valid in the context of} an evaluation $E$

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5666,7 +5666,12 @@ The types denoted by \cv~\tcode{std::nullptr_t} are distinct types.
 A prvalue of type \tcode{std::nullptr_t} is a null pointer
 constant\iref{conv.ptr}. Such values participate in the pointer and the
 pointer-to-member conversions\iref{conv.ptr,conv.mem}.
-\tcode{\keyword{sizeof}(std::nullptr_t)} shall be equal to \tcode{\keyword{sizeof}(\keyword{void}*)}.
+The size\iref{expr.sizeof} and alignment requirement\iref{basic.align} of
+the type \tcode{std::nullptr_t} are those of
+the type ``pointer to \keyword{void}''.
+\begin{note}
+The value representation can comprise no bits\iref{conv.lval}.
+\end{note}
 
 \pnum
 A value of type \tcode{std::meta::info} is called a \defn{reflection}.

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1678,6 +1678,11 @@ are the semantic properties introduced by the declarations
 used in further processing.
 
 \pnum
+There is a \defnadj{program}{point}
+before the first token of the translation unit,
+at least one between every pair of adjacent tokens, and
+at least one after the last token of the translation unit.
+
 A program point $P$ is said to follow
 any declaration in the same translation unit
 whose locus\iref{basic.scope.pdecl} is before $P$.

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3675,12 +3675,6 @@ or
 \end{itemize}
 otherwise, they have distinct addresses
 and occupy disjoint bytes of storage.
-\begin{footnote}
-Under the ``as-if'' rule an
-implementation is allowed to store two objects at the same machine address or
-not store an object at all if the program cannot observe the
-difference\iref{intro.execution}.
-\end{footnote}
 \begin{example}
 \begin{codeblock}
 static const char test1 = 'x';

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -115,13 +115,15 @@ before continuing to parse the program that contains it.
 
 \pnum
 A \defn{variable} is introduced by the
-declaration of
+declaration $D$ of
 \begin{itemize}
 \item
 a reference other than a non-static data member or
 \item
-an object.
+an object,
 \end{itemize}
+where $D$ is not the \grammarterm{parameter-declaration} of
+a \grammarterm{template-parameter}.
 
 \pnum
 An \defn{entity} is a

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3079,9 +3079,7 @@ they appear in the same translation unit, or
 \item
 they both declare type aliases or namespace aliases that have the same underlying entity, or
 \item
-they both declare names with module linkage and are attached to the same module, or
-\item
-they both declare names with external linkage.
+they both declare names with module or external linkage and are attached to the same module.
 \end{itemize}
 \begin{note}
 There are other circumstances in which declarations declare
@@ -3098,9 +3096,11 @@ Such an $H$ can appear only in a header unit.
 \end{note}
 
 \pnum
-If two declarations of an entity are
-attached to different modules, the program is ill-formed;
-no diagnostic is required if neither is reachable from the other.
+\begin{note}
+If two declarations correspond but are
+attached to different modules, the program is ill-formed
+if one precedes the other\iref{basic.scope.scope}.
+\end{note}
 \begin{example}
 \begin{codeblocktu}{\tcode{"decls.h"}}
 int f();            // \#1, attached to the global module
@@ -3112,15 +3112,15 @@ module;
 #include "decls.h"
 export module M;
 export using ::f;   // OK, does not declare an entity, exports \#1
-int g();            // error: matches \#2, but attached to \tcode{M}
+int g();            // error: corresponds to \#2, but attached to \tcode{M}
 export int h();     // \#3
 export int k();     // \#4
 \end{codeblocktu}
 
 \begin{codeblocktu}{Other translation unit}
 import M;
-static int h();     // error: matches \#3
-int k();            // error: matches \#4
+static int h();     // error: conflicts with \#3
+int k();            // error: conflicts with \#4
 \end{codeblocktu}
 \end{example}
 As a consequence of these rules,

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3640,7 +3640,13 @@ that are not bit-fields
 may have the same address if
 \begin{itemize}
 \item one is nested within the other,
-\item at least one is a subobject of zero size and they are not of similar types\iref{conv.qual},
+\item
+they are both nested within some complete object $o$,
+exactly one is a subobject of $o$, and the subobject is of zero size,
+\item
+they are both subobjects of the same complete object,
+at least one is a subobject of zero size, and
+they are not of similar types\iref{conv.qual},
 or
 \item they are both potentially non-unique objects;
 \end{itemize}

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -32,10 +32,26 @@ Clauses.
 \end{note}
 
 \pnum
-A \defn{name} is an \grammarterm{identifier}\iref{lex.name},
-\grammarterm{conversion-function-id}\iref{class.conv.fct},
-\grammarterm{operator-function-id}\iref{over.oper}, or
-\grammarterm{literal-operator-id}\iref{over.literal}.
+A \defn{name} is
+\begin{itemize}
+\item an \grammarterm{identifier} token\iref{lex.token, lex.name} other than
+  \begin{itemize}
+  \item
+  the \grammarterm{identifier} of a
+  \grammarterm{label}\iref{stmt.label} or
+  \grammarterm{literal-operator-id}\iref{over.literal},
+  \item
+  the \grammarterm{identifier} following a \keyword{goto} in a
+  \grammarterm{jump-statement}\iref{stmt.jump.general},
+  \item
+  any \grammarterm{identifier} in a
+  \grammarterm{module-name}\iref{module.unit} or
+  \grammarterm{attribute-token}\iref{dcl.attr.grammar}, or
+  \end{itemize}
+\item a \grammarterm{conversion-function-id}\iref{class.conv.fct},
+\item an \grammarterm{operator-function-id}\iref{over.oper}, or
+\item a \grammarterm{literal-operator-id}\iref{over.literal}.
+\end{itemize}
 
 \pnum
 Two names are \defnx{the same}{name!same} if

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -580,6 +580,10 @@ and each such \grammarterm{member-declaration}
 shall either
 declare at least one member name of the class
 or declare at least one unnamed bit-field.
+A \defnx{user-declared}{entity!user-declared}
+\indextext{user-declared entity|see{entity, user-declared}}
+entity is a direct member or a friend that, in either case,
+is declared by a \grammarterm{member-declaration}.
 
 \pnum
 A \defn{data member} is either a non-function member introduced by a
@@ -1273,8 +1277,9 @@ that is not a function parameter pack
 has a default argument
 (including the case of a constructor with no parameters).
 \indextext{implicitly-declared default constructor}%
-If there is no user-declared constructor or constructor template for class
-\tcode{X} and \tcode{X} is not an anonymous union,
+If a class does not have
+a user-declared constructor or constructor template,
+and the class is not an anonymous union,
 a non-explicit constructor having no parameters is implicitly declared
 as defaulted\iref{dcl.fct.def}.
 An implicitly-declared default constructor is an
@@ -1503,7 +1508,7 @@ void h() {
 \end{example}
 
 \pnum
-If the class definition does not explicitly declare a copy constructor
+If the class does not have a user-declared copy constructor
 and the class is not an anonymous union,
 a non-explicit one is declared \defnx{implicitly}{constructor!copy!implicitly declared}.
 If the class definition declares a move
@@ -1544,8 +1549,8 @@ X::X(X&)
 
 \pnum
 \indextext{constructor!move!implicitly declared}%
-If the definition of a class \tcode{X} does not explicitly declare
-a move constructor, a non-explicit one will be
+If a class \tcode{X} does not have
+a user-declared move constructor, a non-explicit one will be
 implicitly declared as defaulted if and only if
 \begin{itemize}
 \item
@@ -1603,6 +1608,17 @@ A defaulted move constructor that is defined as deleted is ignored by overload
 resolution\iref{over.match,over.over}.
 Such a constructor would otherwise interfere with initialization from
 an rvalue which can use the copy constructor instead.
+\end{note}
+
+\pnum
+\begin{note}
+A using-declaration in a derived class \tcode{C} that
+names a constructor from a base class
+never suppresses the implicit declaration of
+a copy/move constructor of \tcode{C},
+even if the base class constructor would be
+a copy or move constructor
+if declared as a member of \tcode{C}.
 \end{note}
 
 \pnum
@@ -1746,10 +1762,10 @@ void f() {
 \end{note}
 
 \pnum
-If the class definition does not explicitly declare a copy assignment operator
+If the class does not have a user-declared copy assignment operator
 and the class is not an anonymous union,
 one is declared \defnx{implicitly}{assignment operator!copy!implicitly declared}.
-If the class definition declares a move
+If the class has a user-declared move
 constructor or move assignment operator, the implicitly declared copy
 assignment operator is defined as deleted; otherwise, it is
 defaulted\iref{dcl.fct.def}.

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3272,7 +3272,9 @@ Each \grammarterm{member-declaration} in the \grammarterm{member-specification}
 of an anonymous union shall define one or more public non-static data members,
 be an \grammarterm{empty-declaration}, or
 be a \grammarterm{static_assert-declaration}.
-Nested types, anonymous unions, and functions
+Nested types
+(including closure types\iref{expr.prim.lambda.closure} and anonymous unions)
+and functions
 shall not be declared within an anonymous union.
 The names of the members of an anonymous union
 are bound in the scope inhabited by the union declaration.

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -4128,11 +4128,11 @@ deleted function.%
 \indextext{function!virtual|)}
 
 \pnum
-A class with a \keyword{consteval} virtual function that overrides
-a virtual function that is not \keyword{consteval}
+A class with an immediate virtual function that overrides
+a non-immediate virtual function
 shall have consteval-only type\iref{basic.types.general}.
-A \keyword{consteval} virtual function shall not be overridden by
-a virtual function that is not \keyword{consteval}.
+An immediate virtual function shall not be overridden by
+a non-immediate virtual function.
 
 \rSec2[class.abstract]{Abstract classes}%
 

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -1274,7 +1274,7 @@ has a default argument
 (including the case of a constructor with no parameters).
 \indextext{implicitly-declared default constructor}%
 If there is no user-declared constructor or constructor template for class
-\tcode{X},
+\tcode{X} and \tcode{X} is not an anonymous union,
 a non-explicit constructor having no parameters is implicitly declared
 as defaulted\iref{dcl.fct.def}.
 An implicitly-declared default constructor is an
@@ -1503,7 +1503,8 @@ void h() {
 \end{example}
 
 \pnum
-If the class definition does not explicitly declare a copy constructor,
+If the class definition does not explicitly declare a copy constructor
+and the class is not an anonymous union,
 a non-explicit one is declared \defnx{implicitly}{constructor!copy!implicitly declared}.
 If the class definition declares a move
 constructor or move assignment operator, the implicitly declared copy
@@ -1547,6 +1548,9 @@ If the definition of a class \tcode{X} does not explicitly declare
 a move constructor, a non-explicit one will be
 implicitly declared as defaulted if and only if
 \begin{itemize}
+\item
+\tcode{X} is not an anonymous union,
+
 \item
 \tcode{X} does not have a user-declared copy constructor,
 
@@ -1742,7 +1746,8 @@ void f() {
 \end{note}
 
 \pnum
-If the class definition does not explicitly declare a copy assignment operator,
+If the class definition does not explicitly declare a copy assignment operator
+and the class is not an anonymous union,
 one is declared \defnx{implicitly}{assignment operator!copy!implicitly declared}.
 If the class definition declares a move
 constructor or move assignment operator, the implicitly declared copy
@@ -1796,6 +1801,9 @@ If the definition of a class \tcode{X} does not explicitly declare a
 move assignment operator, one
 will be implicitly declared as defaulted if and only if
 \begin{itemize}
+\item
+\tcode{X} is not an anonymous union,
+
 \item
 \tcode{X} does not have a user-declared copy constructor,
 
@@ -2030,7 +2038,8 @@ shall be
 \indextext{generated destructor|see{destructor, default}}%
 \indextext{destructor!default}%
 If a class has no user-declared
-prospective destructor,
+prospective destructor
+and the class is not an anonymous union,
 a prospective destructor is implicitly
 declared as defaulted\iref{dcl.fct.def}.
 An implicitly-declared prospective destructor is an
@@ -2043,7 +2052,8 @@ An implicitly-declared prospective destructor for a class \tcode{X} will have th
 \end{codeblock}
 
 \pnum
-At the end of the definition of a class,
+At the end of the definition of a class
+other than an anonymous union,
 overload resolution is performed
 among the prospective destructors declared in that class
 with an empty argument list
@@ -3266,6 +3276,7 @@ an unnamed object of that type called
 an \defnx{anonymous union member}{member!anonymous union}
 if it is a non-static data member or
 an \defnx{anonymous union variable}{variable!anonymous union} otherwise.
+Each object of such an unnamed type shall be such an unnamed object.
 \indextext{access control!anonymous \tcode{union}}%
 \indextext{restriction!anonymous \tcode{union}}%
 Each \grammarterm{member-declaration} in the \grammarterm{member-specification}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -8803,14 +8803,14 @@ Since destructors do not have names, a
 \grammarterm{using-declaration} cannot refer to a
 destructor for a base class.
 \end{note}
-If a constructor or assignment operator brought from a base class into a derived class
-has the signature of a copy/move constructor or assignment operator
-for the derived class\iref{class.copy.ctor,class.copy.assign},
-the \grammarterm{using-declaration} does not by itself
-suppress the implicit declaration of the derived class member;
-the member from the base class is hidden or overridden
-by the implicitly-declared copy/move constructor or assignment operator
-of the derived class, as described below.
+\begin{note}
+A \grammarterm{using-declarator} that
+names a member function of a base class
+does not suppress the implicit declaration of a special member function
+in the derived class,
+even if their signatures are the
+same\iref{class.default.ctor, class.copy.ctor, class.copy.assign}.
+\end{note}
 
 \pnum
 A \grammarterm{using-declaration} shall not name a \grammarterm{template-id}.

--- a/source/exceptions.tex
+++ b/source/exceptions.tex
@@ -887,7 +887,7 @@ polymorphic class type\iref{expr.typeid},
 or
 \item
 any of the immediate subexpressions\iref{intro.execution}
-of $E$ is potentially-throwing.
+of $E$ that is not an unevaluated operand is potentially-throwing.
 \end{itemize}
 
 \pnum

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -8330,6 +8330,19 @@ It is unspecified whether the value of \tcode{f()} will be \tcode{true} or \tcod
 \rSec2[expr.const.core]{Core constant expressions}
 
 \pnum
+\indextext{type!constexpr-unknown representation}%
+A type has \defnadj{constexpr-unknown}{representation} if it
+\begin{itemize}
+\item is a union,
+\item is a pointer or pointer-to-member type,
+\item is volatile-qualified,
+\item is a class type with a non-static data member of reference type, or
+\item
+has a base class or a non-static member whose
+type has constexpr-unknown representation.
+\end{itemize}
+
+\pnum
 An expression $E$ is a \defnadj{core constant}{expression}
 unless the evaluation of $E$, following the rules of the abstract
 machine\iref{intro.execution}, would evaluate one of the following:
@@ -8555,6 +8568,34 @@ a \grammarterm{yield-expression}\iref{expr.yield};
 a three-way comparison\iref{expr.spaceship},
 relational\iref{expr.rel}, or equality\iref{expr.eq}
 operator where the result is unspecified;
+
+\item
+an equality operator comparing pointers to potentially non-unique objects,
+if the pointer values of the two operands
+are associated with different evaluations\iref{basic.compound} and either
+they can both point to the same offset within
+the same potentially non-unique object or
+one of them points to an object whose
+type has constexpr-unknown representation;
+\begin{example}
+\begin{codeblock}
+constexpr const char *f() { return "foo"; }
+
+constexpr bool b1 = +"foo" == "foo";                // error: non-constant
+constexpr bool b2 = f() == f();                     // error: non-constant
+constexpr const char *p = f();
+constexpr bool b3 = p == p;                         // OK, value of \tcode{b3} is \tcode{true}
+constexpr bool b4 = "xfoo" + 1 == "foo\0y";         // error: non-constant; string literal
+                                                    // object could contain \tcode{"xfoo\textbackslash{}0y"}
+constexpr bool b5 = "foo" == "bar" + 0;             // OK, value of \tcode{b5} is \tcode{false}
+constexpr bool b6 = (const char*)"foo" == "oo";     // OK, value of \tcode{b6} is \tcode{false}; offsets would
+                                                    // be different in a merged string literal object
+
+constexpr std::initializer_list<int *> il1 = { (int *)nullptr };
+constexpr std::initializer_list<unsigned long> il2 = { 0 };
+constexpr bool b7 = il1.begin() == (void *)il2.begin();     // error: non-constant
+\end{codeblock}
+\end{example}
 
 \item
 a \keyword{dynamic_cast}\iref{expr.dynamic.cast} or

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -9206,7 +9206,7 @@ An \defnx{immediate-escalating}{function!immediate-escalating} function is
 the call operator of a lambda that is not declared
 with the \keyword{consteval} specifier,
 \item
-a defaulted special member function
+a non-user-provided defaulted function
 that is not declared with the \keyword{consteval} specifier, or
 \item
 a function that is not a prospective destructor and

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3093,12 +3093,13 @@ std::cout << a << b << c;
 \end{example}
 
 \pnum
-When the \grammarterm{lambda-expression} is evaluated, the entities that are
+The entities that are
 captured by copy are used to direct-initialize each corresponding non-static data member
 of the resulting closure object, and the non-static data members corresponding to the
 \grammarterm{init-capture}{s} are initialized as indicated by the corresponding
 \grammarterm{initializer} (which may be copy- or direct-initialization). (For array members, the array elements are
 direct-initialized in increasing subscript order.) These initializations are performed
+when the \grammarterm{lambda-expression} is evaluated and
 in the (unspecified) order in which the non-static data members are declared.
 \begin{note}
 This ensures that the destructions will occur in the reverse order of the constructions.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5675,6 +5675,8 @@ of the referenced type.
 When applied to a class, the result is the number of bytes in an object
 of that class including any padding required for placing objects of that
 type in an array.
+The amount and placement of padding in a class type
+is a property of the implementation.
 The result of applying \keyword{sizeof} to a
 potentially-overlapping subobject is
 the size of the type, not the size of the subobject.

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2238,7 +2238,8 @@ classes.
 \end{note}
 
 \pnum
-The closure type is not an aggregate type\iref{dcl.init.aggr};
+The closure type is not an aggregate type\iref{dcl.init.aggr}
+and is not \tcode{final}\iref{class.pre};
 it is a structural type\iref{term.structural.type} if and only if
 the lambda has no \grammarterm{lambda-capture}.
 An implementation may define the closure type differently from what

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -8520,10 +8520,11 @@ a non-allocating form\iref{new.delete.placement}
 with an allocated type \tcode{T}, where
 \begin{itemize}
 \item
-the placement argument to the \grammarterm{new-expression} points to
-an object whose type is similar to \tcode{T}\iref{conv.qual} or,
-if \tcode{T} is an array type,
-to the first element of an object of a type similar to \tcode{T}, and
+the placement argument to the \grammarterm{new-expression} points
+to an object that is transparently replaceable\iref{basic.life} by
+the object created by the \grammarterm{new-expression}
+or, if \tcode{T} is an array type,
+to the first element of such an object, and
 \item
 the placement argument points to storage
 whose duration began within the evaluation of $E$;

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -8849,7 +8849,7 @@ constexpr const Base& b = fn(obj);  // error: not a constant expression because 
 \end{itemize}
 or
 \item
-a prvalue core constant expression whose result object\iref{basic.lval}
+a prvalue core constant expression whose result object\iref{basic.lval} (if any)
 satisfies the following constraints:
 \begin{itemize}
 \item

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1436,7 +1436,7 @@ struct C {
 
 \pnum
 If an \grammarterm{id-expression} $E$ denotes
-a member $M$ of an anonymous union\iref{class.union.anon} $U$:
+a variant member $M$ of an anonymous union\iref{class.union.anon} $U$:
 \begin{itemize}
 \item
 If $U$ is a non-static data member,

--- a/source/intro.tex
+++ b/source/intro.tex
@@ -462,6 +462,11 @@ sorts the pairs in increasing order of their \tcode{first} members:
 \end{codeblock}
 \end{example}
 
+\indexdefn{property!of the implementation}%
+\definition{property of the implementation}{defns.impl.prop}
+behavior, for a well-formed program\iref{defns.well.formed}
+construct and correct data, that depends on the implementation
+
 \definition{referenceable type}{defns.referenceable}
 \indexdefn{type!referenceable}%
 type that is either an
@@ -920,10 +925,14 @@ observable behavior of the program are produced.
 
 \pnum
 \indextext{behavior!implementation-defined}%
-Certain aspects and operations of the abstract machine are described in this
+Certain aspects and operations of the abstract machine
+constitute the parameters of the abstract machine and
+are described in this
 document as implementation-defined behavior (for example,
-\tcode{sizeof(int)}). These constitute the parameters of the abstract machine.
-Each implementation shall include documentation describing its characteristics
+\tcode{sizeof(int)})
+or as properties of the implementation (for example, padding in class types).
+For implementation-defined behavior,
+each implementation shall include documentation describing its characteristics
 and behavior in these respects.
 \begin{footnote}
 This documentation also includes

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -1784,6 +1784,15 @@ is the scaled value if representable,
 else the larger or smaller representable value nearest the scaled value,
 chosen in an \impldef{choice of larger or smaller value of
 \grammarterm{floating-point-literal}} manner.
+\begin{example}
+The following example assumes that
+\tcode{std::float32_t} is supported\iref{basic.extended.fp}.
+\begin{codeblock}
+std::float32_t x = 0.0f32;          // value \tcode{0} is exactly representable
+std::float32_t y = 0.1f32;          // rounded to one of two values nearest to \tcode{0.1}
+std::float32_t z = 1e1000000000f32; // either greatest finite value or positive infinity
+\end{codeblock}
+\end{example}
 
 \rSec2[lex.string]{String literals}
 

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -585,6 +585,7 @@ string literal.
 \pnum
 Each preprocessing token that is converted to a token\iref{lex.token}
 shall have the lexical form of a keyword, an identifier, a literal,
+a header name,
 or an operator or punctuator.
 
 \pnum
@@ -872,12 +873,14 @@ The set of alternative tokens is defined in
     identifier\br
     keyword\br
     literal\br
+    header-name\br
     operator-or-punctuator
 \end{bnf}
 
 \pnum
 \indextext{\idxgram{token}}%
-There are five kinds of tokens: identifiers, keywords, literals,
+There are six kinds of tokens: identifiers, keywords, literals,
+header names,
 operators, and other separators.
 \indextext{token|)}
 

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3899,7 +3899,7 @@ determination of the operator's result type.
 \pnum
 For every pair of types \tcode{\placeholder{L}} and \tcode{\placeholder{R}},
 where each of \tcode{\placeholder{L}} and \tcode{\placeholder{R}} is a
-floating-point or promoted integral type,
+cv-unqualified floating-point or promoted integral type,
 there exist candidate operator functions of the form
 \begin{codeblock}
 @\placeholder{LR}@      operator*(@\placeholder{L}@, @\placeholder{R}@);
@@ -3921,14 +3921,14 @@ and
 \tcode{\placeholder{R}}.
 
 \pnum
-For every integral type \tcode{\placeholder{T}}
+For every cv-unqualified integral type \tcode{\placeholder{T}}
 there exists a candidate operator function of the form
 \begin{codeblock}
 std::strong_ordering operator<=>(@\placeholder{T}@, @\placeholder{T}@);
 \end{codeblock}
 
 \pnum
-For every pair of floating-point types
+For every pair of cv-unqualified floating-point types
 \tcode{\placeholder{L}} and \tcode{\placeholder{R}},
 there exists a candidate operator function of the form
 \begin{codeblock}
@@ -4005,8 +4005,9 @@ and
 \pnum
 For every triple
 (\tcode{\placeholder{L}}, \cvqual{vq}, \tcode{\placeholder{R}}),
-where \tcode{\placeholder{L}} is an arithmetic type,
-and \tcode{\placeholder{R}} is a floating-point or promoted integral type,
+where \tcode{\placeholder{L}} is a cv-unqualified arithmetic type
+and \tcode{\placeholder{R}} is
+a cv-unqualified floating-point or promoted integral type,
 there exist candidate operator functions of the form
 \begin{codeblock}
 @\cvqual{vq} \placeholder{L}@&   operator=(@\cvqual{vq} \placeholder{L}@&, @\placeholder{R}@);
@@ -4056,7 +4057,7 @@ For every triple
 \tcode{\placeholder{R}}),
 where
 \tcode{\placeholder{L}}
-is an integral type, and
+is a cv-unqualified integral type and
 \tcode{\placeholder{R}}
 is a promoted integral type,
 there exist candidate operator functions of the form
@@ -4080,7 +4081,7 @@ bool    operator||(bool, bool);
 \pnum
 For every pair of types \tcode{\placeholder{L}} and \tcode{\placeholder{R}},
 where each of \tcode{\placeholder{L}} and \tcode{\placeholder{R}} is a
-floating-point or promoted integral type,
+cv-unqualified floating-point or promoted integral type,
 there exist candidate operator functions of the form
 \begin{codeblock}
 @\placeholder{LR}@      operator?:(bool, @\placeholder{L}@, @\placeholder{R}@);

--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -1056,7 +1056,8 @@ the non-explicit constructors\iref{class.conv.ctor} of that
 class.
 The argument list is the
 \grammarterm{expression-list} or \grammarterm{assignment-expression}
-of the \grammarterm{initializer}.
+of the \grammarterm{initializer};
+for default-initialization, the argument list is empty.
 For default-initialization in the context of copy-list-initialization,
 if an explicit constructor is chosen, the initialization is ill-formed.
 

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -2280,7 +2280,7 @@ The presumed source file name can be changed by the \tcode{\#line} directive\ire
 \item
 \indextext{__line__@\mname{LINE}}%
 \mname{LINE}\\
-\tcode{0} or a decimal integer literal\iref{lex.icon},
+The integer literal \tcode{0} or a decimal integer literal\iref{lex.icon},
 with no digit separators and no \grammarterm{integer-suffix},
 representing the presumed line number of
 the current source line within the current source file.

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1224,7 +1224,7 @@ int infinity_zero () {
 
 \begin{bnf}
 \nontermdef{pp-module}\br
-    \opt{\keyword{export}} \keyword{module} \opt{pp-tokens} \terminal{;} new-line
+    \opt{\keyword{export}} \keyword{module} \opt{pp-tokens} new-line
 \end{bnf}
 
 \pnum
@@ -1233,8 +1233,7 @@ shall be of the form:
 \begin{ncsimplebnf}
 pp-module-name \opt{pp-module-partition} \opt{pp-tokens}
 \end{ncsimplebnf}
-where the \grammarterm{pp-tokens} (if any) shall not begin with
-a \tcode{(} preprocessing token and
+where
 the grammar non-terminals are defined as:
 \begin{ncbnf}
 \nontermdef{pp-module-name}\br
@@ -1251,15 +1250,9 @@ the grammar non-terminals are defined as:
 \end{ncbnf}
 No \grammarterm{identifier} in
 the \grammarterm{pp-module-name} or \grammarterm{pp-module-partition}
-shall currently be defined as an object-like macro.
-
-\pnum
-Any preprocessing tokens after the \tcode{module} preprocessing token
-in the \tcode{module} directive are processed just as in normal text.
-\begin{note}
-Each identifier currently defined as a macro name
-is replaced by its replacement list of preprocessing tokens.
-\end{note}
+shall currently be defined as an object-like macro
+or followed by \tcode{(} as the next preprocessing token at
+the start of phase 4 of translation\iref{lex.phases}.
 
 \pnum
 The \tcode{module} and \tcode{export} (if it exists) preprocessing tokens
@@ -1269,6 +1262,69 @@ are replaced by the \grammarterm{module-keyword} and
 This makes the line no longer a directive
 so it is not removed at the end of phase 4.
 \end{note}
+After this replacement,
+the preprocessing tokens that constituted the directive are
+a \grammarterm{text-line} and are processed as normal text.
+\begin{note}
+No macro expansion is possible for
+the \grammarterm{pp-module-name} and \grammarterm{pp-module-partition}.
+\end{note}
+After such processing,
+there shall be a \tcode{;} or \tcode{[} preprocessing token following
+the \grammarterm{pp-module-name} and
+optional \grammarterm{pp-module-partition}.
+
+\pnum
+\begin{example}
+\begin{codeblocktu}{Importable header \tcode{"common.h"}}
+#define DOT_BAR .bar
+#define MOD_ATTR [[vendor::shiny_module]]
+\end{codeblocktu}
+
+\begin{codeblocktu}{Translation unit \tcode{\#1}}
+module;
+#include "common.h"
+
+export module foo DOT_BAR;      // error: expansion of \tcode{DOT_BAR;} does not begin with \tcode{;} or \tcode{[}
+\end{codeblocktu}
+
+\begin{codeblocktu}{Translation unit \tcode{\#2}}
+module;
+#include "common.h"
+
+export module M MOD_ATTR ;      // OK
+\end{codeblocktu}
+\end{example}
+
+\begin{example}
+\begin{codeblock}
+export module a
+.b;                             // error: preprocessing token after \grammarterm{pp-module-name} is not \tcode{;} or \tcode{[}
+\end{codeblock}
+\end{example}
+
+\begin{example}
+\begin{codeblock}
+export module M [[
+attr1,
+attr2 ]] ;                      // OK
+\end{codeblock}
+\end{example}
+
+\begin{example}
+\begin{codeblock}
+export module M
+[[ attr1,
+attr2 ]] ;                      // OK
+\end{codeblock}
+\end{example}
+
+\begin{example}
+\begin{codeblock}
+export module M; int
+n;                              // OK
+\end{codeblock}
+\end{example}
 
 \rSec1[cpp.import]{Header unit importation}
 \indextext{header unit!preprocessing}%

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -509,12 +509,6 @@ The identifiers \xname{has_include}, \xname{has_embed}, and \xname{has_cpp_attri
 shall not appear in any context not mentioned in this subclause.
 
 \pnum
-Each preprocessing token that remains (in the list of preprocessing tokens that
-will become the controlling expression)
-after all macro replacements have occurred
-shall be in the lexical form of a token\iref{lex.token}.
-
-\pnum
 Preprocessing directives of the forms
 \begin{ncsimplebnf}
 \indextext{\idxcode{\#if}}%

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -2280,7 +2280,9 @@ The presumed source file name can be changed by the \tcode{\#line} directive\ire
 \item
 \indextext{__line__@\mname{LINE}}%
 \mname{LINE}\\
-An integer literal representing the presumed line number of
+\tcode{0} or a decimal integer literal\iref{lex.icon},
+with no digit separators and no \grammarterm{integer-suffix},
+representing the presumed line number of
 the current source line within the current source file.
 \begin{note}
 The presumed line number can be changed by the \tcode{\#line} directive\iref{cpp.line}.

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -1300,7 +1300,8 @@ is \defnx{active}{variable!active} everywhere in the scope to which it belongs
 after its \grammarterm{init-declarator}.
 \indextext{initialization!jump past}%
 \indextext{\idxcode{goto}!initialization and}%
-Upon each transfer of control (including sequential execution of statements)
+Upon each transfer of control (including sequential execution of statements,
+but excluding function calls)
 within a function from point $P$ to point $Q$,
 all block variables with automatic storage duration
 that are active at $P$ and not at $Q$ are destroyed in the reverse order of their construction.

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -35,6 +35,11 @@ Except as indicated, statements are executed in sequence\iref{intro.execution}.
 \begin{bnf}
 \nontermdef{condition}\br
     expression\br
+    condition-declaration
+\end{bnf}
+
+\begin{bnf}
+\nontermdef{condition-declaration}\br
     \opt{attribute-specifier-seq} decl-specifier-seq declarator brace-or-equal-initializer\br
     structured-binding-declaration initializer
 \end{bnf}
@@ -143,7 +148,7 @@ ill-formed. The value of the condition will be referred to as simply
 
 \pnum
 If a \grammarterm{condition} can be syntactically resolved
-as either an expression or a declaration,
+as either an \grammarterm{expression} or a \grammarterm{condition-declaration},
 it is interpreted as the latter.
 
 \pnum

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -4404,10 +4404,10 @@ during overload resolution for a call to a function template specialization\iref
 \item
 when the address of a function template specialization is taken;
 \item
-when a placement operator delete that is a
+when a placement deallocation function that is a
 function template
 specialization
-is selected to match a placement operator new\iref{basic.stc.dynamic.deallocation,expr.new};
+is selected to match a placement allocation function\iref{basic.stc.dynamic.deallocation,expr.new};
 \item
 when a friend function declaration\iref{temp.friend}, an
 explicit instantiation\iref{temp.explicit} or an explicit specialization\iref{temp.expl.spec} refers to
@@ -9639,12 +9639,12 @@ the specialization to which the declaration refers. Specifically, this is done
 for explicit instantiations\iref{temp.explicit}, explicit specializations\iref{temp.expl.spec},
 and certain friend declarations\iref{temp.friend}. This is also done to
 determine whether a deallocation function template specialization matches a placement
-\tcode{operator new}\iref{basic.stc.dynamic.deallocation,expr.new}.
+allocation function\iref{basic.stc.dynamic.deallocation,expr.new}.
 In all these cases, \tcode{P} is the type of the function template being considered
 as a potential match and \tcode{A} is either the function type from the
 declaration
 or the type of the deallocation function that would match the placement
-\tcode{operator new} as described in~\ref{expr.new}. The
+allocation function as described in~\ref{expr.new}. The
 deduction is done as described in~\ref{temp.deduct.type}.
 
 \pnum

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15943,15 +15943,8 @@ Neither \tcode{To} nor \tcode{From} are consteval-only types\iref{basic.types.ge
 
 \pnum
 \constantwhen
-\tcode{To}, \tcode{From}, and the types of all subobjects
-of \tcode{To} and \tcode{From} are types \tcode{T} such that:
-\begin{itemize}
-\item \tcode{is_union_v<T>} is \tcode{false};
-\item \tcode{is_pointer_v<T>} is \tcode{false};
-\item \tcode{is_member_pointer_v<T>} is \tcode{false};
-\item \tcode{is_volatile_v<T>} is \tcode{false}; and
-\item \tcode{T} has no non-static data members of reference type.
-\end{itemize}
+Neither \tcode{To} nor \tcode{From}
+has constexpr-unknown representation\iref{expr.const}.
 
 \pnum
 \returns


### PR DESCRIPTION
Fixes #8823.
Fixes cplusplus/papers#2732

Also fixes #5560

Also fixes cplusplus/CWG#89
Also fixes cplusplus/CWG#338
Also fixes cplusplus/CWG#545
Also fixes cplusplus/CWG#644
Also fixes cplusplus/CWG#656
Also fixes cplusplus/CWG#148
Also fixes cplusplus/CWG#673
Also fixes cplusplus/CWG#687
Also fixes cplusplus/CWG#706
Also fixes cplusplus/CWG#749
Also fixes cplusplus/CWG#813
Also fixes cplusplus/CWG#812
Also fixes cplusplus/CWG#801
Also fixes cplusplus/CWG#802
Also fixes cplusplus/CWG#800
Also fixes cplusplus/CWG#821
Also fixes cplusplus/CWG#826
Also fixes cplusplus/CWG#832
Also fixes cplusplus/CWG#837
Also fixes cplusplus/CWG#841
Also fixes cplusplus/CWG#838

Also fixes cplusplus/papers#2684

Also fixes cplusplus/nbballot#606
Also fixes cplusplus/nbballot#605
Also fixes cplusplus/nbballot#604

Notes:
* CWG2660: Not applied (already fixed by A. Jiang in 35904b92e).
* CWG2765: Targeted text in [expr.const] moved to [expr.const.core].
* CWG2983: The 2nd sentence of [basic.pre]p7 is no longer present.