### PR TITLE
[mdspan.sub.helpers] Fix swapped offset/extent in canonical-slice

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -25946,8 +25946,8 @@ if constexpr (is_convertible_v<S, full_extent_t>) {
   return @\exposid{canonical-index}@<IndexType>(std::move(s));
 } else if constexpr (@\exposconcept{is-extent-slice}@<S>) {
   return extent_slice{
-    .offset = @\exposid{canonical-index}@<IndexType>(std::move(s.extent)),
-    .extent = @\exposid{canonical-index}@<IndexType>(std::move(s.offset)),
+    .offset = @\exposid{canonical-index}@<IndexType>(std::move(s.offset)),
+    .extent = @\exposid{canonical-index}@<IndexType>(std::move(s.extent)),
     .stride = @\exposid{canonical-index}@<IndexType>(std::move(s.stride))
   };
 } else if constexpr (@\exposconcept{is-range-slice}@<S>) {


### PR DESCRIPTION
The `extent_slice` branch of `canonical-slice` ([mdspan.sub.helpers]) initializes `.offset` from `s.extent` and `.extent` from `s.offset`, reversing the intended mapping. This is inconsistent with `canonical-range-slice` and the pre-P3982R2 wording, both of which map offset → offset and extent → extent.