### PR TITLE
[2026-06 LWG Motion 6] P3395R6 (Fix encoding issues and add a formatter for std::error_code)

### DIFF
--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -764,6 +764,9 @@ namespace std {
     constexpr bool @\libglobal{is_error_code_enum_v}@ = is_error_code_enum<T>::value;
   template<class T>
     constexpr bool @\libglobal{is_error_condition_enum_v}@ = is_error_condition_enum<T>::value;
+
+  // \ref{syserr.fmt}, formatter
+  template<class T> struct formatter<error_code, charT>;
 }
 \end{codeblock}
 
@@ -836,7 +839,7 @@ virtual const char* name() const noexcept = 0;
 \begin{itemdescr}
 \pnum
 \returns
-A string naming the error category.
+A string in the ordinary literal encoding naming the error category.
 \end{itemdescr}
 
 \indexlibrarymember{default_error_condition}{error_category}%
@@ -880,7 +883,8 @@ virtual string message(int ev) const = 0;
 \begin{itemdescr}
 \pnum
 \returns
-A string that describes the error condition denoted by \tcode{ev}.
+A string of multibyte characters in the execution character set
+that describes the error condition denoted by \tcode{ev}.
 \end{itemdescr}
 
 \rSec3[syserr.errcat.nonvirtuals]{Non-virtual members}
@@ -1233,6 +1237,98 @@ template<class charT, class traits>
 \pnum
 \effects
 Equivalent to: \tcode{return os << ec.category().name() << ':' << ec.value();}
+\end{itemdescr}
+
+\rSec3[syserr.fmt]{Formatting}
+
+\pnum
+\indexlibraryglobal{formatter}%
+\begin{codeblock}
+template<class charT>
+struct formatter<error_code, charT> {
+  constexpr void set_debug_format();
+
+  constexpr typename basic_format_parse_context<charT>::iterator
+    parse(basic_format_parse_context<charT>& ctx);
+
+  template<class Out>
+    typename basic_format_context<Out, charT>::iterator
+      format(const error_code& ec, basic_format_context<Out, charT>& ctx) const;
+};
+\end{codeblock}
+
+\indexlibrarymember{set_debug_format}{formatter}%
+\begin{itemdecl}
+constexpr void set_debug_format();
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Modifies the state of the \tcode{formatter} to be as if the
+\fmtgrammarterm{error-code-format-spec} parsed by the
+last call to \tcode{parse} contained the \tcode{?} option.
+\end{itemdescr}
+
+\indexlibrarymember{parse}{formatter}%
+\begin{itemdecl}
+constexpr typename basic_format_parse_context<charT>::iterator
+  parse(basic_format_parse_context<charT>& ctx);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Parses the format specifier as an \fmtgrammarterm{error-code-format-spec}
+and stores the parsed specifiers in \tcode{*this}.
+
+\begin{ncbnf}
+\fmtnontermdef{error-code-format-spec}\br
+    \opt{fill-and-align} \opt{width} \opt{\tcode{?}} \opt{\tcode{s}}
+\end{ncbnf}
+
+where the productions \fmtgrammarterm{fill-and-align} and \fmtgrammarterm{width} are
+described in \ref{format.string}.
+
+\pnum
+\returns
+An iterator past the end of the \fmtgrammarterm{error-code-format-spec}.
+\end{itemdescr}
+
+\indexlibrarymember{format}{formatter}%
+\begin{itemdecl}
+template<class Out>
+  typename basic_format_context<Out, charT>::iterator
+    format(const error_code& ec, basic_format_context<Out, charT>& ctx) const;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+If the \tcode{s} option is used, then:
+\begin{itemize}
+\item
+If \tcode{charT} is \tcode{char} and the ordinary literal encoding is UTF-8,
+then let \tcode{msg} be \tcode{ec.message()} transcoded to UTF-8
+with maximal subparts of ill-formed subsequences
+substituted with \unicode{fffd}{replacement character}
+per the Unicode Standard, Chapter 3.9 \unicode{fffd} Substi\-tution in Conversion.
+\item
+Otherwise, let \tcode{msg} be \tcode{ec.message()}
+transcoded to an
+\impldef{encoding of a error message during formatting}
+encoding.
+\end{itemize}
+Otherwise, let \tcode{msg} be
+\tcode{format("\{\}:\{\}", ec.category().name(), ec.value())}.
+If the \tcode{?} option is used then \tcode{msg} is formatted
+as an escaped string\iref{format.string.escaped}.
+Writes \tcode{msg} into \tcode{ctx.out()},
+adjusted according to the \fmtgrammarterm{error-code-format-spec}.
+
+\pnum
+\returns
+An iterator past the end of the output range.
 \end{itemdescr}
 
 

--- a/source/diagnostics.tex
+++ b/source/diagnostics.tex
@@ -1281,14 +1281,13 @@ constexpr typename basic_format_parse_context<charT>::iterator
 \effects
 Parses the format specifier as an \fmtgrammarterm{error-code-format-spec}
 and stores the parsed specifiers in \tcode{*this}.
-
+The syntax of format specifications is
 \begin{ncbnf}
 \fmtnontermdef{error-code-format-spec}\br
-    \opt{fill-and-align} \opt{width} \opt{\tcode{?}} \opt{\tcode{s}}
+    \opt{fill-and-align} \opt{width} \opt{\terminal{?}} \opt{\terminal{s}}
 \end{ncbnf}
-
-where the productions \fmtgrammarterm{fill-and-align} and \fmtgrammarterm{width} are
-described in \ref{format.string}.
+where the productions \fmtgrammarterm{fill-and-align} and \fmtgrammarterm{width}
+are described in \ref{format.string}.
 
 \pnum
 \returns


### PR DESCRIPTION
Fixes: #9093 
Also Fixes https://github.com/cplusplus/papers/issues/2187