### PR TITLE
[utility.swap] Specify which two locations' values are swapped

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -284,7 +284,7 @@ requirements.
 
 \pnum
 \effects
-Exchanges values stored in two locations.
+Exchanges the values of \tcode{a} and \tcode{b}.
 
 \pnum
 \remarks


### PR DESCRIPTION
[LWG4056](https://cplusplus.github.io/LWG/issue4056) is related; it was resolved NAD. But that simply means the clarification must be an editorial issue. So here's the edit.

Historical note: This exact change was suggested during LEWG discussion of [P3055R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3055r1.html) in telecon, way back in March 2024. That paper didn't go anywhere, but this specific editorial change seems to me to have all up-side and no down-side.

Ah, further history: Adding the word "the" makes the phrase "_exchanges the values_" into words of power; that's defined in [concept.swappable](https://eel.is/c++draft/concept.swappable#1). That came up in [the LWG prioritization thread for LWG4056](https://lists.isocpp.org/lib/2024/03/27732.php).