### PR TITLE
[basic.life] Add start_lifetime cross-reference

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -3948,7 +3948,8 @@ except that if the object is a union member or subobject thereof,
 its lifetime only begins if that union member is the
 initialized member in the union\iref{dcl.init.aggr,class.base.init},
 or as described in
-\ref{class.union}, \ref{class.copy.ctor}, and \ref{class.copy.assign},
+\ref{class.union}, \ref{class.copy.ctor}, \ref{class.copy.assign},
+and \ref{obj.lifetime},
 and except as described in \ref{allocator.members}.
 The lifetime of an object \placeholder{o} of type \tcode{T} ends when:
 \begin{itemize}


### PR DESCRIPTION
[P3726R2](https://wg21.link/P3726R2) added `std::start_lifetime`, which can begin the lifetime of a union
member, but did not update the exhaustive lifetime-start list in [basic.life].

Add [obj.lifetime] to that list so it reflects the correct mechanism.
