### PR TITLE
[cfloat.syn], [cmath.syn] Add missing "// optional" comments for some macros

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -9210,8 +9210,8 @@ object refers.
 #define @\libmacro{HUGE_VAL}@ @\seebelow@
 #define @\libmacro{HUGE_VALF}@ @\seebelow@
 #define @\libmacro{HUGE_VALL}@ @\seebelow@
-#define @\libmacro{INFINITY}@ @\seebelow@
-#define @\libmacro{NAN}@ @\seebelow@
+#define @\libmacro{INFINITY}@ @\seebelow@      // optional
+#define @\libmacro{NAN}@ @\seebelow@           // optional
 #define @\libmacro{FP_INFINITE}@ @\seebelow@
 #define @\libmacro{FP_NAN}@ @\seebelow@
 #define @\libmacro{FP_NORMAL}@ @\seebelow@

--- a/source/support.tex
+++ b/source/support.tex
@@ -1830,11 +1830,11 @@ type of \tcode{T}\iref{conv.prom}.
 #define @\libmacro{FLT_ROUNDS}@ @\seebelow@
 #define @\libmacro{FLT_EVAL_METHOD}@ @\seebelow@
 #define @\libmacro{FLT_RADIX}@ @\seebelow@
-#define @\libmacro{INFINITY}@ @\seebelow@
-#define @\libmacro{NAN}@ @\seebelow@
-#define @\libmacro{FLT_SNAN}@ @\seebelow@
-#define @\libmacro{DBL_SNAN}@ @\seebelow@
-#define @\libmacro{LDBL_SNAN}@ @\seebelow@
+#define @\libmacro{INFINITY}@ @\seebelow@          // optional
+#define @\libmacro{NAN}@ @\seebelow@               // optional
+#define @\libmacro{FLT_SNAN}@ @\seebelow@          // optional
+#define @\libmacro{DBL_SNAN}@ @\seebelow@          // optional
+#define @\libmacro{LDBL_SNAN}@ @\seebelow@         // optional
 #define @\libmacro{FLT_MANT_DIG}@ @\seebelow@
 #define @\libmacro{DBL_MANT_DIG}@ @\seebelow@
 #define @\libmacro{LDBL_MANT_DIG}@ @\seebelow@


### PR DESCRIPTION
All of these macros are optionally defined, if and only if the constant is actually representable in the type.

See https://cstd.eisie.net/c23#5.2.5.3.3p28