### PR TITLE
[mdspan.sub.range.slices] Remove code format for range slices

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -25709,7 +25709,7 @@ if
   \end{itemize}
 \end{itemize}
 
-\rSec4[mdspan.sub.range.slices]{\tcode{Range slices}}
+\rSec4[mdspan.sub.range.slices]{Range slices}
 
 \pnum
 \tcode{extent_slice} and \tcode{range_slice} represent a set of


### PR DESCRIPTION
Neither of those two words is a code.