### PR TITLE
[basic.scope.scope] Remove incorrect namespace redeclaration example CWG3214

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -1211,7 +1211,6 @@ namespace A {}
 namespace B = A;
 namespace B = A;        // OK, no effect
 namespace B = B;        // OK, no effect
-namespace A = B;        // OK, no effect
 namespace B {}          // error: different entity for \tcode{B}
 
 void g() {


### PR DESCRIPTION
Since the adoption of P2996 "Reflection for C++26", and the changes it made to [namespace.alias], namespace aliases are no longer alternative names for namespaces but entities of their own kind. Therefore, redeclaring a namespace as a namespace alias, even denoting the original namespace, violates [basic.link]/11.3, since one declaration declares the entity as a namespace and the other does not.