### PR TITLE
[meta.define.static] Move misplaced \end{codeblock}

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -3297,6 +3297,7 @@ if (meta::is_array_type(meta::type_of(array))) {
 } else {
   return span<const T, @\seebelow@>(static_cast<const T*>(nullptr), 0);
 }
+\end{codeblock}
 
 \pnum
 \remarks
@@ -3304,7 +3305,6 @@ The second template argument of the returned \tcode{span} type
 is \tcode{static_cast<size_t>(ranges::size(r))}
 if \tcode{ranges::size(r)} is a constant expression, and
 \tcode{dynamic_extent} otherwise.
-\end{codeblock}
 \end{itemdescr}
 
 \indexlibraryglobal{define_static_object}%

--- a/source/meta.tex
+++ b/source/meta.tex
@@ -3301,10 +3301,10 @@ if (meta::is_array_type(meta::type_of(array))) {
 
 \pnum
 \remarks
-The second template argument of the returned \tcode{span} type
-is \tcode{static_cast<size_t>(ranges::size(r))}
-if \tcode{ranges::size(r)} is a constant expression, and
-\tcode{dynamic_extent} otherwise.
+If \tcode{ranges::size(r)} is a constant expression,
+the second template argument of the returned \tcode{span} type
+is \tcode{static_cast<size_t>(ranges::size(r))};
+otherwise, it is \tcode{dynamic_extent}.
 \end{itemdescr}
 
 \indexlibraryglobal{define_static_object}%


### PR DESCRIPTION
Fixes #8966.