### PR TITLE
[re.tokiter.general] Fix incorrect `suffix.match`

### DIFF
--- a/source/text.tex
+++ b/source/text.tex
@@ -12651,7 +12651,7 @@ A \textit{suffix iterator} is a \tcode{regex_token_iterator} object
 that points to a final sequence of characters at
 the end of the target sequence. In a suffix iterator the
 member \tcode{result} holds a pointer to the data
-member \tcode{suffix}, the value of the member \tcode{suffix.match}
+member \tcode{suffix}, the value of the member \tcode{suffix.matched}
 is \tcode{true}, \tcode{suffix.first} points to the beginning of the
 final sequence, and \tcode{suffix.second} points to the end of the
 final sequence.


### PR DESCRIPTION
The type of `suffix` is a `sub_match` specialization, so the intended expression is probably `suffix.matched`.