### PR TITLE
[cmath.syn] Remove indexing for `abs` declarations

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -9344,10 +9344,10 @@ namespace std {
   constexpr long double         @\libglobal{cbrtl}@(long double x);
 
   // \ref{c.math.abs}, absolute values
-  constexpr int                 @\libglobal{abs}@(int j);                             // freestanding
-  constexpr long int            @\libglobal{abs}@(long int j);                        // freestanding
-  constexpr long long int       @\libglobal{abs}@(long long int j);                   // freestanding
-  constexpr @\placeholdernc{floating-point-type}@ @\libglobal{abs}@(@\placeholdernc{floating-point-type}@ j);             // freestanding-deleted
+  constexpr int                 abs(int j);                             // freestanding
+  constexpr long int            abs(long int j);                        // freestanding
+  constexpr long long int       abs(long long int j);                   // freestanding
+  constexpr @\placeholdernc{floating-point-type}@ abs(@\placeholdernc{floating-point-type}@ j);             // freestanding-deleted
 
   constexpr @\placeholdernc{floating-point-type}@ @\libglobal{fabs}@(@\placeholdernc{floating-point-type}@ x);
   constexpr float               @\libglobal{fabsf}@(float x);


### PR DESCRIPTION
This indexing would be redundant because [c.math.abs] defines the entire overload set.