### PR TITLE
[numeric.limits.members] Correct footnotes and convert to notes and examples

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -1143,10 +1143,10 @@ static constexpr T min() noexcept;
 \begin{itemdescr}
 \pnum
 Minimum finite value.
-\begin{footnote}
+\begin{example}
 Equivalent to \tcode{CHAR_MIN}, \tcode{SHRT_MIN},
 \tcode{FLT_MIN}, \tcode{DBL_MIN}, etc.
-\end{footnote}
+\end{example}
 
 \indextext{number!subnormal}%
 \pnum
@@ -1168,10 +1168,10 @@ static constexpr T max() noexcept;
 \begin{itemdescr}
 \pnum
 Maximum finite value.
-\begin{footnote}
+\begin{example}
 Equivalent to \tcode{CHAR_MAX}, \tcode{SHRT_MAX},
 \tcode{FLT_MAX}, \tcode{DBL_MAX}, etc.
-\end{footnote}
+\end{example}
 
 \pnum
 Meaningful for all specializations in which
@@ -1187,11 +1187,11 @@ static constexpr T lowest() noexcept;
 \pnum
 A finite value \tcode{x} such that there is no other finite
 value \tcode{y} where \tcode{y < x}.
-\begin{footnote}
+\begin{note}
 \tcode{lowest()} is necessary because not all
 floating-point representations have a smallest (most negative) value that is
 the negative of the largest (most positive) finite value.
-\end{footnote}
+\end{note}
 
 \pnum
 Meaningful for all specializations in which \tcode{is_bounded != false}.
@@ -1214,10 +1214,10 @@ For integer types, the number of non-sign bits in the representation.
 \pnum
 For floating-point types, the number of \tcode{radix} digits in the
 significand.
-\begin{footnote}
+\begin{example}
 Equivalent to \tcode{FLT_MANT_DIG}, \tcode{DBL_MANT_DIG},
-\tcode{LDBL_MANT_DIG}.
-\end{footnote}
+\tcode{LDBL_MANT_DIG}, etc.
+\end{example}
 \end{itemdescr}
 
 \indexlibrarymember{digits10}{numeric_limits}%
@@ -1229,10 +1229,10 @@ static constexpr int digits10;
 \pnum
 Number of base 10 digits that can be represented without
 change.
-\begin{footnote}
+\begin{example}
 Equivalent to \tcode{FLT_DIG}, \tcode{DBL_DIG},
-\tcode{LDBL_DIG}.
-\end{footnote}
+\tcode{LDBL_DIG}, etc.
+\end{example}
 
 \pnum
 Meaningful for all specializations in which
@@ -1303,16 +1303,14 @@ static constexpr int radix;
 \pnum
 For floating-point types, specifies the base or radix of the exponent representation
 (often 2).
-\begin{footnote}
-Equivalent to \tcode{FLT_RADIX}.
-\end{footnote}
+\begin{example}
+For \tcode{float},
+equivalent to \tcode{FLT_RADIX}.
+\end{example}
 
 \pnum
 For integer types, specifies the base of the
 representation.
-\begin{footnote}
-Distinguishes types with bases other than 2 (e.g., BCD).
-\end{footnote}
 
 \pnum
 Meaningful for all specializations.
@@ -1327,9 +1325,9 @@ static constexpr T epsilon() noexcept;
 \pnum
 Machine epsilon:  the difference between 1 and the least value greater than 1
 that is representable.
-\begin{footnote}
-Equivalent to \tcode{FLT_EPSILON}, \tcode{DBL_EPSILON}, \tcode{LDBL_EPSILON}.
-\end{footnote}
+\begin{example}
+Equivalent to \tcode{FLT_EPSILON}, \tcode{DBL_EPSILON}, \tcode{LDBL_EPSILON}, etc.
+\end{example}
 
 \pnum
 Meaningful for all floating-point types.
@@ -1356,10 +1354,10 @@ Minimum negative integer such that
 \tcode{radix}
 raised to the power of one less than that integer is a normalized floating-point
 number.
-\begin{footnote}
+\begin{example}
 Equivalent to \tcode{FLT_MIN_EXP}, \tcode{DBL_MIN_EXP},
-\tcode{LDBL_MIN_EXP}.
-\end{footnote}
+\tcode{LDBL_MIN_EXP}, etc.
+\end{example}
 
 \pnum
 Meaningful for all floating-point types.
@@ -1374,10 +1372,10 @@ static constexpr int min_exponent10;
 \pnum
 Minimum negative integer such that 10 raised to that power is in the range
 of normalized floating-point numbers.
-\begin{footnote}
+\begin{example}
 Equivalent to
-\tcode{FLT_MIN_10_EXP}, \tcode{DBL_MIN_10_EXP}, \tcode{LDBL_MIN_10_EXP}.
-\end{footnote}
+\tcode{FLT_MIN_10_EXP}, \tcode{DBL_MIN_10_EXP}, \tcode{LDBL_MIN_10_EXP}, etc.
+\end{example}
 
 \pnum
 Meaningful for all floating-point types.
@@ -1394,10 +1392,10 @@ Maximum positive integer such that
 \tcode{radix}
 raised to the power one less than that integer is a representable finite
 floating-point number.
-\begin{footnote}
+\begin{example}
 Equivalent to \tcode{FLT_MAX_EXP},
-\tcode{DBL_MAX_EXP}, \tcode{LDBL_MAX_EXP}.
-\end{footnote}
+\tcode{DBL_MAX_EXP}, \tcode{LDBL_MAX_EXP}, etc.
+\end{example}
 
 \pnum
 Meaningful for all floating-point types.
@@ -1412,10 +1410,10 @@ static constexpr int max_exponent10;
 \pnum
 Maximum positive integer such that 10 raised to that power is in the
 range of representable finite floating-point numbers.
-\begin{footnote}
+\begin{example}
 Equivalent to
-\tcode{FLT_MAX_10_EXP}, \tcode{DBL_MAX_10_EXP}, \tcode{LDBL_MAX_10_EXP}.
-\end{footnote}
+\tcode{FLT_MAX_10_EXP}, \tcode{DBL_MAX_10_EXP}, \tcode{LDBL_MAX_10_EXP}, etc.
+\end{example}
 
 \pnum
 Meaningful for all floating-point types.
@@ -1645,9 +1643,10 @@ static constexpr float_round_style round_style;
 \begin{itemdescr}
 \pnum
 The rounding style for the type.
-\begin{footnote}
-Equivalent to \tcode{FLT_ROUNDS}.
-\end{footnote}
+\begin{example}
+For \tcode{float},
+equivalent to \tcode{FLT_ROUNDS}.
+\end{example}
 
 \pnum
 Meaningful for all floating-point types.


### PR DESCRIPTION
There are many major issues with [numeric.limits.members] right now:
- Many of the footnotes say something like "Equivalent to `FLT_RADIX`". This doesn't account for `double` being a decimal floating-point type (which is permitted I believe), and doesn't account for any extended floating-point types that are not binary.
- Many footnotes shouldn't be footnotes. To my understanding, footnotes should only be used for references to external documents, not for immediate clarifications or examples.
- Many footnotes are exhaustive when they shouldn't be, by only mentioning the `FLT`, `DBL`, and `LDBL` macro. However, with extended floating-point types, the value of the member can obviously be soemthing other than those three, so there needs to be a `etc.` somewhere.
- There is a footnote attached to the description of `radix` for integers, accounting for representations like BCD. Seeing that since C++20, the representation of integers is always two's complement, this footnote no longer makes any sense.

This PR cleans up all those problems.