### PR TITLE
[ub:expr.shift.neg.and.width] Use std::uint32_t instead of int in example

### DIFF
--- a/source/ub.tex
+++ b/source/ub.tex
@@ -1281,12 +1281,12 @@ the bit-width of a type has undefined behavior.
 
 \pnum
 \begin{example}
+The following example assumes that \tcode{std::uint32_t} is supported\iref{cstdint.syn}.
 \begin{codeblock}
-int y = 1 << -1;        // undefined behavior, shift is negative
+std::uint32_t y = 1 << -1;      // undefined behavior, shift is negative
 
-static_assert(sizeof(int) == 4 && CHAR_BIT == 8);
-int y1 = 1 << 32;       // undefined behavior, shift is equal to the bit width of \tcode{int}
-int y2 = 1 >> 32;       // undefined behavior, shift is equal to the bit width of \tcode{int}
+std::uint32_t y1 = 1 << 32;     // undefined behavior, shift is equal to the bit width of \tcode{std::uint32_t}
+std::uint32_t y2 = 1 >> 32;     // undefined behavior, shift is equal to the bit width of \tcode{std::uint32_t}
 \end{codeblock}
 \end{example}
 


### PR DESCRIPTION
Firstly, I find it unnatural to use `int` and then have to assert various properties to get 32-bit type.

Secondly, the example is incorrect (well, not really, it's still true that a 32-bit shift is UB) because `sizeof(int) == 4 && CHAR_BIT == 8` is not a sufficient assertion. It's possible that `int` is a 16-bit type, with two 8-bit padding bytes and two 8-bit value bytes.

Alternatively, we could also use `numeric_limits<int>::digits` in the assertion or just put the assumption about the width of `int` into prose.