### PR TITLE
[range.join.view, range.join.with.view] Make the comment more smooth.

### DIFF
--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -6789,7 +6789,7 @@ namespace std::ranges {
     V @\exposid{base_}@ = V();                                          // \expos
 
     @\exposidnc{non-propagating-cache}@<iterator_t<V>> @\exposidnc{outer_}@;            // \expos, present only
-                                                            // when \tcode{!\libconcept{forward_range}<V>}
+                                                            // if \tcode{\libconcept{forward_range}<V>} is \tcode{false}
     @\exposidnc{non-propagating-cache}@<remove_cv_t<@\exposidnc{InnerRng}@>> @\exposid{inner_}@;    // \expos, present only
                                                             // if \tcode{is_reference_v<\exposid{InnerRng}>} is \tcode{false}
 
@@ -7323,7 +7323,7 @@ namespace std::ranges {
 
     V @\exposid{base_}@ = V();                                          // \expos
     @\exposid{non-propagating-cache}@<iterator_t<V>> @\exposid{outer_it_}@;         // \expos, present only
-                                                            // when \tcode{!\libconcept{forward_range}<V>}
+                                                            // if \tcode{\libconcept{forward_range}<V>} is \tcode{false}
     @\exposid{non-propagating-cache}@<remove_cv_t<@\exposid{InnerRng}@>> @\exposid{inner_}@;   // \expos, present only
                                                             // if \tcode{is_reference_v<\exposid{InnerRng}>} is \tcode{false}
     Pattern @\exposid{pattern_}@ = Pattern();                           // \expos


### PR DESCRIPTION
The `when !forward_range<V>` here is a bit unnatural.