### PR TITLE
[Editorial] Fix various typos and missing punctuation in multiple code synopses

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -2263,7 +2263,7 @@ namespace std {
               ForwardIterator first, ForwardIterator last, const T& value);
   template<class OutputIterator, class Size,
            class T = iterator_traits<OutputIterator>::value_type>
-    constexpr OutputIterator fill_n(OutputIterator first, Size n, const T& value)
+    constexpr OutputIterator fill_n(OutputIterator first, Size n, const T& value);
   template<class ExecutionPolicy, class ForwardIterator,
            class Size, class T = iterator_traits<ForwardIterator>::value_type>
     ForwardIterator fill_n(ExecutionPolicy&& exec,              // freestanding-deleted, see \ref{algorithms.parallel.overloads}
@@ -3131,7 +3131,7 @@ namespace std {
 
   namespace ranges {
     template<@\libconcept{forward_iterator}@ I, @\libconcept{sentinel_for}@<I> S, class Proj = identity,
-             class T = projected_value_t<I, Proj,
+             class T = projected_value_t<I, Proj>,
              @\libconcept{indirect_strict_weak_order}@<const T*, projected<I, Proj>> Comp = ranges::less>
       constexpr subrange<I>
         equal_range(I first, S last, const T& value, Comp comp = {}, Proj proj = {});

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -11820,7 +11820,7 @@ namespace std {
     map(InputIterator, InputIterator, Compare = Compare(), Allocator = Allocator())
       -> map<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare, Allocator>;
 
-  template<ranges::@\libconcept{input_range}@ R, class Compare = less<@\exposid{range-key-type}@<R>,
+  template<ranges::@\libconcept{input_range}@ R, class Compare = less<@\exposid{range-key-type}@<R>>,
            class Allocator = allocator<@\exposid{range-to-alloc-type}@<R>>>
     map(from_range_t, R&&, Compare = Compare(), Allocator = Allocator())
       -> map<@\exposid{range-key-type}@<R>, @\exposid{range-mapped-type}@<R>, Compare, Allocator>;

--- a/source/exec.tex
+++ b/source/exec.tex
@@ -2085,7 +2085,7 @@ namespace std::execution {
       @\exposid{complete}@(Index(), @\exposidnc{op}@->@\exposid{state}@, @\exposidnc{op}@->@\exposid{rcvr}@, set_error_t(), std::forward<Error>(err));
     }
 
-    void set_stopped() && noexcept
+    void set_stopped() && noexcept {
       @\exposid{complete}@(Index(), @\exposidnc{op}@->@\exposid{state}@, @\exposidnc{op}@->@\exposid{rcvr}@, set_stopped_t());
     }
 

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -3278,7 +3278,7 @@ namespace std {
     static constexpr size_t word_count = n;
     static constexpr size_t round_count = r;
     static constexpr array<result_type, @\exposid{array-size}@> multipliers;
-    static constexpr array<result_type, @\exposid{array-size>}@ round_consts;
+    static constexpr array<result_type, @\exposid{array-size}@> round_consts;
     static constexpr result_type min() { return 0; }
     static constexpr result_type max() { return m - 1; }
     static constexpr result_type default_seed = 20111115u;
@@ -17014,7 +17014,7 @@ namespace std::simd {
     constexpr resize_t<(basic_vec<T, Abis>::size() + ...),
       basic_vec<T, Abis...[0]>> cat(const basic_vec<T, Abis>&...) noexcept;
   template<size_t Bytes, class... Abis>
-    constexpr resize_t<(basic_mask<Bytes, Abis>::size() + ...)>,
+    constexpr resize_t<(basic_mask<Bytes, Abis>::size() + ...),
       basic_mask<Bytes, Abis...[0]>> cat(const basic_mask<Bytes, Abis>&...) noexcept;
 
   // \ref{simd.alg}, algorithms
@@ -17101,13 +17101,13 @@ namespace std::simd {
   template<@\exposconcept{math-floating-point}@ V>
     constexpr @\exposid{deduced-vec-t}@<V> hypot(const V& x, const V& y, const @\exposid{deduced-vec-t}@<V>& z);
   template<@\exposconcept{math-floating-point}@ V>
-    constexpr @\exposid{deduced-vec-t}@<V> hypot(const @\exposid{deduced-vec-t}@<V>& x, const @\exposid{deduced-vec-t}@<V>& y
+    constexpr @\exposid{deduced-vec-t}@<V> hypot(const @\exposid{deduced-vec-t}@<V>& x, const @\exposid{deduced-vec-t}@<V>& y,
                                     @\itcorr@ const V& z);
   template<@\exposconcept{math-floating-point}@ V>
-    constexpr @\exposid{deduced-vec-t}@<V> hypot(const @\exposid{deduced-vec-t}@<V>& x, const V& y
+    constexpr @\exposid{deduced-vec-t}@<V> hypot(const @\exposid{deduced-vec-t}@<V>& x, const V& y,
                                     @\itcorr@ const @\exposid{deduced-vec-t}@<V>& z);
   template<@\exposconcept{math-floating-point}@ V>
-    constexpr @\exposid{deduced-vec-t}@<V> hypot(const V& x, const @\exposid{deduced-vec-t}@<V>& y
+    constexpr @\exposid{deduced-vec-t}@<V> hypot(const V& x, const @\exposid{deduced-vec-t}@<V>& y,
                                     @\itcorr@ const @\exposid{deduced-vec-t}@<V>& z);
   template<@\exposconcept{math-floating-point}@ V>
     constexpr @\exposid{deduced-vec-t}@<V> pow(const V& x, const V& y);
@@ -17196,13 +17196,13 @@ namespace std::simd {
   template<@\exposconcept{math-floating-point}@ V>
     constexpr @\exposid{deduced-vec-t}@<V> fma(const V& x, const V& y, const @\exposid{deduced-vec-t}@<V>& z);
   template<@\exposconcept{math-floating-point}@ V>
-    constexpr @\exposid{deduced-vec-t}@<V> fma(const @\exposid{deduced-vec-t}@<V>& x, const @\exposid{deduced-vec-t}@<V>& y
+    constexpr @\exposid{deduced-vec-t}@<V> fma(const @\exposid{deduced-vec-t}@<V>& x, const @\exposid{deduced-vec-t}@<V>& y,
                                   @\itcorr@ const V& z);
   template<@\exposconcept{math-floating-point}@ V>
-    constexpr @\exposid{deduced-vec-t}@<V> fma(const @\exposid{deduced-vec-t}@<V>& x, const V& y
+    constexpr @\exposid{deduced-vec-t}@<V> fma(const @\exposid{deduced-vec-t}@<V>& x, const V& y,
                                   @\itcorr@ const @\exposid{deduced-vec-t}@<V>& z);
   template<@\exposconcept{math-floating-point}@ V>
-    constexpr @\exposid{deduced-vec-t}@<V> fma(const V& x, const @\exposid{deduced-vec-t}@<V>& y
+    constexpr @\exposid{deduced-vec-t}@<V> fma(const V& x, const @\exposid{deduced-vec-t}@<V>& y,
                                   @\itcorr@ const @\exposid{deduced-vec-t}@<V>& z);
   template<@\exposconcept{math-floating-point}@ V>
     constexpr @\exposid{deduced-vec-t}@<V>
@@ -17214,13 +17214,13 @@ namespace std::simd {
   template<@\exposconcept{math-floating-point}@ V>
     constexpr @\exposid{deduced-vec-t}@<V> lerp(const V& x, const V& y, const @\exposid{deduced-vec-t}@<V>& z);
   template<@\exposconcept{math-floating-point}@ V>
-    constexpr @\exposid{deduced-vec-t}@<V> lerp(const @\exposid{deduced-vec-t}@<V>& x, const @\exposid{deduced-vec-t}@<V>& y
+    constexpr @\exposid{deduced-vec-t}@<V> lerp(const @\exposid{deduced-vec-t}@<V>& x, const @\exposid{deduced-vec-t}@<V>& y,
                                    @\itcorr@ const V& z);
   template<@\exposconcept{math-floating-point}@ V>
-    constexpr @\exposid{deduced-vec-t}@<V> lerp(const @\exposid{deduced-vec-t}@<V>& x, const V& y
+    constexpr @\exposid{deduced-vec-t}@<V> lerp(const @\exposid{deduced-vec-t}@<V>& x, const V& y,
                                    @\itcorr@ const @\exposid{deduced-vec-t}@<V>& z);
   template<@\exposconcept{math-floating-point}@ V>
-    constexpr @\exposid{deduced-vec-t}@<V> lerp(const V& x, const @\exposid{deduced-vec-t}@<V>& y
+    constexpr @\exposid{deduced-vec-t}@<V> lerp(const V& x, const @\exposid{deduced-vec-t}@<V>& y,
                                    @\itcorr@ const @\exposid{deduced-vec-t}@<V>& z);
   template<@\exposconcept{math-floating-point}@ V>
     constexpr rebind_t<int, @\exposid{deduced-vec-t}@<V>> fpclassify(const V& x);

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -5196,7 +5196,7 @@ namespace std::ranges {
   public:
     @\exposid{sentinel}@() = default;
     constexpr @\exposid{sentinel}@(@\exposid{sentinel}@<!Const> other)
-      requires Const && @\libconcept{convertible_to}@<sentinel_t<V>, sentinel_t<@\exposidnc{Base}@>>
+      requires Const && @\libconcept{convertible_to}@<sentinel_t<V>, sentinel_t<@\exposidnc{Base}@>>;
 
     constexpr sentinel_t<@\exposidnc{Base}@> base() const;
 

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -5426,7 +5426,7 @@ namespace std {
                                             memory_order = memory_order::seq_cst) noexcept;
     @\placeholdernc{floating-point-type}@ fetch_min(@\placeholdernc{floating-point-type}@,
                                   memory_order = memory_order::seq_cst) volatile noexcept;
-    constexpr @\placeholdernc{floating-poin-type}@t fetch_min(@\placeholdernc{floating-point-type}@,
+    constexpr @\placeholdernc{floating-point-type}@ fetch_min(@\placeholdernc{floating-point-type}@,
                                             memory_order = memory_order::seq_cst) noexcept;
     @\placeholdernc{floating-point-type}@ fetch_fmaximum(@\placeholdernc{floating-point-type}@,
                                        memory_order = memory_order::seq_cst) volatile noexcept;
@@ -10053,7 +10053,7 @@ namespace std {
     template<class Lock, class Clock, class Duration>
       cv_status wait_until(Lock& lock, chrono::time_point<Clock, Duration> abs_time);
     template<class Lock, class Clock, class Duration, class Predicate>
-      bool wait_until(Lock& lock, chrono::time_point<Clock, Duration abs_time,
+      bool wait_until(Lock& lock, chrono::time_point<Clock, Duration> abs_time,
                       Predicate pred);
     template<class Lock, class Rep, class Period>
       cv_status wait_for(Lock& lock, chrono::duration<Rep, Period> rel_time);


### PR DESCRIPTION
This PR addresses several minor editorial issues within code synopses across multiple files. These discrepancies were identified by running [a custom recursive descent parser](https://github.com/guyutongxue/cxx-draft-to-index) designed to extract symbols from synopsis blocks against the C++ grammar.

#### Summary of changes:

The fixes are purely editorial and do not change any normative meaning.
- **algorithms.tex**:
    - Added missing semicolon to `fill_n`.
    - Fixed unclosed `projected_value_t` template arguments.
- **numerics.tex**: 
    - Added missing commas in parameter lists for `hypot`, `fma`, and `lerp` overloads.
    - Removed a redundant `>` in template head of `basic_mask`.
    - Corrected the placement of the closing `@` for `\exposid{array-size}` in `round_consts`.
- **ranges.tex**: Added missing semicolon to a constructor definition of `filter_view::sentinel`.
- **exec.tex**: Added a missing opening brace `{` for function definition of `basic-receiver::set_stopped`.
- **containers.tex**: Fixed unclosed `less` template arguments.
- **threads.tex**: 
    - Corrected a misplaced `t`: `floating-poin-type` -> `floating-point-type`.
    - Fixed unclosed `chrono::time_point` template arguments.
