### PR TITLE
[diff.cpp03.dcl.dcl] Use "unnamed" but not "anonymous" for namespace

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2284,7 +2284,7 @@ conversion.
 
 \diffref{dcl.link}
 \change
-Names declared in an anonymous namespace
+Names declared in an unnamed namespace
 changed from external linkage to internal linkage;
 language linkage applies to names with external linkage only.
 \rationale


### PR DESCRIPTION
As we refer that term as "unnamed namespace" in [namespace.unnamed].