### PR TITLE
[ub:expr.static.cast.does.not.contain.original.member] Adjust linebreak in example

### DIFF
--- a/source/ub.tex
+++ b/source/ub.tex
@@ -977,7 +977,8 @@ struct D : A, B {};
 
 int main() {
   char D::*p1 = &D::c;
-  char B::*p2 = static_cast<char B::*>(p1); // undefined behavior, \tcode{B} does not contain the original member \tcode{c}
+  char B::*p2 = static_cast<char B::*>(p1); // undefined behavior, \tcode{B} does not contain the
+                                            // original member \tcode{c}
 }
 \end{codeblock}
 \end{example}


### PR DESCRIPTION
Comment breaks onto a new line