### PR TITLE
[2026-06 LWG Motion 5] P4206R0 Revert string support in `std::constant_wrapper`

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -622,7 +622,7 @@ the values of these macros with greater values.
 #define @\defnlibxname{cpp_lib_complex_udls}@                      201309L // also in \libheader{complex}
 #define @\defnlibxname{cpp_lib_concepts}@                          202207L
   // freestanding, also in \libheader{concepts}, \libheader{compare}
-#define @\defnlibxname{cpp_lib_constant_wrapper}@                  202603L // freestanding, also in \libheader{utility}
+#define @\defnlibxname{cpp_lib_constant_wrapper}@                  202606L // freestanding, also in \libheader{utility}
 #define @\defnlibxname{cpp_lib_constexpr_algorithms}@              202306L // also in \libheader{algorithm}, \libheader{utility}
 #define @\defnlibxname{cpp_lib_constexpr_atomic}@                  202411L // also in \libheader{atomic}
 #define @\defnlibxname{cpp_lib_constexpr_bitset}@                  202207L // also in \libheader{bitset}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -98,10 +98,7 @@ namespace std {
   void observable_checkpoint() noexcept;
 
   // \ref{const.wrap.class}, class template \tcode{constant_wrapper}
-  template<class T>
-    struct @\exposidnc{cw-fixed-value}@;              // \expos
-
-  template<@\exposidnc{cw-fixed-value}@ X, class = typename decltype(X)::@\exposid{type}@>
+  template<auto X, class = decltype(X)>
     struct constant_wrapper;
 
   template<class T>
@@ -110,7 +107,7 @@ namespace std {
 
   struct @\exposidnc{cw-operators}@;                  // \expos
 
-  template<@\exposid{cw-fixed-value}@ X>
+  template<auto X>
     constexpr auto @\libglobal{cw}@ = constant_wrapper<X>{};
 
   // \ref{intseq}, compile-time integer sequences%
@@ -754,23 +751,6 @@ Establishes an observable checkpoint\iref{intro.abstract}.
 
 \begin{codeblock}
 namespace std {
-  template<class T>
-  struct @\exposidnc{cw-fixed-value}@ {                                               // \expos
-    using @\exposidnc{type}@ = T;                                                     // \expos
-    constexpr @\exposidnc{cw-fixed-value}@(@\exposidnc{type}@ v) noexcept : @\exposidnc{data}@(v) {}
-    T @\exposidnc{data}@;                                                             // \expos
-  };
-
-  template<class T, size_t Extent>
-  struct @\exposidnc{cw-fixed-value}@<T[Extent]> {                                    // \expos
-    using @\exposidnc{type}@ = T[Extent];                                             // \expos
-    constexpr @\exposidnc{cw-fixed-value}@(T (&arr)[Extent]) noexcept;
-    T @\exposidnc{data}@[Extent];                                                     // \expos
-  };
-
-  template<class T, size_t Extent>
-    @\exposidnc{cw-fixed-value}@(T (&)[Extent]) -> @\exposidnc{cw-fixed-value}@<T[Extent]>;         // \expos
-
   struct @\exposidnc{cw-operators}@ {                                                 // \expos
     // unary operators
     template<@\exposconcept{constexpr-param}@ T>
@@ -914,11 +894,11 @@ namespace std {
         -> constant_wrapper<(T::value >>= R::value)> { return {}; }
   };
 
-  template<@\exposid{cw-fixed-value}@ X, class>
+  template<auto X, class T = decltype(X)>
   struct @\libglobal{constant_wrapper}@ : @\exposid{cw-operators}@ {
-    static constexpr const auto & value = X.@\exposid{data}@;
+    static constexpr decltype(auto) value = (X);
     using type = constant_wrapper;
-    using value_type = decltype(X)::@\exposid{type}@;
+    using value_type = decltype(X);
 
     template<@\exposconcept{constexpr-param}@ R>
       constexpr auto operator=(R) const noexcept
@@ -943,8 +923,11 @@ In particular, this enables use of \tcode{constant_wrapper} values
 that are passed as arguments to constexpr functions to be used in constant expressions.
 
 \pnum
+If a specialization of \tcode{constant_wrapper} is instantiated with a type \tcode{T}
+such that \tcode{is_same_v<T, value_type>} is \tcode{false},
+the program is ill-formed.
 \begin{note}
-The unnamed second template parameter to \tcode{constant_wrapper} is present
+The second template parameter to \tcode{constant_wrapper} is present
 to aid argument-dependent lookup\iref{basic.lookup.argdep}
 in finding overloads for which \tcode{constant_wrapper}'s wrapped value is a suitable argument,
 but for which the \tcode{constant_wrapper} itself is not.
@@ -981,16 +964,6 @@ but for which the \tcode{constant_wrapper} itself is not.
   }
 \end{codeblock}
 \end{example}
-
-\begin{itemdecl}
-constexpr @\exposid{cw-fixed-value}@(T (&arr)[Extent]) noexcept;
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\effects
-Initialize elements of \exposid{data} with corresponding elements of \tcode{arr}.
-\end{itemdescr}
 
 \indexlibrarymember{operator()}{constant_wrapper}%
 \begin{itemdecl}


### PR DESCRIPTION
Fixes #9092
Also fixes https://github.com/cplusplus/papers/issues/2770