### PR TITLE
[dcl.type.decltype] Handle splice specializations

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1720,9 +1720,28 @@ member access\iref{expr.ref}, \tcode{decltype($E$)} is the
 type of the entity named by $E$.
 If there is no such entity, the program is ill-formed;
 
-\item otherwise, if $E$ is an unparenthesized \grammarterm{splice-expression},
+\item otherwise, if $E$ is an unparenthesized \grammarterm{splice-expression}:
+\begin{itemize}
+\item if $E$ is of the form \grammarterm{splice-specifier},
 \tcode{decltype($E$)} is the type of the entity, object, or value
 designated by the \grammarterm{splice-specifier} of $E$;
+\item otherwise, if $E$ is of the form
+\tcode{template \grammarterm{splice-specialization-specifier}}
+and the \grammarterm{splice-specifier} of
+the \grammarterm{splice-specialization-specifier} designates
+a variable template $T$,
+let $S$ be the specialization of $T$
+corresponding to the template argument list of
+the \grammarterm{splice-specialization-specifier};
+\tcode{decltype($E$)} is the type of $S$;
+\item otherwise ($E$ is of the form
+\tcode{template \grammarterm{splice-specifier}},
+or of the form
+\tcode{template \grammarterm{splice-specialization-specifier}}
+whose \grammarterm{splice-specifier} designates a function template),
+$E$ denotes an overload set\iref{expr.prim.splice} and the program is
+ill-formed;
+\end{itemize}
 
 \item otherwise, if $E$ is
 an xvalue, \tcode{decltype($E$)} is \tcode{T\&\&}, where \tcode{T} is the type

--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -1734,13 +1734,14 @@ let $S$ be the specialization of $T$
 corresponding to the template argument list of
 the \grammarterm{splice-specialization-specifier};
 \tcode{decltype($E$)} is the type of $S$;
-\item otherwise ($E$ is of the form
+\item otherwise, if $E$ is of the form
 \tcode{template \grammarterm{splice-specifier}},
 or of the form
 \tcode{template \grammarterm{splice-specialization-specifier}}
-whose \grammarterm{splice-specifier} designates a function template),
+whose \grammarterm{splice-specifier} designates a function template,
 $E$ denotes an overload set\iref{expr.prim.splice} and the program is
 ill-formed;
+\item otherwise, the program is ill-formed;
 \end{itemize}
 
 \item otherwise, if $E$ is


### PR DESCRIPTION
[P2996R13](https://wg21.link/P2996R13), applied in
[#8008](https://github.com/cplusplus/draft/pull/8008), specified `decltype` of
an unparenthesized splice expression in terms of the entity designated by its
`splice-specifier`.

For a `splice-specialization-specifier`, the contained `splice-specifier`
designates the template rather than the selected specialization, as specified
in [basic.splice](https://eel.is/c++draft/basic.splice), so the wording does
not identify the intended type.

Split the cases following
[expr.prim.splice](https://eel.is/c++draft/expr.prim.splice) and
[dcl.type.splice](https://eel.is/c++draft/dcl.type.splice): preserve the
existing rule for a plain `splice-specifier`, use the selected variable-template
specialization's type, and handle function-template overload-set cases
explicitly.
