### PR TITLE
[class.union.anon] Correct definition of union-like class

### DIFF
--- a/source/classes.tex
+++ b/source/classes.tex
@@ -3345,7 +3345,7 @@ in~\ref{dcl.init.aggr}.
 
 \pnum
 \indextext{class!variant member of}%
-A \defnadj{union-like}{class} is a union or a class that has an anonymous union as a direct
+A \defnadj{union-like}{class} is a class that has an anonymous union as a direct
 member. A union-like class \tcode{X} has a set of \defnx{variant members}{variant member}.
 If \tcode{X} is a union, a non-static data member of \tcode{X} that is not an anonymous
 union is a variant member of \tcode{X}. In addition, a non-static data member of an


### PR DESCRIPTION
There is a redundant *union or*, as all unions are classed.
```diff
-  union-like class is a union or a class [...]
+  union-like class is a class [...]
```