### PR TITLE
[2026-06 CWG Motion 11] P3733R1 More named universal character escapes

### DIFF
--- a/source/lex.tex
+++ b/source/lex.tex
@@ -503,8 +503,7 @@ designates the corresponding character
 in the Unicode Standard (chapter 4.8 Name)
 if the \grammarterm{n-char-sequence} is equal
 to its character name or
-to one of its character name aliases of
-type ``control'', ``correction'', or ``alternate'';
+to one of its character name aliases;
 otherwise, the program is ill-formed.
 \begin{note}
 These aliases are listed in

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -2381,7 +2381,7 @@ an \impldef{text of \mname{TIME} when time of translation is not available} vali
 \defnxname{cpp_lambdas}                           & \tcode{200907L} \\ \rowsep
 \defnxname{cpp_modules}                           & \tcode{201907L} \\ \rowsep
 \defnxname{cpp_multidimensional_subscript}        & \tcode{202211L} \\ \rowsep
-\defnxname{cpp_named_character_escapes}           & \tcode{202207L} \\ \rowsep
+\defnxname{cpp_named_character_escapes}           & \tcode{202606L} \\ \rowsep
 \defnxname{cpp_namespace_attributes}              & \tcode{201411L} \\ \rowsep
 \defnxname{cpp_noexcept_function_type}            & \tcode{201510L} \\ \rowsep
 \defnxname{cpp_nontype_template_args}             & \tcode{201911L} \\ \rowsep


### PR DESCRIPTION
Fixes #9078
Also fixes https://github.com/cplusplus/papers/issues/2362