### PR TITLE
[mdspan.layout] Remove stray \tcode.

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -7475,7 +7475,7 @@ extern double d1;
 double d2 = d1;
 double d1 = fd();
 \end{codeblock}
-Both \tcode{d1} and \tcode {d2} can be initialized
+Both \tcode{d1} and \tcode{d2} can be initialized
 either statically or dynamically.
 If \tcode{d1} is initialized statically and \tcode{d2} dynamically,
 both variables are initialized to \tcode{1.0};

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -23428,7 +23428,7 @@ size \exposid{rank_} parameter pack of \tcode{size_}t values:
 \item
 the empty parameter pack, if \exposid{rank_} equals zero;
 \item
-\tcode otherwise, \tcode{0zu}, if \exposid{rank_} equals one;
+otherwise, \tcode{0zu}, if \exposid{rank_} equals one;
 \item
 otherwise, the parameter pack \tcode{0zu}, \tcode{1zu}, \ldots, \tcode{\exposid{rank_}- 1}.
 \end{itemize}
@@ -24075,7 +24075,7 @@ size \exposid{rank_} parameter pack of \tcode{size_}t values:
 \item
 the empty parameter pack, if \exposid{rank_} equals zero;
 \item
-\tcode otherwise, \tcode{0zu}, if \exposid{rank_} equals one;
+otherwise, \tcode{0zu}, if \exposid{rank_} equals one;
 \item
 otherwise, the parameter pack \tcode{0zu}, \tcode{1zu}, \ldots, \tcode{\exposid{rank_}- 1}.
 \end{itemize}

--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -17490,17 +17490,17 @@ The member \tcode{type} is present if and only if
 \end{itemize}
 
 \pnum
-If \tcode V is a specialization of \tcode{basic_vec}, let \tcode{Abi1} denote
+If \tcode{V} is a specialization of \tcode{basic_vec}, let \tcode{Abi1} denote
 an ABI tag such that \tcode{basic_vec<T, Abi1>::\brk{}size()} equals
 \tcode{V::size()}.
-If \tcode V is a specialization of \tcode{basic_mask}, let \tcode{Abi1}
+If \tcode{V} is a specialization of \tcode{basic_mask}, let \tcode{Abi1}
 denote an ABI tag such that \tcode{basic_mask<sizeof(T),
 Abi1>::\brk{}size()} equals \tcode{V::size()}.
 
 \pnum
 Where present, the member typedef \tcode{type} names \tcode{basic_vec<T, Abi1>}
-if \tcode V is a specialization of \tcode{basic_vec} or
-\tcode{basic_mask<sizeof(T), Abi1>} if \tcode V is a specialization of
+if \tcode{V} is a specialization of \tcode{basic_vec} or
+\tcode{basic_mask<sizeof(T), Abi1>} if \tcode{V} is a specialization of
 \tcode{basic_mask}.
 \end{itemdescr}
 


### PR DESCRIPTION
I threw in a couple of other \tcode fixes for things that weren't rendering wrong but were still unconventional (and cxxdraft-htmlgen doesn't handle `\tcode V`).