### PR TITLE
[views.multidim] Index various `<mdspan>` components

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -21281,8 +21281,8 @@ namespace std {
   template<class LayoutMapping>
     struct submdspan_mapping_result;
 
-  struct full_extent_t { explicit full_extent_t() = default; };
-  inline constexpr full_extent_t full_extent{};
+  struct @\libglobal{full_extent_t}@ { explicit full_extent_t() = default; };
+  inline constexpr full_extent_t @\libglobal{full_extent}@{};
 
   template<class IndexType, size_t... Extents, class... SliceSpecifiers>
     constexpr auto subextents(const extents<IndexType, Extents...>&, SliceSpecifiers...);
@@ -21321,13 +21321,13 @@ namespace std {
   template<class IndexType, size_t... Extents>
   class @\libglobal{extents}@ {
   public:
-    using index_type = IndexType;
-    using size_type = make_unsigned_t<index_type>;
-    using rank_type = size_t;
+    using @\libmember{index_type}{extents}@ = IndexType;
+    using @\libmember{size_type}{extents}@ = make_unsigned_t<index_type>;
+    using @\libmember{rank_type}{extents}@ = size_t;
 
     // \ref{mdspan.extents.obs}, observers of the multidimensional index space
-    static constexpr rank_type rank() noexcept { return sizeof...(Extents); }
-    static constexpr rank_type rank_dynamic() noexcept { return @\exposid{dynamic-index}@(rank()); }
+    static constexpr rank_type @\libmember{rank}{extents}@() noexcept { return sizeof...(Extents); }
+    static constexpr rank_type @\libmember{rank_dynamic}{extents}@() noexcept { return @\exposid{dynamic-index}@(rank()); }
     static constexpr size_t static_extent(rank_type) noexcept;
     constexpr index_type extent(rank_type) const noexcept;
 
@@ -22096,25 +22096,25 @@ the \grammarterm{qualified-id} \tcode{X::extents_type} denotes \tcode{E}.
 
 \begin{codeblock}
 namespace std {
-  struct layout_left {
+  struct @\libglobal{layout_left}@ {
     template<class Extents>
       class mapping;
   };
-  struct layout_right {
+  struct @\libglobal{layout_right}@ {
     template<class Extents>
       class mapping;
   };
-  struct layout_stride {
+  struct @\libglobal{layout_stride}@ {
     template<class Extents>
       class mapping;
   };
 
   template<size_t PaddingValue>
-  struct layout_left_padded {
+  struct @\libglobal{layout_left_padded}@ {
     template<class Extents> class mapping;
   };
   template<size_t PaddingValue>
-  struct layout_right_padded {
+  struct @\libglobal{layout_right_padded}@ {
     template<class Extents> class mapping;
   };
 }
@@ -22138,16 +22138,17 @@ for any such type \tcode{T}.
 where the leftmost extent has stride 1, and
 strides increase left-to-right as the product of extents.
 
+\indexlibrarymember{mapping}{layout_left}%
 \begin{codeblock}
 namespace std {
   template<class Extents>
   class layout_left::mapping {
   public:
-    using extents_type = Extents;
-    using index_type = extents_type::index_type;
-    using size_type = extents_type::size_type;
-    using rank_type = extents_type::rank_type;
-    using layout_type = layout_left;
+    using @\libmember{extents_type}{layout_left::mapping}@ = Extents;
+    using @\libmember{index_type}{layout_left::mapping}@ = extents_type::index_type;
+    using @\libmember{size_type}{layout_left::mapping}@ = extents_type::size_type;
+    using @\libmember{rank_type}{layout_left::mapping}@ = extents_type::rank_type;
+    using @\libmember{layout_type}{layout_left::mapping}@ = layout_left;
 
     // \ref{mdspan.layout.left.cons}, constructors
     constexpr mapping() noexcept = default;
@@ -22170,20 +22171,20 @@ namespace std {
     constexpr mapping& operator=(const mapping&) noexcept = default;
 
     // \ref{mdspan.layout.left.obs}, observers
-    constexpr const extents_type& extents() const noexcept { return @\exposid{extents_}@; }
+    constexpr const extents_type& @\libmember{extents}{layout_left::mapping}@() const noexcept { return @\exposid{extents_}@; }
 
     constexpr index_type required_span_size() const noexcept;
 
     template<class... Indices>
       constexpr index_type operator()(Indices...) const noexcept;
 
-    static constexpr bool is_always_unique() noexcept { return true; }
-    static constexpr bool is_always_exhaustive() noexcept { return true; }
-    static constexpr bool is_always_strided() noexcept { return true; }
+    static constexpr bool @\libmember{is_always_unique}{layout_left::mapping}@() noexcept { return true; }
+    static constexpr bool @\libmember{is_always_exhaustive}{layout_left::mapping}@() noexcept { return true; }
+    static constexpr bool @\libmember{is_always_strided}{layout_left::mapping}@() noexcept { return true; }
 
-    static constexpr bool is_unique() noexcept { return true; }
-    static constexpr bool is_exhaustive() noexcept { return true; }
-    static constexpr bool is_strided() noexcept { return true; }
+    static constexpr bool @\libmember{is_unique}{layout_left::mapping}@() noexcept { return true; }
+    static constexpr bool @\libmember{is_exhaustive}{layout_left::mapping}@() noexcept { return true; }
+    static constexpr bool @\libmember{is_strided}{layout_left::mapping}@() noexcept { return true; }
 
     constexpr index_type stride(rank_type) const noexcept;
 
@@ -22467,16 +22468,17 @@ Equivalent to: \tcode{return x.extents() == y.extents();}
 where the rightmost extent is stride 1, and
 strides increase right-to-left as the product of extents.
 
+\indexlibrarymember{mapping}{layout_right}%
 \begin{codeblock}
 namespace std {
   template<class Extents>
   class layout_right::mapping {
   public:
-    using extents_type = Extents;
-    using index_type = extents_type::index_type;
-    using size_type = extents_type::size_type;
-    using rank_type = extents_type::rank_type;
-    using layout_type = layout_right;
+    using @\libmember{extents_type}{layout_right::mapping}@ = Extents;
+    using @\libmember{index_type}{layout_right::mapping}@ = extents_type::index_type;
+    using @\libmember{size_type}{layout_right::mapping}@ = extents_type::size_type;
+    using @\libmember{rank_type}{layout_right::mapping}@ = extents_type::rank_type;
+    using @\libmember{layout_type}{layout_right::mapping}@ = layout_right;
 
     // \ref{mdspan.layout.right.cons}, constructors
     constexpr mapping() noexcept = default;
@@ -22499,20 +22501,20 @@ namespace std {
     constexpr mapping& operator=(const mapping&) noexcept = default;
 
     // \ref{mdspan.layout.right.obs}, observers
-    constexpr const extents_type& extents() const noexcept { return @\exposid{extents_}@; }
+    constexpr const extents_type& @\libmember{extents}{layout_right::mapping}@() const noexcept { return @\exposid{extents_}@; }
 
     constexpr index_type required_span_size() const noexcept;
 
     template<class... Indices>
       constexpr index_type operator()(Indices...) const noexcept;
 
-    static constexpr bool is_always_unique() noexcept { return true; }
-    static constexpr bool is_always_exhaustive() noexcept { return true; }
-    static constexpr bool is_always_strided() noexcept { return true; }
+    static constexpr bool @\libmember{is_always_unique}{layout_right::mapping}@() noexcept { return true; }
+    static constexpr bool @\libmember{is_always_exhaustive}{layout_right::mapping}@() noexcept { return true; }
+    static constexpr bool @\libmember{is_always_strided}{layout_right::mapping}@() noexcept { return true; }
 
-    static constexpr bool is_unique() noexcept { return true; }
-    static constexpr bool is_exhaustive() noexcept { return true; }
-    static constexpr bool is_strided() noexcept { return true; }
+    static constexpr bool @\libmember{is_unique}{layout_right::mapping}@() noexcept { return true; }
+    static constexpr bool @\libmember{is_exhaustive}{layout_right::mapping}@() noexcept { return true; }
+    static constexpr bool @\libmember{is_strided}{layout_right::mapping}@() noexcept { return true; }
 
     constexpr index_type stride(rank_type) const noexcept;
 
@@ -22799,16 +22801,17 @@ Equivalent to: \tcode{return x.extents() == y.extents();}
 \tcode{layout_stride} provides a layout mapping
 where the strides are user-defined.
 
+\indexlibrarymember{mapping}{layout_stride}%
 \begin{codeblock}
 namespace std {
   template<class Extents>
   class layout_stride::mapping {
   public:
-    using extents_type = Extents;
-    using index_type = extents_type::index_type;
-    using size_type = extents_type::size_type;
-    using rank_type = extents_type::rank_type;
-    using layout_type = layout_stride;
+    using @\libmember{extents_type}{layout_stride::mapping}@ = Extents;
+    using @\libmember{index_type}{layout_stride::mapping}@ = extents_type::index_type;
+    using @\libmember{size_type}{layout_stride::mapping}@ = extents_type::size_type;
+    using @\libmember{rank_type}{layout_stride::mapping}@ = extents_type::rank_type;
+    using @\libmember{layout_type}{layout_stride::mapping}@ = layout_stride;
 
   private:
     static constexpr rank_type @\exposid{rank_}@ = extents_type::rank();    // \expos
@@ -22828,23 +22831,23 @@ namespace std {
     constexpr mapping& operator=(const mapping&) noexcept = default;
 
     // \ref{mdspan.layout.stride.obs}, observers
-    constexpr const extents_type& extents() const noexcept { return @\exposid{extents_}@; }
-    constexpr array<index_type, @\exposid{rank_}@> strides() const noexcept { return @\exposid{strides_}@; }
+    constexpr const extents_type& @\libmember{extents}{layout_stride::mapping}@() const noexcept { return @\exposid{extents_}@; }
+    constexpr array<index_type, @\exposid{rank_}@> @\libmember{strides}{layout_stride::mapping}@() const noexcept { return @\exposid{strides_}@; }
 
     constexpr index_type required_span_size() const noexcept;
 
     template<class... Indices>
       constexpr index_type operator()(Indices...) const noexcept;
 
-    static constexpr bool is_always_unique() noexcept { return true; }
+    static constexpr bool @\libmember{is_always_unique}{layout_stride::mapping}@() noexcept { return true; }
     static constexpr bool is_always_exhaustive() noexcept;
-    static constexpr bool is_always_strided() noexcept { return true; }
+    static constexpr bool @\libmember{is_always_strided}{layout_stride::mapping}@() noexcept { return true; }
 
-    static constexpr bool is_unique() noexcept { return true; }
+    static constexpr bool @\libmember{is_unique}{layout_stride::mapping}@() noexcept { return true; }
     constexpr bool is_exhaustive() const noexcept;
-    static constexpr bool is_strided() noexcept { return true; }
+    static constexpr bool @\libmember{is_strided}{layout_stride::mapping}@() noexcept { return true; }
 
-    constexpr index_type stride(rank_type i) const noexcept { return @\exposid{strides_}@[i]; }
+    constexpr index_type @\libmember{stride}{layout_stride::mapping}@(rank_type i) const noexcept { return @\exposid{strides_}@[i]; }
 
     template<class OtherMapping>
       friend constexpr bool operator==(const mapping&, const OtherMapping&) noexcept;
@@ -23199,19 +23202,20 @@ that behaves like \tcode{layout_left::mapping},
 except that the padding stride \tcode{stride(1)}
 can be greater than or equal to \tcode{extent(0)}.
 
+\indexlibrarymember{mapping}{layout_left_padded}%
 \begin{codeblock}
 namespace std {
   template<size_t PaddingValue>
   template<class Extents>
   class layout_left_padded<PaddingValue>::mapping {
   public:
-    static constexpr size_t padding_value = PaddingValue;
+    static constexpr size_t @\libmember{padding_value}{layout_left_padded::mapping}@ = PaddingValue;
 
-    using extents_type = Extents;
-    using index_type = extents_type::index_type;
-    using size_type = extents_type::size_type;
-    using rank_type = extents_type::rank_type;
-    using layout_type = layout_left_padded<PaddingValue>;
+    using @\libmember{extents_type}{layout_left_padded::mapping}@ = Extents;
+    using @\libmember{index_type}{layout_left_padded::mapping}@ = extents_type::index_type;
+    using @\libmember{size_type}{layout_left_padded::mapping}@ = extents_type::size_type;
+    using @\libmember{rank_type}{layout_left_padded::mapping}@ = extents_type::rank_type;
+    using @\libmember{layout_type}{layout_left_padded::mapping}@ = layout_left_padded<PaddingValue>;
 
   private:
     static constexpr size_t @\exposid{rank_}@ = extents_type::rank();         // \expos
@@ -23244,20 +23248,20 @@ namespace std {
     constexpr mapping& operator=(const mapping&) noexcept = default;
 
     // \ref{mdspan.layout.leftpad.obs}, observers
-    constexpr const extents_type& extents() const noexcept { return @\exposid{extents_}@; }
+    constexpr const extents_type& @\libmember{extents}{layout_left_padded::mapping}@() const noexcept { return @\exposid{extents_}@; }
     constexpr array<index_type, @\exposid{rank_}@> strides() const noexcept;
 
     constexpr index_type required_span_size() const noexcept;
     template<class... Indices>
       constexpr index_type operator()(Indices...) const noexcept;
 
-    static constexpr bool is_always_unique() noexcept { return true; }
+    static constexpr bool @\libmember{is_always_unique}{layout_left_padded::mapping}@() noexcept { return true; }
     static constexpr bool is_always_exhaustive() noexcept;
-    static constexpr bool is_always_strided() noexcept { return true; }
+    static constexpr bool @\libmember{is_always_strided}{layout_left_padded::mapping}@() noexcept { return true; }
 
-    static constexpr bool is_unique() noexcept { return true; }
+    static constexpr bool @\libmember{is_unique}{layout_left_padded::mapping}@() noexcept { return true; }
     constexpr bool is_exhaustive() const noexcept;
-    static constexpr bool is_strided() noexcept { return true; }
+    static constexpr bool @\libmember{is_strided}{layout_left_padded::mapping}@() noexcept { return true; }
 
     constexpr index_type stride(rank_type) const noexcept;
 
@@ -23696,6 +23700,7 @@ either the constraints or the preconditions.
 
 \rSec5[mdspan.layout.leftpad.obs]{Observers}
 
+\indexlibrarymember{strides}{layout_left_padded::mapping}%
 \begin{itemdecl}
 constexpr array<index_type, @\exposid{rank_}@> strides() const noexcept;
 \end{itemdecl}
@@ -23706,6 +23711,7 @@ constexpr array<index_type, @\exposid{rank_}@> strides() const noexcept;
 \tcode{array<index_type, \exposid{rank_}>(\{stride(P_rank)...\})}.
 \end{itemdescr}
 
+\indexlibrarymember{required_span_size}{layout_left_padded::mapping}%
 \begin{itemdecl}
 constexpr index_type required_span_size() const noexcept;
 \end{itemdecl}
@@ -23721,6 +23727,7 @@ otherwise, \tcode{(*this)(\exposid{extents_}.extent(P_rank) - index_type(1)...) 
 \end{itemize}
 \end{itemdescr}
 
+\indexlibrarymember{operator()}{layout_left_padded::mapping}%
 \begin{itemdecl}
 template<class... Indices>
 constexpr index_type operator()(Indices... idxs) const noexcept;
@@ -23748,6 +23755,7 @@ a multidimensional index in \tcode{extents()}\iref{mdspan.overview}.
 \tcode{((static_cast<index_type>(std::move(idxs)) * stride(P_rank)) + ... + 0)}.
 \end{itemdescr}
 
+\indexlibrarymember{is_always_exhaustive}{layout_left_padded::mapping}%
 \begin{itemdecl}
 static constexpr bool is_always_exhaustive() noexcept;
 \end{itemdecl}
@@ -23768,6 +23776,7 @@ otherwise, \tcode{false}.
 \end{itemize}
 \end{itemdescr}
 
+\indexlibrarymember{is_exhaustive}{layout_left_padded::mapping}%
 \begin{itemdecl}
 constexpr bool is_exhaustive() const noexcept;
 \end{itemdecl}
@@ -23779,6 +23788,7 @@ constexpr bool is_exhaustive() const noexcept;
 otherwise, \tcode{extents_.extent(0) == stride(1)}.
 \end{itemdescr}
 
+\indexlibrarymember{stride}{layout_left_padded::mapping}%
 \begin{itemdecl}
 constexpr index_type stride(rank_type r) const noexcept;
 \end{itemdecl}
@@ -23801,6 +23811,7 @@ all values \tcode{extents_.extent($k$)} with $k$ in the range \range{1}{r}.
 \end{itemize}
 \end{itemdescr}
 
+\indexlibrarymember{operator==}{layout_left_padded::mapping}%
 \begin{itemdecl}
 template<class LayoutLeftPaddedMapping>
   friend constexpr bool operator==(const mapping& x, const LayoutLeftPaddedMapping& y) noexcept;
@@ -23835,19 +23846,20 @@ except that the padding stride \tcode{stride(extents_type::rank() - 2)}
 can be greater than or equal to
 \tcode{extents_type::ex\-tent(extents_type::rank() - 1)}.
 
+\indexlibrarymember{mapping}{layout_right_padded}%
 \begin{codeblock}
 namespace std {
   template<size_t PaddingValue>
   template<class Extents>
   class layout_right_padded<PaddingValue>::mapping {
   public:
-    static constexpr size_t padding_value = PaddingValue;
+    static constexpr size_t @\libmember{padding_value}{layout_right_padded::mapping}@ = PaddingValue;
 
-    using extents_type = Extents;
-    using index_type = extents_type::index_type;
-    using size_type = extents_type::size_type;
-    using rank_type = extents_type::rank_type;
-    using layout_type = layout_right_padded<PaddingValue>;
+    using @\libmember{extents_type}{layout_right_padded::mapping}@ = Extents;
+    using @\libmember{index_type}{layout_right_padded::mapping}@ = extents_type::index_type;
+    using @\libmember{size_type}{layout_right_padded::mapping}@ = extents_type::size_type;
+    using @\libmember{rank_type}{layout_right_padded::mapping}@ = extents_type::rank_type;
+    using @\libmember{layout_type}{layout_right_padded::mapping}@ = layout_right_padded<PaddingValue>;
 
   private:
     static constexpr size_t @\exposid{rank_}@ = extents_type::rank();    // \expos
@@ -23881,7 +23893,7 @@ namespace std {
     constexpr mapping& operator=(const mapping&) noexcept = default;
 
     // \ref{mdspan.layout.rightpad.obs}, observers
-    constexpr const extents_type& extents() const noexcept { return @\exposid{extents_}@; }
+    constexpr const extents_type& @\libmember{extents}{layout_right_padded::mapping}@() const noexcept { return @\exposid{extents_}@; }
     constexpr array<index_type, @\exposid{rank_}@> strides() const noexcept;
 
     constexpr index_type required_span_size() const noexcept;
@@ -23889,13 +23901,13 @@ namespace std {
     template<class... Indices>
       constexpr index_type operator()(Indices...) const noexcept;
 
-    static constexpr bool is_always_unique() noexcept { return true; }
+    static constexpr bool @\libmember{is_always_unique}{layout_right_padded::mapping}@() noexcept { return true; }
     static constexpr bool is_always_exhaustive() noexcept;
-    static constexpr bool is_always_strided() noexcept { return true; }
+    static constexpr bool @\libmember{is_always_strided}{layout_right_padded::mapping}@() noexcept { return true; }
 
-    static constexpr bool is_unique() noexcept { return true; }
+    static constexpr bool @\libmember{is_unique}{layout_right_padded::mapping}@() noexcept { return true; }
     constexpr bool is_exhaustive() const noexcept;
-    static constexpr bool is_strided() noexcept { return true; }
+    static constexpr bool @\libmember{is_strided}{layout_right_padded::mapping}@() noexcept { return true; }
 
     constexpr index_type stride(rank_type) const noexcept;
 
@@ -24336,7 +24348,7 @@ so the padding stride affects neither the constraints nor the preconditions.
 
 \rSec5[mdspan.layout.rightpad.obs]{Observers}
 
-\indexlibrarymember{layout_right_padded::mapping}{strides}%
+\indexlibrarymember{strides}{layout_right_padded::mapping}%
 \begin{itemdecl}
 constexpr array<index_type, @\exposid{rank_}@> strides() const noexcept;
 \end{itemdecl}
@@ -24347,7 +24359,7 @@ constexpr array<index_type, @\exposid{rank_}@> strides() const noexcept;
 \tcode{array<index_type, \exposid{rank_}>({stride(P_rank)...})}.
 \end{itemdescr}
 
-\indexlibrarymember{layout_right_padded::mapping}{required_span_size}%
+\indexlibrarymember{required_span_size}{layout_right_padded::mapping}%
 \begin{itemdecl}
 constexpr index_type required_span_size() const noexcept;
 \end{itemdecl}
@@ -24359,7 +24371,7 @@ constexpr index_type required_span_size() const noexcept;
 otherwise \tcode{(*this)(\exposid{extents_}.extent(P_rank) - index_type(1)...) + 1}.
 \end{itemdescr}
 
-\indexlibrarymember{layout_right_padded::mapping}{operator()}%
+\indexlibrarymember{operator()}{layout_right_padded::mapping}%
 \begin{itemdecl}
 template<class... Indices>
 constexpr index_type operator()(Indices... idxs) const noexcept;
@@ -24387,7 +24399,7 @@ a multidimensional index in \tcode{extents()}\iref{mdspan.overview}.
 \tcode{((static_cast<index_type>(std::move(idxs)) * stride(P_rank)) + ... + 0)}.
 \end{itemdescr}
 
-\indexlibrarymember{layout_right_padded::mapping}{is_always_exhaustive}%
+\indexlibrarymember{is_always_exhaustive}{layout_right_padded::mapping}%
 \begin{itemdecl}
 static constexpr bool is_always_exhaustive() noexcept;
 \end{itemdecl}
@@ -24408,7 +24420,7 @@ otherwise, \tcode{false}.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrarymember{layout_right_padded::mapping}{is_exhaustive}%
+\indexlibrarymember{is_exhaustive}{layout_right_padded::mapping}%
 \begin{itemdecl}
 constexpr bool is_exhaustive() const noexcept;
 \end{itemdecl}
@@ -24423,6 +24435,7 @@ otherwise,
 \end{codeblock}
 \end{itemdescr}
 
+\indexlibrarymember{stride}{layout_right_padded::mapping}%
 \begin{itemdecl}
 constexpr index_type stride(rank_type r) const noexcept;
 \end{itemdecl}
@@ -24447,7 +24460,7 @@ with $k$ in the range of \range{r + 1}{\exposid{rank_} - 1}.
 \end{itemize}
 \end{itemdescr}
 
-\indexlibrarymember{layout_right_padded::mapping}{operator==}%
+\indexlibrarymember{operator==}{layout_right_padded::mapping}%
 \begin{itemdecl}
 template<class LayoutRightPaddedMapping>
   friend constexpr bool operator==(const mapping& x, const LayoutRightPaddedMapping& y) noexcept;
@@ -24640,11 +24653,11 @@ The expression is equality-preserving.
 \begin{codeblock}
 namespace std {
   template<class ElementType>
-  struct default_accessor {
-    using offset_policy = default_accessor;
-    using element_type = ElementType;
-    using reference = ElementType&;
-    using data_handle_type = ElementType*;
+  struct @\libglobal{default_accessor}@ {
+    using @\libmember{offset_policy}{default_accessor}@ = default_accessor;
+    using @\libmember{element_type}{default_accessor}@ = ElementType;
+    using @\libmember{reference}{default_accessor}@ = ElementType&;
+    using @\libmember{data_handle_type}{default_accessor}@ = ElementType*;
 
     constexpr default_accessor() noexcept = default;
     template<class OtherElementType>
@@ -24717,12 +24730,12 @@ Equivalent to: \tcode{return p + i;}
 namespace std {
   template<class ElementType, size_t ByteAlignment>
   struct @\libglobal{aligned_accessor}@ {
-    using offset_policy = default_accessor<ElementType>;
-    using element_type = ElementType;
-    using reference = ElementType&;
-    using data_handle_type = ElementType*;
+    using @\libmember{offset_policy}{aligned_accessor}@ = default_accessor<ElementType>;
+    using @\libmember{element_type}{aligned_accessor}@ = ElementType;
+    using @\libmember{reference}{aligned_accessor}@ = ElementType&;
+    using @\libmember{data_handle_type}{aligned_accessor}@ = ElementType*;
 
-    static constexpr size_t byte_alignment = ByteAlignment;
+    static constexpr size_t @\libmember{byte_alignment}{aligned_accessor}@ = ByteAlignment;
 
     constexpr aligned_accessor() noexcept = default;
     template<class OtherElementType, size_t OtherByteAlignment>
@@ -24908,25 +24921,25 @@ Equivalent to: \tcode{return assume_aligned<byte_alignment>(p) + i;}
 namespace std {
   template<class ElementType, class Extents, class LayoutPolicy = layout_right,
            class AccessorPolicy = default_accessor<ElementType>>
-  class mdspan {
+  class @\libglobal{mdspan}@ {
   public:
-    using extents_type = Extents;
-    using layout_type = LayoutPolicy;
-    using accessor_type = AccessorPolicy;
-    using mapping_type = layout_type::template mapping<extents_type>;
-    using element_type = ElementType;
-    using value_type = remove_cv_t<element_type>;
-    using index_type = extents_type::index_type;
-    using size_type = extents_type::size_type;
-    using rank_type = extents_type::rank_type;
-    using data_handle_type = accessor_type::data_handle_type;
-    using reference = accessor_type::reference;
+    using @\libmember{extents_type}{mdspan}@ = Extents;
+    using @\libmember{layout_type}{mdspan}@ = LayoutPolicy;
+    using @\libmember{accessor_type}{mdspan}@ = AccessorPolicy;
+    using @\libmember{mapping_type}{mdspan}@ = layout_type::template mapping<extents_type>;
+    using @\libmember{element_type}{mdspan}@ = ElementType;
+    using @\libmember{value_type}{mdspan}@ = remove_cv_t<element_type>;
+    using @\libmember{index_type}{mdspan}@ = extents_type::index_type;
+    using @\libmember{size_type}{mdspan}@ = extents_type::size_type;
+    using @\libmember{rank_type}{mdspan}@ = extents_type::rank_type;
+    using @\libmember{data_handle_type}{mdspan}@ = accessor_type::data_handle_type;
+    using @\libmember{reference}{mdspan}@ = accessor_type::reference;
 
-    static constexpr rank_type rank() noexcept { return extents_type::rank(); }
-    static constexpr rank_type rank_dynamic() noexcept { return extents_type::rank_dynamic(); }
-    static constexpr size_t static_extent(rank_type r) noexcept
+    static constexpr rank_type @\libmember{rank}{mdspan}@() noexcept { return extents_type::rank(); }
+    static constexpr rank_type @\libmember{rank_dynamic}{mdspan}@() noexcept { return extents_type::rank_dynamic(); }
+    static constexpr size_t @\libmember{static_extent}{mdspan}@(rank_type r) noexcept
       { return extents_type::static_extent(r); }
-    constexpr index_type extent(rank_type r) const noexcept { return extents().extent(r); }
+    constexpr index_type @\libmember{extent}{mdspan}@(rank_type r) const noexcept { return extents().extent(r); }
 
     // \ref{mdspan.mdspan.cons}, constructors
     constexpr mdspan();
@@ -24977,25 +24990,25 @@ namespace std {
 
     friend constexpr void swap(mdspan& x, mdspan& y) noexcept;
 
-    constexpr const extents_type& extents() const noexcept { return @\exposid{map_}@.extents(); }
-    constexpr const data_handle_type& data_handle() const noexcept { return @\exposid{ptr_}@; }
-    constexpr const mapping_type& mapping() const noexcept { return @\exposid{map_}@; }
-    constexpr const accessor_type& accessor() const noexcept { return @\exposid{acc_}@; }
+    constexpr const extents_type& @\libmember{extents}{mdspan}@() const noexcept { return @\exposid{map_}@.extents(); }
+    constexpr const data_handle_type& @\libmember{data_handle}{mdspan}@() const noexcept { return @\exposid{ptr_}@; }
+    constexpr const mapping_type& @\libmember{mapping}{mdspan}@() const noexcept { return @\exposid{map_}@; }
+    constexpr const accessor_type& @\libmember{accessor}{mdspan}@() const noexcept { return @\exposid{acc_}@; }
 
-    static constexpr bool is_always_unique()
+    static constexpr bool @\libmember{is_always_unique}{mdspan}@()
       { return mapping_type::is_always_unique(); }
-    static constexpr bool is_always_exhaustive()
+    static constexpr bool @\libmember{is_always_exhaustive}{mdspan}@()
       { return mapping_type::is_always_exhaustive(); }
-    static constexpr bool is_always_strided()
+    static constexpr bool @\libmember{is_always_strided}{mdspan}@()
       { return mapping_type::is_always_strided(); }
 
-    constexpr bool is_unique() const
+    constexpr bool @\libmember{is_unique}{mdspan}@() const
       { return @\exposid{map_}@.is_unique(); }
-    constexpr bool is_exhaustive() const
+    constexpr bool @\libmember{is_exhaustive}{mdspan}@() const
       { return @\exposid{map_}@.is_exhaustive(); }
-    constexpr bool is_strided() const
+    constexpr bool @\libmember{is_strided}{mdspan}@() const
       { return @\exposid{map_}@.is_strided(); }
-    constexpr index_type stride(rank_type r) const
+    constexpr index_type @\libmember{stride}{mdspan}@(rank_type r) const
       { return @\exposid{map_}@.stride(r); }
 
   private:
@@ -25723,20 +25736,20 @@ increase by increments of \tcode{stride}.
 namespace std {
   template<class OffsetType, class ExtentType, class StrideType>
   struct extent_slice {
-    using offset_type = OffsetType;
-    using extent_type = ExtentType;
-    using stride_type = StrideType;
+    using @\libmember{offset_type}{extent_slice}@ = OffsetType;
+    using @\libmember{extent_type}{extent_slice}@ = ExtentType;
+    using @\libmember{stride_type}{extent_slice}@ = StrideType;
 
-    [[no_unique_address]] offset_type offset{};
-    [[no_unique_address]] extent_type extent{};
-    [[no_unique_address]] stride_type stride{};
+    [[no_unique_address]] offset_type @\libmember{offset}{extent_slice}@{};
+    [[no_unique_address]] extent_type @\libmember{extent}{extent_slice}@{};
+    [[no_unique_address]] stride_type @\libmember{stride}{extent_slice}@{};
   };
 
   template<class FirstType, class LastType, class StrideType = constant_wrapper<1zu>>
   struct range_slice {
-    [[no_unique_address]] FirstType first{};
-    [[no_unique_address]] LastType last{};
-    [[no_unique_address]] StrideType stride{};
+    [[no_unique_address]] FirstType @\libmember{first}{range_slice}@{};
+    [[no_unique_address]] LastType @\libmember{last}{range_slice}@{};
+    [[no_unique_address]] StrideType @\libmember{stride}{range_slice}@{};
   };
 }
 \end{codeblock}
@@ -25770,8 +25783,8 @@ are returned by overloads of \tcode{submdspan_mapping}.
 namespace std {
   template<class LayoutMapping>
   struct submdspan_mapping_result {
-    [[no_unique_address]] LayoutMapping mapping = LayoutMapping();
-    size_t offset{};
+    [[no_unique_address]] LayoutMapping @\libmember{mapping}{submdspan_mapping_result}@ = LayoutMapping();
+    size_t @\libmember{offset}{submdspan_mapping_result}@{};
   };
 }
 \end{codeblock}


### PR DESCRIPTION
Drive-by: Make the indexing style of `layout_right_padded::mapping` members conventional (`\indexlibrarymember{member}{scope}`).

Follows up #8793.