### PR TITLE
[format.arguments, depr.format.arg] Apply `\exposid` consistently

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -805,7 +805,7 @@ template<class Visitor, class Context>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return visit(std::forward<Visitor>(vis), arg.value);}
+Equivalent to: \tcode{return visit(std::forward<Visitor>(vis), arg.\exposid{value_});}
 \end{itemdescr}
 
 \rSec1[depr.ctime]{Deprecated time formatting}

--- a/source/text.tex
+++ b/source/text.tex
@@ -8475,13 +8475,13 @@ namespace std {
     class handle;
 
   private:
-    using char_type = Context::char_type;                                       // \expos
+    using @\exposid{char-type}@ = Context::char_type;                                       // \expos
 
-    variant<monostate, bool, char_type,
+    variant<monostate, bool, @\exposid{char-type}@,
             int, unsigned int, long long int, unsigned long long int,
             float, double, long double,
-            const char_type*, basic_string_view<char_type>,
-            const void*, handle> value;                                         // \expos
+            const @\exposid{char-type}@*, basic_string_view<@\exposid{char-type}@>,
+            const void*, handle> @\exposid{value_}@;                                        // \expos
 
     template<class T> constexpr explicit basic_format_arg(T& v) noexcept;       // \expos
 
@@ -8528,56 +8528,56 @@ template<class T> constexpr explicit basic_format_arg(T& v) noexcept;
 
 \pnum
 \expects
-If \tcode{decay_t<T>} is \tcode{char_type*} or \tcode{const char_type*},
-\tcode{static_cast<const char_\linebreak{}type*>(v)} points to an NTCTS\iref{defns.ntcts}.
+If \tcode{decay_t<T>} is \tcode{\exposid{char-type}*} or \tcode{const \exposid{char-type}*},
+\tcode{static_cast<const \exposid{char-\linebreak{}type}*>(v)} points to an NTCTS\iref{defns.ntcts}.
 
 \pnum
 \effects
 Let \tcode{TD} be \tcode{remove_const_t<T>}.
 \begin{itemize}
 \item
-If \tcode{TD} is \tcode{bool} or \tcode{char_type},
-initializes \tcode{value} with \tcode{v};
+If \tcode{TD} is \tcode{bool} or \exposid{char-type},
+initializes \exposid{value_} with \tcode{v};
 \item
-otherwise, if \tcode{TD} is \tcode{char} and \tcode{char_type} is
-\keyword{wchar_t}, initializes \tcode{value} with
+otherwise, if \tcode{TD} is \tcode{char} and \exposid{char-type} is
+\keyword{wchar_t}, initializes \exposid{value_} with
 \tcode{static_cast<wchar_t>(static_cast<unsigned char>(v))};
 \item
 otherwise, if \tcode{TD} is a signed integer type\iref{basic.fundamental}
 and \tcode{sizeof(TD) <= sizeof(int)},
-initializes \tcode{value} with \tcode{static_cast<int>(v)};
+initializes \exposid{value_} with \tcode{static_cast<int>(v)};
 \item
 otherwise, if \tcode{TD} is an unsigned integer type and
 \tcode{sizeof(TD) <= sizeof(unsigned int)}, initializes
-\tcode{value} with \tcode{static_cast<unsigned int>(v)};
+\exposid{value_} with \tcode{static_cast<unsigned int>(v)};
 \item
 otherwise, if \tcode{TD} is a signed integer type and
 \tcode{sizeof(TD) <= sizeof(long long int)}, initializes
-\tcode{value} with \tcode{static_cast<long long int>(v)};
+\exposid{value_} with \tcode{static_cast<long long int>(v)};
 \item
 otherwise, if \tcode{TD} is an unsigned integer type and
 \tcode{sizeof(TD) <= sizeof(unsigned long long int)}, initializes
-\tcode{value} with
+\exposid{value_} with
 \tcode{static_cast<unsigned long long int>(v)};
 \item
 otherwise, if \tcode{TD} is a standard floating-point type,
-initializes \tcode{value} with \tcode{v};
+initializes \exposid{value_} with \tcode{v};
 \item
 otherwise, if \tcode{TD} is
 a specialization of \tcode{basic_string_view} or \tcode{basic_string} and
-\tcode{TD::value_type} is \tcode{char_type},
-initializes \tcode{value} with
-\tcode{basic_string_view<char_type>(v.data(), v.size())};
+\tcode{TD::value_type} is \exposid{char-type},
+initializes \exposid{value_} with
+\tcode{basic_string_view<\exposid{char-type}>(v.data(), v.size())};
 \item
 otherwise, if \tcode{decay_t<TD>} is
-\tcode{char_type*} or \tcode{const char_type*},
-initializes \tcode{value} with \tcode{static_cast<const char_type*>(v)};
+\tcode{\exposid{char-type}*} or \tcode{const \exposid{char-type}*},
+initializes \exposid{value_} with \tcode{static_cast<const \exposid{char-type}*>(v)};
 \item
 otherwise, if \tcode{is_void_v<remove_pointer_t<TD>>} is \tcode{true} or
 \tcode{is_null_pointer_v<TD>} is \tcode{true},
-initializes \tcode{value} with \tcode{static_cast<const void*>(v)};
+initializes \exposid{value_} with \tcode{static_cast<const void*>(v)};
 \item
-otherwise, initializes \tcode{value} with \tcode{handle(v)}.
+otherwise, initializes \exposid{value_} with \tcode{handle(v)}.
 \end{itemize}
 \begin{note}
 Constructing \tcode{basic_format_arg} from a pointer to a member is ill-formed
@@ -8596,7 +8596,7 @@ constexpr explicit operator bool() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{!holds_alternative<monostate>(value)}.
+\tcode{!holds_alternative<monostate>(\exposid{value_})}.
 \end{itemdescr}
 
 \indexlibrarymember{visit}{basic_format_arg}%
@@ -8608,7 +8608,7 @@ template<class Visitor>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return arg.value.visit(std::forward<Visitor>(vis));}
+Equivalent to: \tcode{return arg.\exposid{value_}.visit(std::forward<Visitor>(vis));}
 \end{itemdescr}
 
 \indexlibrarymember{visit}{basic_format_arg}%
@@ -8620,7 +8620,7 @@ template<class R, class Visitor>
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return arg.value.visit<R>(std::forward<Visitor>(vis));}
+Equivalent to: \tcode{return arg.\exposid{value_}.visit<R>(std::forward<Visitor>(vis));}
 \end{itemdescr}
 
 \pnum
@@ -8632,14 +8632,14 @@ The class \tcode{handle} allows formatting an object of a user-defined type.
 namespace std {
   template<class Context>
   class basic_format_arg<Context>::handle {
-    const void* ptr_;                                                   // \expos
-    void (*format_)(basic_format_parse_context<char_type>&,
+    const void* @\exposid{ptr_}@;                                                   // \expos
+    void (*@\exposid{format_}@)(basic_format_parse_context<@\exposid{char-type}@>&,
                     Context&, const void*);                             // \expos
 
     template<class T> constexpr explicit handle(T& val) noexcept;       // \expos
 
   public:
-    constexpr void format(basic_format_parse_context<char_type>&, Context& ctx) const;
+    constexpr void format(basic_format_parse_context<@\exposid{char-type}@>&, Context& ctx) const;
   };
 }
 \end{codeblock}
@@ -8668,10 +8668,10 @@ and \tcode{TD} otherwise.
 \pnum
 \effects
 Initializes
-\tcode{ptr_} with \tcode{addressof(val)} and
-\tcode{format_} with
+\exposid{ptr_} with \tcode{addressof(val)} and
+\exposid{format_} with
 \begin{codeblock}
-[](basic_format_parse_context<char_type>& parse_ctx,
+[](basic_format_parse_context<@\exposid{char-type}@>& parse_ctx,
    Context& format_ctx, const void* ptr) {
   typename Context::template formatter_type<TD> f;
   parse_ctx.advance_to(f.parse(parse_ctx));
@@ -8683,13 +8683,13 @@ Initializes
 
 \indexlibrarymember{format}{basic_format_arg::handle}%
 \begin{itemdecl}
-constexpr void format(basic_format_parse_context<char_type>& parse_ctx, Context& format_ctx) const;
+constexpr void format(basic_format_parse_context<@\exposid{char-type}@>& parse_ctx, Context& format_ctx) const;
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{format_(parse_ctx, format_ctx, ptr_);}
+Equivalent to: \tcode{\exposid{format_}(parse_ctx, format_ctx, \exposid{ptr_});}
 \end{itemdescr}
 
 \rSec3[format.arg.store]{Class template \exposid{format-arg-store}}
@@ -8748,8 +8748,8 @@ Equivalent to:
 namespace std {
   template<class Context>
   class basic_format_args {
-    size_t size_;                               // \expos
-    const basic_format_arg<Context>* data_;     // \expos
+    size_t @\exposid{size_}@;                               // \expos
+    const basic_format_arg<Context>* @\exposid{data_}@;     // \expos
 
   public:
     template<class... Args>
@@ -8787,8 +8787,8 @@ template<class... Args>
 \pnum
 \effects
 Initializes
-\tcode{size_} with \tcode{sizeof...(Args)} and
-\tcode{data_} with \tcode{store.args.data()}.
+\exposid{size_} with \tcode{sizeof...(Args)} and
+\exposid{data_} with \tcode{store.\exposid{args}.data()}.
 \end{itemdescr}
 
 \indexlibrarymember{get}{basic_format_args}%
@@ -8799,7 +8799,7 @@ constexpr basic_format_arg<Context> get(size_t i) const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{i < size_ ?\ data_[i] :\ basic_format_arg<Context>()}.
+\tcode{i < \exposid{size_} ?\ \exposid{data_}[i] :\ basic_format_arg<Context>()}.
 \end{itemdescr}
 
 \rSec2[format.tuple]{Tuple formatter}


### PR DESCRIPTION
This is a "manually rebased" version of #6007.

There're conflicting changes since 2022-11-28.
- 804846a56f7e73dafe4ebd621fa81097d2e94603 relocated many contents to [text] (text.tex).
- LWG3631 largely reworded the internal constructor of `basic_format_arg`.
- [P2637R3](https://wg21.link/p2637r3) deprecated `visit_format_arg`, so `visit_format_arg` is now in [depr.format.arg].

Previously missed change(s):
- `args` in `store.args.data()` is also exposition-only (per [format.arg.store]), so it should be embraced by `\exposid{}`.