### PR TITLE
[input.output] Add \recommended at the start of "Implementations should" paragraphs

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -936,6 +936,7 @@ by functions in the iostreams library,
 to report errors detected during stream buffer operations.
 
 \pnum
+\recommended
 When throwing \tcode{ios_base::failure} exceptions, implementations should provide
 values of \tcode{ec} that identify the specific reason for the failure.
 \begin{note}
@@ -13469,6 +13470,7 @@ namespace std::ranges {
 \end{codeblock}
 
 \pnum
+\recommended
 Implementations should ensure that the resolution and range of
 \tcode{file_time_type} reflect the operating system dependent resolution and range
 of file time values.
@@ -16093,6 +16095,7 @@ and may store additional objects for file attributes
 such as hard link count, status, symlink status, file size, and last write time.
 
 \pnum
+\recommended
 Implementations should store such additional file attributes
 during directory iteration if their values are available
 and storing the values would allow the implementation to eliminate file system accesses


### PR DESCRIPTION
Lays some groundwork for #8548