### PR TITLE
[2026-06 LWG Motion 14] P3104R6 Bit permutations

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -604,7 +604,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_bind_back}@                         202306L // freestanding, also in \libheader{functional}
 #define @\defnlibxname{cpp_lib_bind_front}@                        202306L // freestanding, also in \libheader{functional}
 #define @\defnlibxname{cpp_lib_bit_cast}@                          201806L // freestanding, also in \libheader{bit}
-#define @\defnlibxname{cpp_lib_bitops}@                            202606L // freestanding, also in \libheader{bit}
+#define @\defnlibxname{cpp_lib_bitops}@                            202607L // freestanding, also in \libheader{bit}
 #define @\defnlibxname{cpp_lib_bitset}@                            202306L // also in \libheader{bitset}
 #define @\defnlibxname{cpp_lib_bool_constant}@                     201505L // freestanding, also in \libheader{type_traits}
 #define @\defnlibxname{cpp_lib_bounded_array_traits}@              201902L // freestanding, also in \libheader{type_traits}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16781,7 +16781,7 @@ template<class T>
 
 \pnum
 \returns
-$\mathsf{repeat}(x, m)$, where
+$\mathsf{repeat}(x, l)$, where
 $\mathsf{repeat}$ is given by \eqref{bit.permute.repeat},
 $x$ is \tcode{x}, and
 $l$ is \tcode{l}.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16340,6 +16340,16 @@ namespace std {
   template<class T>
     constexpr int popcount(T x) noexcept;
 
+  // \ref{bit.permute}, permutation
+  template<class T>
+    constexpr T bit_reverse(T x) noexcept;
+  template<class T>
+    constexpr T bit_repeat(T x, int l);
+  template<class T>
+    constexpr T bit_compress(T x, T m) noexcept;
+  template<class T>
+    constexpr T bit_expand(T x, T m) noexcept;
+
   // \ref{bit.endian}, endian
   enum class endian {
     little = @\seebelow@,
@@ -16717,6 +16727,149 @@ template<class T>
 \pnum
 \returns
 The number of \tcode{1} bits in the value of \tcode{x}.
+\end{itemdescr}
+
+\rSec2[bit.permute]{Permutation}
+
+\pnum
+In the following descriptions,
+let $N$ denote the value of \tcode{numeric_limits<T>::digits}, and
+let $\alpha_n$ denote the value of the $n^\text{th}$ least significant bit
+in the base-2 representation of an integer $\alpha$,
+so that $\alpha$ equals $\sum_{n=0}^{N-1} \alpha_n 2^n$.
+
+\indexlibraryglobal{bit_reverse}%
+\begin{itemdecl}
+template<class T>
+  constexpr T bit_reverse(T x) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{T} is an unsigned integer type\iref{basic.fundamental}.
+
+\pnum
+\returns
+$\mathsf{reverse}(x)$, where
+$\mathsf{reverse}$ is given by \eqref{bit.permute.reverse}, and
+$x$ is \tcode{x}.
+\begin{formula}{bit.permute.reverse}
+\mathsf{reverse}(x) = \sum_{n=0}^{N-1} x_n \, 2^{N-n-1}
+\end{formula}
+
+\pnum
+\begin{note}
+\tcode{bit_reverse(bit_reverse(x))} equals \tcode{x}.
+\end{note}
+\end{itemdescr}
+
+\indexlibraryglobal{bit_repeat}%
+\begin{itemdecl}
+template<class T>
+  constexpr T bit_repeat(T x, int l);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{T} is an unsigned integer type\iref{basic.fundamental}.
+
+\pnum
+\expects
+\tcode{l} is greater than zero.
+
+\pnum
+\returns
+$\mathsf{repeat}(x, m)$, where
+$\mathsf{repeat}$ is given by \eqref{bit.permute.repeat},
+$x$ is \tcode{x}, and
+$l$ is \tcode{l}.
+\begin{formula}{bit.permute.repeat}
+\mathsf{repeat}(x, l) = \sum_{n=0}^{N-1} x_{(n \bmod l)} \, 2^n
+\end{formula}
+
+\pnum
+\throws
+Nothing.
+
+\pnum
+\remarks
+A function call expression that violates the precondition in the \expects
+element is not a core constant expression\iref{expr.const.core}.
+
+\pnum
+\begin{example}
+\tcode{bit_repeat(uint32_t\{0xc\}, 4)} equals \tcode{0xcccccccc}.
+\end{example}
+\end{itemdescr}
+
+\indexlibraryglobal{bit_compress}%
+\begin{itemdecl}
+template<class T>
+  constexpr T bit_compress(T x, T m) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{T} is an unsigned integer type\iref{basic.fundamental}.
+
+\pnum
+\returns
+$\mathsf{compress}(x, m)$, where
+$\mathsf{compress}$ is given by \eqref{bit.permute.compress},
+$x$ is \tcode{x}, and
+$m$ is \tcode{m}.
+\begin{formula}{bit.permute.compress}
+\mathsf{compress}(x, m) =
+  \sum_{n=0}^{N-1} m_n x_n \, 2^{\left(\sum_{k=0}^{n-1} m_k\right)}
+\end{formula}
+
+\pnum
+\begin{example}
+\tcode{bit_compress(0b\placeholder{ABCD}, 0b0101)} equals
+\tcode{0b00\placeholder{BD}}
+for any bits
+\tcode{\placeholder{A}},
+\tcode{\placeholder{B}},
+\tcode{\placeholder{C}}, and
+\tcode{\placeholder{D}}.
+\end{example}
+\end{itemdescr}
+
+\indexlibraryglobal{bit_expand}%
+\begin{itemdecl}
+template<class T>
+  constexpr T bit_expand(T x, T m) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\tcode{T} is an unsigned integer type\iref{basic.fundamental}.
+
+\pnum
+\returns
+$\mathsf{expand}(x, m)$, where
+$\mathsf{expand}$ is given by \eqref{bit.permute.expand},
+$x$ is \tcode{x}, and
+$m$ is \tcode{m}.
+\begin{formula}{bit.permute.expand}
+\mathsf{expand}(x, m) =
+  \sum_{n=0}^{N-1} m_n \, x_{\left(\sum_{k=0}^{n-1} m_k\right)} \, 2^n
+\end{formula}
+
+\pnum
+\begin{example}
+\tcode{bit_expand(0b\placeholder{ABCD}, 0b0101)} equals
+\tcode{0b0\placeholder{C}0\placeholder{D}}
+for any bits
+\tcode{\placeholder{A}},
+\tcode{\placeholder{B}},
+\tcode{\placeholder{C}}, and
+\tcode{\placeholder{D}}.
+\end{example}
 \end{itemdescr}
 
 \rSec2[bit.endian]{Endian}


### PR DESCRIPTION
Fixes #9101
Also fixes https://github.com/cplusplus/papers/issues/1768

> [!NOTE]
> The Bump of `cpp_lib_bitops` to `202607L` instead of `202606L` is deliberate. See the paper wording for an explanation.