### PR TITLE
[diff.iso] Update out of date C compatibility entries

### DIFF
--- a/source/compatibility.tex
+++ b/source/compatibility.tex
@@ -2870,21 +2870,6 @@ Programs which depend upon \tcode{sizeof('x')} are probably rare.
 
 \diffref{lex.string}
 \change
-Concatenated \grammarterm{string-literal}s can no longer have
-conflicting \grammarterm{encoding-prefix}es.
-\rationale
-Removal of non-portable feature.
-\effect
-Concatenation of \grammarterm{string-literal}s
-with different \grammarterm{encoding-prefix}es
-is now ill-formed.
-\difficulty
-Syntactic transformation.
-\howwide
-Seldom.
-
-\diffref{lex.string}
-\change
 String literals made const.\\
 The type of a \grammarterm{string-literal} is changed
 from ``array of \tcode{char}''
@@ -3431,34 +3416,6 @@ Syntactic transformation.
 \howwide
 Rare.
 
-\diffref{dcl.fct}
-\change
-In \Cpp{}, a function declared with an empty parameter list takes no arguments.
-In C, an empty parameter list means that the number and type of the function arguments are unknown.
-
-\begin{example}
-\begin{codeblock}
-int f();            // means   \tcode{int f(void)} in \Cpp{}
-                    // \tcode{int f(} unknown \tcode{)} in C
-\end{codeblock}
-\end{example}
-
-\rationale
-This is to avoid function calls
-with the wrong number or type of arguments.
-\effect
-Change to semantics of well-defined feature.
-This feature was marked as ``obsolescent'' in C.
-\difficulty
-Syntactic transformation.
-The function declarations using C incomplete declaration style must
-be completed to become full prototype declarations.
-A program may need to be updated further if different calls to the
-same (non-prototype) function have different numbers of arguments or
-if the type of corresponding arguments differed.
-\howwide
-Common.
-
 \diffref{dcl.fct} [see \ref{expr.sizeof}]
 \change
 In \Cpp{}, types may not be defined in return or parameter types.
@@ -3486,19 +3443,6 @@ The type definitions must be moved to file scope, or in header files.
 Seldom.
 This style of type definition is seen as poor coding style.
 
-\diffref{dcl.fct.def}
-\change
-In \Cpp{}, the syntax for function definition excludes the ``old-style'' C function.
-In C, ``old-style'' syntax is allowed, but deprecated as ``obsolescent''.
-\rationale
-Prototypes are essential to type safety.
-\effect
-Deletion of semantically well-defined feature.
-\difficulty
-Syntactic transformation.
-\howwide
-Common in old programs, but already known to be obsolescent.
-
 \diffref{dcl.init.aggr}
 \change
 In \Cpp{}, designated initialization support is restricted
@@ -3509,7 +3453,7 @@ must be specified in declaration order,
 designators for array elements and nested designators
 are not supported,
 and
-designated and non-designated initializers
+designated and non-designated initializers for non-static data members
 cannot be mixed in the same initializer list.
 
 \begin{example}


### PR DESCRIPTION
[diff.lex]
- C23 also removed mixed prefixed string literal concatenation
  - https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2594.htm

[diff.dcl]
- C23 removed unprototyped function declarations
  - https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2841.htm
- C23 removed old-style function definitions
  - https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2432.pdf
- The pre-existing description for incompatibility about data member initializers became incomplete in C++29, although the compatibility with C was not improved or worsened.
  - https://wg21.link/p2287r6

Fixes #9266