### PR TITLE
[cstdlib.syn] Add missing index entries and remove stray entries

### DIFF
--- a/source/support.tex
+++ b/source/support.tex
@@ -102,67 +102,19 @@ and as noted in
 \rSec2[cstdlib.syn]{Header \tcode{<cstdlib>} synopsis}
 
 \indexheader{cstdlib}%
-\indexlibraryglobal{EXIT_FAILURE}%
-\indexlibraryglobal{EXIT_SUCCESS}%
-\indexlibraryglobal{MB_CUR_MAX}%
-\indexlibraryglobal{NULL}%
-\indexlibraryglobal{RAND_MAX}%
-\indexlibraryglobal{_Exit}%
-\indexlibraryglobal{abort}%
-\indexlibraryglobal{abs}%
-\indexlibraryglobal{aligned_alloc}%
-\indexlibraryglobal{at_quick_exit}%
-\indexlibraryglobal{atexit}%
-\indexlibraryglobal{atof}%
-\indexlibraryglobal{atoi}%
-\indexlibraryglobal{atol}%
-\indexlibraryglobal{atoll}%
-\indexlibraryglobal{bsearch}%
-\indexlibraryglobal{calloc}%
-\indexlibraryglobal{div}%
-\indexlibraryglobal{div_t}%
-\indexlibraryglobal{exit}%
-\indexlibraryglobal{free}%
-\indexlibraryglobal{getenv}%
-\indexlibraryglobal{labs}%
-\indexlibraryglobal{ldiv}%
-\indexlibraryglobal{ldiv_t}%
-\indexlibraryglobal{llabs}%
-\indexlibraryglobal{lldiv}%
-\indexlibraryglobal{lldiv_t}%
-\indexlibraryglobal{malloc}%
-\indexlibraryglobal{mblen}%
-\indexlibraryglobal{mbstowcs}%
-\indexlibraryglobal{mbtowc}%
-\indexlibraryglobal{qsort}%
-\indexlibraryglobal{quick_exit}%
-\indexlibraryglobal{rand}%
-\indexlibraryglobal{realloc}%
-\indexlibraryglobal{size_t}%
-\indexlibraryglobal{srand}%
-\indexlibraryglobal{strtod}%
-\indexlibraryglobal{strtof}%
-\indexlibraryglobal{strtol}%
-\indexlibraryglobal{strtold}%
-\indexlibraryglobal{strtoll}%
-\indexlibraryglobal{strtoul}%
-\indexlibraryglobal{strtoull}%
-\indexlibraryglobal{system}%
-\indexlibraryglobal{wcstombs}%
-\indexlibraryglobal{wctomb}%
 \begin{codeblock}
 namespace std {
-  using size_t = @\seebelow@;                                             // freestanding
-  using div_t = @\seebelow@;                                              // freestanding
-  using ldiv_t = @\seebelow@;                                             // freestanding
-  using lldiv_t = @\seebelow@;                                            // freestanding
+  using @\libglobal{size_t}@ = @\seebelow@;                                             // freestanding
+  using @\libglobal{div_t}@ = @\seebelow@;                                              // freestanding
+  using @\libglobal{ldiv_t}@ = @\seebelow@;                                             // freestanding
+  using @\libglobal{lldiv_t}@ = @\seebelow@;                                            // freestanding
 }
 
-#define NULL @\seebelow@                                                  // freestanding
-#define EXIT_FAILURE @\seebelow@                                          // freestanding
-#define EXIT_SUCCESS @\seebelow@                                          // freestanding
-#define RAND_MAX @\seebelow@
-#define MB_CUR_MAX @\seebelow@
+#define @\libmacro{NULL}@ @\seebelow@                                                  // freestanding
+#define @\libmacro{EXIT_FAILURE}@ @\seebelow@                                          // freestanding
+#define @\libmacro{EXIT_SUCCESS}@ @\seebelow@                                          // freestanding
+#define @\libmacro{RAND_MAX}@ @\seebelow@
+#define @\libmacro{MB_CUR_MAX}@ @\seebelow@
 
 namespace std {
   // Exposition-only function type aliases
@@ -181,33 +133,33 @@ namespace std {
   [[noreturn]] void _Exit(int status) noexcept;                         // freestanding
   [[noreturn]] void quick_exit(int status) noexcept;                    // freestanding
 
-  char* getenv(const char* name);
-  int system(const char* string);
+  char* @\libglobal{getenv}@(const char* name);
+  int @\libglobal{system}@(const char* string);
 
   // \ref{c.malloc}, C library memory allocation
   void* aligned_alloc(size_t alignment, size_t size);
   void* calloc(size_t nmemb, size_t size);
   void free(void* ptr);
-  void free_sized(void* ptr, size_t size);
-  void free_aligned_sized(void* ptr, size_t alignment, size_t size);
+  void @\libglobal{free_sized}@(void* ptr, size_t size);
+  void @\libglobal{free_aligned_sized}@(void* ptr, size_t alignment, size_t size);
   void* malloc(size_t size);
   void* realloc(void* ptr, size_t size);
-  size_t memalignment(const void* p);                                   // freestanding
+  size_t @\libglobal{memalignment}@(const void* p);                                   // freestanding
 
-  double atof(const char* nptr);
-  int atoi(const char* nptr);
-  long int atol(const char* nptr);
-  long long int atoll(const char* nptr);
-  double strtod(const char* nptr, char** endptr);
-  int strfromd(char* s, size_t n, const char* format, double fp);
-  int strfromf(char* s, size_t n, const char* format, float fp);
-  int strfroml(char* s, size_t n, const char* format, long double fp);
-  float strtof(const char* nptr, char** endptr);
-  long double strtold(const char* nptr, char** endptr);
-  long int strtol(const char* nptr, char** endptr, int base);
-  long long int strtoll(const char* nptr, char** endptr, int base);
-  unsigned long int strtoul(const char* nptr, char** endptr, int base);
-  unsigned long long int strtoull(const char* nptr, char** endptr, int base);
+  double @\libglobal{atof}@(const char* nptr);
+  int @\libglobal{atoi}@(const char* nptr);
+  long int @\libglobal{atol}@(const char* nptr);
+  long long int @\libglobal{atoll}@(const char* nptr);
+  double @\libglobal{strtod}@(const char* nptr, char** endptr);
+  int @\libglobal{strfromd}@(char* s, size_t n, const char* format, double fp);
+  int @\libglobal{strfromf}@(char* s, size_t n, const char* format, float fp);
+  int @\libglobal{strfroml}@(char* s, size_t n, const char* format, long double fp);
+  float @\libglobal{strtof}@(const char* nptr, char** endptr);
+  long double @\libglobal{strtold}@(const char* nptr, char** endptr);
+  long int @\libglobal{strtol}@(const char* nptr, char** endptr, int base);
+  long long int @\libglobal{strtoll}@(const char* nptr, char** endptr, int base);
+  unsigned long int @\libglobal{strtoul}@(const char* nptr, char** endptr, int base);
+  unsigned long long int @\libglobal{strtoull}@(const char* nptr, char** endptr, int base);
 
   // \ref{c.mb.wcs}, multibyte / wide string and character conversion functions
   int mblen(const char* s, size_t n);
@@ -238,14 +190,14 @@ namespace std {
   constexpr long long int abs(long long int j);                         // freestanding
   constexpr @\placeholder{floating-point-type}@ abs(@\placeholder{floating-point-type}@ j);             // freestanding-deleted
 
-  constexpr long int labs(long int j);                                  // freestanding
-  constexpr long long int llabs(long long int j);                       // freestanding
+  constexpr long int @\libglobal{labs}@(long int j);                                  // freestanding
+  constexpr long long int @\libglobal{llabs}@(long long int j);                       // freestanding
 
-  constexpr div_t div(int numer, int denom);                            // freestanding
+  constexpr div_t @\libglobal{div}@(int numer, int denom);                            // freestanding
   constexpr ldiv_t div(long int numer, long int denom);                 // freestanding; see \ref{library.c}
   constexpr lldiv_t div(long long int numer, long long int denom);      // freestanding; see \ref{library.c}
-  constexpr ldiv_t ldiv(long int numer, long int denom);                // freestanding
-  constexpr lldiv_t lldiv(long long int numer, long long int denom);    // freestanding
+  constexpr ldiv_t @\libglobal{ldiv}@(long int numer, long int denom);                // freestanding
+  constexpr lldiv_t @\libglobal{lldiv}@(long long int numer, long long int denom);    // freestanding
 }
 \end{codeblock}
 


### PR DESCRIPTION
The indexing in [cstdlib.syn] is really broken in a number of ways:
- Several symbols are not indexed anywhere, especially the more recent C23 stuff. For example, there is no index entry for `memalignment`, `free_sized`, `strfromf`, etc. I haven't counted, but there should be at least a dozen missing entries here.
- Several index entries point to declarations, not to definitions, by virtue of having dedicated subclauses with definitions. For example, there are index entries for `rand` and `srand`, even though those are defined in [c.math.rand]. Traditionally, we do not index declarations.
- The synopsis spans at least two pages, so some of the index entries point to the wrong page.
- The big pile of `\indexlibrayglobal` makes it difficult to maintain the indexing in this area. Inline `\libglobal` is better.