### PR TITLE
[exec.let] Fix let-env argument in let-state env_t and constructor

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -4252,7 +4252,7 @@ Let \exposid{let-state} denote the following exposition-only class template:
 \begin{codeblock}
 template<class Cpo, class Sndr, class Fn, class Rcvr, class ArgsVariant, class OpsVariant>
 struct @\exposid{let-state}@ {
-  using @\exposidnc{env_t}@ = decltype(@\exposidnc{let-env}@(declval<Sndr>()), get_env(declval<Rcvr&>()));  // \expos
+  using @\exposidnc{env_t}@ = decltype(@\exposidnc{let-env}@(declval<Sndr>(), get_env(declval<Rcvr&>())));  // \expos
   Fn @\exposidnc{fn}@;                                                                        // \expos
   env_t @\exposidnc{env}@;                                                                    // \expos
   ArgsVariant @\exposidnc{args}@;                                                             // \expos
@@ -4316,7 +4316,7 @@ struct @\exposid{let-state}@ {
   using @\exposidnc{op_t}@ = connect_result_t<Sndr, @\exposidnc{receiver}@>;                                // \expos
 
   constexpr @\exposidnc{let-state}@(Sndr&& sndr, Fn fn, Rcvr& rcvr)                           // \expos
-    : @\exposid{fn}@(std::move(fn)), @\exposid{env}@(@\exposid{let-env}@(sndr), get_env(rcvr)),
+    : @\exposid{fn}@(std::move(fn)), @\exposid{env}@(@\exposid{let-env}@(sndr, get_env(rcvr))),
       @\exposid{ops}@(in_place_type<@\exposid{op_t}@>, std::forward<Sndr>(sndr), @\exposid{receiver}@{*this, rcvr}) {}
 };
 \end{codeblock}


### PR DESCRIPTION
Fix two `let-state` uses of `let-env` mis-parenthesized while applying [P3826R5](https://wg21.link/p3826r5) in [#8919](https://github.com/cplusplus/draft/pull/8919). The misapplication left `get_env(...)` outside `let-env(...)`, turning both uses into comma expressions.