### PR TITLE
[diff.expr] Strike line in example that is UB in C23

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -3161,7 +3161,6 @@ but results in undefined behavior in \Cpp{}.
 void f() {
   char *p = nullptr;
   char *p2 = &*p;       // well-defined in C, undefined behavior in \Cpp{}
-  char *p3 = &p[0];     // well-defined in C, undefined behavior in \Cpp{}
   int a[5];
   int *q = &a[5];       // well-defined in C, undefined behavior in \Cpp{}
 }


### PR DESCRIPTION
In C23, "p + 0" is undefined behavior if p is a nullptr, regardless of whether the result is dereferenced.

Fixes #9248