### PR TITLE
[dcl.contract.func] Index 'pre'/'post' grammar occurrences.

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -4668,12 +4668,12 @@ void m() {
 
 \begin{bnf}
 \nontermdef{precondition-specifier}\br
-  \terminal{pre} \opt{attribute-specifier-seq} \terminal{(} conditional-expression \terminal{)}
+  \keyword{pre} \opt{attribute-specifier-seq} \terminal{(} conditional-expression \terminal{)}
 \end{bnf}
 
 \begin{bnf}
 \nontermdef{postcondition-specifier}\br
-  \terminal{post} \opt{attribute-specifier-seq} \terminal{(} \opt{result-name-introducer} conditional-expression \terminal{)}
+  \keyword{post} \opt{attribute-specifier-seq} \terminal{(} \opt{result-name-introducer} conditional-expression \terminal{)}
 \end{bnf}
 
 \pnum


### PR DESCRIPTION
<img width="1661" height="251" alt="image" src="https://github.com/user-attachments/assets/50c0dee9-30d4-4c37-8295-d5fa4239f99e" />
(And same for `post`.)