### PR TITLE
[expr.prim.pack.index] Replace "in" with "of" in paragraph 1

### DIFF
--- a/source/expressions.tex
+++ b/source/expressions.tex
@@ -2079,7 +2079,7 @@ and a prvalue otherwise.
 \end{bnf}
 
 \pnum
-The \grammarterm{id-expression} $P$ in a \grammarterm{pack-index-expression}
+The \grammarterm{id-expression} $P$ of a \grammarterm{pack-index-expression}
 shall be an \grammarterm{identifier} that denotes a pack.
 
 \pnum


### PR DESCRIPTION
Closes #9288

There is an argument to be made that this is not editorial, but I personally think this is basically a typo. The combination "The" and "in" doesn't make any sense anyway here. It would need to be

> An *id-expression* $P$ in a *pack-index-expression*

to make any sense. The intent is pretty clear, especially since this paragraph refers to the grammar snippet immediately above, so it obviously refers to the *id-expression* of the *pack-index-expression* as shown above, rather than making some broad and recursive statement.

Implementers are obviously going to be doing the right thing anyway. It would be evil and unhinged to assume that every *id-expression* recursively needs to denote a pack just because it's nested somewhere in a *pack-index-expression*.