### PR TITLE
[expr.const.core] Fix typo

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -8603,7 +8603,7 @@ It is unspecified whether the value of \tcode{f()} will be \tcode{true} or \tcod
 A type has \defnadj{constexpr-unknown}{representation} if it
 \begin{itemize}
 \item is a union,
-\item is \tcode{std::meta::type_info},
+\item is \tcode{std::meta::info},
 \item is a pointer or pointer-to-member type,
 \item is volatile-qualified,
 \item is a class type with a non-static data member of reference type, or


### PR DESCRIPTION
This fixes a misapplication of P4101R1, introduced by commit 154eccbe38722c6ecc67da9ce881f03188e4d2cf.