### PR TITLE
[depr.ctime.syn] Add asctime and ctime to index

### DIFF
--- a/source/future.tex
+++ b/source/future.tex
@@ -812,6 +812,9 @@ Equivalent to: \tcode{return visit(std::forward<Visitor>(vis), arg.\exposid{valu
 
 \pnum
 The header \libheaderref{ctime} has the following additions:
+
+\indexlibraryglobal{asctime}%
+\indexlibraryglobal{ctime}%
 \begin{codeblock}
 char* asctime(const tm* timeptr);
 char* ctime(const time_t* timer);


### PR DESCRIPTION
#8011 moved these to [depr] and got rid of the index entry entirely, rather than repointing the indexing.