### PR TITLE
[simd.math] Fix various indexing problems

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -19753,110 +19753,77 @@ lookup\iref{basic.lookup.argdep} contrary to \ref{contents}.
 
 \rSec3[simd.math]{Mathematical functions}
 
-\indexlibrarymember{ilogb}{simd}
-\indexlibrarymember{abs}{simd}
-\indexlibrarymember{fabs}{simd}
-\indexlibrarymember{ceil}{simd}
-\indexlibrarymember{floor}{simd}
-\indexlibrarymember{nearbyint}{simd}
-\indexlibrarymember{rint}{simd}
-\indexlibrarymember{lrint}{simd}
-\indexlibrarymember{llrint}{simd}
-\indexlibrarymember{round}{simd}
-\indexlibrarymember{lround}{simd}
-\indexlibrarymember{llround}{simd}
-\indexlibrarymember{fmod}{simd}
-\indexlibrarymember{trunc}{simd}
-\indexlibrarymember{remainder}{simd}
-\indexlibrarymember{copysign}{simd}
-\indexlibrarymember{nextafter}{simd}
-\indexlibrarymember{fdim}{simd}
-\indexlibrarymember{fmax}{simd}
-\indexlibrarymember{fmin}{simd}
-\indexlibrarymember{fma}{simd}
-\indexlibrarymember{fpclassify}{simd}
-\indexlibrarymember{isfinite}{simd}
-\indexlibrarymember{isinf}{simd}
-\indexlibrarymember{isnan}{simd}
-\indexlibrarymember{isnormal}{simd}
-\indexlibrarymember{signbit}{simd}
-\indexlibrarymember{isgreater}{simd}
-\indexlibrarymember{isgreaterequal}{simd}
-\indexlibrarymember{isless}{simd}
-\indexlibrarymember{islessequal}{simd}
-\indexlibrarymember{islessgreater}{simd}
-\indexlibrarymember{isunordered}{simd}
 \begin{itemdecl}
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr rebind_t<int, @\exposid{deduced-vec-t}@<V>> ilogb(const V& x);
+  constexpr rebind_t<int, @\exposid{deduced-vec-t}@<V>> @\libmember{ilogb}{simd}@(const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr @\exposid{deduced-vec-t}@<V> abs(const V& j);
+  constexpr @\exposid{deduced-vec-t}@<V> @\libmember{abs}{simd}@(const V& j);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr @\exposid{deduced-vec-t}@<V> fabs(const V& x);
+  constexpr @\exposid{deduced-vec-t}@<V> @\libmember{fabs}{simd}@(const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr @\exposid{deduced-vec-t}@<V> ceil(const V& x);
+  constexpr @\exposid{deduced-vec-t}@<V> @\libmember{ceil}{simd}@(const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr @\exposid{deduced-vec-t}@<V> floor(const V& x);
+  constexpr @\exposid{deduced-vec-t}@<V> @\libmember{floor}{simd}@(const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> nearbyint(const V& x);
+  @\exposid{deduced-vec-t}@<V> @\libmember{nearbyint}{simd}@(const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> rint(const V& x);
+  @\exposid{deduced-vec-t}@<V> @\libmember{rint}{simd}@(const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  rebind_t<long int, @\exposid{deduced-vec-t}@<V>> lrint(const V& x);
+  rebind_t<long int, @\exposid{deduced-vec-t}@<V>> @\libmember{lrint}{simd}@(const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  rebind_t<long long int, @\exposid{deduced-vec-t}@<V>> llrint(const V& x);
+  rebind_t<long long int, @\exposid{deduced-vec-t}@<V>> @\libmember{llrint}{simd}@(const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr @\exposid{deduced-vec-t}@<V> round(const V& x);
+  constexpr @\exposid{deduced-vec-t}@<V> @\libmember{round}{simd}@(const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr rebind_t<long int, @\exposid{deduced-vec-t}@<V>> lround(const V& x);
+  constexpr rebind_t<long int, @\exposid{deduced-vec-t}@<V>> @\libmember{lround}{simd}@(const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr rebind_t<long long int, @\exposid{deduced-vec-t}@<V>> llround(const V& x);
+  constexpr rebind_t<long long int, @\exposid{deduced-vec-t}@<V>> @\libmember{llround}{simd}@(const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr @\exposid{deduced-vec-t}@<V> fmod(const V& x, const V& y);
+  constexpr @\exposid{deduced-vec-t}@<V> @\libmember{fmod}{simd}@(const V& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V> fmod(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V> fmod(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr @\exposid{deduced-vec-t}@<V> trunc(const V& x);
+  constexpr @\exposid{deduced-vec-t}@<V> @\libmember{trunc}{simd}@(const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr @\exposid{deduced-vec-t}@<V> remainder(const V& x, const V& y);
+  constexpr @\exposid{deduced-vec-t}@<V> @\libmember{remainder}{simd}@(const V& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V> remainder(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V> remainder(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr @\exposid{deduced-vec-t}@<V> copysign(const V& x, const V& y);
+  constexpr @\exposid{deduced-vec-t}@<V> @\libmember{copysign}{simd}@(const V& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V> copysign(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V> copysign(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr @\exposid{deduced-vec-t}@<V> nextafter(const V& x, const V& y);
+  constexpr @\exposid{deduced-vec-t}@<V> @\libmember{nextafter}{simd}@(const V& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V> nextafter(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V> nextafter(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr @\exposid{deduced-vec-t}@<V> fdim(const V& x, const V& y);
+  constexpr @\exposid{deduced-vec-t}@<V> @\libmember{fdim}{simd}@(const V& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V> fdim(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V> fdim(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr @\exposid{deduced-vec-t}@<V> fmax(const V& x, const V& y);
+  constexpr @\exposid{deduced-vec-t}@<V> @\libmember{fmax}{simd}@(const V& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V> fmax(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V> fmax(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr @\exposid{deduced-vec-t}@<V> fmin(const V& x, const V& y);
+  constexpr @\exposid{deduced-vec-t}@<V> @\libmember{fmin}{simd}@(const V& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V> fmin(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V> fmin(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr @\exposid{deduced-vec-t}@<V> fma(const V& x, const V& y, const V& z);
+  constexpr @\exposid{deduced-vec-t}@<V> @\libmember{fma}{simd}@(const V& x, const V& y, const V& z);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V> fma(const @\exposid{deduced-vec-t}@<V>& x, const V& y, const V& z);
 template<@\exposconcept{math-floating-point}@ V>
@@ -19873,26 +19840,26 @@ template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V>
     fma(const V& x, const @\exposid{deduced-vec-t}@<V>& y, const @\exposid{deduced-vec-t}@<V>& z);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr rebind_t<int, @\exposid{deduced-vec-t}@<V>> fpclassify(const V& x);
+  constexpr rebind_t<int, @\exposid{deduced-vec-t}@<V>> @\libmember{fpclassify}{simd}@(const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type isfinite(const V& x);
+  constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type @\libmember{isfinite}{simd}@(const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type isinf(const V& x);
+  constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type @\libmember{isinf}{simd}@(const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type isnan(const V& x);
+  constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type @\libmember{isnan}{simd}@(const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type isnormal(const V& x);
+  constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type @\libmember{isnormal}{simd}@(const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type signbit(const V& x);
+  constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type @\libmember{signbit}{simd}@(const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type isgreater(const V& x, const V& y);
+  constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type @\libmember{isgreater}{simd}@(const V& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type isgreater(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type isgreater(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type
-    isgreaterequal(const V& x, const V& y);
+    @\libmember{isgreaterequal}{simd}@(const V& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type
     isgreaterequal(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
@@ -19901,7 +19868,7 @@ template<@\exposconcept{math-floating-point}@ V>
     isgreaterequal(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type
-    isless(const V& x, const V& y);
+    @\libmember{isless}{simd}@(const V& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type
     isless(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
@@ -19910,7 +19877,7 @@ template<@\exposconcept{math-floating-point}@ V>
     isless(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type
-    islessequal(const V& x, const V& y);
+    @\libmember{islessequal}{simd}@(const V& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type
     islessequal(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
@@ -19919,7 +19886,7 @@ template<@\exposconcept{math-floating-point}@ V>
     islessequal(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type
-    islessgreater(const V& x, const V& y);
+    @\libmember{islessgreater}{simd}@(const V& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type
     islessgreater(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
@@ -19928,7 +19895,7 @@ template<@\exposconcept{math-floating-point}@ V>
     islessgreater(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type
-    isunordered(const V& x, const V& y);
+    @\libmember{isunordered}{simd}@(const V& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr typename @\exposid{deduced-vec-t}@<V>::mask_type
     isunordered(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
@@ -19965,17 +19932,14 @@ occur, the value of \tcode{ret[i]} is unspecified.
 It is unspecified whether \tcode{errno}\iref{errno} is accessed.
 \end{itemdescr}
 
-\indexlibrarymember{ldexp}{simd}
-\indexlibrarymember{scalbn}{simd}
-\indexlibrarymember{scalbln}{simd}
 \begin{itemdecl}
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr @\exposid{deduced-vec-t}@<V> ldexp(const V& x, const rebind_t<int, @\exposid{deduced-vec-t}@<V>>& exp);
+  constexpr @\exposid{deduced-vec-t}@<V> @\libmember{ldexp}{simd}@(const V& x, const rebind_t<int, @\exposid{deduced-vec-t}@<V>>& exp);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr @\exposid{deduced-vec-t}@<V> scalbn(const V& x, const rebind_t<int, @\exposid{deduced-vec-t}@<V>>& n);
+  constexpr @\exposid{deduced-vec-t}@<V> @\libmember{scalbn}{simd}@(const V& x, const rebind_t<int, @\exposid{deduced-vec-t}@<V>>& n);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V>
-    scalbln(const V& x, const rebind_t<long int, @\exposid{deduced-vec-t}@<V>>& n);
+    @\libmember{scalbln}{simd}@(const V& x, const rebind_t<long int, @\exposid{deduced-vec-t}@<V>>& n);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -20023,79 +19987,36 @@ An object where the $i^{\textrm{th}}$ element is initialized to the result of
 
 \end{itemdescr}
 
-\indexlibrarymember{acos}{simd}
-\indexlibrarymember{asin}{simd}
-\indexlibrarymember{atan}{simd}
-\indexlibrarymember{atan2}{simd}
-\indexlibrarymember{cos}{simd}
-\indexlibrarymember{sin}{simd}
-\indexlibrarymember{tan}{simd}
-\indexlibrarymember{acosh}{simd}
-\indexlibrarymember{asinh}{simd}
-\indexlibrarymember{atanh}{simd}
-\indexlibrarymember{cosh}{simd}
-\indexlibrarymember{sinh}{simd}
-\indexlibrarymember{tanh}{simd}
-\indexlibrarymember{exp}{simd}
-\indexlibrarymember{exp2}{simd}
-\indexlibrarymember{expm1}{simd}
-\indexlibrarymember{log}{simd}
-\indexlibrarymember{log10}{simd}
-\indexlibrarymember{log1p}{simd}
-\indexlibrarymember{log2}{simd}
-\indexlibrarymember{logb}{simd}
-\indexlibrarymember{cbrt}{simd}
-\indexlibrarymember{hypot}{simd}
-\indexlibrarymember{hypot}{simd}
-\indexlibrarymember{pow}{simd}
-\indexlibrarymember{sqrt}{simd}
-\indexlibrarymember{erf}{simd}
-\indexlibrarymember{erfc}{simd}
-\indexlibrarymember{lgamma}{simd}
-\indexlibrarymember{tgamma}{simd}
-\indexlibrarymember{lerp}{simd}
-\indexlibrarymember{beta}{simd}
-\indexlibrarymember{comp_ellint_1}{simd}
-\indexlibrarymember{comp_ellint_2}{simd}
-\indexlibrarymember{comp_ellint_3}{simd}
-\indexlibrarymember{cyl_bessel_i}{simd}
-\indexlibrarymember{cyl_bessel_j}{simd}
-\indexlibrarymember{cyl_bessel_k}{simd}
-\indexlibrarymember{cyl_neumann}{simd}
-\indexlibrarymember{ellint_1}{simd}
-\indexlibrarymember{ellint_2}{simd}
-\indexlibrarymember{ellint_3}{simd}
-\indexlibrarymember{expint}{simd}
 \begin{itemdecl}
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> acos(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> asin(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> atan(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{acos}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{asin}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{atan}{simd}@(const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr @\exposid{deduced-vec-t}@<V> atan2(const V& y, const V& x);
+  constexpr @\exposid{deduced-vec-t}@<V> @\libmember{atan2}{simd}@(const V& y, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V> atan2(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V> atan2(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> cos(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> sin(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> tan(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> acosh(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> asinh(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> atanh(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> cosh(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> sinh(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> tanh(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> exp(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> exp2(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> expm1(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> log(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> log10(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> log1p(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> log2(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> logb(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> cbrt(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{cos}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{sin}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{tan}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{acosh}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{asinh}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{atanh}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{cosh}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{sinh}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{tanh}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{exp}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{exp2}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{expm1}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{log}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{log10}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{log1p}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{log2}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{logb}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{cbrt}{simd}@(const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr @\exposid{deduced-vec-t}@<V> hypot(const V& x, const V& y);
+  constexpr @\exposid{deduced-vec-t}@<V> @\libmember{hypot}{simd}@(const V& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V> hypot(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
@@ -20118,18 +20039,18 @@ template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V>
     hypot(const V& x, const @\exposid{deduced-vec-t}@<V>& y, const @\exposid{deduced-vec-t}@<V>& z);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr @\exposid{deduced-vec-t}@<V> pow(const V& x, const V& y);
+  constexpr @\exposid{deduced-vec-t}@<V> @\libmember{pow}{simd}@(const V& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V> pow(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V> pow(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> sqrt(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> erf(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> erfc(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> lgamma(const V& x);
-template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> tgamma(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{sqrt}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{erf}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{erfc}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{lgamma}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> constexpr @\exposid{deduced-vec-t}@<V> @\libmember{tgamma}{simd}@(const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  constexpr @\exposid{deduced-vec-t}@<V> lerp(const V& a, const V& b, const V& t) noexcept;
+  constexpr @\exposid{deduced-vec-t}@<V> @\libmember{lerp}{simd}@(const V& a, const V& b, const V& t) noexcept;
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V> lerp(const @\exposid{deduced-vec-t}@<V>& x, const V& y, const V& z);
 template<@\exposconcept{math-floating-point}@ V>
@@ -20146,57 +20067,57 @@ template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V>
     lerp(const V& x, const @\exposid{deduced-vec-t}@<V>& y, const @\exposid{deduced-vec-t}@<V>& z);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> beta(const V& x, const V& y);
+  @\exposid{deduced-vec-t}@<V> @\libmember{beta}{simd}@(const V& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> beta(const @\exposid{deduced-vec-t}@<V>& x, const V& y);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> beta(const V& x, const @\exposid{deduced-vec-t}@<V>& y);
-template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-vec-t}@<V> comp_ellint_1(const V& k);
-template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-vec-t}@<V> comp_ellint_2(const V& k);
+template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-vec-t}@<V> @\libmember{comp_ellint_1}{simd}@(const V& k);
+template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-vec-t}@<V> @\libmember{comp_ellint_2}{simd}@(const V& k);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> comp_ellint_3(const V& k, const V& nu);
+  @\exposid{deduced-vec-t}@<V> @\libmember{comp_ellint_3}{simd}@(const V& k, const V& nu);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> comp_ellint_3(const @\exposid{deduced-vec-t}@<V>& k, const V& nu);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> comp_ellint_3(const V& k, const @\exposid{deduced-vec-t}@<V>& nu);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> cyl_bessel_i(const V& nu, const V& x);
+  @\exposid{deduced-vec-t}@<V> @\libmember{cyl_bessel_i}{simd}@(const V& nu, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> cyl_bessel_i(const @\exposid{deduced-vec-t}@<V>& nu, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> cyl_bessel_i(const V& nu, const @\exposid{deduced-vec-t}@<V>& x);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> cyl_bessel_j(const V& nu, const V& x);
+  @\exposid{deduced-vec-t}@<V> @\libmember{cyl_bessel_j}{simd}@(const V& nu, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> cyl_bessel_j(const @\exposid{deduced-vec-t}@<V>& nu, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> cyl_bessel_j(const V& nu, const @\exposid{deduced-vec-t}@<V>& x);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> cyl_bessel_k(const V& nu, const V& x);
+  @\exposid{deduced-vec-t}@<V> @\libmember{cyl_bessel_k}{simd}@(const V& nu, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> cyl_bessel_k(const @\exposid{deduced-vec-t}@<V>& nu, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> cyl_bessel_k(const V& nu, const @\exposid{deduced-vec-t}@<V>& x);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> cyl_neumann(const V& nu, const V& x);
+  @\exposid{deduced-vec-t}@<V> @\libmember{cyl_neumann}{simd}@(const V& nu, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> cyl_neumann(const @\exposid{deduced-vec-t}@<V>& nu, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> cyl_neumann(const V& nu, const @\exposid{deduced-vec-t}@<V>& x);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> ellint_1(const V& k, const V& phi);
+  @\exposid{deduced-vec-t}@<V> @\libmember{ellint_1}{simd}@(const V& k, const V& phi);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> ellint_1(const @\exposid{deduced-vec-t}@<V>& k, const V& phi);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> ellint_1(const V& k, const @\exposid{deduced-vec-t}@<V>& phi);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> ellint_2(const V& k, const V& phi);
+  @\exposid{deduced-vec-t}@<V> @\libmember{ellint_2}{simd}@(const V& k, const V& phi);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> ellint_2(const @\exposid{deduced-vec-t}@<V>& k, const V& phi);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> ellint_2(const V& k, const @\exposid{deduced-vec-t}@<V>& phi);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> ellint_3(const V& k, const V& nu, const V& phi);
+  @\exposid{deduced-vec-t}@<V> @\libmember{ellint_3}{simd}@(const V& k, const V& nu, const V& phi);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> ellint_3(const @\exposid{deduced-vec-t}@<V>& k, const V& nu, const V& phi);
 template<@\exposconcept{math-floating-point}@ V>
@@ -20209,8 +20130,8 @@ template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> ellint_3(const @\exposid{deduced-vec-t}@<V>& k, const V& nu, const @\exposid{deduced-vec-t}@<V>& phi);
 template<@\exposconcept{math-floating-point}@ V>
   @\exposid{deduced-vec-t}@<V> ellint_3(const V& k, const @\exposid{deduced-vec-t}@<V>& nu, const @\exposid{deduced-vec-t}@<V>& phi);
-template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-vec-t}@<V> expint(const V& x);
-template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-vec-t}@<V> riemann_zeta(const V& x);
+template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-vec-t}@<V> @\libmember{expint}{simd}@(const V& x);
+template<@\exposconcept{math-floating-point}@ V> @\exposid{deduced-vec-t}@<V> @\libmember{riemann_zeta}{simd}@(const V& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -20241,18 +20162,15 @@ occur, the value of \tcode{ret[i]} is unspecified.
 It is unspecified whether \tcode{errno}\iref{errno} is accessed.
 \end{itemdescr}
 
-\indexlibrarymember{assoc_laguerre}{simd}
-\indexlibrarymember{assoc_legendre}{simd}
-\indexlibrarymember{sph_legendre}{simd}
 \begin{itemdecl}
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> assoc_laguerre(const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& n,
+  @\exposid{deduced-vec-t}@<V> @\libmember{assoc_laguerre}{simd}@(const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& n,
                                  @\itcorr@ const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& m, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> assoc_legendre(const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& l,
+  @\exposid{deduced-vec-t}@<V> @\libmember{assoc_legendre}{simd}@(const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& l,
                                  @\itcorr@ const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& m, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> sph_legendre(const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& l,
+  @\exposid{deduced-vec-t}@<V> @\libmember{sph_legendre}{simd}@(const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& l,
                                @\itcorr@ const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& m, const V& theta);
 \end{itemdecl}
 
@@ -20274,23 +20192,17 @@ An object that is element-wise approximately equal to the result of calling
 \tcode{\placeholder{math-func-vec}} with the parameters of the above functions.
 \end{itemdescr}
 
-\indexlibrarymember{hermite}{simd}
-\indexlibrarymember{laguerre}{simd}
-\indexlibrarymember{legendre}{simd}
-\indexlibrarymember{riemann_zeta}{simd}
-\indexlibrarymember{sph_bessel}{simd}
-\indexlibrarymember{sph_neumann}{simd}
 \begin{itemdecl}
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> hermite(const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& n, const V& x);
+  @\exposid{deduced-vec-t}@<V> @\libmember{hermite}{simd}@(const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& n, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> laguerre(const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& n, const V& x);
+  @\exposid{deduced-vec-t}@<V> @\libmember{laguerre}{simd}@(const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& n, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> legendre(const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& l, const V& x);
+  @\exposid{deduced-vec-t}@<V> @\libmember{legendre}{simd}@(const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& l, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> sph_bessel(const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& n, const V& x);
+  @\exposid{deduced-vec-t}@<V> @\libmember{sph_bessel}{simd}@(const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& n, const V& x);
 template<@\exposconcept{math-floating-point}@ V>
-  @\exposid{deduced-vec-t}@<V> sph_neumann(const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& n, const V& x);
+  @\exposid{deduced-vec-t}@<V> @\libmember{sph_neumann}{simd}@(const rebind_t<unsigned, @\exposid{deduced-vec-t}@<V>>& n, const V& x);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -20342,6 +20254,7 @@ Sets \tcode{*exp} to \tcode{ret.second}.
 \tcode{ret.first}.
 \end{itemdescr}
 
+\indexlibrarymember{remquo}{simd}
 \begin{itemdecl}
 template<@\exposconcept{math-floating-point}@ V>
   constexpr @\exposid{deduced-vec-t}@<V> remquo(const V& x, const V& y,


### PR DESCRIPTION
Fixes #9200

1. There was indexing of `simd::riemann_zeta` without any declaration in the code block below.
2. Indexing for `simd::remquo` was missing.
3. Various declaration blocks were overly large for out-of-line indexing. For consistency, all blocks declaring multiple functions were converted to inline indexing. This change is in the same style as #9163 If you look at the PDF, you will find that several of the code blocks in [simd.math] span multiple pages, so the library index ends up pointing to the wrong page, sometimes off by multiple pages.