### PR TITLE
Unhyphenate "potentially-evaluated"

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -6449,7 +6449,7 @@ a subexpression of an immediate subexpression of $E$.
 Expressions appearing in the \grammarterm{compound-statement} of a \grammarterm{lambda-expression}
 are not subexpressions of the \grammarterm{lambda-expression}.
 \end{note}
-The \defnadjx{potentially-evaluated}{subexpressions}{subexpression} of
+The \defnadjx{potentially evaluated}{subexpressions}{subexpression} of
 an expression, conversion, or \grammarterm{initializer} $E$ are
 \begin{itemize}
 \item

--- a/source/basic.tex
+++ b/source/basic.tex
@@ -6463,7 +6463,7 @@ a subexpression of an immediate subexpression of $E$.
 Expressions appearing in the \grammarterm{compound-statement} of a \grammarterm{lambda-expression}
 are not subexpressions of the \grammarterm{lambda-expression}.
 \end{note}
-The \defnadjx{potentially-evaluated}{subexpressions}{subexpression} of
+The \defnadjx{potentially evaluated}{subexpressions}{subexpression} of
 an expression, conversion, or \grammarterm{initializer} $E$ are
 \begin{itemize}
 \item

--- a/source/classes.tex
+++ b/source/classes.tex
@@ -722,7 +722,7 @@ shall not directly or indirectly cause the implicit definition of a
 defaulted default constructor for the enclosing class or the
 exception specification of that constructor.
 An immediate invocation\iref{expr.const.imm} that
-is a potentially-evaluated subexpression\iref{intro.execution}
+is a potentially evaluated subexpression\iref{intro.execution}
 of a default member initializer
 is neither evaluated nor checked for whether it
 is a constant expression at the point where the subexpression appears.

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4393,7 +4393,7 @@ The names in the
 default argument are looked up, and the semantic constraints are checked,
 at the point where the default argument appears, except that
 an immediate invocation\iref{expr.const.imm} that
-is a potentially-evaluated subexpression\iref{intro.execution} of
+is a potentially evaluated subexpression\iref{intro.execution} of
 the \grammarterm{initializer-clause} in a \grammarterm{parameter-declaration} is
 neither evaluated
 nor checked for whether it is a constant expression at that point.
@@ -5800,7 +5800,7 @@ and not the unnamed bit-field before it.
 
 \pnum
 If a member has a default member initializer
-and a potentially-evaluated subexpression thereof is an aggregate
+and a potentially evaluated subexpression thereof is an aggregate
 initialization that would use that default member initializer,
 the program is ill-formed.
 \begin{example}

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4449,7 +4449,7 @@ The names in the
 default argument are looked up, and the semantic constraints are checked,
 at the point where the default argument appears, except that
 an immediate invocation\iref{expr.const.imm} that
-is a potentially-evaluated subexpression\iref{intro.execution} of
+is a potentially evaluated subexpression\iref{intro.execution} of
 the \grammarterm{initializer-clause} in a \grammarterm{parameter-declaration} is
 neither evaluated
 nor checked for whether it is a constant expression at that point.
@@ -5955,7 +5955,7 @@ and not the unnamed bit-field before it.
 
 \pnum
 If a member has a default member initializer
-and a potentially-evaluated subexpression thereof is an aggregate
+and a potentially evaluated subexpression thereof is an aggregate
 initialization that would use that default member initializer,
 the program is ill-formed.
 \begin{example}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5480,7 +5480,7 @@ default argument\iref{dcl.fct.default}.
 An \grammarterm{await-expression} shall not appear in the initializer of
 a block variable with static or thread storage duration.
 An \grammarterm{await-expression} shall not be
-a potentially-evaluated subexpression
+a potentially evaluated subexpression
 of the predicate of a contract assertion\iref{basic.contract}.
 A context within a function where an \grammarterm{await-expression} can appear
 is called a \term{suspension context} of the function.
@@ -9513,7 +9513,7 @@ as a core constant expression, the
 is the program point $P$ determined as follows:
 \begin{itemize}
 \item
-If $E$ is a potentially-evaluated subexpression of
+If $E$ is a potentially evaluated subexpression of
 a default member initializer $I$, and
 $V$ is the evaluation of $E$ in the evaluation of $I$
 as an immediate subexpression of a (possibly aggregate) initialization, then
@@ -9526,7 +9526,7 @@ used by an aggregate initialization appearing at $P$.
 
 \item
 Otherwise,
-if $E$ is a potentially-evaluated subexpression of
+if $E$ is a potentially evaluated subexpression of
 a default argument $A$\iref{dcl.fct.default}, and
 $V$ is the evaluation of $E$ in the evaluation of $A$ as
 an immediate subexpression of a function call\iref{expr.call}, then
@@ -9668,7 +9668,7 @@ In some cases, constant evaluation is needed to determine whether such an expres
 or
 
 \item
-a potentially-evaluated subexpression\iref{intro.execution} of one of the above.
+a potentially evaluated subexpression\iref{intro.execution} of one of the above.
 \end{itemize}
 
 \indextext{function!needed for constant evaluation}%

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -5625,7 +5625,7 @@ default argument\iref{dcl.fct.default}.
 An \grammarterm{await-expression} shall not appear in the initializer of
 a block variable with static or thread storage duration.
 An \grammarterm{await-expression} shall not be
-a potentially-evaluated subexpression
+a potentially evaluated subexpression
 of the predicate of a contract assertion\iref{basic.contract}.
 A context within a function where an \grammarterm{await-expression} can appear
 is called a \term{suspension context} of the function.
@@ -9738,7 +9738,7 @@ as a core constant expression, the
 is the program point $P$ determined as follows:
 \begin{itemize}
 \item
-If $E$ is a potentially-evaluated subexpression of
+If $E$ is a potentially evaluated subexpression of
 a default member initializer $I$, and
 $V$ is the evaluation of $E$ in the evaluation of $I$
 as an immediate subexpression of a (possibly aggregate) initialization, then
@@ -9751,7 +9751,7 @@ used by an aggregate initialization appearing at $P$.
 
 \item
 Otherwise,
-if $E$ is a potentially-evaluated subexpression of
+if $E$ is a potentially evaluated subexpression of
 a default argument $A$\iref{dcl.fct.default}, and
 $V$ is the evaluation of $E$ in the evaluation of $A$ as
 an immediate subexpression of a function call\iref{expr.call}, then
@@ -9893,7 +9893,7 @@ In some cases, constant evaluation is needed to determine whether such an expres
 or
 
 \item
-a potentially-evaluated subexpression\iref{intro.execution} of one of the above.
+a potentially evaluated subexpression\iref{intro.execution} of one of the above.
 \end{itemize}
 
 \indextext{function!needed for constant evaluation}%

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -5219,7 +5219,7 @@ Given a program point $P$,
 let \tcode{\exposid{eval-point}($P$)} be the following program point:
 \begin{itemize}
 \item
-  If a potentially-evaluated subexpression\iref{intro.execution}
+  If a potentially evaluated subexpression\iref{intro.execution}
   of a default member initializer $I$
   for a member of class $C$\iref{class.mem.general}
   appears at $P$,
@@ -5239,7 +5239,7 @@ let \tcode{\exposid{eval-point}($P$)} be the following program point:
     corresponding to the constructor definition that is using $I$.
   \end{itemize}
   \item
-    Otherwise, if a potentially-evaluated subexpression
+    Otherwise, if a potentially evaluated subexpression
     of a default argument\iref{dcl.fct.default} appears at $P$,
     \tcode{\exposid{eval-point}($Q$)},
     where $Q$ is the point at which the invocation of the function\iref{expr.call}

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -4951,7 +4951,7 @@ Given a program point $P$,
 let \tcode{\exposid{eval-point}($P$)} be the following program point:
 \begin{itemize}
 \item
-  If a potentially-evaluated subexpression\iref{intro.execution}
+  If a potentially evaluated subexpression\iref{intro.execution}
   of a default member initializer $I$
   for a member of class $C$\iref{class.mem.general}
   appears at $P$,
@@ -4971,7 +4971,7 @@ let \tcode{\exposid{eval-point}($P$)} be the following program point:
     corresponding to the constructor definition that is using $I$.
   \end{itemize}
   \item
-    Otherwise, if a potentially-evaluated subexpression
+    Otherwise, if a potentially evaluated subexpression
     of a default argument\iref{dcl.fct.default} appears at $P$,
     \tcode{\exposid{eval-point}($Q$)},
     where $Q$ is the point at which the invocation of the function\iref{expr.call}


### PR DESCRIPTION
Currently we define unhyphenated "_potentially evaluated_" in [basic.def.odr]/3 for expressions and conversions, but also define hyphenated "_potentially-evaluated subexpressions_" in [intro.execution]/4.

It's probably better to use a single form, and the hyphen shouldn't b used for compounds modifying a noun if an adverb ending in "ly" is used.

Fixes #8937.