### PR TITLE
[linalg.algs.blas1.matonenorm] Use \tcode for A

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -14130,7 +14130,7 @@ is convertible to \tcode{Scalar}.
 \item
 \tcode{init} if \tcode{A.extent(1)} is zero;
 \item
-otherwise, the sum of \tcode{init} and the one norm of the matrix $A$.
+otherwise, the sum of \tcode{init} and the one norm of the matrix \tcode{A}.
 \end{itemize}
 \begin{note}
 The one norm of the matrix \tcode{A}


### PR DESCRIPTION
This is consistent with other places.