### PR TITLE
[simd.mask.overview] Put content after \recommended onto a separate line

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -20950,7 +20950,8 @@ If \tcode{basic_mask<Bytes, Abi>} is enabled,
 \tcode{basic_mask<Bytes, Abi>} is trivially copyable.
 
 \pnum
-\recommended Implementations should support implicit conversions between
+\recommended
+Implementations should support implicit conversions between
 specializations of \tcode{basic_mask} and appropriate \impldef{conversions
 of \tcode{basic_mask} from/to implementation-specific vector types} types.
 \begin{note}


### PR DESCRIPTION
This is necessary to keep the source fixes separate from #9146.
