### PR TITLE
[dcl.array] Use "sequence" instead of "set" when discussing array elements

### DIFF
--- a/source/declarations.tex
+++ b/source/declarations.tex
@@ -3588,7 +3588,7 @@ has cv-qualified type; see~\ref{basic.type.qualifier}.
 
 \pnum
 An object of type ``array of \tcode{N} \tcode{U}'' consists of
-a contiguously allocated non-empty set
+a contiguously allocated non-empty sequence
 of \tcode{N} subobjects of type \tcode{U},
 known as the \defnx{elements}{array!element} of the array,
 and numbered \tcode{0} to \tcode{N-1}.


### PR DESCRIPTION
Closes https://github.com/cplusplus/CWG/issues/556

That core issue request pointed out two problems:
- "numbered `0` to `N-1`" is vague. We recently clarified this by saying that the first element is numbered `0`, which makes that wording meaningful and clear enough.
- We use the word "set" when discussing array elements, but "set" is usually an unordered construct. This part seems editorial and is fixed here.