### PR TITLE
[meta.define.static] Fix indent

### DIFF
--- a/source/meta.tex
+++ b/source/meta.tex
@@ -3293,7 +3293,7 @@ using T = ranges::range_value_t<R>;
 meta::info array = meta::reflect_constant_array(r);
 if (meta::is_array_type(meta::type_of(array))) {
   return span<const T, @\seebelow@>(meta::extract<const T*>(array),
-                                    meta::extent(meta::type_of(array)));
+                                  meta::extent(meta::type_of(array)));
 } else {
   return span<const T, @\seebelow@>(static_cast<const T*>(nullptr), 0);
 }


### PR DESCRIPTION
@\seebelow@ is 11 characters long.
However, the actual displayed "see below" is 9 characters.