### PR TITLE
[utility.arg.requirements] reformat in a style like [container.reqmts]

### DIFF
--- a/source/algorithms.tex
+++ b/source/algorithms.tex
@@ -4618,10 +4618,10 @@ template<class InputIterator, class Function>
 \pnum
 \expects
 \tcode{Function} meets
-the \oldconcept{MoveConstructible} requirements (\tref{cpp17.moveconstructible}).
+the \oldconcept{MoveConstructible} requirements\iref{cpp17.moveconstructible}.
 \begin{note}
 \tcode{Function} need not meet the requirements of
-\oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible}).
+\oldconcept{CopyConstructible}\iref{cpp17.copyconstructible}.
 \end{note}
 
 \pnum
@@ -6570,7 +6570,7 @@ do not overlap.
 For the parallel algorithm overload in namespace \tcode{std},
 there can be a performance cost
 if \tcode{iterator_traits<For\-ward\-It\-er\-ator1>::value_type}
-does not meet the \oldconcept{\-Move\-Constructible} (\tref{cpp17.moveconstructible}) requirements.
+does not meet the \oldconcept{\-Move\-Constructible}\iref{cpp17.moveconstructible} requirements.
 For the parallel algorithm overloads in namespace \tcode{ranges},
 there can be a performance cost
 if \tcode{iter_value_t<I>} does not model \libconcept{move_constructible}.
@@ -7597,7 +7597,7 @@ Let $E(\tcode{i})$ be
 \expects
 For the algorithms in namespace \tcode{std},
 the type of \tcode{*first}
-meets the \oldconcept{MoveAssignable} requirements (\tref{cpp17.moveassignable}).
+meets the \oldconcept{MoveAssignable} requirements\iref{cpp17.moveassignable}.
 
 \pnum
 \effects
@@ -7747,7 +7747,7 @@ do not overlap.
 For the parallel algorithm overloads in namespace \tcode{std},
 there can be a performance cost
 if \tcode{iterator_traits<ForwardIterator1>::value_type} does not meet
-the \oldconcept{\-Move\-Constructible} (\tref{cpp17.moveconstructible}) requirements.
+the \oldconcept{\-Move\-Constructible}\iref{cpp17.moveconstructible} requirements.
 For the parallel algorithm overloads in namespace \tcode{ranges},
 there can be a performance cost
 if \tcode{iter_value_t<I>} does not model \libconcept{move_constructible}.
@@ -7848,7 +7848,7 @@ let $E(\tcode{i})$ be
 For the overloads in namespace \tcode{std},
 \tcode{pred} is an equivalence relation and
 the type of \tcode{*first} meets
-the \oldconcept{MoveAssignable} requirements (\tref{cpp17.moveassignable}).
+the \oldconcept{MoveAssignable} requirements\iref{cpp17.moveassignable}.
 
 \pnum
 \effects
@@ -7982,9 +7982,9 @@ Let:
     the \oldconcept{ForwardIterator} requirements and
     its value type is the same as \tcode{T},
     then \tcode{T} meets
-    the \oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}) requirements.
+    the \oldconcept{CopyAssignable}\iref{cpp17.copyassignable} requirements.
     Otherwise, \tcode{T} meets both
-    the \oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible}) and
+    the \oldconcept{CopyConstructible}\iref{cpp17.copyconstructible} and
     \oldconcept{CopyAssignable} requirements.
   \end{itemize}
 \end{itemize}
@@ -8198,8 +8198,8 @@ For the overloads in namespace \tcode{std},
 \tcode{ForwardIterator} meets
 the \oldconcept{ValueSwappable} requirements\iref{swappable.requirements}, and
 the type of \tcode{*first} meets
-the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{MoveAssignable} (\tref{cpp17.moveassignable}) requirements.
+the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} and
+\oldconcept{MoveAssignable}\iref{cpp17.moveassignable} requirements.
 
 \pnum
 \effects
@@ -8803,8 +8803,8 @@ For the overloads in namespace \tcode{std},
 \tcode{RandomAccessIterator} meets
 the \oldconcept{Value\-Swappable} requirements\iref{swappable.requirements} and
 the type of \tcode{*first} meets
-the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{MoveAssignable} (\tref{cpp17.moveassignable}) requirements.
+the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} and
+\oldconcept{MoveAssignable}\iref{cpp17.moveassignable} requirements.
 
 \pnum
 \effects
@@ -8871,8 +8871,8 @@ For the overloads in namespace \tcode{std},
 \tcode{RandomAccessIterator} meets
 the \oldconcept{Value\-Swappable} requirements\iref{swappable.requirements} and
 the type of \tcode{*first} meets
-the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{MoveAssignable} (\tref{cpp17.moveassignable}) requirements.
+the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} and
+\oldconcept{MoveAssignable}\iref{cpp17.moveassignable} requirements.
 
 \pnum
 \effects
@@ -8945,8 +8945,8 @@ For the overloads in namespace \tcode{std},
 \tcode{RandomAccessIterator} meets
 the \oldconcept{ValueSwappable} requirements\iref{swappable.requirements} and
 the type of \tcode{*first} meets
-the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{MoveAssignable} (\tref{cpp17.moveassignable}) requirements.
+the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} and
+\oldconcept{MoveAssignable}\iref{cpp17.moveassignable} requirements.
 
 \pnum
 \effects
@@ -9092,8 +9092,8 @@ For the overloads in namespace \tcode{std},
 \tcode{RandomAccessIterator} meets
 the \oldconcept{Value\-Swappable} requirements\iref{swappable.requirements},
 the type of \tcode{*result_first} meets
-the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{\-Move\-Assignable} (\tref{cpp17.moveassignable}) requirements.
+the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} and
+\oldconcept{\-Move\-Assignable}\iref{cpp17.moveassignable} requirements.
 
 \pnum
 For iterators \tcode{a1} and \tcode{b1} in \range{first}{last}, and
@@ -9330,8 +9330,8 @@ For the overloads in namespace \tcode{std},
 \tcode{RandomAccessIterator} meets
 the \oldconcept{ValueSwappable} requirements\iref{swappable.requirements}, and
 the type of \tcode{*first} meets
-the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{MoveAssignable} (\tref{cpp17.moveassignable}) requirements.
+the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} and
+\oldconcept{MoveAssignable}\iref{cpp17.moveassignable} requirements.
 
 \pnum
 \effects
@@ -9796,8 +9796,8 @@ For the overloads in namespace \tcode{std},
 \tcode{BidirectionalIterator} meets
 the \oldconcept{Value\-Swappable} requirements\iref{swappable.requirements} and
 the type of \tcode{*first} meets
-the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{MoveAssignable} (\tref{cpp17.moveassignable}) requirements.
+the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} and
+\oldconcept{MoveAssignable}\iref{cpp17.moveassignable} requirements.
 
 \pnum
 \effects
@@ -10196,8 +10196,8 @@ For the overloads in namespace \tcode{std},
 \tcode{BidirectionalIterator} meets
 the \oldconcept{Value\-Swappable} requirements\iref{swappable.requirements} and
 the type of \tcode{*first} meets
-the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{MoveAssignable} (\tref{cpp17.moveassignable}) requirements.
+the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} and
+\oldconcept{MoveAssignable}\iref{cpp17.moveassignable} requirements.
 
 \pnum
 \effects
@@ -10963,8 +10963,8 @@ For the overloads in namespace \tcode{std},
 \tcode{RandomAccessIterator} meets
 the \oldconcept{ValueSwappable} requirements\iref{swappable.requirements} and
 the type of \tcode{*first} meets
-the \oldconcept{MoveConstructible} requirements (\tref{cpp17.moveconstructible}) and
-the \oldconcept{MoveAssignable} requirements (\tref{cpp17.moveassignable}).
+the \oldconcept{MoveConstructible} requirements\iref{cpp17.moveconstructible} and
+the \oldconcept{MoveAssignable} requirements\iref{cpp17.moveassignable}.
 
 \pnum
 \effects
@@ -11016,8 +11016,8 @@ For the overloads in namespace \tcode{std},
 \tcode{RandomAccessIterator} meets
 the \oldconcept{ValueSwappable} requirements\iref{swappable.requirements} and
 the type of \tcode{*first} meets
-the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{MoveAssignable} (\tref{cpp17.moveassignable}) requirements.
+the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} and
+\oldconcept{MoveAssignable}\iref{cpp17.moveassignable} requirements.
 
 \pnum
 \effects
@@ -11072,8 +11072,8 @@ For the overloads in namespace \tcode{std},
 \tcode{RandomAccessIterator} meets
 the \oldconcept{ValueSwap\-pable} requirements\iref{swappable.requirements} and
 the type of \tcode{*first} meets
-the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{MoveAssignable} (\tref{cpp17.moveassignable}) requirements.
+the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} and
+\oldconcept{MoveAssignable}\iref{cpp17.moveassignable} requirements.
 
 \pnum
 \effects
@@ -11125,8 +11125,8 @@ For the overloads in namespace \tcode{std},
 \tcode{RandomAccessIterator} meets
 the \oldconcept{ValueSwappable} requirements\iref{swappable.requirements} and
 the type of \tcode{*first} meets
-the \oldconcept{MoveConst\-ruct\-ible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{Move\-Assign\-able} (\tref{cpp17.moveassignable}) requirements.
+the \oldconcept{MoveConst\-ruct\-ible}\iref{cpp17.moveconstructible} and
+\oldconcept{Move\-Assign\-able}\iref{cpp17.moveassignable} requirements.
 
 \pnum
 \effects
@@ -11313,7 +11313,7 @@ template<class T, class Proj = identity,
 \pnum
 \expects
 For the first form, \tcode{T} meets the
-\oldconcept{LessThanComparable} requirements (\tref{cpp17.lessthancomparable}).
+\oldconcept{LessThanComparable} requirements\iref{cpp17.lessthancomparable}.
 
 \pnum
 \returns
@@ -11360,7 +11360,7 @@ template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-acces
 For the overloads in namespace \tcode{std},
 \tcode{T} meets the \oldconcept{\-Copy\-Constructible} requirements.
 For the first form, \tcode{T} meets the \oldconcept{LessThanComparable}
-requirements (\tref{cpp17.lessthancomparable}).
+requirements\iref{cpp17.lessthancomparable}.
 
 \pnum
 \returns
@@ -11396,7 +11396,7 @@ template<class T, class Proj = identity,
 \pnum
 \expects
 For the first form, \tcode{T} meets the
-\oldconcept{LessThanComparable} requirements (\tref{cpp17.lessthancomparable}).
+\oldconcept{LessThanComparable} requirements\iref{cpp17.lessthancomparable}.
 
 \pnum
 \returns
@@ -11443,7 +11443,7 @@ template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-acces
 For the overloads in namespace \tcode{std},
 \tcode{T} meets the \oldconcept{\-Copy\-Constructible} requirements.
 For the first form, \tcode{T} meets the \oldconcept{LessThanComparable}
-requirements (\tref{cpp17.lessthancomparable}).
+requirements\iref{cpp17.lessthancomparable}.
 
 \pnum
 \returns
@@ -11481,7 +11481,7 @@ template<class T, class Proj = identity,
 \pnum
 \expects
 For the first form, \tcode{T} meets the
-\oldconcept{LessThanComparable} requirements (\tref{cpp17.lessthancomparable}).
+\oldconcept{LessThanComparable} requirements\iref{cpp17.lessthancomparable}.
 
 \pnum
 \returns
@@ -11529,7 +11529,7 @@ template<@\exposconcept{execution-policy}@ Ep, @\exposconcept{sized-random-acces
 For the overloads in namespace \tcode{std},
 \tcode{T} meets the \oldconcept{\-Copy\-Constructible} requirements.
 For the first form, type \tcode{T} meets the \oldconcept{LessThanComparable}
-requirements (\tref{cpp17.lessthancomparable}).
+requirements\iref{cpp17.lessthancomparable}.
 
 \pnum
 \returns
@@ -11751,7 +11751,7 @@ for the overloads with no parameter \tcode{proj}.
 \tcode{bool(invoke(comp, invoke(proj, hi), invoke(proj, lo)))} is \tcode{false}.
 For the first form, type \tcode{T}
 meets the \oldconcept{LessThan\-Comparable}
-requirements (\tref{cpp17.lessthancomparable}).
+requirements\iref{cpp17.lessthancomparable}.
 
 \pnum
 \returns
@@ -12331,8 +12331,8 @@ template<class InputIterator, class T, class BinaryOperation>
 \pnum
 \expects
 \tcode{T} meets
-the \oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible})
-and \oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}) requirements.
+the \oldconcept{CopyConstructible}\iref{cpp17.copyconstructible}
+and \oldconcept{CopyAssignable}\iref{cpp17.copyassignable} requirements.
 In the range \crange{first}{last},
 \tcode{binary_op} neither modifies elements
 nor invalidates iterators or subranges.
@@ -12454,7 +12454,7 @@ are convertible to \tcode{T}.
 \expects
 \begin{itemize}
 \item
-  \tcode{T} meets the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) requirements.
+  \tcode{T} meets the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} requirements.
 \item
   \tcode{binary_op} neither invalidates iterators or subranges,
   nor modifies elements in the range \crange{first}{last}.
@@ -12498,8 +12498,8 @@ template<class InputIterator1, class InputIterator2, class T,
 \pnum
 \expects
 \tcode{T} meets
-the \oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible})
-and \oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}) requirements.
+the \oldconcept{CopyConstructible}\iref{cpp17.copyconstructible}
+and \oldconcept{CopyAssignable}\iref{cpp17.copyassignable} requirements.
 In the ranges \crange{first1}{last1} and
 \crange{first2}{first2 + (last1 - first1)}
 \tcode{binary_op1} and \tcode{binary_op2}
@@ -12594,7 +12594,7 @@ All of
 \expects
 \begin{itemize}
 \item
-  \tcode{T} meets the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) requirements.
+  \tcode{T} meets the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} requirements.
 \item
   Neither \tcode{binary_op1} nor \tcode{binary_op2}
   invalidates subranges, nor modifies elements in the ranges
@@ -12644,7 +12644,7 @@ template<class ExecutionPolicy,
 \expects
 \begin{itemize}
 \item
-  \tcode{T} meets the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) requirements.
+  \tcode{T} meets the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} requirements.
 \item
   Neither \tcode{unary_op} nor \tcode{binary_op} invalidates subranges,
   nor modifies elements in the range \crange{first}{last}.
@@ -12793,7 +12793,7 @@ template<class ExecutionPolicy,
 \expects
 \begin{itemize}
 \item
-  \tcode{T} meets the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) requirements.
+  \tcode{T} meets the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} requirements.
 \item
   \tcode{binary_op} neither invalidates iterators or subranges,
   nor modifies elements in
@@ -12914,7 +12914,7 @@ is convertible to \tcode{U}.
 \begin{itemize}
 \item
   If \tcode{init} is provided,
-  \tcode{T} meets the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) requirements;
+  \tcode{T} meets the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} requirements;
   otherwise, \tcode{U}
   meets the \oldconcept{MoveConstructible} requirements.
 \item
@@ -12993,7 +12993,7 @@ template<class ExecutionPolicy,
 \expects
 \begin{itemize}
 \item
-  \tcode{T} meets the \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) requirements.
+  \tcode{T} meets the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} requirements.
 \item
   Neither \tcode{unary_op} nor \tcode{binary_op}
   invalidates iterators or subranges, nor modifies elements in
@@ -13092,7 +13092,7 @@ is convertible to \tcode{U}.
 \begin{itemize}
 \item
   If \tcode{init} is provided, \tcode{T} meets the
-  \oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) requirements;
+  \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} requirements;
   otherwise, \tcode{U} meets the
   \oldconcept{MoveConstructible} requirements.
 \item
@@ -13193,7 +13193,7 @@ that denotes an object of type \tcode{minus<>}.
 \begin{itemize}
 \item
   For the overloads with no \tcode{ExecutionPolicy},
-  \tcode{T} meets the \oldconcept{MoveAssignable} (\tref{cpp17.moveassignable})
+  \tcode{T} meets the \oldconcept{MoveAssignable}\iref{cpp17.moveassignable}
   requirements.
 \item
   For all overloads, in the ranges \crange{first}{last}

--- a/source/concepts.tex
+++ b/source/concepts.tex
@@ -754,7 +754,7 @@ template<class T>
 \begin{itemdescr}
 \pnum
 \begin{note}
-Unlike the \oldconcept{Destructible} requirements~(\tref{cpp17.destructible}), this
+Unlike the \oldconcept{Destructible} requirements\iref{cpp17.destructible}, this
 concept forbids destructors that are potentially throwing, even if a particular
 invocation of the destructor does not actually throw.
 \end{note}

--- a/source/future.tex
+++ b/source/future.tex
@@ -467,7 +467,7 @@ template<class T> bool operator!=(const T& x, const T& y);
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{T} meets the \oldconcept{EqualityComparable} requirements (\tref{cpp17.equalitycomparable}).
+\tcode{T} meets the \oldconcept{EqualityComparable} requirements\iref{cpp17.equalitycomparable}.
 
 \pnum
 \returns
@@ -482,7 +482,7 @@ template<class T> bool operator>(const T& x, const T& y);
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{T} meets the \oldconcept{LessThanComparable} requirements (\tref{cpp17.lessthancomparable}).
+\tcode{T} meets the \oldconcept{LessThanComparable} requirements\iref{cpp17.lessthancomparable}.
 
 \pnum
 \returns
@@ -497,7 +497,7 @@ template<class T> bool operator<=(const T& x, const T& y);
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{T} meets the \oldconcept{LessThanComparable} requirements (\tref{cpp17.lessthancomparable}).
+\tcode{T} meets the \oldconcept{LessThanComparable} requirements\iref{cpp17.lessthancomparable}.
 
 \pnum
 \returns
@@ -512,7 +512,7 @@ template<class T> bool operator>=(const T& x, const T& y);
 \begin{itemdescr}
 \pnum
 \expects
-\tcode{T} meets the \oldconcept{LessThanComparable} requirements (\tref{cpp17.lessthancomparable}).
+\tcode{T} meets the \oldconcept{LessThanComparable} requirements\iref{cpp17.lessthancomparable}.
 
 \pnum
 \returns

--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -1684,10 +1684,10 @@ An \tcode{fpos} type specifies file position information.
 It holds a state object
 whose type is equal to the template parameter \tcode{stateT}.
 Type \tcode{stateT} shall meet
-the \oldconcept{DefaultConstructible} (\tref{cpp17.defaultconstructible}),
-\oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible}),
-\oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}), and
-\oldconcept{Destructible} (\tref{cpp17.destructible}) requirements.
+the \oldconcept{DefaultConstructible}\iref{cpp17.defaultconstructible},
+\oldconcept{CopyConstructible}\iref{cpp17.copyconstructible},
+\oldconcept{CopyAssignable}\iref{cpp17.copyassignable}, and
+\oldconcept{Destructible}\iref{cpp17.destructible} requirements.
 If \tcode{is_trivially_copy_constructible_v<stateT>} is \tcode{true},
 then \tcode{fpos<stateT>} has a trivial copy constructor.
 If \tcode{is_trivially_copy_assignable_v<stateT>} is \tcode{true},
@@ -1699,7 +1699,7 @@ the \oldconcept{DefaultConstructible},
 \oldconcept{CopyConstructible},
 \oldconcept{CopyAssignable},
 \oldconcept{Destructible},
-and \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable}) requirements.
+and \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable} requirements.
 In addition, the expressions shown in \tref{fpos.operations}
 are valid and have the indicated semantics.
 In that table,

--- a/source/iterators.tex
+++ b/source/iterators.tex
@@ -2094,7 +2094,7 @@ meets the requirements of an input iterator for the value type
 \tcode{T}
 if
 \tcode{X} meets the \oldconcept{Iterator}\iref{iterator.iterators} and
-\oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable}) requirements and
+\oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable} requirements and
 the expressions in \tref{inputiterator} are valid and have
 the indicated semantics.
 
@@ -2184,7 +2184,7 @@ such an algorithm should be a single pass algorithm.
 \begin{note}
 For input iterators, \tcode{a == b} does not imply \tcode{++a == ++b}.
 (Equality does not guarantee the substitution property or referential transparency.)
-Value type \tcode{T} is not required to be a \oldconcept{CopyAssignable} type (\tref{cpp17.copyassignable}).
+Value type \tcode{T} is not required to be a \oldconcept{CopyAssignable} type\iref{cpp17.copyassignable}.
 Such an algorithm can be used with istreams as the source of the input data through the
 \tcode{istream_iterator}
 class template.

--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -262,8 +262,8 @@ The library specification uses a typographical convention for naming
 requirements. Names in \textit{italic} type that begin with the prefix
 \oldconcept{} refer to sets of well-defined expression requirements typically
 presented in tabular form, possibly with additional prose semantic requirements.
-For example, \oldconcept{Destructible}~(\tref{cpp17.destructible}) is such a named
-requirement. Names in \tcode{constant width} type refer to library concepts
+For example, \oldconcept{Destructible}\iref{cpp17.destructible} is such a named requirement.
+Names in \tcode{constant width} type refer to library concepts
 which are presented as a concept definition\iref{temp}, possibly with additional
 prose semantic requirements. For example,
 \libconcept{destructible}\iref{concept.destructible}
@@ -1800,11 +1800,12 @@ allocators.
 
 \rSec3[utility.arg.requirements]{Template argument requirements}
 
+\rSec4[utility.arg.requirements.general]{General}
+
 \pnum
 The template definitions in the \Cpp{} standard library
-refer to various named requirements whose details are set out in
-Tables~\ref{tab:cpp17.equalitycomparable}--\ref{tab:cpp17.destructible}.
-In these tables,
+refer to various named requirements whose details are set out below.
+For each requirement in \ref{utility.arg.requirements}:
 \begin{itemize}
 \item
 \tcode{T} denotes an object or reference type to be
@@ -1824,105 +1825,218 @@ supplied by a \Cpp{} program instantiating a template,
 rvalue of type \tcode{const T}.
 \end{itemize}
 
-\begin{oldconcepttable}{EqualityComparable}{}{cpp17.equalitycomparable}
-{x{1in}x{1in}p{3in}}
-\topline
-\hdstyle{Expression}  &   \hdstyle{Return type} &   \rhdr{Requirement} \\ \capsep
-\tcode{a == b}  &
-\tcode{decltype(a == b)} models \exposconceptx{boolean-testa\-ble}{boolean-testable} &
-\tcode{==} is an equivalence relation,
-that is, it has the following properties:
+\rSec4[cpp17.equalitycomparable]{\defnoldconcept{EqualityComparable} requirements}
+
+\pnum
+A type \tcode{T} meets the \oldconcept{EqualityComparable} requirements if the following
+expression is well-formed and has the specified semantics:
+\begin{itemdecl}
+a == b
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{decltype(a == b)} models \exposconceptx{boolean-testa\-ble}{boolean-testable}
+
+\pnum
+\remarks
+\tcode{==} is an equivalence relation, that is, it has the following properties:
 \begin{itemize}
-\item
-For all \tcode{a}, \tcode{a == a}.
-\item
-If \tcode{a == b}, then \tcode{b == a}.
-\item
-If \tcode{a == b} and \tcode{b == c}, then \tcode{a == c}.
-\end{itemize} \\
-\end{oldconcepttable}
+\item For all \tcode{a}, \tcode{a == a}.
+\item If \tcode{a == b}, then \tcode{b == a}.
+\item If \tcode{a == b} and \tcode{b == c}, then \tcode{a == c}.
+\end{itemize}
+\end{itemdescr}
 
-\begin{oldconcepttable}{LessThanComparable}{}{cpp17.lessthancomparable}
-{x{1in}x{1in}p{3in}}
-\topline
-\hdstyle{Expression}  &   \hdstyle{Return type} &   \hdstyle{Requirement} \\ \capsep
-\tcode{a < b}   &
-\tcode{decltype(a < b)} models \exposconceptx{boolean-testa\-ble}{boolean-testable} &
-\tcode{<} is a strict weak ordering relation\iref{alg.sorting}    \\
-\end{oldconcepttable}
+\rSec4[cpp17.lessthancomparable]{\defnoldconcept{LessThanComparable} requirements}
 
-\begin{oldconcepttable}{DefaultConstructible}{}{cpp17.defaultconstructible}
-{x{2.15in}p{3in}}
-\topline
-\hdstyle{Expression}        &     \hdstyle{Post-condition}  \\ \capsep
-\tcode{T t;}      &     object \tcode{t} is default-initialized   \\ \rowsep
-\tcode{T u\{\};}    &     object \tcode{u} is value-initialized or aggregate-initialized \\ \rowsep
-\tcode{T()}\br\tcode{T\{\}}  &  an object of type \tcode{T} is value-initialized
-                                or aggregate-initialized \\
-\end{oldconcepttable}
+\pnum
+A type \tcode{T} meets the \oldconcept{LessThanComparable} requirements if the following
+expression is well-formed and has the specified semantics:
+\begin{itemdecl}
+a < b
+\end{itemdecl}
 
-\begin{oldconcepttable}{MoveConstructible}{}{cpp17.moveconstructible}
-{p{1in}p{4.15in}}
-\topline
-\hdstyle{Expression}          &   \hdstyle{Post-condition}  \\ \capsep
-\tcode{T u = rv;}    &   \tcode{u} is equivalent to the value of \tcode{rv} before the construction\\ \rowsep
-\tcode{T(rv)}       &
-  \tcode{T(rv)} is equivalent to the value of \tcode{rv} before the construction \\ \rowsep
-\multicolumn{2}{|p{5.3in}|}{
-  \tcode{rv}'s state is unspecified
-  \begin{tailnote}
-\tcode{rv} must still meet the requirements of the library
-  component that is using it. The operations listed in those requirements must
-  work as specified whether \tcode{rv} has been moved from or not.
-\end{tailnote}
-}\\
-\end{oldconcepttable}
+\begin{itemdescr}
+\pnum
+\result
+\tcode{decltype(a < b)} models \exposconceptx{boolean-testa\-ble}{boolean-testable}
 
-\begin{oldconcepttable}{CopyConstructible}{ (in addition to \oldconcept{MoveConstructible})}{cpp17.copyconstructible}
-{p{1in}p{4.15in}}
-\topline
-\hdstyle{Expression}          &   \hdstyle{Post-condition}  \\ \capsep
-\tcode{T u = v;}     &   the value of \tcode{v} is unchanged and is equivalent to \tcode{ u}\\ \rowsep
-\tcode{T(v)}        &
-  the value of \tcode{v} is unchanged and is equivalent to \tcode{T(v)} \\
-\end{oldconcepttable}
+\pnum
+\remarks
+\tcode{<} is a strict weak ordering relation\iref{alg.sorting}
+\end{itemdescr}
 
-\begin{oldconcepttable}{MoveAssignable}{}{cpp17.moveassignable}
-{p{1in}p{1in}p{1in}p{1.9in}}
-\topline
-\hdstyle{Expression} & \hdstyle{Return type} & \hdstyle{Return value} & \hdstyle{Post-condition} \\ \capsep
-\tcode{t = rv}  &   \tcode{T\&} &   \tcode{t}       &
-  If \tcode{t} and \tcode{rv} do not refer to the same object,
-  \tcode{t} is equivalent to the value of \tcode{rv} before the assignment\\ \rowsep
-\multicolumn{4}{|p{5.3in}|}{
-  \tcode{rv}'s state is unspecified.
-  \begin{tailnote}
-  \tcode{rv} must still meet the requirements of the library
-  component that is using it, whether or not \tcode{t} and \tcode{rv} refer to the same object.
-  The operations listed in those requirements must
-  work as specified whether \tcode{rv} has been moved from or not.
-\end{tailnote}
-}\\
-\end{oldconcepttable}
+\rSec4[cpp17.defaultconstructible]{\defnoldconcept{DefaultConstructible} requirements}
 
-\begin{oldconcepttable}{CopyAssignable}{ (in addition to \oldconcept{MoveAssignable})}{cpp17.copyassignable}
-{p{1in}p{1in}p{1in}p{1.9in}}
-\topline
-\hdstyle{Expression} & \hdstyle{Return type} & \hdstyle{Return value} & \hdstyle{Post-condition} \\ \capsep
-\tcode{t = v}   &   \tcode{T\&} &   \tcode{t}   &   \tcode{t} is equivalent to \tcode{v}, the value of \tcode{v} is unchanged\\
-\end{oldconcepttable}
+\pnum
+A type \tcode{T} meets the \oldconcept{DefaultConstructible} requirements if the following
+expressions are well-formed and have the specified semantics:
+\begin{itemdecl}
+T t;
+\end{itemdecl}
 
-\begin{oldconcepttable}{Destructible}{}{cpp17.destructible}
-{p{1in}p{4.15in}}
-\topline
-\hdstyle{Expression}      &   \hdstyle{Post-condition}  \\ \capsep
-\tcode{a.\~T()} & No exception is propagated. \\ \rowsep
-\multicolumn{2}{|l|}{
-  \begin{tailnote}
-  Array types and non-object types are not \oldconcept{Destructible}.
-  \end{tailnote}
-} \\
-\end{oldconcepttable}
+\begin{itemdescr}
+\pnum
+\ensures
+The object \tcode{t} is default-initialized.
+\end{itemdescr}
+
+\begin{itemdecl}
+T u{};
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ensures
+The object \tcode{u} is value-initialized or aggregate-initialized.
+\end{itemdescr}
+
+\begin{itemdecl}
+T()
+T{}
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ensures
+An object of type \tcode{T} is value-initialized or aggregate-initialized.
+\end{itemdescr}
+
+\rSec4[cpp17.moveconstructible]{\defnoldconcept{MoveConstructible} requirements}
+
+\pnum
+A type \tcode{T} meets the \oldconcept{MoveConstructible} requirements if the following
+statement and expressions are well-formed and have the specified semantics:
+\begin{itemdecl}
+T u = rv;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ensures
+\tcode{u} is equivalent to the value of \tcode{rv} before the construction.
+\end{itemdescr}
+
+\begin{itemdecl}
+T(rv)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ensures
+\tcode{T(rv)} is equivalent to the value of \tcode{rv} before the construction.
+\end{itemdescr}
+
+\tcode{rv}'s state is unspecified.
+
+\begin{note}
+\tcode{rv} must still meet the requirements of the library component that is using it.
+The operations listed in those requirements must work as specified whether \tcode{rv}
+has been moved or not.
+\end{note}
+
+\rSec4[cpp17.copyconstructible]{\defnoldconcept{CopyConstructible} requirements}
+
+\pnum
+A type is \tcode{T} meets the \oldconcept{CopyConstructible} requirements
+(in addition to the \oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} requirements)
+if the following expressions are well-formed and have the specified semantics:
+\begin{itemdecl}
+T u = v;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ensures
+The value of \tcode{v} is unchanged and is equivalent to \tcode{u}.
+\end{itemdescr}
+
+\begin{itemdecl}
+T(u)
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ensures
+The value of \tcode{v} is unchanged and is equivalent to \tcode{T(v)}.
+\end{itemdescr}
+
+\rSec4[cpp17.moveassignable]{\defnoldconcept{MoveAssignable} requirements}
+
+\pnum
+A type \tcode{T} meets the \oldconcept{MoveAssignable} requirements if the following
+statement and expressions are well-formed and have the specified semantics:
+\begin{itemdecl}
+t = rv;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{T\&}
+
+\pnum
+\ensures
+If \tcode{t} and \tcode{rv} do not refer to the same object,
+\tcode{t} is equivalent to the value of \tcode{rv} before the assignment.
+
+\pnum
+\returns
+\tcode{t}
+\end{itemdescr}
+
+\tcode{rv}'s state is unspecified
+\begin{note}
+\tcode{rv} must still meet the requirements of the library component that is using it,
+whether or not \tcode{t} and \tcode{rv} refer to the same object.
+The operations listed in those requirements must work as specified whether \tcode{rv}
+has been moved or not.
+\end{note}
+
+\rSec4[cpp17.copyassignable]{\defnoldconcept{CopyAssignable} requirements}
+
+\pnum
+A type \tcode{T} meets the \oldconcept{CopyAssignable} requirements
+(in addition to the \oldconcept{MoveAssignable}\iref{cpp17.moveassignable} requirements)
+if the following expression is well-formed and has the specified semantics:
+\begin{itemdecl}
+t = v
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\result
+\tcode{T\&}
+
+\pnum
+\ensures
+\tcode{t} is equivalent to \tcode{v}, the value of \tcode{v} is unchanged.
+
+\pnum
+\returns
+\tcode{t}
+\end{itemdescr}
+
+\rSec4[cpp17.destructible]{\defnoldconcept{Destructible} requirements}
+
+\pnum
+A type \tcode{T} meets the \oldconcept{Destructible} requirements if the following
+expression is well-formed and has the specified semantics:
+\begin{itemdecl}
+a.~T()
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ensures
+No exception is propagated.
+\end{itemdescr}
+
+\begin{note}
+Array types and non-object types are not \oldconcept{Destructible}
+\end{note}
 
 \rSec3[swappable.requirements]{Swappable requirements}
 
@@ -2113,8 +2227,8 @@ a value of type (possibly const) \tcode{std::nullptr_t}.
 A type \tcode{H} meets the \defnoldconcept{Hash} requirements if
 \begin{itemize}
 \item it is a function object type\iref{function.objects},
-\item it meets the \oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible}) and
-  \oldconcept{Destructible} (\tref{cpp17.destructible}) requirements, and
+\item it meets the \oldconcept{CopyConstructible}\iref{cpp17.copyconstructible} and
+  \oldconcept{Destructible}\iref{cpp17.destructible} requirements, and
 \item the expressions shown in \tref{cpp17.hash}
 are valid and have the indicated semantics.
 \end{itemize}
@@ -2798,7 +2912,7 @@ Identical to or derived from \tcode{true_type} or \tcode{false_type}.
 \tcode{true_type} only if an allocator of type \tcode{X} should be copied
 when the client container is copy-assigned;
 if so, \tcode{X} shall meet
-the \oldconcept{CopyAssignable} requirements (\tref{cpp17.copyassignable}) and
+the \oldconcept{CopyAssignable} requirements\iref{cpp17.copyassignable} and
 the copy operation shall not throw exceptions.
 
 \pnum
@@ -2820,7 +2934,7 @@ Identical to or derived from \tcode{true_type} or \tcode{false_type}.
 \tcode{true_type} only if an allocator of type \tcode{X} should be moved
 when the client container is move-assigned;
 if so, \tcode{X} shall meet
-the \oldconcept{MoveAssignable} requirements (\tref{cpp17.moveassignable}) and
+the \oldconcept{MoveAssignable} requirements\iref{cpp17.moveassignable} and
 the move operation shall not throw exceptions.
 
 \pnum
@@ -2872,7 +2986,7 @@ Default: \tcode{is_empty<X>::type}
 
 \pnum
 An allocator type \tcode{X} shall meet the
-\oldconcept{CopyConstructible} requirements (\tref{cpp17.copyconstructible}).
+\oldconcept{CopyConstructible} requirements\iref{cpp17.copyconstructible}.
 The \tcode{XX::pointer}, \tcode{XX::const_pointer}, \tcode{XX::void_pointer}, and
 \tcode{XX::const_void_pointer} types shall meet the
 \oldconcept{Nullable\-Pointer} requirements (\tref{cpp17.nullablepointer}).

--- a/source/memory.tex
+++ b/source/memory.tex
@@ -2803,7 +2803,7 @@ pointer as appropriate for that deleter.
 
 \pnum
 If the deleter's type \tcode{D} is not a reference type, \tcode{D} shall meet
-the \oldconcept{Destructible} requirements (\tref{cpp17.destructible}).
+the \oldconcept{Destructible} requirements\iref{cpp17.destructible}.
 
 \pnum
 If the \grammarterm{qualified-id} \tcode{remove_reference_t<D>::pointer} is valid and denotes a
@@ -2837,7 +2837,7 @@ constexpr unique_ptr(nullptr_t) noexcept;
 
 \pnum
 \expects
-\tcode{D} meets the \oldconcept{DefaultConstructible} requirements (\tref{cpp17.defaultconstructible}),
+\tcode{D} meets the \oldconcept{DefaultConstructible} requirements\iref{cpp17.defaultconstructible},
 and that construction does not throw an exception.
 
 \pnum
@@ -2864,7 +2864,7 @@ constexpr explicit unique_ptr(type_identity_t<pointer> p) noexcept;
 
 \pnum
 \expects
-\tcode{D} meets the \oldconcept{DefaultConstructible} requirements (\tref{cpp17.defaultconstructible}),
+\tcode{D} meets the \oldconcept{DefaultConstructible} requirements\iref{cpp17.defaultconstructible},
 and that construction does not throw an exception.
 
 \pnum
@@ -2944,7 +2944,7 @@ constexpr unique_ptr(unique_ptr&& u) noexcept;
 \expects
 If \tcode{D} is not a reference type,
 \tcode{D} meets the \oldconcept{MoveConstructible}
-requirements (\tref{cpp17.moveconstructible}).
+requirements\iref{cpp17.moveconstructible}.
 Construction
 of the deleter from an rvalue of type \tcode{D} does not
 throw an exception.
@@ -3052,7 +3052,7 @@ constexpr unique_ptr& operator=(unique_ptr&& u) noexcept;
 \pnum
 \expects
 If \tcode{D} is not a reference type, \tcode{D} meets the
-\oldconcept{MoveAssignable} requirements (\tref{cpp17.moveassignable}) and assignment
+\oldconcept{MoveAssignable} requirements\iref{cpp17.moveassignable} and assignment
 of the deleter from an rvalue of type \tcode{D} does not throw an exception.
 Otherwise, \tcode{D} is a reference type;
 \tcode{remove_reference_t<D>} meets the \oldconcept{CopyAssignable}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -2025,8 +2025,8 @@ according to \ref{strings} and \ref{input.output}.
 
 \pnum
 \tcode{E} shall meet the
-\oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible})
-and \oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}) requirements.
+\oldconcept{CopyConstructible}\iref{cpp17.copyconstructible}
+and \oldconcept{CopyAssignable}\iref{cpp17.copyassignable} requirements.
 These operations shall each be of complexity
 no worse than \bigoh{\text{size of state}}.
 
@@ -2454,8 +2454,8 @@ according to \ref{strings} and \ref{input.output}.
 
 \pnum
 \tcode{D} shall meet the
-\oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible})
-and \oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}) requirements.
+\oldconcept{CopyConstructible}\iref{cpp17.copyconstructible}
+and \oldconcept{CopyAssignable}\iref{cpp17.copyassignable} requirements.
 
 \pnum
 The sequence of numbers
@@ -2486,10 +2486,10 @@ for convenience of exposition only.
 
 \pnum
 \tcode{P} shall meet the
-\oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible}),
-\oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}),
+\oldconcept{Copy\-Construct\-ible}\iref{cpp17.copyconstructible},
+\oldconcept{Copy\-Assignable}\iref{cpp17.copyassignable},
 and
-\oldconcept{Equality\-Comp\-arable} (\tref{cpp17.equalitycomparable}) requirements.
+\oldconcept{Equality\-Comparable}\iref{cpp17.equalitycomparable} requirements.
 
 \pnum
 For each of the constructors of \tcode{D}

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -238,10 +238,10 @@ using state_type = @\seebelow@;
 \pnum
 \expects
 \tcode{state_type} meets the
-\oldconcept{Destructible} (\tref{cpp17.destructible}),
-\oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}),
-\oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible}), and
-\oldconcept{DefaultConstructible} (\tref{cpp17.defaultconstructible}) requirements.
+\oldconcept{Destructible}\iref{cpp17.destructible},
+\oldconcept{CopyAssignable}\iref{cpp17.copyassignable},
+\oldconcept{CopyConstructible}\iref{cpp17.copyconstructible}, and
+\oldconcept{DefaultConstructible}\iref{cpp17.defaultconstructible} requirements.
 \end{itemdescr}
 
 \rSec2[char.traits.specializations]{\tcode{char_traits} specializations}

--- a/source/text.tex
+++ b/source/text.tex
@@ -7020,11 +7020,11 @@ As specified in~\ref{format.err.report}.
 A type \tcode{F} meets the \defnnewoldconcept{BasicFormatter} requirements if
 it meets the
 \begin{itemize}
-\item \oldconcept{DefaultConstructible} (\tref{cpp17.defaultconstructible}),
-\item \oldconcept{CopyConstructible} (\tref{cpp17.copyconstructible}),
-\item \oldconcept{CopyAssignable} (\tref{cpp17.copyassignable}),
+\item \oldconcept{DefaultConstructible}\iref{cpp17.defaultconstructible},
+\item \oldconcept{CopyConstructible}\iref{cpp17.copyconstructible},
+\item \oldconcept{CopyAssignable}\iref{cpp17.copyassignable},
 \item \oldconcept{Swappable}\iref{swappable.requirements}, and
-\item \oldconcept{Destructible} (\tref{cpp17.destructible})
+\item \oldconcept{Destructible}\iref{cpp17.destructible}
 \end{itemize}
 requirements, and
 the expressions shown in \tref{formatter.basic} are valid and

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -4525,8 +4525,7 @@ parameter as the arguments.
 
 \begin{note}
 If the pointers point to different complete objects (or subobjects thereof),
-the \tcode{<} operator does not establish a strict weak ordering
-(\tref{cpp17.lessthancomparable}, \ref{expr.rel}).
+the \tcode{<} operator does not establish a strict weak ordering\iref{cpp17.lessthancomparable,expr.rel}.
 \end{note}
 \end{itemdescr}
 
@@ -4573,7 +4572,8 @@ with \tcode{*\exposid{ptr}} and the first parameter as the arguments.
 \begin{note}
 If the pointers point to different complete objects (or subobjects thereof),
 the \tcode{<} operator does not establish
-a strict weak ordering~(\tref{cpp17.lessthancomparable}, \ref{expr.rel}).
+a strict weak ordering
+(\ref{cpp17.lessthancomparable}, \ref{expr.rel}).
 \end{note}
 \end{itemdescr}
 
@@ -6153,8 +6153,7 @@ parameter as the arguments.
 
 \begin{note}
 If the pointers point to different complete objects (or subobjects thereof),
-the \tcode{<} operator does not establish a strict weak ordering
-(\tref{cpp17.lessthancomparable}, \ref{expr.rel}).
+the \tcode{<} operator does not establish a strict weak ordering\iref{cpp17.lessthancomparable,expr.rel}.
 \end{note}
 \end{itemdescr}
 
@@ -6208,7 +6207,7 @@ the first parameter as the arguments.
 \begin{note}
 If the pointers point to different complete objects (or subobjects thereof),
 the \tcode{<} operator does not establish
-a strict weak ordering~(\tref{cpp17.lessthancomparable}, \ref{expr.rel}).
+a strict weak ordering~\iref{cpp17.lessthancomparable,expr.rel}.
 \end{note}
 \end{itemdescr}
 
@@ -11206,8 +11205,8 @@ execute atomically.
 
 \pnum
 \tcode{CompletionFunction} shall meet the
-\oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}) and
-\oldconcept{Destructible} (\tref{cpp17.destructible}) requirements.
+\oldconcept{MoveConstructible}\iref{cpp17.moveconstructible} and
+\oldconcept{Destructible}\iref{cpp17.destructible} requirements.
 \tcode{is_nothrow_invocable_v<CompletionFunction\&>} shall be \tcode{true}.
 
 \pnum
@@ -11215,15 +11214,15 @@ The default value of the \tcode{CompletionFunction} template parameter is
 an unspecified type, such that,
 in addition to satisfying the requirements of \tcode{CompletionFunction},
 it meets the \oldconcept{DefaultConstructible}
-requirements (\tref{cpp17.defaultconstructible}) and
+requirements\iref{cpp17.defaultconstructible} and
 \tcode{\exposid{completion}()} has no effects.
 
 \pnum
 \tcode{barrier::arrival_token} is an unspecified type,
 such that it meets the
-\oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible}),
-\oldconcept{MoveAssignable} (\tref{cpp17.moveassignable}), and
-\oldconcept{Destructible} (\tref{cpp17.destructible}) requirements.
+\oldconcept{MoveConstructible}\iref{cpp17.moveconstructible},
+\oldconcept{MoveAssignable}\iref{cpp17.moveassignable}, and
+\oldconcept{Destructible}\iref{cpp17.destructible} requirements.
 
 \indexlibrarymember{max}{barrier}%
 \begin{itemdecl}

--- a/source/time.tex
+++ b/source/time.tex
@@ -1038,9 +1038,9 @@ A type \tcode{TC} meets the \defnoldconcept{TrivialClock} requirements if
 
 \item
 the types \tcode{TC::rep}, \tcode{TC::duration}, and \tcode{TC::time_point}
-meet the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable}) and
-\oldconcept{LessThanComparable} (\tref{cpp17.lessthancomparable})
-and \oldconcept{Swappable}\iref{swappable.requirements}
+meet the \oldconcept{Swappable}\iref{swappable.requirements} and
+\oldconcept{LessThanComparable}\iref{cpp17.lessthancomparable}
+and \oldconcept{EqualityComparable}~\iref{cpp17.equalitycomparable}
 requirements and the requirements of
 numeric types\iref{numeric.requirements},
 \begin{note}
@@ -3985,8 +3985,8 @@ It normally holds values in the range 1 to 31,
 but may hold non-negative values outside this range.
 It can be constructed with any \tcode{unsigned} value,
 which will be subsequently truncated to fit into \tcode{day}'s unspecified internal storage.
-\tcode{day} meets the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable})
-and \oldconcept{LessThanComparable} (\tref{cpp17.lessthancomparable}) requirements,
+\tcode{day} meets the \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable}
+and \oldconcept{LessThanComparable}\iref{cpp17.lessthancomparable} requirements,
 and participates in basic arithmetic with \tcode{days} objects,
 which represent a difference between two \tcode{day} objects.
 
@@ -4278,8 +4278,8 @@ It normally holds values in the range 1 to 12,
 but may hold non-negative values outside this range.
 It can be constructed with any \tcode{unsigned} value,
 which will be subsequently truncated to fit into \tcode{month}'s unspecified internal storage.
-\tcode{month} meets the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable})
-and \oldconcept{LessThanComparable} (\tref{cpp17.lessthancomparable}) requirements,
+\tcode{month} meets the \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable}
+and \oldconcept{LessThanComparable}\iref{cpp17.lessthancomparable} requirements,
 and participates in basic arithmetic with \tcode{months} objects,
 which represent a difference between two \tcode{month} objects.
 
@@ -4588,8 +4588,8 @@ namespace std::chrono {
 It can represent values in the range \crange{min()}{max()}.
 It can be constructed with any \tcode{int} value,
 which will be subsequently truncated to fit into \tcode{year}'s unspecified internal storage.
-\tcode{year} meets the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable})
-and \oldconcept{LessThanComparable} (\tref{cpp17.lessthancomparable}) requirements,
+\tcode{year} meets the \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable}
+and \oldconcept{LessThanComparable}\iref{cpp17.lessthancomparable} requirements,
 and participates in basic arithmetic with \tcode{years} objects,
 which represent a difference between two \tcode{year} objects.
 
@@ -4943,7 +4943,7 @@ corresponding to Sunday through Saturday, but
 it may hold non-negative values outside this range.
 It can be constructed with any \tcode{unsigned} value,
 which will be subsequently truncated to fit into \tcode{weekday}'s unspecified internal storage.
-\tcode{weekday} meets the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable}) requirements.
+\tcode{weekday} meets the \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable} requirements.
 \begin{note}
 \tcode{weekday} is not
 \oldconcept{LessThanComparable}
@@ -5526,8 +5526,8 @@ namespace std::chrono {
 \pnum
 \tcode{month_day} represents a specific day of a specific month,
 but with an unspecified year.
-\tcode{month_day} meets the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable})
-and \oldconcept{LessThanComparable} (\tref{cpp17.lessthancomparable}) requirements.
+\tcode{month_day} meets the \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable}
+and \oldconcept{LessThanComparable}\iref{cpp17.lessthancomparable} requirements.
 
 \pnum
 \tcode{month_day} is a trivially copyable and standard-layout class type.
@@ -6027,8 +6027,8 @@ namespace std::chrono {
 \tcode{year_month} represents a specific month of a specific year,
 but with an unspecified day.
 \tcode{year_month} is a field-based time point with a resolution of \tcode{months}.
-\tcode{year_month} meets the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable})
-and \oldconcept{LessThanComparable} (\tref{cpp17.lessthancomparable}) requirements.
+\tcode{year_month} meets the \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable}
+and \oldconcept{LessThanComparable}\iref{cpp17.lessthancomparable} requirements.
 
 \pnum
 \tcode{year_month} is a trivially copyable and standard-layout class type.
@@ -6383,8 +6383,8 @@ but not \tcode{days}-oriented arithmetic.
 For the latter, there is a conversion to \tcode{sys_days},
 which efficiently supports \tcode{days}-oriented arithmetic.
 \end{note}
-\tcode{year_month_day} meets the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable})
-and \oldconcept{LessThanComparable} (\tref{cpp17.lessthancomparable}) requirements.
+\tcode{year_month_day} meets the \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable}
+and \oldconcept{LessThanComparable}\iref{cpp17.lessthancomparable} requirements.
 
 \pnum
 \tcode{year_month_day} is a trivially copyable and standard-layout class type.
@@ -6844,8 +6844,8 @@ but not \tcode{days}-oriented arithmetic.
 For the latter, there is a conversion to \tcode{sys_days},
 which efficiently supports \tcode{days}-oriented arithmetic.
 \end{note}
-\tcode{year_month_day_last} meets the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable})
-and \oldconcept{LessThanComparable} (\tref{cpp17.lessthancomparable}) requirements.
+\tcode{year_month_day_last} meets the \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable}
+and \oldconcept{LessThanComparable}\iref{cpp17.lessthancomparable} requirements.
 
 \pnum
 \tcode{year_month_day_last} is a trivially copyable and standard-layout class type.
@@ -7215,7 +7215,7 @@ but not \tcode{days}-oriented arithmetic.
 For the latter, there is a conversion to \tcode{sys_days},
 which efficiently supports \tcode{days}-oriented arithmetic.
 \end{note}
-\tcode{year_month_weekday} meets the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable}) requirements.
+\tcode{year_month_weekday} meets the \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable} requirements.
 
 \pnum
 \tcode{year_month_weekday} is a trivially copyable and standard-layout class type.
@@ -7608,7 +7608,7 @@ but not \tcode{days}-oriented arithmetic.
 For the latter, there is a conversion to \tcode{sys_days},
 which efficiently supports \tcode{days}-oriented arithmetic.
 \end{note}
-\tcode{year_month_weekday_last} meets the \oldconcept{EqualityComparable} (\tref{cpp17.equalitycomparable}) requirements.
+\tcode{year_month_weekday_last} meets the \oldconcept{EqualityComparable}\iref{cpp17.equalitycomparable} requirements.
 
 \pnum
 \tcode{year_month_weekday_last} is a trivially copyable and standard-layout class type.

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -274,9 +274,9 @@ template<class T>
 Type
 \tcode{T}
 meets the
-\oldconcept{MoveConstructible} (\tref{cpp17.moveconstructible})
+\oldconcept{MoveConstructible}\iref{cpp17.moveconstructible}
 and
-\oldconcept{MoveAssignable} (\tref{cpp17.moveassignable})
+\oldconcept{MoveAssignable}\iref{cpp17.moveassignable}
 requirements.
 
 \pnum
@@ -3685,7 +3685,7 @@ and \tcode{remove_cvref_t<X>} is a type other than \tcode{in_place_t} or \tcode{
 If a specialization of \tcode{optional} is instantiated with a type \tcode{T}
 that is not a valid contained type for \tcode{optional}, the program is ill-formed.
 If \tcode{T} is an object type,
-\tcode{T} shall meet the \oldconcept{Destructible} requirements (\tref{cpp17.destructible}).
+\tcode{T} shall meet the \oldconcept{Destructible} requirements\iref{cpp17.destructible}.
 
 \rSec3[optional.ctor]{Constructors}
 
@@ -6140,7 +6140,7 @@ is nested within\iref{intro.object} the
 
 \pnum
 All types in \tcode{Types} shall meet
-the \oldconcept{Destructible} requirements (\tref{cpp17.destructible}).
+the \oldconcept{Destructible} requirements\iref{cpp17.destructible}.
 
 \pnum
 A program that instantiates the definition of \tcode{variant} with
@@ -8572,7 +8572,7 @@ that is not a valid template argument for \tcode{unexpected} is ill-formed.
 
 \pnum
 When \tcode{T} is not \cv{} \tcode{void}, it shall meet
-the \oldconcept{Destructible} requirements (\tref{cpp17.destructible}).
+the \oldconcept{Destructible} requirements\iref{cpp17.destructible}.
 \tcode{E} shall meet
 the \oldconcept{Destructible} requirements.
 
@@ -9991,7 +9991,7 @@ is not a valid template argument for \tcode{unexpected} is ill-formed.
 
 \pnum
 \tcode{E} shall meet the requirements of
-\oldconcept{Destructible} (\tref{cpp17.destructible}).
+\oldconcept{Destructible}\iref{cpp17.destructible}.
 
 \rSec3[expected.void.cons]{Constructors}
 
@@ -16274,10 +16274,10 @@ any attempts to use it as a \oldconcept{Hash} will be ill-formed.
 An enabled specialization \tcode{hash<Key>} will:
 \begin{itemize}
 \item meet the \oldconcept{Hash} requirements (\tref{cpp17.hash}),
-with \tcode{Key} as the function
-call argument type, the \oldconcept{Default\-Constructible} requirements (\tref{cpp17.defaultconstructible}),
-the \oldconcept{CopyAssignable} requirements (\tref{cpp17.copyassignable}),
+with \tcode{Key} as the function call argument type,
+the \oldconcept{DefaultConstructible} requirements\iref{cpp17.defaultconstructible},
 the \oldconcept{Swappable} requirements\iref{swappable.requirements},
+the \oldconcept{CopyAssignable} requirements~\iref{cpp17.copyassignable},
 \item meet the requirement that if \tcode{k1 == k2} is \tcode{true}, \tcode{h(k1) == h(k2)} is
 also \tcode{true}, where \tcode{h} is an object of type \tcode{hash<Key>} and \tcode{k1} and \tcode{k2}
 are objects of type \tcode{Key};


### PR DESCRIPTION
It looks like this now

<img width="742" height="495" alt="image" src="https://github.com/user-attachments/assets/e9ef69bd-2df5-4991-8cc4-a60813e64938" />

Additional work was needed to change some `\tref{}` to `\iref{}` across the document, along with two reflows of paragraphs to stop hbox badness

I did some mild rewording in source/lib-intro.tex to make it make sense in the new format. I hope to have not introduced any wording defects! :)