### PR TITLE
[stdatomic.h.syn] No longer speak of [u]intptr_t as optional

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -7466,7 +7466,7 @@ any declarations in namespace \tcode{std}.
 
 \pnum
 Each of the \grammarterm{using-declaration}s for
-\tcode{int$N$_t}, \tcode{uint$N$_t}, \tcode{intptr_t}, and \tcode{uintptr_t}
+\tcode{int$N$_t} and \tcode{uint$N$_t}
 listed above is declared if and only if the implementation declares
 the corresponding \grammarterm{typedef-name} in \ref{atomics.syn}.
 


### PR DESCRIPTION
Fixes #9302

Following P3248R5 (Require `[u]intptr_t`), `intptr_t` and `uintptr_t` are always present, so `atomic_intptr_t` and `atomic_uintptr_t` are always present too.