### PR TITLE
[simd.creation] Add missing escaping to braces in `\tcode`

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -19643,7 +19643,7 @@ Either \tcode{T} is vectorizable and \tcode{is_arithmetic_v<T>} is \tcode{true},
 If \tcode{is_arithmetic_v<T>} is \tcode{true},
 the value of \tcode{iota<T>} is equal to \tcode{T()}.
 Otherwise, the value of \tcode{iota<T>} is equal to
-\tcode{T([](typename T::value_type i) { return i; })}.
+\tcode{T([](typename T::value_type i) \{ return i; \})}.
 \end{itemdescr}
 
 \rSec3[simd.alg]{Algorithms}


### PR DESCRIPTION
The braces would be lost in the generated PDF without escaping.

Fixes #9236.