### PR TITLE
[numarray] Remove incorrect comments for deleted default constructors

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -8506,7 +8506,7 @@ namespace std {
     const slice_array& operator=(const slice_array&) const;
     void operator=(const T&) const;
 
-    slice_array() = delete;     // as implied by declaring copy constructor above
+    slice_array() = delete;
   };
 }
 \end{codeblock}
@@ -8788,7 +8788,7 @@ namespace std {
     const gslice_array& operator=(const gslice_array&) const;
     void operator=(const T&) const;
 
-    gslice_array() = delete;    // as implied by declaring copy constructor above
+    gslice_array() = delete;
   };
 }
 \end{codeblock}
@@ -8916,7 +8916,7 @@ namespace std {
     const mask_array& operator=(const mask_array&) const;
     void operator=(const T&) const;
 
-    mask_array() = delete;      // as implied by declaring copy constructor above
+    mask_array() = delete;
   };
 }
 \end{codeblock}
@@ -9033,7 +9033,7 @@ namespace std {
     const indirect_array& operator=(const indirect_array&) const;
     void operator=(const T&) const;
 
-    indirect_array() = delete;  // as implied by declaring copy constructor above
+    indirect_array() = delete;
   };
 }
 \end{codeblock}


### PR DESCRIPTION
Explicitly declaring a copy constructor doesn't make the default constructor deleted, but makes it not implicitly declared at all. So it's not quite correct to say "as implied by declaring copy constructor above" for these deleted default constructors.
Moreover, the difference between deleting and not having default constructor is observable, as shown in LWG3160.