### PR TITLE
[flat.multimap] Apply "constexpr" to flat_multimap::operator=(initializer_list)

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -18635,7 +18635,7 @@ namespace std {
       constexpr flat_multimap(sorted_equivalent_t, initializer_list<value_type> il,
                               const key_compare& comp, const Alloc& a);
 
-    flat_multimap& operator=(initializer_list<value_type>);
+    constexpr flat_multimap& operator=(initializer_list<value_type>);
 
     // iterators
     constexpr iterator               begin() noexcept;


### PR DESCRIPTION
"constexpr" was applied to flat_map::operator=(initializer_list) in commit e1502d2 "P3372R3 constexpr containers and adaptors," but it was missed here. I don't believe this was intentional.

Apologies if there's already an LWG issue for this.