### PR TITLE
[linalg.scaled.scaledaccessor] Added underline for members

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -12697,12 +12697,12 @@ namespace std::linalg {
     constexpr reference access(data_handle_type p, size_t i) const;
     constexpr offset_policy::data_handle_type offset(data_handle_type p, size_t i) const;
 
-    constexpr const ScalingFactor& @\libmember{scaling_factor}{scaled_accessor}@() const noexcept { return @\exposid{scaling-factor}@; }
-    constexpr const NestedAccessor& @\libmember{nested_accessor}{scaled_accessor}@() const noexcept { return @\exposid{nested-accessor}@; }
+    constexpr const ScalingFactor& @\libmember{scaling_factor}{scaled_accessor}@() const noexcept { return @\exposid{scaling-factor_}@; }
+    constexpr const NestedAccessor& @\libmember{nested_accessor}{scaled_accessor}@() const noexcept { return @\exposid{nested-accessor_}@; }
 
   private:
-    ScalingFactor @\exposid{scaling-factor}@{};                              // \expos
-    NestedAccessor @\exposid{nested-accessor}@{};                            // \expos
+    ScalingFactor @\exposid{scaling-factor_}@{};                              // \expos
+    NestedAccessor @\exposid{nested-accessor_}@{};                            // \expos
   };
 }
 \end{codeblock}
@@ -12738,10 +12738,10 @@ template<class OtherNestedAccessor>
 \effects
 \begin{itemize}
 \item
-Direct-non-list-initializes \exposid{scaling-factor}
+Direct-non-list-initializes \exposid{scaling-factor_}
 with \tcode{other.scaling_factor()}, and
 \item
-direct-non-list-initializes \exposid{nested-accessor}
+direct-non-list-initializes \exposid{nested-accessor_}
 with \tcode{other.nested_accessor()}.
 \end{itemize}
 \end{itemdescr}
@@ -12756,9 +12756,9 @@ constexpr scaled_accessor(const ScalingFactor& s, const NestedAccessor& a);
 \effects
 \begin{itemize}
 \item
-Direct-non-list-initializes \exposid{scaling-factor} with \tcode{s}, and
+Direct-non-list-initializes \exposid{scaling-factor_} with \tcode{s}, and
 \item
-direct-non-list-initializes \exposid{nested-accessor} with \tcode{a}.
+direct-non-list-initializes \exposid{nested-accessor_} with \tcode{a}.
 \end{itemize}
 \end{itemdescr}
 
@@ -12771,7 +12771,7 @@ constexpr reference access(data_handle_type p, size_t i) const;
 \pnum
 \returns
 \begin{codeblock}
-scaling_factor() * NestedAccessor::element_type(@\exposid{nested-accessor}@.access(p, i))
+scaling_factor() * NestedAccessor::element_type(@\exposid{nested-accessor_}@.access(p, i))
 \end{codeblock}
 \end{itemdescr}
 
@@ -12783,7 +12783,7 @@ constexpr offset_policy::data_handle_type offset(data_handle_type p, size_t i) c
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{\exposid{nested-accessor}.offset(p, i)}
+\tcode{\exposid{nested-accessor_}.offset(p, i)}
 \end{itemdescr}
 
 \rSec3[linalg.scaled.scaled]{Function template \tcode{scaled}}


### PR DESCRIPTION
This is consistent with the rest of [linalg].