### PR TITLE
[cpp.pre] Remove confused footnote about 'lines'

### DIFF
--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -229,15 +229,6 @@ one of the two preceding forms.
 
 The last preprocessing token in the sequence is the first preprocessing token within the sequence that
 is immediately followed by whitespace containing a new-line character.
-\begin{footnote}
-Thus,
-preprocessing directives are commonly called ``lines''.
-These ``lines'' have no other syntactic significance,
-as all whitespace is equivalent except in certain situations
-during preprocessing (see the
-\tcode{\#}
-character string literal creation operator in~\ref{cpp.stringize}, for example).
-\end{footnote}
 \begin{note}
 A new-line character ends the preprocessing directive even if it occurs
 within what would otherwise be an invocation of a function-like macro.


### PR DESCRIPTION
Fixes #8934 