### PR TITLE
[dcl.enum] "its scope" => "its target scope"

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -7814,7 +7814,7 @@ the type of the \grammarterm{id-expression} \tcode{y} is ``\tcode{const volatile
 
 \pnum
 An enumeration is a distinct type\iref{basic.compound} with named
-constants. Its name becomes an \grammarterm{enum-name} within its scope.
+constants. Its name becomes an \grammarterm{enum-name} within its target scope.
 
 \begin{bnf}
 \nontermdef{enum-name}\br


### PR DESCRIPTION
An enum's name is not bound to its own scope, but to its target scope.