### PR TITLE
[mdspan.syn, mdspan.sub.range.slices] Remove redundant std

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -21275,7 +21275,7 @@ namespace std {
   // \ref{mdspan.sub}, \tcode{submdspan} creation
   template<class OffsetType, class LengthType, class StrideType>
     struct extent_slice;
-  template<class FirstType, class LastType, class StrideType = std::constant_wrapper<1zu>>
+  template<class FirstType, class LastType, class StrideType = constant_wrapper<1zu>>
     struct range_slice;
 
   template<class LayoutMapping>
@@ -25732,7 +25732,7 @@ namespace std {
     [[no_unique_address]] stride_type stride{};
   };
 
-  template<class FirstType, class LastType, class StrideType = std::constant_wrapper<1zu>>
+  template<class FirstType, class LastType, class StrideType = constant_wrapper<1zu>>
   struct range_slice {
     [[no_unique_address]] FirstType first{};
     [[no_unique_address]] LastType last{};


### PR DESCRIPTION
They seem unnecessary here.