### PR TITLE
[mdspan.layout.leftpad.obs, mdspan.layout.rightpad.obs] Fix return type of `operator()`

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -23733,7 +23733,7 @@ otherwise, \tcode{(*this)(\exposid{extents_}.extent(P_rank) - index_type(1)...) 
 
 \begin{itemdecl}
 template<class... Indices>
-constexpr size_t operator()(Indices... idxs) const noexcept;
+constexpr index_type operator()(Indices... idxs) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -24368,7 +24368,7 @@ otherwise \tcode{(*this)(\exposid{extents_}.extent(P_rank) - index_type(1)...) +
 \indexlibrarymember{layout_right_padded::mapping}{operator()}%
 \begin{itemdecl}
 template<class... Indices>
-constexpr size_t operator()(Indices... idxs) const noexcept;
+constexpr index_type operator()(Indices... idxs) const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
This is consistent with the declaration.