### PR TITLE
[mdspan.sub.map.sliceable] Fix M::extent_type to M::extents_type

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -26074,11 +26074,11 @@ Let:
 \item
   \tcode{M} denote a layout mapping class;
 \item
-  \tcode{IT} denote \tcode{M::extent_type::index_type};
+  \tcode{IT} denote \tcode{M::extents_type::index_type};
 \item
   \tcode{m} denote a value of type (possibly const) \tcode{M};
 \item
-  \tcode{M_rank} be equal to \tcode{M::extent_type::rank()};
+  \tcode{M_rank} be equal to \tcode{M::extents_type::rank()};
 \item
   \tcode{valid_slices} denote a pack of (possibly const) objects
   for which \tcode{sizeof...(valid_slices) == M_rank} is \tcode{true} and,


### PR DESCRIPTION
Layout mapping types expose `extents_type`, not `extent_type` (the latter is a member of `extent_slice`). The Let clause in `[mdspan.sub.map.sliceable]` defines `IT` and `M_rank` via the undefined member `M::extent_type`, making the subsequent sliceable layout mapping requirements uninterpretable.

The same subclause uses `LayoutMapping::extents_type::rank()` and `SM::extents_type::{rank,index_type}` correctly elsewhere.