### PR TITLE
[linalg.algs.blas2.rank1,linalg.algs.blas2.symherrank1] Restore missing arguments in P3371R5 updating overloads

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -14994,7 +14994,7 @@ These functions correspond to the BLAS functions
 For the overloads without an \tcode{ExecutionPolicy} argument,
 equivalent to:
 \begin{codeblock}
-matrix_rank_1_update(x, conjugated(y), A);
+matrix_rank_1_update(x, conjugated(y), E, A);
 \end{codeblock}
 \item
 otherwise, equivalent to:

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -15150,11 +15150,14 @@ where the scalar $\alpha$ is \tcode{\exposid{real-if-needed}(alpha)}.
 
 \indexlibraryglobal{hermitian_matrix_rank_1_update}%
 \begin{itemdecl}
-template<@\exposconcept{scalar}@ Scalar, @\exposconcept{possibly-packed-out-matrix}@ OutMat, class Triangle>
-  void hermitian_matrix_rank_1_update(InVec x, OutMat A, Triangle t);
+template<@\exposconcept{scalar}@ Scalar, @\exposconcept{in-vector}@ InVec, @\exposconcept{in-matrix}@ InMat, @\exposconcept{possibly-packed-out-matrix}@ OutMat,
+         class Triangle>
+  void hermitian_matrix_rank_1_update(Scalar alpha, InVec x, InMat E, OutMat A, Triangle t);
 template<class ExecutionPolicy,
-         @\exposconcept{scalar}@ Scalar, @\exposconcept{possibly-packed-out-matrix}@ OutMat, class Triangle>
-  void hermitian_matrix_rank_1_update(ExecutionPolicy&& exec, InVec x, OutMat A, Triangle t);
+         @\exposconcept{scalar}@ Scalar, @\exposconcept{in-vector}@ InVec, @\exposconcept{in-matrix}@ InMat, @\exposconcept{possibly-packed-out-matrix}@ OutMat,
+         class Triangle>
+  void hermitian_matrix_rank_1_update(ExecutionPolicy&& exec,
+                                      Scalar alpha, InVec x, InMat E, OutMat A, Triangle t);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
The detailed wording for two updating overloads introduced by P3371R5 is inconsistent with the synopsis and surrounding effects wording.

- `[linalg.algs.blas2.rank1]` — `matrix_rank_1_update_c` non-`ExecutionPolicy` Effects codeblock dispatches to the 3-arg overwriting overload, dropping `E`.
- `[linalg.algs.blas2.symherrank1]` — updating `hermitian_matrix_rank_1_update` detailed declaration drops `in-vector InVec`, `in-matrix InMat`, `Scalar alpha`, and `InMat E`, even though Effects compute `A = E + alpha x x^H` and Remarks state "A may alias E".