### PR TITLE
[exec.stopped.opt] Add transform_sender tag

### DIFF
--- a/source/exec.tex
+++ b/source/exec.tex
@@ -5117,7 +5117,7 @@ is ill-formed;
 otherwise,
 if \tcode{\libconcept{sender_in}<\exposid{child-type}<Sndr>, \exposid{FWD-\brk{}ENV-\brk{}T}(Env)>}
 is \tcode{false},
-the expression \tcode{stopped_as_optional.transform_sender(sndr, env)}
+the expression \tcode{stopped_as_optional.transform_sender(set_value, sndr, env)}
 is equivalent to \tcode{\exposid{not-a-sen\-der}()};
 otherwise, it is equivalent to:
 \begin{codeblock}


### PR DESCRIPTION
Pass `set_value` to `stopped_as_optional.transform_sender` in the not-a-sender branch, matching the tagged call used by the guard in the same paragraph.