### PR TITLE
[2026-03 CWG Motion 13] Issue 3141 in P4160R0 (CWG3141 Unique objects from define_static_array)

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3646,8 +3646,7 @@ An object is a \defnadj{potentially non-unique}{object} if it is
 \item
   the backing array of an initializer list\iref{dcl.init.ref}, or
 \item
-  the object introduced by a call to \tcode{std::meta::reflect_constant_array}
-  or \tcode{std::meta::reflect_constant_string}\iref{meta.define.static}, or
+  a template parameter object of array type\iref{meta.define.static}, or
 \item
   a subobject thereof.
 \end{itemize}

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -532,6 +532,8 @@ to the type of the template parameter\iref{temp.arg.nontype}.
 There can be template parameter objects of array type\iref{meta.define.static},
 but such an object is never denoted by an \grammarterm{id-expression}
 that names a constant template parameter.
+Such an object can have an address that
+is not unique among all other in-lifetime objects\iref{intro.object}.
 \end{note}
 \begin{note}
 If an \grammarterm{id-expression} names


### PR DESCRIPTION
Fixes #8834.
Fixes cplusplus/papers#2732

Also fixes #8568

Notes:
* [temp.param]p13 See FIXME: "in-lifetime" is not a thing.
