### PR TITLE
[cmath.syn] Align declaration of `fpclassify` with other functions

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -9488,7 +9488,7 @@ namespace std {
                                      @\placeholdernc{floating-point-type}@ t) noexcept;
 
   // \ref{c.math.fpclass}, classification / comparison functions
-  constexpr int @\libglobal{fpclassify}@(@\placeholdernc{floating-point-type}@ x);
+  constexpr int  @\libglobal{fpclassify}@(@\placeholdernc{floating-point-type}@ x);
   constexpr bool @\libglobal{isfinite}@(@\placeholdernc{floating-point-type}@ x);
   constexpr bool @\libglobal{isinf}@(@\placeholdernc{floating-point-type}@ x);
   constexpr bool @\libglobal{isnan}@(@\placeholdernc{floating-point-type}@ x);


### PR DESCRIPTION
Throughout [cmath.syn], the established style is to align function names to account for differences in return type length, such as in:
```cpp
double      nan(const char* tagp);
float       nanf(const char* tagp);
long double nanl(const char* tagp);
```

`fpclassify` does not follow that style, which is inconsistent.