### PR TITLE
[exec.when.all] Fix receiver parameter name

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -4796,7 +4796,7 @@ The member \tcode{\exposid{impls-for}<when_all_t>::\exposid{get-env}}
 is initialized with a callable object
 equivalent to the following lambda expression:
 \begin{codeblock}
-[]<class State, class Rcvr>(auto&&, State& state, const Receiver& rcvr) noexcept {
+[]<class State, class Rcvr>(auto&&, State& state, const Rcvr& rcvr) noexcept {
   return @\exposid{make-when-all-env}@(state.@\exposid{stop-src}@, get_env(rcvr));
 }
 \end{codeblock}


### PR DESCRIPTION
Use the lambda's `Rcvr` template parameter instead of undeclared `Receiver` in the `when_all` environment helper.