### PR TITLE
[dcl.contract.func] Fix placeholder and IFNDR comment

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4707,7 +4707,7 @@ the declarations $D_1$ and $D_2$, respectively, except for
 renaming of the parameters of \placeholder{f},
 \item
 renaming of template parameters of
-a template enclosing \placeholder{}, and
+a template enclosing \placeholder{f}, and
 \item
 renaming of the result binding\iref{dcl.contract.res}, if any,
 \end{itemize}
@@ -4738,7 +4738,7 @@ bool b1, b2;
 
 void f() pre (b1) pre ([]{ return b2; }());
 void f();                       // OK, \grammarterm{function-contract-specifier}s omitted
-void f() pre (b1) pre ([]{ return b2; }()); // error: closures have different types.
+void f() pre (b1) pre ([]{ return b2; }()); // ill-formed, no diagnostic required: closures have different types
 void f() pre (b1);              // error: \grammarterm{function-contract-specifier}s only partially repeated
 
 int g() post(r : b1);


### PR DESCRIPTION
Restore the missing `f` in the template-parameter-renaming bullet and use the no-diagnostic-required comment form for the differing-closures example.