### PR TITLE
P3424R2 Deallocation Functions with Throwing Exception Specification Are Ill-formed

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4678,6 +4678,8 @@ Array deletion cannot use a destroying operator delete.
 \pnum
 \indextext{\idxcode{delete}!overloading and}%
 Each deallocation function shall return \keyword{void}.
+A deallocation function shall not have
+a potentially throwing exception specification\iref{except.spec}.
 If the function is a destroying operator delete
 declared in class type \tcode{C},
 the type of its first parameter shall be ``pointer to \tcode{C}'';
@@ -4712,7 +4714,6 @@ instance is never a usual deallocation function, regardless of its
 signature.
 
 \pnum
-If a deallocation function terminates by throwing an exception, the behavior is undefined\ubdef{basic.stc.alloc.dealloc.throw}.
 The value of the first argument supplied to a deallocation function may
 be a null pointer value; if so, and if the deallocation function is one
 supplied in the standard library, the call has no effect.

--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -11,7 +11,27 @@ Subclause \ref{diff.cpp26} lists the differences between \Cpp{} and
 ISO \CppXXVI{},
 by the chapters of this document.
 
-\rSec2[diff.cpp26.dcl]{\ref{dcl}: declarations}
+\rSec2[diff.cpp26.basic]{\ref*{basic}: basics}
+
+\diffref{basic.stc.dynamic.deallocation}
+\change
+Potentially throwing exception specifications
+on deallocation functions are ill-formed.
+\rationale
+Removes potential undefined behavior.
+\effect
+Valic \CppXXVI{} code that declares a deallocation function
+with a potentially throwing exception specification
+becomes ill-formed.
+\begin{example}
+\begin{codeblock}
+struct T {
+  void operator delete(void *) noexcept(false);         // ill-formed; previously well-formed
+};
+\end{codeblock}
+\end{example}
+
+\rSec2[diff.cpp26.dcl]{\ref*{dcl}: declarations}
 
 \diffref{dcl.init}
 \change

--- a/source/ub.tex
+++ b/source/ub.tex
@@ -392,25 +392,6 @@ void operator delete(void* ptr) noexcept {
 \end{codeblock}
 \end{example}
 
-\ubdescription{basic.stc.alloc.dealloc.throw}
-
-\pnum
-If a call to a deallocation function terminates
-by throwing an exception the behavior is undefined.
-\pnum
-\begin{example}
-\begin{codeblock}
-struct X {
-  void operator delete(void*) noexcept(false) { throw "oops"; }
-};
-void f()
-{
-  X* x = new X();
-  delete x;     // undefined behavior
-}
-\end{codeblock}
-\end{example}
-
 \ubdescription{basic.stc.alloc.zero.dereference}
 
 \pnum


### PR DESCRIPTION
Editorial note: The entry in [ub] that described the undefined behavior that is removed by this paper has also been removed.

Fixes #9081.

Also fixes cplusplus/papers#2148