### PR TITLE
[basic.indet] Fix misapplication of P2795R5

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -4303,7 +4303,7 @@ the result of the evaluation is that erroneous value:
   that object is initialized to an indeterminate
   value or that erroneous value, respectively.
 \item
-  If an indeterminate value of
+  If an indeterminate or erroneous value of
   unsigned ordinary character type or \tcode{std::byte} type
   is produced by the evaluation of the initialization expression
   when initializing an object of \tcode{std::byte} type,


### PR DESCRIPTION
We also need to add "or erroneous" to [basic.indet]/2.4.

Fixes #9273.