### PR TITLE
[mdspan.sub.sub] Fix submdspan slice canonicalization

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -21297,7 +21297,7 @@ namespace std {
            class AccessorPolicy, class... SliceSpecifiers>
     constexpr auto submdspan(
       const mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy>& src,
-      SliceSpecifiers... slices) -> @\seebelow@;
+      SliceSpecifiers... raw_slices) -> @\seebelow@;
 
   template<class T, class IndexType>
     concept @\defexposconcept{index-pair-like}@ =               // \expos
@@ -26579,7 +26579,7 @@ template<class ElementType, class Extents, class LayoutPolicy,
          class AccessorPolicy, class... SliceSpecifiers>
   constexpr auto submdspan(
     const mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy>& src,
-    SliceSpecifiers... slices) -> @\seebelow@;
+    SliceSpecifiers... raw_slices) -> @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -26589,7 +26589,7 @@ Let \tcode{index_type} be \tcode{typename Extents::index_type}.
 \pnum
 Let \tcode{slices} be the pack introduced by the following declaration:
 \begin{codeblock}
-auto [...slices] = canonical_slices(src, raw_slices...);
+auto [...slices] = canonical_slices(src.extents(), raw_slices...);
 \end{codeblock}
 
 \pnum


### PR DESCRIPTION
Two integration errors in `submdspan`'s slice canonicalization Let clause introduced by P3663R3:

- the function parameter pack is named `slices`, but the Let clause references an undefined `raw_slices`; rename the parameter to match `subextents` (`[mdspan.sub.extents]`).
- `src` is an `mdspan` but `canonical_slices` takes an `extents` object (`[mdspan.sub.canonical]`); pass `src.extents()` instead of `src`.