### PR TITLE
[thread.{thread.constr,jthread.cons}] Move the "existence of $i$ to Mandates:.

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -1802,13 +1802,12 @@ template<class... Args> explicit thread(Args&&... args);
 \end{itemize}
 
 \pnum
-Then:
-\begin{itemize}
-\item
 Let $i$ be the smallest value such that
 \tcode{decay_t<Args...[$i$]>}
-is not a thread attribute type.
-If no such $i$ exists, the program is ill-formed.
+is not a thread attribute type,
+if such a value exists.
+Then the following notation is used:
+\begin{itemize}
 \item
 Let \tcode{F} be \tcode{Args...[$i$]}.
 \item
@@ -1833,7 +1832,7 @@ such that $i < j < \tcode{sizeof...(args)}$.
 
 \pnum
 \mandates
-The following are all \tcode{true}:
+The value $i$ exists, and the following are all \tcode{true}:
 \begin{itemize}
 \item \tcode{is_constructible_v<decay_t<F>, F>},
 \item \tcode{(is_constructible_v<decay_t<FArgs>, FArgs> \&\& ...)},
@@ -2178,13 +2177,12 @@ template<class... Args> explicit jthread(Args&&... args);
 \end{itemize}
 
 \pnum
-Then:
-\begin{itemize}
-\item
 Let $i$ be the smallest value such that
 \tcode{decay_t<Args...[$i$]>}
-is not a thread attribute type.
-If no such $i$ exists, the program is ill-formed.
+is not a thread attribute type,
+if such a value exists.
+Then the following notation is used:
+\begin{itemize}
 \item
 Let \tcode{F} be \tcode{Args...[$i$]}.
 \item
@@ -2209,7 +2207,7 @@ such that $i < j < \tcode{sizeof...(args)}$.
 
 \pnum
 \mandates
-The following are all \tcode{true}:
+The value $i$ exists, and the following are all \tcode{true}:
 \begin{itemize}
 \item \tcode{is_constructible_v<decay_t<F>, F>},
 \item \tcode{(is_constructible_v<decay_t<FArgs>, FArgs> \&\& ...)},


### PR DESCRIPTION
This change separates the local notational definitions from the requirement whose violation makes the program ill-formed: the latter should probably appear in one of the standard Elements rather than in a rogue paragraph.