### PR TITLE
[thread.mutex.requirements] Remove normative duplication and refine cross-reference

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -7301,7 +7301,7 @@ recursive and non-recursive mutexes are supplied.
 The \defn{mutex types} are the standard library types \tcode{mutex},
 \tcode{recursive_mutex}, \tcode{timed_mutex}, \tcode{recursive_timed_mutex},
 \tcode{shared_mutex}, and \tcode{shared_timed_mutex}.
-They meet the requirements set out in \ref{thread.mutex.requirements.mutex}.
+They meet the requirements set out in \ref{thread.mutex.requirements.mutex.general}.
 In this description, \tcode{m} denotes an object of a mutex type.
 \begin{note}
 The mutex types meet the \oldconcept{Lockable} requirements\iref{thread.req.lockable.req}.
@@ -7497,9 +7497,7 @@ contains a mutex that is used to protect the reference count.
 \end{note}
 
 \pnum
-The class \tcode{mutex} meets
-all of the mutex requirements\iref{thread.mutex.requirements}.
-It is a standard-layout class\iref{class.prop}.
+The class \tcode{mutex} is a standard-layout class\iref{class.prop}.
 
 \pnum
 \begin{note}
@@ -7544,9 +7542,7 @@ thread to acquire ownership of that object will fail (for \tcode{try_lock()}) or
 (for \tcode{lock()}) until the first thread has completely released ownership.
 
 \pnum
-The class \tcode{recursive_mutex} meets
-all of the mutex requirements\iref{thread.mutex.requirements}.
-It is a standard-layout class\iref{class.prop}.
+The class \tcode{recursive_mutex} is a standard-layout class\iref{class.prop}.
 
 \pnum
 A thread that owns a \tcode{recursive_mutex} object may acquire additional levels of
@@ -7706,9 +7702,7 @@ call to \tcode{try_lock_for()} or \tcode{try_lock_until()} times out (having
 failed to obtain ownership).
 
 \pnum
-The class \tcode{timed_mutex} meets
-all of the timed mutex requirements\iref{thread.timedmutex.requirements}.
-It is a standard-layout class\iref{class.prop}.
+The class \tcode{timed_mutex} is a standard-layout class\iref{class.prop}.
 
 \pnum
 The behavior of a program is undefined if
@@ -7757,9 +7751,7 @@ ownership or the call to \tcode{try_lock_for()} or \tcode{try_lock_until()}
 times out (having failed to obtain ownership).
 
 \pnum
-The class \tcode{recursive_timed_mutex} meets
-all of the timed mutex requirements\iref{thread.timedmutex.requirements}.
-It is a standard-layout class\iref{class.prop}.
+The class \tcode{recursive_timed_mutex} is a standard-layout class\iref{class.prop}.
 
 \pnum
 A thread that owns a \tcode{recursive_timed_mutex} object may acquire additional
@@ -7790,7 +7782,7 @@ The behavior of a program is undefined if
 \pnum
 The standard library types \tcode{shared_mutex} and \tcode{shared_timed_mutex}
 are \defn{shared mutex types}. Shared mutex types meet the requirements of
-mutex types\iref{thread.mutex.requirements.mutex} and additionally
+mutex types\iref{thread.mutex.requirements.mutex.general} and additionally
 meet the requirements set out below. In this description,
 \tcode{m} denotes an object of a shared mutex type.
 \begin{note}
@@ -7801,7 +7793,7 @@ requirements\iref{thread.req.lockable.shared}.
 \pnum
 \indextext{block (execution)}%
 In addition to the exclusive lock ownership mode specified
-in~\ref{thread.mutex.requirements.mutex}, shared mutex types provide a
+in~\ref{thread.mutex.requirements.mutex.general}, shared mutex types provide a
 \defn{shared lock} ownership mode. Multiple execution agents can
 simultaneously hold a shared lock ownership of a shared mutex type. But no
 execution agent holds a shared lock while another execution agent holds an
@@ -7943,9 +7935,7 @@ The class \tcode{shared_mutex} provides a non-recursive mutex
 with shared ownership semantics.
 
 \pnum
-The class \tcode{shared_mutex} meets
-all of the shared mutex requirements\iref{thread.sharedmutex.requirements}.
-It is a standard-layout class\iref{class.prop}.
+The class \tcode{shared_mutex} is a standard-layout class\iref{class.prop}.
 
 \pnum
 The behavior of a program is undefined if
@@ -7965,8 +7955,8 @@ The behavior of a program is undefined if
 \pnum
 The standard library type \tcode{shared_timed_mutex} is a
 \defn{shared timed mutex type}. Shared timed mutex types meet the requirements of
-timed mutex types\iref{thread.timedmutex.requirements},
-shared mutex types\iref{thread.sharedmutex.requirements}, and additionally
+timed mutex types\iref{thread.timedmutex.requirements.general},
+shared mutex types\iref{thread.sharedmutex.requirements.general}, and additionally
 meet the requirements set out below. In this description,
 \tcode{m} denotes an object of a shared timed mutex type,
 \tcode{rel_time} denotes an object of a specialization of
@@ -8105,9 +8095,7 @@ The class \tcode{shared_timed_mutex} provides a non-recursive mutex with shared
 ownership semantics.
 
 \pnum
-The class \tcode{shared_timed_mutex} meets
-all of the shared timed mutex requirements\iref{thread.sharedtimedmutex.requirements}.
-It is a standard-layout class\iref{class.prop}.
+The class \tcode{shared_timed_mutex} is a standard-layout class\iref{class.prop}.
 
 \pnum
 The behavior of a program is undefined if


### PR DESCRIPTION
See also LWG2126. That issue suggests turning the normatively duplicative sentences into notes. I don't think such notes have much value when the normative text they repeat is just a page or two away.