### PR TITLE
[func.wrap.ref.ctor] Restore class T in constant_wrapper constructor head

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -15804,7 +15804,7 @@ is expression-equivalent\iref{defns.expression.equivalent} to
 
 \indexlibraryctor{function_ref}%
 \begin{itemdecl}
-template<auto c, class F>
+template<auto c, class F, class T>
   constexpr function_ref(constant_wrapper<c, F> f, @\cv{}@ T* obj) noexcept;
 \end{itemdecl}
 


### PR DESCRIPTION
Restore the missing `class T` template parameter in the out-of-line `function_ref` constructor declaration so it matches the synopsis.