### PR TITLE
[linalg.algs.blas1.iamax] Fix return type of vector_idx_abs_max

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -11143,9 +11143,9 @@ namespace std::linalg {
 
   // \ref{linalg.algs.blas1.iamax}, index of maximum absolute value of vector elements
   template<@\exposconcept{in-vector}@ InVec>
-    typename InVec::extents_type vector_idx_abs_max(InVec v);
+    typename InVec::size_type vector_idx_abs_max(InVec v);
   template<class ExecutionPolicy, @\exposconcept{in-vector}@ InVec>
-    typename InVec::extents_type vector_idx_abs_max(ExecutionPolicy&& exec, InVec v);
+    typename InVec::size_type vector_idx_abs_max(ExecutionPolicy&& exec, InVec v);
 
   // \ref{linalg.algs.blas1.matfrobnorm}, Frobenius norm of a matrix
   template<@\exposconcept{in-matrix}@ InMat, @\exposconcept{scalar}@ Scalar>
@@ -13980,9 +13980,9 @@ return vector_abs_sum(std::forward<ExecutionPolicy>(exec), v, T{});
 \indexlibraryglobal{vector_idx_abs_max}%
 \begin{itemdecl}
 template<@\exposconcept{in-vector}@ InVec>
-  typename InVec::extents_type vector_idx_abs_max(InVec v);
+  typename InVec::size_type vector_idx_abs_max(InVec v);
 template<class ExecutionPolicy, @\exposconcept{in-vector}@ InVec>
-  typename InVec::extents_type vector_idx_abs_max(ExecutionPolicy&& exec, InVec v);
+  typename InVec::size_type vector_idx_abs_max(ExecutionPolicy&& exec, InVec v);
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
The declarations of `vector_idx_abs_max` in `[linalg.syn]` and `[linalg.algs.blas1.iamax]` use `extents_type` (a `std::extents` shape type) as the return type, but the *Returns* clause specifies a scalar index of type `size_type`. Replace `extents_type` with `size_type` in all four declaration sites.