### PR TITLE
[2026-06 LWG Motion 15] P3772R2 `std::simd` overloads for bit permutations

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -17191,6 +17191,7 @@ namespace std::simd {
 
   // \ref{simd.bit}, bit manipulation
   template<@\exposconcept{simd-vec-type}@ V> constexpr V byteswap(const V& v) noexcept;
+  template<@\exposconcept{simd-integral}@ V> constexpr V bit_reverse(const V& v) noexcept;
   template<@\exposconcept{simd-vec-type}@ V> constexpr V bit_ceil(const V& v);
   template<@\exposconcept{simd-vec-type}@ V> constexpr V bit_floor(const V& v) noexcept;
 
@@ -17217,6 +17218,11 @@ namespace std::simd {
   template<@\exposconcept{simd-vec-type}@ V>
     constexpr V  rotr(const V& v, int s) noexcept;
 
+  template<@\exposconcept{simd-integral}@ V0, @\exposconcept{simd-integral}@ V1>
+    constexpr V0 bit_repeat(const V0& v, const V1& l);
+  template<@\exposconcept{simd-integral}@ V>
+    constexpr V  bit_repeat(const V& v, int l);
+
   template<@\exposconcept{simd-vec-type}@ V>
     constexpr rebind_t<make_signed_t<typename V::value_type>, V>
       bit_width(const V& v) noexcept;
@@ -17235,6 +17241,16 @@ namespace std::simd {
   template<@\exposconcept{simd-vec-type}@ V>
     constexpr rebind_t<make_signed_t<typename V::value_type>, V>
       popcount(const V& v) noexcept;
+
+  template<@\exposconcept{simd-integral}@ V>
+    constexpr V bit_compress(const V& v, const V& m) noexcept;
+  template<@\exposconcept{simd-integral}@ V>
+    constexpr V bit_expand(const V& v, const V& m) noexcept;
+
+  template<@\exposconcept{simd-integral}@ V>
+    constexpr V bit_compress(const V& v, typename V::value_type m) noexcept;
+  template<@\exposconcept{simd-integral}@ V>
+    constexpr V bit_expand(const V& v, typename V::value_type m) noexcept;
 
   // \ref{simd.complex.math}, complex math
   template<@\exposconcept{simd-complex}@ V>
@@ -17407,17 +17423,21 @@ namespace std {
   using simd::byteswap;
   using simd::bit_ceil;
   using simd::bit_floor;
+  using simd::bit_reverse;
   using simd::has_single_bit;
   using simd::shl;
   using simd::shr;
   using simd::rotl;
   using simd::rotr;
+  using simd::bit_repeat;
   using simd::bit_width;
   using simd::countl_zero;
   using simd::countl_one;
   using simd::countr_zero;
   using simd::countr_one;
   using simd::popcount;
+  using simd::bit_compress;
+  using simd::bit_expand;
 
   // See \ref{simd.complex.math}, \tcode{vec} complex math
   using simd::real;
@@ -20416,6 +20436,23 @@ the result of \tcode{std::byteswap(v[$i$])} for all $i$ in the range
 \range{0}{V::size()}.
 \end{itemdescr}
 
+\indexlibrarymember{bit_reverse}{simd}
+\begin{itemdecl}
+template<@\exposconcept{simd-integral}@ V> constexpr V bit_reverse(const V& v) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+The type \tcode{V::value_type} is an unsigned integer type\iref{basic.fundamental}.
+
+\pnum
+\returns
+A \tcode{basic_vec} object where the $i^\text{th}$ element is initialized to
+the result of \tcode{std::bit_reverse(\brk{}v[$i$])} for all $i$ in the range
+\range{0}{V::size()}.
+\end{itemdescr}
+
 \indexlibrarymember{bit_ceil}{simd}
 \begin{itemdecl}
 template<@\exposconcept{simd-vec-type}@ V> constexpr V bit_ceil(const V& v);
@@ -20535,11 +20572,14 @@ where \tcode{\placeholder{bit-func}} is the corresponding scalar function from \
 
 \indexlibrarymember{rotl}{simd}
 \indexlibrarymember{rotr}{simd}
+\indexlibrarymember{bit_repeat}{simd}
 \begin{itemdecl}
 template<@\exposconcept{simd-vec-type}@ V0, @\exposconcept{simd-vec-type}@ V1>
   constexpr V0 rotl(const V0& v0, const V1& v1) noexcept;
 template<@\exposconcept{simd-vec-type}@ V0, @\exposconcept{simd-vec-type}@ V1>
   constexpr V0 rotr(const V0& v0, const V1& v1) noexcept;
+template<@\exposconcept{simd-integral}@ V0, @\exposconcept{simd-integral}@ V1>
+  constexpr V0 bit_repeat(const V0& v0, const V1& v1);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -20557,18 +20597,31 @@ template<@\exposconcept{simd-vec-type}@ V0, @\exposconcept{simd-vec-type}@ V1>
 \end{itemize}
 
 \pnum
+\expects
+For \tcode{bit_repeat},
+\tcode{v1[$i$] > 0} is \tcode{true}
+for all $i$ in the range \range{0}{V0::size()}.
+
+\pnum
 \returns
 A \tcode{basic_vec} object where the $i^\text{th}$ element is initialized to
 the result of \tcode{\placeholder{bit-func}(v0[$i$],
 static_cast<int>(v1[$i$]))} for all $i$ in the range \range{0}{V0::size()},
 where \tcode{\placeholder{bit-func}} is the corresponding scalar function from \libheader{bit}.
+
+\pnum
+\remarks
+A function call expression that violates the precondition in the \expects
+element is not a core constant expression\iref{expr.const.core}.
 \end{itemdescr}
 
 \indexlibrarymember{rotl}{simd}
 \indexlibrarymember{rotr}{simd}
+\indexlibrarymember{bit_repeat}{simd}
 \begin{itemdecl}
 template<@\exposconcept{simd-vec-type}@ V> constexpr V rotl(const V& v, int s) noexcept;
 template<@\exposconcept{simd-vec-type}@ V> constexpr V rotr(const V& v, int s) noexcept;
+template<@\exposconcept{simd-integral}@ V> constexpr V bit_repeat(const V& v, int l);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -20577,11 +20630,21 @@ template<@\exposconcept{simd-vec-type}@ V> constexpr V rotr(const V& v, int s) n
 The type \tcode{V::value_type} is an unsigned integer type\iref{basic.fundamental}.
 
 \pnum
+\expects
+For \tcode{bit_repeat},
+\tcode{l > 0} is \tcode{true}.
+
+\pnum
 \returns
 A \tcode{basic_vec} object where the $i^\text{th}$ element is initialized to
 the result of \tcode{\placeholder{bit-func}(v[$i$], s)} for all $i$ in the
 range \range{0}{V::size()}, where \tcode{\placeholder{bit-func}} is the corresponding
 scalar function from \libheader{bit}.
+
+\pnum
+\remarks
+A function call expression that violates the precondition in the \expects
+element is not a core constant expression\iref{expr.const.core}.
 \end{itemdescr}
 
 \indexlibrarymember{bit_width}{simd}
@@ -20616,6 +20679,52 @@ A \tcode{basic_vec} object where the $i^\text{th}$ element is initialized to
 the result of \tcode{\placeholder{bit-func}(v[$i$])} for all $i$ in the range
 \range{0}{V::size()}, where \tcode{\placeholder{bit-func}} is the corresponding scalar
 function from \libheader{bit}.
+\end{itemdescr}
+
+\indexlibrarymember{bit_compress}{simd}
+\indexlibrarymember{bit_expand}{simd}
+\begin{itemdecl}
+template<@\exposconcept{simd-integral}@ V>
+  constexpr V bit_compress(const V& v, const V& m) noexcept;
+template<@\exposconcept{simd-integral}@ V>
+  constexpr V bit_expand(const V& v, const V& m) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+The type \tcode{V::value_type} is an unsigned integer type\iref{basic.fundamental}.
+
+\pnum
+\returns
+A \tcode{basic_vec} object where the $i^\text{th}$ element is initialized to
+the result of \tcode{\placeholder{bit-func}(v[$i$], m[$i$])}
+for all $i$ in the range \range{0}{V::size()},
+where \tcode{\placeholder{bit-func}} is the corresponding
+scalar function from \libheader{bit}.
+\end{itemdescr}
+
+\indexlibrarymember{bit_compress}{simd}
+\indexlibrarymember{bit_expand}{simd}
+\begin{itemdecl}
+template<@\exposconcept{simd-integral}@ V>
+  constexpr V bit_compress(const V& v, typename V::value_type m) noexcept;
+template<@\exposconcept{simd-integral}@ V>
+  constexpr V bit_expand(const V& v, typename V::value_type m) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\constraints
+The type \tcode{V::value_type} is an unsigned integer type\iref{basic.fundamental}.
+
+\pnum
+\returns
+A \tcode{basic_vec} object where the $i^\text{th}$ element is initialized to
+the result of \tcode{\placeholder{bit-func}(v[$i$], m)}
+for all $i$ in the range \range{0}{V::size()},
+where \tcode{\placeholder{bit-func}} is the corresponding
+scalar function from \libheader{bit}.
 \end{itemdescr}
 
 \rSec3[simd.complex.math]{Complex math}

--- a/source/support.tex
+++ b/source/support.tex
@@ -841,7 +841,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_shared_timed_mutex}@                201402L // also in \libheader{shared_mutex}
 #define @\defnlibxname{cpp_lib_shift}@                             202202L // also in \libheader{algorithm}
 #define @\defnlibxname{cpp_lib_simd}@                              202606L // also in \libheader{simd}
-#define @\defnlibxname{cpp_lib_simd_bitops}@                       202606L // also in \libheader{simd}
+#define @\defnlibxname{cpp_lib_simd_bitops}@                       202607L // also in \libheader{simd}
 #define @\defnlibxname{cpp_lib_simd_complex}@                      202502L // also in \libheader{simd}
 #define @\defnlibxname{cpp_lib_simd_permutations}@                 202506L // also in \libheader{simd}
 #define @\defnlibxname{cpp_lib_smart_ptr_for_overwrite}@           202002L // also in \libheader{memory}


### PR DESCRIPTION
Fixes #9102
Also fixes https://github.com/cplusplus/papers/issues/2387

Note that the instruction to "bump `cpp_lib_simd_bitops`" doesn't really make sense because that macro has been introduced by #9068.

Maybe it would make sense to set it to `202607L` now that I think about it; `cpp_lib_bitops` is also being set to `202607L` at LWG's request for Bit permutations.