### PR TITLE
[simd.math,simd.reductions] Fix undeclared identifiers in std::simd

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -18926,7 +18926,7 @@ The value of an element \tcode{x[$j$]} for which \tcode{x[$i$] < x[$j$]} is
 \begin{itemdecl}
 template<class T, class Abi>
   constexpr T reduce_min(
-    const basic_vec<T, Abi>&, const typename basic_vec<T, Abi>::mask_type&) noexcept;
+    const basic_vec<T, Abi>& x, const typename basic_vec<T, Abi>::mask_type& mask) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -18963,7 +18963,7 @@ The value of an element \tcode{x[$j$]} for which \tcode{x[$j$] < x[$i$]} is
 \begin{itemdecl}
 template<class T, class Abi>
   constexpr T reduce_max(
-    const basic_vec<T, Abi>&, const typename basic_vec<T, Abi>::mask_type&) noexcept;
+    const basic_vec<T, Abi>& x, const typename basic_vec<T, Abi>::mask_type& mask) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -18974,7 +18974,7 @@ template<class T, class Abi>
 \pnum
 \returns
 If \tcode{none_of(mask)} is \tcode{true}, returns
-\tcode{numeric_limits<V::value_type>::lowest()}.
+\tcode{numeric_limits<T>::lowest()}.
 Otherwise, returns the value of a selected element \tcode{x[$j$]} for which
 \tcode{x[$j$] < x[$i$]} is \tcode{false} for all selected indices $i$ of
 \tcode{mask}.
@@ -20537,7 +20537,7 @@ Let \tcode{V} be \tcode{basic_vec<T, Abi>}.
 Let \tcode{\placeholder{modf-vec}} denote:
 \begin{codeblock}
 pair<V, V> @\placeholder{modf-vec}@(const V& x) {
-  T r1[Ret::size()];
+  T r1[V::size()];
   V r0([&](@\exposid{simd-size-type}@ i) {
     return modf(V(x)[i], &r1[i]);
   });


### PR DESCRIPTION
Fix undeclared identifiers in `std::simd` wording: use `V::size()` in `modf-vec` and `T` in masked `reduce_max`. Also name the previously unnamed `x` and `mask` parameters in the masked `reduce_min`/`reduce_max` declarations so they match their Returns descriptions.