### PR TITLE
[mem.res.pool.ctor] Reword awkward "calls will be fewer" in note

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -8176,9 +8176,8 @@ from its own internal data structures.
 The resulting object will hold a copy of \tcode{upstream},
 but will not own the resource to which \tcode{upstream} points.
 \begin{note}
-The intention is that calls to \tcode{upstream->allocate()}
-will be substantially fewer than calls to \tcode{this->allocate()}
-in most cases.
+The intention is that in most cases there will be substantially fewer
+calls to \tcode{upstream->allocate()} than to \tcode{this->allocate()}.
 \end{note}
 The behavior of the pooling mechanism is tuned
 according to the value of the \tcode{opts} argument.


### PR DESCRIPTION
It seems much simpler to just say "there will be fewer calls".