### PR TITLE
LWG Motion 37: P4159R0 Make `sender_in` and `receiver_of` exposition-only

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -1357,7 +1357,7 @@ template<class Sch, class Env>
 A receiver represents the continuation of an asynchronous operation.
 The \libconcept{receiver} concept defines
 the requirements for a receiver type\iref{exec.async.ops}.
-The \exposconcept{receiver-of} concept defines
+The exposition-only concept \exposconcept{receiver-of} defines
 the requirements for a receiver type that is usable as
 the first argument of a set of completion operations
 corresponding to a set of completion signatures.
@@ -2477,7 +2477,7 @@ the requirements for a sender type\iref{exec.async.ops}.
 The \libconcept{sender_in} concept defines
 the requirements for a sender type
 that can create asynchronous operations given an associated environment type.
-The \exposconcept{sender-to} concept defines
+The exposition-only concept \exposconcept{sender-to} defines
 the requirements for a sender type
 that can connect with a specific receiver type.
 The \tcode{get_env} customization point object is used to access

--- a/source/exec.tex
+++ b/source/exec.tex
@@ -510,7 +510,7 @@ namespace std::execution {
     concept @\libconcept{receiver}@ = @\seebelow@;
 
   template<class Rcvr, class Completions>
-    concept @\libconcept{receiver_of}@ = @\seebelow@;
+    concept @\exposconceptnc{receiver-of}@ = @\seebelownc@;                            // \expos
 
   template<class Rcvr, class ChildOp>
     concept @\libconcept{inlinable_receiver}@ = @\seebelow@;
@@ -548,7 +548,7 @@ namespace std::execution {
     concept @\libconcept{dependent_sender}@ = @\seebelow@;
 
   template<class Sndr, class Rcvr>
-    concept @\libconcept{sender_to}@ = @\seebelow@;
+    concept @\exposconceptnc{sender-to}@ = @\seebelownc@;                              // \expos
 
   template<class... Ts>
     struct @\exposidnc{type-list}@;                                           // \expos
@@ -578,7 +578,7 @@ namespace std::execution {
     using @\exposidnc{single-sender-value-type}@ = @\seebelownc@;                 // \expos
 
   template<class Sndr, class... Env>
-    concept @\exposconcept{single-sender}@ = @\seebelow@;                         // \expos
+    concept @\exposconceptnc{single-sender}@ = @\seebelownc@;                          // \expos
 
   template<@\libconcept{sender}@ Sndr>
     using tag_of_t = @\seebelow@;
@@ -1012,7 +1012,7 @@ is a core constant expression and has value \tcode{true}.
 
 \pnum
 Given subexpressions \tcode{sndr} and \tcode{rcvr}
-such that \tcode{sender_to<decltype((sndr)), decltype((rcvr))>} is \tcode{true}
+such that \tcode{\exposid{sender-to}<decltype((sndr)), decltype((rcvr))>} is \tcode{true}
 and the expression \tcode{get_start_scheduler(get_env(rcvr))} is well-formed,
 an operation state that is the result of calling \tcode{connect(sndr, rcvr)}
 shall, if it is started, be started on an execution agent
@@ -1357,7 +1357,7 @@ template<class Sch, class Env>
 A receiver represents the continuation of an asynchronous operation.
 The \libconcept{receiver} concept defines
 the requirements for a receiver type\iref{exec.async.ops}.
-The \libconcept{receiver_of} concept defines
+The \exposconcept{receiver-of} concept defines
 the requirements for a receiver type that is usable as
 the first argument of a set of completion operations
 corresponding to a set of completion signatures.
@@ -1391,7 +1391,7 @@ namespace std::execution {
       };
 
   template<class Rcvr, class Completions>
-    concept @\deflibconcept{receiver_of}@ =
+    concept @\defexposconcept{receiver-of}@ =
       @\libconcept{receiver}@<Rcvr> && @\exposconcept{has-completions}@<Rcvr, Completions>;
 }
 \end{codeblock}
@@ -1619,7 +1619,7 @@ an object equal to the result\iref{concepts.equality}, and
 let \tcode{Sndr} be \tcode{decltype((sndr))}.
 Let \tcode{rcvr} be a receiver of type \tcode{Rcvr}
 with associated environment \tcode{env} of type \tcode{Env}
-such that \tcode{\libconcept{sender_to}<Sndr, Rcvr>} is \tcode{true}.
+such that \tcode{\exposconcept{sender-to}<Sndr, Rcvr>} is \tcode{true}.
 For the default implementation of the algorithm that produced \tcode{sndr},
 connecting \tcode{sndr} to \tcode{rcvr} and
 starting the resulting operation state\iref{exec.async.ops}
@@ -2477,7 +2477,7 @@ the requirements for a sender type\iref{exec.async.ops}.
 The \libconcept{sender_in} concept defines
 the requirements for a sender type
 that can create asynchronous operations given an associated environment type.
-The \libconcept{sender_to} concept defines
+The \exposconcept{sender-to} concept defines
 the requirements for a sender type
 that can connect with a specific receiver type.
 The \tcode{get_env} customization point object is used to access
@@ -2532,9 +2532,9 @@ namespace std::execution {
       @\libconcept{sender}@<Sndr> && bool_constant<@\exposid{is-dependent-sender-helper}@<Sndr>()>::value;
 
   template<class Sndr, class Rcvr>
-    concept @\deflibconcept{sender_to}@ =
+    concept @\defexposconcept{sender-to}@ =
       @\libconcept{sender_in}@<Sndr, env_of_t<Rcvr>> &&
-      @\libconcept{receiver_of}@<Rcvr, completion_signatures_of_t<Sndr, env_of_t<Rcvr>>> &&
+      @\exposconcept{receiver-of}@<Rcvr, completion_signatures_of_t<Sndr, env_of_t<Rcvr>>> &&
       requires (Sndr&& sndr, Rcvr&& rcvr) {
         connect(std::forward<Sndr>(sndr), std::forward<Rcvr>(rcvr));
       };
@@ -3199,7 +3199,7 @@ namespace std::execution {
     return awaiter{fn};
   }
 
-  @\exposid{operation-state-task}@ @\exposid{connect-awaitable}@(DS sndr, DR rcvr) requires @\libconcept{receiver_of}@<DR, Sigs> {
+  @\exposid{operation-state-task}@ @\exposid{connect-awaitable}@(DS sndr, DR rcvr) requires @\exposconcept{receiver-of}@<DR, Sigs> {
     exception_ptr ep;
     try {
       if constexpr (@\libconcept{same_as}@<V, void>) {
@@ -3251,7 +3251,7 @@ The following are \tcode{true}:
 \item
 \tcode{\libconcept{sender_in}<Sndr, env_of_t<Rcvr>>}
 \item
-\tcode{\libconcept{receiver_of}<Rcvr, completion_signatures_of_t<Sndr, env_of_t<Rcvr>>>}
+\tcode{\exposconcept{receiver-of}<Rcvr, completion_signatures_of_t<Sndr, env_of_t<Rcvr>>>}
 \end{itemize}
 
 \rSec2[exec.factories]{Sender factories}
@@ -6153,7 +6153,7 @@ Equivalent to \tcode{\exposid{state}->\exposid{loop}.finish()}.
 
 \pnum
 For a subexpression \tcode{sndr}, let \tcode{Sndr} be \tcode{decltype((sndr))}.
-If \tcode{\libconcept{sender_to}<Sndr, \exposid{sync-wait-receiver}<\linebreak Sndr>>}
+If \tcode{\exposconcept{sender-to}<Sndr, \exposid{sync-wait-receiver}<\linebreak Sndr>>}
 is \tcode{false},
 the expression \tcode{sync_wait.apply_sender(sndr)} is ill-formed;
 otherwise, it is equivalent to:
@@ -6831,7 +6831,7 @@ until the end of the lifetime of its associated \tcode{run_loop} instance.
 \pnum
 Let \exposid{sndr} be an expression of type \exposid{run-loop-sender},
 let \exposid{rcvr} be an expression
-such that \tcode{\libconcept{receiver_of}<decltype((\exposid{rcvr})), CS>} is \tcode{true}
+such that \tcode{\exposconcept{receiver-of}<decl\-type((\exposid{rcvr})), CS>} is \tcode{true}
 where \tcode{CS} is the \tcode{completion_signatures} specialization above.
 Let \tcode{C} be either \tcode{set_value_t} or \tcode{set_stopped_t}.
 Then:
@@ -7027,7 +7027,7 @@ namespace std::execution {
   template<class Sndr, class Promise>
     concept @\defexposconcept{awaitable-sender}@ =
       @\exposconcept{single-sender}@<Sndr, env_of_t<Promise>> &&
-      @\libconcept{sender_to}@<Sndr,
+      @\exposconcept{sender-to}@<Sndr,
                 typename @\exposid{sender-awaitable}@<Sndr, Promise>::@\exposid{awaitable-receiver}@> &&    // \seebelow
       requires (Promise& p) {
         { p.unhandled_stopped() } -> @\libconcept{convertible_to}@<coroutine_handle<>>;
@@ -7422,7 +7422,7 @@ is \tcode{completion_signatures<set_value_t()>}.
 \pnum
 Let \tcode{sndr} be an expression of type \exposid{inline-sender},
 let \tcode{rcvr} be an expression such that
-\tcode{\libconcept{receiver_of}<decltype((rcvr)), CS>} is \tcode{true}
+\tcode{\exposconcept{receiver-of}<decl\-type((rcvr)), CS>} is \tcode{true}
 where \tcode{CS} is \tcode{completion_signatures<set_value_t()>},
 then the expression \tcode{connect(sndr, rcvr)} has
 type \tcode{\exposid{inline-state}<remove_cvref_t<decltype((rcvr))>>}


### PR DESCRIPTION
Fixes #8871.
Fixes cplusplus/papers#2686

Also fixes cplusplus/papers#2507