### PR TITLE
[depr.iterator] and [depr.ostream.inserters]: use \rSec instead of \Sec

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -1059,7 +1059,7 @@ template<class T> constexpr T kill_dependency(T y) noexcept;
 \tcode{y}.
 \end{itemdescr}
 
-\Sec1[depr.istream.extractors]{Deprecated \tcode{signed char} and \tcode{unsigned char} extraction}
+\rSec1[depr.istream.extractors]{Deprecated \tcode{signed char} and \tcode{unsigned char} extraction}
 \pnum
 The header \libheaderref{istream} has the following additions:
 
@@ -1132,7 +1132,7 @@ local error state before \tcode{setstate} is called.
 \tcode{in}.
 \end{itemdescr}
 
-\Sec1[depr.ostream.inserters]{Deprecated \tcode{signed char} and \tcode{unsigned char} insertion}
+\rSec1[depr.ostream.inserters]{Deprecated \tcode{signed char} and \tcode{unsigned char} insertion}
 \pnum
 The header \libheaderref{ostream} has the following additions:
 


### PR DESCRIPTION
https://github.com/cplusplus/draft/pull/9122 used \Sec1 commands instead of \rSec1, inconsistent with all other sectioning commands in the Standard.  This PR corrects that.