### PR TITLE
[class.mem.general] Add ANN to data member description note

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -969,7 +969,11 @@ if $W$ is not $\bot$ and is otherwise not a bit-field, and
 \item
 it is declared with
 the attribute \tcode{[[no_unique_address]]}\iref{dcl.attr.nouniqueaddr}
-if $\mathit{NUA}$ is true and is otherwise declared without that attribute.
+if $\mathit{NUA}$ is true and is otherwise declared without that attribute, and
+\item
+for each reflection \tcode{r} in $\mathit{ANN}$,
+it has an annotation\iref{dcl.attr.annotation}
+whose underlying constant is \tcode{r}.
 \end{itemize}
 Data member descriptions are represented by reflections\iref{basic.fundamental}
 returned by \tcode{std::meta::data_member_spec}\iref{meta.reflection.define.aggregate} and


### PR DESCRIPTION
Add the missing `ANN` bullet to the explanatory note for data member descriptions, matching the annotation component already present in the sextuple definition.