### PR TITLE
[mdspan.sub.map.sliceable] Use lm in sliceable-mapping concept body

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -26173,7 +26173,7 @@ for which \tcode{sizeof...(fe) == LayoutMapping::extents_type::rank()} is \tcode
 A type \tcode{LayoutMapping} satisfies \exposconcept{sliceable-mapping} if
 \begin{itemize}
 \item
-  the expression \tcode{submdspan_mapping(m, fe...)} is well-formed
+  the expression \tcode{submdspan_mapping(lm, fe...)} is well-formed
   when treated as an unevaluated operand, and
 \item
   the type of that expression is a specialization of


### PR DESCRIPTION
The `sliceable-mapping` concept body introduces `lm` (an object of type `LayoutMapping`) but then uses `m` (an object of type `M` from the surrounding requirements section, with `M` not bound to `LayoutMapping`) in the `submdspan_mapping` well-formedness check.