### PR TITLE
[lib] Index C23 library feature-test macros

### DIFF
--- a/source/iostreams.tex
+++ b/source/iostreams.tex
@@ -18872,7 +18872,7 @@ As specified in~\ref{fs.err.report}.
 \indexlibraryglobal{ferror}%
 \indexlibraryglobal{perror}%
 \begin{codeblock}
-#define __STDC_VERSION_STDIO_H__ 202311L
+#define @\libmacro{__STDC_VERSION_STDIO_H__}@ 202311L
 
 namespace std {
   using size_t = @\textit{see \ref{support.types.layout}}@;
@@ -19045,7 +19045,7 @@ namespace std {
   constexpr imaxdiv_t div(intmax_t, intmax_t);  // optional, see below
 }
 
-#define __STDC_VERSION_INTTYPES_H__ 202311L
+#define @\libmacro{__STDC_VERSION_INTTYPES_H__}@ 202311L
 
 #define PRId@\placeholdernc{N}@ @\seebelow@
 #define PRIi@\placeholdernc{N}@ @\seebelow@

--- a/source/strings.tex
+++ b/source/strings.tex
@@ -5501,7 +5501,7 @@ The same suffix \tcode{s} is used for \tcode{chrono::duration} literals denoting
 \indexlibraryglobal{strtok}%
 \indexlibraryglobal{strxfrm}%
 \begin{codeblock}
-#define __STDC_VERSION_STRING_H__ 202311L
+#define @\libmacro{__STDC_VERSION_STRING_H__}@ 202311L
 
 namespace std {
   using size_t = @\textit{see \ref{support.types.layout}}@;                                            // freestanding

--- a/source/support.tex
+++ b/source/support.tex
@@ -1825,7 +1825,7 @@ type of \tcode{T}\iref{conv.prom}.
 \indexheader{cfloat}%
 \begin{codeblock}
 // all freestanding
-#define __STDC_VERSION_FLOAT_H__ 202311L
+#define @\libmacro{__STDC_VERSION_FLOAT_H__}@ 202311L
 
 #define @\libmacro{FLT_ROUNDS}@ @\seebelow@
 #define @\libmacro{FLT_EVAL_METHOD}@ @\seebelow@
@@ -1944,7 +1944,7 @@ macros that specify limits of integer types.
 \indexlibraryglobal{UINTMAX_C}%
 \begin{codeblock}
 // all freestanding
-#define __STDC_VERSION_STDINT_H__ 202311L
+#define @\libmacro{__STDC_VERSION_STDINT_H__}@ 202311L
 
 namespace std {
   using int8_t         = @\textit{signed integer type}@;   // optional
@@ -6366,7 +6366,7 @@ function.
 \indexheader{cstdarg}%
 \begin{codeblock}
 // all freestanding
-#define __STDC_VERSION_STDARG_H__ 202311L
+#define @\libmacro{__STDC_VERSION_STDARG_H__}@ 202311L
 
 namespace std {
   using @\libglobal{va_list}@ = @\seebelow@;
@@ -6408,7 +6408,7 @@ for compatibility with prior revisions of \Cpp{}.
 \indexlibraryglobal{longjmp}%
 \indexlibraryglobal{setjmp}%
 \begin{codeblock}
-#define __STDC_VERSION_SETJMP_H__ 202311L
+#define @\libmacro{__STDC_VERSION_SETJMP_H__}@ 202311L
 
 namespace std {
   using jmp_buf = @\seebelow@;

--- a/source/text.tex
+++ b/source/text.tex
@@ -13177,7 +13177,7 @@ are the same as the C standard library header \libheader{wctype.h}.
 \indexlibraryglobal{wprintf}%
 \indexlibraryglobal{wscanf}%
 \begin{codeblock}
-#define __STDC_VERSION_WCHAR_H__ 202311L
+#define @\libmacro{__STDC_VERSION_WCHAR_H__}@ 202311L
 
 namespace std {
   using size_t = @\textit{see \ref{support.types.layout}}@;                                             // freestanding
@@ -13287,7 +13287,7 @@ but they have the same behavior as in the C standard library\iref{library.c}.
 \indexlibraryglobal{mbrtoc32}%
 \indexlibraryglobal{c32rtomb}%
 \begin{codeblock}
-#define __STDC_VERSION_UCHAR_H__ 202311L
+#define @\libmacro{__STDC_VERSION_UCHAR_H__}@ 202311L
 
 namespace std {
   using mbstate_t = @\seebelow@;

--- a/source/time.tex
+++ b/source/time.tex
@@ -11647,7 +11647,7 @@ The specialization is enabled\iref{unord.hash}.
 \indexlibraryglobal{timegm}%
 \indexlibraryglobal{tm}%
 \begin{codeblock}
-#define __STDC_VERSION_TIME_H__ 202311L
+#define @\libmacro{__STDC_VERSION_TIME_H__}@ 202311L
 
 #define @\libmacro{NULL}@ @\textit{see \ref{support.types.nullptr}}@
 #define @\libmacro{CLOCKS_PER_SEC}@ @\seebelow@


### PR DESCRIPTION
Previously, some but not all of C23 library feature-test macros were indexed. This PR indexes the remaining.