### PR TITLE
[2026-06 LWG Motion 7] P3505R4 Fix the default floating-point representation in std::format

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -868,7 +868,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_three_way_comparison}@              201907L // freestanding, also in \libheader{compare}
 #define @\defnlibxname{cpp_lib_to_address}@                        201711L // freestanding, also in \libheader{memory}
 #define @\defnlibxname{cpp_lib_to_array}@                          201907L // freestanding, also in \libheader{array}
-#define @\defnlibxname{cpp_lib_to_chars}@                          202306L // also in \libheader{charconv}
+#define @\defnlibxname{cpp_lib_to_chars}@                          202606L // also in \libheader{charconv}
 #define @\defnlibxname{cpp_lib_to_string}@                         202306L // also in \libheader{string}
 #define @\defnlibxname{cpp_lib_to_underlying}@                     202102L // freestanding, also in \libheader{utility}
 #define @\defnlibxname{cpp_lib_transformation_trait_aliases}@      201304L // freestanding, also in \libheader{type_traits}

--- a/source/text.tex
+++ b/source/text.tex
@@ -174,13 +174,18 @@ to_chars_result to_chars(char* first, char* last, @\placeholder{floating-point-t
 \begin{itemdescr}
 \pnum
 \effects
+Let \tcode{T} be \tcode{\placeholder{floating-point-type}}.
 \tcode{value} is converted to a string
 in the style of \tcode{printf}
 in the \tcode{"C"} locale.
-The conversion specifier is \tcode{f} or \tcode{e},
-chosen according to the requirement for a shortest representation
-(see above);
-a tie is resolved in favor of \tcode{f}.
+The conversion specifier is \tcode{f} if
+the absolute value of \tcode{value} is in the range \range{$l$}{$u$}, where
+$l$ is the smallest value larger than or equal to $10^{-4}$
+that is representable by \tcode{T} and
+$u$ is the largest value smaller than or equal to
+$\tcode{std::numeric_limits<T>::radix}^{\tcode{std::numeric_limits<T>::digits + 1}}$
+rounded down to the nearest power of 10 representable by \tcode{T},
+otherwise \tcode{e}.
 
 \pnum
 \throws


### PR DESCRIPTION
Fixes #9094
Also fixes https://github.com/cplusplus/papers/issues/2245