### PR TITLE
[support] Correct formatting for exposition-only names

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -166,17 +166,17 @@ namespace std {
 
 namespace std {
   // Exposition-only function type aliases
-  extern "C" using @\placeholdernc{c-atexit-handler}@ = void();                           // \expos
-  extern "C++" using @\placeholdernc{atexit-handler}@ = void();                           // \expos
-  extern "C" using @\placeholdernc{c-compare-pred}@ = int(const void*, const void*);      // \expos
-  extern "C++" using @\placeholdernc{compare-pred}@ = int(const void*, const void*);      // \expos
+  extern "C" using @\exposidnc{c-atexit-handler}@ = void();                           // \expos
+  extern "C++" using @\exposidnc{atexit-handler}@ = void();                           // \expos
+  extern "C" using @\exposidnc{c-compare-pred}@ = int(const void*, const void*);      // \expos
+  extern "C++" using @\exposidnc{compare-pred}@ = int(const void*, const void*);      // \expos
 
   // \ref{support.start.term}, start and termination
   [[noreturn]] void abort() noexcept;                                   // freestanding
-  int atexit(@\placeholder{c-atexit-handler}@* func) noexcept;                          // freestanding
-  int atexit(@\placeholder{atexit-handler}@* func) noexcept;                            // freestanding
-  int at_quick_exit(@\placeholder{c-atexit-handler}@* func) noexcept;                   // freestanding
-  int at_quick_exit(@\placeholder{atexit-handler}@* func) noexcept;                     // freestanding
+  int atexit(@\exposid{c-atexit-handler}@* func) noexcept;                          // freestanding
+  int atexit(@\exposid{atexit-handler}@* func) noexcept;                            // freestanding
+  int at_quick_exit(@\exposid{c-atexit-handler}@* func) noexcept;                   // freestanding
+  int at_quick_exit(@\exposid{atexit-handler}@* func) noexcept;                     // freestanding
   [[noreturn]] void exit(int status);                                   // freestanding
   [[noreturn]] void _Exit(int status) noexcept;                         // freestanding
   [[noreturn]] void quick_exit(int status) noexcept;                    // freestanding
@@ -218,15 +218,15 @@ namespace std {
 
   // \ref{alg.c.library}, C standard library algorithms
   void* bsearch(const void* key, void* base, size_t nmemb, size_t size,         // freestanding
-                @\placeholder{c-compare-pred}@*@\itcorr[-1]@ compar);
+                @\exposid{c-compare-pred}@*@\itcorr[-1]@ compar);
   void* bsearch(const void* key, void* base, size_t nmemb, size_t size,         // freestanding
-                @\placeholder{compare-pred}@*@\itcorr[-1]@ compar);
+                @\exposid{compare-pred}@*@\itcorr[-1]@ compar);
   const void* bsearch(const void* key, const void* base, size_t nmemb,          // freestanding
-                      size_t size, @\placeholder{c-compare-pred}@*@\itcorr[-1]@ compar);
+                      size_t size, @\exposid{c-compare-pred}@*@\itcorr[-1]@ compar);
   const void* bsearch(const void* key, const void* base, size_t nmemb,          // freestanding
-                      size_t size, @\placeholder{compare-pred}@*@\itcorr[-1]@ compar);
-  void qsort(void* base, size_t nmemb, size_t size, @\placeholder{c-compare-pred}@*@\itcorr[-1]@ compar);    // freestanding
-  void qsort(void* base, size_t nmemb, size_t size, @\placeholder{compare-pred}@*@\itcorr[-1]@ compar);      // freestanding
+                      size_t size, @\exposid{compare-pred}@*@\itcorr[-1]@ compar);
+  void qsort(void* base, size_t nmemb, size_t size, @\exposid{c-compare-pred}@*@\itcorr[-1]@ compar);    // freestanding
+  void qsort(void* base, size_t nmemb, size_t size, @\exposid{compare-pred}@*@\itcorr[-1]@ compar);      // freestanding
 
   // \ref{c.math.rand}, low-quality random number generation
   int rand();
@@ -2147,8 +2147,8 @@ The function \tcode{abort} is signal-safe\iref{support.signal}.
 
 \indexlibraryglobal{atexit}%
 \begin{itemdecl}
-int atexit(@\placeholder{c-atexit-handler}@* f) noexcept;
-int atexit(@\placeholder{atexit-handler}@* f) noexcept;
+int atexit(@\exposid{c-atexit-handler}@* f) noexcept;
+int atexit(@\exposid{atexit-handler}@* f) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -2243,8 +2243,8 @@ are defined in \libheaderref{cstdlib}.
 
 \indexlibraryglobal{at_quick_exit}%
 \begin{itemdecl}
-int at_quick_exit(@\placeholder{c-atexit-handler}@* f) noexcept;
-int at_quick_exit(@\placeholder{atexit-handler}@* f) noexcept;
+int at_quick_exit(@\exposid{c-atexit-handler}@* f) noexcept;
+int at_quick_exit(@\exposid{atexit-handler}@* f) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -3480,7 +3480,7 @@ namespace std {
     const char* name() const noexcept;
 
   private:
-    const type_info* target;    // \expos
+    const type_info* @\exposid{target}@;    // \expos
     // Note that the use of a pointer here, rather than a reference,
     // means that the default copy/move constructor and assignment
     // operators will be provided and work as expected.
@@ -3502,7 +3502,7 @@ type_index(const type_info& rhs) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Constructs a \tcode{type_index} object, the equivalent of \tcode{target = \&rhs}.
+Constructs a \tcode{type_index} object, the equivalent of \tcode{\exposid{target} = \&rhs}.
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{type_index}%
@@ -3513,7 +3513,7 @@ bool operator==(const type_index& rhs) const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{*target == *rhs.target}.
+\tcode{*\exposid{target} == *rhs.\exposid{target}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<}{type_index}%
@@ -3524,7 +3524,7 @@ bool operator<(const type_index& rhs) const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{target->before(*rhs.target)}.
+\tcode{\exposid{target}->before(*rhs.\exposid{target})}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>}{type_index}%
@@ -3535,7 +3535,7 @@ bool operator>(const type_index& rhs) const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{rhs.target->before(*target)}.
+\tcode{rhs.\exposid{target}->before(*\exposid{target})}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=}{type_index}%
@@ -3546,7 +3546,7 @@ bool operator<=(const type_index& rhs) const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{!rhs.target->before(*target)}.
+\tcode{!rhs.\exposid{target}->before(*\exposid{target})}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>=}{type_index}%
@@ -3557,7 +3557,7 @@ bool operator>=(const type_index& rhs) const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{!target->before(*rhs.target)}.
+\tcode{!\exposid{target}->before(*rhs.\exposid{target})}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{type_index}%
@@ -3570,8 +3570,8 @@ strong_ordering operator<=>(const type_index& rhs) const noexcept;
 \effects
 Equivalent to:
 \begin{codeblock}
-if (*target == *rhs.target) return strong_ordering::equal;
-if (target->before(*rhs.target)) return strong_ordering::less;
+if (*@\exposid{target}@ == *rhs.@\exposid{target}@) return strong_ordering::equal;
+if (@\exposid{target}@->before(*rhs.@\exposid{target}@)) return strong_ordering::less;
 return strong_ordering::greater;
 \end{codeblock}
 \end{itemdescr}
@@ -3584,7 +3584,7 @@ size_t hash_code() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{target->hash_code()}.
+\tcode{\exposid{target}->hash_code()}.
 \end{itemdescr}
 
 \indexlibrarymember{name}{type_index}%
@@ -3595,7 +3595,7 @@ const char* name() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{target->name()}.
+\tcode{\exposid{target}->name()}.
 \end{itemdescr}
 
 \indexlibrarymember{hash}{type_index}%
@@ -3647,10 +3647,10 @@ namespace std {
     constexpr const char* function_name() const noexcept;
 
   private:
-    uint_least32_t line_;               // \expos
-    uint_least32_t column_;             // \expos
-    const char* file_name_;             // \expos
-    const char* function_name_;         // \expos
+    uint_least32_t @\exposid{line_}@;               // \expos
+    uint_least32_t @\exposid{column_}@;             // \expos
+    const char* @\exposid{file_name_}@;             // \expos
+    const char* @\exposid{function_name_}@;         // \expos
   };
 }
 \end{codeblock}
@@ -3667,7 +3667,7 @@ are trivial.
 \end{note}
 
 \pnum
-The data members \tcode{file_name_} and \tcode{function_name_}
+The data members \exposid{file_name_} and \exposid{function_name_}
 always each refer to an \ntbs{}.
 
 \pnum
@@ -3708,21 +3708,21 @@ static consteval source_location current() noexcept;
 \begin{libefftabvalue}
   {Value of object returned by \tcode{current}}
   {support.srcloc.current}
-\tcode{line_}    &
+\exposid{line_}    &
   A presumed line number\iref{cpp.predefined}.
   Line numbers are presumed to be 1-indexed;
   however, an implementation is encouraged to use 0
   when the line number is unknown. \\ \rowsep
-\tcode{column_}  &
+\exposid{column_}  &
   An \impldef{column value of \tcode{source_location::current}} value denoting
-  some offset from the start of the line denoted by \tcode{line_}.
+  some offset from the start of the line denoted by \exposid{line_}.
   Column numbers are presumed to be 1-indexed;
   however, an implementation is encouraged to use 0
   when the column number is unknown. \\ \rowsep
-\tcode{file_name_} &
+\exposid{file_name_} &
   A presumed name of the current source file\iref{cpp.predefined} as an \ntbs{}.
   \\ \rowsep
-\tcode{function_name_} &
+\exposid{function_name_} &
   A name of the current function
   such as in \mname{func}\iref{dcl.fct.def.general} if any,
   an empty string otherwise. \\
@@ -3795,7 +3795,7 @@ constexpr uint_least32_t line() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{line_}.
+\exposid{line_}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -3804,7 +3804,7 @@ constexpr uint_least32_t column() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{column_}.
+\exposid{column_}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -3813,7 +3813,7 @@ constexpr const char* file_name() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{file_name_}.
+\exposid{file_name_}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -3822,7 +3822,7 @@ constexpr const char* function_name() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{function_name_}.
+\exposid{function_name_}.
 \end{itemdescr}
 
 \rSec1[support.exception]{Exception handling}
@@ -4832,8 +4832,8 @@ whose value typically corresponds to that of an enumerator
 from one of the following exposition-only enumerations:
 
 \begin{codeblock}
-enum class @\placeholdernc{ord}@ { @\placeholdernc{equal}@ = 0, @\placeholdernc{equivalent}@ = @\placeholdernc{equal}@, @\placeholdernc{less}@ = -1, @\placeholdernc{greater}@ = 1 }; // \expos
-enum class @\placeholdernc{ncmp}@ { @\placeholdernc{unordered}@ = -127 };                                     // \expos
+enum class @\exposidnc{ord}@ { @\exposidnc{equal}@ = 0, @\exposidnc{equivalent}@ = @\exposidnc{equal}@, @\exposidnc{less}@ = -1, @\exposidnc{greater}@ = 1 }; // \expos
+enum class @\exposidnc{ncmp}@ { @\exposidnc{unordered}@ = -127 };                                     // \expos
 \end{codeblock}
 
 \pnum
@@ -4888,9 +4888,9 @@ namespace std {
 
     // exposition-only constructors
     constexpr explicit
-      partial_ordering(@\placeholder{ord}@ v) noexcept : @\exposid{value}@(int(v)), @\exposid{is-ordered}@(true) {}     // \expos
+      partial_ordering(@\exposid{ord}@ v) noexcept : @\exposid{value}@(int(v)), @\exposid{is-ordered}@(true) {}     // \expos
     constexpr explicit
-      partial_ordering(@\placeholder{ncmp}@ v) noexcept : @\exposid{value}@(int(v)), @\exposid{is-ordered}@(false) {}   // \expos
+      partial_ordering(@\exposid{ncmp}@ v) noexcept : @\exposid{value}@(int(v)), @\exposid{is-ordered}@(false) {}   // \expos
 
   public:
     // valid values
@@ -4915,10 +4915,10 @@ namespace std {
   };
 
   // valid values' definitions
-  inline constexpr partial_ordering partial_ordering::less(@\placeholder{ord}@::@\placeholder{less}@);
-  inline constexpr partial_ordering partial_ordering::equivalent(@\placeholder{ord}@::@\placeholder{equivalent}@);
-  inline constexpr partial_ordering partial_ordering::greater(@\placeholder{ord}@::@\placeholder{greater}@);
-  inline constexpr partial_ordering partial_ordering::unordered(@\placeholder{ncmp}@::@\placeholder{unordered}@);
+  inline constexpr partial_ordering partial_ordering::less(@\exposid{ord}@::@\exposid{less}@);
+  inline constexpr partial_ordering partial_ordering::equivalent(@\exposid{ord}@::@\exposid{equivalent}@);
+  inline constexpr partial_ordering partial_ordering::greater(@\exposid{ord}@::@\exposid{greater}@);
+  inline constexpr partial_ordering partial_ordering::unordered(@\exposid{ncmp}@::@\exposid{unordered}@);
 }
 \end{codeblock}
 
@@ -4999,7 +4999,7 @@ namespace std {
     int @\exposid{value}@;  // \expos
 
     // exposition-only constructors
-    constexpr explicit weak_ordering(@\placeholder{ord}@ v) noexcept : @\exposid{value}@(int(v)) {} // \expos
+    constexpr explicit weak_ordering(@\exposid{ord}@ v) noexcept : @\exposid{value}@(int(v)) {} // \expos
 
   public:
     // valid values
@@ -5026,9 +5026,9 @@ namespace std {
   };
 
   // valid values' definitions
-  inline constexpr weak_ordering weak_ordering::less(@\placeholder{ord}@::@\placeholder{less}@);
-  inline constexpr weak_ordering weak_ordering::equivalent(@\placeholder{ord}@::@\placeholder{equivalent}@);
-  inline constexpr weak_ordering weak_ordering::greater(@\placeholder{ord}@::@\placeholder{greater}@);
+  inline constexpr weak_ordering weak_ordering::less(@\exposid{ord}@::@\exposid{less}@);
+  inline constexpr weak_ordering weak_ordering::equivalent(@\exposid{ord}@::@\exposid{equivalent}@);
+  inline constexpr weak_ordering weak_ordering::greater(@\exposid{ord}@::@\exposid{greater}@);
 }
 \end{codeblock}
 
@@ -5125,7 +5125,7 @@ namespace std {
     int @\exposid{value}@;  // \expos
 
     // exposition-only constructors
-    constexpr explicit strong_ordering(@\placeholder{ord}@ v) noexcept : @\exposid{value}@(int(v)) {}   // \expos
+    constexpr explicit strong_ordering(@\exposid{ord}@ v) noexcept : @\exposid{value}@(int(v)) {}   // \expos
 
   public:
     // valid values
@@ -5154,10 +5154,10 @@ namespace std {
   };
 
   // valid values' definitions
-  inline constexpr strong_ordering strong_ordering::less(@\placeholder{ord}@::@\placeholder{less}@);
-  inline constexpr strong_ordering strong_ordering::equal(@\placeholder{ord}@::@\placeholder{equal}@);
-  inline constexpr strong_ordering strong_ordering::equivalent(@\placeholder{ord}@::@\placeholder{equivalent}@);
-  inline constexpr strong_ordering strong_ordering::greater(@\placeholder{ord}@::@\placeholder{greater}@);
+  inline constexpr strong_ordering strong_ordering::less(@\exposid{ord}@::@\exposid{less}@);
+  inline constexpr strong_ordering strong_ordering::equal(@\exposid{ord}@::@\exposid{equal}@);
+  inline constexpr strong_ordering strong_ordering::equivalent(@\exposid{ord}@::@\exposid{equivalent}@);
+  inline constexpr strong_ordering strong_ordering::greater(@\exposid{ord}@::@\exposid{greater}@);
 }
 \end{codeblock}
 
@@ -5827,7 +5827,7 @@ namespace std {
     void destroy() const;
 
   private:
-    void* ptr;  // \expos
+    void* @\exposid{ptr}@;  // \expos
   };
 
   template<class Promise>
@@ -5858,7 +5858,7 @@ namespace std {
     Promise& promise() const;
 
   private:
-    void* ptr;  // \expos
+    void* @\exposid{ptr}@;  // \expos
   };
 }
 \end{codeblock}
@@ -5949,7 +5949,7 @@ constexpr void* address() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{ptr}.
+\exposid{ptr}.
 \end{itemdescr}
 
 \indexlibrarymember{from_address}{coroutine_handle}%
@@ -6163,7 +6163,7 @@ namespace std {
     constexpr void* address() const noexcept;
   private:
     coroutine_handle(@\unspec@);
-    void* ptr;  // \expos
+    void* @\exposid{ptr}@;  // \expos
   };
 }
 \end{codeblock}
@@ -6252,11 +6252,11 @@ constexpr void* address() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{ptr}.
+\exposid{ptr}.
 
 \pnum
 \remarks
-A \tcode{noop_coroutine_handle}'s \tcode{ptr} is always a
+A \tcode{noop_coroutine_handle}'s \exposid{ptr} is always a
 non-null pointer value.
 \end{itemdescr}
 
@@ -6443,8 +6443,8 @@ namespace std {
   using sig_atomic_t = @\seebelow@;
 
   // \ref{support.signal}, signal handlers
-  extern "C" using @\placeholdernc{signal-handler}@ = void(int);  // \expos
-  @\placeholder{signal-handler}@* signal(int sig, @\placeholder{signal-handler}@* func);
+  extern "C" using @\exposidnc{signal-handler}@ = void(int);  // \expos
+  @\exposid{signal-handler}@* signal(int sig, @\exposid{signal-handler}@* func);
 
   int raise(int sig);
 }

--- a/source/support.tex
+++ b/source/support.tex
@@ -3492,7 +3492,7 @@ namespace std {
     const char* name() const noexcept;
 
   private:
-    const type_info* target;    // \expos
+    const type_info* @\exposid{target}@;    // \expos
     // Note that the use of a pointer here, rather than a reference,
     // means that the default copy/move constructor and assignment
     // operators will be provided and work as expected.
@@ -3514,7 +3514,7 @@ type_index(const type_info& rhs) noexcept;
 \begin{itemdescr}
 \pnum
 \effects
-Constructs a \tcode{type_index} object, the equivalent of \tcode{target = \&rhs}.
+Constructs a \tcode{type_index} object, the equivalent of \tcode{\exposid{target} = \&rhs}.
 \end{itemdescr}
 
 \indexlibrarymember{operator==}{type_index}%
@@ -3525,7 +3525,7 @@ bool operator==(const type_index& rhs) const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{*target == *rhs.target}.
+\tcode{*\exposid{target} == *rhs.\exposid{target}}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<}{type_index}%
@@ -3536,7 +3536,7 @@ bool operator<(const type_index& rhs) const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{target->before(*rhs.target)}.
+\tcode{\exposid{target}->before(*rhs.\exposid{target})}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>}{type_index}%
@@ -3547,7 +3547,7 @@ bool operator>(const type_index& rhs) const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{rhs.target->before(*target)}.
+\tcode{rhs.\exposid{target}->before(*\exposid{target})}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=}{type_index}%
@@ -3558,7 +3558,7 @@ bool operator<=(const type_index& rhs) const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{!rhs.target->before(*target)}.
+\tcode{!rhs.\exposid{target}->before(*\exposid{target})}.
 \end{itemdescr}
 
 \indexlibrarymember{operator>=}{type_index}%
@@ -3569,7 +3569,7 @@ bool operator>=(const type_index& rhs) const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{!target->before(*rhs.target)}.
+\tcode{!\exposid{target}->before(*rhs.\exposid{target})}.
 \end{itemdescr}
 
 \indexlibrarymember{operator<=>}{type_index}%
@@ -3582,8 +3582,8 @@ strong_ordering operator<=>(const type_index& rhs) const noexcept;
 \effects
 Equivalent to:
 \begin{codeblock}
-if (*target == *rhs.target) return strong_ordering::equal;
-if (target->before(*rhs.target)) return strong_ordering::less;
+if (*@\exposid{target}@ == *rhs.@\exposid{target}@) return strong_ordering::equal;
+if (@\exposid{target}@->before(*rhs.@\exposid{target}@)) return strong_ordering::less;
 return strong_ordering::greater;
 \end{codeblock}
 \end{itemdescr}
@@ -3596,7 +3596,7 @@ size_t hash_code() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{target->hash_code()}.
+\tcode{\exposid{target}->hash_code()}.
 \end{itemdescr}
 
 \indexlibrarymember{name}{type_index}%
@@ -3607,7 +3607,7 @@ const char* name() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{target->name()}.
+\tcode{\exposid{target}->name()}.
 \end{itemdescr}
 
 \indexlibrarymember{hash}{type_index}%
@@ -3659,10 +3659,10 @@ namespace std {
     constexpr const char* function_name() const noexcept;
 
   private:
-    uint_least32_t line_;               // \expos
-    uint_least32_t column_;             // \expos
-    const char* file_name_;             // \expos
-    const char* function_name_;         // \expos
+    uint_least32_t @\exposid{line_}@;               // \expos
+    uint_least32_t @\exposid{column_}@;             // \expos
+    const char* @\exposid{file_name_}@;             // \expos
+    const char* @\exposid{function_name_}@;         // \expos
   };
 }
 \end{codeblock}
@@ -3679,7 +3679,7 @@ are trivial.
 \end{note}
 
 \pnum
-The data members \tcode{file_name_} and \tcode{function_name_}
+The data members \exposid{file_name_} and \exposid{function_name_}
 always each refer to an \ntbs{}.
 
 \pnum
@@ -3720,21 +3720,21 @@ static consteval source_location current() noexcept;
 \begin{libefftabvalue}
   {Value of object returned by \tcode{current}}
   {support.srcloc.current}
-\tcode{line_}    &
+\exposid{line_}    &
   A presumed line number\iref{cpp.predefined}.
   Line numbers are presumed to be 1-indexed;
   however, an implementation is encouraged to use 0
   when the line number is unknown. \\ \rowsep
-\tcode{column_}  &
+\exposid{column_}  &
   An \impldef{column value of \tcode{source_location::current}} value denoting
-  some offset from the start of the line denoted by \tcode{line_}.
+  some offset from the start of the line denoted by \exposid{line_}.
   Column numbers are presumed to be 1-indexed;
   however, an implementation is encouraged to use 0
   when the column number is unknown. \\ \rowsep
-\tcode{file_name_} &
+\exposid{file_name_} &
   A presumed name of the current source file\iref{cpp.predefined} as an \ntbs{}.
   \\ \rowsep
-\tcode{function_name_} &
+\exposid{function_name_} &
   A name of the current function
   such as in \mname{func}\iref{dcl.fct.def.general} if any,
   an empty string otherwise. \\
@@ -3807,7 +3807,7 @@ constexpr uint_least32_t line() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{line_}.
+\exposid{line_}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -3816,7 +3816,7 @@ constexpr uint_least32_t column() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{column_}.
+\exposid{column_}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -3825,7 +3825,7 @@ constexpr const char* file_name() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{file_name_}.
+\exposid{file_name_}.
 \end{itemdescr}
 
 \begin{itemdecl}
@@ -3834,7 +3834,7 @@ constexpr const char* function_name() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{function_name_}.
+\exposid{function_name_}.
 \end{itemdescr}
 
 \rSec1[support.exception]{Exception handling}
@@ -5839,7 +5839,7 @@ namespace std {
     void destroy() const;
 
   private:
-    void* ptr;  // \expos
+    void* @\exposid{ptr}@;  // \expos
   };
 
   template<class Promise>
@@ -5870,7 +5870,7 @@ namespace std {
     Promise& promise() const;
 
   private:
-    void* ptr;  // \expos
+    void* @\exposid{ptr}@;  // \expos
   };
 }
 \end{codeblock}
@@ -5961,7 +5961,7 @@ constexpr void* address() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{ptr}.
+\exposid{ptr}.
 \end{itemdescr}
 
 \indexlibrarymember{from_address}{coroutine_handle}%
@@ -6175,7 +6175,7 @@ namespace std {
     constexpr void* address() const noexcept;
   private:
     coroutine_handle(@\unspec@);
-    void* ptr;  // \expos
+    void* @\exposid{ptr}@;  // \expos
   };
 }
 \end{codeblock}
@@ -6264,11 +6264,11 @@ constexpr void* address() const noexcept;
 \begin{itemdescr}
 \pnum
 \returns
-\tcode{ptr}.
+\exposid{ptr}.
 
 \pnum
 \remarks
-A \tcode{noop_coroutine_handle}'s \tcode{ptr} is always a
+A \tcode{noop_coroutine_handle}'s \exposid{ptr} is always a
 non-null pointer value.
 \end{itemdescr}
 


### PR DESCRIPTION
Also correct improper uses of `\placeholder(nc)` to `\exposid(nc)`.

Towards #5940.