### PR TITLE
[over.built] Add commas after "e.g."

### DIFF
--- a/source/overloading.tex
+++ b/source/overloading.tex
@@ -3845,11 +3845,11 @@ to not be included in the set of candidate functions.
 In this subclause, the term
 \defn{promoted integral type}
 is used to refer to those cv-unqualified integral types which are preserved by
-integral promotion\iref{conv.prom} (including e.g.
+integral promotion\iref{conv.prom} (including e.g.,
 \tcode{int}
 and
 \tcode{long}
-but excluding e.g.
+but excluding e.g.,
 \tcode{char}).
 \begin{note}
 In all cases where a promoted integral type is

--- a/tools/check-source.sh
+++ b/tools/check-source.sh
@@ -212,9 +212,9 @@ done |
     fail '"shall", "should", or "may" inside a note' || failed=1
 
 # Comma after e.g. and i.e.
-grep -n "e\.g\.[^,]" $texfiles |
+grep -nP "e\.g\.(?!,)" $texfiles |
     fail '"e.g." must be followed by a comma'
-grep -n "i\.e\.[^,]" $texfiles |
+grep -nP "i\.e\.(?!,)" $texfiles |
     fail '"i.e." must be followed by a comma'
 
 


### PR DESCRIPTION
- Branching off from https://github.com/cplusplus/draft/pull/9146
- The current check doesn't work because it requires a non-comma character to be matched, and there is none at the end of the line