### PR TITLE
[ptrtag.pair.get] Add missing template parameter `I`

### DIFF
--- a/source/memory.tex
+++ b/source/memory.tex
@@ -562,7 +562,7 @@ namespace std {
       using type = TagT;
     };
 
-  template<class Ptr, unsigned BitsRequested, class TagT>
+  template<size_t I, class Ptr, unsigned BitsRequested, class TagT>
     constexpr tuple_element_t<I, pointer_tag_pair<Ptr, BitsRequested, TagT>>        // freestanding
       get(pointer_tag_pair<Ptr, BitsRequested, TagT> p) noexcept;
 
@@ -2567,7 +2567,7 @@ comparing values of type \tcode{tag_type}.
 
 \indexlibrarymember{get}{pointer_tag_pair}%
 \begin{itemdecl}
-template<class Ptr, unsigned BitsRequested, class TagT>
+template<size_t I, class Ptr, unsigned BitsRequested, class TagT>
   constexpr tuple_element_t<I, pointer_tag_pair<Ptr, BitsRequested, TagT>>
     get(pointer_tag_pair<Ptr, BitsRequested, TagT> p) noexcept;
 \end{itemdecl}


### PR DESCRIPTION
I'm assuming this is a typo in the paper.