### PR TITLE
[basic.start.term] Describe sequencing of function calls, not of functions

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -7661,7 +7661,7 @@ are called as part of a call to
 \indexlibraryglobal{exit}%
 \tcode{std::exit}\iref{support.start.term}.
 The call to \tcode{std::exit} is sequenced before
-the destructions and the registered functions.
+the destructions and calls to registered functions.
 \begin{note}
 Returning from \tcode{main} invokes \tcode{std::exit}\iref{basic.start.main}.
 \end{note}


### PR DESCRIPTION
Closes #9280

https://github.com/cplusplus/draft/issues/9280#issuecomment-5467358932 mentions that "call" should be replaced with "invoke", but I don't see how to implement that nicely and consistently.

We use "call" 20 times in [[basic.start.term]](https://eel.is/c++draft/basic.start.term), so I don't see a need to get hung up on it in only the first paragraph, especially if it decreases local consistency with the rest of the subclause.