### PR TITLE
[exec.let] Place left curly bracket at end

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -4259,8 +4259,7 @@ struct @\exposid{let-state}@ {
   OpsVariant @\exposidnc{ops}@;                                                               // \expos
 
   template<class Tag, class... Ts>
-  constexpr void @\exposid{impl}@(Rcvr& rcvr, Tag tag, Ts&&... ts) noexcept // \expos
-  {
+  constexpr void @\exposid{impl}@(Rcvr& rcvr, Tag tag, Ts&&... ts) noexcept {               // \expos
     using args_t = @\exposid{decayed-tuple}@<Ts...>;
     using receiver_type = @\exposid{receiver2}@<Rcvr, env_t>;
     using sender_type = apply_result_t<Fn, args_t&>;


### PR DESCRIPTION
Also fixes comment alignment