### PR TITLE
[ub:expr.add.out.of.bounds] Merge the two examples into one

### DIFF
--- a/source/ub.tex
+++ b/source/ub.tex
@@ -1208,19 +1208,11 @@ Creating an out of bounds pointer has undefined behavior.
 \pnum
 \begin{example}
 \begin{codeblock}
-static const int arrs[10]{};
-
-int main() {
-  const int *y = arrs + 11;             // undefined behavior, creating an out of bounds pointer
-}
-\end{codeblock}
-\end{example}
-
-\begin{example}
-\begin{codeblock}
+static const int arr[10]{};
 static const int arrs[10][10]{};
 
 int main() {
+  const int *y = arr + 11;              // undefined behavior, creating an out of bounds pointer
   const int(*y)[10] = arrs + 11;        // undefined behavior, creating an out of bounds pointer
 }
 \end{codeblock}


### PR DESCRIPTION
1. It's unclear why we need two example blocks. That seems like unnecessary fluff.
2. The name `arrs` for the first array doesn't make sense; it should just be `arr` because it's not several arrays (array of arrays), so it shouldn't have a plural name.