### PR TITLE
[expr.const.defns,temp.inst] Hyphenate "potentially constant evaluated"

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -9643,8 +9643,8 @@ is evaluated even in an unevaluated operand\iref{term.unevaluated.operand}.
 \end{note}
 
 \pnum
-\indextext{expression!potentially constant evaluated}%
-An expression or conversion is \defn{potentially constant evaluated}
+\indextext{expression!potentially constant-evaluated}%
+An expression or conversion is \defn{potentially constant-evaluated}
 if it is:
 \begin{itemize}
 \item
@@ -9679,10 +9679,10 @@ if it is:
 \begin{itemize}
 \item
 a constexpr function that is named by an expression\iref{basic.def.odr}
-that is potentially constant evaluated, or
+that is potentially constant-evaluated, or
 
 \item
-a potentially-constant variable named by a potentially constant evaluated expression.
+a potentially-constant variable named by a potentially constant-evaluated expression.
 \end{itemize}
 
 \pnum

--- a/source/templates.tex
+++ b/source/templates.tex
@@ -6800,7 +6800,7 @@ template<bool B, typename T> void g(...);
 template<bool B, typename T> void h(decltype(int{B ? f<T>() : 0}));
 template<bool B, typename T> void h(...);
 void x() {
-  g<false, int>(0); // OK, \tcode{B ? f<T>() :\ 0} is not potentially constant evaluated
+  g<false, int>(0); // OK, \tcode{B ? f<T>() :\ 0} is not potentially constant-evaluated
   h<false, int>(0); // error, instantiates \tcode{f<int>} even though \tcode{B} evaluates to \tcode{false} and
                     // list-initialization of \tcode{int} from \tcode{int} cannot be narrowing
 }


### PR DESCRIPTION
For consistency with "manifestly constant-evaluated".

Fixes #8936.