### PR TITLE
[expr.const.i{nit,mm}] Add xrefs for "manifestly constant-evaluated"

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -9143,7 +9143,7 @@ In the course of this determination,
 has the value \keyword{true}.
 \end{note}
 \begin{note}
-Furthermore, if the initialization is manifestly constant-evaluated,
+Furthermore, if the initialization is manifestly constant-evaluated\iref{expr.const.defns},
 its evaluation during translation
 can still evaluate contract assertions
 with other evaluation semantics,
@@ -9254,7 +9254,7 @@ its innermost enclosing non-block scope is
 a function parameter scope of an immediate function,
 \item
 it is a subexpression of a manifestly constant-evaluated expression
-or conversion, or
+or conversion\iref{expr.const.defns}, or
 \item
 its enclosing statement is enclosed\iref{stmt.pre} by
 the \grammarterm{compound-statement} of a consteval if statement\iref{stmt.if}.


### PR DESCRIPTION
After the "constant expressions" reorganisation the definition is now in a different subclause.