### PR TITLE
[cmath.syn] Convert uses of `\indexlibraryglobal` to `\libglobal`

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -9206,202 +9206,6 @@ An iterator referencing one past the last value in the array.
 \rSec2[cmath.syn]{Header \tcode{<cmath>} synopsis}
 
 \indexheader{cmath}%
-\indexlibraryglobal{abs}%
-\indexlibraryglobal{acos}%
-\indexlibraryglobal{acosf}%
-\indexlibraryglobal{acosh}%
-\indexlibraryglobal{acoshf}%
-\indexlibraryglobal{acoshl}%
-\indexlibraryglobal{acosl}%
-\indexlibraryglobal{asin}%
-\indexlibraryglobal{asinf}%
-\indexlibraryglobal{asinh}%
-\indexlibraryglobal{asinhf}%
-\indexlibraryglobal{asinhl}%
-\indexlibraryglobal{asinl}%
-\indexlibraryglobal{atan}%
-\indexlibraryglobal{atan2}%
-\indexlibraryglobal{atan2f}%
-\indexlibraryglobal{atan2l}%
-\indexlibraryglobal{atanf}%
-\indexlibraryglobal{atanh}%
-\indexlibraryglobal{atanhf}%
-\indexlibraryglobal{atanhl}%
-\indexlibraryglobal{atanl}%
-\indexlibraryglobal{cbrt}%
-\indexlibraryglobal{cbrtf}%
-\indexlibraryglobal{cbrtl}%
-\indexlibraryglobal{ceil}%
-\indexlibraryglobal{ceilf}%
-\indexlibraryglobal{ceill}%
-\indexlibraryglobal{copysign}%
-\indexlibraryglobal{copysignf}%
-\indexlibraryglobal{copysignl}%
-\indexlibraryglobal{cos}%
-\indexlibraryglobal{cosf}%
-\indexlibraryglobal{cosh}%
-\indexlibraryglobal{coshf}%
-\indexlibraryglobal{coshl}%
-\indexlibraryglobal{cosl}%
-\indexlibraryglobal{double_t}%
-\indexlibraryglobal{erf}%
-\indexlibraryglobal{erfc}%
-\indexlibraryglobal{erfcf}%
-\indexlibraryglobal{erfcl}%
-\indexlibraryglobal{erff}%
-\indexlibraryglobal{erfl}%
-\indexlibraryglobal{exp}%
-\indexlibraryglobal{exp2}%
-\indexlibraryglobal{exp2f}%
-\indexlibraryglobal{exp2l}%
-\indexlibraryglobal{expf}%
-\indexlibraryglobal{expl}%
-\indexlibraryglobal{expm1}%
-\indexlibraryglobal{expm1f}%
-\indexlibraryglobal{expm1l}%
-\indexlibraryglobal{fabs}%
-\indexlibraryglobal{fabsf}%
-\indexlibraryglobal{fabsl}%
-\indexlibraryglobal{fdim}%
-\indexlibraryglobal{fdimf}%
-\indexlibraryglobal{fdiml}%
-\indexlibraryglobal{float_t}%
-\indexlibraryglobal{floor}%
-\indexlibraryglobal{floorf}%
-\indexlibraryglobal{floorl}%
-\indexlibraryglobal{fma}%
-\indexlibraryglobal{fmaf}%
-\indexlibraryglobal{fmal}%
-\indexlibraryglobal{fmax}%
-\indexlibraryglobal{fmaxf}%
-\indexlibraryglobal{fmaxl}%
-\indexlibraryglobal{fmaximum}%
-\indexlibraryglobal{fmaximum_num}%
-\indexlibraryglobal{fmin}%
-\indexlibraryglobal{fminf}%
-\indexlibraryglobal{fminl}%
-\indexlibraryglobal{fminimum}%
-\indexlibraryglobal{fminimum_num}%
-\indexlibraryglobal{fmod}%
-\indexlibraryglobal{fmodf}%
-\indexlibraryglobal{fmodl}%
-\indexlibraryglobal{fpclassify}%
-\indexlibraryglobal{frexp}%
-\indexlibraryglobal{frexpf}%
-\indexlibraryglobal{frexpl}%
-\indexlibraryglobal{hypot}%
-\indexlibraryglobal{hypotf}%
-\indexlibraryglobal{hypotl}%
-\indexlibraryglobal{ilogb}%
-\indexlibraryglobal{ilogbf}%
-\indexlibraryglobal{ilogbl}%
-\indexlibraryglobal{isfinite}%
-\indexlibraryglobal{isgreater}%
-\indexlibraryglobal{isgreaterequal}%
-\indexlibraryglobal{isinf}%
-\indexlibraryglobal{isless}%
-\indexlibraryglobal{islessequal}%
-\indexlibraryglobal{islessgreater}%
-\indexlibraryglobal{isnan}%
-\indexlibraryglobal{isnormal}%
-\indexlibraryglobal{isunordered}%
-\indexlibraryglobal{ldexp}%
-\indexlibraryglobal{ldexpf}%
-\indexlibraryglobal{ldexpl}%
-\indexlibraryglobal{lgamma}%
-\indexlibraryglobal{lgammaf}%
-\indexlibraryglobal{lgammal}%
-\indexlibraryglobal{llrint}%
-\indexlibraryglobal{llrintf}%
-\indexlibraryglobal{llrintl}%
-\indexlibraryglobal{llround}%
-\indexlibraryglobal{llroundf}%
-\indexlibraryglobal{llroundl}%
-\indexlibraryglobal{log}%
-\indexlibraryglobal{log10}%
-\indexlibraryglobal{log10f}%
-\indexlibraryglobal{log10l}%
-\indexlibraryglobal{log1p}%
-\indexlibraryglobal{log1pf}%
-\indexlibraryglobal{log1pl}%
-\indexlibraryglobal{log2}%
-\indexlibraryglobal{log2f}%
-\indexlibraryglobal{log2l}%
-\indexlibraryglobal{logb}%
-\indexlibraryglobal{logbf}%
-\indexlibraryglobal{logbl}%
-\indexlibraryglobal{logf}%
-\indexlibraryglobal{logl}%
-\indexlibraryglobal{lrint}%
-\indexlibraryglobal{lrintf}%
-\indexlibraryglobal{lrintl}%
-\indexlibraryglobal{lround}%
-\indexlibraryglobal{lroundf}%
-\indexlibraryglobal{lroundl}%
-\indexlibraryglobal{modf}%
-\indexlibraryglobal{modff}%
-\indexlibraryglobal{modfl}%
-\indexlibraryglobal{nan}%
-\indexlibraryglobal{nanf}%
-\indexlibraryglobal{nanl}%
-\indexlibraryglobal{nearbyint}%
-\indexlibraryglobal{nearbyintf}%
-\indexlibraryglobal{nearbyintl}%
-\indexlibraryglobal{nextafter}%
-\indexlibraryglobal{nextafterf}%
-\indexlibraryglobal{nextafterl}%
-\indexlibraryglobal{nexttoward}%
-\indexlibraryglobal{nexttowardf}%
-\indexlibraryglobal{nexttowardl}%
-\indexlibraryglobal{nextup}%
-\indexlibraryglobal{nextupf}%
-\indexlibraryglobal{nextupl}%
-\indexlibraryglobal{nextdown}%
-\indexlibraryglobal{nextdownf}%
-\indexlibraryglobal{nextdownl}%
-\indexlibraryglobal{pow}%
-\indexlibraryglobal{powf}%
-\indexlibraryglobal{powl}%
-\indexlibraryglobal{remainder}%
-\indexlibraryglobal{remainderf}%
-\indexlibraryglobal{remainderl}%
-\indexlibraryglobal{remquo}%
-\indexlibraryglobal{remquof}%
-\indexlibraryglobal{remquol}%
-\indexlibraryglobal{rint}%
-\indexlibraryglobal{rintf}%
-\indexlibraryglobal{rintl}%
-\indexlibraryglobal{round}%
-\indexlibraryglobal{roundf}%
-\indexlibraryglobal{roundl}%
-\indexlibraryglobal{scalbln}%
-\indexlibraryglobal{scalblnf}%
-\indexlibraryglobal{scalblnl}%
-\indexlibraryglobal{scalbn}%
-\indexlibraryglobal{scalbnf}%
-\indexlibraryglobal{scalbnl}%
-\indexlibraryglobal{signbit}%
-\indexlibraryglobal{sin}%
-\indexlibraryglobal{sinf}%
-\indexlibraryglobal{sinh}%
-\indexlibraryglobal{sinhf}%
-\indexlibraryglobal{sinhl}%
-\indexlibraryglobal{sinl}%
-\indexlibraryglobal{sqrt}%
-\indexlibraryglobal{sqrtf}%
-\indexlibraryglobal{sqrtl}%
-\indexlibraryglobal{tan}%
-\indexlibraryglobal{tanf}%
-\indexlibraryglobal{tanh}%
-\indexlibraryglobal{tanhf}%
-\indexlibraryglobal{tanhl}%
-\indexlibraryglobal{tanl}%
-\indexlibraryglobal{tgamma}%
-\indexlibraryglobal{tgammaf}%
-\indexlibraryglobal{tgammal}%
-\indexlibraryglobal{trunc}%
-\indexlibraryglobal{truncf}%
-\indexlibraryglobal{truncl}%
 \begin{codeblock}
 #define @\libmacro{HUGE_VAL}@ @\seebelow@
 #define @\libmacro{HUGE_VALF}@ @\seebelow@
@@ -9424,278 +9228,278 @@ An iterator referencing one past the last value in the array.
 #define @\libmacro{math_errhandling}@ @\seebelow@
 
 namespace std {
-  using float_t = @\seebelow@;
-  using double_t = @\seebelow@;
+  using @\libglobal{float_t}@ = @\seebelow@;
+  using @\libglobal{double_t}@ = @\seebelow@;
 
-  constexpr @\placeholdernc{floating-point-type}@ acos(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               acosf(float x);
-  constexpr long double         acosl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{acos}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{acosf}@(float x);
+  constexpr long double         @\libglobal{acosl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ asin(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               asinf(float x);
-  constexpr long double         asinl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{asin}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{asinf}@(float x);
+  constexpr long double         @\libglobal{asinl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ atan(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               atanf(float x);
-  constexpr long double         atanl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{atan}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{atanf}@(float x);
+  constexpr long double         @\libglobal{atanl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ atan2(@\placeholdernc{floating-point-type}@ y, @\placeholdernc{floating-point-type}@ x);
-  constexpr float               atan2f(float y, float x);
-  constexpr long double         atan2l(long double y, long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{atan2}@(@\placeholdernc{floating-point-type}@ y, @\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{atan2f}@(float y, float x);
+  constexpr long double         @\libglobal{atan2l}@(long double y, long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ cos(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               cosf(float x);
-  constexpr long double         cosl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{cos}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{cosf}@(float x);
+  constexpr long double         @\libglobal{cosl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ sin(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               sinf(float x);
-  constexpr long double         sinl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{sin}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{sinf}@(float x);
+  constexpr long double         @\libglobal{sinl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ tan(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               tanf(float x);
-  constexpr long double         tanl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{tan}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{tanf}@(float x);
+  constexpr long double         @\libglobal{tanl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ acosh(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               acoshf(float x);
-  constexpr long double         acoshl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{acosh}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{acoshf}@(float x);
+  constexpr long double         @\libglobal{acoshl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ asinh(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               asinhf(float x);
-  constexpr long double         asinhl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{asinh}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{asinhf}@(float x);
+  constexpr long double         @\libglobal{asinhl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ atanh(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               atanhf(float x);
-  constexpr long double         atanhl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{atanh}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{atanhf}@(float x);
+  constexpr long double         @\libglobal{atanhl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ cosh(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               coshf(float x);
-  constexpr long double         coshl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{cosh}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{coshf}@(float x);
+  constexpr long double         @\libglobal{coshl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ sinh(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               sinhf(float x);
-  constexpr long double         sinhl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{sinh}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{sinhf}@(float x);
+  constexpr long double         @\libglobal{sinhl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ tanh(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               tanhf(float x);
-  constexpr long double         tanhl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{tanh}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{tanhf}@(float x);
+  constexpr long double         @\libglobal{tanhl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ exp(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               expf(float x);
-  constexpr long double         expl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{exp}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{expf}@(float x);
+  constexpr long double         @\libglobal{expl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ exp2(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               exp2f(float x);
-  constexpr long double         exp2l(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{exp2}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{exp2f}@(float x);
+  constexpr long double         @\libglobal{exp2l}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ expm1(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               expm1f(float x);
-  constexpr long double         expm1l(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{expm1}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{expm1f}@(float x);
+  constexpr long double         @\libglobal{expm1l}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ frexp(@\placeholdernc{floating-point-type}@ value, int* exp);
-  constexpr float               frexpf(float value, int* exp);
-  constexpr long double         frexpl(long double value, int* exp);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{frexp}@(@\placeholdernc{floating-point-type}@ value, int* exp);
+  constexpr float               @\libglobal{frexpf}@(float value, int* exp);
+  constexpr long double         @\libglobal{frexpl}@(long double value, int* exp);
 
-  constexpr int ilogb(@\placeholdernc{floating-point-type}@ x);
-  constexpr int ilogbf(float x);
-  constexpr int ilogbl(long double x);
+  constexpr int @\libglobal{ilogb}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr int @\libglobal{ilogbf}@(float x);
+  constexpr int @\libglobal{ilogbl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ ldexp(@\placeholdernc{floating-point-type}@ x, int exp);
-  constexpr float               ldexpf(float x, int exp);
-  constexpr long double         ldexpl(long double x, int exp);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{ldexp}@(@\placeholdernc{floating-point-type}@ x, int exp);
+  constexpr float               @\libglobal{ldexpf}@(float x, int exp);
+  constexpr long double         @\libglobal{ldexpl}@(long double x, int exp);
 
-  constexpr @\placeholdernc{floating-point-type}@ log(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               logf(float x);
-  constexpr long double         logl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{log}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{logf}@(float x);
+  constexpr long double         @\libglobal{logl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ log10(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               log10f(float x);
-  constexpr long double         log10l(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{log10}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{log10f}@(float x);
+  constexpr long double         @\libglobal{log10l}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ log1p(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               log1pf(float x);
-  constexpr long double         log1pl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{log1p}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{log1pf}@(float x);
+  constexpr long double         @\libglobal{log1pl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ log2(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               log2f(float x);
-  constexpr long double         log2l(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{log2}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{log2f}@(float x);
+  constexpr long double         @\libglobal{log2l}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ logb(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               logbf(float x);
-  constexpr long double         logbl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{logb}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{logbf}@(float x);
+  constexpr long double         @\libglobal{logbl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ modf(@\placeholdernc{floating-point-type}@ value, @\placeholdernc{floating-point-type}@* iptr);
-  constexpr float               modff(float value, float* iptr);
-  constexpr long double         modfl(long double value, long double* iptr);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{modf}@(@\placeholdernc{floating-point-type}@ value, @\placeholdernc{floating-point-type}@* iptr);
+  constexpr float               @\libglobal{modff}@(float value, float* iptr);
+  constexpr long double         @\libglobal{modfl}@(long double value, long double* iptr);
 
-  constexpr @\placeholdernc{floating-point-type}@ scalbn(@\placeholdernc{floating-point-type}@ x, int n);
-  constexpr float               scalbnf(float x, int n);
-  constexpr long double         scalbnl(long double x, int n);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{scalbn}@(@\placeholdernc{floating-point-type}@ x, int n);
+  constexpr float               @\libglobal{scalbnf}@(float x, int n);
+  constexpr long double         @\libglobal{scalbnl}@(long double x, int n);
 
-  constexpr @\placeholdernc{floating-point-type}@ scalbln(@\placeholdernc{floating-point-type}@ x, long int n);
-  constexpr float               scalblnf(float x, long int n);
-  constexpr long double         scalblnl(long double x, long int n);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{scalbln}@(@\placeholdernc{floating-point-type}@ x, long int n);
+  constexpr float               @\libglobal{scalblnf}@(float x, long int n);
+  constexpr long double         @\libglobal{scalblnl}@(long double x, long int n);
 
-  constexpr @\placeholdernc{floating-point-type}@ cbrt(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               cbrtf(float x);
-  constexpr long double         cbrtl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{cbrt}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{cbrtf}@(float x);
+  constexpr long double         @\libglobal{cbrtl}@(long double x);
 
   // \ref{c.math.abs}, absolute values
-  constexpr int                 abs(int j);                             // freestanding
-  constexpr long int            abs(long int j);                        // freestanding
-  constexpr long long int       abs(long long int j);                   // freestanding
-  constexpr @\placeholdernc{floating-point-type}@ abs(@\placeholdernc{floating-point-type}@ j);             // freestanding-deleted
+  constexpr int                 @\libglobal{abs}@(int j);                             // freestanding
+  constexpr long int            @\libglobal{abs}@(long int j);                        // freestanding
+  constexpr long long int       @\libglobal{abs}@(long long int j);                   // freestanding
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{abs}@(@\placeholdernc{floating-point-type}@ j);             // freestanding-deleted
 
-  constexpr @\placeholdernc{floating-point-type}@ fabs(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               fabsf(float x);
-  constexpr long double         fabsl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{fabs}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{fabsf}@(float x);
+  constexpr long double         @\libglobal{fabsl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ hypot(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
-  constexpr float               hypotf(float x, float y);
-  constexpr long double         hypotl(long double x, long double y);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{hypot}@(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr float               @\libglobal{hypotf}@(float x, float y);
+  constexpr long double         @\libglobal{hypotl}@(long double x, long double y);
 
   // \ref{c.math.hypot3}, three-dimensional hypotenuse
   constexpr @\placeholdernc{floating-point-type}@ hypot(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y,
                                       @\placeholdernc{floating-point-type}@ z);
 
-  constexpr @\placeholdernc{floating-point-type}@ pow(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
-  constexpr float               powf(float x, float y);
-  constexpr long double         powl(long double x, long double y);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{pow}@(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr float               @\libglobal{powf}@(float x, float y);
+  constexpr long double         @\libglobal{powl}@(long double x, long double y);
 
-  constexpr @\placeholdernc{floating-point-type}@ sqrt(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               sqrtf(float x);
-  constexpr long double         sqrtl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{sqrt}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{sqrtf}@(float x);
+  constexpr long double         @\libglobal{sqrtl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ erf(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               erff(float x);
-  constexpr long double         erfl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{erf}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{erff}@(float x);
+  constexpr long double         @\libglobal{erfl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ erfc(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               erfcf(float x);
-  constexpr long double         erfcl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{erfc}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{erfcf}@(float x);
+  constexpr long double         @\libglobal{erfcl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ lgamma(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               lgammaf(float x);
-  constexpr long double         lgammal(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{lgamma}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{lgammaf}@(float x);
+  constexpr long double         @\libglobal{lgammal}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ tgamma(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               tgammaf(float x);
-  constexpr long double         tgammal(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{tgamma}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{tgammaf}@(float x);
+  constexpr long double         @\libglobal{tgammal}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ ceil(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               ceilf(float x);
-  constexpr long double         ceill(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{ceil}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{ceilf}@(float x);
+  constexpr long double         @\libglobal{ceill}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ floor(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               floorf(float x);
-  constexpr long double         floorl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{floor}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{floorf}@(float x);
+  constexpr long double         @\libglobal{floorl}@(long double x);
 
-  @\placeholdernc{floating-point-type}@ nearbyint(@\placeholdernc{floating-point-type}@ x);
-  float               nearbyintf(float x);
-  long double         nearbyintl(long double x);
+  @\placeholdernc{floating-point-type}@ @\libglobal{nearbyint}@(@\placeholdernc{floating-point-type}@ x);
+  float               @\libglobal{nearbyintf}@(float x);
+  long double         @\libglobal{nearbyintl}@(long double x);
 
-  @\placeholdernc{floating-point-type}@ rint(@\placeholdernc{floating-point-type}@ x);
-  float               rintf(float x);
-  long double         rintl(long double x);
+  @\placeholdernc{floating-point-type}@ @\libglobal{rint}@(@\placeholdernc{floating-point-type}@ x);
+  float               @\libglobal{rintf}@(float x);
+  long double         @\libglobal{rintl}@(long double x);
 
-  long int lrint(@\placeholdernc{floating-point-type}@ x);
-  long int lrintf(float x);
-  long int lrintl(long double x);
+  long int @\libglobal{lrint}@(@\placeholdernc{floating-point-type}@ x);
+  long int @\libglobal{lrintf}@(float x);
+  long int @\libglobal{lrintl}@(long double x);
 
-  long long int llrint(@\placeholdernc{floating-point-type}@ x);
-  long long int llrintf(float x);
-  long long int llrintl(long double x);
+  long long int @\libglobal{llrint}@(@\placeholdernc{floating-point-type}@ x);
+  long long int @\libglobal{llrintf}@(float x);
+  long long int @\libglobal{llrintl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ round(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               roundf(float x);
-  constexpr long double         roundl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{round}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{roundf}@(float x);
+  constexpr long double         @\libglobal{roundl}@(long double x);
 
-  constexpr long int lround(@\placeholdernc{floating-point-type}@ x);
-  constexpr long int lroundf(float x);
-  constexpr long int lroundl(long double x);
+  constexpr long int @\libglobal{lround}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr long int @\libglobal{lroundf}@(float x);
+  constexpr long int @\libglobal{lroundl}@(long double x);
 
-  constexpr long long int llround(@\placeholdernc{floating-point-type}@ x);
-  constexpr long long int llroundf(float x);
-  constexpr long long int llroundl(long double x);
+  constexpr long long int @\libglobal{llround}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr long long int @\libglobal{llroundf}@(float x);
+  constexpr long long int @\libglobal{llroundl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ trunc(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               truncf(float x);
-  constexpr long double         truncl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{trunc}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{truncf}@(float x);
+  constexpr long double         @\libglobal{truncl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ fmod(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
-  constexpr float               fmodf(float x, float y);
-  constexpr long double         fmodl(long double x, long double y);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{fmod}@(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr float               @\libglobal{fmodf}@(float x, float y);
+  constexpr long double         @\libglobal{fmodl}@(long double x, long double y);
 
-  constexpr @\placeholdernc{floating-point-type}@ remainder(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
-  constexpr float               remainderf(float x, float y);
-  constexpr long double         remainderl(long double x, long double y);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{remainder}@(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr float               @\libglobal{remainderf}@(float x, float y);
+  constexpr long double         @\libglobal{remainderl}@(long double x, long double y);
 
-  constexpr @\placeholdernc{floating-point-type}@ remquo(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y, int* quo);
-  constexpr float               remquof(float x, float y, int* quo);
-  constexpr long double         remquol(long double x, long double y, int* quo);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{remquo}@(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y, int* quo);
+  constexpr float               @\libglobal{remquof}@(float x, float y, int* quo);
+  constexpr long double         @\libglobal{remquol}@(long double x, long double y, int* quo);
 
-  constexpr @\placeholdernc{floating-point-type}@ copysign(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
-  constexpr float               copysignf(float x, float y);
-  constexpr long double         copysignl(long double x, long double y);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{copysign}@(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr float               @\libglobal{copysignf}@(float x, float y);
+  constexpr long double         @\libglobal{copysignl}@(long double x, long double y);
 
-  double      nan(const char* tagp);
-  float       nanf(const char* tagp);
-  long double nanl(const char* tagp);
+  double      @\libglobal{nan}@(const char* tagp);
+  float       @\libglobal{nanf}@(const char* tagp);
+  long double @\libglobal{nanl}@(const char* tagp);
 
-  constexpr @\placeholdernc{floating-point-type}@ nextafter(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
-  constexpr float               nextafterf(float x, float y);
-  constexpr long double         nextafterl(long double x, long double y);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{nextafter}@(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr float               @\libglobal{nextafterf}@(float x, float y);
+  constexpr long double         @\libglobal{nextafterl}@(long double x, long double y);
 
-  constexpr @\placeholdernc{floating-point-type}@ nexttoward(@\placeholdernc{floating-point-type}@ x, long double y);
-  constexpr float               nexttowardf(float x, long double y);
-  constexpr long double         nexttowardl(long double x, long double y);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{nexttoward}@(@\placeholdernc{floating-point-type}@ x, long double y);
+  constexpr float               @\libglobal{nexttowardf}@(float x, long double y);
+  constexpr long double         @\libglobal{nexttowardl}@(long double x, long double y);
 
-  constexpr @\placeholdernc{floating-point-type}@ nextup(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               nextupf(float x);
-  constexpr long double         nextupl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{nextup}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{nextupf}@(float x);
+  constexpr long double         @\libglobal{nextupl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ nextdown(@\placeholdernc{floating-point-type}@ x);
-  constexpr float               nextdownf(float x);
-  constexpr long double         nextdownl(long double x);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{nextdown}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr float               @\libglobal{nextdownf}@(float x);
+  constexpr long double         @\libglobal{nextdownl}@(long double x);
 
-  constexpr @\placeholdernc{floating-point-type}@ fdim(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
-  constexpr float               fdimf(float x, float y);
-  constexpr long double         fdiml(long double x, long double y);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{fdim}@(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr float               @\libglobal{fdimf}@(float x, float y);
+  constexpr long double         @\libglobal{fdiml}@(long double x, long double y);
 
-  constexpr @\placeholdernc{floating-point-type}@ fmax(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
-  constexpr float               fmaxf(float x, float y);
-  constexpr long double         fmaxl(long double x, long double y);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{fmax}@(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr float               @\libglobal{fmaxf}@(float x, float y);
+  constexpr long double         @\libglobal{fmaxl}@(long double x, long double y);
 
-  constexpr @\placeholdernc{floating-point-type}@ fmin(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
-  constexpr float               fminf(float x, float y);
-  constexpr long double         fminl(long double x, long double y);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{fmin}@(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr float               @\libglobal{fminf}@(float x, float y);
+  constexpr long double         @\libglobal{fminl}@(long double x, long double y);
 
-  constexpr @\placeholdernc{floating-point-type}@ fmaximum(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
-  constexpr @\placeholdernc{floating-point-type}@ fmaximum_num(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
-  constexpr @\placeholdernc{floating-point-type}@ fminimum(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
-  constexpr @\placeholdernc{floating-point-type}@ fminimum_num(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{fmaximum}@(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{fmaximum_num}@(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{fminimum}@(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{fminimum_num}@(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
 
-  constexpr @\placeholdernc{floating-point-type}@ fma(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y,
+  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{fma}@(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y,
                                     @\placeholdernc{floating-point-type}@ z);
-  constexpr float               fmaf(float x, float y, float z);
-  constexpr long double         fmal(long double x, long double y, long double z);
+  constexpr float               @\libglobal{fmaf}@(float x, float y, float z);
+  constexpr long double         @\libglobal{fmal}@(long double x, long double y, long double z);
 
   // \ref{c.math.lerp}, linear interpolation
   constexpr @\placeholdernc{floating-point-type}@ lerp(@\placeholdernc{floating-point-type}@ a, @\placeholdernc{floating-point-type}@ b,
                                      @\placeholdernc{floating-point-type}@ t) noexcept;
 
   // \ref{c.math.fpclass}, classification / comparison functions
-  constexpr int fpclassify(@\placeholdernc{floating-point-type}@ x);
-  constexpr bool isfinite(@\placeholdernc{floating-point-type}@ x);
-  constexpr bool isinf(@\placeholdernc{floating-point-type}@ x);
-  constexpr bool isnan(@\placeholdernc{floating-point-type}@ x);
-  constexpr bool isnormal(@\placeholdernc{floating-point-type}@ x);
-  constexpr bool signbit(@\placeholdernc{floating-point-type}@ x);
-  constexpr bool isgreater(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
-  constexpr bool isgreaterequal(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
-  constexpr bool isless(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
-  constexpr bool islessequal(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
-  constexpr bool islessgreater(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
-  constexpr bool isunordered(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr int @\libglobal{fpclassify}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr bool @\libglobal{isfinite}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr bool @\libglobal{isinf}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr bool @\libglobal{isnan}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr bool @\libglobal{isnormal}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr bool @\libglobal{signbit}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr bool @\libglobal{isgreater}@(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr bool @\libglobal{isgreaterequal}@(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr bool @\libglobal{isless}@(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr bool @\libglobal{islessequal}@(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr bool @\libglobal{islessgreater}@(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
+  constexpr bool @\libglobal{isunordered}@(@\placeholdernc{floating-point-type}@ x, @\placeholdernc{floating-point-type}@ y);
 
   // \ref{sf.cmath}, mathematical special functions
 


### PR DESCRIPTION
Fixes #9162 