### PR TITLE
[namespace.std] Allow rejection of programs when they add declarations to the namespace std

### DIFF
--- a/source/lib-intro.tex
+++ b/source/lib-intro.tex
@@ -3009,10 +3009,10 @@ installation of handler functions during execution\iref{handler.functions}.
 
 \pnum
 Unless otherwise specified,
-the behavior of a \Cpp{} program is undefined if it adds declarations or definitions to namespace
+a \Cpp{} program shall not add declarations or definitions to namespace
 \tcode{std}
 or to a namespace within namespace
-\tcode{std}.
+\tcode{std}; no diagnostic is required.
 
 \pnum
 Unless explicitly prohibited,


### PR DESCRIPTION
Changing the behaviour from undefined to ill-formed (no diagnostics required) in [namespace.std] when a program attempts to add a declaration to the namespace std.