### PR TITLE
[diff.expr] Update incorrect comment

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -3077,7 +3077,7 @@ using a unary \tcode{+}.
 int arr1[5];
 int arr2[5];
 int same = arr1 == arr2;        // valid C, ill-formed C++
-int idem = arr1 == +arr2;       // valid in both C and C++
+int idem = arr1 == +arr2;       // valid C++, constraint violation in C
 \end{codeblock}
 \end{example}
 \howwide

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -3076,8 +3076,8 @@ using a unary \tcode{+}.
 \begin{codeblock}
 int arr1[5];
 int arr2[5];
-int same = arr1 == arr2;        // valid C, ill-formed C++
-int idem = arr1 == +arr2;       // valid C++, constraint violation in C
+int same = arr1 == arr2;        // valid C, ill-formed \Cpp{}
+int idem = arr1 == +arr2;       // valid \Cpp{}, constraint violation in C
 \end{codeblock}
 \end{example}
 \howwide


### PR DESCRIPTION
+arr2 is a constraint violation in C, rather than being valid.