### PR TITLE
[linalg.transp.layout.transpose] Replace `size_t` with `rank_type`

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -13113,7 +13113,7 @@ namespace std::linalg {
       constexpr bool @\libmember{is_exhaustive}{layout_transpose::mapping}@() const { return @\exposid{nested-mapping_}@.is_exhaustive(); }
       constexpr bool @\libmember{is_strided}{layout_transpose::mapping}@() const { return @\exposid{nested-mapping_}@.is_strided(); }
 
-      constexpr index_type stride(size_t r) const;
+      constexpr index_type stride(rank_type r) const;
 
       template<class OtherExtents>
         friend constexpr bool operator==(const mapping& x, const mapping<OtherExtents>& y);
@@ -13158,7 +13158,7 @@ with \tcode{\exposid{transpose-extents}(map.extents())}.
 
 \indexlibrarymember{layout_transpose::mapping}{stride}%
 \begin{itemdecl}
-constexpr index_type stride(size_t r) const;
+constexpr index_type stride(rank_type r) const;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
This is editorial. 
Although the `rank_type` of Extents is always `size_t`, using `rank_type` here is more consistent with other `mapping` struct in the standards.