### PR TITLE
[numarray] Move [valarray.range] to suitable place and level

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -7930,6 +7930,52 @@ does not
 invalidate references or pointers to the elements of the array.
 \end{itemdescr}
 
+\rSec3[valarray.range]{Range access}
+
+\pnum
+The \tcode{iterator} type
+is a type that meets the requirements of a mutable
+\oldconcept{RandomAccessIterator}\iref{random.access.iterators}
+and models \libconcept{contiguous_iterator}\iref{iterator.concept.contiguous}.
+Its \tcode{value_type} is the template
+parameter \tcode{T} and its \tcode{reference} type is \tcode{T\&}.
+The \tcode{const_iterator} type meets the requirements of a constant
+\oldconcept{RandomAccessIterator}
+and models \libconcept{contiguous_iterator}.
+Its \tcode{value_type} is the template
+parameter \tcode{T} and its \tcode{reference} type is \tcode{const T\&}.
+
+\pnum
+The iterators returned by \tcode{begin} and \tcode{end} for an array
+are guaranteed to be valid until the member function
+\tcode{resize(size_t, T)}\iref{valarray.members} is called for that
+array or until the lifetime of that array ends, whichever happens
+first.
+
+\indexlibrarymember{begin}{valarray}%
+\begin{itemdecl}
+iterator begin();
+const_iterator begin() const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+An iterator referencing the first value in the array.
+\end{itemdescr}
+
+\indexlibrarymember{end}{valarray}%
+\begin{itemdecl}
+iterator end();
+const_iterator end() const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\returns
+An iterator referencing one past the last value in the array.
+\end{itemdescr}
+
 \rSec3[valarray.members]{Member functions}
 
 \indexlibrarymember{swap}{valarray}%
@@ -9153,52 +9199,6 @@ to the elements of the
 object to which the
 \tcode{indirect_array}
 object refers.
-\end{itemdescr}
-
-\rSec2[valarray.range]{Range access}
-
-\pnum
-The \tcode{iterator} type
-is a type that meets the requirements of a mutable
-\oldconcept{RandomAccessIterator}\iref{random.access.iterators}
-and models \libconcept{contiguous_iterator}\iref{iterator.concept.contiguous}.
-Its \tcode{value_type} is the template
-parameter \tcode{T} and its \tcode{reference} type is \tcode{T\&}.
-The \tcode{const_iterator} type meets the requirements of a constant
-\oldconcept{RandomAccessIterator}
-and models \libconcept{contiguous_iterator}.
-Its \tcode{value_type} is the template
-parameter \tcode{T} and its \tcode{reference} type is \tcode{const T\&}.
-
-\pnum
-The iterators returned by \tcode{begin} and \tcode{end} for an array
-are guaranteed to be valid until the member function
-\tcode{resize(size_t, T)}\iref{valarray.members} is called for that
-array or until the lifetime of that array ends, whichever happens
-first.
-
-\indexlibrarymember{begin}{valarray}%
-\begin{itemdecl}
-iterator begin();
-const_iterator begin() const;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-An iterator referencing the first value in the array.
-\end{itemdescr}
-
-\indexlibrarymember{end}{valarray}%
-\begin{itemdecl}
-iterator end();
-const_iterator end() const;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\returns
-An iterator referencing one past the last value in the array.
 \end{itemdescr}
 
 \rSec1[c.math]{Mathematical functions for floating-point types}


### PR DESCRIPTION
For the sake of consistency with the synopsis of `valarray` (after the modifications from P3016R6), [valarray.cassign] should be placed between [valarray.cassign] and [valarray.members]. Moreover, it should be in level `\rSec3` now.