### PR TITLE
[ifndr:lex.name.reserved] Don't escape underscores in \tcode.

### DIFF
--- a/source/ifndr.tex
+++ b/source/ifndr.tex
@@ -32,12 +32,12 @@ is ill-formed, no diagnostic required.
 \pnum
 \begin{example}
 \begin{codeblock}
-int _z; // IFNDR, \tcode{\_z} is reserved because it starts with \tcode{\_} at global scope
+int _z; // IFNDR, \tcode{_z} is reserved because it starts with \tcode{_} at global scope
 
 int main() {
-    int __x;    // IFNDR, \tcode{\_\_x} is reserved because it starts with \tcode{\_\_}
-    int _Y;     // IFNDR, \tcode{\_Y} is reserved because it starts with \tcode{\_} followed by a capital letter
-    int x__y;   // IFNDR, \tcode{x\_\_y} is reserved because it contains \tcode{\_\_}
+    int __x;    // IFNDR, \tcode{__x} is reserved because it starts with \tcode{__}
+    int _Y;     // IFNDR, \tcode{_Y} is reserved because it starts with \tcode{_} followed by a capital letter
+    int x__y;   // IFNDR, \tcode{x__y} is reserved because it contains \tcode{__}
 }
 \end{codeblock}
 \end{example}


### PR DESCRIPTION
No change in the PDF.