### PR TITLE
[2026-06 CWG Motion 10] P3950R1 return_value & return_void Are Not Mutually Exclusive

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -7554,17 +7554,6 @@ of a coroutine is ill-formed\iref{dcl.contract.func}.
 \end{note}
 
 \pnum
-If searches for the names \tcode{return_void} and \tcode{return_value}
-in the scope of the promise type each find any declarations,
-the program is ill-formed.
-\begin{note}
-If \tcode{return_void} is found, flowing off
-the end of a coroutine is equivalent to a \keyword{co_return} with no operand.
-Otherwise, flowing off the end of a coroutine
-results in undefined behavior\iref{stmt.return.coroutine}.
-\end{note}
-
-\pnum
 The expression \tcode{\exposid{promise}.get_return_object()} is used
 to initialize
 the returned reference or prvalue result object of a call to a coroutine.

--- a/source/preprocessor.tex
+++ b/source/preprocessor.tex
@@ -2369,7 +2369,7 @@ an \impldef{text of \mname{TIME} when time of translation is not available} vali
 \defnxname{cpp_hex_float}                         & \tcode{201603L} \\ \rowsep
 \defnxname{cpp_if_consteval}                      & \tcode{202106L} \\ \rowsep
 \defnxname{cpp_if_constexpr}                      & \tcode{201606L} \\ \rowsep
-\defnxname{cpp_impl_coroutine}                    & \tcode{201902L} \\ \rowsep
+\defnxname{cpp_impl_coroutine}                    & \tcode{202606L} \\ \rowsep
 \defnxname{cpp_impl_destroying_delete}            & \tcode{201806L} \\ \rowsep
 \defnxname{cpp_impl_reflection}                   & \tcode{202603L} \\ \rowsep
 \defnxname{cpp_impl_three_way_comparison}         & \tcode{201907L} \\ \rowsep

--- a/source/statements.tex
+++ b/source/statements.tex
@@ -1221,8 +1221,7 @@ shall be a prvalue of type \keyword{void}.
 \end{itemize}
 
 \pnum
-If a search for the name \tcode{return_void} in the scope of the promise type
-finds any declarations,
+If overload resolution for \placeholder{p}\tcode{.return_void()} succeeds,
 flowing off the end of a coroutine's \grammarterm{function-body}
 is equivalent to a \keyword{co_return} with no operand;
 otherwise flowing off the end of a coroutine's \grammarterm{function-body}


### PR DESCRIPTION
Fixes: #9077
Also Fixes: https://github.com/cplusplus/papers/issues/2601