### PR TITLE
[diff] Reorder Annex C entries to respect clause numbering

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -818,30 +818,6 @@ which is intended to be instantiated only with cv-unqualified object types.
 Valid \CppXX{} code that instantiated the removed specialization
 can become ill-formed.
 
-\rSec2[diff.cpp20.strings]{\ref*{strings}: strings library}
-
-\diffref{string.classes}
-\change
-Additional rvalue overload for the \tcode{substr} member function and
-the corresponding constructor.
-\rationale
-Improve efficiency of operations on rvalues.
-\effect
-Valid \CppXX{} code that created a substring
-by calling \tcode{substr} (or the corresponding constructor)
-on an xvalue expression with type \tcode{S}
-that is a specialization of \tcode{basic_string}
-may change meaning in this revision of \Cpp{}.
-\begin{example}
-\begin{codeblock}
-std::string s1 = "some long string that forces allocation", s2 = s1;
-std::move(s1).substr(10, 5);
-assert(s1 == s2);       // unspecified, previously guaranteed to be \tcode{true}
-std::string s3(std::move(s2), 10, 5);
-assert(s1 == s2);       // unspecified, previously guaranteed to be \tcode{true}
-\end{codeblock}
-\end{example}
-
 \rSec2[diff.cpp20.containers]{\ref*{containers}: containers library}
 
 \diffref{associative.reqmts,unord.req}
@@ -863,6 +839,30 @@ struct D : private B {
     s.erase(*this);             // ill-formed; previously well-formed
   }
 };
+\end{codeblock}
+\end{example}
+
+\rSec2[diff.cpp20.strings]{\ref*{strings}: strings library}
+
+\diffref{string.classes}
+\change
+Additional rvalue overload for the \tcode{substr} member function and
+the corresponding constructor.
+\rationale
+Improve efficiency of operations on rvalues.
+\effect
+Valid \CppXX{} code that created a substring
+by calling \tcode{substr} (or the corresponding constructor)
+on an xvalue expression with type \tcode{S}
+that is a specialization of \tcode{basic_string}
+may change meaning in this revision of \Cpp{}.
+\begin{example}
+\begin{codeblock}
+std::string s1 = "some long string that forces allocation", s2 = s1;
+std::move(s1).substr(10, 5);
+assert(s1 == s2);       // unspecified, previously guaranteed to be \tcode{true}
+std::string s3(std::move(s2), 10, 5);
+assert(s1 == s2);       // unspecified, previously guaranteed to be \tcode{true}
 \end{codeblock}
 \end{example}
 
@@ -1944,30 +1944,6 @@ std::shared_ptr<int> ptr(std::move(arr));   // error: \tcode{int(*)[]} is not co
 \end{codeblock}
 \end{example}
 
-\rSec2[diff.cpp14.string]{\ref*{strings}: strings library}
-
-\diffref{basic.string}
-\change
-Non-const \tcode{.data()} member added.
-\rationale
-The lack of a non-const \tcode{.data()}
-differed from the similar member of \tcode{std::vector}.
-This change regularizes behavior.
-\effect
-Overloaded functions which have differing code paths
-for \tcode{char*} and \tcode{const char*} arguments
-will execute differently
-when called with a non-const string's \tcode{.data()} member
-in this revision of \Cpp{}.
-\begin{example}
-\begin{codeblock}
-int f(char *) = delete;
-int f(const char *);
-string s;
-int x = f(s.data());            // ill-formed; previously well-formed
-\end{codeblock}
-\end{example}
-
 \rSec2[diff.cpp14.containers]{\ref*{containers}: containers library}
 
 \diffref{associative.reqmts}
@@ -1995,6 +1971,30 @@ int main() {
   const std::set<int, compare> s;
   s.find(0);
 }
+\end{codeblock}
+\end{example}
+
+\rSec2[diff.cpp14.string]{\ref*{strings}: strings library}
+
+\diffref{basic.string}
+\change
+Non-const \tcode{.data()} member added.
+\rationale
+The lack of a non-const \tcode{.data()}
+differed from the similar member of \tcode{std::vector}.
+This change regularizes behavior.
+\effect
+Overloaded functions which have differing code paths
+for \tcode{char*} and \tcode{const char*} arguments
+will execute differently
+when called with a non-const string's \tcode{.data()} member
+in this revision of \Cpp{}.
+\begin{example}
+\begin{codeblock}
+int f(char *) = delete;
+int f(const char *);
+string s;
+int x = f(s.data());            // ill-formed; previously well-formed
 \end{codeblock}
 \end{example}
 
@@ -2604,28 +2604,6 @@ Valid \CppIII{} code that depends on function object types being derived from
 \tcode{unary_function} or \tcode{binary_function} may fail to compile
 in this revision of \Cpp{}.
 
-\rSec2[diff.cpp03.strings]{\ref*{strings}: strings library}
-
-\diffref{string.classes}
-\change
-\tcode{basic_string} requirements no longer allow reference-counted
-strings.
-\rationale
-Invalidation is subtly different with reference-counted strings.
-This change regularizes behavior.
-\effect
-Valid \CppIII{} code may execute differently in this revision of \Cpp{}.
-
-\diffref{string.require}
-\change
-Loosen \tcode{basic_string} invalidation rules.
-\rationale
-Allow small-string optimization.
-\effect
-Valid \CppIII{} code may execute differently in this revision of \Cpp{}.
-Some \keyword{const} member functions, such as \tcode{data} and \tcode{c_str},
-no longer invalidate iterators.
-
 \rSec2[diff.cpp03.containers]{\ref*{containers}: containers library}
 
 \diffref{container.requirements}
@@ -2732,6 +2710,38 @@ revision of \Cpp{}. For example, \tcode{std::remove} and
 \tcode{std::remove_if} may leave the tail of the input sequence with a
 different set of values than previously.
 
+\rSec2[diff.cpp03.strings]{\ref*{strings}: strings library}
+
+\diffref{string.classes}
+\change
+\tcode{basic_string} requirements no longer allow reference-counted
+strings.
+\rationale
+Invalidation is subtly different with reference-counted strings.
+This change regularizes behavior.
+\effect
+Valid \CppIII{} code may execute differently in this revision of \Cpp{}.
+
+\diffref{string.require}
+\change
+Loosen \tcode{basic_string} invalidation rules.
+\rationale
+Allow small-string optimization.
+\effect
+Valid \CppIII{} code may execute differently in this revision of \Cpp{}.
+Some \keyword{const} member functions, such as \tcode{data} and \tcode{c_str},
+no longer invalidate iterators.
+
+\rSec2[diff.cpp03.locale]{\ref*{text}: text processing library}
+
+\diffref{facet.num.get.virtuals}
+\change
+The \tcode{num_get} facet recognizes hexadecimal floating-point values.
+\rationale
+Required by new feature.
+\effect
+Valid \CppIII{} code may have different behavior in this revision of \Cpp{}.
+
 \rSec2[diff.cpp03.numerics]{\ref*{numerics}: numerics library}
 
 \diffref{complex.numbers}
@@ -2743,16 +2753,6 @@ Compatibility with C99.
 Valid \CppIII{} code that uses implementation-specific knowledge about the
 binary representation of the required template specializations of
 \tcode{std::complex} may not be compatible with this revision of \Cpp{}.
-
-\rSec2[diff.cpp03.locale]{\ref*{localization}: localization library}
-
-\diffref{facet.num.get.virtuals}
-\change
-The \tcode{num_get} facet recognizes hexadecimal floating-point values.
-\rationale
-Required by new feature.
-\effect
-Valid \CppIII{} code may have different behavior in this revision of \Cpp{}.
 
 \rSec2[diff.cpp03.input.output]{\ref*{input.output}: input/output library}
 


### PR DESCRIPTION
After clause renumbering efforts in C++23 and C++26, currently [strings] is Clause 27, which makes the Annex C entries unordered in relation to actual clause numbers (for instance, under [diff.cpp20], [diff.cpp20.strings] refers to Clause 27, while [diff.cpp20.containers] refers to Clause 23; however, the former comes first). Therefore, this PR seeks to correct the situation by reordering the entries with regard to current clause numbers:

- Swap the positions of [diff.cpp20.strings] and [diff.cpp20.containers]
- Swap the positions of [diff.cpp14.strings] and [diff.cpp14.containers]
- Move [diff.cpp03.strings] after [diff.cpp03.algorithms]
- [diff.cpp03.locale] is currently the only Annex C entry that does not refer to a whole clause, making its title "28.3: localization library" which is inconsistent with everything else. This PR thus makes it refer to Clause 28 (text processing library) instead, and moves it before [diff.cpp03.numerics] to maintain the numerical ordering
  - It seems inappropriate to change the stable labels for this; there have been precedents for [diff.cppXX.foo] not referring to [foo] before (e.g. [diff.cpp23.io], [diff.stat])