### PR TITLE
[expr.ref] Do not say that the direct base relationship is (T1, B)

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -4258,7 +4258,7 @@ If \tcode{E2} is a \grammarterm{splice-expression},
 then let \tcode{T1} be the type of \tcode{E1}.
 \tcode{E2} shall designate either
 a member of \tcode{T1} or
-a direct base class relationship $(\tcode{T1}, \tcode{B})$.
+a direct base class relationship.
 
 \pnum
 If \tcode{E2} designates a bit-field, \tcode{E1.E2} is a bit-field. The


### PR DESCRIPTION
[CWG 3114](https://cplusplus.github.io/CWG/issues/3114.html) makes it clear that the first type in the direct base relationship does not need to be `T1`.