### PR TITLE
[basic.fundamental] Remove bullet for reflections being function parameters

### DIFF
--- a/source/basic.tex
+++ b/source/basic.tex
@@ -5749,7 +5749,6 @@ every other reflection is a representation of
 \item a variable\iref{basic.pre},
 \item a structured binding\iref{dcl.struct.bind},
 \item a function\iref{dcl.fct},
-\item a function parameter,
 \item an enumerator\iref{dcl.enum},
 \item an annotation\iref{dcl.attr.grammar},
 \item a type alias\iref{dcl.typedef},


### PR DESCRIPTION
Function parameters are already covered by the preceding bullet stating that a reflection may be a representation of a variable. Every function parameter is a variable, and having a distinct bullet misleads the reader into believing it is not.

This misunderstanding that function parameters are not variables led to CWG3005.

See prior discussion at:
- https://github.com/cplusplus/CWG/issues/1004