### PR TITLE
[fs.class.path] Use a typedef-name instead of a typedef in a definition

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -13789,7 +13789,7 @@ namespace std::filesystem {
 
 \indexlibrarymember{value_type}{path}%
 \pnum
-\tcode{value_type} is a \keyword{typedef} for the
+\tcode{value_type} is a \grammarterm{typedef-name} for the
 operating system dependent encoded character type used to represent pathnames.
 
 \indexlibrarymember{preferred_separator}{path}%


### PR DESCRIPTION
Fixes #8963 