### PR TITLE
[2026-06 LWG Motion 13] P3692R4 How to Avoid OOTA Without Really Trying

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -3009,6 +3009,29 @@ if (r2 == 42) x.store(42, memory_order::relaxed);
 \end{codeblock}
 \end{note}
 
+\begin{note}
+An implementation that
+translates to instruction sequences for a physical machine and
+treats non-volatile atomic accesses as though they were volatile
+does not produce out-of-thin-air values for a program free of undefined behavior.
+An implementation that
+performs only thread-at-a-time analysis in support of optimizations
+that omit and merge non-volatile atomic accesses to the same object and
+reorder non-volatile atomic accesses to different objects (when permitted by the as-if rule) and
+otherwise treats non-volatile atomic accesses as though they were volatile
+does not produce out-of-thin-air values for a program free of undefined behavior.
+The possibility of out-of-thin-air values remains
+for implementations not meeting these restrictions.
+\end{note}
+
+\pnum
+\begin{note}
+Unlike abstract machines,
+physical machines are subject to instruction-execution and information-transfer latencies.
+Physical machines carefully manage any speculative execution
+so as to avoid generating out-of-thin-air values at the hardware level.
+\end{note}
+
 \pnum
 An atomic read-modify-write operation always reads the value
 from the side effect that immediately precedes the side effect of the


### PR DESCRIPTION
Fixes #9100
Also fixes https://github.com/cplusplus/papers/issues/2322

---

I feel like we could prettify the first note (in a subsequent PR) a bit by factoring out the

> An implementation that ... does not produce out-of-thin-air values for a program free of undefined behavior

This could be done in a follow-up PR that turns this into

> An implementation does not produce out-of-thin-air values for a program free of undefined behavior if
> - ..., or
> - ...

where the two bullets are the two sentences that we have now.