### PR TITLE
[CWG 2026-06-18] P2414R12 Pointer lifetime-end zap proposed solutions

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -739,10 +739,19 @@ bool f() {
 
 \item Otherwise, the object indicated by the glvalue is read\iref{defns.access}.
 Let \tcode{V} be the value contained in the object.
-If \tcode{T} is an integer type,
-the prvalue result is
-the value of type \tcode{T} congruent\iref{basic.fundamental} to \tcode{V}, and
+The prvalue result is
+\begin{itemize}
+\item
+the value of type \tcode{T} congruent\iref{basic.fundamental} to \tcode{V}
+if \tcode{T} is an integer type,
+\item
+the result of \tcode{reinterpret_cast<T>(reinterpret_cast<std::uintptr_t>(V))}
+if \tcode{T} is volatile-qualified
+and \tcode{V} is a pointer value
+that is not valid in the context of the evaluation\iref{basic.compound}, and
+\item
 \tcode{V} otherwise.
+\end{itemize}
 \end{itemize}
 
 \pnum
@@ -8414,9 +8423,19 @@ In simple assignment (\tcode{=}),
 let \tcode{V} be the result of the right operand;
 the object referred to by the left operand is
 modified\iref{defns.access} by replacing its value
-with \tcode{V} or,
+with
+\begin{itemize}
+\item
+the value congruent\iref{basic.fundamental} to \tcode{V}
 if the object is of integer type,
-with the value congruent\iref{basic.fundamental} to \tcode{V}.
+\item
+the result of \tcode{reinterpret_cast<T>(reinterpret_cast<std::uintptr_t>(V))}
+if the left operand is a volatile-qualified glvalue of pointer type \tcode{T}
+and \tcode{V} is a pointer value
+that is not valid in the context of the evaluation\iref{basic.compound}, and
+\item
+\tcode{V} otherwise.
+\end{itemize}
 
 \pnum
 \indextext{assignment!conversion by}%

--- a/source/threads.tex
+++ b/source/threads.tex
@@ -4171,6 +4171,14 @@ the specialization \tcode{atomic_ref<\placeholder{pointer-type}>} provides
 additional atomic operations appropriate to pointer types.
 
 \pnum
+Except during constant evaluation,
+when an operation on an atomic pointer
+would otherwise result in a pointer value \tcode{p}
+that is not valid in the context of the evaluation\iref{basic.compound},
+that result instead is
+\tcode{reinterpret_cast<T*>(reinterpret_cast<uintptr_t>(p))}.
+
+\pnum
 The program is ill-formed
 if \tcode{is_always_lock_free} is \tcode{false} and
 \tcode{is_volatile_v<\placeholder{pointer-type}>} is \tcode{true}.
@@ -5817,6 +5825,14 @@ namespace std {
 There is a partial specialization of the \tcode{atomic} class template for pointers.
 Specializations of this partial specialization are standard-layout structs.
 They each have a trivial destructor.
+
+\pnum
+Except during constant evaluation,
+when an operation on an atomic pointer
+would otherwise result in a pointer value \tcode{p}
+that is not valid in the context of the evaluation\iref{basic.compound},
+that result instead is
+\tcode{reinterpret_cast<T*>(reinterpret_cast<uintptr_t>(p))}.
 
 \pnum
 Descriptions are provided below only for members that differ from the primary template.


### PR DESCRIPTION
[conv.lval]p3.5 [expr.assign]p2 Replaced non-existent reference "6.7.5.5.3" with [basic.compound]

Fixes #9085.

Also fixes cplusplus/papers#1084