### PR TITLE
[expr.prim.splice] Apply contract constification to variable templates

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3676,7 +3676,7 @@ overload resolution is performed\iref{over.match,over.over}.
 Otherwise, if $T$ is a variable template,
 let $S$ be the specialization of $T$ corresponding to
 the template argument list of the \grammarterm{splice-specialization-specifier}.
-The expression $E$ is an lvalue referring to the object or function $X$
+The expression $E$ is an lvalue referring to the object or function
 associated with or referenced by $S$.
 If $E$ appears in the predicate of a contract assertion $C$\iref{basic.contract}
 and $S$ is
@@ -3690,6 +3690,11 @@ of type ``reference to \tcode{U}'',
 \end{itemize}
 then the type of $E$ is \tcode{const U},
 otherwise $E$ has the same type as that of $S$.
+\begin{note}
+The type of a \grammarterm{splice-expression}
+designating a variable template specialization of reference type
+will be adjusted to a non-reference type\iref{expr.type}.
+\end{note}
 \item
 Otherwise, the expression is ill-formed.
 \end{itemize}

--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -3659,7 +3659,7 @@ the resulting specializations are considered as candidate functions.
 \end{note}
 
 \pnum
-For a \grammarterm{splice-expression} of
+For a \grammarterm{splice-expression} $E$ of
 the form \tcode{template \grammarterm{splice-specialization-specifier}},
 the \grammarterm{splice-specifier} of
 the \grammarterm{splice-specialization-specifier}
@@ -3676,8 +3676,20 @@ overload resolution is performed\iref{over.match,over.over}.
 Otherwise, if $T$ is a variable template,
 let $S$ be the specialization of $T$ corresponding to
 the template argument list of the \grammarterm{splice-specialization-specifier}.
-The expression is an lvalue referring to
-the object associated with $S$ and has the same type as that of $S$.
+The expression $E$ is an lvalue referring to the object or function $X$
+associated with or referenced by $S$.
+If $E$ appears in the predicate of a contract assertion $C$\iref{basic.contract}
+and $S$ is
+\begin{itemize}
+\item
+a variable declared outside of $C$
+of object type \tcode{U}, or
+\item
+a variable declared outside of $C$
+of type ``reference to \tcode{U}'',
+\end{itemize}
+then the type of $E$ is \tcode{const U},
+otherwise $E$ has the same type as that of $S$.
 \item
 Otherwise, the expression is ill-formed.
 \end{itemize}


### PR DESCRIPTION
[P3598R0](https://wg21.link/P3598R0), resolving
[CWG3158](https://cplusplus.github.io/CWG/issues/3158.html) and applied in
[#8887](https://github.com/cplusplus/draft/pull/8887), added
contract-predicate constification to the `splice-specifier` form in
[expr.prim.splice]. It did not update the variable-template
`splice-specialization-specifier` form specified by
[P2996R13](https://wg21.link/P2996R13).

Apply the same shallow constification rule to that form.
