### PR TITLE
[2026-06 LWG Motion 10] P3248R5 Require `[u]intptr_t`

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -1960,7 +1960,7 @@ namespace std {
   using int_least@\placeholdernc{N}@_t   = @\seebelow@;             // optional
 
   using intmax_t       = @\textit{signed integer type}@;
-  using intptr_t       = @\textit{signed integer type}@;   // optional
+  using intptr_t       = @\textit{signed integer type}@;
 
   using uint8_t        = @\textit{unsigned integer type}@; // optional
   using uint16_t       = @\textit{unsigned integer type}@; // optional
@@ -1981,7 +1981,7 @@ namespace std {
   using uint_least@\placeholdernc{N}@_t  = @\seebelow@;             // optional
 
   using uintmax_t      = @\textit{unsigned integer type}@;
-  using uintptr_t      = @\textit{unsigned integer type}@; // optional
+  using uintptr_t      = @\textit{unsigned integer type}@;
 }
 
 #define INT@\placeholdernc{N}@_MIN          @\seebelow@
@@ -2008,11 +2008,11 @@ namespace std {
 #define INTMAX_WIDTH      @\seebelow@
 #define UINTMAX_WIDTH     @\seebelow@
 
-#define INTPTR_MIN        @\seebelow@              // optional
-#define INTPTR_MAX        @\seebelow@              // optional
-#define UINTPTR_MAX       @\seebelow@              // optional
-#define INTPTR_WIDTH      @\seebelow@              // optional
-#define UINTPTR_WIDTH     @\seebelow@              // optional
+#define INTPTR_MIN        @\seebelow@
+#define INTPTR_MAX        @\seebelow@
+#define UINTPTR_MAX       @\seebelow@
+#define INTPTR_WIDTH      @\seebelow@
+#define UINTPTR_WIDTH     @\seebelow@
 
 #define PTRDIFF_MIN       @\seebelow@
 #define PTRDIFF_MAX       @\seebelow@
@@ -2040,7 +2040,10 @@ namespace std {
 
 \pnum
 The header defines all types and macros the same as
-the C standard library header \libheader{stdint.h}.
+the C standard library header \libheader{stdint.h},
+except that the types \tcode{intptr_t} and \tcode{uintptr_t} and
+the macros \tcode{INTPTR_MIN}, \tcode{INTPTR_MAX}, and \tcode{UINTPTR_MAX}
+are always defined.
 The types denoted by \tcode{intmax_t} and \tcode{uintmax_t}
 are not required to be able to represent all values of extended integer types
 wider than \tcode{long long} and \tcode{unsigned long long}, respectively.

--- a/source/text.tex
+++ b/source/text.tex
@@ -6661,12 +6661,10 @@ Pointer presentation types also apply to \tcode{nullptr_t}.
 \topline
 \lhdr{Type} & \rhdr{Meaning} \\ \rowsep
 none, \tcode{p} &
-If \tcode{uintptr_t} is declared,
 \begin{codeblock}
 to_chars(first, last, reinterpret_cast<uintptr_t>(value), 16)
 \end{codeblock}
-with the prefix \tcode{0x} inserted immediately before the output of \tcode{to_chars};
-otherwise, implementation-defined.
+with the prefix \tcode{0x} inserted immediately before the output of \tcode{to_chars}.
 \\ \rowsep
 \tcode{P} &
 The same as \tcode{p},

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -2808,11 +2808,9 @@ namespace std {
 \indexlibraryglobal{atomic_intmax_t}%
 \indexlibraryglobal{atomic_uintmax_t}%
 \pnum
-The type aliases \tcode{atomic_int$N$_t}, \tcode{atomic_uint$N$_t},
-\tcode{atomic_intptr_t}, and \tcode{atomic_uintptr_t}
+The type aliases \tcode{atomic_int$N$_t} and \tcode{atomic_uint$N$_t}
 are declared if and only if
-\tcode{int$N$_t}, \tcode{uint$N$_t},
-\tcode{intptr_t}, and \tcode{uintptr_t}
+\tcode{int$N$_t} and \tcode{uint$N$_t}
 are declared, respectively.
 
 \pnum


### PR DESCRIPTION
Fixes #9097
Also fixes https://github.com/cplusplus/papers/issues/1909