### PR TITLE
[tuple.apply] Remove unnecessary std namespace

### DIFF
--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -2991,12 +2991,10 @@ template<class F, @\exposconcept{tuple-like}@ Tuple>
 \effects
 Given the exposition-only function template:
 \begin{codeblock}
-namespace std {
-  template<class F, @\exposconcept{tuple-like}@ Tuple, size_t... I>
-  constexpr decltype(auto) @\placeholdernc{apply-impl}@(F&& f, Tuple&& t, index_sequence<I...>) {
-                                                                        // \expos
-    return @\placeholdernc{INVOKE}@(std::forward<F>(f), get<I>(std::forward<Tuple>(t))...);     // see \ref{func.require}
-  }
+template<class F, @\exposconcept{tuple-like}@ Tuple, size_t... I>
+constexpr decltype(auto) @\placeholdernc{apply-impl}@(F&& f, Tuple&& t, index_sequence<I...>) {
+                                                                      // \expos
+  return @\placeholdernc{INVOKE}@(std::forward<F>(f), get<I>(std::forward<Tuple>(t))...);     // see \ref{func.require}
 }
 \end{codeblock}
 Equivalent to:
@@ -3024,12 +3022,10 @@ is \tcode{false}.
 \effects
 Given the exposition-only function template:
 \begin{codeblock}
-namespace std {
-  template<class T, @\exposconcept{tuple-like}@ Tuple, size_t... I>
-    requires is_constructible_v<T, decltype(get<I>(declval<Tuple>()))...>
-  constexpr T @\placeholdernc{make-from-tuple-impl}@(Tuple&& t, index_sequence<I...>) {   // \expos
-    return T(get<I>(std::forward<Tuple>(t))...);
-  }
+template<class T, @\exposconcept{tuple-like}@ Tuple, size_t... I>
+  requires is_constructible_v<T, decltype(get<I>(declval<Tuple>()))...>
+constexpr T @\placeholdernc{make-from-tuple-impl}@(Tuple&& t, index_sequence<I...>) {   // \expos
+  return T(get<I>(std::forward<Tuple>(t))...);
 }
 \end{codeblock}
 Equivalent to:


### PR DESCRIPTION
I mean, for an exposition-only function template, do we really need to specifically specify that it under the namespace `std`? I don't think so, and it seems we haven't done this elsewhere.