### PR TITLE
[2026-06 LWG Motion 11] P3793R2 Better shifting

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -17197,6 +17197,16 @@ namespace std::simd {
   template<@\exposconcept{simd-vec-type}@ V>
     constexpr typename V::mask_type has_single_bit(const V& v) noexcept;
 
+  template<@\exposconcept{simd-integral}@ VX, @\exposconcept{simd-integral}@ VS>
+    constexpr VX shl(const VX& x, const VS& s) noexcept;
+  template<@\exposconcept{simd-integral}@ V, class S>
+    constexpr V  shl(const V& x, S s) noexcept;
+
+  template<@\exposconcept{simd-integral}@ VX, @\exposconcept{simd-integral}@ VS>
+    constexpr VX shr(const VX& x, const VS& s) noexcept;
+  template<@\exposconcept{simd-integral}@ V, class S>
+    constexpr V  shr(const V& x, S s) noexcept;
+
   template<@\exposconcept{simd-vec-type}@ V0, @\exposconcept{simd-vec-type}@ V1>
     constexpr V0 rotl(const V0& v, const V1& s) noexcept;
   template<@\exposconcept{simd-vec-type}@ V>
@@ -17398,6 +17408,8 @@ namespace std {
   using simd::bit_ceil;
   using simd::bit_floor;
   using simd::has_single_bit;
+  using simd::shl;
+  using simd::shr;
   using simd::rotl;
   using simd::rotr;
   using simd::bit_width;
@@ -20465,6 +20477,60 @@ The type \tcode{V::value_type} is an unsigned integer type\iref{basic.fundamenta
 A \tcode{basic_mask} object where the $i^\text{th}$ element is initialized
 to the result of \tcode{std::has_single_bit(v[$i$])} for all $i$ in the range
 \range{0}{V::size()}.
+\end{itemdescr}
+
+\indexlibrarymember{shl}{simd}
+\indexlibrarymember{shr}{simd}
+\begin{itemdecl}
+template<@\exposconcept{simd-integral}@ VX, @\exposconcept{simd-integral}@ VS>
+  constexpr VX shl(const VX& x, const VS& s) noexcept;
+template<@\exposconcept{simd-integral}@ VX, @\exposconcept{simd-integral}@ VS>
+  constexpr VX shr(const VX& x, const VS& s) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\begin{itemize}
+\item
+Each of \tcode{VX::value_type} and \tcode{VS::value_type}
+is a signed or unsigned integer type\iref{basic.fundamental},
+\item
+\tcode{VX::size() == VS::size()} is \tcode{true}, and
+\item
+\tcode{sizeof(typename VX::value_type) == sizeof(typename VS::value_type)}
+is \tcode{true}.
+\end{itemize}
+
+\pnum
+\returns
+A \tcode{basic_vec} object where the $i^\text{th}$ element is initialized to
+the result of \tcode{\placeholder{bit-func}(x[$i$], s[$i$])}
+for all $i$ in the range \range{0}{VX::size()},
+where \tcode{\placeholder{bit-func}} is the corresponding scalar function from \libheader{bit}.
+\end{itemdescr}
+
+\indexlibrarymember{shl}{simd}
+\indexlibrarymember{shr}{simd}
+\begin{itemdecl}
+template<@\exposconcept{simd-integral}@ V, class S>
+  constexpr V shl(const V& x, S s) noexcept;
+template<@\exposconcept{simd-integral}@ V, class S>
+  constexpr V shr(const V& x, S s) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+Each of \tcode{VX::value_type} and \tcode{S}
+is a signed or unsigned integer type\iref{basic.fundamental}.
+
+\pnum
+\returns
+A \tcode{basic_vec} object where the $i^\text{th}$ element is initialized to
+the result of \tcode{\placeholder{bit-func}(x[$i$], s)}
+for all $i$ in the range \range{0}{VX::size()},
+where \tcode{\placeholder{bit-func}} is the corresponding scalar function from \libheader{bit}.
 \end{itemdescr}
 
 \indexlibrarymember{rotl}{simd}

--- a/source/support.tex
+++ b/source/support.tex
@@ -604,7 +604,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_bind_back}@                         202306L // freestanding, also in \libheader{functional}
 #define @\defnlibxname{cpp_lib_bind_front}@                        202306L // freestanding, also in \libheader{functional}
 #define @\defnlibxname{cpp_lib_bit_cast}@                          201806L // freestanding, also in \libheader{bit}
-#define @\defnlibxname{cpp_lib_bitops}@                            201907L // freestanding, also in \libheader{bit}
+#define @\defnlibxname{cpp_lib_bitops}@                            202606L // freestanding, also in \libheader{bit}
 #define @\defnlibxname{cpp_lib_bitset}@                            202306L // also in \libheader{bitset}
 #define @\defnlibxname{cpp_lib_bool_constant}@                     201505L // freestanding, also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_bounded_array_traits}@              201902L // freestanding, also in \libheader{type_traits}
@@ -840,6 +840,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_shared_timed_mutex}@                201402L // also in \libheader{shared_mutex}
 #define @\defnlibxname{cpp_lib_shift}@                             202202L // also in \libheader{algorithm}
 #define @\defnlibxname{cpp_lib_simd}@                              202606L // also in \libheader{simd}
+#define @\defnlibxname{cpp_lib_simd_bitops}@                       202606L // also in \libheader{simd}
 #define @\defnlibxname{cpp_lib_simd_complex}@                      202502L // also in \libheader{simd}
 #define @\defnlibxname{cpp_lib_simd_permutations}@                 202506L // also in \libheader{simd}
 #define @\defnlibxname{cpp_lib_smart_ptr_for_overwrite}@           202002L // also in \libheader{memory}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16316,6 +16316,12 @@ namespace std {
   template<class T>
     constexpr int bit_width(T x) noexcept;
 
+  // \ref{bit.shift}, shifting
+  template<class T, class S>
+    constexpr T shl(T x, S s) noexcept;
+  template<class T, class S>
+    constexpr T shr(T x, S s) noexcept;
+
   // \ref{bit.rotate}, rotating
   template<class T>
     constexpr T rotl(T x, int s) noexcept;
@@ -16519,6 +16525,48 @@ If \tcode{x == 0}, \tcode{0};
 otherwise one plus the base-2 logarithm of \tcode{x},
 with any fractional part discarded.
 
+\end{itemdescr}
+
+\rSec2[bit.shift]{Shifting}
+
+\pnum
+Within this subclause,
+the result $r$ of an arithmetic operation is
+first represented in a hypothetical integer type with sufficient range,
+then converted to \tcode{T} as if by \tcode{static_cast<T>($r$)}.
+
+\indexlibraryglobal{shl}%
+\begin{itemdecl}
+template<class T, class S>
+  constexpr T shl(T x, S s) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+Each of \tcode{T} and \tcode{S}
+is a signed or unsigned integer type\iref{basic.fundamental}.
+
+\pnum
+\returns
+$x \times 2^s$ rounded towards negative infinity.
+\end{itemdescr}
+
+\indexlibraryglobal{shr}%
+\begin{itemdecl}
+template<class T, class S>
+  constexpr T shr(T x, S s) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+Each of \tcode{T} and \tcode{S}
+is a signed or unsigned integer type\iref{basic.fundamental}.
+
+\pnum
+\returns
+$x \times 2^{-s}$ rounded towards negative infinity.
 \end{itemdescr}
 
 \rSec2[bit.rotate]{Rotating}


### PR DESCRIPTION
Fixes #9098
Also fixes https://github.com/cplusplus/papers/issues/2399

> [!NOTE]
> The rename of `simd-vec-type` to `simd-integral` was deliberately omitted for now so that we can have a green CI build. It's trivial for Thomas to apply that or for a fixup commit to add that in.