### PR TITLE
[cstring.syn] Add various missing index entries

### DIFF
--- a/source/strings.tex
+++ b/source/strings.tex
@@ -5477,69 +5477,46 @@ The same suffix \tcode{s} is used for \tcode{chrono::duration} literals denoting
 
 \rSec2[cstring.syn]{Header \tcode{<cstring>} synopsis}
 
-\indexlibraryglobal{memchr}%
-\indexlibraryglobal{memcmp}%
-\indexlibraryglobal{memcpy}%
-\indexlibraryglobal{memmove}%
-\indexlibraryglobal{memset}%
-\indexlibraryglobal{size_t}%
-\indexlibraryglobal{strcat}%
-\indexlibraryglobal{strchr}%
-\indexlibraryglobal{strcmp}%
-\indexlibraryglobal{strcoll}%
-\indexlibraryglobal{strcpy}%
-\indexlibraryglobal{strcspn}%
-\indexlibraryglobal{strerror}%
-\indexlibraryglobal{strlen}%
-\indexlibraryglobal{strncat}%
-\indexlibraryglobal{strncmp}%
-\indexlibraryglobal{strncpy}%
-\indexlibraryglobal{strpbrk}%
-\indexlibraryglobal{strrchr}%
-\indexlibraryglobal{strspn}%
-\indexlibraryglobal{strstr}%
-\indexlibraryglobal{strtok}%
-\indexlibraryglobal{strxfrm}%
 \begin{codeblock}
 #define @\libmacro{__STDC_VERSION_STRING_H__}@ 202311L
 
 namespace std {
-  using size_t = @\textit{see \ref{support.types.layout}}@;                                            // freestanding
+  using @\libglobal{size_t}@ = @\textit{see \ref{support.types.layout}}@;                                            // freestanding
 
-  void* memcpy(void* s1, const void* s2, size_t n);                     // freestanding
-  void* memccpy(void* s1, const void* s2, int c, size_t n);             // freestanding
-  void* memmove(void* s1, const void* s2, size_t n);                    // freestanding
-  char* strcpy(char* s1, const char* s2);                               // freestanding
-  char* strncpy(char* s1, const char* s2, size_t n);                    // freestanding
-  char* strdup(const char* s);
-  char* strndup(const char* s, size_t size);
-  char* strcat(char* s1, const char* s2);                               // freestanding
-  char* strncat(char* s1, const char* s2, size_t n);                    // freestanding
-  int memcmp(const void* s1, const void* s2, size_t n);                 // freestanding
-  int strcmp(const char* s1, const char* s2);                           // freestanding
-  int strcoll(const char* s1, const char* s2);
-  int strncmp(const char* s1, const char* s2, size_t n);                // freestanding
-  size_t strxfrm(char* s1, const char* s2, size_t n);
-  const void* memchr(const void* s, int c, size_t n);                   // freestanding; see \ref{library.c}
+  void* @\libglobal{memcpy}@(void* s1, const void* s2, size_t n);                     // freestanding
+  void* @\libglobal{memccpy}@(void* s1, const void* s2, int c, size_t n);             // freestanding
+  void* @\libglobal{memmove}@(void* s1, const void* s2, size_t n);                    // freestanding
+  char* @\libglobal{strcpy}@(char* s1, const char* s2);                               // freestanding
+  char* @\libglobal{strncpy}@(char* s1, const char* s2, size_t n);                    // freestanding
+  char* @\libglobal{strdup}@(const char* s);
+  char* @\libglobal{strndup}@(const char* s, size_t size);
+  char* @\libglobal{strcat}@(char* s1, const char* s2);                               // freestanding
+  char* @\libglobal{strncat}@(char* s1, const char* s2, size_t n);                    // freestanding
+  int @\libglobal{memcmp}@(const void* s1, const void* s2, size_t n);                 // freestanding
+  int @\libglobal{strcmp}@(const char* s1, const char* s2);                           // freestanding
+  int @\libglobal{strcoll}@(const char* s1, const char* s2);
+  int @\libglobal{strncmp}@(const char* s1, const char* s2, size_t n);                // freestanding
+  size_t @\libglobal{strxfrm}@(char* s1, const char* s2, size_t n);
+  const void* @\libglobal{memchr}@(const void* s, int c, size_t n);                   // freestanding; see \ref{library.c}
   void* memchr(void* s, int c, size_t n);                               // freestanding; see \ref{library.c}
-  const char* strchr(const char* s, int c);                             // freestanding; see \ref{library.c}
+  const char* @\libglobal{strchr}@(const char* s, int c);                             // freestanding; see \ref{library.c}
   char* strchr(char* s, int c);                                         // freestanding; see \ref{library.c}
-  size_t strcspn(const char* s1, const char* s2);                       // freestanding
-  const char* strpbrk(const char* s1, const char* s2);                  // freestanding; see \ref{library.c}
+  size_t @\libglobal{strcspn}@(const char* s1, const char* s2);                       // freestanding
+  const char* @\libglobal{strpbrk}@(const char* s1, const char* s2);                  // freestanding; see \ref{library.c}
   char* strpbrk(char* s1, const char* s2);                              // freestanding; see \ref{library.c}
-  const char* strrchr(const char* s, int c);                            // freestanding; see \ref{library.c}
+  const char* @\libglobal{strrchr}@(const char* s, int c);                            // freestanding; see \ref{library.c}
   char* strrchr(char* s, int c);                                        // freestanding; see \ref{library.c}
-  size_t strspn(const char* s1, const char* s2);                        // freestanding
-  const char* strstr(const char* s1, const char* s2);                   // freestanding; see \ref{library.c}
+  size_t @\libglobal{strspn}@(const char* s1, const char* s2);                        // freestanding
+  const char* @\libglobal{strstr}@(const char* s1, const char* s2);                   // freestanding; see \ref{library.c}
   char* strstr(char* s1, const char* s2);                               // freestanding; see \ref{library.c}
-  char* strtok(char* s1, const char* s2);
-  void* memset(void* s, int c, size_t n);                               // freestanding
-  void* memset_explicit(void* s, int c, size_t n);                      // freestanding
-  char* strerror(int errnum);
-  size_t strlen(const char* s);                                         // freestanding
+  char* @\libglobal{strtok}@(char* s1, const char* s2);
+  void* @\libglobal{memset}@(void* s, int c, size_t n);                               // freestanding
+  void* @\libglobal{memset_explicit}@(void* s, int c, size_t n);                      // freestanding
+  char* @\libglobal{strerror}@(int errnum);
+  size_t @\libglobal{strlen}@(const char* s);                                         // freestanding
 }
 
-#define NULL @\textit{see \ref{support.types.nullptr}}@                                                // freestanding
+#define @\libmacro{NULL}@ @\textit{see \ref{support.types.nullptr}}@                                                // freestanding
 \end{codeblock}
 
 \pnum


### PR DESCRIPTION
We have inevitably messed up maintaining another big `\indexlibraryglobal` block in [cstring.syn]:
- `NULL` is `#define`d here, but is not indexed as a macro.
- Some C23 functions are not indexed anywhere, like `memccpy` and `memset_explicit`.