### PR TITLE
[2026-06 LWG Motion 12] P3242R4 Copy and fill for mdspan

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -21322,6 +21322,17 @@ namespace std {
       @\exposconcept{pair-like}@<T> &&
       @\libconcept{convertible_to}@<tuple_element_t<0, T>, IndexType> &&
       @\libconcept{convertible_to}@<tuple_element_t<1, T>, IndexType>;
+
+  // \ref{mdspan.copy}, multidimensional copy algorithms
+  template<class Src, class Dst>
+    constexpr void copy(const Src& src, const Dst& dst);
+  template<class ExecutionPolicy, class Src, class Dst>
+    void copy(ExecutionPolicy&& policy, const Src& src, const Dst& dst);
+
+  template<class Dst, class T = Dst::value_type>
+    constexpr void fill(const Dst& dst, const T& value);
+  template<class ExecutionPolicy, class Dst, class T = Dst::value_type>
+    void fill(ExecutionPolicy&& policy, const Dst& dst, const T& value);
 }
 \end{codeblock}
 
@@ -26703,3 +26714,78 @@ void zero_surface(mdspan<T, E, L, A> grid3d) {
 }
 \end{codeblock}
 \end{example}
+
+\rSec3[mdspan.copy]{Multidimensional copy algorithms}
+
+\indexlibraryglobal{copy}%
+\begin{itemdecl}
+template<class Src, class Dst>
+  constexpr void copy(const Src& src, const Dst& dst);
+
+template<class ExecutionPolicy, class Src, class Dst>
+  void copy(ExecutionPolicy&& policy, const Src& src, const Dst& dst);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\begin{itemize}
+\item
+\tcode{Src} and \tcode{Dst} are specializations of \tcode{mdspan},
+\item
+\tcode{is_assignable_v<typename Dst::reference, typename Src::reference>}
+is \tcode{true}, and
+\item
+\tcode{is_constructible_v<typename Src::extents_type, typename Dst::extents_type>}
+is \tcode{true}.
+\end{itemize}
+\begin{note}
+This constraint effectively verifies
+that the ranks of the extents are the same and
+that each extent is either static and the same,
+or \tcode{dynamic_extent}.
+\end{note}
+
+\pnum
+\expects
+\begin{itemize}
+\item
+\tcode{dst.is_unique()} is \tcode{true}, and
+\item
+for each multidimensional index \tcode{i} in \tcode{src.extents()},
+there is no multidimensional index \tcode{j} in \tcode{dst.extents()}
+such that \tcode{src[i]} and \tcode{dst[j]} refer to the same element.
+\end{itemize}
+
+\pnum
+\hardexpects
+\tcode{src.extents()} equals \tcode{dst.extents()}.
+
+\pnum
+\effects
+Assigns each element of src to the corresponding element of \tcode{dst}.
+\end{itemdescr}
+
+\indexlibraryglobal{fill}%
+\begin{itemdecl}
+template<class Dst, class T = Dst::value_type>
+  constexpr void fill(const Dst& dst, const T& value);
+
+template<class ExecutionPolicy, class Dst, class T = Dst::value_type>
+  void fill(ExecutionPolicy&& policy, const Dst& dst, const T& value);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+\begin{itemize}
+\item
+\tcode{Dst} is a specializations of \tcode{mdspan}, and
+\item
+\tcode{is_assignable_v<typename Dst::reference, const T\&>} is \tcode{true}.
+\end{itemize}
+
+\pnum
+\effects
+Assigns \tcode{value} to each element of \tcode{dst}.
+\end{itemdescr}

--- a/source/support.tex
+++ b/source/support.tex
@@ -767,6 +767,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_math_constants}@                    201907L // also in \libheader{numbers}
 #define @\defnlibxname{cpp_lib_math_special_functions}@            201603L // also in \libheader{cmath}
 #define @\defnlibxname{cpp_lib_mdspan}@                            202406L // freestanding, also in \libheader{mdspan}
+#define @\defnlibxname{cpp_lib_mdspan_copy}@                       202606L // also in \libheader{mdspan}
 #define @\defnlibxname{cpp_lib_memory_resource}@                   201603L // also in \libheader{memory_resource}
 #define @\defnlibxname{cpp_lib_modules}@                           202207L // freestanding
 #define @\defnlibxname{cpp_lib_move_iterator_concept}@             202207L // freestanding, also in \libheader{iterator}


### PR DESCRIPTION
Fixes https://github.com/cplusplus/draft/issues/9099
Also fixes https://github.com/cplusplus/papers/issues/1885

I had to fix up a few things:
- In synopsis, removed blank line between overloads. I believe we usually bundle those together.
- Added missing comment in synopsis after `[mdspan.copy]`.
- Reordered `\hardexpexts` and `\expects` (order in the paper is wrong and does not match [structure.specifications]).