### PR TITLE
[fs.path.member] Fix indexing for `(generic_)native_encoded_string`

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -14660,7 +14660,7 @@ be performed by \tcode{a}. Conversion, if any, is specified by
 \ref{fs.path.cvt}.
 \end{itemdescr}
 
-\indexlibrarymember{system_encoded_string}{path}%
+\indexlibrarymember{native_encoded_string}{path}%
 \indexlibrarymember{wstring}{path}%
 \indexlibrarymember{u8string}{path}%
 \indexlibrarymember{u16string}{path}%
@@ -14735,7 +14735,7 @@ be performed by \tcode{a}. Conversion, if any, is specified by
 \ref{fs.path.cvt}.
 \end{itemdescr}
 
-\indexlibrarymember{generic_system_encoded_string}{path}%
+\indexlibrarymember{generic_native_encoded_string}{path}%
 \indexlibrarymember{generic_wstring}{path}%
 \indexlibrarymember{generic_u8string}{path}%
 \indexlibrarymember{generic_u16string}{path}%


### PR DESCRIPTION
LWG4512 renamed two member functions of `path`. However, the commit applying LWG4512 did not update the indexing correspondingly.

Closes #9226.