### PR TITLE
[expr.prim.id.general] Unindex id-expression as text

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -1381,7 +1381,6 @@ meaning, except as otherwise indicated.
 
 \pnum
 \indextext{name}%
-\indextext{id-expression}%
 An \grammarterm{id-expression} is a restricted form of a
 \grammarterm{primary-expression}.
 \begin{note}


### PR DESCRIPTION
The grammarterm is already indexed. I don't think the adjacent entries in the index add any value:

<img width="392" height="78" alt="image" src="https://github.com/user-attachments/assets/5b3199c6-6a37-4747-9bf8-046eb49a156d" />
