### PR TITLE
[stmt.expand] Fix example 2

### DIFF
--- a/source/statements.tex
+++ b/source/statements.tex
@@ -971,7 +971,7 @@ consteval int f() {
   constexpr std::array<int, 3> arr {1, 2, 3};
   int result = 0;
   template for (constexpr int s : arr) {                // OK, iterating expansion statement
-    result += sizeof(char[s]);
+    result += s;
   }
   return result;
 }


### PR DESCRIPTION
`sizeof(char[s])` does not make sense, adding `s` to `result` directly would pass the assertion.