### PR TITLE
[bit.permute] Create notation for the popcount of the first n bits.

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16733,12 +16733,17 @@ The number of \tcode{1} bits in the value of \tcode{x}.
 
 \pnum
 In the following descriptions,
+\begin{itemize}
+\item
 let $N$ denote the value of \tcode{numeric_limits<T>::digits},
+\item
 let $\alpha_n$ denote the value of the $n^\text{th}$ least significant bit
 in the base-2 representation of an integer $\alpha$,
-so that $\alpha$ equals $\sum_{n=0}^{N-1} \alpha_n 2^n$,
-and let $\sigma(\alpha, n) = \sum_{k=0}^{n-1} \alpha_k$
+so that $\alpha$ equals $\sum_{n=0}^{N-1} \alpha_n 2^n$, and
+\item
+let $\sigma(\alpha, n) = \sum_{k=0}^{n-1} \alpha_k$
 be the count of one-bits among the lowest $n$ bits of $\alpha$.
+\end{itemize}
 
 \indexlibraryglobal{bit_reverse}%
 \begin{itemdecl}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -16733,10 +16733,12 @@ The number of \tcode{1} bits in the value of \tcode{x}.
 
 \pnum
 In the following descriptions,
-let $N$ denote the value of \tcode{numeric_limits<T>::digits}, and
+let $N$ denote the value of \tcode{numeric_limits<T>::digits},
 let $\alpha_n$ denote the value of the $n^\text{th}$ least significant bit
 in the base-2 representation of an integer $\alpha$,
-so that $\alpha$ equals $\sum_{n=0}^{N-1} \alpha_n 2^n$.
+so that $\alpha$ equals $\sum_{n=0}^{N-1} \alpha_n 2^n$,
+and let $\sigma(\alpha, n) = \sum_{k=0}^{n-1} \alpha_k$
+be the count of one-bits among the lowest $n$ bits of $\alpha$.
 
 \indexlibraryglobal{bit_reverse}%
 \begin{itemdecl}
@@ -16823,7 +16825,7 @@ $x$ is \tcode{x}, and
 $m$ is \tcode{m}.
 \begin{formula}{bit.permute.compress}
 \mathsf{compress}(x, m) =
-  \sum_{n=0}^{N-1} m_n x_n \, 2^{\left(\sum_{k=0}^{n-1} m_k\right)}
+  \sum_{n=0}^{N-1} m_n x_n \, 2^{\sigma(m, n)}
 \end{formula}
 
 \pnum
@@ -16857,7 +16859,7 @@ $x$ is \tcode{x}, and
 $m$ is \tcode{m}.
 \begin{formula}{bit.permute.expand}
 \mathsf{expand}(x, m) =
-  \sum_{n=0}^{N-1} m_n \, x_{\left(\sum_{k=0}^{n-1} m_k\right)} \, 2^n
+  \sum_{n=0}^{N-1} m_n \, x_{\sigma(m, n)} \, 2^n
 \end{formula}
 
 \pnum


### PR DESCRIPTION
This avoids having to put a complex expression into sub- and superscripts in the definitions of "expand" and "compress".