### PR TITLE
[utility.arg.requirements] Strike redundant text about core language rules

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -1824,12 +1824,6 @@ supplied by a \Cpp{} program instantiating a template,
 rvalue of type \tcode{const T}.
 \end{itemize}
 
-\pnum
-In general, a default constructor is not required. Certain container class
-member function signatures specify \tcode{T()} as a default argument.
-\tcode{T()} shall be a well-defined expression\iref{dcl.init} if one of those
-signatures is called using the default argument\iref{dcl.fct.default}.
-
 \begin{oldconcepttable}{EqualityComparable}{}{cpp17.equalitycomparable}
 {x{1in}x{1in}p{3in}}
 \topline


### PR DESCRIPTION
Fixes #8983 