### PR TITLE
Improve sentence structures by removing colons

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1004,11 +1004,11 @@ allocated within \tcode{X}.
 \item
 \tcode{T} is \defnx{\oldconcept{MoveInsertable} into \tcode{X}}
 {\oldconceptname{MoveInsertable} into X@\oldconcept{MoveInsertable} into \tcode{X}}
-means that the following expression
-is well-formed:
+means that the expression
 \begin{codeblock}
 allocator_traits<A>::construct(m, p, rv)
 \end{codeblock}
+is well-formed
 and its evaluation causes the following postcondition to hold: The value
 of \tcode{*p} is equivalent to the value of \tcode{rv} before the evaluation.
 \begin{note}
@@ -1019,10 +1019,11 @@ of \tcode{*p} is equivalent to the value of \tcode{rv} before the evaluation.
 \tcode{T} is \defnx{\oldconcept{CopyInsertable} into \tcode{X}}
 {\oldconceptname{CopyInsertable} into X@\oldconcept{CopyInsertable} into \tcode{X}}
 means that, in addition to \tcode{T} being \oldconcept{MoveInsertable} into
-\tcode{X}, the following expression is well-formed:
+\tcode{X}, the expression
 \begin{codeblock}
 allocator_traits<A>::construct(m, p, v)
 \end{codeblock}
+is well-formed
 and its evaluation causes the following postcondition to hold:
 The value of \tcode{v} is unchanged and is equivalent to \tcode{*p}.
 

--- a/source/ranges.tex
+++ b/source/ranges.tex
@@ -11659,11 +11659,11 @@ ranges::iter_swap(std::get<@$i$@>(l.@\exposid{current_}@), std::get<@$i$@>(r.@\e
 \pnum
 \remarks
 The exception specification is equivalent to
-the logical \logop{and} of the following expressions:
+the logical \logop{and} of the expressions
 \begin{codeblock}
 noexcept(ranges::iter_swap(std::get<@$i$@>(l.@\exposid{current_}@), std::get<@$i$@>(r.@\exposid{current_}@)))
 \end{codeblock}
-for every integer $0 \leq i < \tcode{sizeof...(Views)}$.
+for all integers $0 \leq i < \tcode{sizeof...(Views)}$.
 \end{itemdescr}
 
 \rSec3[range.zip.sentinel]{Class template \tcode{zip_view::\exposid{sentinel}}}
@@ -16864,15 +16864,15 @@ Equivalent to: \tcode{return \exposid{tuple-transform}(ranges::iter_move, i.\exp
 \pnum
 \remarks
 The exception specification is equivalent to
-the logical \logop{and} of the following expressions:
-\begin{itemize}
-\item
-\tcode{noexcept(ranges::iter_move(std::get<$N$>(i.\exposid{current_})))}
-for every integer\newline $0 \le N \le \tcode{sizeof...(Vs)}$,
-\item
-\tcode{is_nothrow_move_constructible_v<range_rvalue_reference_t<\exposid{maybe-const}<Const, T>>>}\newline
-for every type \tcode{T} in \tcode{First, Vs...}.
-\end{itemize}
+the logical \logop{and} of the expressions
+\begin{codeblock}
+noexcept(ranges::iter_move(std::get<@$N$@>(i.@\exposid{current_}@)))
+\end{codeblock}
+for all integers $0 \le N \le \tcode{sizeof...(Vs)}$ and
+\begin{codeblock}
+is_nothrow_move_constructible_v<range_rvalue_reference_t<@\exposid{maybe-const}@<Const, T>>>
+\end{codeblock}
+for all types \tcode{T} in \tcode{First, Vs...}.
 \end{itemdescr}
 
 \indexlibrarymember{iter_swap}{cartesian_product_view::\exposid{iterator}}%
@@ -16892,12 +16892,11 @@ ranges::iter_swap(std::get<@$i$@>(l.@\exposid{current_}@), std::get<@$i$@>(r.@\e
 
 \pnum
 \remarks
-The exception specification is equivalent to the logical \logop{and} of the following expressions:
-\begin{itemize}
-\item
-\tcode{noexcept(ranges::iter_swap(std::get<$i$>(l.\exposid{current_}), std::get<$i$>(r.\exposid{current_})))}
-for\newline every integer $0 \le i \le \tcode{sizeof...(Vs)}$.
-\end{itemize}
+The exception specification is equivalent to the logical \logop{and} of the expressions
+\begin{codeblock}
+noexcept(ranges::iter_swap(std::get<@$i$@>(l.@\exposid{current_}@), std::get<@$i$@>(r.@\exposid{current_}@)))
+\end{codeblock}
+for all integers $0 \le i \le \tcode{sizeof...(Vs)}$.
 \end{itemdescr}
 
 \rSec2[range.cache.latest]{Cache latest view}


### PR DESCRIPTION
We are dealing with long, complete sentences, where it does not seem appropriate to separate parts with colons.

I suggest various rewrites that incorporate the complex object of the sentence in a more natural way.

In [ranges], I would also like to change "for each" to "for all" in the description of the argument of the "logical AND".