### PR TITLE
[const.wrap.class] Remove `constexpr` and `noexcept` from `operator,`

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -863,7 +863,7 @@ namespace std {
         { return {}; }
 
     template<@\exposconcept{constexpr-param}@ L, @\exposconcept{constexpr-param}@ R>
-      friend constexpr auto operator,(L, R) noexcept = delete;
+      friend auto operator,(L, R) = delete;
     template<@\exposconcept{constexpr-param}@ L, @\exposconcept{constexpr-param}@ R>
       friend constexpr auto operator->*(L, R) noexcept -> constant_wrapper<L::value->*(R::value)>
         { return {}; }

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -843,7 +843,7 @@ namespace std {
         { return {}; }
 
     template<@\exposconcept{constexpr-param}@ L, @\exposconcept{constexpr-param}@ R>
-      friend constexpr auto operator,(L, R) noexcept = delete;
+      friend auto operator,(L, R) = delete;
     template<@\exposconcept{constexpr-param}@ L, @\exposconcept{constexpr-param}@ R>
       friend constexpr auto operator->*(L, R) noexcept -> constant_wrapper<L::value->*(R::value)>
         { return {}; }


### PR DESCRIPTION
As the overloaded `operator,` is deleted, `constexpr` and `noexcept` are meaningless, so it might be better to remove them for the sake of clarity.

Fixes #8951.