### PR TITLE
[2026-06 LWG Motion 8] P3154R3 (Deprecating signed character types in iostreams)

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -1058,3 +1058,110 @@ template<class T> constexpr T kill_dependency(T y) noexcept;
 \returns
 \tcode{y}.
 \end{itemdescr}
+
+\Sec1[depr.istream.extractors]{Deprecated \tcode{signed char} and \tcode{unsigned char} extraction}
+\pnum
+The header \libheaderref{istream} has the following additions:
+
+\begin{itemdecl}
+template<class traits>
+  basic_istream<char, traits>& operator>>(basic_istream<char, traits>& in, unsigned char& c);
+template<class traits>
+  basic_istream<char, traits>& operator>>(basic_istream<char, traits>& in, signed char& c);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Behaves like a formatted input member
+(as described in\iref{istream.formatted.reqmts})
+of \tcode{in}.
+A character is extracted from \tcode{in},
+if one is available, and stored in \tcode{c}.
+Otherwise, \tcode{ios_base::failbit} is set
+in the input function's local error state
+before setstate is called.
+
+\pnum
+\returns
+\tcode{in}.
+\end{itemdescr}
+
+\pnum
+\begin{itemdecl}
+template<class traits, size_t N>
+  basic_istream<char, traits>& operator>>(basic_istream<char, traits>& in, unsigned char (&s)[N]);
+template<class traits, size_t N>
+  basic_istream<char, traits>& operator>>(basic_istream<char, traits>& in, signed char (&s)[N]);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Behaves like a formatted input member
+(as described in\iref{istream.formatted.reqmts})
+of \tcode{in}.
+After a sentry object is constructed,
+\tcode{operator>>} extracts characters and stores them into \tcode{s}.
+If \tcode{width()} is greater than zero,
+\tcode{n} is \tcode{min(size_t(width()), N)}.
+Otherwise \tcode{n} is \tcode{N}.
+\tcode{n} is the maximum number of characters stored.
+
+\pnum
+Characters are extracted and stored until any of the following occurs:
+\begin{itemize}
+\item \tcode{n - 1} characters are stored;
+\item end of file occurs on the input sequence;
+\item letting \tcode{ct} be \tcode{use_facet<ctype<charT>>(in.getloc())}, \tcode{ct.is(ct.space, s)}
+      is \tcode{true}.
+\end{itemize}
+
+\pnum
+\tcode{operator>>} then stores a null byte (\tcode{charT()}) in the next position,
+which may be the first position if no characters were extracted.
+\tcode{operator>>} then calls \tcode{width(0)}.
+
+\pnum
+If the function extracted no characters,
+\tcode{ios_bit::failbit} is set in the input function's
+local error state before \tcode{setstate} is called.
+
+\pnum
+\returns
+\tcode{in}.
+\end{itemdescr}
+
+\Sec1[depr.ostream.inserters]{Deprecated \tcode{signed char} and \tcode{unsigned char} insertion}
+\pnum
+The header \libheaderref{ostream} has the following additions:
+
+\pnum
+\begin{itemdecl}
+template<class traits>
+  basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>& out, signed char c);
+template<class traits>
+  basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>& out, unsigned char c);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return out << static_cast<char>(c);}
+\end{itemdescr}
+
+\pnum
+\begin{itemdecl}
+template<class traits>
+  basic_ostream<char, traits>&
+    operator<<(basic_ostream<char, traits>& out, const signed char* s);
+template<class traits>
+  basic_ostream<char, traits>&
+    operator<<(basic_ostream<char, traits>& out, const unsigned char* s);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return out << reinterpret_cast<const char*>(s);}
+\end{itemdescr}

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -4387,17 +4387,9 @@ namespace std {
   // \ref{istream.extractors}, character extraction templates
   template<class charT, class traits>
     basic_istream<charT, traits>& operator>>(basic_istream<charT, traits>&, charT&);
-  template<class traits>
-    basic_istream<char, traits>& operator>>(basic_istream<char, traits>&, unsigned char&);
-  template<class traits>
-    basic_istream<char, traits>& operator>>(basic_istream<char, traits>&, signed char&);
 
   template<class charT, class traits, size_t N>
     basic_istream<charT, traits>& operator>>(basic_istream<charT, traits>&, charT(&)[N]);
-  template<class traits, size_t N>
-    basic_istream<char, traits>& operator>>(basic_istream<char, traits>&, unsigned char(&)[N]);
-  template<class traits, size_t N>
-    basic_istream<char, traits>& operator>>(basic_istream<char, traits>&, signed char(&)[N]);
 }
 \end{codeblock}
 
@@ -4919,10 +4911,6 @@ This extractor does not behave as a formatted input function
 \begin{itemdecl}
 template<class charT, class traits, size_t N>
   basic_istream<charT, traits>& operator>>(basic_istream<charT, traits>& in, charT (&s)[N]);
-template<class traits, size_t N>
-  basic_istream<char, traits>& operator>>(basic_istream<char, traits>& in, unsigned char (&s)[N]);
-template<class traits, size_t N>
-  basic_istream<char, traits>& operator>>(basic_istream<char, traits>& in, signed char (&s)[N]);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -4976,10 +4964,6 @@ before \tcode{setstate} is called.
 \begin{itemdecl}
 template<class charT, class traits>
   basic_istream<charT, traits>& operator>>(basic_istream<charT, traits>& in, charT& c);
-template<class traits>
-  basic_istream<char, traits>& operator>>(basic_istream<char, traits>& in, unsigned char& c);
-template<class traits>
-  basic_istream<char, traits>& operator>>(basic_istream<char, traits>& in, signed char& c);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6004,11 +5988,6 @@ namespace std {
     basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>&, char);
 
   template<class traits>
-    basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>&, signed char);
-  template<class traits>
-    basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>&, unsigned char);
-
-  template<class traits>
     basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>&, wchar_t) = delete;
   template<class traits>
     basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>&, char8_t) = delete;
@@ -6032,11 +6011,6 @@ namespace std {
     basic_ostream<charT, traits>& operator<<(basic_ostream<charT, traits>&, const char*);
   template<class traits>
     basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>&, const char*);
-
-  template<class traits>
-    basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>&, const signed char*);
-  template<class traits>
-    basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>&, const unsigned char*);
 
   template<class traits>
     basic_ostream<char, traits>&
@@ -6719,11 +6693,6 @@ template<class charT, class traits>
 // specialization
 template<class traits>
   basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>& out, char c);
-// signed and unsigned
-template<class traits>
-  basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>& out, signed char c);
-template<class traits>
-  basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>& out, unsigned char c);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6755,11 +6724,6 @@ template<class charT, class traits>
   basic_ostream<charT, traits>& operator<<(basic_ostream<charT, traits>& out, const char* s);
 template<class traits>
   basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>& out, const char* s);
-template<class traits>
-  basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>& out, const signed char* s);
-template<class traits>
-  basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>& out,
-                                          const unsigned char* s);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -6790,10 +6754,7 @@ and the second is of type
 for the overload where the first argument is of type
 \tcode{basic_ostream<charT, traits>\&}
 and the second is of type
-\tcode{const char*},
-\item
-\tcode{traits::length(reinterpret_cast<const char*>(s))}
-for the other two overloads.
+\tcode{const char*}.
 \end{itemize}
 Determines padding for \tcode{seq} as described
 in~\ref{ostream.formatted.reqmts}. Inserts \tcode{seq} into


### PR DESCRIPTION
Fixes #9095
Also Fixes https://github.com/cplusplus/papers/issues/1804