### PR TITLE
[compare.syn] Remove stray "is_geq" index entry

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -4762,16 +4762,6 @@ The header \libheaderdef{compare} specifies types, objects, and functions
 for use primarily in connection with
 the three-way comparison operator\iref{expr.spaceship}.
 
-\indexlibraryglobal{is_eq}%
-\indexlibraryglobal{is_neq}%
-\indexlibraryglobal{is_lt}%
-\indexlibraryglobal{is_lteq}%
-\indexlibraryglobal{is_gt}%
-\indexlibraryglobal{is_geq}%
-\indexlibraryglobal{is_gteq}%
-\indexlibraryglobal{common_comparison_category_t}%
-\indexlibraryglobal{compare_three_way_result_t}%
-\indexlibraryglobal{type_order_v}%
 \begin{codeblock}
 // all freestanding
 namespace std {
@@ -4781,12 +4771,12 @@ namespace std {
   class strong_ordering;
 
   // named comparison functions
-  constexpr bool is_eq  (partial_ordering cmp) noexcept { return cmp == 0; }
-  constexpr bool is_neq (partial_ordering cmp) noexcept { return cmp != 0; }
-  constexpr bool is_lt  (partial_ordering cmp) noexcept { return cmp < 0; }
-  constexpr bool is_lteq(partial_ordering cmp) noexcept { return cmp <= 0; }
-  constexpr bool is_gt  (partial_ordering cmp) noexcept { return cmp > 0; }
-  constexpr bool is_gteq(partial_ordering cmp) noexcept { return cmp >= 0; }
+  constexpr bool @\libglobal{is_eq}@  (partial_ordering cmp) noexcept { return cmp == 0; }
+  constexpr bool @\libglobal{is_neq}@ (partial_ordering cmp) noexcept { return cmp != 0; }
+  constexpr bool @\libglobal{is_lt}@  (partial_ordering cmp) noexcept { return cmp < 0; }
+  constexpr bool @\libglobal{is_lteq}@(partial_ordering cmp) noexcept { return cmp <= 0; }
+  constexpr bool @\libglobal{is_gt}@  (partial_ordering cmp) noexcept { return cmp > 0; }
+  constexpr bool @\libglobal{is_gteq}@(partial_ordering cmp) noexcept { return cmp >= 0; }
 
   // \ref{cmp.common}, common comparison category type
   template<class... Ts>
@@ -4794,7 +4784,7 @@ namespace std {
     using type = @\seebelow@;
   };
   template<class... Ts>
-    using common_comparison_category_t = common_comparison_category<Ts...>::type;
+    using @\libglobal{common_comparison_category_t}@ = common_comparison_category<Ts...>::type;
 
   // \ref{cmp.concept}, concept \libconcept{three_way_comparable}
   template<class T, class Cat = partial_ordering>
@@ -4806,7 +4796,7 @@ namespace std {
   template<class T, class U = T> struct compare_three_way_result;
 
   template<class T, class U = T>
-    using compare_three_way_result_t = compare_three_way_result<T, U>::type;
+    using @\libglobal{compare_three_way_result_t}@ = compare_three_way_result<T, U>::type;
 
   // \ref{comparisons.three.way}, class \tcode{compare_three_way}
   struct compare_three_way;
@@ -4826,7 +4816,7 @@ namespace std {
     struct type_order;
 
   template<class T, class U>
-    constexpr strong_ordering type_order_v = type_order<T, U>::value;
+    constexpr strong_ordering @\libglobal{type_order_v}@ = type_order<T, U>::value;
 }
 \end{codeblock}
 


### PR DESCRIPTION
Notice that we have a `\indexlibraryglobal{is_geq}%` line here, but there is no such symbol in the standard library. This was introduced in f8814d2c66efc888f94c23b2e5d344119123ffcf

Additionally, this change converts the up-front `\indexlibraryglobal` to inline indexing with `\libglobal`, which could have prevented this problem and may prevent further issues going forward.