### PR TITLE
[Motions 2026 03 cwg 3] P4160R0 non-DR issues

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4977,7 +4977,7 @@ initialized from $E$.
 \pnum
 The sixth context is when a temporary object is created
 in the \grammarterm{expansion-initializer}
-of a destructuring expansion statement.
+of an iterating or destructuring expansion statement.
 If such a temporary object would otherwise be destroyed
 at the end of that \grammarterm{expansion-initializer},
 the object persists for the lifetime of the reference

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -222,6 +222,23 @@ Type deduction from \#1 does not succeed;
 type deductions from \#2 and \#3 both succeed.
 \end{example}
 
+\rSec2[diff.cpp23.cpp]{\ref{cpp}: preprocessing directives}
+
+\diffref{cpp.replace.general}
+\change
+Additional restrictions on macro names.
+\rationale
+Avoid hard to diagnose or non-portable constructs.
+\effect
+Keywords,
+names of identifiers with special meaning\iref{lex.name},
+and (unless otherwise specified) \grammarterm{attribute-token}{s}
+specified in \ref{dcl.attr}
+may not be used as macro names.
+For example, valid \CppXXIII{} code that
+defines \tcode{post} or \tcode{pre} as macros
+is invalid in this revision of \Cpp{}.
+
 \rSec2[diff.cpp23.library]{\ref{library}: library introduction}
 
 \diffref{headers}

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -3464,14 +3464,15 @@ Common.
 
 \diffref{dcl.enum}
 \change
-In \Cpp{}, the type of an enumerator is its enumeration. In C, the type of an enumerator is \keyword{int}.
+In \Cpp{}, the type of an enumerator is its enumeration. In C, the type of an enumerator is an integer type.
 
 \begin{example}
 \begin{codeblock}
 enum e { A };
-sizeof(A) == sizeof(int)        // in C
-sizeof(A) == sizeof(e)          // in \Cpp{}
-/* and @sizeof(int)@ is not necessarily equal to @sizeof(e)@ */
+void f() {
+  auto x = A;
+  int *p = &x;                  // valid C, invalid \Cpp{}
+}
 \end{codeblock}
 \end{example}
 
@@ -3483,10 +3484,6 @@ Change to semantics of well-defined feature.
 Semantic transformation.
 \howwide
 Seldom.
-The only time this affects existing C code is when the size of an
-enumerator is taken.
-Taking the size of an enumerator is not a
-common C coding practice.
 
 \diffref{dcl.align}
 \change

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -10256,11 +10256,8 @@ $E$ shall be a constant expression;
 the result of $E$ is the \defnadj{underlying}{constant} of the annotation.
 
 \pnum
-Each \grammarterm{annotation} produces a unique annotation.
-
-\pnum
-Substituting into an \grammarterm{annotation}
-is not in the immediate context.
+Each \grammarterm{annotation} or instantiation thereof
+produces a unique annotation.
 \begin{example}
 \begin{codeblock}
 [[=1]] void f();
@@ -10272,6 +10269,16 @@ and \tcode{g} has five annotations.
 These can be queried with metafunctions
 such as \tcode{std::\brk{}meta::\brk{}anno\-tations_of}\iref{meta.reflection.annotation}.
 \end{example}
+\begin{example}
+\begin{codeblock}
+template<int> int x [[=1]];
+static_assert(annotations_of(^^x<0>) != annotations_of(^^x<1>));    // OK
+\end{codeblock}
+\end{example}
+
+\pnum
+Substituting into an \grammarterm{annotation}
+is not in the immediate context.
 \begin{example}
 \begin{codeblock}
 template<class T>

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -9513,6 +9513,13 @@ lookup\iref{basic.lookup} is performed on any of the identifiers contained in an
 requirements on the \grammarterm{attribute-argument-clause} (if any).
 
 \pnum
+\begin{note}
+Unless otherwise specified,
+an \grammarterm{attribute-token} specified in this document cannot be used
+as a macro name\iref{cpp.replace.general}.
+\end{note}
+
+\pnum
 An \grammarterm{annotation} followed by an ellipsis
 is a pack expansion\iref{temp.variadic}.
 

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -7741,10 +7741,10 @@ In either case, \exposid{e} is an lvalue if the type of the entity \exposid{e}
 is an lvalue reference and an xvalue otherwise.
 Given the type $\tcode{T}_i$ designated by
 \tcode{std::tuple_element<i, E>::type} and
-the type $\tcode{U}_i$ designated by
-either \tcode{$\tcode{T}_i$\&} or \tcode{$\tcode{T}_i$\&\&},
-where $\tcode{U}_i$ is an lvalue reference if
-the initializer is an lvalue and an rvalue reference otherwise,
+the type $\tcode{U}_i$ defined
+as $\tcode{T}_i$ if the initializer is a prvalue,
+as ``lvalue reference to $\tcode{T}_i$'' if the initializer is an lvalue, or
+as ``rvalue reference to $\tcode{T}_i$'' otherwise,
 variables are introduced with unique names $\tcode{r}_i$ as follows:
 
 \begin{ncbnf}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -10228,14 +10228,26 @@ if their respective types are all empty.
 \pnum
 An annotation may be applied
 to a \grammarterm{base-specifier} or
-to any declaration of a
+to a declaration $D$ of a
 type,
 type alias,
 variable,
 function,
 namespace,
 enumerator, or
-non-static data member.
+non-static data member,
+unless
+\begin{itemize}
+\item the host scope of $X$ differs from its target scope or
+\item $X$ is a non-defining friend declaration,
+\end{itemize}
+where $X$ is
+\begin{itemize}
+\item
+$D'$ if $D$ is a function parameter declaration in
+a function declarator\iref{dcl.fct} of a function declaration $D'$ and
+\item $D$ otherwise.
+\end{itemize}
 
 \pnum
 Let $E$ be the expression

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -9419,39 +9419,93 @@ consteval {                                 // \#1
 \end{example}
 
 \pnum
-The \defn{evaluation context} is a set of program points
-that determines the behavior of certain functions
-used for reflection\iref{meta.reflection}.
+During an evaluation $V$\iref{intro.execution} of
+an expression, conversion, or initialization $E$
+as a core constant expression, the
+\indextext{point of!evaluation}%
+\indextext{point!of evaluation}%
+\indextext{evaluation!point of evaluation, during}%
+\defnx{point of evaluation of $E$ during $V$}{point of evaluation during evaluation}
+is the program point $P$ determined as follows:
+\begin{itemize}
+\item
+If $E$ is a potentially-evaluated subexpression of
+a default member initializer $I$, and
+$V$ is the evaluation of $E$ in the evaluation of $I$
+as an immediate subexpression of a (possibly aggregate) initialization, then
+$P$ is the point of evaluation of that initialization.
+\begin{tailnote}
+For example,
+$E$ can be an immediate invocation in a default member initializer
+used by an aggregate initialization appearing at $P$.
+\end{tailnote}
+
+\item
+Otherwise,
+if $E$ is a potentially-evaluated subexpression of
+a default argument $A$\iref{dcl.fct.default}, and
+$V$ is the evaluation of $E$ in the evaluation of $A$ as
+an immediate subexpression of a function call\iref{expr.call}, then
+$P$ is the point of evaluation of that function call.
+
+\item
+Otherwise,
+$P$ is the point at which $E$ appears.
+\end{itemize}
 During the evaluation $V$ of an expression $E$ as a core constant expression,
-the evaluation context of an evaluation $X$\iref{intro.execution}
-consists of the following points:
+the \defnadj{evaluation}{context} of an evaluation $X$
+during $V$ is the set $C$ of program points determined as follows:
 \begin{itemize}
 \item
-The program point $\textit{EVAL-PT}(L)$,
-where $L$ is the point at which $E$ appears, and
-where $\textit{EVAL-PT}(P)$, for a point $P$,
-is a point $R$ determined as follows:
-\begin{itemize}
+If $X$ occurs during the evaluation $Y$ of
+a manifestly constant-evaluated expression,
+where $Y$ occurs during $V$, then
+$C$ is the evaluation context of $X$ during $Y$.
 \item
-If a potentially-evaluated subexpression\iref{intro.execution} of
-a default member initializer $I$ appears at $P$, and
-a (possibly aggregate) initialization during $V$ is using $I$,
-then $R$ is $\textit{EVAL-PT}(Q)$
-where $Q$ is the point at which that initialization appears.
-\item
-Otherwise, if a potentially-evaluated subexpression of
-a default argument\iref{dcl.fct.default} appears at $P$, and
-an invocation of a function\iref{expr.call} during $V$
-is using that default argument,
-then $R$ is $\textit{EVAL-PT}(Q)$
-where $Q$ is the point at which that invocation appears.
-\item
-Otherwise, $R$ is $P$.
+Otherwise, $C$ contains
+  \begin{itemize}
+  \item
+  the point of evaluation of $E$ during $V$ and
+  each synthesized point in the instantiation context thereof and
+  \item
+  each synthesized point corresponding to an injected declaration
+  produced by any evaluation executed during $V$ that
+  is sequenced before $X$\iref{intro.execution}.
+  \end{itemize}
 \end{itemize}
-\item
-Each synthesized point corresponding to an injected declaration produced by
-any evaluation sequenced before $X$\iref{intro.execution}.
-\end{itemize}
+\begin{note}
+The evaluation context determines the behavior of certain functions
+used for reflection\iref{meta.reflection}.
+\end{note}
+\begin{example}
+\begin{codeblock}
+struct S;
+consteval std::size_t f(int p) {
+  constexpr std::size_t r = /* @\tcode{Q}@ */
+    std::meta::is_complete_type(^^S) ? 1 : 2;   // \#1
+  if (!std::meta::is_complete_type(^^S)) {      // \#2
+    std::meta::define_aggregate(^^S, {});
+  }
+  return (p > 0) ? f(p - 1) : r;
+}
+
+consteval {
+  if (f(1) != 2) {
+    throw;                                      // OK, not evaluated
+  }
+}
+\end{codeblock}
+During each evaluation of
+\tcode{std::meta::is_complete_type(\caret\caret{}S)}
+at \#1\iref{meta.reflection.queries} that is
+executed during the evaluation of \tcode{f(1) != 2},
+the evaluation context contains \tcode{Q},
+but does not contain the synthesized point
+associated with the injected declaration of \tcode{S}.
+However, the synthesized point is in the evaluation context of
+\tcode{std::meta::is_complete_type(\caret\caret{}S)} at \#2
+during the evaluation of \tcode{f(0)}.
+\end{example}
 
 \rSec2[expr.const.defns]{Further definitions}
 

--- a/source/lex.tex
+++ b/source/lex.tex
@@ -983,6 +983,12 @@ token as a regular \grammarterm{identifier}.
 \end{multicolfloattable}
 
 \pnum
+\begin{note}
+Identifiers with special meaning
+cannot be used as macro names\iref{cpp.replace.general}.
+\end{note}
+
+\pnum
 \indextext{\idxcode{_}|see{character, underscore}}%
 \indextext{character!underscore!in identifier}%
 \indextext{reserved identifier}%
@@ -1119,6 +1125,11 @@ is reserved for future use.
 \keyword{wchar_t} \\
 \keyword{while} \\
 \end{multicolfloattable}
+
+\pnum
+\begin{note}
+Keywords cannot be used as macro names\iref{cpp.replace.general}.
+\end{note}
 
 \pnum
 Furthermore, the alternative representations shown in

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -1580,7 +1580,7 @@ part of the replacement list for either form of macro.
 \indextext{unit!translation}%
 A translation unit shall not \tcode{\#define} or \tcode{\#undef}
 macro names lexically identical
-to keywords,
+to keywords\iref{lex.key},
 to the identifiers listed in \tref{lex.name.special}, or
 to the \grammarterm{attribute-token}{s} described in~\ref{dcl.attr},
 except that the macro names \tcode{likely} and \tcode{unlikely} may be

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -874,7 +874,7 @@ Otherwise, if $S$ is an iterating expansion statement, $S$ is equivalent to:
 \begin{codeblock}
 {
   @\grammarterm{init-statement}@
-  constexpr auto&& @\exposidnc{range}@ = @\grammarterm{expansion-initializer}@;
+  constexpr decltype(auto) @\exposidnc{range}@ = (@\grammarterm{expansion-initializer}@);
   constexpr auto @\exposidnc{begin}@ = @\exposidnc{begin-expr}@;            // see \ref{stmt.ranged}
   constexpr auto @\exposidnc{end}@ = @\exposidnc{end-expr}@;                // see \ref{stmt.ranged}
 

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -827,7 +827,7 @@ An expression is \defn{expansion-iterable} if it does not have array type and ei
 \tcode{E.begin()} and \tcode{E.end()}, or
 \item
 argument-dependent lookups for \tcode{begin(E)} and for \tcode{end(E)}
-each find at least one function or function template.
+each find at least one viable candidate\iref{over.match.viable}.
 \end{itemize}
 
 \pnum

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -874,10 +874,8 @@ Otherwise, if $S$ is an iterating expansion statement, $S$ is equivalent to:
 \begin{codeblock}
 {
   @\grammarterm{init-statement}@
-  constexpr decltype(auto) @\exposidnc{range}@ = (@\grammarterm{expansion-initializer}@);
-  constexpr auto @\exposidnc{begin}@ = @\exposidnc{begin-expr}@;            // see \ref{stmt.ranged}
-  constexpr auto @\exposidnc{end}@ = @\exposidnc{end-expr}@;                // see \ref{stmt.ranged}
-
+  @\opt{constexpr}@ decltype(auto) @\exposidnc{range}@ = (@\grammarterm{expansion-initializer}@);
+  @\opt{constexpr}@ auto @\exposidnc{begin}@ = @\exposidnc{begin-expr}@;         // see \ref{stmt.ranged}
   @$S_{0}$@
   @\vdots@
   @$S_{N-1}$@
@@ -885,30 +883,34 @@ Otherwise, if $S$ is an iterating expansion statement, $S$ is equivalent to:
 \end{codeblock}
 where $N$ is the result of evaluating the expression
 \begin{codeblock}
-[] consteval {
+[&] consteval {
   std::ptrdiff_t result = 0;
-  for (auto i = @\exposid{begin}@; i != @\exposid{end}@; ++i) ++result;
+  auto b = @\exposid{begin-expr}@;
+  auto e = @\exposid{end-expr}@;
+  for (; b != e; ++b) ++result;
   return result;                                // distance from \exposid{begin} to \exposid{end}
 }()
 \end{codeblock}
 and $S_{i}$ is
 \begin{codeblock}
 {
-  constexpr auto @\exposid{iter}@ = @\exposid{begin}@ + decltype(begin - begin){@\placeholder{i}@};
+  @\opt{constexpr}@ auto @\exposid{iter}@ = @\exposid{begin}@ + decltype(begin - begin){@\placeholder{i}@};
   @\grammarterm{for-range-declaration}@ = *@\exposid{iter}@;
   @\grammarterm{compound-statement}@
 }
 \end{codeblock}
-The variables \exposid{range}, \exposid{begin}, \exposid{end}, and \exposid{iter}
+The variables \exposid{range}, \exposid{begin}, and \exposid{iter}
 are defined for exposition only.
+The keyword \keyword{constexpr} is present in the declarations
+of \exposid{range}, \exposid{begin}, and \exposid{iter}
+if and only if
+\keyword{constexpr} is one of the \grammarterm{decl-specifier}{s} of
+the \grammarterm{decl-specifier-seq} of
+the \grammarterm{for-range-declaration}.
 The identifier \tcode{\placeholder{i}} is considered to be
 a prvalue of type \tcode{std::ptrdiff_t};
 the program is ill-formed if
 \tcode{\placeholder{i}} is not representable as such a value.
-\begin{note}
-The instantiation is ill-formed if \exposid{range}
-is not a constant expression\iref{expr.const.const}.
-\end{note}
 
 \item
 Otherwise, $S$ is a destructuring expansion statement and,

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -935,10 +935,13 @@ where $N$ is the structured binding size of the type
 of the \grammarterm{expansion-initializer} and $S_{i}$ is
 \begin{codeblock}
 {
-  @\grammarterm{for-range-declaration}@ = @$u_{i}$@;
+  @\grammarterm{for-range-declaration}@ = @$v_{i}$@;
   @\grammarterm{compound-statement}@
 }
 \end{codeblock}
+If the \grammarterm{expansion-initializer} is an lvalue, then
+$v_{i}$ is $u_{i}$;
+otherwise, $v_{i}$ is \tcode{static_cast<decltype($u_{i}$)\&\&>($u_{i}$)}.
 The keyword \keyword{constexpr} is present in the declaration
 of $u_{0}, u_{1}, \dotsc, u_{N-1}$ if and only if
 \keyword{constexpr} is one of the \grammarterm{decl-specifier}s

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6032,12 +6032,13 @@ A \grammarterm{reflect-expression} is value-dependent if
 \begin{itemize}
 \item
 it is of the form \tcode{\caret\caret \grammarterm{reflection-name}} and
-the \grammarterm{reflection-name}
+either lookup for the \grammarterm{reflection-name} finds a declaration that
+inhabits a scope corresponding to a templated entity or
+the \grammarterm{reflection-name} is
 \begin{itemize}
-\item is a dependent qualified name,
-\item is a dependent \grammarterm{namespace-name},
-\item is the name of a template parameter, or
-\item names a dependent member of the current instantiation\iref{temp.dep.type},
+\item a dependent qualified name,
+\item a dependent \grammarterm{namespace-name}, or
+\item the name of a template parameter,
 \end{itemize}
 \item
 it is of the form \tcode{\caret\caret \grammarterm{type-id}} and

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -193,7 +193,8 @@ if it is
 \begin{itemize}
 \item a template,
 \item an entity defined\iref{basic.def} or created\iref{class.temporary}
-      within the \grammarterm{compound-statement}
+      within the
+      \grammarterm{for-range-declaration} or \grammarterm{compound-statement}
       of an \grammarterm{expansion-statement}\iref{stmt.expand},
 \item an entity defined or created in a templated entity,
 \item a member of a templated entity,

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -2194,7 +2194,7 @@ The normal form of \tcode{CI} is the result of substituting,
 in the normal form \tcode{N} of \tcode{CE},
 appearances of \tcode{C}{'s} template parameters
 in the parameter mappings of the atomic constraints in \tcode{N}
-with their respective arguments from \tcode{C}.
+with their respective arguments from \tcode{CI}.
 If any such substitution results in an invalid type or expression,
 the program is ill-formed; no diagnostic is required.
 \end{itemize}


### PR DESCRIPTION
Fixes #8824.
Fixes cplusplus/papers#2732

Also fixes cplusplus/CWG#808
Also fixes cplusplus/CWG#803
Also fixes cplusplus/CWG#809
Also fixes cplusplus/CWG#805
Also fixes cplusplus/CWG#807
Also fixes cplusplus/CWG#828
Also fixes cplusplus/CWG#825
Also fixes cplusplus/CWG#835
Also fixes cplusplus/CWG#848
Also fixes cplusplus/CWG#810

Also fixes cplusplus/nbballot#683
Also fixes cplusplus/nbballot#666

Also fixes cplusplus/papers#2659
Also fixes cplusplus/papers#2615

Notes:
* CWG3162: Also fixes CWG3127.
* CWG3124: Replaced /function-declarator/ with function declarator.