### PR TITLE
[stdbit.h.syn], [numeric.c.ckdint] Replace misuses of `\xrefc` with `\IsoC`

### DIFF
--- a/source/numerics.tex
+++ b/source/numerics.tex
@@ -21396,5 +21396,5 @@ signed or unsigned integer type\iref{basic.fundamental}.
 \remarks
 Each function template has the same semantics as
 the corresponding type-generic macro with the same name
-specified in \xrefc{7.20}.
+specified in \IsoC{} 7.20.
 \end{itemdescr}

--- a/source/utilities.tex
+++ b/source/utilities.tex
@@ -17031,7 +17031,7 @@ an \impldef{return types for \tcode{<stdbit.h>} functions} unsigned integer type
 large enough to represent all possible result values.
 Each function template has the same semantics
 as the corresponding type-generic function with the same name
-specified in \xrefc{7.18}.
+specified in \IsoC{} 7.18.
 
 \pnum
 \mandates


### PR DESCRIPTION
<img width="1150" height="99" alt="grafik" src="https://github.com/user-attachments/assets/2df0d72e-8ac0-40b9-8904-040427b4290d" />
