### PR TITLE
[saferecl.hp.base] Merge sentences to avoid visual confusion

### DIFF
--- a/source/threads.tex
+++ b/source/threads.tex
@@ -13723,7 +13723,7 @@ void retire(D d = D()) noexcept;
 \pnum
 \expects
 \tcode{*this} is
-a base class subobject of an object \tcode{x} of type \tcode{T}.
+a base class subobject of an object \tcode{x} of type \tcode{T} and
 \tcode{x} is not retired.
 Move-assigning \tcode{d} to \tcode{deleter} does not exit via an exception.
 


### PR DESCRIPTION
Requested by LWG during its 2026-09-04 telecon. The existing text looks like a class member access `T.x`.