### PR TITLE
[time] Cleanup exposition-only names

### DIFF
--- a/source/time.tex
+++ b/source/time.tex
@@ -800,9 +800,9 @@ namespace std::chrono {
   strong_ordering operator<=>(const time_zone_link& x, const time_zone_link& y);
 
   // \ref{time.format}, formatting
-  template<class Duration> struct @\placeholder{local-time-format-t}@;        // \expos
+  template<class Duration> struct @\exposid{local-time-format-t}@;        // \expos
   template<class Duration>
-    @\placeholder{local-time-format-t}@<Duration>
+    @\exposid{local-time-format-t}@<Duration>
       local_time_format(local_time<Duration> time, const string* abbrev = nullptr,
                         const seconds* offset_sec = nullptr);
 }
@@ -823,7 +823,7 @@ namespace std {
   template<class Duration, class charT>
     struct formatter<chrono::local_time<Duration>, charT>;
   template<class Duration, class charT>
-    struct formatter<chrono::@\placeholder{local-time-format-t}@<Duration>, charT>;
+    struct formatter<chrono::@\exposid{local-time-format-t}@<Duration>, charT>;
   template<class charT> struct formatter<chrono::day, charT>;
   template<class charT> struct formatter<chrono::month, charT>;
   template<class charT> struct formatter<chrono::year, charT>;
@@ -1245,7 +1245,7 @@ namespace std::chrono {
     using period = Period::type;
 
   private:
-    rep rep_;       // \expos
+    rep @\exposid{rep_}@;       // \expos
 
   public:
     // \ref{time.duration.cons}, construct/copy/destroy
@@ -1304,7 +1304,7 @@ those thrown by the indicated operations on their representations.
 \pnum
 The defaulted copy constructor of \tcode{duration} shall be a
 constexpr function if and only if the required initialization
-of the member \tcode{rep_} for copy and move, respectively, would
+of the member \exposid{rep_} for copy and move, respectively, would
 be constexpr-suitable\iref{dcl.constexpr}.
 
 \pnum
@@ -1342,7 +1342,7 @@ duration<int, milli> d2(3.5);       // error
 
 \pnum
 \effects
-Initializes \tcode{rep_} with \tcode{r}.
+Initializes \exposid{rep_} with \tcode{r}.
 \end{itemdescr}
 
 \indexlibraryctor{duration}%
@@ -1378,7 +1378,7 @@ duration<int, milli> ms2 = us;      // error
 
 \pnum
 \effects
-Initializes \tcode{rep_} with \tcode{duration_cast<duration>(d).count()}.
+Initializes \exposid{rep_} with \tcode{duration_cast<duration>(d).count()}.
 \end{itemdescr}
 
 \rSec2[time.duration.observer]{Observer}
@@ -1391,7 +1391,7 @@ constexpr rep count() const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{rep_}.
+\exposid{rep_}.
 \end{itemdescr}
 
 \rSec2[time.duration.arithmetic]{Arithmetic}
@@ -1415,7 +1415,7 @@ constexpr common_type_t<duration> operator-() const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{common_type_t<duration>(-rep_)}.
+\tcode{common_type_t<duration>(-\exposid{rep_})}.
 \end{itemdescr}
 
 \indexlibrarymember{operator++}{duration}%
@@ -1426,7 +1426,7 @@ constexpr duration& operator++();
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{++rep_}.
+Equivalent to: \tcode{++\exposid{rep_}}.
 
 \pnum
 \returns
@@ -1441,7 +1441,7 @@ constexpr duration operator++(int);
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return duration(rep_++);}
+Equivalent to: \tcode{return duration(\exposid{rep_}++);}
 \end{itemdescr}
 
 \indexlibrarymember{operator--}{duration}%
@@ -1452,7 +1452,7 @@ constexpr duration& operator--();
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{--rep_}.
+Equivalent to: \tcode{--\exposid{rep_}}.
 
 \pnum
 \returns
@@ -1467,7 +1467,7 @@ constexpr duration operator--(int);
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return duration(rep_-{}-);}
+Equivalent to: \tcode{return duration(\exposid{rep_}-{}-);}
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{duration}%
@@ -1478,7 +1478,7 @@ constexpr duration& operator+=(const duration& d);
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{rep_ += d.count()}.
+Equivalent to: \tcode{\exposid{rep_} += d.count()}.
 
 \pnum
 \returns
@@ -1493,7 +1493,7 @@ constexpr duration& operator-=(const duration& d);
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{rep_ -= d.count()}.
+Equivalent to: \tcode{\exposid{rep_} -= d.count()}.
 
 \pnum
 \returns
@@ -1508,7 +1508,7 @@ constexpr duration& operator*=(const rep& rhs);
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{rep_ *= rhs}.
+Equivalent to: \tcode{\exposid{rep_} *= rhs}.
 
 \pnum
 \returns
@@ -1523,7 +1523,7 @@ constexpr duration& operator/=(const rep& rhs);
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{rep_ /= rhs}.
+Equivalent to: \tcode{\exposid{rep_} /= rhs}.
 
 \pnum
 \returns
@@ -1538,7 +1538,7 @@ constexpr duration& operator%=(const rep& rhs);
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{rep_ \%= rhs}.
+Equivalent to: \tcode{\exposid{rep_} \%= rhs}.
 
 \pnum
 \returns
@@ -1553,7 +1553,7 @@ constexpr duration& operator%=(const duration& rhs);
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{rep_ \%= rhs.count()}.
+Equivalent to: \tcode{\exposid{rep_} \%= rhs.count()}.
 
 \pnum
 \returns
@@ -2225,7 +2225,7 @@ namespace std::chrono {
     using period   = duration::period;
 
   private:
-    duration d_;                                                // \expos
+    duration @\exposid{d_}@;                                                // \expos
 
   public:
     // \ref{time.point.cons}, construct
@@ -2266,7 +2266,7 @@ constexpr time_point();
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{d_} with \tcode{duration::zero()}.
+Initializes \exposid{d_} with \tcode{duration::zero()}.
 Such a \tcode{time_point} object represents the epoch.
 \end{itemdescr}
 
@@ -2278,7 +2278,7 @@ constexpr explicit time_point(const duration& d);
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{d_} with \tcode{d}.
+Initializes \exposid{d_} with \tcode{d}.
 Such a \tcode{time_point} object represents the epoch \tcode{+ d}.
 \end{itemdescr}
 
@@ -2295,7 +2295,7 @@ template<class Duration2>
 
 \pnum
 \effects
-Initializes \tcode{d_} with \tcode{t.time_since_epoch()}.
+Initializes \exposid{d_} with \tcode{t.time_since_epoch()}.
 \end{itemdescr}
 
 \rSec2[time.point.observer]{Observer}
@@ -2308,7 +2308,7 @@ constexpr duration time_since_epoch() const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{d_}.
+\exposid{d_}.
 \end{itemdescr}
 
 \rSec2[time.point.arithmetic]{Arithmetic}
@@ -2321,7 +2321,7 @@ constexpr time_point& operator++();
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{++d_}.
+Equivalent to: \tcode{++\exposid{d_}}.
 
 \pnum
 \returns
@@ -2336,7 +2336,7 @@ constexpr time_point operator++(int);
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return time_point\{d_++\};}
+Equivalent to: \tcode{return time_point\{\exposid{d_}++\};}
 \end{itemdescr}
 
 \indexlibrarymember{operator--}{time_point}%
@@ -2347,7 +2347,7 @@ constexpr time_point& operator--();
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{--d_}.
+Equivalent to: \tcode{--\exposid{d_}}.
 
 \pnum
 \returns
@@ -2362,7 +2362,7 @@ constexpr time_point operator--(int);
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return time_point\{d_-{}-\};}
+Equivalent to: \tcode{return time_point\{\exposid{d_}-{}-\};}
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{time_point}%
@@ -2373,7 +2373,7 @@ constexpr time_point& operator+=(const duration& d);
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{d_ += d}.
+Equivalent to: \tcode{\exposid{d_} += d}.
 
 \pnum
 \returns
@@ -2388,7 +2388,7 @@ constexpr time_point& operator-=(const duration& d);
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{d_ -= d}.
+Equivalent to: \tcode{\exposid{d_} -= d}.
 
 \pnum
 \returns
@@ -2744,7 +2744,7 @@ template<class charT, class traits, class Duration>
 \effects
 Equivalent to:
 \begin{codeblock}
-return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:L%F %T}"), tp);
+return os << format(os.getloc(), @\exposid{STATICALLY-WIDEN}@<charT>("{:L%F %T}"), tp);
 \end{codeblock}
 
 \pnum
@@ -2940,7 +2940,7 @@ template<class charT, class traits, class Duration>
 \effects
 Equivalent to:
 \begin{codeblock}
-return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:L%F %T}"), t);
+return os << format(os.getloc(), @\exposid{STATICALLY-WIDEN}@<charT>("{:L%F %T}"), t);
 \end{codeblock}
 
 \pnum
@@ -3146,7 +3146,7 @@ template<class charT, class traits, class Duration>
 \effects
 Equivalent to:
 \begin{codeblock}
-return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:L%F %T}"), t);
+return os << format(os.getloc(), @\exposid{STATICALLY-WIDEN}@<charT>("{:L%F %T}"), t);
 \end{codeblock}
 
 \pnum
@@ -3309,7 +3309,7 @@ template<class charT, class traits, class Duration>
 \effects
 Equivalent to:
 \begin{codeblock}
-return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:L%F %T}"), t);
+return os << format(os.getloc(), @\exposid{STATICALLY-WIDEN}@<charT>("{:L%F %T}"), t);
 \end{codeblock}
 
 \pnum
@@ -3432,7 +3432,7 @@ template<class charT, class traits, class Duration>
 \effects
 Equivalent to:
 \begin{codeblock}
-return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:L%F %T}"), t);
+return os << format(os.getloc(), @\exposid{STATICALLY-WIDEN}@<charT>("{:L%F %T}"), t);
 \end{codeblock}
 \end{itemdescr}
 
@@ -3959,7 +3959,7 @@ or the last day of the week of a month.
 \begin{codeblock}
 namespace std::chrono {
   class day {
-    unsigned char d_;           // \expos
+    unsigned char @\exposid{d_}@;           // \expos
   public:
     day() = default;
     constexpr explicit day(unsigned d) noexcept;
@@ -4002,7 +4002,7 @@ constexpr explicit day(unsigned d) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{d_} with \tcode{d}.
+Initializes \exposid{d_} with \tcode{d}.
 The value held is unspecified if \tcode{d} is not in the range \crange{0}{255}.
 \end{itemdescr}
 
@@ -4014,7 +4014,7 @@ constexpr day& operator++() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-\tcode{++d_}.
+\tcode{++\exposid{d_}}.
 
 \pnum
 \returns
@@ -4044,7 +4044,7 @@ constexpr day& operator--() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{--d_}.
+Equivalent to: \tcode{--\exposid{d_}}.
 
 \pnum
 \returns
@@ -4104,7 +4104,7 @@ constexpr explicit operator unsigned() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{d_}.
+\exposid{d_}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{day}%
@@ -4115,7 +4115,7 @@ constexpr bool ok() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{1 <= d_ \&\& d_ <= 31}.
+\tcode{1 <= \exposid{d_} \&\& \exposid{d_} <= 31}.
 \end{itemdescr}
 
 \rSec3[time.cal.day.nonmembers]{Non-member functions}
@@ -4199,8 +4199,8 @@ template<class charT, class traits>
 Equivalent to:
 \begin{codeblock}
 return os << (d.ok() ?
-  format(@\placeholder{STATICALLY-WIDEN}@<charT>("{:%d}"), d) :
-  format(@\placeholder{STATICALLY-WIDEN}@<charT>("{:%d} is not a valid day"), d));
+  format(@\exposid{STATICALLY-WIDEN}@<charT>("{:%d}"), d) :
+  format(@\exposid{STATICALLY-WIDEN}@<charT>("{:%d} is not a valid day"), d));
 \end{codeblock}
 \end{itemdescr}
 
@@ -4252,7 +4252,7 @@ constexpr chrono::day operator""d(unsigned long long d) noexcept;
 \begin{codeblock}
 namespace std::chrono {
   class month {
-    unsigned char m_;           // \expos
+    unsigned char @\exposid{m_}@;           // \expos
   public:
     month() = default;
     constexpr explicit month(unsigned m) noexcept;
@@ -4295,7 +4295,7 @@ constexpr explicit month(unsigned m) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{m_} with \tcode{m}.
+Initializes \exposid{m_} with \tcode{m}.
 The value held is unspecified if \tcode{m} is not in the range \crange{0}{255}.
 \end{itemdescr}
 
@@ -4397,7 +4397,7 @@ constexpr explicit operator unsigned() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{m_}.
+\exposid{m_}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{month}%
@@ -4408,7 +4408,7 @@ constexpr bool ok() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{1 <= m_ \&\& m_ <= 12}.
+\tcode{1 <= \exposid{m_} \&\& \exposid{m_} <= 12}.
 \end{itemdescr}
 
 \rSec3[time.cal.month.nonmembers]{Non-member functions}
@@ -4512,8 +4512,8 @@ template<class charT, class traits>
 Equivalent to:
 \begin{codeblock}
 return os << (m.ok() ?
-  format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:L%b}"), m) :
-  format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{} is not a valid month"),
+  format(os.getloc(), @\exposid{STATICALLY-WIDEN}@<charT>("{:L%b}"), m) :
+  format(os.getloc(), @\exposid{STATICALLY-WIDEN}@<charT>("{} is not a valid month"),
          static_cast<unsigned>(m)));
 \end{codeblock}
 \end{itemdescr}
@@ -4555,7 +4555,7 @@ that value will be assigned to \tcode{*offset} if \tcode{offset} is non-null.
 \begin{codeblock}
 namespace std::chrono {
   class year {
-    short y_;                   // \expos
+    short @\exposid{y_}@;                   // \expos
   public:
     year() = default;
     constexpr explicit year(int y) noexcept;
@@ -4605,7 +4605,7 @@ constexpr explicit year(int y) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{y_} with \tcode{y}.
+Initializes \exposid{y_} with \tcode{y}.
 The value held is unspecified if \tcode{y} is not in the range \crange{-32767}{32767}.
 \end{itemdescr}
 
@@ -4617,7 +4617,7 @@ constexpr year& operator++() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-\tcode{++y_}.
+\tcode{++\exposid{y_}}.
 
 \pnum
 \returns
@@ -4647,7 +4647,7 @@ constexpr year& operator--() noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-\tcode{--y_}.
+\tcode{--\exposid{y_}}.
 
 \pnum
 \returns
@@ -4718,7 +4718,7 @@ constexpr year operator-() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{year\{-y_\}}.
+\tcode{year\{-\exposid{y_}\}}.
 \end{itemdescr}
 
 \indexlibrarymember{is_leap}{year}%
@@ -4729,7 +4729,7 @@ constexpr bool is_leap() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{y_ \% 4 == 0 \&\& (y_ \% 100 != 0 || y_ \% 400 == 0)}.
+\tcode{\exposid{y_} \% 4 == 0 \&\& (\exposid{y_} \% 100 != 0 || \exposid{y_} \% 400 == 0)}.
 \end{itemdescr}
 
 \indexlibrarymember{operator int}{year}%
@@ -4740,7 +4740,7 @@ constexpr explicit operator int() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{y_}.
+\exposid{y_}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{year}%
@@ -4751,7 +4751,7 @@ constexpr bool ok() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{min().y_ <= y_ \&\& y_ <= max().y_}.
+\tcode{min().\exposid{y_} <= \exposid{y_} \&\& \exposid{y_} <= max().\exposid{y_}}.
 \end{itemdescr}
 
 \indexlibrarymember{min}{year}%
@@ -4857,8 +4857,8 @@ template<class charT, class traits>
 Equivalent to:
 \begin{codeblock}
 return os << (y.ok() ?
-  format(@\placeholder{STATICALLY-WIDEN}@<charT>("{:%Y}"), y) :
-  format(@\placeholder{STATICALLY-WIDEN}@<charT>("{:%Y} is not a valid year"), y));
+  format(@\exposid{STATICALLY-WIDEN}@<charT>("{:%Y}"), y) :
+  format(@\exposid{STATICALLY-WIDEN}@<charT>("{:%Y} is not a valid year"), y));
 \end{codeblock}
 \end{itemdescr}
 
@@ -4910,7 +4910,7 @@ constexpr chrono::year operator""y(unsigned long long y) noexcept;
 \begin{codeblock}
 namespace std::chrono {
   class weekday {
-    unsigned char wd_;          // \expos
+    unsigned char @\exposid{wd_}@;          // \expos
   public:
     weekday() = default;
     constexpr explicit weekday(unsigned wd) noexcept;
@@ -4964,7 +4964,7 @@ constexpr explicit weekday(unsigned wd) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{wd_} with \tcode{wd == 7 ?\ 0 :\ wd}.
+Initializes \exposid{wd_} with \tcode{wd == 7 ?\ 0 :\ wd}.
 The value held is unspecified if \tcode{wd} is not in the range \crange{0}{255}.
 \end{itemdescr}
 
@@ -4977,13 +4977,13 @@ constexpr weekday(const sys_days& dp) noexcept;
 \pnum
 \effects
 Computes what day of the week corresponds to the \tcode{sys_days} \tcode{dp},
-and initializes that day of the week in \tcode{wd_}.
+and initializes that day of the week in \exposid{wd_}.
 
 \pnum
 \begin{example}
 If \tcode{dp} represents 1970-01-01,
 the constructed \tcode{weekday} represents Thursday
-by storing \tcode{4} in \tcode{wd_}.
+by storing \tcode{4} in \exposid{wd_}.
 \end{example}
 \end{itemdescr}
 
@@ -4996,7 +4996,7 @@ constexpr explicit weekday(const local_days& dp) noexcept;
 \pnum
 \effects
 Computes what day of the week corresponds to the \tcode{local_days} \tcode{dp},
-and initializes that day of the week in \tcode{wd_}.
+and initializes that day of the week in \exposid{wd_}.
 
 \pnum
 \ensures
@@ -5102,7 +5102,7 @@ constexpr unsigned c_encoding() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{wd_}.
+\exposid{wd_}.
 \end{itemdescr}
 
 \indexlibrarymember{iso_encoding}{weekday}%
@@ -5113,7 +5113,7 @@ constexpr unsigned iso_encoding() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{wd_ == 0u ?\ 7u :\ wd_}.
+\tcode{\exposid{wd_} == 0u ?\ 7u :\ \exposid{wd_}}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{weekday}%
@@ -5124,7 +5124,7 @@ constexpr bool ok() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{wd_ <= 6}.
+\tcode{\exposid{wd_} <= 6}.
 \end{itemdescr}
 
 \indexlibrarymember{operator[]}{weekday}%
@@ -5159,7 +5159,7 @@ constexpr bool operator==(const weekday& x, const weekday& y) noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{x.wd_ == y.wd_}.
+\tcode{x.\exposid{wd_} == y.\exposid{wd_}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+}{weekday}%
@@ -5171,7 +5171,7 @@ constexpr weekday operator+(const weekday& x, const days& y) noexcept;
 \pnum
 \returns
 \begin{codeblock}
-weekday{modulo(static_cast<long long>(x.wd_) + y.count(), 7)}
+weekday{modulo(static_cast<long long>(x.\exposid{wd_}) + y.count(), 7)}
 \end{codeblock}
 where \tcode{modulo(n, 7)} computes the remainder of \tcode{n} divided by 7 using Euclidean division.
 \begin{note}
@@ -5239,9 +5239,9 @@ template<class charT, class traits>
 Equivalent to:
 \begin{codeblock}
 return os << (wd.ok() ?
-  format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:L%a}"), wd) :
-  format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{} is not a valid weekday"),
-         static_cast<unsigned>(wd.wd_)));
+  format(os.getloc(), @\exposid{STATICALLY-WIDEN}@<charT>("{:L%a}"), wd) :
+  format(os.getloc(), @\exposid{STATICALLY-WIDEN}@<charT>("{} is not a valid weekday"),
+         static_cast<unsigned>(wd.@\exposid{wd_}@)));
 \end{codeblock}
 \end{itemdescr}
 
@@ -5282,8 +5282,8 @@ that value will be assigned to \tcode{*offset} if \tcode{offset} is non-null.
 \begin{codeblock}
 namespace std::chrono {
   class weekday_indexed {
-    chrono::weekday  wd_;       // \expos
-    unsigned char    index_;    // \expos
+    chrono::weekday  @\exposid{wd_}@;       // \expos
+    unsigned char    @\exposid{index_}@;    // \expos
 
   public:
     weekday_indexed() = default;
@@ -5329,7 +5329,7 @@ constexpr weekday_indexed(const chrono::weekday& wd, unsigned index) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{wd_} with \tcode{wd} and \tcode{index_} with \tcode{index}.
+Initializes \exposid{wd_} with \tcode{wd} and \exposid{index_} with \tcode{index}.
 The values held are unspecified if \tcode{!wd.ok()} or \tcode{index} is not in the range \crange{0}{7}.
 \end{itemdescr}
 
@@ -5341,7 +5341,7 @@ constexpr chrono::weekday weekday() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{wd_}.
+\exposid{wd_}.
 \end{itemdescr}
 
 \indexlibrarymember{index}{weekday_indexed}%
@@ -5352,7 +5352,7 @@ constexpr unsigned index() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{index_}.
+\exposid{index_}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{weekday_indexed}%
@@ -5363,7 +5363,7 @@ constexpr bool ok() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{wd_.ok() \&\& 1 <= index_ \&\& index_ <= 5}.
+\tcode{\exposid{wd_}.ok() \&\& 1 <= \exposid{index_} \&\& \exposid{index_} <= 5}.
 \end{itemdescr}
 
 \rSec3[time.cal.wdidx.nonmembers]{Non-member functions}
@@ -5393,8 +5393,8 @@ Equivalent to:
 \begin{codeblock}
 auto i = wdi.index();
 return os << (i >= 1 && i <= 5 ?
-  format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:L}[{}]"), wdi.weekday(), i) :
-  format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:L}[{} is not a valid index]"),
+  format(os.getloc(), @\exposid{STATICALLY-WIDEN}@<charT>("{:L}[{}]"), wdi.weekday(), i) :
+  format(os.getloc(), @\exposid{STATICALLY-WIDEN}@<charT>("{:L}[{} is not a valid index]"),
          wdi.weekday(), i));
 \end{codeblock}
 \end{itemdescr}
@@ -5407,7 +5407,7 @@ return os << (i >= 1 && i <= 5 ?
 \begin{codeblock}
 namespace std::chrono {
   class weekday_last {
-    chrono::weekday wd_;                // \expos
+    chrono::weekday @\exposid{wd_}@;                // \expos
 
   public:
     constexpr explicit weekday_last(const chrono::weekday& wd) noexcept;
@@ -5446,7 +5446,7 @@ constexpr explicit weekday_last(const chrono::weekday& wd) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{wd_} with \tcode{wd}.
+Initializes \exposid{wd_} with \tcode{wd}.
 \end{itemdescr}
 
 \indexlibrarymember{weekday_last}{weekday}%
@@ -5457,7 +5457,7 @@ constexpr chrono::weekday weekday() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{wd_}.
+\exposid{wd_}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{weekday_last}%
@@ -5468,7 +5468,7 @@ constexpr bool ok() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{wd_.ok()}.
+\tcode{\exposid{wd_}.ok()}.
 \end{itemdescr}
 
 \rSec3[time.cal.wdlast.nonmembers]{Non-member functions}
@@ -5496,7 +5496,7 @@ template<class charT, class traits>
 \effects
 Equivalent to:
 \begin{codeblock}
-return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:L}[last]"), wdl.weekday());
+return os << format(os.getloc(), @\exposid{STATICALLY-WIDEN}@<charT>("{:L}[last]"), wdl.weekday());
 \end{codeblock}
 \end{itemdescr}
 
@@ -5508,8 +5508,8 @@ return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:L}[l
 \begin{codeblock}
 namespace std::chrono {
   class month_day {
-    chrono::month m_;           // \expos
-    chrono::day   d_;           // \expos
+    chrono::month @\exposid{m_}@;           // \expos
+    chrono::day   @\exposid{d_}@;           // \expos
 
   public:
     month_day() = default;
@@ -5541,7 +5541,7 @@ constexpr month_day(const chrono::month& m, const chrono::day& d) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{m_} with \tcode{m}, and \tcode{d_} with \tcode{d}.
+Initializes \exposid{m_} with \tcode{m}, and \exposid{d_} with \tcode{d}.
 \end{itemdescr}
 
 \indexlibrarymember{month}{month_day}%
@@ -5552,7 +5552,7 @@ constexpr chrono::month month() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{m_}.
+\exposid{m_}.
 \end{itemdescr}
 
 \indexlibrarymember{day}{month_day}%
@@ -5563,7 +5563,7 @@ constexpr chrono::day day() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{d_}.
+\exposid{d_}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{month_day}%
@@ -5575,11 +5575,11 @@ constexpr bool ok() const noexcept;
 \pnum
 \returns
 \tcode{true} if
-\tcode{m_.ok()} is \tcode{true},
-\tcode{1d <= d_}, and
-\tcode{d_} is less than or equal to the number of days in month \tcode{m_};
+\tcode{\exposid{m_}.ok()} is \tcode{true},
+\tcode{1d <= \exposid{d_}}, and
+\exposid{d_} is less than or equal to the number of days in month \exposid{m_};
 otherwise returns \tcode{false}.
-When \tcode{m_ == February},
+When \tcode{\exposid{m_} == February},
 the number of days is considered to be 29.
 \end{itemdescr}
 
@@ -5623,7 +5623,7 @@ template<class charT, class traits>
 \effects
 Equivalent to:
 \begin{codeblock}
-return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:L}/{}"),
+return os << format(os.getloc(), @\exposid{STATICALLY-WIDEN}@<charT>("{:L}/{}"),
                     md.month(), md.day());
 \end{codeblock}
 \end{itemdescr}
@@ -5663,7 +5663,7 @@ that value will be assigned to \tcode{*offset} if \tcode{offset} is non-null.
 \begin{codeblock}
 namespace std::chrono {
   class month_day_last {
-    chrono::month m_;                   // \expos
+    chrono::month @\exposid{m_}@;                   // \expos
 
   public:
     constexpr explicit month_day_last(const chrono::month& m) noexcept;
@@ -5701,7 +5701,7 @@ constexpr explicit month_day_last(const chrono::month& m) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{m_} with \tcode{m}.
+Initializes \exposid{m_} with \tcode{m}.
 \end{itemdescr}
 
 \indexlibrarymember{month}{month_day_last}%
@@ -5712,7 +5712,7 @@ constexpr month month() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{m_}.
+\exposid{m_}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{month_day_last}%
@@ -5723,7 +5723,7 @@ constexpr bool ok() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{m_.ok()}.
+\tcode{\exposid{m_}.ok()}.
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{month_day_last}%
@@ -5760,7 +5760,7 @@ template<class charT, class traits>
 \effects
 Equivalent to:
 \begin{codeblock}
-return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:L}/last"), mdl.month());
+return os << format(os.getloc(), @\exposid{STATICALLY-WIDEN}@<charT>("{:L}/last"), mdl.month());
 \end{codeblock}
 \end{itemdescr}
 
@@ -5772,8 +5772,8 @@ return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:L}/l
 \begin{codeblock}
 namespace std::chrono {
   class month_weekday {
-    chrono::month           m_;         // \expos
-    chrono::weekday_indexed wdi_;       // \expos
+    chrono::month           @\exposid{m_}@;         // \expos
+    chrono::weekday_indexed @\exposid{wdi_}@;       // \expos
   public:
     constexpr month_weekday(const chrono::month& m, const chrono::weekday_indexed& wdi) noexcept;
 
@@ -5812,7 +5812,7 @@ constexpr month_weekday(const chrono::month& m, const chrono::weekday_indexed& w
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{m_} with \tcode{m}, and \tcode{wdi_} with \tcode{wdi}.
+Initializes \exposid{m_} with \tcode{m}, and \exposid{wdi_} with \tcode{wdi}.
 \end{itemdescr}
 
 \indexlibrarymember{month}{month_weekday}%
@@ -5823,7 +5823,7 @@ constexpr chrono::month month() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{m_}.
+\exposid{m_}.
 \end{itemdescr}
 
 \indexlibrarymember{weekday_indexed}{month_weekday}%
@@ -5834,7 +5834,7 @@ constexpr chrono::weekday_indexed weekday_indexed() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{wdi_}.
+\exposid{wdi_}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{month_weekday}%
@@ -5845,7 +5845,7 @@ constexpr bool ok() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{m_.ok() \&\& wdi_.ok()}.
+\tcode{\exposid{m_}.ok() \&\& \exposid{wdi_}.ok()}.
 \end{itemdescr}
 
 \rSec3[time.cal.mwd.nonmembers]{Non-member functions}
@@ -5873,7 +5873,7 @@ template<class charT, class traits>
 \effects
 Equivalent to:
 \begin{codeblock}
-return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:L}/{:L}"),
+return os << format(os.getloc(), @\exposid{STATICALLY-WIDEN}@<charT>("{:L}/{:L}"),
                     mwd.month(), mwd.weekday_indexed());
 \end{codeblock}
 \end{itemdescr}
@@ -5886,8 +5886,8 @@ return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:L}/{
 \begin{codeblock}
 namespace std::chrono {
   class month_weekday_last {
-    chrono::month        m_;    // \expos
-    chrono::weekday_last wdl_;  // \expos
+    chrono::month        @\exposid{m_}@;    // \expos
+    chrono::weekday_last @\exposid{wdl_}@;  // \expos
   public:
     constexpr month_weekday_last(const chrono::month& m,
                                  const chrono::weekday_last& wdl) noexcept;
@@ -5928,7 +5928,7 @@ constexpr month_weekday_last(const chrono::month& m,
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{m_} with \tcode{m}, and \tcode{wdl_} with \tcode{wdl}.
+Initializes \exposid{m_} with \tcode{m}, and \exposid{wdl_} with \tcode{wdl}.
 \end{itemdescr}
 
 \indexlibrarymember{month}{month_weekday_last}%
@@ -5939,7 +5939,7 @@ constexpr chrono::month month() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{m_}.
+\exposid{m_}.
 \end{itemdescr}
 
 \indexlibrarymember{weekday_last}{month_weekday_last}%
@@ -5950,7 +5950,7 @@ constexpr chrono::weekday_last weekday_last() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{wdl_}.
+\exposid{wdl_}.
 \end{itemdescr}
 
 \indexlibrarymember{ok}{month_weekday_last}%
@@ -5961,7 +5961,7 @@ constexpr bool ok() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{m_.ok() \&\& wdl_.ok()}.
+\tcode{\exposid{m_}.ok() \&\& \exposid{wdl_}.ok()}.
 \end{itemdescr}
 
 \rSec3[time.cal.mwdlast.nonmembers]{Non-member functions}
@@ -5989,7 +5989,7 @@ template<class charT, class traits>
 \effects
 Equivalent to:
 \begin{codeblock}
-return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:L}/{:L}"),
+return os << format(os.getloc(), @\exposid{STATICALLY-WIDEN}@<charT>("{:L}/{:L}"),
                     mwdl.month(), mwdl.weekday_last());
 \end{codeblock}
 \end{itemdescr}
@@ -6002,8 +6002,8 @@ return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:L}/{
 \begin{codeblock}
 namespace std::chrono {
   class year_month {
-    chrono::year  y_;           // \expos
-    chrono::month m_;           // \expos
+    chrono::year  @\exposid{y_}@;           // \expos
+    chrono::month @\exposid{m_}@;           // \expos
 
   public:
     year_month() = default;
@@ -6042,7 +6042,7 @@ constexpr year_month(const chrono::year& y, const chrono::month& m) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{y_} with \tcode{y}, and \tcode{m_} with \tcode{m}.
+Initializes \exposid{y_} with \tcode{y}, and \exposid{m_} with \tcode{m}.
 \end{itemdescr}
 
 \indexlibrarymember{year}{year_month}%
@@ -6053,7 +6053,7 @@ constexpr chrono::year year() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{y_}.
+\exposid{y_}.
 \end{itemdescr}
 
 \indexlibrarymember{month}{year_month}%
@@ -6064,7 +6064,7 @@ constexpr chrono::month month() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{m_}.
+\exposid{m_}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{year_month}%
@@ -6151,7 +6151,7 @@ constexpr bool ok() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{y_.ok() \&\& m_.ok()}.
+\tcode{\exposid{y_}.ok() \&\& \exposid{m_}.ok()}.
 \end{itemdescr}
 
 \rSec3[time.cal.ym.nonmembers]{Non-member functions}
@@ -6303,7 +6303,7 @@ template<class charT, class traits>
 \effects
 Equivalent to:
 \begin{codeblock}
-return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{}/{:L}"),
+return os << format(os.getloc(), @\exposid{STATICALLY-WIDEN}@<charT>("{}/{:L}"),
                     ym.year(), ym.month());
 \end{codeblock}
 \end{itemdescr}
@@ -6345,9 +6345,9 @@ that value will be assigned to \tcode{*offset} if \tcode{offset} is non-null.
 \begin{codeblock}
 namespace std::chrono {
   class year_month_day {
-    chrono::year  y_;           // \expos
-    chrono::month m_;           // \expos
-    chrono::day   d_;           // \expos
+    chrono::year  @\exposid{y_}@;           // \expos
+    chrono::month @\exposid{m_}@;           // \expos
+    chrono::day   @\exposid{d_}@;           // \expos
 
   public:
     year_month_day() = default;
@@ -6400,9 +6400,9 @@ constexpr year_month_day(const chrono::year& y, const chrono::month& m,
 \pnum
 \effects
 Initializes
-\tcode{y_} with \tcode{y},
-\tcode{m_} with \tcode{m}, and
-\tcode{d_} with \tcode{d}.
+\exposid{y_} with \tcode{y},
+\exposid{m_} with \tcode{m}, and
+\exposid{d_} with \tcode{d}.
 \end{itemdescr}
 
 \indexlibraryctor{year_month_day}%
@@ -6414,9 +6414,9 @@ constexpr year_month_day(const year_month_day_last& ymdl) noexcept;
 \pnum
 \effects
 Initializes
-\tcode{y_} with \tcode{ymdl.year()},
-\tcode{m_} with \tcode{ymdl.month()}, and
-\tcode{d_} with \tcode{ymdl.day()}.
+\exposid{y_} with \tcode{ymdl.year()},
+\exposid{m_} with \tcode{ymdl.month()}, and
+\exposid{d_} with \tcode{ymdl.day()}.
 \begin{note}
 This conversion from \tcode{year_month_day_last} to \tcode{year_month_day}
 can be more efficient than converting a \tcode{year_month_day_last} to a \tcode{sys_days},
@@ -6538,7 +6538,7 @@ constexpr chrono::year year() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{y_}.
+\exposid{y_}.
 \end{itemdescr}
 
 \indexlibrarymember{month}{year_month_day}%
@@ -6549,7 +6549,7 @@ constexpr chrono::month month() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{m_}.
+\exposid{m_}.
 \end{itemdescr}
 
 \indexlibrarymember{day}{year_month_day}%
@@ -6560,7 +6560,7 @@ constexpr chrono::day day() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{d_}.
+\exposid{d_}.
 \end{itemdescr}
 
 \indexlibrarymember{operator sys_days}{year_month_day}%
@@ -6575,8 +6575,8 @@ If \tcode{ok()},
 returns a \tcode{sys_days}
 holding a count of days from the \tcode{sys_days} epoch to \tcode{*this}
 (a negative value if \tcode{*this} represents a date prior to the \tcode{sys_days} epoch).
-Otherwise, if \tcode{y_.ok() \&\& m_.ok()} is \tcode{true},
-returns \tcode{sys_days\{y_/m_/1d\} + (d_ - 1d)}.
+Otherwise, if \tcode{\exposid{y_}.ok() \&\& \exposid{m_}.ok()} is \tcode{true},
+returns \tcode{sys_days\{\exposid{y_}/\exposid{m_}/1d\} + (\exposid{d_} - 1d)}.
 Otherwise the value returned is unspecified.
 
 \pnum
@@ -6614,9 +6614,9 @@ constexpr bool ok() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-If \tcode{y_.ok()} is \tcode{true},
-and \tcode{m_.ok()} is \tcode{true},
-and \tcode{d_} is in the range \crange{1d}{(y_/m_/last).day()},
+If \tcode{\exposid{y_}.ok()} is \tcode{true},
+and \tcode{\exposid{m_}.ok()} is \tcode{true},
+and \exposid{d_} is in the range \crange{1d}{(\exposid{y_}/\exposid{m_}/last).day()},
 then returns \tcode{true}; otherwise returns \tcode{false}.
 \end{itemdescr}
 
@@ -6767,8 +6767,8 @@ template<class charT, class traits>
 Equivalent to:
 \begin{codeblock}
 return os << (ymd.ok() ?
-  format(@\placeholder{STATICALLY-WIDEN}@<charT>("{:%F}"), ymd) :
-  format(@\placeholder{STATICALLY-WIDEN}@<charT>("{:%F} is not a valid date"), ymd));
+  format(@\exposid{STATICALLY-WIDEN}@<charT>("{:%F}"), ymd) :
+  format(@\exposid{STATICALLY-WIDEN}@<charT>("{:%F} is not a valid date"), ymd));
 \end{codeblock}
 \end{itemdescr}
 
@@ -6809,8 +6809,8 @@ that value will be assigned to \tcode{*offset} if \tcode{offset} is non-null.
 \begin{codeblock}
 namespace std::chrono {
   class year_month_day_last {
-    chrono::year           y_;          // \expos
-    chrono::month_day_last mdl_;        // \expos
+    chrono::year           @\exposid{y_}@;          // \expos
+    chrono::month_day_last @\exposid{mdl_}@;        // \expos
 
   public:
     constexpr year_month_day_last(const chrono::year& y,
@@ -6860,7 +6860,7 @@ constexpr year_month_day_last(const chrono::year& y,
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{y_} with \tcode{y} and \tcode{mdl_} with \tcode{mdl}.
+Initializes \exposid{y_} with \tcode{y} and \exposid{mdl_} with \tcode{mdl}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{year_month_day_last}%
@@ -6947,7 +6947,7 @@ constexpr chrono::year year() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{y_}.
+\exposid{y_}.
 \end{itemdescr}
 
 \indexlibrarymember{month}{year_month_day_last}%
@@ -6958,7 +6958,7 @@ constexpr chrono::month month() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{mdl_.month()}.
+\tcode{\exposid{mdl_}.month()}.
 \end{itemdescr}
 
 \indexlibrarymember{month_day_last}{year_month_day_last}%
@@ -6969,7 +6969,7 @@ constexpr chrono::month_day_last month_day_last() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{mdl_}.
+\exposid{mdl_}.
 \end{itemdescr}
 
 \indexlibrarymember{day}{year_month_day_last}%
@@ -7022,7 +7022,7 @@ constexpr bool ok() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{y_.ok() \&\& mdl_.ok()}.
+\tcode{\exposid{y_}.ok() \&\& \exposid{mdl_}.ok()}.
 \end{itemdescr}
 
 \rSec3[time.cal.ymdlast.nonmembers]{Non-member functions}
@@ -7162,7 +7162,7 @@ template<class charT, class traits>
 \effects
 Equivalent to:
 \begin{codeblock}
-return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{}/{:L}"),
+return os << format(os.getloc(), @\exposid{STATICALLY-WIDEN}@<charT>("{}/{:L}"),
                     ymdl.year(), ymdl.month_day_last());
 \end{codeblock}
 \end{itemdescr}
@@ -7175,9 +7175,9 @@ return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{}/{:L
 \begin{codeblock}
 namespace std::chrono {
   class year_month_weekday {
-    chrono::year            y_;         // \expos
-    chrono::month           m_;         // \expos
-    chrono::weekday_indexed wdi_;       // \expos
+    chrono::year            @\exposid{y_}@;         // \expos
+    chrono::month           @\exposid{m_}@;         // \expos
+    chrono::weekday_indexed @\exposid{wdi_}@;       // \expos
 
   public:
     year_month_weekday() = default;
@@ -7230,7 +7230,7 @@ constexpr year_month_weekday(const chrono::year& y, const chrono::month& m,
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{y_} with \tcode{y}, \tcode{m_} with \tcode{m}, and \tcode{wdi_} with \tcode{wdi}.
+Initializes \exposid{y_} with \tcode{y}, \exposid{m_} with \tcode{m}, and \exposid{wdi_} with \tcode{wdi}.
 \end{itemdescr}
 
 \indexlibraryctor{year_month_weekday}%
@@ -7346,7 +7346,7 @@ constexpr chrono::year year() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{y_}.
+\exposid{y_}.
 \end{itemdescr}
 
 \indexlibrarymember{month}{year_month_weekday}%
@@ -7357,7 +7357,7 @@ constexpr chrono::month month() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{m_}.
+\exposid{m_}.
 \end{itemdescr}
 
 \indexlibrarymember{weekday}{year_month_weekday}%
@@ -7368,7 +7368,7 @@ constexpr chrono::weekday weekday() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{wdi_.weekday()}.
+\tcode{\exposid{wdi_}.weekday()}.
 \end{itemdescr}
 
 \indexlibrarymember{index}{year_month_weekday}%
@@ -7379,7 +7379,7 @@ constexpr unsigned index() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{wdi_.index()}.
+\tcode{\exposid{wdi_}.index()}.
 \end{itemdescr}
 
 \indexlibrarymember{weekday_indexed}{year_month_weekday}%
@@ -7390,7 +7390,7 @@ constexpr chrono::weekday_indexed weekday_indexed() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{wdi_}.
+\exposid{wdi_}.
 \end{itemdescr}
 
 \indexlibrarymember{operator sys_days}{year_month_weekday}%
@@ -7401,7 +7401,7 @@ constexpr operator sys_days() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-If \tcode{y_.ok() \&\& m_.ok() \&\& wdi_.weekday().ok()},
+If \tcode{\exposid{y_}.ok() \&\& \exposid{m_}.ok() \&\& \exposid{wdi_}.weekday().ok()},
 returns a \tcode{sys_days} that
 represents the date \tcode{(index() - 1) * 7} days after
 the first \tcode{weekday()} of \tcode{year()/month()}.
@@ -7432,9 +7432,9 @@ constexpr bool ok() const noexcept;
 \pnum
 \returns
 If any of
-\tcode{y_.ok()},
-\tcode{m_.ok()}, or
-\tcode{wdi_.ok()}
+\tcode{\exposid{y_}.ok()},
+\tcode{\exposid{m_}.ok()}, or
+\tcode{\exposid{wdi_}.ok()}
 is \tcode{false}, returns \tcode{false}.
 Otherwise, if \tcode{*this} represents a valid date,
 returns \tcode{true}.
@@ -7558,7 +7558,7 @@ template<class charT, class traits>
 \effects
 Equivalent to:
 \begin{codeblock}
-return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{}/{:L}/{:L}"),
+return os << format(os.getloc(), @\exposid{STATICALLY-WIDEN}@<charT>("{}/{:L}/{:L}"),
                     ymwd.year(), ymwd.month(), ymwd.weekday_indexed());
 \end{codeblock}
 \end{itemdescr}
@@ -7571,9 +7571,9 @@ return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{}/{:L
 \begin{codeblock}
 namespace std::chrono {
   class year_month_weekday_last {
-    chrono::year         y_;    // \expos
-    chrono::month        m_;    // \expos
-    chrono::weekday_last wdl_;  // \expos
+    chrono::year         @\exposid{y_}@;    // \expos
+    chrono::month        @\exposid{m_}@;    // \expos
+    chrono::weekday_last @\exposid{wdl_}@;  // \expos
 
   public:
     constexpr year_month_weekday_last(const chrono::year& y, const chrono::month& m,
@@ -7623,7 +7623,7 @@ constexpr year_month_weekday_last(const chrono::year& y, const chrono::month& m,
 \begin{itemdescr}
 \pnum
 \effects
-Initializes \tcode{y_} with \tcode{y}, \tcode{m_} with \tcode{m}, and \tcode{wdl_} with \tcode{wdl}.
+Initializes \exposid{y_} with \tcode{y}, \exposid{m_} with \tcode{m}, and \exposid{wdl_} with \tcode{wdl}.
 \end{itemdescr}
 
 \indexlibrarymember{operator+=}{year_month_weekday_last}%
@@ -7710,7 +7710,7 @@ constexpr chrono::year year() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{y_}.
+\exposid{y_}.
 \end{itemdescr}
 
 \indexlibrarymember{month}{year_month_weekday_last}%
@@ -7721,7 +7721,7 @@ constexpr chrono::month month() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{m_}.
+\exposid{m_}.
 \end{itemdescr}
 
 \indexlibrarymember{weekday}{year_month_weekday_last}%
@@ -7732,7 +7732,7 @@ constexpr chrono::weekday weekday() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{wdl_.weekday()}.
+\tcode{\exposid{wdl_}.weekday()}.
 \end{itemdescr}
 
 \indexlibrarymember{weekday_last}{year_month_weekday_last}%
@@ -7743,7 +7743,7 @@ constexpr chrono::weekday_last weekday_last() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{wdl_}.
+\exposid{wdl_}.
 \end{itemdescr}
 
 \indexlibrarymember{operator sys_days}{year_month_weekday_last}%
@@ -7779,7 +7779,7 @@ constexpr bool ok() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{y_.ok() \&\& m_.ok() \&\& wdl_.ok()}.
+\tcode{\exposid{y_}.ok() \&\& \exposid{m_}.ok() \&\& \exposid{wdl_}.ok()}.
 \end{itemdescr}
 
 \rSec3[time.cal.ymwdlast.nonmembers]{Non-member functions}
@@ -7906,7 +7906,7 @@ template<class charT, class traits>
 \effects
 Equivalent to:
 \begin{codeblock}
-return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{}/{:L}/{:L}"),
+return os << format(os.getloc(), @\exposid{STATICALLY-WIDEN}@<charT>("{}/{:L}/{:L}"),
                     ymwdl.year(), ymwdl.month(), ymwdl.weekday_last());
 \end{codeblock}
 \end{itemdescr}
@@ -8427,11 +8427,11 @@ namespace std::chrono {
     constexpr precision to_duration() const noexcept;
 
   private:
-    bool            is_neg;     // \expos
-    chrono::hours   h;          // \expos
-    chrono::minutes m;          // \expos
-    chrono::seconds s;          // \expos
-    precision       ss;         // \expos
+    bool            @\exposid{is-neg}@;     // \expos
+    chrono::hours   @\exposid{h_}@;         // \expos
+    chrono::minutes @\exposid{m_}@;         // \expos
+    chrono::seconds @\exposid{s_}@;         // \expos
+    precision       @\exposid{ss_}@;        // \expos
   };
 }
 \end{codeblock}
@@ -8533,23 +8533,23 @@ Constructs an object of type \tcode{hh_mm_ss}
 which represents the \tcode{Duration d} with precision \tcode{precision}.
 \begin{itemize}
 \item
-  Initializes \tcode{is_neg} with \tcode{d < Duration::zero()}.
+  Initializes \exposid{is-neg} with \tcode{d < Duration::zero()}.
   Let \tcode{\placeholder{ABS_D}} represent
-  \tcode{-d} if \tcode{is_neg} is \tcode{true} and
+  \tcode{-d} if \exposid{is-neg} is \tcode{true} and
   \tcode{d} otherwise.
 \item
-  Initializes \tcode{h} with \tcode{duration_cast<chrono::hours>(\placeholder{ABS_D})}.
+  Initializes \exposid{h_} with \tcode{duration_cast<chrono::hours>(\placeholder{ABS_D})}.
 \item
-  Initializes \tcode{m}
+  Initializes \exposid{m_}
   with \tcode{duration_cast<chrono::minutes>(\placeholder{ABS_D} - hours())}.
 \item
-  Initializes \tcode{s}
+  Initializes \exposid{s_}
   with \tcode{duration_cast<chrono::seconds>(\placeholder{ABS_D} - hours() - minutes())}.
 \item
   If \tcode{treat_as_floating_point_v<precision::rep>} is \tcode{true},
-  initializes \tcode{ss} with \tcode{\placeholder{ABS_D} - hours() - minutes() - seconds()}.
-  Otherwise, initializes \tcode{ss}
-  with \tcode{duration_cast<precision>(\placeholder{ABS_D} - hours() - minutes() - seconds())}.
+  initializes \exposid{ss_} with \linebreak{}\tcode{\placeholder{ABS_D} - hours() - minutes() - seconds()}.
+  Otherwise, initializes \exposid{ss_}
+  with \linebreak{}\tcode{duration_cast<precision>(\placeholder{ABS_D} - hours() - minutes() - seconds())}.
 \end{itemize}
 \begin{note}
 When \tcode{precision::rep} is integral and
@@ -8572,7 +8572,7 @@ constexpr bool is_negative() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{is_neg}.
+\exposid{is-neg}.
 \end{itemdescr}
 
 \indexlibrarymember{hours}{hh_mm_ss}%
@@ -8583,7 +8583,7 @@ constexpr chrono::hours hours() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{h}.
+\exposid{h_}.
 \end{itemdescr}
 
 \indexlibrarymember{minutes}{hh_mm_ss}%
@@ -8594,7 +8594,7 @@ constexpr chrono::minutes minutes() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{m}.
+\exposid{m_}.
 \end{itemdescr}
 
 \indexlibrarymember{seconds}{hh_mm_ss}%
@@ -8605,7 +8605,7 @@ constexpr chrono::seconds seconds() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{s}.
+\exposid{s_}.
 \end{itemdescr}
 
 \indexlibrarymember{subseconds}{hh_mm_ss}%
@@ -8616,7 +8616,7 @@ constexpr precision subseconds() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{ss}.
+\exposid{ss_}.
 \end{itemdescr}
 
 \indexlibrarymember{to_duration}{hh_mm_ss}%
@@ -8627,8 +8627,8 @@ constexpr precision to_duration() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-If \tcode{is_neg}, returns \tcode{-(h + m + s + ss)},
-otherwise returns \tcode{h + m + s + ss}.
+If \exposid{is-neg}, returns \tcode{-(\exposid{h_} + \exposid{m_} + \exposid{s_} + \exposid{ss_})},
+otherwise returns \tcode{\exposid{h_} + \exposid{m_} + \exposid{s_} + \exposid{ss_}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator precision}{hh_mm_ss}%
@@ -8655,7 +8655,7 @@ template<class charT, class traits, class Duration>
 \effects
 Equivalent to:
 \begin{codeblock}
-return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:L%T}"), hms);
+return os << format(os.getloc(), @\exposid{STATICALLY-WIDEN}@<charT>("{:L%T}"), hms);
 \end{codeblock}
 
 \pnum
@@ -9641,10 +9641,10 @@ namespace std::chrono {
     using duration = common_type_t<Duration, seconds>;
 
   private:
-    TimeZonePtr        zone_;                   // \expos
-    sys_time<duration> tp_;                     // \expos
+    TimeZonePtr        @\exposid{zone_}@;                   // \expos
+    sys_time<duration> @\exposid{tp_}@;                     // \expos
 
-    using traits = zoned_traits<TimeZonePtr>;   // \expos
+    using @\exposid{traits_}@ = zoned_traits<TimeZonePtr>;  // \expos
 
   public:
     zoned_time();
@@ -9751,12 +9751,12 @@ zoned_time();
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{traits::default_zone()} is a well-formed expression.
+\tcode{\exposid{traits_}::default_zone()} is a well-formed expression.
 
 \pnum
 \effects
-Initializes \tcode{zone_} with \tcode{traits::default_zone()} and
-default constructs \tcode{tp_}.
+Initializes \exposid{zone_} with \tcode{\exposid{traits_}::default_zone()} and
+default constructs \exposid{tp_}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -9766,11 +9766,11 @@ zoned_time(const sys_time<Duration>& st);
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{traits::default_zone()} is a well-formed expression.
+\tcode{\exposid{traits_}::default_zone()} is a well-formed expression.
 
 \pnum
 \effects
-Initializes \tcode{zone_} with \tcode{traits::default_zone()} and \tcode{tp_} with \tcode{st}.
+Initializes \exposid{zone_} with \tcode{\exposid{traits_}::default_zone()} and \exposid{tp_} with \tcode{st}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -9784,8 +9784,8 @@ explicit zoned_time(TimeZonePtr z);
 
 \pnum
 \effects
-Initializes \tcode{zone_} with \tcode{std::move(z)} and
-default constructs \tcode{tp_}.
+Initializes \exposid{zone_} with \tcode{std::move(z)} and
+default constructs \exposid{tp_}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -9795,13 +9795,13 @@ explicit zoned_time(string_view name);
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{traits::locate_zone(string_view\{\})} is a well-formed expression and
-\tcode{zoned_time} is constructible from the return type of \tcode{traits::locate_zone(string_view\{\})}.
+\tcode{\exposid{traits_}::locate_zone(string_view\{\})} is a well-formed expression and
+\tcode{zoned_time} is constructible from the return type of \tcode{\exposid{traits_}::locate_zone(string_view\{\})}.
 
 \pnum
 \effects
-Initializes \tcode{zone_} with \tcode{traits::locate_zone(name)} and
-default constructs \tcode{tp_}.
+Initializes \exposid{zone_} with \tcode{\exposid{traits_}::locate_zone(name)} and
+default constructs \exposid{tp_}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -9816,7 +9816,7 @@ template<class Duration2>
 
 \pnum
 \effects
-Initializes \tcode{zone_} with \tcode{y.zone_} and \tcode{tp_} with \tcode{y.tp_}.
+Initializes \exposid{zone_} with \tcode{y.\exposid{zone_}} and \exposid{tp_} with \tcode{y.\exposid{tp_}}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -9830,7 +9830,7 @@ zoned_time(TimeZonePtr z, const sys_time<Duration>& st);
 
 \pnum
 \effects
-Initializes \tcode{zone_} with \tcode{std::move(z)} and \tcode{tp_} with \tcode{st}.
+Initializes \exposid{zone_} with \tcode{std::move(z)} and \exposid{tp_} with \tcode{st}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -9840,11 +9840,11 @@ zoned_time(string_view name, const sys_time<Duration>& st);
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{zoned_time} is constructible from the return type of \tcode{traits::locate_zone(name)} and \tcode{st}.
+\tcode{zoned_time} is constructible from the return type of \tcode{\exposid{traits_}::locate_zone(name)} and \tcode{st}.
 
 \pnum
 \effects
-Equivalent to construction with \tcode{\{traits::locate_zone(name), st\}}.
+Equivalent to construction with \tcode{\{\exposid{traits_}::locate_zone(name), st\}}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -9867,7 +9867,7 @@ is \tcode{true}.
 
 \pnum
 \effects
-Initializes \tcode{zone_} with \tcode{std::move(z)} and \tcode{tp_} with \tcode{zone_->to_sys(tp)}.
+Initializes \exposid{zone_} with \tcode{std::move(z)} and \exposid{tp_} with \tcode{\exposid{zone_}->to_sys(tp)}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -9877,11 +9877,11 @@ zoned_time(string_view name, const local_time<Duration>& tp);
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{zoned_time} is constructible from the return type of \tcode{traits::locate_zone(name)} and \tcode{tp}.
+\tcode{zoned_time} is constructible from the return type of \tcode{\exposid{traits_}::locate_zone(name)} and \tcode{tp}.
 
 \pnum
 \effects
-Equivalent to construction with \tcode{\{traits::locate_zone(name), tp\}}.
+Equivalent to construction with \tcode{\{\exposid{traits_}::locate_zone(name), tp\}}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -9904,7 +9904,7 @@ is \tcode{true}.
 
 \pnum
 \effects
-Initializes \tcode{zone_} with \tcode{std::move(z)} and \tcode{tp_} with \tcode{zone_->to_sys(tp, c)}.
+Initializes \exposid{zone_} with \tcode{std::move(z)} and \exposid{tp_} with \tcode{\exposid{zone_}->to_sys(tp, c)}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -9915,11 +9915,11 @@ zoned_time(string_view name, const local_time<Duration>& tp, choose c);
 \pnum
 \constraints
 \tcode{zoned_time} is constructible from
-the return type of \tcode{traits::locate_zone(name)}, \tcode{local_time<Duration>}, and \tcode{choose}.
+the return type of \tcode{\exposid{traits_}::locate_zone(name)}, \tcode{local_time<Duration>}, and \tcode{choose}.
 
 \pnum
 \effects
-Equivalent to construction with \tcode{\{traits::locate_zone(name), tp, c\}}.
+Equivalent to construction with \tcode{\{\exposid{traits_}::locate_zone(name), tp, c\}}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -9938,7 +9938,7 @@ template<class Duration2, class TimeZonePtr2>
 
 \pnum
 \effects
-Initializes \tcode{zone_} with \tcode{std::move(z)} and \tcode{tp_} with \tcode{y.tp_}.
+Initializes \exposid{zone_} with \tcode{std::move(z)} and \exposid{tp_} with \tcode{y.\exposid{tp_}}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -9974,12 +9974,12 @@ template<class Duration2, class TimeZonePtr2>
 \pnum
 \constraints
 \tcode{zoned_time} is constructible from
-the return type of \tcode{traits::locate_zone(name)} and
+the return type of \tcode{\exposid{traits_}::locate_zone(name)} and
 the type \tcode{zoned_time<Duration2, TimeZonePtr2>}.
 
 \pnum
 \effects
-Equivalent to construction with \tcode{\{traits::locate_zone(name), y\}}.
+Equivalent to construction with \tcode{\{\exposid{traits_}::locate_zone(name), y\}}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -9991,13 +9991,13 @@ template<class Duration2, class TimeZonePtr2>
 \pnum
 \constraints
 \tcode{zoned_time} is constructible from
-the return type of \tcode{traits::locate_zone(name)},
+the return type of \tcode{\exposid{traits_}::locate_zone(name)},
 the type \tcode{zoned_time<Duration2, TimeZonePtr2>}, and
 the type \tcode{choose}.
 
 \pnum
 \effects
-Equivalent to construction with \tcode{\{traits::locate_zone(name), y, c\}}.
+Equivalent to construction with \tcode{\{\exposid{traits_}::locate_zone(name), y, c\}}.
 
 \pnum
 \begin{note}
@@ -10070,7 +10070,7 @@ TimeZonePtr get_time_zone() const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{zone_}.
+\exposid{zone_}.
 \end{itemdescr}
 
 \indexlibrarymember{get_local_time}{zoned_time}%
@@ -10081,7 +10081,7 @@ local_time<duration> get_local_time() const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{zone_->to_local(tp_)}.
+\tcode{\exposid{zone_}->to_local(\exposid{tp_})}.
 \end{itemdescr}
 
 \indexlibrarymember{get_sys_time}{zoned_time}%
@@ -10092,7 +10092,7 @@ sys_time<duration> get_sys_time() const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{tp_}.
+\exposid{tp_}.
 \end{itemdescr}
 
 \indexlibrarymember{get_info}{zoned_time}%
@@ -10103,7 +10103,7 @@ sys_info get_info() const;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{zone_->get_info(tp_)}.
+\tcode{\exposid{zone_}->get_info(\exposid{tp_})}.
 \end{itemdescr}
 
 \rSec3[time.zone.zonedtime.nonmembers]{Non-member functions}
@@ -10118,7 +10118,7 @@ template<class Duration1, class Duration2, class TimeZonePtr>
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{x.zone_ == y.zone_ \&\& x.tp_ == y.tp_}.
+\tcode{x.\exposid{zone_} == y.\exposid{zone_} \&\& x.\exposid{tp_} == y.\exposid{tp_}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<<}{zoned_time}%
@@ -10134,7 +10134,7 @@ template<class charT, class traits, class Duration, class TimeZonePtr>
 \effects
 Equivalent to:
 \begin{codeblock}
-return os << format(os.getloc(), @\placeholder{STATICALLY-WIDEN}@<charT>("{:L%F %T %Z}"), t);
+return os << format(os.getloc(), @\exposid{STATICALLY-WIDEN}@<charT>("{:L%F %T %Z}"), t);
 \end{codeblock}
 \end{itemdescr}
 
@@ -10975,17 +10975,17 @@ an exception of type \tcode{format_error} is thrown.
 
 \indexlibrary{local-time-format-t@\exposid{local-time-format-t}}%
 \begin{codeblock}
-template<class Duration> struct @\placeholder{local-time-format-t}@ {           // \expos
-  local_time<Duration> time;                                    // \expos
-  const string* abbrev;                                         // \expos
-  const seconds* offset_sec;                                    // \expos
+template<class Duration> struct @\exposid{local-time-format-t}@ {           // \expos
+  local_time<Duration> @\exposid{time_}@;                                   // \expos
+  const string* @\exposid{abbrev_}@;                                        // \expos
+  const seconds* @\exposid{offset-sec}@;                                    // \expos
 };
 \end{codeblock}
 
 \indexlibraryglobal{local_time_format}%
 \begin{itemdecl}
 template<class Duration>
-  @\placeholder{local-time-format-t}@<Duration>
+  @\exposid{local-time-format-t}@<Duration>
     local_time_format(local_time<Duration> time, const string* abbrev = nullptr,
                       const seconds* offset_sec = nullptr);
 \end{itemdecl}
@@ -10999,7 +10999,7 @@ template<class Duration>
 \indexlibrary{\idxcode{formatter}!specializations!chrono::local-time-format-t@\tcode{chrono::\exposid{local-time-format-t}}}%
 \begin{itemdecl}
 template<class Duration, class charT>
-  struct formatter<chrono::@\placeholder{local-time-format-t}@<Duration>, charT>;
+  struct formatter<chrono::@\exposid{local-time-format-t}@<Duration>, charT>;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11013,16 +11013,16 @@ If the \fmtgrammarterm{chrono-specs} is omitted,
 the result is equivalent to using \tcode{\%F \%T \%Z} as
 the \fmtgrammarterm{chrono-specs}.
 If \tcode{\%Z} is used,
-it is replaced with \tcode{*f.abbrev}
-if \tcode{f.abbrev} is not a null pointer value.
+it is replaced with \tcode{*f.\exposid{abbrev_}}
+if \tcode{f.\exposid{abbrev_}} is not a null pointer value.
 If \tcode{\%Z} is used
-and \tcode{f.abbrev} is a null pointer value,
+and \tcode{f.\exposid{abbrev_}} is a null pointer value,
 an exception of type \tcode{format_error} is thrown.
 If \tcode{\%z} (or a modified variant of \tcode{\%z}) is used,
-it is formatted with the value of \tcode{*f.offset_sec}
-if \tcode{f.offset_sec} is not a null pointer value.
+it is formatted with the value of \tcode{*f.\exposid{offset-sec}}
+if \tcode{f.\exposid{offset-sec}} is not a null pointer value.
 If \tcode{\%z} (or a modified variant of \tcode{\%z}) is used
-and \tcode{f.offset_sec} is a null pointer value,
+and \tcode{f.\exposid{offset-sec}} is a null pointer value,
 then an exception of type \tcode{format_error} is thrown.
 \end{itemdescr}
 
@@ -11030,7 +11030,7 @@ then an exception of type \tcode{format_error} is thrown.
 \begin{codeblock}
 template<class Duration, class TimeZonePtr, class charT>
 struct formatter<chrono::zoned_time<Duration, TimeZonePtr>, charT>
-    : formatter<chrono::@\placeholder{local-time-format-t}@<common_type_t<Duration, seconds>>, charT> {
+    : formatter<chrono::@\exposid{local-time-format-t}@<common_type_t<Duration, seconds>>, charT> {
   template<class FormatContext>
     typename FormatContext::iterator
       format(const chrono::zoned_time<Duration, TimeZonePtr>& tp, FormatContext& ctx) const;
@@ -11050,7 +11050,7 @@ template<class FormatContext>
 Equivalent to:
 \begin{codeblock}
 sys_info info = tp.get_info();
-return formatter<chrono::@\placeholder{local-time-format-t}@<common_type_t<Duration, seconds>>, charT>::
+return formatter<chrono::@\exposid{local-time-format-t}@<common_type_t<Duration, seconds>>, charT>::
          format({tp.get_local_time(), &info.abbrev, &info.offset}, ctx);
 \end{codeblock}
 \end{itemdescr}


### PR DESCRIPTION
1. Apply `\exposid` to all exposition-only members in [time].
2. For _`local-time-format-t`_ and _`STATICALLY-WIDEN`_, change uses of `\placeholder` to `\exposid`.
3. Rename some members of `hh_mm_ss`, `zoned_time`, and _`local-time-format-t`_ in the style of either _`name_`_ or _`kebab-case`_.
4. Add `\linebreak{}` to [time.hms.members] to avoid overfull `\hbox`.

Towards #5940.