### PR TITLE
[mdspan.sub] Fix S::extend_type typo

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -25706,7 +25706,7 @@ either $x$ is equal to \tcode{dynamic_extent}; or
     \tcode{0} otherwise,
   \item
     $e$ is the value of \tcode{S::extent_type::value}
-    if \tcode{S::extend_type} is a specialization of \tcode{constant_wrapper} and
+    if \tcode{S::extent_type} is a specialization of \tcode{constant_wrapper} and
     \tcode{0} otherwise,
   \item
     $t$ is the value of \tcode{S::stride_type::value}


### PR DESCRIPTION
Use `S::extent_type` in the condition for `e`, matching the value expression and the member declared by `extent_slice`.