### PR TITLE
[round.style] Remove "the" to clarify there may be multiple values

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -1000,7 +1000,7 @@ if the rounding style is toward zero
 \tcode{round_to_nearest}
 if the rounding style is to the nearest representable value;
 if there are two equally near such values,
-the one with an even least significant digit is chosen
+one with an even least significant digit is chosen
 \item
 \indexlibraryglobal{round_toward_infinity}%
 \tcode{round_toward_infinity}


### PR DESCRIPTION
Fixes #8942

The current wording "the one" suggests that a disambiguation takes place in all cases, but that's not true. For binary floating-point numbers with one-digit precision, both `9.5` and `10.0` have an even least significant binary digit and are equally near to `9.75`, so rounding is ambiguous in that case.