### PR TITLE
Upgrade deprecated Node.js 20 actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: install GNU tools
         if: matrix.cfg.os == 'macos-15'
@@ -67,7 +67,7 @@ jobs:
 
       - name: upload PDF
         if: matrix.cfg.os == 'ubuntu-24.04'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: draft-snapshot
           path: source/std.pdf


### PR DESCRIPTION
<img width="955" height="497" alt="image" src="https://github.com/user-attachments/assets/b94feb43-5e75-4bfc-8bd9-e690643a0448" />

They don't make it super clear what would happen with those old actions, but I suspect we would get CI failures starting June 2 if we didn't upgrade.
