### PR TITLE
[simd] Remove unnecessary `\tcode` around `\exposid`

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -17724,8 +17724,8 @@ The class template \tcode{flags} acts like an integer bit-flag for types.
 
 \pnum
 \constraints
-Every type in the parameter pack \tcode{Flags} is one of \tcode{\exposid{convert-flag}},
-\tcode{\exposid{aligned-flag}}, or \tcode{\exposid{over\-aligned-\brk{}flag}<N>}.
+Every type in the parameter pack \tcode{Flags} is one of \exposid{convert-flag},
+\exposid{aligned-flag}, or \tcode{\exposid{over\-aligned-\brk{}flag}<N>}.
 
 \rSec3[simd.flags.oper]{\tcode{flags} operators}
 
@@ -18300,7 +18300,7 @@ Let \tcode{mask} be \tcode{mask_type(true)} for the overload with no
 \pnum
 \mandates
 If the template parameter pack \tcode{Flags} does not contain
-\tcode{\exposid{convert-flag}}, then the conversion from
+\exposid{convert-flag}, then the conversion from
 \tcode{ranges::range_value_t<R>} to \tcode{value_type} is value-preserving.
 
 \pnum
@@ -18308,7 +18308,7 @@ If the template parameter pack \tcode{Flags} does not contain
 \begin{itemize}
  \item
    If the template parameter pack \tcode{Flags} contains
-   \tcode{\exposid{aligned-flag}}, \tcode{ranges::data(r)} points to
+   \exposid{aligned-flag}, \tcode{ranges::data(r)} points to
    storage aligned by \tcode{alignment_v<basic_vec,
    ranges::range_value_t<R>>}.
  \item
@@ -19119,7 +19119,7 @@ Let
    \tcode{V} is an enabled specialization of \tcode{basic_vec}, and
  \item
    if the template parameter pack \tcode{Flags} does not contain
-   \tcode{\exposid{convert-flag}}, then the conversion from
+   \exposid{convert-flag}, then the conversion from
    \tcode{ranges::range_value_t<R>} to \tcode{V::value_type} is
    value-preserving.
 \end{itemize}
@@ -19135,7 +19135,7 @@ Let
    parameter.
  \item
    If the template parameter pack \tcode{Flags} contains
-   \tcode{\exposid{aligned-flag}}, \tcode{ranges::data(r)} points to storage
+   \exposid{aligned-flag}, \tcode{ranges::data(r)} points to storage
    aligned by \tcode{alignment_v<V, ranges::range_value_t<R>>}.
  \item
    If the template parameter pack \tcode{Flags} contains
@@ -19282,7 +19282,7 @@ Let
    \tcode{ranges::range_value_t<R>} is a vectorizable type, and
  \item
    if the template parameter pack \tcode{Flags} does not contain
-   \tcode{\exposid{convert-flag}}, then the conversion from \tcode{T} to
+   \exposid{convert-flag}, then the conversion from \tcode{T} to
    \tcode{ranges::range_value_t<R>} is value-preserving.
 \end{itemize}
 
@@ -19297,7 +19297,7 @@ Let
    parameter.
  \item
    If the template parameter pack \tcode{Flags} contains
-   \tcode{\exposid{aligned-flag}}, \tcode{ranges::data(r)} points to storage
+   \exposid{aligned-flag}, \tcode{ranges::data(r)} points to storage
    aligned by \tcode{alignment_v<basic_vec<T, Abi>,
    ranges::range_value_t<R>>}.
  \item
@@ -19475,7 +19475,7 @@ Let:
 elements in \tcode{selector}, in ascending order.
 \item
 \tcode{\exposidnc{bit-lookup}($b$)} be a function which returns the index
-where $b$ appears in \tcode{\exposid{set-indices}}.
+where $b$ appears in \exposid{set-indices}.
 \item
 \tcode{\exposidnc{select-value}($i$)} be a function which returns
 \tcode{v[\exposidnc{bit-lookup}($i$)]} if \tcode{selector[$i$]} is
@@ -19886,7 +19886,7 @@ Equivalent to:
 \begin{codeblock}
 return @\exposid{simd-select-impl}@(c, a, b);
 \end{codeblock}
-where \tcode{\exposid{simd-select-impl}} is found by argument-dependent
+where \exposid{simd-select-impl} is found by argument-dependent
 lookup\iref{basic.lookup.argdep} contrary to \ref{contents}.
 \end{itemdescr}
 

--- a/tools/check-source.sh
+++ b/tools/check-source.sh
@@ -87,7 +87,7 @@ grep -n 'U+' $texfiles |
     fail 'use \\unicode or \\ucode or \\uname instead' || failed=1
 
 # Discourage double-wrapping \tcode{\exposid{data_}}
-grep -n '\\tcode{\\exposid{[a-zA-Z0-9_]*}}' $texfiles |
+grep -n '\\tcode{\\exposid{[a-zA-Z0-9_-]*}}' $texfiles |
     fail 'double-wrapped \\exposid in \\tcode' || failed=1
 
 # Hex digits inside \ucode and \unicode must be lowercase so that \textsc works


### PR DESCRIPTION
- Branching off from https://github.com/cplusplus/draft/pull/9146
- The current check doesn't work because a hyphen character is not matched.