### PR TITLE
[simd.{syn,math}] Rename parameters of new overloads of various special maths functions:

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -17305,59 +17305,62 @@ namespace std::simd {
   template<@\exposconcept{math-floating-point}@ V>
     @\exposid{deduced-vec-t}@<V> comp_ellint_3(const V& k, const V& nu);
   template<@\exposconcept{math-floating-point}@ V>
-    @\exposid{deduced-vec-t}@<V> comp_ellint_3(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
+    @\exposid{deduced-vec-t}@<V> comp_ellint_3(const @\exposid{deduced-vec-t}@<V>& k, const V& nu);
   template<@\exposconcept{math-floating-point}@ V>
-    @\exposid{deduced-vec-t}@<V> comp_ellint_3(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
+    @\exposid{deduced-vec-t}@<V> comp_ellint_3(const V& k, const @\exposid{deduced-vec-t}@<V>& nu);
   template<@\exposconcept{math-floating-point}@ V>
     @\exposid{deduced-vec-t}@<V> cyl_bessel_i(const V& nu, const V& x);
   template<@\exposconcept{math-floating-point}@ V>
-    @\exposid{deduced-vec-t}@<V> cyl_bessel_i(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
+    @\exposid{deduced-vec-t}@<V> cyl_bessel_i(const @\exposid{deduced-vec-t}@<V>& nu, const V& x);
   template<@\exposconcept{math-floating-point}@ V>
-    @\exposid{deduced-vec-t}@<V> cyl_bessel_i(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
+    @\exposid{deduced-vec-t}@<V> cyl_bessel_i(const V& nu, const @\exposid{deduced-vec-t}@<V>& x);
   template<@\exposconcept{math-floating-point}@ V>
     @\exposid{deduced-vec-t}@<V> cyl_bessel_j(const V& nu, const V& x);
   template<@\exposconcept{math-floating-point}@ V>
-    @\exposid{deduced-vec-t}@<V> cyl_bessel_j(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
+    @\exposid{deduced-vec-t}@<V> cyl_bessel_j(const @\exposid{deduced-vec-t}@<V>& nu, const V& x);
   template<@\exposconcept{math-floating-point}@ V>
-    @\exposid{deduced-vec-t}@<V> cyl_bessel_j(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
+    @\exposid{deduced-vec-t}@<V> cyl_bessel_j(const V& nu, const @\exposid{deduced-vec-t}@<V>& x);
   template<@\exposconcept{math-floating-point}@ V>
     @\exposid{deduced-vec-t}@<V> cyl_bessel_k(const V& nu, const V& x);
   template<@\exposconcept{math-floating-point}@ V>
-    @\exposid{deduced-vec-t}@<V> cyl_bessel_k(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
+    @\exposid{deduced-vec-t}@<V> cyl_bessel_k(const @\exposid{deduced-vec-t}@<V>& nu, const V& x);
   template<@\exposconcept{math-floating-point}@ V>
-    @\exposid{deduced-vec-t}@<V> cyl_bessel_k(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
+    @\exposid{deduced-vec-t}@<V> cyl_bessel_k(const V& nu, const @\exposid{deduced-vec-t}@<V>& x);
   template<@\exposconcept{math-floating-point}@ V>
     @\exposid{deduced-vec-t}@<V> cyl_neumann(const V& nu, const V& x);
   template<@\exposconcept{math-floating-point}@ V>
-    @\exposid{deduced-vec-t}@<V> cyl_neumann(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
+    @\exposid{deduced-vec-t}@<V> cyl_neumann(const @\exposid{deduced-vec-t}@<V>& nu, const V& x);
   template<@\exposconcept{math-floating-point}@ V>
-    @\exposid{deduced-vec-t}@<V> cyl_neumann(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
+    @\exposid{deduced-vec-t}@<V> cyl_neumann(const V& nu, const @\exposid{deduced-vec-t}@<V>& x);
   template<@\exposconcept{math-floating-point}@ V>
     @\exposid{deduced-vec-t}@<V> ellint_1(const V& k, const V& phi);
   template<@\exposconcept{math-floating-point}@ V>
-    @\exposid{deduced-vec-t}@<V> ellint_1(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
+    @\exposid{deduced-vec-t}@<V> ellint_1(const @\exposid{deduced-vec-t}@<V>& k, const V& phi);
   template<@\exposconcept{math-floating-point}@ V>
-    @\exposid{deduced-vec-t}@<V> ellint_1(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
+    @\exposid{deduced-vec-t}@<V> ellint_1(const V& k, const @\exposid{deduced-vec-t}@<V>& phi);
   template<@\exposconcept{math-floating-point}@ V>
     @\exposid{deduced-vec-t}@<V> ellint_2(const V& k, const V& phi);
   template<@\exposconcept{math-floating-point}@ V>
-    @\exposid{deduced-vec-t}@<V> ellint_2(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
+    @\exposid{deduced-vec-t}@<V> ellint_2(const @\exposid{deduced-vec-t}@<V>& k, const V& phi);
   template<@\exposconcept{math-floating-point}@ V>
-    @\exposid{deduced-vec-t}@<V> ellint_2(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
+    @\exposid{deduced-vec-t}@<V> ellint_2(const V& k, const @\exposid{deduced-vec-t}@<V>& phi);
   template<@\exposconcept{math-floating-point}@ V>
     @\exposid{deduced-vec-t}@<V> ellint_3(const V& k, const V& nu, const V& phi);
   template<@\exposconcept{math-floating-point}@ V>
-    @\exposid{deduced-vec-t}@<V> ellint_3(const @\exposid{deduced-vec-t}@<V>& x, const V& y, const V& z);
+    @\exposid{deduced-vec-t}@<V> ellint_3(const @\exposid{deduced-vec-t}@<V>& k, const V& nu, const V& phi);
   template<@\exposconcept{math-floating-point}@ V>
-    @\exposid{deduced-vec-t}@<V> ellint_3(const V& x, const @\exposid{deduced-vec-t}@<V>& y, const V& z);
+    @\exposid{deduced-vec-t}@<V> ellint_3(const V& k, const @\exposid{deduced-vec-t}@<V>& nu, const V& phi);
   template<@\exposconcept{math-floating-point}@ V>
-    @\exposid{deduced-vec-t}@<V> ellint_3(const V& x, const V& y, const @\exposid{deduced-vec-t}@<V>& z);
+    @\exposid{deduced-vec-t}@<V> ellint_3(const V& k, const V& nu, const @\exposid{deduced-vec-t}@<V>& phi);
   template<@\exposconcept{math-floating-point}@ V>
-    @\exposid{deduced-vec-t}@<V> ellint_3(const @\exposid{deduced-vec-t}@<V>& x, const @\exposid{deduced-vec-t}@<V>& y, const V& z);
+    @\exposid{deduced-vec-t}@<V> ellint_3(const @\exposid{deduced-vec-t}@<V>& k, const @\exposid{deduced-vec-t}@<V>& nu,
+                             @\itcorr@ const V& phi);
   template<@\exposconcept{math-floating-point}@ V>
-    @\exposid{deduced-vec-t}@<V> ellint_3(const @\exposid{deduced-vec-t}@<V>& x, const V& y, const @\exposid{deduced-vec-t}@<V>& z);
+    @\exposid{deduced-vec-t}@<V> ellint_3(const @\exposid{deduced-vec-t}@<V>& k, const V& nu,
+                             @\itcorr@ const @\exposid{deduced-vec-t}@<V>& phi);
   template<@\exposconcept{math-floating-point}@ V>
-    @\exposid{deduced-vec-t}@<V> ellint_3(const V& x, const @\exposid{deduced-vec-t}@<V>& y, const @\exposid{deduced-vec-t}@<V>& z);
+    @\exposid{deduced-vec-t}@<V> ellint_3(const V& k, const @\exposid{deduced-vec-t}@<V>& nu,
+                             @\itcorr@ const @\exposid{deduced-vec-t}@<V>& phi);
   template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-vec-t}@<V> expint(const V& x);
   template<@\exposconcept{math-floating-point}@ V>
     @\exposid{deduced-vec-t}@<V> hermite(const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& n, const V& x);
@@ -20289,59 +20292,59 @@ template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-vec-t}@<V> co
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> comp_ellint_3(const V& k, const V& nu);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> comp_ellint_3(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
+  @\exposid{deduced-vec-t}@<V> comp_ellint_3(const @\exposid{deduced-vec-t}@<V>& k, const V& nu);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> comp_ellint_3(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
+  @\exposid{deduced-vec-t}@<V> comp_ellint_3(const V& k, const @\exposid{deduced-vec-t}@<V>& nu);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> cyl_bessel_i(const V& nu, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> cyl_bessel_i(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
+  @\exposid{deduced-vec-t}@<V> cyl_bessel_i(const @\exposid{deduced-vec-t}@<V>& nu, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> cyl_bessel_i(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
+  @\exposid{deduced-vec-t}@<V> cyl_bessel_i(const V& nu, const @\exposid{deduced-vec-t}@<V>& x);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> cyl_bessel_j(const V& nu, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> cyl_bessel_j(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
+  @\exposid{deduced-vec-t}@<V> cyl_bessel_j(const @\exposid{deduced-vec-t}@<V>& nu, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> cyl_bessel_j(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
+  @\exposid{deduced-vec-t}@<V> cyl_bessel_j(const V& nu, const @\exposid{deduced-vec-t}@<V>& x);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> cyl_bessel_k(const V& nu, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> cyl_bessel_k(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
+  @\exposid{deduced-vec-t}@<V> cyl_bessel_k(const @\exposid{deduced-vec-t}@<V>& nu, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> cyl_bessel_k(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
+  @\exposid{deduced-vec-t}@<V> cyl_bessel_k(const V& nu, const @\exposid{deduced-vec-t}@<V>& x);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> cyl_neumann(const V& nu, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> cyl_neumann(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
+  @\exposid{deduced-vec-t}@<V> cyl_neumann(const @\exposid{deduced-vec-t}@<V>& nu, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> cyl_neumann(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
+  @\exposid{deduced-vec-t}@<V> cyl_neumann(const V& nu, const @\exposid{deduced-vec-t}@<V>& x);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> ellint_1(const V& k, const V& phi);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> ellint_1(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
+  @\exposid{deduced-vec-t}@<V> ellint_1(const @\exposid{deduced-vec-t}@<V>& k, const V& phi);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> ellint_1(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
+  @\exposid{deduced-vec-t}@<V> ellint_1(const V& k, const @\exposid{deduced-vec-t}@<V>& phi);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> ellint_2(const V& k, const V& phi);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> ellint_2(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
+  @\exposid{deduced-vec-t}@<V> ellint_2(const @\exposid{deduced-vec-t}@<V>& k, const V& phi);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> ellint_2(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
+  @\exposid{deduced-vec-t}@<V> ellint_2(const V& k, const @\exposid{deduced-vec-t}@<V>& phi);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> ellint_3(const V& k, const V& nu, const V& phi);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> ellint_3(const @\exposid{deduced-vec-t}@<V>& x, const V& y, const V& z);
+  @\exposid{deduced-vec-t}@<V> ellint_3(const @\exposid{deduced-vec-t}@<V>& k, const V& nu, const V& phi);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> ellint_3(const V& x, const @\exposid{deduced-vec-t}@<V>& y, const V& z);
+  @\exposid{deduced-vec-t}@<V> ellint_3(const V& k, const @\exposid{deduced-vec-t}@<V>& nu, const V& phi);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> ellint_3(const V& x, const V& y, const @\exposid{deduced-vec-t}@<V>& z);
+  @\exposid{deduced-vec-t}@<V> ellint_3(const V& k, const V& nu, const @\exposid{deduced-vec-t}@<V>& phi);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> ellint_3(const @\exposid{deduced-vec-t}@<V>& x, const @\exposid{deduced-vec-t}@<V>& y, const V& z);
+  @\exposid{deduced-vec-t}@<V> ellint_3(const @\exposid{deduced-vec-t}@<V>& k, const @\exposid{deduced-vec-t}@<V>& nu, const V& phi);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> ellint_3(const @\exposid{deduced-vec-t}@<V>& x, const V& y, const @\exposid{deduced-vec-t}@<V>& z);
+  @\exposid{deduced-vec-t}@<V> ellint_3(const @\exposid{deduced-vec-t}@<V>& k, const V& nu, const @\exposid{deduced-vec-t}@<V>& phi);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> ellint_3(const V& x, const @\exposid{deduced-vec-t}@<V>& y, const @\exposid{deduced-vec-t}@<V>& z);
+  @\exposid{deduced-vec-t}@<V> ellint_3(const V& k, const @\exposid{deduced-vec-t}@<V>& nu, const @\exposid{deduced-vec-t}@<V>& phi);
 template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-vec-t}@<V> expint(const V& x);
 template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-vec-t}@<V> riemann_zeta(const V& x);
 \end{itemdecl}


### PR DESCRIPTION
* For comp_ellint_3: from "x, y" to "k, nu"
* For cyl_bessel_{i,j,k}: from "x, y" to "nu, x"
* For cyl_neumann: from "x, y" to "nu, x"
* For ellint_{1,2}: from "x, y" to "k, phi"
* For ellint_{1,2}: from "x, y, z" to "k, nu, phi"

The paper P3844R4 (LWG Motion 4) added those overloads with parameters named differently from the names of the existing overloads, but the latter names seem more appropriate.

Addresses editorial review committee feedback.